### PR TITLE
[new release] icalendar (0.1.2)

### DIFF
--- a/packages/icalendar/icalendar.0.1.2/opam
+++ b/packages/icalendar/icalendar.0.1.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/roburio/icalendar"
+bug-reports: "https://github.com/roburio/icalendar/issues"
+dev-repo: "git+https://github.com/roburio/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://roburio.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom"
+  "re"
+  "uri"
+  "astring"
+  "rresult"
+  "ptime"
+  "ppx_deriving"
+  "gmap" {>= "0.3.0"}
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+url {
+  src:
+    "https://github.com/roburio/icalendar/releases/download/v0.1.2/icalendar-v0.1.2.tbz"
+  checksum: [
+    "sha256=5bb41c000a239d4e7c21d18992dd264e8879185f371bdfde55e307856bc08a7f"
+    "sha512=2ccc3b2dbc5d33c555c5c01fd72d0fb431388a3cb569a0e7d4ded15d1d71471204d1cebca50675f6cbd8487b88d34003f238fa7d9cfb996f95b8f8f68149339f"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Escape special characters in text values when generating ics string representation
* Iana_param/X_param constructors take a string (pair of strings) as parameter
  (Iana_param of string -> param_value list icalparameter), instead of as value
  (Iana_param of string * param_value list icalparameter).
  (Iana_param "X-FOO", "MY VALUE") and
  (Iana_param "X-BAR", "MY OTHER VALUE") are now distinct in a Param_map