### PR TITLE
Package ocsigen-toolkit.2.3.1

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.7.0"}
+  "calendar"
+]
+url {
+  src: "https://github.com/jrochel/ocsigen-toolkit/archive/2.3.1.tar.gz"
+  checksum: [
+    "md5=81a683e96b76bc86d943894a36f90b61"
+    "sha512=9280c7eb2c96bbef0b8d07bbc4473cf8309042efd9d461ce7dace579680a6e0a8860cfe2a0148250625405896fcbee0400fb92370b58eefef8485cd78aecb9b8"
+  ]
+}

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.1/opam
@@ -9,7 +9,6 @@ dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
 license: "LGPL-2.1 with OCaml linking exception"
 build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
-remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.1/opam
@@ -16,7 +16,7 @@ depends: [
   "calendar"
 ]
 url {
-  src: "https://github.com/jrochel/ocsigen-toolkit/archive/2.3.1.tar.gz"
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.3.1.tar.gz"
   checksum: [
     "md5=81a683e96b76bc86d943894a36f90b61"
     "sha512=9280c7eb2c96bbef0b8d07bbc4473cf8309042efd9d461ce7dace579680a6e0a8860cfe2a0148250625405896fcbee0400fb92370b58eefef8485cd78aecb9b8"


### PR DESCRIPTION
### `ocsigen-toolkit.2.3.1`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0