### PR TITLE
netchannel / mirage-block-xen: require mirage-xen 4.0.0

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.1.6.2/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.6.2/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"
   "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "3.3.0"}
+  "mirage-xen" {>= "4.0.0"}
   "rresult"
 ]
 build: [

--- a/packages/netchannel/netchannel.1.12.0/opam
+++ b/packages/netchannel/netchannel.1.12.0/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-net-lwt" {>= "2.0.0"}
   "io-page" {>= "1.5.0"}
   "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "3.3.0"}
+  "mirage-xen" {>= "4.0.0"}
   "ipaddr" {>= "3.0.0"}
   "mirage-profile" {>="0.3"}
   "shared-memory-ring" {>="3.0.0"}


### PR DESCRIPTION
/cc @avsm

(see failing CI at https://travis-ci.org/ocaml/opam-repository/jobs/550981012 and https://travis-ci.org/ocaml/opam-repository/jobs/550996224)