### PR TITLE
[new release] vchan-xen, vchan-unix and vchan (4.0.3)

### DIFF
--- a/packages/vchan-unix/vchan-unix.4.0.3/opam
+++ b/packages/vchan-unix/vchan-unix.4.0.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "vchan" {>="4.0.0"}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "io-page-unix"
+  "mirage-flow-lwt" {>= "1.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "xen-evtchn-unix"
+  "xen-gnt-unix"
+  "sexplib"
+  "cmdliner"
+  "result"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v4.0.3/vchan-v4.0.3.tbz"
+  checksum: [
+    "sha256=881561336d1b52443512297e156586aa0ae4c8637f273b9316e873a35afabfa7"
+    "sha512=691394329b1cbd1c5c842b607fe7fd9ba5a959b501e75dfaf818d02a82d507399cba9a9e4e97c2c69ad1fec078f5f994b8dae539fef3946af6cb355b3eed5c60"
+  ]
+}

--- a/packages/vchan-xen/vchan-xen.4.0.3/opam
+++ b/packages/vchan-xen/vchan-xen.4.0.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "vchan" {=version}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "mirage-flow-lwt" {>= "1.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "mirage-xen" {>= "4.0.0"}
+  "xenstore_transport" {>= "1.0.0"}
+  "sexplib"
+  "cmdliner"
+  "result"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v4.0.3/vchan-v4.0.3.tbz"
+  checksum: [
+    "sha256=881561336d1b52443512297e156586aa0ae4c8637f273b9316e873a35afabfa7"
+    "sha512=691394329b1cbd1c5c842b607fe7fd9ba5a959b501e75dfaf818d02a82d507399cba9a9e4e97c2c69ad1fec078f5f994b8dae539fef3946af6cb355b3eed5c60"
+  ]
+}

--- a/packages/vchan/vchan.4.0.3/opam
+++ b/packages/vchan/vchan.4.0.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+description: """
+This is an implementation of the Xen "libvchan" or "vchan" communication
+protocol in OCaml. It allows fast inter-domain communication using shared
+memory.
+"""
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "mirage-flow-lwt" {>= "1.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "sexplib"
+  "cmdliner"
+  "result"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v4.0.3/vchan-v4.0.3.tbz"
+  checksum: [
+    "sha256=881561336d1b52443512297e156586aa0ae4c8637f273b9316e873a35afabfa7"
+    "sha512=691394329b1cbd1c5c842b607fe7fd9ba5a959b501e75dfaf818d02a82d507399cba9a9e4e97c2c69ad1fec078f5f994b8dae539fef3946af6cb355b3eed5c60"
+  ]
+}


### PR DESCRIPTION
This is an implementation of the Xen "libvchan" or "vchan" communication

- Project page: <a href="https://github.com/mirage/ocaml-vchan">https://github.com/mirage/ocaml-vchan</a>
- Documentation: <a href="https://mirage.github.io/ocaml-vchan">https://mirage.github.io/ocaml-vchan</a>

##### CHANGES:

* Use mirage-xen 4.0.0 `Os_xen` interface (mirage/ocaml-vchan#128 @TheLortex)
* Update opam metadata to remove `{build}` for ppx (@avsm)
