### PR TITLE
frama-c: mark incompatible with 4.08

### DIFF
--- a/packages/frama-c/frama-c.19.0/opam
+++ b/packages/frama-c/frama-c.19.0/opam
@@ -80,7 +80,7 @@ install: [
 ]
 
 depends: [
-  "ocaml" { >= "4.02.3" }
+  "ocaml" { >= "4.02.3" & < "4.08.0" }
   "ocamlgraph" { >= "1.8.8" & < "1.9~" }
   "ocamlfind" # needed beyond build stage, used by -load-module
   "zarith"


### PR DESCRIPTION
We just identified an issue with unmarshalling in OCaml 4.08, which prevents Frama-C from working properly in some cases.