### PR TITLE
Package fdkaac.0.3.0

### DIFF
--- a/packages/fdkaac/fdkaac.0.3.0/opam
+++ b/packages/fdkaac/fdkaac.0.3.0/opam
@@ -6,20 +6,19 @@ bug-reports: "https://github.com/savonet/ocaml-fdkaac/issues"
 license: "GPL-2.0"
 dev-repo: "git+https://github.com/savonet/ocaml-fdkaac.git"
 build: [
-  ["./bootstrap"] {dev}
+  ["./bootstrap"] {pinned}
   ["./configure" "--prefix=%{prefix}%"] {os != "macos"}
   ["./configure" "OCAMLFLAGS=-cclib -L/usr/local/lib" "--prefix=%{prefix}%"]
     {os = "macos"}
   [make]
 ]
 install: [make "install"]
-remove: ["ocamlfind" "remove" "fdkaac"]
 depends: [
   "ocaml"
   "ocamlfind" {build}
 ]
 conflicts: [
-  "liquidsoap" {< "1.4.0}
+  "liquidsoap" {< "1.4.0"}
 ]
 depexts: [
   ["fdk-aac-dev"] {os-distribution = "alpine"}
@@ -36,7 +35,6 @@ description: """
 The FDK AAC Codec Library For Android contains an encoder implementation of the
 Advanced Audio Coding (AAC) audio codec.
 """
-flags: light-uninstall
 url {
   src:
     "https://github.com/savonet/ocaml-fdkaac/releases/download/0.3.0/ocaml-fdkaac-0.3.0.tar.gz"

--- a/packages/fdkaac/fdkaac.0.3.0/opam
+++ b/packages/fdkaac/fdkaac.0.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-fdkaac"
+bug-reports: "https://github.com/savonet/ocaml-fdkaac/issues"
+license: "GPL-2.0"
+dev-repo: "git+https://github.com/savonet/ocaml-fdkaac.git"
+build: [
+  ["./bootstrap"] {dev}
+  ["./configure" "--prefix=%{prefix}%"] {os != "macos"}
+  ["./configure" "OCAMLFLAGS=-cclib -L/usr/local/lib" "--prefix=%{prefix}%"]
+    {os = "macos"}
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "fdkaac"]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+]
+depexts: [
+  ["fdk-aac-dev"] {os-distribution = "alpine"}
+  ["libfdk-aac"] {os-distribution = "arch"}
+  ["fdk-aac-devel"] {os-distribution = "centos"}
+  ["fdk-aac-devel"] {os-distribution = "fedora"}
+  ["fdk-aac-devel"] {os-family = "suse"}
+  ["libfdk-aac-dev"] {os-distribution = "debian"}
+  ["libfdk-aac-dev"] {os-distribution = "ubuntu"}
+  ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Fraunhofer FDK AAC Codec Library"
+description: """
+The FDK AAC Codec Library For Android contains an encoder implementation of the
+Advanced Audio Coding (AAC) audio codec."""
+flags: light-uninstall
+url {
+  src:
+    "https://github.com/savonet/ocaml-fdkaac/releases/download/0.3.0/ocaml-fdkaac-0.3.0.tar.gz"
+  checksum: [
+    "md5=86b157a74cf53bb60083719d2f712636"
+    "sha512=5262d4f873741404d808c579b030f2a90da3a5e3241e71a9575a90c55d584fd55cce10a8cff115913c3e44f1576bb69c5c1b020ab96f22ee214b6b1552a0f624"
+  ]
+}

--- a/packages/fdkaac/fdkaac.0.3.0/opam
+++ b/packages/fdkaac/fdkaac.0.3.0/opam
@@ -18,6 +18,9 @@ depends: [
   "ocaml"
   "ocamlfind" {build}
 ]
+conflicts: [
+  "liquidsoap" {< "1.4.0}
+]
 depexts: [
   ["fdk-aac-dev"] {os-distribution = "alpine"}
   ["libfdk-aac"] {os-distribution = "arch"}

--- a/packages/fdkaac/fdkaac.0.3.0/opam
+++ b/packages/fdkaac/fdkaac.0.3.0/opam
@@ -34,7 +34,8 @@ depexts: [
 synopsis: "Fraunhofer FDK AAC Codec Library"
 description: """
 The FDK AAC Codec Library For Android contains an encoder implementation of the
-Advanced Audio Coding (AAC) audio codec."""
+Advanced Audio Coding (AAC) audio codec.
+"""
 flags: light-uninstall
 url {
   src:


### PR DESCRIPTION
### `fdkaac.0.3.0`
Fraunhofer FDK AAC Codec Library
The FDK AAC Codec Library For Android contains an encoder implementation of the
Advanced Audio Coding (AAC) audio codec.



---
* Homepage: https://github.com/savonet/ocaml-fdkaac
* Source repo: git+https://github.com/savonet/ocaml-fdkaac.git
* Bug tracker: https://github.com/savonet/ocaml-fdkaac/issues

---
:camel: Pull-request generated by opam-publish v2.0.0