### PR TITLE
[new release] domain-name (0.2.1)

### DIFF
--- a/packages/domain-name/domain-name.0.2.1/opam
+++ b/packages/domain-name/domain-name.0.2.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/hannesm/domain-name"
+doc: "https://hannesm.github.io/domain-name/doc"
+bug-reports: "https://github.com/hannesm/domain-name/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build}
+  "fmt"
+  "astring"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/domain-name.git"
+synopsis: "RFC 1035 Internet domain names"
+description: """
+A domain name is a sequence of labels separated by dots, such as `foo.example`.
+Each label may contain any bytes. The length of each label may not exceed 63
+charactes.  The total length of a domain name is limited to 253 (byte
+representation is 255), but other protocols (such as SMTP) may apply even
+smaller limits.  A domain name label is case preserving, comparison is done in a
+case insensitive manner.
+"""
+url {
+  src:
+    "https://github.com/hannesm/domain-name/releases/download/v0.2.1/domain-name-v0.2.1.tbz"
+  checksum: [
+    "sha256=b86ec83dc94a1257f7a7d151adbd0d49fbeaebedb6f650efda4bb0f72af7a1d6"
+    "sha512=f251d04780bf622cf7be305063c55cfa25340938be2080c2989444465ef5c77be9fee9d0db343c17ca970bf90faa2c76b7c400db92ac8c4d2b680da46488c349"
+  ]
+}


### PR DESCRIPTION
RFC 1035 Internet domain names

- Project page: <a href="https://github.com/hannesm/domain-name">https://github.com/hannesm/domain-name</a>
- Documentation: <a href="https://hannesm.github.io/domain-name/doc">https://hannesm.github.io/domain-name/doc</a>

##### CHANGES:

* getter functions for labels:
  get_label : 'a t -> int -> (string, [> `Msg of string ]) result
  get_label_exn : 'a t -> int -> string
* count_labels : 'a t -> int
