### PR TITLE
Package flac.0.1.5

### DIFF
--- a/packages/flac/flac.0.1.5/opam
+++ b/packages/flac/flac.0.1.5/opam
@@ -3,6 +3,7 @@ maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-flac"
 build: [
+  ["./bootstrap"] {dev}
   ["./configure" "--prefix" prefix] {os != "macos"}
   [
     "./configure"
@@ -17,6 +18,7 @@ build: [
 install: [
   [make "install"]
 ]
+remove: ["ocamlfind" "remove" "flac"]
 depends: [
   "ocaml" {>= "4.03"}
   "ocamlfind" {build}
@@ -35,10 +37,13 @@ depexts: [
 ]
 bug-reports: "https://github.com/savonet/ocaml-flac/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-flac.git"
-synopsis:
-  "Interface for the Free Lossless Audio Codec otherwise known as FLAC"
+synopsis: "Interface for the Free Lossless Audio Codec otherwise known as FLAC"
+flags: light-uninstall
 url {
   src:
     "https://github.com/savonet/ocaml-flac/releases/download/0.1.5/ocaml-flac-0.1.5.tar.gz"
-  checksum: "md5=7f4ee8cbb681ae94d80890d37553c197"
+  checksum: [
+    "md5=7f4ee8cbb681ae94d80890d37553c197"
+    "sha512=8cdadec3986460d5e5dc6a5af690b4b2e2c8414469ab1e84350a8ef77069fa0883ac138138dd9e0e48abe7356c5c623048510e0854e85f2cce70ef8cbe7ce9fb"
+  ]
 }


### PR DESCRIPTION
### `flac.0.1.5`
Interface for the Free Lossless Audio Codec otherwise known as FLAC



---
* Homepage: https://github.com/savonet/ocaml-flac
* Source repo: git+https://github.com/savonet/ocaml-flac.git
* Bug tracker: https://github.com/savonet/ocaml-flac/issues

---
:camel: Pull-request generated by opam-publish v2.0.0