### PR TITLE
[new release] plotkicadsch and kicadsch (0.5.1)

### DIFF
--- a/packages/kicadsch/kicadsch.0.5.1/opam
+++ b/packages/kicadsch/kicadsch.0.5.1/opam
@@ -17,7 +17,6 @@ build: [
 ]
 depends: [
   "dune" {build}
-  "dune-release" {build}
   "ounit" {with-test}
   "ocaml" {>="4.07"}
 ]

--- a/packages/kicadsch/kicadsch.0.5.1/opam
+++ b/packages/kicadsch/kicadsch.0.5.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+doc: "https://jnavila.github.io/plotkicadsch/index"
+synopsis: "Library to read and convert Kicad Sch files"
+description: """
+Library able to read Kicad libraries and sch file and
+drive a painter to paint the schematics.
+"""
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {build}
+  "dune-release" {build}
+  "ounit" {with-test}
+  "ocaml" {>="4.07"}
+]
+authors: "Jean-Noel Avila <jn.avila@free.fr>"
+url {
+  src:
+    "https://github.com/jnavila/plotkicadsch/releases/download/v0.5.1/plotkicadsch-v0.5.1.tbz"
+  checksum: [
+    "sha256=5dece188f3751fecdfae8e7b5e678fdc3871f6c1e348b30ab969ce336cdb0b5a"
+    "sha512=fe5b3cccad2ea9af016548ddf8b1d44b4bc32c51cb278efe80eb66582d1a604b8ef6d83f4659fe4ca08ff073e9344d01c80fc12d01154a38a0497163d34e6773"
+  ]
+}

--- a/packages/plotkicadsch/plotkicadsch.0.5.1/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.5.1/opam
@@ -17,7 +17,6 @@ build: [
 ]
 depends: [
   "dune" {build}
-  "dune-release" {build}
   "kicadsch" {= "0.5.0"}
   "tyxml" {>= "4.0.0"}
   "lwt"

--- a/packages/plotkicadsch/plotkicadsch.0.5.1/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.5.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+doc: "https://jnavila.github.io/plotkicadsch/index"
+synopsis: "Utilities to print and compare version of Kicad schematics"
+description: """
+Two utilities:
+ * plotkicadsch is able to plot schematic sheets to SVG files
+ * plotgitsch is able to compare git revisions of schematics
+"""
+license: "ISC"
+dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {build}
+  "dune-release" {build}
+  "kicadsch" {= "0.5.0"}
+  "tyxml" {>= "4.0.0"}
+  "lwt"
+  "lwt_ppx" {build}
+  "sha"
+  "git" {>= "2.0.0"}
+  "git-unix"
+  "base64" {>= "3.0.0"}
+  "patience_diff" { < "v0.12.0" }
+  "core_kernel"
+  "cmdliner"
+]
+authors: "Jean-Noel Avila <jn.avila@free.fr>"
+url {
+  src:
+    "https://github.com/jnavila/plotkicadsch/releases/download/v0.5.1/plotkicadsch-v0.5.1.tbz"
+  checksum: [
+    "sha256=5dece188f3751fecdfae8e7b5e678fdc3871f6c1e348b30ab969ce336cdb0b5a"
+    "sha512=fe5b3cccad2ea9af016548ddf8b1d44b4bc32c51cb278efe80eb66582d1a604b8ef6d83f4659fe4ca08ff073e9344d01c80fc12d01154a38a0497163d34e6773"
+  ]
+}


### PR DESCRIPTION
Utilities to print and compare version of Kicad schematics

- Project page: <a href="https://jnavila.github.io/plotkicadsch/">https://jnavila.github.io/plotkicadsch/</a>
- Documentation: <a href="https://jnavila.github.io/plotkicadsch/index">https://jnavila.github.io/plotkicadsch/index</a>

##### CHANGES:

- fix compatibility with kicad 5.x
