### PR TITLE
+ elasticsearch-cli 1.1

### DIFF
--- a/packages/elasticsearch-cli/elasticsearch-cli.1.1/opam
+++ b/packages/elasticsearch-cli/elasticsearch-cli.1.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Raman Varabets <roman.vorobets@gmail.com>"
+authors: ["Raman Varabets <roman.vorobets@gmail.com>"]
+homepage: "https://github.com/cyborgize/es-cli"
+dev-repo: "git+https://github.com/cyborgize/es-cli.git"
+bug-reports: "https://github.com/cyborgize/es-cli/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "dune" {build & >= "1.5"}
+  "mybuild" {build}
+  "atdgen" {>= "1.6.0"}
+  "cmdliner"
+  "devkit" {>= "1.0"}
+  "extlib" {>= "1.7.1"}
+  "lwt" {>= "3.2.0"}
+  "lwt_ppx"
+  "re2" {>= "v0.9.0" & < "v0.13"}
+]
+synopsis: "Command-line client for Elasticsearch"
+url {
+  src: "https://github.com/cyborgize/es-cli/archive/1.1.tar.gz"
+  checksum: "md5=556372f8ce7b92800d111adf5640fdf9"
+}


### PR DESCRIPTION
- `delete` tool
- `get` and `put`: accept either index and doc_id, or index/[doc_type/]doc_id
- `get` and `delete`: accept multiple ids
- `get` and `put`: fix bugs.