### PR TITLE
Package ocaml-cry.0.6.3

### DIFF
--- a/packages/ocaml-cry/ocaml-cry.0.6.3/opam
+++ b/packages/ocaml-cry/ocaml-cry.0.6.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-cry"
+bug-reports: "https://github.com/savonet/ocaml-cry/issues"
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+]
+depopts: [
+  "ssl"
+  "osx-secure-transport"
+]
+build: [
+  ["./bootstrap"] {pinned}
+  ["./configure" "--prefix" prefix]
+  [make "clean"] {pinned}
+  [make]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/savonet/ocaml-cry.git"
+synopsis:
+  "The cry library is an implementation of the shout protocol to connect to audio diffusion servers such as icecast"
+url {
+  src:
+    "https://github.com/savonet/ocaml-cry/releases/download/0.6.3/ocaml-cry-0.6.2.tar.gz"
+  checksum: [
+    "md5=dff2e4dc29d1f3e0b96b51cf31ea8e21"
+    "sha512=77fce115149a0a5d90763fe2c1ef6c7700fb8a21ce682cd27841c470da79c6e73e1543758d5de95dbc050ecd7ce61274267261c5e2aa604e5af47c72019ed66b"
+  ]
+}


### PR DESCRIPTION
### `ocaml-cry.0.6.3`
The cry library is an implementation of the shout protocol to connect to audio diffusion servers such as icecast



---
* Homepage: https://github.com/savonet/ocaml-cry
* Source repo: git+https://github.com/savonet/ocaml-cry.git
* Bug tracker: https://github.com/savonet/ocaml-cry/issues

---
:camel: Pull-request generated by opam-publish v2.0.0