### PR TITLE
[new release] mirage-bootvar-xen (0.6.0)

### DIFF
--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.6.0/opam
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Handle boot-time arguments for Xen platform"
+description: """
+Simple library for reading MirageOS unikernel boot parameters from Xen.
+
+To send boot parameters to the unikernel you can either add them as options in the "extra=" field in the .xl-file.
+"""
+
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-bootvar-xen"
+bug-reports: "https://github.com/mirage/mirage-bootvar-xen/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-bootvar-xen.git"
+doc: "https://mirage.github.io/mirage-bootvar-xen/"
+license: "ISC"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {build & >= "1.0"}
+  "mirage-xen" { >= "4.0.0"}
+  "lwt" {>="2.4.3"}
+  "astring"
+  "parse-argv"
+  "ocaml" { >= "4.04.2" }
+]
+url {
+  src:
+    "https://github.com/mirage/mirage-bootvar-xen/releases/download/v0.6.0/mirage-bootvar-xen-v0.6.0.tbz"
+  checksum: [
+    "sha256=0e3773a82ef8bf0460137379b02500610c7d966832727a4a23dec18c700dcb5c"
+    "sha512=eed49d1190755e90afbfc9b7845090a21991e5cfaf84786130d9cef5150e6e08ba7f9cfbde888df5d35a02b355d65ae9da380dd6efc81a39892c9d8e405c16cf"
+  ]
+}


### PR DESCRIPTION
Handle boot-time arguments for Xen platform

- Project page: <a href="https://github.com/mirage/mirage-bootvar-xen">https://github.com/mirage/mirage-bootvar-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-bootvar-xen/">https://mirage.github.io/mirage-bootvar-xen/</a>

##### CHANGES:

* Port to dune from jbuilder (mirage/mirage-bootvar-xen#38 @TheLortex @avsm)
* Adapt to mirage-xen 4.0.0 `Os_xen` interface (mirage/mirage-bootvar-xen#37 @TheLortex)
* Update Travis to test 4.06 as well (@avsm).
