### PR TITLE
Enable musl variant under Linux.

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
@@ -15,7 +15,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
   [
     "./configure"
     "-prefix"

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
@@ -19,7 +19,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
   [
     "./configure"
     "--prefix=%{prefix}%"
@@ -29,7 +29,7 @@ build: [
     "LIBS=-static"
     "--disable-graph-lib"
     "--disable-shared"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
   [make "world"]
   [make "world.opt"]
 ]


### PR DESCRIPTION
The `musl+static+flambda` variants for 4.07.1 and 4.08.0 were disabled when running under linux.  Even when the OPAM description explicitly mentions [Arch Linux][a] and [Debian][d].

This changes the os filters to use the [musl][m] static build configuration options.

[a]: https://www.archlinux.org/
[d]: https://www.debian.org/
[m]: http://www.musl-libc.org/