### PR TITLE
[new release] mirage-net-xen and netchannel (1.12.0)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.1.10.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.10.1/opam
@@ -19,7 +19,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "io-page-xen" {>= "2.0.0"}
   "mirage-xen" {>= "1.1.0" & < "4.0.0"}
-  "netchannel" {= "1.10.0"}
+  "netchannel" {= "1.10.1"}
   "lwt-dllist"
   "logs" {>= "0.5.0"}
 ]

--- a/packages/mirage-net-xen/mirage-net-xen.1.10.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.10.1/opam
@@ -19,7 +19,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "io-page-xen" {>= "2.0.0"}
   "mirage-xen" {>= "1.1.0" & < "4.0.0"}
-  "netchannel" {>= "1.10.0"}
+  "netchannel" {= "1.10.0"}
   "lwt-dllist"
   "logs" {>= "0.5.0"}
 ]

--- a/packages/mirage-net-xen/mirage-net-xen.1.10.2/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.10.2/opam
@@ -19,7 +19,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "io-page-xen" {>= "2.0.0"}
   "mirage-xen" {>= "3.3.0" & < "4.0.0"}
-  "netchannel" {>= "1.10.1"}
+  "netchannel" {= "1.10.2"}
   "lwt-dllist"
   "logs" {>= "0.5.0"}
 ]

--- a/packages/mirage-net-xen/mirage-net-xen.1.11.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.11.0/opam
@@ -19,7 +19,7 @@ depends: [
   "io-page" {>= "1.5.0"}
   "io-page-xen" {>= "2.0.0"}
   "mirage-xen" {>= "3.3.0" & < "4.0.0"}
-  "netchannel" {>= "1.10.1"}
+  "netchannel" {= "1.11.0"}
   "lwt-dllist"
   "logs" {>= "0.5.0"}
 ]

--- a/packages/mirage-net-xen/mirage-net-xen.1.12.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.12.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"  {build & >= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "io-page" {>= "1.5.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "4.0.0"}
+  "netchannel" {>= "1.10.1"}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v1.12.0/mirage-net-xen-v1.12.0.tbz"
+  checksum: [
+    "sha256=84c0a40e7530962d8c345853531f7d95b1c10df3d7713d3f082078c302d5dca1"
+    "sha512=328d63788c7ce34c9fdf191535b4b499c74c75dbfdefb8a2115b1fe773fbfe7f06ea88bca2e9122ee026cec6517ed782a37573f22ecc46f917723cd7384c8c63"
+  ]
+}

--- a/packages/netchannel/netchannel.1.12.0/opam
+++ b/packages/netchannel/netchannel.1.12.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"  {build & >= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "io-page" {>= "1.5.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "3.3.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-profile" {>="0.3"}
+  "shared-memory-ring" {>="3.0.0"}
+  "sexplib" {>= "113.01.00"}
+  "logs" {>= "0.5.0"}
+  "rresult"
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+
+Note: the `Netif` module is the public API.
+The `Netchannel` API is still under development.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v1.12.0/mirage-net-xen-v1.12.0.tbz"
+  checksum: [
+    "sha256=84c0a40e7530962d8c345853531f7d95b1c10df3d7713d3f082078c302d5dca1"
+    "sha512=328d63788c7ce34c9fdf191535b4b499c74c75dbfdefb8a2115b1fe773fbfe7f06ea88bca2e9122ee026cec6517ed782a37573f22ecc46f917723cd7384c8c63"
+  ]
+}


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* Cope with frontend moving directly to Closed state (@talex5, mirage/mirage-net-xen#89)
* Remove colons in log prefixes (@yomimono, mirage/mirage-net-xen#91)
* Use mirage-xen.4.0.0 `Os_xen` interface (@TheLortex, mirage/mirage-net-xen#90)
