### PR TITLE
Package bnfgen.2.0

### DIFF
--- a/packages/bnfgen/bnfgen.2.0/opam
+++ b/packages/bnfgen/bnfgen.2.0/opam
@@ -19,12 +19,12 @@ build: [
 ]
 depends: [
   "menhir" {build}
-  "dune" {build & >= "1.4.0"}
+  "dune" {>= "1.4.0"}
 ]
 url {
   src: "https://github.com/dmbaturin/bnfgen/archive/2.0.tar.gz"
   checksum: [
-    "md5=89ae8d4e9db009b8b54ebcc9df18715d"
-    "sha512=98ee1c9cf2506b6aa3b7ea24c8fb7f3b7166c81be677d06895ba2e76ae34e259315ec99308457e121e82f6ab727325afb4ddd03b297c420e7c41583510e35c48"
+    "md5=efb520633eac4197509ddc9e020c53a9"
+    "sha512=840be6c7bb98590457aa9fd64593eb5995a5ae9d77cb4a883cb2f5ff65008de5dd29f3b2d86a746d5edafb7c449b0223a7c82d6ec1a3209c98c9430609e117a7"
   ]
 }

--- a/packages/bnfgen/bnfgen.2.0/opam
+++ b/packages/bnfgen/bnfgen.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Random text generator that takes context-free grammars from BNF files"
+description: """
+BNFGen generates random texts based on user-defined context-free grammars
+specified in a BNF-like syntax.
+You can specify "weight" for rules with alternation to change the probabilities,
+for example, in `<foo> ::= 10 <foo> "foo" | "foo";` the recursive option will be
+ten times more likely to be taken.
+"""
+maintainer: "Daniil Baturin <daniil@baturin.org>"
+authors: "Daniil Baturin <daniil@baturin.org>"
+license: "MIT"
+homepage: "https://github.com/dmbaturin/bnfgen"
+bug-reports: "https://github.com/dmbaturin/bnfgen/issues"
+dev-repo: "git+https://github.com/dmbaturin/bnfgen"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name]
+]
+depends: [
+  "ocamlfind" {build}
+  "menhir" {build}
+  "dune" {build & >= "1.4.0"}
+]
+url {
+  src: "https://github.com/dmbaturin/bnfgen/archive/2.0.tar.gz"
+  checksum: [
+    "md5=89ae8d4e9db009b8b54ebcc9df18715d"
+    "sha512=98ee1c9cf2506b6aa3b7ea24c8fb7f3b7166c81be677d06895ba2e76ae34e259315ec99308457e121e82f6ab727325afb4ddd03b297c420e7c41583510e35c48"
+  ]
+}

--- a/packages/bnfgen/bnfgen.2.0/opam
+++ b/packages/bnfgen/bnfgen.2.0/opam
@@ -18,7 +18,6 @@ build: [
   ["dune" "build" "-p" name]
 ]
 depends: [
-  "ocamlfind" {build}
   "menhir" {build}
   "dune" {build & >= "1.4.0"}
 ]


### PR DESCRIPTION
### `bnfgen.2.0`
Random text generator that takes context-free grammars from BNF files
BNFGen generates random texts based on user-defined context-free grammars
specified in a BNF-like syntax.
You can specify "weight" for rules with alternation to change the probabilities,
for example, in `<foo> ::= 10 <foo> "foo" | "foo";` the recursive option will be
ten times more likely to be taken.



---
* Homepage: https://github.com/dmbaturin/bnfgen
* Source repo: git+https://github.com/dmbaturin/bnfgen
* Bug tracker: https://github.com/dmbaturin/bnfgen/issues

---
:camel: Pull-request generated by opam-publish v2.0.0