### PR TITLE
Package ocsigen-toolkit.2.3.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.0/opam
@@ -16,7 +16,7 @@ depends: [
   "calendar"
 ]
 url {
-  src: "https://github.com/jrochel/ocsigen-toolkit/archive/2.3.1.tar.gz"
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.3.1.tar.gz"
   checksum: [
     "md5=17bcac19ebe8e98479e7704946000035"
     "sha512=aaa259ee0e5e015d340e409090280596ab001bb015a49d7be3d1f06fa400c94428b3cb65bba1c53b8ab06382b830542da314656a3b4d914d457e26ceb8333fef"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.7.0"}
+  "calendar"
+]
+url {
+  src: "https://github.com/jrochel/ocsigen-toolkit/archive/2.3.1.tar.gz"
+  checksum: [
+    "md5=17bcac19ebe8e98479e7704946000035"
+    "sha512=aaa259ee0e5e015d340e409090280596ab001bb015a49d7be3d1f06fa400c94428b3cb65bba1c53b8ab06382b830542da314656a3b4d914d457e26ceb8333fef"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.3.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0