### PR TITLE
Deprecate cfgen, since it was renamed to bnfgen

### DIFF
--- a/packages/cfgen/cfgen.1.0/opam
+++ b/packages/cfgen/cfgen.1.0/opam
@@ -2,31 +2,15 @@ opam-version: "2.0"
 maintainer: "Daniil Baturin <daniil@baturin.org>"
 authors: "Daniil Baturin <daniil@baturin.org>"
 homepage: "https://github.com/dmbaturin/cfgen"
-bug-reports: "https://github.com/dmbaturin/cfgen/issues"
+bug-reports: "https://github.com/dmbaturin/bnfgen/issues"
 license: "MIT"
-dev-repo: "git+https://github.com/dmbaturin/cfgen.git"
-build: [
-  ["./configure" "--prefix=%{prefix}%"]
-  [make]
-]
-install: [make "install"]
-remove: ["ocamlfind" "remove" "cfgen"]
-depends: [
-  "ocaml"
-  "ocamlfind" {build}
-  "menhir" {build}
-]
+dev-repo: "git+https://github.com/dmbaturin/bnfgen.git"
+depends: [ "ocaml" "bnfgen"]
 post-messages: [
-  "Warning: cfgen has been renamed to bnfgen and this package is no longer updated.\
-   For updated versions, install bnfgen instead."
+  "cfgen has been renamed to bnfgen and this package is now a transition package.\
+   Use bnfgen instead."
 ]
-synopsis: "This package was renamed and is no longer updated. Use bnfgen package instead."
+synopsis: "This package was renamed to bnfgen."
 description: """
 cfgen has been renamed to bnfgen.
-This package is only kept for compatibility and no longer updated.
-For newer versions, install bnfgen instead."""
-flags: light-uninstall
-url {
-  src: "https://github.com/dmbaturin/cfgen/archive/1.0.zip"
-  checksum: "md5=8036d9283ae8c83a710872a9455f4435"
-}
+This is a transition package, use bnfgen package instead."""

--- a/packages/cfgen/cfgen.1.0/opam
+++ b/packages/cfgen/cfgen.1.0/opam
@@ -16,14 +16,15 @@ depends: [
   "ocamlfind" {build}
   "menhir" {build}
 ]
-synopsis: "Context-free grammar based random text generator"
+post-messages: [
+  "Warning: cfgen has been renamed to bnfgen and this package is no longer updated.\
+   For updated versions, install bnfgen instead."
+]
+synopsis: "This package was renamed and is no longer updated. Use bnfgen package instead."
 description: """
-cfgen generated random text based on context-free grammars
-defined in BNF-like syntax. It's primarily meant for parser
-fuzzing. If a rule has multiple alternative, they are selected
-randomly. To influence the choice, you can specify weight for
-each alternative, as in
-<start> ::= 10 "aaa" <start> | 5 "bbb" <start> | "ccc";"""
+cfgen has been renamed to bnfgen.
+This package is only kept for compatibility and no longer updated.
+For newer versions, install bnfgen instead."""
 flags: light-uninstall
 url {
   src: "https://github.com/dmbaturin/cfgen/archive/1.0.zip"


### PR DESCRIPTION
Related to #14390 
I've added prominent deprecation warnings to the description and post-messaged

Since github now leaves proper redirects after renaming repos, and the 1.0 tag is still there, cfgen still seems to install fine.