### PR TITLE
[new release] terminal_size (0.1.4)

### DIFF
--- a/packages/terminal_size/terminal_size.0.1.4/opam
+++ b/packages/terminal_size/terminal_size.0.1.4/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/terminal_size"
+bug-reports: "https://github.com/cryptosense/terminal_size/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/terminal_size.git"
+doc: "https://cryptosense.github.io/terminal_size/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "alcotest" {with-test}
+  "dune" {build & >= "1.10.0"}
+  "ocaml" {>= "4.02.0"}
+]
+synopsis: "Get the dimensions of the terminal"
+description: """
+You can use this small library to detect the dimensions of the terminal window
+attached to a process.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/terminal_size/releases/download/v0.1.4/terminal_size-v0.1.4.tbz"
+  checksum: [
+    "sha256=fdca1fee7d872c4a8e5ab003d9915b6782b272e2a3661ca877f2d78dd25371a7"
+    "sha512=595e123d5496c2a7de306bf89d0c5ce0d99ea233da87c94c18fb8c366375029c6bbbbaae93e42cc50fd90a35a2501eb2c6a0ddbbc508836d0a0b11bcebe76881"
+  ]
+}


### PR DESCRIPTION
Get the dimensions of the terminal

- Project page: <a href="https://github.com/cryptosense/terminal_size">https://github.com/cryptosense/terminal_size</a>
- Documentation: <a href="https://cryptosense.github.io/terminal_size/doc">https://cryptosense.github.io/terminal_size/doc</a>

##### CHANGES:

*2019-05-24*

Build system:

- Upgrade to opam 2
- Build with dune
