### PR TITLE
Package ocsigen-toolkit.2.3.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.0/opam
@@ -16,7 +16,7 @@ depends: [
   "calendar"
 ]
 url {
-  src: "https://github.com/jrochel/ocsigen-toolkit/archive/2.3.0.tar.gz"
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.3.0.tar.gz"
   checksum: [
     "md5=2fcdbd05344c0a1d7ee0a1806716a603"
     "sha512=2757a7ecf47b59f685b421ce3126be4a1295dc7e3429e4de73445541f858724933dac0fd2bea182081ee25c66ebb973e8bd1cda7ddf03ce73b0a42633e1e1380"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.7.0"}
+  "calendar"
+]
+url {
+  src: "https://github.com/jrochel/ocsigen-toolkit/archive/2.3.0.tar.gz"
+  checksum: [
+    "md5=2fcdbd05344c0a1d7ee0a1806716a603"
+    "sha512=2757a7ecf47b59f685b421ce3126be4a1295dc7e3429e4de73445541f858724933dac0fd2bea182081ee25c66ebb973e8bd1cda7ddf03ce73b0a42633e1e1380"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.3.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0