### PR TITLE
[new release] mirage-block-xen (1.6.2)

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.1.6.2/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.6.2/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott" "Thomas Leonard"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-block-xen"
+doc: "https://mirage.github.io/mirage-block-xen/"
+bug-reports: "https://github.com/mirage/mirage-block-xen/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build}
+  "cmdliner"
+  "logs"
+  "stringext"
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_cstruct" {build & >= "3.6.0"}
+  "shared-memory-ring-lwt"
+  "mirage-block-lwt" {>= "1.0.0"}
+  "ipaddr"
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "3.3.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block-xen.git"
+synopsis: "MirageOS block driver for Xen that implements the blkfront/back protocol"
+description: """
+This library allows a Mirage OCaml application to
+
+  1. read and write blocks from any Xen "backend" (server)
+  2. service block requests from any Xen "frontend" (client)
+
+This library can be used in both kernelspace (on Xen)
+or in userspace (using libraries that come with Xen).
+
+This library depends on the
+[shared-memory-ring](https://github.com/mirage/shared-memory-ring)
+library which enables high-throughput, low-latency data
+transfers over shared memory on both x86 and ARM architectures,
+using the standard Xen RPC and event channel semantics.
+"""
+
+pin-depends: [
+  ["mirage-xen.dev" "git+https://github.com/mirage/mirage-xen"]
+]
+url {
+  src:
+    "https://github.com/mirage/mirage-block-xen/releases/download/v1.6.2/mirage-block-xen-v1.6.2.tbz"
+  checksum: [
+    "sha256=a56bb75672eb28b947386222849abfb353ad6b4f74030ddd4a90cd033ce696a2"
+    "sha512=9124ff42b902681a3ab077fb64866b86f4a180d05fd89ada1a1ad4145ce3e9a35e3a3d88ce4ffb15457fa8aee04a8b892c88d0be4ebd7619a29552acf281e811"
+  ]
+}


### PR DESCRIPTION
MirageOS block driver for Xen that implements the blkfront/back protocol

- Project page: <a href="https://github.com/mirage/mirage-block-xen">https://github.com/mirage/mirage-block-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-xen/">https://mirage.github.io/mirage-block-xen/</a>

##### CHANGES:

* Use mirage-xen 4.0 `Os_xen` module (mirage/mirage-block-xen#81 @TheLortex)
* generate exact Merlin files by rearranging build (mirage/mirage-block-xen#82 @avsm)
