### PR TITLE
[new release] hacl_x25519 (0.1.0)

### DIFF
--- a/packages/hacl_x25519/hacl_x25519.0.1.0/opam
+++ b/packages/hacl_x25519/hacl_x25519.0.1.0/opam
@@ -15,6 +15,7 @@ build: [
  ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
+  "ocaml"
   "dune" {>= "1.7.0"}
   "cstruct" {>= "3.5.0"}
   "eqaf"

--- a/packages/hacl_x25519/hacl_x25519.0.1.0/opam
+++ b/packages/hacl_x25519/hacl_x25519.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Etienne Millon <me@emillon.org>"
+authors: [
+    "Etienne Millon <me@emillon.org>"
+    "INRIA and Microsoft Corporation"
+]
+license: "MIT"
+homepage: "https://github.com/mirage/hacl"
+bug-reports: "https://github.com/mirage/hacl/issues"
+dev-repo: "git+https://github.com/mirage/hacl.git"
+doc: "https://mirage.github.io/hacl/doc"
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" {>= "1.7.0"}
+  "cstruct" {>= "3.5.0"}
+  "eqaf"
+  "ppx_deriving_yojson" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+  "hex" {with-test}
+  "ppx_blob" {with-test}
+  "benchmark" {with-test}
+]
+synopsis: "Primitives for Elliptic Curve Cryptography taken from Project Everest"
+description: """
+This is an implementation of the X25519 key exchange algorithm, using code from
+Project Everest.
+
+Cryptographic primitives should not be used in end applications, they are better
+used as part of a cryptographic library.
+"""
+url {
+  src:
+    "https://github.com/mirage/hacl/releases/download/v0.1.0/hacl_x25519-v0.1.0.tbz"
+  checksum: [
+    "sha256=62cdc0aadeea63a81094cbc9fd3f63140946cb56cd314c2bd465265e0108cb35"
+    "sha512=5b82f6d918aeae6c560eaba2f438d9c1269f9f2fdd3c28f4ab6ac4186b0a5cd84dfd55ee7d1c7a903ee363cb2308b2c325b7437a5c50454822563e75422dcc17"
+  ]
+}


### PR DESCRIPTION
Primitives for Elliptic Curve Cryptography taken from Project Everest

- Project page: <a href="https://github.com/mirage/hacl">https://github.com/mirage/hacl</a>
- Documentation: <a href="https://mirage.github.io/hacl/doc">https://mirage.github.io/hacl/doc</a>

##### CHANGES:

*2019-06-28*

Initial release.
