### PR TITLE
[new release] mirage-console-lwt, mirage-console-unix, mirage-console-xen-proto, mirage-console-xen, mirage-console-xen-backend and mirage-console (2.4.3)

### DIFF
--- a/packages/mirage-console-lwt/mirage-console-lwt.2.4.3/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.4.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console" {=version}
+  "lwt"
+  "cstruct" {>= "1.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage consoles using Lwt"
+description: """
+This implements a MirageOS console device using the Lwt
+concurrency libary for concurrency.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.3/mirage-console-v2.4.3.tbz"
+  checksum: [
+    "sha256=9677d51f4075567b488b45ce7f9ee6512fb4f03e72209bb761cc7bd64570cc5b"
+    "sha512=e08a353738bae403418047b19e585543f91f5027c690240d8b3c13b35f62856216d4405ccd758c71ba9c1567638215bb8ef85776965f233ed2ef84d966a1358b"
+  ]
+}

--- a/packages/mirage-console-unix/mirage-console-unix.2.4.3/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.2.4.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "lwt"
+  "cstruct" {>= "3.0.0"}
+  "cstruct-lwt"
+  "mirage-console-lwt" {=version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage consoles for Unix"
+description: """
+This implements a MirageOS console device for use with
+Unix-based targets.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.3/mirage-console-v2.4.3.tbz"
+  checksum: [
+    "sha256=9677d51f4075567b488b45ce7f9ee6512fb4f03e72209bb761cc7bd64570cc5b"
+    "sha512=e08a353738bae403418047b19e585543f91f5027c690240d8b3c13b35f62856216d4405ccd758c71ba9c1567638215bb8ef85776965f233ed2ef84d966a1358b"
+  ]
+}

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.4.3/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.4.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console-lwt" {=version}
+  "mirage-console-xen-proto" {=version}
+  "mirage-xen" {>= "4.0.0"}
+  "lwt"
+  "io-page-xen" {>= "2.0.0"}
+  "xenstore"
+  "xen-evtchn"
+  "shared-memory-ring-lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console backend for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.3/mirage-console-v2.4.3.tbz"
+  checksum: [
+    "sha256=9677d51f4075567b488b45ce7f9ee6512fb4f03e72209bb761cc7bd64570cc5b"
+    "sha512=e08a353738bae403418047b19e585543f91f5027c690240d8b3c13b35f62856216d4405ccd758c71ba9c1567638215bb8ef85776965f233ed2ef84d966a1358b"
+  ]
+}

--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.4.3/opam
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.2.4.3/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console-lwt" {>= "2.2.0"}
+  "rresult"
+  "xenstore"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console protocol for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.3/mirage-console-v2.4.3.tbz"
+  checksum: [
+    "sha256=9677d51f4075567b488b45ce7f9ee6512fb4f03e72209bb761cc7bd64570cc5b"
+    "sha512=e08a353738bae403418047b19e585543f91f5027c690240d8b3c13b35f62856216d4405ccd758c71ba9c1567638215bb8ef85776965f233ed2ef84d966a1358b"
+  ]
+}

--- a/packages/mirage-console-xen/mirage-console-xen.2.4.3/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.4.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console-lwt" {=version}
+  "mirage-console-xen-proto" {=version}
+  "xen-evtchn"
+  "io-page-xen"
+  "mirage-xen" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.3/mirage-console-v2.4.3.tbz"
+  checksum: [
+    "sha256=9677d51f4075567b488b45ce7f9ee6512fb4f03e72209bb761cc7bd64570cc5b"
+    "sha512=e08a353738bae403418047b19e585543f91f5027c690240d8b3c13b35f62856216d4405ccd758c71ba9c1567638215bb8ef85776965f233ed2ef84d966a1358b"
+  ]
+}

--- a/packages/mirage-console/mirage-console.2.4.3/opam
+++ b/packages/mirage-console/mirage-console.2.4.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementations of Mirage console devices"
+description: """
+This is a general implementation of a console device, intended
+for use in MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.3/mirage-console-v2.4.3.tbz"
+  checksum: [
+    "sha256=9677d51f4075567b488b45ce7f9ee6512fb4f03e72209bb761cc7bd64570cc5b"
+    "sha512=e08a353738bae403418047b19e585543f91f5027c690240d8b3c13b35f62856216d4405ccd758c71ba9c1567638215bb8ef85776965f233ed2ef84d966a1358b"
+  ]
+}


### PR DESCRIPTION
Implementation of Mirage consoles using Lwt

- Project page: <a href="https://github.com/mirage/mirage-console">https://github.com/mirage/mirage-console</a>
- Documentation: <a href="https://mirage.github.io/mirage-console/">https://mirage.github.io/mirage-console/</a>

##### CHANGES:

* Use mirage-xen 4.0 `Os_xen` interface (mirage/mirage-console#77 @TheLortex)
