### PR TITLE
[new release] dockerfile-opam, dockerfile and dockerfile-cmd (6.2.0)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.6.2.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.6.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL - generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "dockerfile-opam" {>= "3.0.0"}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "ppx_sexp_conv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.2.0/dockerfile-v6.2.0.tbz"
+  checksum: [
+    "sha256=d4a1a15d6f1141b8d08df2c87c2b5d113ec3076ce3115b2ca44900a4cea0c2d7"
+    "sha512=06a4472701f474142328fe9129292afedf21138b43e0ffc5eca135e6f89275525d56462e935441b5df5fef3114df1baa83b126dcdb16d6d778fe75aa18b7686f"
+  ]
+}

--- a/packages/dockerfile-opam/dockerfile-opam.6.2.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.6.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution
+support for generating dockerfiles."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "dockerfile" {= version}
+  "ocaml-version" {>= "1.0.0"}
+  "cmdliner"
+  "astring"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.2.0/dockerfile-v6.2.0.tbz"
+  checksum: [
+    "sha256=d4a1a15d6f1141b8d08df2c87c2b5d113ec3076ce3115b2ca44900a4cea0c2d7"
+    "sha512=06a4472701f474142328fe9129292afedf21138b43e0ffc5eca135e6f89275525d56462e935441b5df5fef3114df1baa83b126dcdb16d6d778fe75aa18b7686f"
+  ]
+}

--- a/packages/dockerfile/dockerfile.6.2.0/opam
+++ b/packages/dockerfile/dockerfile.6.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.2.0/dockerfile-v6.2.0.tbz"
+  checksum: [
+    "sha256=d4a1a15d6f1141b8d08df2c87c2b5d113ec3076ce3115b2ca44900a4cea0c2d7"
+    "sha512=06a4472701f474142328fe9129292afedf21138b43e0ffc5eca135e6f89275525d56462e935441b5df5fef3114df1baa83b126dcdb16d6d778fe75aa18b7686f"
+  ]
+}


### PR DESCRIPTION
Dockerfile eDSL -- opam support

- Project page: <a href="https://github.com/avsm/ocaml-dockerfile">https://github.com/avsm/ocaml-dockerfile</a>
- Documentation: <a href="https://avsm.github.io/ocaml-dockerfile/">https://avsm.github.io/ocaml-dockerfile/</a>

##### CHANGES:

- Add Fedora 30, Debian 10 (Buster), OpenSUSE 15.1 (Leap) and
  Alpine 3.10 to the distribution list (@avsm)
- Ensure Alpine 3.9 has an arm64 build (@avsm)
- Deprecate Ubuntu 14.04, Fedora 27/28 and Alpine 3.8 in favour of
  newer upstream versions (@avsm)
