### PR TITLE
Update package override.0.2.0

### DIFF
--- a/packages/override/override.0.2.0/opam
+++ b/packages/override/override.0.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+bug-reports: "https://gitlab.inria.fr/tmartine/override"
+homepage: "https://gitlab.inria.fr/tmartine/override"
+doc: "https://gitlab.inria.fr/tmartine/override"
+license: "BSD"
+dev-repo: "git+https://gitlab.inria.fr/tmartine/override"
+synopsis: "PPX extension for overriding modules"
+description: """
+PPX extensions [%%override], [%%import], [%%include] and [%%rewrite] to import
+and change module interfaces.
+"""
+depends: [
+  "dune" {>= "1.10.0"}
+  "ppxlib" {>= "0.6.0"}
+  "stdcompat" {>= "9"}
+  "ppx_show" {>= "0.1.0"}
+  "ppx_compare" {>= "v0.12.0"}
+  "cppo" {>= "1.6.4"}
+]
+url {
+  src: "https://gitlab.inria.fr/tmartine/override/-/archive/0.2.0/override-0.2.0.tar.gz"
+  checksum: "sha512=cb76a85b5c144e9afd0187e7a1ed0afbe12c5365a1b72ef1476cc007129f19851b2a9d6e07185a798d99a1c9cd12aa7ec3d279f664cf9cebec5641e7986070dc"
+}


### PR DESCRIPTION
- compatibility with OCaml 4.08.0

- remove dependency to ppx_tools

- add examples/typedtree_collect_texp_apply

- bootstrapped equivalence checking for Parsetree.core_type: matching
  between types for applying rewriting rules is now complete, and is
  implemented by overriding Parsetree and deriving eq. The former
  incomplete equivalence checking is used to bootstrap.

- support aliases even if the target module is defined in the same
  module (we do not take declaration order into account yet, so there
  can be wrong shadowings, and even loops, even if we suppress the
  trivial ones).

- renamed types are substituded globally in mutually recursive type
  definitions.