### PR TITLE
[bug-fix release] override 0.2.1

### DIFF
--- a/packages/override/override.0.2.1/opam
+++ b/packages/override/override.0.2.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+bug-reports: "https://gitlab.inria.fr/tmartine/override"
+homepage: "https://gitlab.inria.fr/tmartine/override"
+doc: "https://gitlab.inria.fr/tmartine/override"
+license: "BSD"
+dev-repo: "git+https://gitlab.inria.fr/tmartine/override"
+synopsis: "PPX extension for overriding modules"
+description: """
+PPX extensions [%%override], [%%import], [%%include] and [%%rewrite] to import
+and change module interfaces.
+"""
+depends: [
+  "dune" {>= "1.10.0"}
+  "ppxlib" {>= "0.6.0"}
+  "stdcompat" {>= "9"}
+  "ppx_show" {>= "0.1.0"}
+  "ppx_compare" {>= "v0.12.0"}
+  "cppo" {>= "1.6.4"}
+]
+url {
+  src: "https://gitlab.inria.fr/tmartine/override/-/archive/0.2.1/override-0.2.1.tar.gz"
+  checksum: "sha512=572a489776ac241a6126ed9680ba94279628d5fa8da9c8dd24e7cd1722ff6c19e45cc7d045b96bc9acb702caf549da8f4486b0b14b277352cd0d6d13c5066e7d"
+}

--- a/packages/override/override.0.2.1/opam
+++ b/packages/override/override.0.2.1/opam
@@ -27,5 +27,5 @@ depends: [
 ]
 url {
   src: "https://gitlab.inria.fr/tmartine/override/-/archive/0.2.1/override-0.2.1.tar.gz"
-  checksum: "sha512=572a489776ac241a6126ed9680ba94279628d5fa8da9c8dd24e7cd1722ff6c19e45cc7d045b96bc9acb702caf549da8f4486b0b14b277352cd0d6d13c5066e7d"
+  checksum: "sha512=e58f747981eaeed94c920af81f210835f9ad6d5ca70f540040662af096436d703ffdf1532d51242beaecc3ea54a2de7193b4d274e06d70d3b2d2f48c474f727b"
 }


### PR DESCRIPTION
Changes with respect to 0.2.0:
- attributes applied on `[%%types]` are applied once by declaration
  group. (Previously, attributes were applied to each types in a group,
  leading ppxlib's deriving to make n * n expansions for a group of
  n types -- one for each type/attribute pair).