### PR TITLE
[New package] ppx_show 0.1.0

### DIFF
--- a/packages/ppx_show/ppx_show.0.1.0/opam
+++ b/packages/ppx_show/ppx_show.0.1.0/opam
@@ -10,7 +10,7 @@ authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
 bug-reports: "https://gitlab.inria.fr/tmartine/ppx_show"
 homepage: "https://gitlab.inria.fr/tmartine/ppx_show"
 doc: "https://gitlab.inria.fr/tmartine/ppx_show"
-license: "MIT"
+license: "BSD"
 dev-repo: "git+https://gitlab.inria.fr/tmartine/ppx_show"
 synopsis: "OCaml PPX deriver for deriving show based on ppxlib"
 depends: [
@@ -19,5 +19,5 @@ depends: [
 ]
 url {
   src: "https://gitlab.inria.fr/tmartine/ppx_show/-/archive/0.1.0/ppx_show-0.1.0.tar.gz"
-  checksum: "sha512=aa279534b51558c86a7f7e90ab2a5285c7b885e6388910fe6c40d4f095f0d38128dc4497adf703bc462c2904faf773fd3d05827f7485b995f6466489d730e276"
+  checksum: "sha512=5c69974e05a97ffe59b4edc0ac2a94a62e27d7bdc8fd74a53be18848f8648442a67fcf61ebf45500b78133d19c687f6d6b48db9e9589d67915cf9d9d94380068"
 }

--- a/packages/ppx_show/ppx_show.0.1.0/opam
+++ b/packages/ppx_show/ppx_show.0.1.0/opam
@@ -14,5 +14,5 @@ depends: ["ppxlib"]
 synopsis: "OCaml PPX deriver for deriving show based on ppxlib"
 url {
   src: "https://gitlab.inria.fr/tmartine/ppx_show/-/archive/0.1.0/ppx_show-0.1.0.tar.gz"
-  checksum: "sha512=2c0c161bc16b8717782739b9fa30a7d5192a0179fcd86a948cbcb923de328416a2202d577612ecdea4a33bea0d9a4d61d42a2e9b302dcf6882685ceac3e062c0"
+  checksum: "sha512=ea11458672dbdfa809042b511c844300b3eb22266f2e50b72395fddf0e6b677a1cc9267934ce8d9aaa7604ad2335532ebe61a6043b6f15e581d6b5b4557fb8ed"
 }

--- a/packages/ppx_show/ppx_show.0.1.0/opam
+++ b/packages/ppx_show/ppx_show.0.1.0/opam
@@ -12,6 +12,10 @@ license: "MIT"
 dev-repo: "https://gitlab.inria.fr/tmartine/ppx_show"
 depends: ["ppxlib"]
 synopsis: "OCaml PPX deriver for deriving show based on ppxlib"
+depends: [
+  "ppxlib" {>= "0.8.0"}
+  "stdcompat" {>= "9"}
+]
 url {
   src: "https://gitlab.inria.fr/tmartine/ppx_show/-/archive/0.1.0/ppx_show-0.1.0.tar.gz"
   checksum: "sha512=ea11458672dbdfa809042b511c844300b3eb22266f2e50b72395fddf0e6b677a1cc9267934ce8d9aaa7604ad2335532ebe61a6043b6f15e581d6b5b4557fb8ed"

--- a/packages/ppx_show/ppx_show.0.1.0/opam
+++ b/packages/ppx_show/ppx_show.0.1.0/opam
@@ -7,9 +7,11 @@ build: [
 ]
 maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
 authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+bug-reports: "https://gitlab.inria.fr/tmartine/ppx_show"
+homepage: "https://gitlab.inria.fr/tmartine/ppx_show"
 doc: "https://gitlab.inria.fr/tmartine/ppx_show"
 license: "MIT"
-dev-repo: "https://gitlab.inria.fr/tmartine/ppx_show"
+dev-repo: "git+https://gitlab.inria.fr/tmartine/ppx_show"
 synopsis: "OCaml PPX deriver for deriving show based on ppxlib"
 depends: [
   "ppxlib" {>= "0.8.0"}
@@ -17,5 +19,5 @@ depends: [
 ]
 url {
   src: "https://gitlab.inria.fr/tmartine/ppx_show/-/archive/0.1.0/ppx_show-0.1.0.tar.gz"
-  checksum: "sha512=ea11458672dbdfa809042b511c844300b3eb22266f2e50b72395fddf0e6b677a1cc9267934ce8d9aaa7604ad2335532ebe61a6043b6f15e581d6b5b4557fb8ed"
+  checksum: "sha512=aa279534b51558c86a7f7e90ab2a5285c7b885e6388910fe6c40d4f095f0d38128dc4497adf703bc462c2904faf773fd3d05827f7485b995f6466489d730e276"
 }

--- a/packages/ppx_show/ppx_show.0.1.0/opam
+++ b/packages/ppx_show/ppx_show.0.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+doc: "https://gitlab.inria.fr/tmartine/ppx_show"
+license: "MIT"
+dev-repo: "https://gitlab.inria.fr/tmartine/ppx_show"
+depends: ["ppxlib"]
+synopsis: "OCaml PPX deriver for deriving show based on ppxlib"
+url {
+  src: "https://gitlab.inria.fr/tmartine/ppx_show/-/archive/0.1.0/ppx_show-0.1.0.tar.gz"
+  checksum: "sha512=2c0c161bc16b8717782739b9fa30a7d5192a0179fcd86a948cbcb923de328416a2202d577612ecdea4a33bea0d9a4d61d42a2e9b302dcf6882685ceac3e062c0"
+}

--- a/packages/ppx_show/ppx_show.0.1.0/opam
+++ b/packages/ppx_show/ppx_show.0.1.0/opam
@@ -10,7 +10,6 @@ authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
 doc: "https://gitlab.inria.fr/tmartine/ppx_show"
 license: "MIT"
 dev-repo: "https://gitlab.inria.fr/tmartine/ppx_show"
-depends: ["ppxlib"]
 synopsis: "OCaml PPX deriver for deriving show based on ppxlib"
 depends: [
   "ppxlib" {>= "0.8.0"}


### PR DESCRIPTION
OCaml PPX deriver for deriving `show` based on `ppxlib`.

This library reimplements the `show` plugin from [`ppx_deriving`] as a
`ppxlib` deriver.
In particular, this deriver works with OCaml 4.08.0.

[`ppx_deriving`]: https://github.com/ocaml-ppx/ppx_deriving