### PR TITLE
Package ssl.0.5.8

### DIFF
--- a/packages/ssl/ssl.0.5.8/opam
+++ b/packages/ssl/ssl.0.5.8/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+homepage: "https://github.com/savonet/ocaml-ssl"
+dev-repo: "git+https://github.com/savonet/ocaml-ssl.git"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.2.1"}
+  "base-unix"
+  "conf-openssl"
+]
+synopsis: "Bindings for OpenSSL"
+authors: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+url {
+  src: "https://github.com/savonet/ocaml-ssl/archive/0.5.8.tar.gz"
+  checksum: [
+    "md5=4b2cd1e21f25989b958e880f7b4791d1"
+    "sha512=b9bdb1f9c7df9b49c9cda47909e5a9c0d05dbfed54df0d2dd378fda860c0d5e2f7cd4b675a505b8b325b796567ec7a88dcf7be2154cb407ce026ee4ecb9bc592"
+  ]
+}


### PR DESCRIPTION
### `ssl.0.5.8`
Bindings for OpenSSL



---
* Homepage: https://github.com/savonet/ocaml-ssl
* Source repo: git+https://github.com/savonet/ocaml-ssl.git
* Bug tracker: https://github.com/savonet/ocaml-ssl/issues

---
:camel: Pull-request generated by opam-publish v2.0.0