### PR TITLE
obus: update to new github repository and add new release

### DIFF
--- a/packages/mpris/mpris.0.1.1/opam
+++ b/packages/mpris/mpris.0.1.1/opam
@@ -12,6 +12,7 @@ depends: [
   "oasis" {build}
   "ocamlbuild" {build}
   "ocamlfind" {build}
+  "lwt_camlp4"
   "obus"
 ]
 dev-repo: "git://github.com/johnelse/ocaml-mpris"

--- a/packages/mpris/mpris.0.1.1/opam
+++ b/packages/mpris/mpris.0.1.1/opam
@@ -12,7 +12,7 @@ depends: [
   "oasis" {build}
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "lwt_camlp4"
+  "lwt" {< "4.0.0"}
   "obus"
 ]
 dev-repo: "git://github.com/johnelse/ocaml-mpris"

--- a/packages/obus/obus.1.1.6/opam
+++ b/packages/obus/obus.1.1.6/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-maintainer: "jeremie@dimino.org"
+maintainer: "freyrnjordrson@gmail.com"
 authors: ["Jérémie Dimino"]
-homepage: "https://github.com/diml/obus"
-bug-reports: "https://github.com/diml/obus/issues"
+homepage: "https://github.com/ocaml-community/obus"
+bug-reports: "https://github.com/ocaml-community/obus/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -17,11 +17,11 @@ depends: [
   "xmlm"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/diml/obus"
+dev-repo: "git://github.com/ocaml-community/obus"
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "A pure OCaml implementation of DBus"
 flags: light-uninstall
 url {
-  src: "https://github.com/diml/obus/archive/1.1.6.tar.gz"
+  src: "https://github.com/ocaml-community/obus/archive/1.1.6.tar.gz"
   checksum: "md5=935f941a34145230dfb9e59d715cc1fd"
 }

--- a/packages/obus/obus.1.1.7/opam
+++ b/packages/obus/obus.1.1.7/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-maintainer: "jeremie@dimino.org"
+maintainer: "freyrnjordrson@gmail.com"
 authors: ["Jérémie Dimino"]
-homepage: "https://github.com/diml/obus"
-bug-reports: "https://github.com/diml/obus/issues"
+homepage: "https://github.com/ocaml-community/obus"
+bug-reports: "https://github.com/ocaml-community/obus/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -17,11 +17,11 @@ depends: [
   "xmlm"
   "ocamlbuild" {build}
 ]
-dev-repo: "git://github.com/diml/obus"
+dev-repo: "git://github.com/ocaml-community/obus"
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "A pure OCaml implementation of DBus"
 flags: light-uninstall
 url {
-  src: "https://github.com/diml/obus/archive/1.1.7.tar.gz"
+  src: "https://github.com/ocaml-community/obus/archive/1.1.7.tar.gz"
   checksum: "md5=3a82fde56e3c98084847cf40b4aae7d0"
 }

--- a/packages/obus/obus.1.1.8/opam
+++ b/packages/obus/obus.1.1.8/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-maintainer: "jeremie@dimino.org"
+maintainer: "freyrnjordrson@gmail.com"
 authors: ["Jérémie Dimino"]
-homepage: "https://github.com/diml/obus"
-bug-reports: "https://github.com/diml/obus/issues"
+homepage: "https://github.com/ocaml-community/obus"
+bug-reports: "https://github.com/ocaml-community/obus/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
@@ -21,11 +21,11 @@ depends: [
   "ocamlbuild" {build}
   "oasis" {build}
 ]
-dev-repo: "git://github.com/diml/obus"
+dev-repo: "git://github.com/ocaml-community/obus"
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "A pure OCaml implementation of DBus"
 flags: light-uninstall
 url {
-  src: "https://github.com/diml/obus/archive/1.1.8.tar.gz"
+  src: "https://github.com/ocaml-community/obus/archive/1.1.8.tar.gz"
   checksum: "md5=976947861f1dfa3d3da68378f25377c1"
 }

--- a/packages/obus/obus.1.2.0/opam
+++ b/packages/obus/obus.1.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+
+name: "obus"
+synopsis: "Pure Ocaml implementation of the D-Bus protocol"
+maintainer: "freyrnjordrson@gmail.com"
+authors: [ "Jérémie Dimino" ]
+homepage: "https://github.com/ocaml-community/obus"
+bug-reports: "https://github.com/ocaml-community/obus/issues"
+dev-repo: "git+https://github.com/ocaml-community/obus.git"
+license: "BSD3"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {build}
+  "menhir" {build}
+  "xmlm"
+  "lwt" {>= "2.7.0"}
+  "lwt_ppx"
+  "lwt_log"
+  "lwt_react"
+  "ocaml-migrate-parsetree"
+  "ppxlib"
+]
+
+url {
+  src: "https://github.com/ocaml-community/obus/archive/1.2.0.tar.gz"
+  checksum: "md5=0896d5078bfd486a65cf9fa73a984b3f"
+}

--- a/packages/obus/obus.1.2.0/opam
+++ b/packages/obus/obus.1.2.0/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 
-name: "obus"
 synopsis: "Pure Ocaml implementation of the D-Bus protocol"
 maintainer: "freyrnjordrson@gmail.com"
 authors: [ "Jérémie Dimino" ]


### PR DESCRIPTION
* a new release of `obus` library (OCaml native D-Bus interface).
* `obus` moved to `ocaml-community` repo
* mpris.0.1.1: add missing lwt_camlp4 dependency