### PR TITLE
Package uritemplate.0.2.0

### DIFF
--- a/packages/uritemplate/uritemplate.0.2.0/opam
+++ b/packages/uritemplate/uritemplate.0.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "OCaml implementation of URI templates (RFC6570)"
+tags: "uri url templates RFC6570"
+maintainer: "Corin Chaplin <git@corinchaplin.co.uk>"
+authors: "Corin Chaplin <git@corinchaplin.co.uk>"
+license: "MIT"
+homepage: "https://github.com/CorinChappy/uritemplate-ocaml"
+bug-reports: "https://github.com/CorinChappy/uritemplate-ocaml/issues"
+doc: "https://corinchappy.github.io/uritemplate-ocaml/"
+depends: [
+  "dune" {build}
+  "stdcompat" {>= "5"}
+  "ounit" {with-test}
+  "atdgen" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version >= "4.03.0"}
+]
+dev-repo: "git+https://https://github.com/CorinChappy/uritemplate-ocaml.git"
+url {
+  src:
+    "https://github.com/CorinChappy/uritemplate-ocaml/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=b3eec15514757084d33264808dbee138"
+    "sha512=b958b0d78b4723d210863c2d0b0abdbdcf227cdbabea4fc01de9b839db8063c2856982c736aaed5a2e32df7ad0c70e3f80ce791862eba77fa1a0bc7ffe017f29"
+  ]
+}

--- a/packages/uritemplate/uritemplate.0.2.0/opam
+++ b/packages/uritemplate/uritemplate.0.2.0/opam
@@ -8,6 +8,7 @@ homepage: "https://github.com/CorinChappy/uritemplate-ocaml"
 bug-reports: "https://github.com/CorinChappy/uritemplate-ocaml/issues"
 doc: "https://corinchappy.github.io/uritemplate-ocaml/"
 depends: [
+  "ocaml"
   "dune" {build}
   "stdcompat" {>= "5"}
   "ounit" {with-test}


### PR DESCRIPTION
### `uritemplate.0.2.0`
OCaml implementation of URI templates (RFC6570)



---
* Homepage: https://github.com/CorinChappy/uritemplate-ocaml
* Source repo: git+https://https://github.com/CorinChappy/uritemplate-ocaml.git
* Bug tracker: https://github.com/CorinChappy/uritemplate-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0