### PR TITLE
[new release] ocaml-version (2.1.0)

### DIFF
--- a/packages/ocaml-version/ocaml-version.2.1.0/opam
+++ b/packages/ocaml-version/ocaml-version.2.1.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/avsm/ocaml-version"
+doc: "https://avsm.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/avsm/ocaml-version/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-version.git"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+Browse the [API documentation](http://anil-code.recoil.org/ocaml-version/ocaml-version/Ocaml_version/index.html) for more
+details.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/avsm/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+url {
+  src:
+    "https://github.com/avsm/ocaml-version/releases/download/v2.1.0/ocaml-version-v2.1.0.tbz"
+  checksum: [
+    "sha256=beca7e6ae29f2b1c3072308e217713ec112c202770a94a82d97fef22c11624d6"
+    "sha512=c46a26c304295e0690d23420aa65fe211a2d6c3382e3f1f9c860fa9a2de6c8002f1b4bd9f22b6f17f966156f0eb0c57dbc34b1b8e779736b12d970178e027718"
+  ]
+}


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/avsm/ocaml-version">https://github.com/avsm/ocaml-version</a>
- Documentation: <a href="https://avsm.github.io/ocaml-version/doc">https://avsm.github.io/ocaml-version/doc</a>

##### CHANGES:

* Add OCaml 4.08.0 release
* Add support for 4.10 as the new trunk.
