### PR TITLE
Use os-family = "debian"

### DIFF
--- a/packages/0install/0install.2.10/opam
+++ b/packages/0install/0install.2.10/opam
@@ -22,8 +22,7 @@ depends: [
 ]
 depopts: [ "obus" "lablgtk" ]
 depexts: [
-  ["unzip"] {os-distribution = "ubuntu"}
-  ["unzip"] {os-distribution = "debian"}
+  ["unzip"] {os-family = "debian"}
 ]
 synopsis: "The antidote to app-stores"
 description: """

--- a/packages/0install/0install.2.11/opam
+++ b/packages/0install/0install.2.11/opam
@@ -22,8 +22,7 @@ depends: [
 ]
 depopts: [ "obus" "lablgtk" ]
 depexts: [
-  ["unzip"] {os-distribution = "ubuntu"}
-  ["unzip"] {os-distribution = "debian"}
+  ["unzip"] {os-family = "debian"}
   ["gnupg"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "The antidote to app-stores"

--- a/packages/0install/0install.2.12.1/opam
+++ b/packages/0install/0install.2.12.1/opam
@@ -23,8 +23,7 @@ depends: [
 ]
 depopts: [ "obus" "lablgtk" "lwt_glib" ]
 depexts: [
-  ["unzip"] {os-distribution = "ubuntu"}
-  ["unzip"] {os-distribution = "debian"}
+  ["unzip"] {os-family = "debian"}
   ["gnupg2"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "The antidote to app-stores"

--- a/packages/0install/0install.2.12.3/opam
+++ b/packages/0install/0install.2.12.3/opam
@@ -22,8 +22,7 @@ depends: [
 depopts: [ "obus" "lablgtk" "lwt_glib" ]
 conflicts: [ "lwt" {>= "4.0.0"} ]
 depexts: [
-  ["unzip"] {os-distribution = "ubuntu"}
-  ["unzip"] {os-distribution = "debian"}
+  ["unzip"] {os-family = "debian"}
   ["gnupg"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "The antidote to app-stores"

--- a/packages/0install/0install.2.12/opam
+++ b/packages/0install/0install.2.12/opam
@@ -22,8 +22,7 @@ depends: [
 ]
 depopts: [ "obus" "lablgtk" ]
 depexts: [
-  ["unzip"] {os-distribution = "ubuntu"}
-  ["unzip"] {os-distribution = "debian"}
+  ["unzip"] {os-family = "debian"}
   ["gnupg"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "The antidote to app-stores"

--- a/packages/0install/0install.2.14.1/opam
+++ b/packages/0install/0install.2.14.1/opam
@@ -24,8 +24,7 @@ conflicts: [
   "lablgtk" {< "2.18.2"}
 ]
 depexts: [
-  ["unzip"] {os-distribution = "ubuntu"}
-  ["unzip"] {os-distribution = "debian"}
+  ["unzip"] {os-family = "debian"}
   ["gnupg"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "The antidote to app-stores"

--- a/packages/0install/0install.2.14/opam
+++ b/packages/0install/0install.2.14/opam
@@ -24,8 +24,7 @@ conflicts: [
   "lablgtk" {< "2.18.2"}
 ]
 depexts: [
-  ["unzip"] {os-distribution = "ubuntu"}
-  ["unzip"] {os-distribution = "debian"}
+  ["unzip"] {os-family = "debian"}
   ["gnupg"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "The antidote to app-stores"

--- a/packages/0install/0install.2.6.2/opam
+++ b/packages/0install/0install.2.6.2/opam
@@ -20,8 +20,7 @@ depends: [
 ]
 depopts: [ "obus" "lablgtk" ]
 depexts: [
-  ["unzip"] {os-distribution = "ubuntu"}
-  ["unzip"] {os-distribution = "debian"}
+  ["unzip"] {os-family = "debian"}
 ]
 synopsis: "The antidote to app-stores"
 description: """

--- a/packages/0install/0install.2.8/opam
+++ b/packages/0install/0install.2.8/opam
@@ -20,8 +20,7 @@ depends: [
 ]
 depopts: [ "obus" "lablgtk" ]
 depexts: [
-  ["unzip"] {os-distribution = "ubuntu"}
-  ["unzip"] {os-distribution = "debian"}
+  ["unzip"] {os-family = "debian"}
 ]
 synopsis: "The antidote to app-stores"
 description: """

--- a/packages/0install/0install.2.9.1/opam
+++ b/packages/0install/0install.2.9.1/opam
@@ -22,8 +22,7 @@ depends: [
 ]
 depopts: [ "obus" "lablgtk" ]
 depexts: [
-  ["unzip"] {os-distribution = "ubuntu"}
-  ["unzip"] {os-distribution = "debian"}
+  ["unzip"] {os-family = "debian"}
 ]
 synopsis: "The antidote to app-stores"
 description: """

--- a/packages/aio/aio.0.0.3/opam
+++ b/packages/aio/aio.0.0.3/opam
@@ -8,8 +8,7 @@ build: make
 remove: [[make "uninstall"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libaio-dev"] {os-distribution = "debian"}
-  ["libaio-dev"] {os-distribution = "ubuntu"}
+  ["libaio-dev"] {os-family = "debian"}
 ]
 patches: ["meta.patch"]
 install: [make "install"]

--- a/packages/alsa/alsa.0.2.1/opam
+++ b/packages/alsa/alsa.0.2.1/opam
@@ -11,8 +11,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libasound2-dev"] {os-distribution = "debian"}
-  ["libasound2-dev"] {os-distribution = "ubuntu"}
+  ["libasound2-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/alsa/alsa.0.2.2/opam
+++ b/packages/alsa/alsa.0.2.2/opam
@@ -15,8 +15,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libasound2-dev"] {os-distribution = "debian"}
-  ["libasound2-dev"] {os-distribution = "ubuntu"}
+  ["libasound2-dev"] {os-family = "debian"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-alsa/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-alsa.git"

--- a/packages/alsa/alsa.0.2.3/opam
+++ b/packages/alsa/alsa.0.2.3/opam
@@ -16,8 +16,7 @@ depexts: [
   ["alsa-lib-devel"] {os-distribution = "centos"}
   ["alsa-lib-devel"] {os-distribution = "fedora"}
   ["alsa-lib-devel"] {os-family = "suse"}
-  ["libasound2-dev"] {os-distribution = "debian"}
-  ["libasound2-dev"] {os-distribution = "ubuntu"}
+  ["libasound2-dev"] {os-family = "debian"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-alsa/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-alsa.git"

--- a/packages/ao/ao.0.2.0/opam
+++ b/packages/ao/ao.0.2.0/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "ao"]]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config" {build}]
 depexts: [
-  ["libao-dev"] {os-distribution = "debian"}
-  ["libao-dev"] {os-distribution = "ubuntu"}
+  ["libao-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/ao/ao.0.2.1/opam
+++ b/packages/ao/ao.0.2.1/opam
@@ -16,8 +16,7 @@ depexts: [
   ["libao-devel"] {os-distribution = "fedora"}
   ["libao-devel"] {os-family = "suse"}
   ["libao"] {os = "macos" & os-distribution = "homebrew"}
-  ["libao-dev"] {os-distribution = "debian"}
-  ["libao-dev"] {os-distribution = "ubuntu"}
+  ["libao-dev"] {os-family = "debian"}
   ["libao"] {os = "freebsd"}
   ["libao-dev"] {os-distribution = "alpine"}
 ]

--- a/packages/arakoon/arakoon.1.9.17/opam
+++ b/packages/arakoon/arakoon.1.9.17/opam
@@ -36,8 +36,7 @@ depends: [
 ]
 available: opam-version >= "1.2" & os != "macos"
 depexts: [
-  ["help2man"] {os-distribution = "ubuntu"}
-  ["help2man"] {os-distribution = "debian"}
+  ["help2man"] {os-family = "debian"}
 ]
 synopsis:
   "A distributed key-value store that guarantees consistency above anything else."

--- a/packages/assimp/assimp.0.1/opam
+++ b/packages/assimp/assimp.0.1/opam
@@ -13,8 +13,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libassimp-dev"] {os-distribution = "debian"}
-  ["libassimp-dev"] {os-distribution = "ubuntu"}
+  ["libassimp-dev"] {os-family = "debian"}
 ]
 synopsis: "OCaml bindings to Assimp, Open Asset Import Library"
 description: """

--- a/packages/assimp/assimp.0.3/opam
+++ b/packages/assimp/assimp.0.3/opam
@@ -14,8 +14,7 @@ depends: [
   "result"
 ]
 depexts: [
-  ["libassimp-dev"] {os-distribution = "debian"}
-  ["libassimp-dev"] {os-distribution = "ubuntu"}
+  ["libassimp-dev"] {os-family = "debian"}
   ["assimp"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "OCaml bindings to Assimp, Open Asset Import Library"

--- a/packages/async_ssl/async_ssl.111.06.00/opam
+++ b/packages/async_ssl/async_ssl.111.06.00/opam
@@ -15,8 +15,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libssl-dev"] {os-distribution = "debian"}
-  ["libssl-dev"] {os-distribution = "ubuntu"}
+  ["libssl-dev"] {os-family = "debian"}
   ["openssl-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/async_ssl/async_ssl.111.08.00/opam
+++ b/packages/async_ssl/async_ssl.111.08.00/opam
@@ -15,8 +15,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libssl-dev"] {os-distribution = "debian"}
-  ["libssl-dev"] {os-distribution = "ubuntu"}
+  ["libssl-dev"] {os-family = "debian"}
   ["openssl-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/async_ssl/async_ssl.111.21.00/opam
+++ b/packages/async_ssl/async_ssl.111.21.00/opam
@@ -15,8 +15,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libssl-dev"] {os-distribution = "debian"}
-  ["libssl-dev"] {os-distribution = "ubuntu"}
+  ["libssl-dev"] {os-family = "debian"}
   ["openssl-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/async_ssl/async_ssl.112.17.00/opam
+++ b/packages/async_ssl/async_ssl.112.17.00/opam
@@ -15,8 +15,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libssl-dev"] {os-distribution = "debian"}
-  ["libssl-dev"] {os-distribution = "ubuntu"}
+  ["libssl-dev"] {os-family = "debian"}
   ["openssl-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/bap-llvm/bap-llvm.1.0.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.0.0/opam
@@ -34,8 +34,7 @@ depends: [
   "conf-env-travis"
 ]
 depexts: [
-  ["clang"] {os-distribution = "ubuntu"}
-  ["clang"] {os-distribution = "debian"}
+  ["clang"] {os-family = "debian"}
 ]
 synopsis: "BAP LLVM backend"
 description:

--- a/packages/bap-llvm/bap-llvm.1.1.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.1.0/opam
@@ -34,8 +34,7 @@ depends: [
   "conf-env-travis"
 ]
 depexts: [
-  ["clang"] {os-distribution = "ubuntu"}
-  ["clang"] {os-distribution = "debian"}
+  ["clang"] {os-family = "debian"}
 ]
 synopsis: "BAP LLVM backend"
 description:

--- a/packages/bap-llvm/bap-llvm.1.2.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.2.0/opam
@@ -35,8 +35,7 @@ depends: [
   "conf-env-travis"
 ]
 depexts: [
-  ["clang"] {os-distribution = "ubuntu"}
-  ["clang"] {os-distribution = "debian"}
+  ["clang"] {os-family = "debian"}
 ]
 synopsis: "BAP LLVM backend"
 description:

--- a/packages/bap-llvm/bap-llvm.1.3.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.3.0/opam
@@ -37,8 +37,7 @@ depends: [
   "monads"
 ]
 depexts: [
-  ["clang"] {os-distribution = "ubuntu"}
-  ["clang"] {os-distribution = "debian"}
+  ["clang"] {os-family = "debian"}
 ]
 synopsis: "BAP LLVM backend"
 description:

--- a/packages/bap-llvm/bap-llvm.1.4.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.4.0/opam
@@ -37,8 +37,7 @@ depends: [
   "monads"
 ]
 depexts: [
-  ["clang"] {os-distribution = "ubuntu"}
-  ["clang"] {os-distribution = "debian"}
+  ["clang"] {os-family = "debian"}
 ]
 synopsis: "BAP LLVM backend"
 description:

--- a/packages/bap-llvm/bap-llvm.1.5.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.5.0/opam
@@ -37,8 +37,7 @@ depends: [
   "monads"
 ]
 depexts: [
-  ["clang"] {os-distribution = "ubuntu"}
-  ["clang"] {os-distribution = "debian"}
+  ["clang"] {os-family = "debian"}
 ]
 synopsis: "BAP LLVM backend"
 description:

--- a/packages/bap-llvm/bap-llvm.1.6.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.6.0/opam
@@ -37,8 +37,7 @@ depends: [
   "monads"
 ]
 depexts: [
-  ["clang"] {os-distribution = "ubuntu"}
-  ["clang"] {os-distribution = "debian"}
+  ["clang"] {os-family = "debian"}
 ]
 synopsis: "BAP LLVM backend"
 description:

--- a/packages/camlbz2/camlbz2.0.6.0/opam
+++ b/packages/camlbz2/camlbz2.0.6.0/opam
@@ -13,8 +13,7 @@ build: [
 remove: [["ocamlfind" "remove" "bz2"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libbz2-dev"] {os-distribution = "debian"}
-  ["libbz2-dev"] {os-distribution = "ubuntu"}
+  ["libbz2-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Bindings for bzip2"

--- a/packages/camldm/camldm.0.1.0/opam
+++ b/packages/camldm/camldm.0.1.0/opam
@@ -12,8 +12,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libdevmapper-dev"] {os-distribution = "debian"}
-  ["libdevmapper-dev"] {os-distribution = "ubuntu"}
+  ["libdevmapper-dev"] {os-family = "debian"}
   ["device-mapper-devel"] {os-distribution = "centos"}
 ]
 dev-repo: "git://github.com/jonludlam/camldm"

--- a/packages/camlhighlight/camlhighlight.3.0/opam
+++ b/packages/camlhighlight/camlhighlight.3.0/opam
@@ -22,8 +22,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libsource-highlight-dev"] {os-distribution = "debian"}
-  ["libsource-highlight-dev"] {os-distribution = "ubuntu"}
+  ["libsource-highlight-dev"] {os-family = "debian"}
   ["source-highlight"] {os = "macos" & os-distribution = "homebrew"}
 ]
 substs: ["sexp-dir.patch"]

--- a/packages/camlhighlight/camlhighlight.4.0/opam
+++ b/packages/camlhighlight/camlhighlight.4.0/opam
@@ -23,8 +23,7 @@ depends: [
   "tyxml" {>= "3.2" & < "3.6"}
 ]
 depexts: [
-  ["libsource-highlight-dev"] {os-distribution = "debian"}
-  ["libsource-highlight-dev"] {os-distribution = "ubuntu"}
+  ["libsource-highlight-dev"] {os-family = "debian"}
   ["source-highlight"] {os = "macos" & os-distribution = "homebrew"}
 ]
 substs: ["sexp-dir.patch"]

--- a/packages/camlhighlight/camlhighlight.5.0/opam
+++ b/packages/camlhighlight/camlhighlight.5.0/opam
@@ -23,8 +23,7 @@ depends: [
   "tyxml" {>= "3.6" & < "4.0"}
 ]
 depexts: [
-  ["libsource-highlight-dev"] {os-distribution = "debian"}
-  ["libsource-highlight-dev"] {os-distribution = "ubuntu"}
+  ["libsource-highlight-dev"] {os-family = "debian"}
   ["source-highlight"] {os = "macos" & os-distribution = "homebrew"}
 ]
 substs: ["sexp-dir.patch"]

--- a/packages/camlp4/camlp4.4.01+system/opam
+++ b/packages/camlp4/camlp4.4.01+system/opam
@@ -8,8 +8,7 @@ build: [
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 depexts: [
-  ["camlp4-extra"] {os-distribution = "debian"}
-  ["camlp4-extra"] {os-distribution = "ubuntu"}
+  ["camlp4-extra"] {os-family = "debian"}
 ]
 synopsis:
   "Camlp4 is a system for writing extensible parsers for programming languages"

--- a/packages/camlp4/camlp4.4.02+system/opam
+++ b/packages/camlp4/camlp4.4.02+system/opam
@@ -8,8 +8,7 @@ build: [
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 depexts: [
-  ["camlp4-extra"] {os-distribution = "debian"}
-  ["camlp4-extra"] {os-distribution = "ubuntu"}
+  ["camlp4-extra"] {os-family = "debian"}
 ]
 synopsis:
   "Camlp4 is a system for writing extensible parsers for programming languages"

--- a/packages/camlp4/camlp4.4.03+system/opam
+++ b/packages/camlp4/camlp4.4.03+system/opam
@@ -8,8 +8,7 @@ build: [
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 depexts: [
-  ["camlp4-extra"] {os-distribution = "debian"}
-  ["camlp4-extra"] {os-distribution = "ubuntu"}
+  ["camlp4-extra"] {os-family = "debian"}
 ]
 synopsis:
   "Camlp4 is a system for writing extensible parsers for programming languages"

--- a/packages/camlp4/camlp4.4.04+system/opam
+++ b/packages/camlp4/camlp4.4.04+system/opam
@@ -8,8 +8,7 @@ build: [
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 depexts: [
-  ["camlp4-extra"] {os-distribution = "debian"}
-  ["camlp4-extra"] {os-distribution = "ubuntu"}
+  ["camlp4-extra"] {os-family = "debian"}
   ["camlp4"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis:

--- a/packages/camlp4/camlp4.4.05+system/opam
+++ b/packages/camlp4/camlp4.4.05+system/opam
@@ -8,8 +8,7 @@ build: [
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 depexts: [
-  ["camlp4-extra"] {os-distribution = "debian"}
-  ["camlp4-extra"] {os-distribution = "ubuntu"}
+  ["camlp4-extra"] {os-family = "debian"}
   ["camlp4"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis:

--- a/packages/camlp4/camlp4.4.06+system/opam
+++ b/packages/camlp4/camlp4.4.06+system/opam
@@ -9,8 +9,7 @@ build: [
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 depexts: [
-  ["camlp4-extra"] {os-distribution = "debian"}
-  ["camlp4-extra"] {os-distribution = "ubuntu"}
+  ["camlp4-extra"] {os-family = "debian"}
   ["camlp4"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis:

--- a/packages/camlp4/camlp4.4.07+system/opam
+++ b/packages/camlp4/camlp4.4.07+system/opam
@@ -9,8 +9,7 @@ build: [
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 depexts: [
-  ["camlp4-extra"] {os-distribution = "debian"}
-  ["camlp4-extra"] {os-distribution = "ubuntu"}
+  ["camlp4-extra"] {os-family = "debian"}
   ["camlp4"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis:

--- a/packages/camltc/camltc.0.9.3/opam
+++ b/packages/camltc/camltc.0.9.3/opam
@@ -25,8 +25,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["git"] {os-distribution = "ubuntu"}
-  ["git"] {os-distribution = "debian"}
+  ["git"] {os-family = "debian"}
 ]
 synopsis: "OCaml bindings for tokyo cabinet"
 authors: ["Jan Doms" "Joost Damad" "Romain Slootmaekers" "Nicolas Trangez"]

--- a/packages/camltc/camltc.0.9.4/opam
+++ b/packages/camltc/camltc.0.9.4/opam
@@ -26,8 +26,7 @@ depends: [
 ]
 available: opam-version > "1.2.0"
 depexts: [
-  ["git"] {os-distribution = "ubuntu"}
-  ["git"] {os-distribution = "debian"}
+  ["git"] {os-family = "debian"}
 ]
 synopsis: "OCaml bindings for tokyo cabinet"
 authors: ["Jan Doms" "Joost Damad" "Romain Slootmaekers" "Nicolas Trangez"]

--- a/packages/camltc/camltc.0.9.5/opam
+++ b/packages/camltc/camltc.0.9.5/opam
@@ -27,8 +27,7 @@ depends: [
 ]
 available: opam-version > "1.2.0"
 depexts: [
-  ["git"] {os-distribution = "ubuntu"}
-  ["git"] {os-distribution = "debian"}
+  ["git"] {os-family = "debian"}
 ]
 synopsis: "OCaml bindings for tokyo cabinet"
 authors: ["Jan Doms" "Joost Damad" "Romain Slootmaekers" "Nicolas Trangez"]

--- a/packages/camltc/camltc.0.9.6/opam
+++ b/packages/camltc/camltc.0.9.6/opam
@@ -27,8 +27,7 @@ depends: [
 ]
 available: opam-version > "1.2.0"
 depexts: [
-  ["git"] {os-distribution = "ubuntu"}
-  ["git"] {os-distribution = "debian"}
+  ["git"] {os-family = "debian"}
 ]
 synopsis: "OCaml bindings for tokyo cabinet"
 authors: ["Jan Doms" "Joost Damad" "Romain Slootmaekers" "Nicolas Trangez"]

--- a/packages/camlzip/camlzip.1.04/opam
+++ b/packages/camlzip/camlzip.1.04/opam
@@ -12,8 +12,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["zlib1g-dev"] {os-distribution = "debian"}
-  ["zlib1g-dev"] {os-distribution = "ubuntu"}
+  ["zlib1g-dev"] {os-family = "debian"}
   ["zlib-devel"] {os-distribution = "centos"}
   ["zlib-devel"] {os-distribution = "rhel"}
   ["zlib-devel"] {os-distribution = "fedora"}

--- a/packages/camlzip/camlzip.1.05/opam
+++ b/packages/camlzip/camlzip.1.05/opam
@@ -16,8 +16,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["zlib1g-dev"] {os-distribution = "debian"}
-  ["zlib1g-dev"] {os-distribution = "ubuntu"}
+  ["zlib1g-dev"] {os-family = "debian"}
   ["zlib-devel"] {os-distribution = "centos"}
   ["zlib-devel"] {os-distribution = "rhel"}
   ["zlib-devel"] {os-distribution = "fedora"}

--- a/packages/camlzip/camlzip.1.06/opam
+++ b/packages/camlzip/camlzip.1.06/opam
@@ -17,8 +17,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["zlib1g-dev"] {os-distribution = "debian"}
-  ["zlib1g-dev"] {os-distribution = "ubuntu"}
+  ["zlib1g-dev"] {os-family = "debian"}
   ["zlib-devel"] {os-distribution = "centos"}
   ["zlib-devel"] {os-distribution = "rhel"}
   ["zlib-devel"] {os-distribution = "fedora"}

--- a/packages/camlzip/camlzip.1.07/opam
+++ b/packages/camlzip/camlzip.1.07/opam
@@ -17,8 +17,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["zlib1g-dev"] {os-distribution = "debian"}
-  ["zlib1g-dev"] {os-distribution = "ubuntu"}
+  ["zlib1g-dev"] {os-family = "debian"}
   ["zlib-devel"] {os-distribution = "centos"}
   ["zlib-devel"] {os-distribution = "rhel"}
   ["zlib-devel"] {os-distribution = "fedora"}

--- a/packages/conf-aclocal/conf-aclocal.1.0.0/opam
+++ b/packages/conf-aclocal/conf-aclocal.1.0.0/opam
@@ -10,8 +10,7 @@ depexts: [
   ["automake"] {os-distribution = "centos"}
   ["automake"] {os-distribution = "fedora"}
   ["automake"] {os-family = "suse"}
-  ["automake"] {os-distribution = "debian"}
-  ["automake"] {os-distribution = "ubuntu"}
+  ["automake"] {os-family = "debian"}
   ["automake"] {os-distribution = "nixos"}
   ["automake"] {os-distribution = "arch"}
 ]

--- a/packages/conf-autoconf/conf-autoconf.0.1/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.1/opam
@@ -9,8 +9,7 @@ build: [
 ]
 depends: ["conf-which" {build}]
 depexts: [
-  ["autoconf"] {os-distribution = "debian"}
-  ["autoconf"] {os-distribution = "ubuntu"}
+  ["autoconf"] {os-family = "debian"}
   ["autoconf"] {os-distribution = "centos"}
   ["autoconf"] {os-distribution = "fedora"}
   ["autoconf"] {os-distribution = "arch"}

--- a/packages/conf-bap-llvm/conf-bap-llvm.1/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1/opam
@@ -12,8 +12,7 @@ depends: [
   "conf-which" {build}
 ]
 depexts: [
-  ["llvm-3.8-dev"] {os-distribution = "debian"}
-  ["llvm-3.8-dev"] {os-distribution = "ubuntu"}
+  ["llvm-3.8-dev"] {os-family = "debian"}
   ["llvm-3.8"] {os = "macos" & os-distribution = "macports"}
 ]
 conflicts: ["conf-llvm"]

--- a/packages/conf-binutils/conf-binutils.0.1/opam
+++ b/packages/conf-binutils/conf-binutils.0.1/opam
@@ -12,8 +12,7 @@ build: [
 ]
 
 depexts: [
-  ["binutils-multiarch"] {os-distribution = "debian"}
-  ["binutils-multiarch"] {os-distribution = "ubuntu"}
+  ["binutils-multiarch"] {os-family = "debian"}
   ["binutils"] {os = "macos" & os-distribution = "homebrew"}
   [
     "arm-aout-binutils"

--- a/packages/conf-binutils/conf-binutils.0.2/opam
+++ b/packages/conf-binutils/conf-binutils.0.2/opam
@@ -12,8 +12,7 @@ build: [
 ]
 
 depexts: [
-  ["binutils-multiarch"] {os-distribution = "debian"}
-  ["binutils-multiarch"] {os-distribution = "ubuntu"}
+  ["binutils-multiarch"] {os-family = "debian"}
   ["binutils"] {os = "macos" & os-distribution = "homebrew"}
   [
     "arm-aout-binutils"

--- a/packages/conf-blas/conf-blas.1/opam
+++ b/packages/conf-blas/conf-blas.1/opam
@@ -11,9 +11,8 @@ build: [
   ["%{build}%/test-win.sh"] {os = "win32"}
 ]
 depexts: [
-  ["libblas-dev"] {os-distribution = "debian"}
+  ["libblas-dev"] {os-family = "debian"}
   ["libblas-devel"] {os-distribution = "mageia"}
-  ["libblas-dev"] {os-distribution = "ubuntu"}
   ["blas-devel"] {os-distribution = "centos"}
   ["blas-devel"] {os-distribution = "fedora"}
   ["blas-devel"] {os-distribution = "rhel"}

--- a/packages/conf-bluetooth/conf-bluetooth.1/opam
+++ b/packages/conf-bluetooth/conf-bluetooth.1/opam
@@ -10,8 +10,7 @@ build: [
   ["sh" "-exc" "${CC:-gcc} $CFLAGS -c test-unix.c"] {os = "freebsd"}
 ]
 depexts: [
-  ["libbluetooth-dev"] {os-distribution = "debian"}
-  ["libbluetooth-dev"] {os-distribution = "ubuntu"}
+  ["libbluetooth-dev"] {os-family = "debian"}
   ["bluez-libs-devel"] {os-distribution = "centos"}
   ["bluez-libs-devel"] {os-distribution = "fedora"}
   ["bluez-libs-devel"] {os-distribution = "mageia"}

--- a/packages/conf-bmake/conf-bmake.1.0/opam
+++ b/packages/conf-bmake/conf-bmake.1.0/opam
@@ -9,8 +9,7 @@ build: [
   ["sh" "./detect_program.sh" "./conf-bmake.config" "make"] {(os = "freebsd" | os = "openbsd" | os = "netbsd")}
 ]
 depexts: [
-  ["bmake"] {os-distribution = "debian"}
-  ["bmake"] {os-distribution = "ubuntu"}
+  ["bmake"] {os-family = "debian"}
   ["bmake"] {os-distribution = "centos"}
   ["bmake"] {os-distribution = "fedora"}
   ["bmake"] {os-distribution = "arch"}

--- a/packages/conf-boost/conf-boost.1/opam
+++ b/packages/conf-boost/conf-boost.1/opam
@@ -5,8 +5,7 @@ authors: "Beman Dawes, David Abrahams, et al."
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
 depexts: [
-  ["libboost-dev"] {os-distribution = "debian"}
-  ["libboost-dev"] {os-distribution = "ubuntu"}
+  ["libboost-dev"] {os-family = "debian"}
   ["boost"] {os-distribution = "nixos"}
   ["boost-dev"] {os-distribution = "alpine"}
   ["boost-devel"] {os-distribution = "fedora"}

--- a/packages/conf-brotli/conf-brotli.0.0.1/opam
+++ b/packages/conf-brotli/conf-brotli.0.0.1/opam
@@ -6,10 +6,9 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
 build: [ "pkg-config" "libbrotlidec" "libbrotlienc" ]
 depexts: [
-  ["libbrotli-dev"] {os-distribution = "debian"}
+  ["libbrotli-dev"] {os-family = "debian"}
   ["libbrotli"] {os = "freebsd"}
   ["brotli"] {os-distribution = "homebrew" & os = "macos"}
-  ["libbrotli-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on a brotli system installation"
 description:

--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -11,8 +11,7 @@ build: [
 ]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libcairo2-dev"] {os-distribution = "debian"}
-  ["libcairo2-dev"] {os-distribution = "ubuntu"}
+  ["libcairo2-dev"] {os-family = "debian"}
   ["libcairo-devel"] {os-distribution = "mageia"}
   ["cairo" "cairo-devel"] {os-distribution = "centos"}
   ["cairo-devel"] {os-distribution = "fedora"}

--- a/packages/conf-clang/conf-clang.1/opam
+++ b/packages/conf-clang/conf-clang.1/opam
@@ -6,8 +6,7 @@ authors: "The LLVM devs"
 license: "University of Illinois/NCSA Open Source License"
 build: ["clang" "--version"]
 depexts: [
-  ["clang"] {os-distribution = "debian"}
-  ["clang"] {os-distribution = "ubuntu"}
+  ["clang"] {os-family = "debian"}
   ["clang"] {os-distribution = "fedora"}
   ["clang"] {os-distribution = "rhel"}
   ["clang"] {os-distribution = "centos"}

--- a/packages/conf-cmake/conf-cmake.1/opam
+++ b/packages/conf-cmake/conf-cmake.1/opam
@@ -8,8 +8,7 @@ build: ["bash" "-ex" "configure.sh"]
 depexts: [
   ["cmake"] {os-distribution = "homebrew" & os = "macos"}
   ["cmake"] {os-distribution = "macports" & os = "macos"}
-  ["cmake"] {os-distribution = "debian"}
-  ["cmake"] {os-distribution = "ubuntu"}
+  ["cmake"] {os-family = "debian"}
   ["cmake3" "epel-release"] {os-distribution = "centos"}
   ["cmake"] {os-distribution = "fedora"}
   ["cmake"] {os-distribution = "alpine"}

--- a/packages/conf-cpio/conf-cpio.1/opam
+++ b/packages/conf-cpio/conf-cpio.1/opam
@@ -6,8 +6,7 @@ authors: "GNU Project | BSD"
 license: "GPL-3 | BSD"
 build: ["cpio" "--version"]
 depexts: [
-  ["cpio"] {os-distribution = "debian"}
-  ["cpio"] {os-distribution = "ubuntu"}
+  ["cpio"] {os-family = "debian"}
   ["cpio"] {os-distribution = "fedora"}
   ["cpio"] {os-distribution = "rhel"}
   ["cpio"] {os-distribution = "centos"}

--- a/packages/conf-dbm/conf-dbm.1.0.0/opam
+++ b/packages/conf-dbm/conf-dbm.1.0.0/opam
@@ -15,8 +15,7 @@ build: [
              cc test_ndbm.c -v -I/usr/include -I/usr/local/include -lndbm"
 ]
 depexts: [
-  ["libgdbm-dev"] {os-distribution = "debian"}
-  ["libgdbm-dev"] {os-distribution = "ubuntu"}
+  ["libgdbm-dev"] {os-family = "debian"}
   ["gdbm"] {os-distribution = "nixos"}
   ["gdbm-devel"] {os-distribution = "centos"}
   ["gdbm-devel"] {os-distribution = "rhel"}

--- a/packages/conf-expat/conf-expat.1/opam
+++ b/packages/conf-expat/conf-expat.1/opam
@@ -7,9 +7,8 @@ license: "MIT"
 build: [["pkg-config" "expat"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libexpat1-dev"] {os-distribution = "debian"}
+  ["libexpat1-dev"] {os-family = "debian"}
   ["libexpat1-devel"] {os-distribution = "mageia"}
-  ["libexpat1-dev"] {os-distribution = "ubuntu"}
   ["expat-devel"] {os-distribution = "fedora"}
 ]
 synopsis: "Virtual package relying on an expat system installation"

--- a/packages/conf-fftw3/conf-fftw3.1/opam
+++ b/packages/conf-fftw3/conf-fftw3.1/opam
@@ -7,8 +7,7 @@ license: "GPL"
 build: [["pkg-config" "fftw3"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libfftw3-dev"] {os-distribution = "ubuntu"}
-  ["libfftw3-dev"] {os-distribution = "debian"}
+  ["libfftw3-dev"] {os-family = "debian"}
   ["fftw-devel"] {os-distribution = "centos"}
   ["fftw-dev"] {os-distribution = "alpine"}
   ["fftw-devel"] {os-distribution = "fedora"}

--- a/packages/conf-freetype/conf-freetype.1/opam
+++ b/packages/conf-freetype/conf-freetype.1/opam
@@ -7,8 +7,7 @@ license: "GPL"
 build: [["pkg-config" "freetype2"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libfreetype6-dev"] {os-distribution = "ubuntu"}
-  ["libfreetype6-dev"] {os-distribution = "debian"}
+  ["libfreetype6-dev"] {os-family = "debian"}
   ["freetype-dev"] {os-distribution = "alpine"}
   ["freetype-devel"] {os-distribution = "centos"}
   ["freetype-devel"] {os-distribution = "fedora"}

--- a/packages/conf-ftgl/conf-ftgl.1/opam
+++ b/packages/conf-ftgl/conf-ftgl.1/opam
@@ -7,9 +7,8 @@ license: "MIT"
 build: [["pkg-config" "ftgl"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libftgl-dev"] {os-distribution = "debian"}
+  ["libftgl-dev"] {os-family = "debian"}
   ["libftgl-devel"] {os-distribution = "mageia"}
-  ["libftgl-dev"] {os-distribution = "ubuntu"}
   ["ftgl-devel"] {os-distribution = "fedora"}
 ]
 synopsis: "Virtual package relying on an ftgl system installation"

--- a/packages/conf-g++/conf-g++.1.0/opam
+++ b/packages/conf-g++/conf-g++.1.0/opam
@@ -10,8 +10,7 @@ depexts: [
   ["gcc-c++"] {os-distribution = "centos"}
   ["gcc-c++"] {os-distribution = "fedora"}
   ["gcc-c++"] {os-family = "suse"}
-  ["g++"] {os-distribution = "debian"}
-  ["g++"] {os-distribution = "ubuntu"}
+  ["g++"] {os-family = "debian"}
   ["gcc"] {os-distribution = "nixos"}
   ["gcc"] {os-distribution = "arch"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-gd/conf-gd.1/opam
+++ b/packages/conf-gd/conf-gd.1/opam
@@ -5,13 +5,13 @@ homepage: "https://libgd.github.io/"
 license: "MIT"
 build: [["pkg-config" "gdlib"]]
 depexts: [
-  ["gd-dev" "libpng-dev" "libjpeg-turbo-dev" "freetype-dev" "zlib-dev"] {os-distribution = "alpine"}
+  ["gd-dev" "libpng-dev" "libjpeg-turbo-dev" "freetype-dev" "zlib-dev"]
+    {os-distribution = "alpine"}
   ["gd"] {os-distribution = "arch"}
   ["libgd3-devel"] {os-distribution = "centos"}
   ["libgd3-devel"] {os-distribution = "fedora"}
   ["libgd3-devel"] {os-family = "suse"}
-  ["libgd-dev"] {os-distribution = "debian"}
-  ["libgd-dev"] {os-distribution = "ubuntu"}
+  ["libgd-dev"] {os-family = "debian"}
   ["gd"] {os-distribution = "nixos"}
   ["gd"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-gfortran/conf-gfortran.0/opam
+++ b/packages/conf-gfortran/conf-gfortran.0/opam
@@ -8,8 +8,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 build: ["gfortran" "--version"]
 depexts: [
-  ["gfortran"] {os-distribution = "debian"}
-  ["gfortran"] {os-distribution = "ubuntu"}
+  ["gfortran"] {os-family = "debian"}
   ["gfortran"] {os-distribution = "alpine"}
   ["gcc-gfortran"] {os-distribution = "fedora"}
   ["gcc-gfortran"] {os-distribution = "centos"}

--- a/packages/conf-git/conf-git.1.0/opam
+++ b/packages/conf-git/conf-git.1.0/opam
@@ -12,8 +12,7 @@ depexts: [
   ["git"] {os-distribution = "centos"}
   ["git"] {os-distribution = "fedora"}
   ["git"] {os-family = "suse"}
-  ["git"] {os-distribution = "debian"}
-  ["git"] {os-distribution = "ubuntu"}
+  ["git"] {os-family = "debian"}
   ["git"] {os-distribution = "nixos"}
   ["git"] {os-distribution = "arch"}
   ["git"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -6,8 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "LGPL 2.1"
 build: [["pkg-config" "libglade-2.0"]]
 depexts: [
-  ["libglade2-dev"] {os-distribution = "debian"}
-  ["libglade2-dev"] {os-distribution = "ubuntu"}
+  ["libglade2-dev"] {os-family = "debian"}
   ["libglade2-devel"] {os-distribution = "fedora"}
 ]
 synopsis: "Virtual package relying on a libglade system installation"

--- a/packages/conf-gles2/conf-gles2.1/opam
+++ b/packages/conf-gles2/conf-gles2.1/opam
@@ -7,8 +7,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: ["pkg-config" "glesv2"] {os != "macos"}
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libgles2-mesa-dev"] {os-distribution = "debian"}
-  ["libgles2-mesa-dev"] {os-distribution = "ubuntu"}
+  ["libgles2-mesa-dev"] {os-family = "debian"}
   ["mesa"] {os-distribution = "arch"}
   ["mesa-dev"] {os-distribution = "alpine"}
   ["mesa-libGLES-devel"] {os-distribution = "centos"}

--- a/packages/conf-glew/conf-glew.1/opam
+++ b/packages/conf-glew/conf-glew.1/opam
@@ -11,9 +11,8 @@ license: "modified BSD"
 build: [["pkg-config" "glew"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libglew-dev"] {os-distribution = "debian"}
+  ["libglew-dev"] {os-family = "debian"}
   ["libglew-devel"] {os-distribution = "mageia"}
-  ["libglew-dev"] {os-distribution = "ubuntu"}
   ["glew-devel"] {os-distribution = "fedora"}
 ]
 synopsis: "Virtual package relying on a GLEW system installation"

--- a/packages/conf-glfw3/conf-glfw3.1/opam
+++ b/packages/conf-glfw3/conf-glfw3.1/opam
@@ -9,8 +9,7 @@ license: "Zlib"
 build: [["pkg-config" "glfw3"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libglfw3-dev"] {os-distribution = "debian"}
-  ["libglfw3-dev"] {os-distribution = "ubuntu"}
+  ["libglfw3-dev"] {os-family = "debian"}
   ["glfw-devel" "epel-release"] {os-distribution = "centos"}
   ["glfw-devel"] {os-distribution = "rhel"}
   ["glfw-devel"] {os-distribution = "fedora"}

--- a/packages/conf-glfw3/conf-glfw3.2/opam
+++ b/packages/conf-glfw3/conf-glfw3.2/opam
@@ -10,9 +10,9 @@ flags: conf
 build: [["pkg-config" "glfw3"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libglfw3-dev"] {os-distribution = "debian"}
-  ["libglfw3-dev"] {os-distribution = "ubuntu"}
-  ["glfw-devel" "epel-release" "mesa-libGL-devel"] {os-distribution = "centos"}
+  ["libglfw3-dev"] {os-family = "debian"}
+  ["glfw-devel" "epel-release" "mesa-libGL-devel"]
+    {os-distribution = "centos"}
   ["glfw-devel"] {os-distribution = "rhel"}
   ["glfw-devel"] {os-distribution = "fedora"}
   ["glfw-dev"] {os-distribution = "alpine"}

--- a/packages/conf-glib-2/conf-glib-2.1/opam
+++ b/packages/conf-glib-2/conf-glib-2.1/opam
@@ -6,8 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "LGPL-2.0"
 build: [["pkg-config" "glib-2.0"]]
 depexts: [
-  ["libglib2.0-dev"] {os-distribution = "debian"}
-  ["libglib2.0-dev"] {os-distribution = "ubuntu"}
+  ["libglib2.0-dev"] {os-family = "debian"}
   ["glib2-devel"] {os-distribution = "fedora"}
   ["glib2-devel"] {os-distribution = "centos"}
   ["glib-dev"] {os-distribution = "alpine"}

--- a/packages/conf-glpk/conf-glpk.1/opam
+++ b/packages/conf-glpk/conf-glpk.1/opam
@@ -8,8 +8,7 @@ build: [
   ["cc" "-c" "-l:libglpk.a"]
 ]
 depexts: [
-  ["libglpk-dev"] {os-distribution = "debian"}
-  ["libglpk-dev"] {os-distribution = "ubuntu"}
+  ["libglpk-dev"] {os-family = "debian"}
   ["glpk"] {os-distribution = "fedora"}
   ["glpk"] {os-distribution = "centos"}
   ["glpk"] {os-distribution = "rhel"}

--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -12,8 +12,7 @@ build: [
   ] {os = "macos"}
 ]
 depexts: [
-  ["libgmp-dev"] {os-distribution = "debian"}
-  ["libgmp-dev"] {os-distribution = "ubuntu"}
+  ["libgmp-dev"] {os-family = "debian"}
   ["gmp"] {os = "macos" & os-distribution = "homebrew"}
   ["gmp" "gmp-devel"] {os-distribution = "centos"}
   ["gmp" "gmp-devel"] {os-distribution = "fedora"}

--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -5,8 +5,7 @@ authors: "The GNOME Project"
 license: "LGPL 2.1"
 build: [["pkg-config" "libgnomecanvas-2.0"]]
 depexts: [
-  ["libgnomecanvas2-dev"] {os-distribution = "debian"}
-  ["libgnomecanvas2-dev"] {os-distribution = "ubuntu"}
+  ["libgnomecanvas2-dev"] {os-family = "debian"}
   ["libgnomecanvas-devel"] {os-distribution = "fedora"}
   ["libgnomecanvas"] {os = "macos" & os-distribution = "homebrew"}
   ["libgnomecanvas"] {os-distribution = "arch"}

--- a/packages/conf-gnuplot/conf-gnuplot.0.1/opam
+++ b/packages/conf-gnuplot/conf-gnuplot.0.1/opam
@@ -9,8 +9,7 @@ build: [
 ]
 depends: ["conf-which" {build}]
 depexts: [
-  ["gnuplot-x11"] {os-distribution = "debian"}
-  ["gnuplot-x11"] {os-distribution = "ubuntu"}
+  ["gnuplot-x11"] {os-family = "debian"}
   ["gnuplot"] {os-distribution = "centos"}
   ["gnuplot"] {os-distribution = "fedora"}
   ["gnuplot"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-graphviz/conf-graphviz.0.1/opam
+++ b/packages/conf-graphviz/conf-graphviz.0.1/opam
@@ -9,8 +9,7 @@ build: [
 ]
 depends: ["conf-which" {build}]
 depexts: [
-  ["graphviz"] {os-distribution = "debian"}
-  ["graphviz"] {os-distribution = "ubuntu"}
+  ["graphviz"] {os-family = "debian"}
   ["graphviz"] {os-distribution = "fedora"}
   ["graphviz"] {os-distribution = "centos"}
   ["graphviz"] {os-distribution = "arch"}

--- a/packages/conf-gsl/conf-gsl.1/opam
+++ b/packages/conf-gsl/conf-gsl.1/opam
@@ -5,9 +5,8 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL"
 build: [["pkg-config" "gsl"]]
 depexts: [
-  ["libgsl0-dev"] {os-distribution = "debian"}
+  ["libgsl0-dev"] {os-family = "debian"}
   ["libgsl-devel"] {os-distribution = "mageia"}
-  ["libgsl0-dev"] {os-distribution = "ubuntu"}
   ["gsl-devel"] {os-distribution = "centos"}
   ["gsl-devel"] {os-distribution = "fedora"}
   ["gsl-devel"] {os-distribution = "rhel"}

--- a/packages/conf-gssapi/conf-gssapi.1/opam
+++ b/packages/conf-gssapi/conf-gssapi.1/opam
@@ -4,8 +4,7 @@ homepage: "http://web.mit.edu/kerberos/"
 authors: "The MIT Kerberos Team"
 build: [["pkg-config" "krb5-gssapi" "mit-krb5-gssapi"]]
 depexts: [
-  ["libkrb5-dev"] {os-distribution = "debian"}
-  ["libkrb5-dev"] {os-distribution = "ubuntu"}
+  ["libkrb5-dev"] {os-family = "debian"}
 ]
 synopsis: "Virtual package relying on a krb5-gssapi system installation"
 description:

--- a/packages/conf-gtksourceview/conf-gtksourceview.2/opam
+++ b/packages/conf-gtksourceview/conf-gtksourceview.2/opam
@@ -10,12 +10,11 @@ depexts: [
   ["gtksourceview2-dev"] {os-distribution = "alpine"}
   ["gtksourceview2"] {os-distribution = "arch"}
   ["epel-release" "gtksourceview2-devel"] {os-distribution = "centos"}
-  ["libgtksourceview2.0-dev"] {os-distribution = "debian"}
+  ["libgtksourceview2.0-dev"] {os-family = "debian"}
   ["gtksourceview2-devel"] {os-distribution = "fedora"}
   ["gtksourceview2"] {os = "freebsd"}
   ["gtksourceview"] {os = "openbsd"}
   ["gtksourceview2-devel"] {os-family = "suse"}
-  ["libgtksourceview2.0-dev"] {os-distribution = "ubuntu"}
   ["gtksourceview" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a GtkSourceView system installation"

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
@@ -10,12 +10,11 @@ depexts: [
   ["gtksourceview-dev"] {os-distribution = "alpine"}
   ["gtksourceview3"] {os-distribution = "arch"}
   ["epel-release" "gtksourceview3-devel"] {os-distribution = "centos"}
-  ["libgtksourceview-3.0-dev"] {os-distribution = "debian"}
+  ["libgtksourceview-3.0-dev"] {os-family = "debian"}
   ["gtksourceview3-devel"] {os-distribution = "fedora"}
   ["gtksourceview3"] {os = "freebsd"}
   ["gtksourceview3"] {os = "openbsd"}
   ["gtksourceview3-devel"] {os-family = "suse"}
-  ["libgtksourceview-3.0-dev"] {os-distribution = "ubuntu"}
   ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a GtkSourceView-3 system installation"

--- a/packages/conf-hidapi/conf-hidapi.0/opam
+++ b/packages/conf-hidapi/conf-hidapi.0/opam
@@ -10,8 +10,7 @@ build: [
 ]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libhidapi-dev"] {os-distribution = "ubuntu"}
-  ["libhidapi-dev"] {os-distribution = "debian"}
+  ["libhidapi-dev"] {os-family = "debian"}
   ["hidapi"] {os-distribution = "arch"}
   ["hidapi"] {os = "macos" & os-distribution = "homebrew"}
   ["hidapi"] {os = "freebsd"}

--- a/packages/conf-lapack/conf-lapack.1/opam
+++ b/packages/conf-lapack/conf-lapack.1/opam
@@ -11,9 +11,8 @@ build: [
   ["%{build}%/test-win.sh"] {os = "win32"}
 ]
 depexts: [
-  ["liblapack-dev"] {os-distribution = "debian"}
+  ["liblapack-dev"] {os-family = "debian"}
   ["liblapack-devel"] {os-distribution = "mageia"}
-  ["liblapack-dev"] {os-distribution = "ubuntu"}
   ["lapack-devel"] {os-distribution = "centos"}
   ["lapack-devel"] {os-distribution = "fedora"}
   ["lapack-devel"] {os-distribution = "rhel"}

--- a/packages/conf-leveldb/conf-leveldb.1/opam
+++ b/packages/conf-leveldb/conf-leveldb.1/opam
@@ -6,8 +6,7 @@ homepage: "http://code.google.com/p/leveldb/"
 license: "BSD"
 build: [["cc" "-c" "test.cc"]]
 depexts: [
-  ["libleveldb-dev"] {os-distribution = "debian"}
-  ["libleveldb-dev"] {os-distribution = "ubuntu"}
+  ["libleveldb-dev"] {os-family = "debian"}
   ["leveldb"] {os = "macos" & os-distribution = "homebrew"}
   ["leveldb-devel"] {os-distribution = "centos"}
 ]

--- a/packages/conf-libMagickCore/conf-libMagickCore.1/opam
+++ b/packages/conf-libMagickCore/conf-libMagickCore.1/opam
@@ -5,9 +5,8 @@ homepage: "http://www.imagemagick.org/"
 license: "Apache"
 build: [["pkg-config" "MagickCore"]]
 depexts: [
-  ["libmagickcore-dev"] {os-distribution = "debian"}
+  ["libmagickcore-dev"] {os-family = "debian"}
   ["libMagick-devel"] {os-distribution = "mageia"}
-  ["libmagickcore-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on an ImageMagick system installation"
 description: """

--- a/packages/conf-libcurl/conf-libcurl.1/opam
+++ b/packages/conf-libcurl/conf-libcurl.1/opam
@@ -6,9 +6,8 @@ license: "BSD-like"
 build: ["pkg-config" "libcurl"] {os != "macos"}
 depends: ["conf-pkg-config" {build & os != "macos"}]
 depexts: [
-  ["libcurl4-gnutls-dev"] {os-distribution = "debian"}
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
   ["libcurl-devel"] {os-distribution = "mageia"}
-  ["libcurl4-gnutls-dev"] {os-distribution = "ubuntu"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
   ["curl"] {os-distribution = "nixos"}
   ["curl"] {os-distribution = "arch"}

--- a/packages/conf-libev/conf-libev.4-11/opam
+++ b/packages/conf-libev/conf-libev.4-11/opam
@@ -4,8 +4,7 @@ homepage: "http://software.schmorp.de/pkg/libev.html"
 authors: "Marc Lehmann"
 build: [["sh" "./build.sh"]]
 depexts: [
-  ["libev-dev"] {os-distribution = "debian"}
-  ["libev-dev"] {os-distribution = "ubuntu"}
+  ["libev-dev"] {os-family = "debian"}
   ["libev"] {os = "macos" & os-distribution = "homebrew"}
   ["libev-dev"] {os-distribution = "alpine"}
   ["libev"] {os-distribution = "arch"}

--- a/packages/conf-libffi/conf-libffi.1/opam
+++ b/packages/conf-libffi/conf-libffi.1/opam
@@ -5,9 +5,8 @@ homepage: "http://sourceware.org/libffi/"
 license: "MIT"
 build: [["pkg-config" "libffi"]]
 depexts: [
-  ["libffi-dev"] {os-distribution = "debian"}
+  ["libffi-dev"] {os-family = "debian"}
   ["libffi5-devel"] {os-distribution = "mageia"}
-  ["libffi-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on a libffi system installation"
 description:

--- a/packages/conf-libgif/conf-libgif.1/opam
+++ b/packages/conf-libgif/conf-libgif.1/opam
@@ -16,8 +16,7 @@ authors: [
 homepage: "http://giflib.sourceforge.net/"
 license: "GIFLIB"
 depexts: [
-  ["libgif-dev"] {os-distribution = "debian"}
-  ["libgif-dev"] {os-distribution = "ubuntu"}
+  ["libgif-dev"] {os-family = "debian"}
   ["giflib"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a libgif system installation"

--- a/packages/conf-libgsasl/conf-libgsasl.1/opam
+++ b/packages/conf-libgsasl/conf-libgsasl.1/opam
@@ -6,8 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL"
 build: [["cc" "-c" "test.c"]]
 depexts: [
-  ["libgsasl7-dev"] {os-distribution = "debian"}
-  ["libgsasl7-dev"] {os-distribution = "ubuntu"}
+  ["libgsasl7-dev"] {os-family = "debian"}
   ["gsasl"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a GSASL lib system installation"

--- a/packages/conf-libjpeg/conf-libjpeg.1/opam
+++ b/packages/conf-libjpeg/conf-libjpeg.1/opam
@@ -10,8 +10,7 @@ license: "BSD-like"
 build: ["pkg-config" "libjpeg"]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libjpeg-dev"] {os-distribution = "debian"}
-  ["libjpeg-dev"] {os-distribution = "ubuntu"}
+  ["libjpeg-dev"] {os-family = "debian"}
   ["jpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a libjpeg system installation"

--- a/packages/conf-liblz4/conf-liblz4.1/opam
+++ b/packages/conf-liblz4/conf-liblz4.1/opam
@@ -7,8 +7,7 @@ license: "GPLv2 & BSD-2-clause"
 build: ["pkg-config" "liblz4"]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["liblz4-dev"] {os-distribution = "debian"}
-  ["liblz4-dev"] {os-distribution = "ubuntu"}
+  ["liblz4-dev"] {os-family = "debian"}
   ["lz4-devel"] {os-distribution = "centos"}
   ["lz4-devel"] {os-distribution = "rhel"}
   ["lz4-devel"] {os-distribution = "fedora"}

--- a/packages/conf-libmosquitto/conf-libmosquitto.1/opam
+++ b/packages/conf-libmosquitto/conf-libmosquitto.1/opam
@@ -9,8 +9,7 @@ build: [
   ["brew" "ls" "--versions" "mosquitto"] {os = "macos"}
 ]
 depexts: [
-  ["libmosquitto-dev"] {os-distribution = "debian"}
-  ["libmosquitto-dev"] {os-distribution = "ubuntu"}
+  ["libmosquitto-dev"] {os-family = "debian"}
   ["mosquitto-dev"] {os-distribution = "alpine"}
   ["mosquitto"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-libpcre/conf-libpcre.1/opam
+++ b/packages/conf-libpcre/conf-libpcre.1/opam
@@ -11,9 +11,8 @@ build: [["pkg-config" "libpcre"]]
 depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depexts: [
-  ["libpcre3-dev"] {os-distribution = "debian"}
+  ["libpcre3-dev"] {os-family = "debian"}
   ["libpcre-devel"] {os-distribution = "mageia"}
-  ["libpcre3-dev"] {os-distribution = "ubuntu"}
   ["pcre-devel"] {os-distribution = "centos"}
   ["pcre-devel"] {os-distribution = "fedora"}
   ["pcre-devel"] {os-distribution = "rhel"}

--- a/packages/conf-libsodium/conf-libsodium.1/opam
+++ b/packages/conf-libsodium/conf-libsodium.1/opam
@@ -21,8 +21,7 @@ license: "ISC"
 build: [["pkg-config" "libsodium"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libsodium-dev"] {os-distribution = "debian"}
-  ["libsodium-dev"] {os-distribution = "ubuntu"}
+  ["libsodium-dev"] {os-family = "debian"}
   ["security/libsodium"] {os = "freebsd"}
   ["libsodium"] {os-distribution = "homebrew" & os = "macos"}
   ["libsodium-dev"] {os-distribution = "alpine"}

--- a/packages/conf-libsvm/conf-libsvm.3/opam
+++ b/packages/conf-libsvm/conf-libsvm.3/opam
@@ -9,8 +9,7 @@ build: [
   ["sh" "-exc" "cc $CFLAGS -DDARWIN test.c -lsvm"] {os = "macos"}
 ]
 depexts: [
-  ["libsvm-dev"] {os-distribution = "ubuntu"}
-  ["libsvm-dev"] {os-distribution = "debian"}
+  ["libsvm-dev"] {os-family = "debian"}
   ["libsvm"] {os-distribution = "arch"}
   ["sci-libs/libsvm"] {os-distribution = "gentoo"}
   ["libsvm-devel"] {os-distribution = "fedora"}

--- a/packages/conf-libudev/conf-libudev.1/opam
+++ b/packages/conf-libudev/conf-libudev.1/opam
@@ -11,8 +11,7 @@ build: [
   ["pkg-config" "libudev"]
 ]
 depexts: [
-  ["libudev-dev"] {os-distribution = "debian"}
-  ["libudev-dev"] {os-distribution = "ubuntu"}
+  ["libudev-dev"] {os-family = "debian"}
   ["eudev-dev"] {os-distribution = "alpine"}
   ["systemd-devel"] {os-distribution = "centos"}
   ["systemd-devel"] {os-distribution = "fedora"}

--- a/packages/conf-libuv/conf-libuv.1/opam
+++ b/packages/conf-libuv/conf-libuv.1/opam
@@ -9,8 +9,7 @@ build: [
   ["pkg-config" "libuv" "--atleast-version=1"]
 ]
 depexts: [
-  ["libuv1-dev"] {os-distribution = "debian"}
-  ["libuv1-dev"] {os-distribution = "ubuntu"}
+  ["libuv1-dev"] {os-family = "debian"}
   ["libuv"] {os = "macos" & os-distribution = "homebrew"}
   ["libuv"] {os = "freebsd"}
   ["libuv-dev"] {os-distribution = "alpine"}

--- a/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
+++ b/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
@@ -6,8 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: [ "GPL 2.0" ]
 build: [["ls" "/usr/include/linux/stddef.h"]]
 depexts: [
-  ["linux-libc-dev"] {os-distribution = "debian"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["linux-glibc-devel"] {os-family = "suse"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["kernel-headers"] {os-distribution = "centos"}

--- a/packages/conf-lldb/conf-lldb.3.5/opam
+++ b/packages/conf-lldb/conf-lldb.3.5/opam
@@ -5,8 +5,7 @@ authors: "LLVM Developer Group"
 license: "LLVM"
 build: [["ls" "/usr/lib/llvm-3.5/include/lldb/API/SBDebugger.h"]]
 depexts: [
-  ["liblldb-3.5-dev"] {os-distribution = "debian"}
-  ["liblldb-3.5-dev"] {os-distribution = "ubuntu"}
+  ["liblldb-3.5-dev"] {os-family = "debian"}
 ]
 post-messages: [
   "This package requires LLDB 3.5 development packages installed on your system" {failure}

--- a/packages/conf-llvm/conf-llvm.3.4/opam
+++ b/packages/conf-llvm/conf-llvm.3.4/opam
@@ -9,8 +9,7 @@ build: [
 ]
 depends: ["conf-which" {build}]
 depexts: [
-  ["llvm-3.4-dev"] {os-distribution = "debian"}
-  ["llvm-3.4-dev"] {os-distribution = "ubuntu"}
+  ["llvm-3.4-dev"] {os-family = "debian"}
   ["llvm-3.4"] {os = "macos" & os-distribution = "macports"}
 ]
 post-messages:

--- a/packages/conf-llvm/conf-llvm.3.8/opam
+++ b/packages/conf-llvm/conf-llvm.3.8/opam
@@ -10,8 +10,7 @@ build: [
 depexts: [
   ["llvm@3.8"] {os-distribution = "homebrew" & os = "macos"}
   ["llvm-3.8"] {os-distribution = "macports" & os = "macos"}
-  ["llvm-3.8-dev"] {os-distribution = "debian"}
-  ["llvm-3.8-dev"] {os-distribution = "ubuntu"}
+  ["llvm-3.8-dev"] {os-family = "debian"}
   ["devel/llvm38"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"

--- a/packages/conf-llvm/conf-llvm.3.9/opam
+++ b/packages/conf-llvm/conf-llvm.3.9/opam
@@ -10,8 +10,7 @@ build: [
 depexts: [
   ["llvm@3.9"] {os-distribution = "homebrew" & os = "macos"}
   ["llvm-3.9"] {os-distribution = "macports" & os = "macos"}
-  ["llvm-3.9-dev"] {os-distribution = "debian"}
-  ["llvm-3.9-dev"] {os-distribution = "ubuntu"}
+  ["llvm-3.9-dev"] {os-family = "debian"}
   ["llvm3.9-devel"] {os-distribution = "fedora"}
   ["llvm3.9-dev"] {os-distribution = "alpine"}
   ["devel/llvm39"] {os = "freebsd"}

--- a/packages/conf-llvm/conf-llvm.4.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.4.0.0/opam
@@ -10,8 +10,7 @@ build: [
 depexts: [
   ["llvm@4"] {os-distribution = "homebrew" & os = "macos"}
   ["llvm-4.0"] {os-distribution = "macports" & os = "macos"}
-  ["llvm-4.0-dev"] {os-distribution = "debian"}
-  ["llvm-4.0-dev"] {os-distribution = "ubuntu"}
+  ["llvm-4.0-dev"] {os-family = "debian"}
   ["llvm4"] {os-distribution = "alpine"}
   ["llvm4"] {os-family = "suse"}
   ["devel/llvm40"] {os = "freebsd"}

--- a/packages/conf-llvm/conf-llvm.5.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.5.0.0/opam
@@ -10,8 +10,7 @@ build: [
 depexts: [
   ["llvm@5"] {os-distribution = "homebrew" & os = "macos"}
   ["llvm-5.0"] {os-distribution = "macports" & os = "macos"}
-  ["llvm-5.0-dev"] {os-distribution = "debian"}
-  ["llvm-5.0-dev"] {os-distribution = "ubuntu"}
+  ["llvm-5.0-dev"] {os-family = "debian"}
   ["llvm5"] {os-distribution = "alpine"}
   ["llvm5"] {os-family = "suse"}
   ["devel/llvm50"] {os = "freebsd"}

--- a/packages/conf-llvm/conf-llvm.6.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.6.0.0/opam
@@ -10,8 +10,7 @@ build: [
 depexts: [
   ["llvm@6"] {os-distribution = "homebrew" & os = "macos"}
   ["llvm-6.0"] {os-distribution = "macports" & os = "macos"}
-  ["llvm-6.0-dev"] {os-distribution = "debian"}
-  ["llvm-6.0-dev"] {os-distribution = "ubuntu"}
+  ["llvm-6.0-dev"] {os-family = "debian"}
   ["llvm6"] {os-distribution = "alpine"}
   ["llvm6"] {os-family = "suse"}
   ["devel/llvm60"] {os = "freebsd"}

--- a/packages/conf-llvm/conf-llvm.7.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.7.0.0/opam
@@ -10,8 +10,7 @@ build: [
 depexts: [
   ["llvm@7"] {os-distribution = "homebrew" & os = "macos"}
   ["llvm-7.0"] {os-distribution = "macports" & os = "macos"}
-  ["llvm-7-dev"] {os-distribution = "debian"}
-  ["llvm-7-dev"] {os-distribution = "ubuntu"}
+  ["llvm-7-dev"] {os-family = "debian"}
   ["llvm7"] {os-distribution = "alpine"}
   ["llvm7"] {os-family = "suse"}
   ["devel/llvm70"] {os = "freebsd"}

--- a/packages/conf-llvm/conf-llvm.8.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.8.0.0/opam
@@ -10,8 +10,7 @@ build: [
 depexts: [
   ["llvm@8"] {os-distribution = "homebrew" & os = "macos"}
   ["llvm-8.0"] {os-distribution = "macports" & os = "macos"}
-  ["llvm-8-dev"] {os-distribution = "debian"}
-  ["llvm-8-dev"] {os-distribution = "ubuntu"}
+  ["llvm-8-dev"] {os-family = "debian"}
   ["llvm8"] {os-distribution = "alpine"}
   ["llvm8"] {os-family = "suse"}
   ["devel/llvm80"] {os = "freebsd"}

--- a/packages/conf-lua/conf-lua.1/opam
+++ b/packages/conf-lua/conf-lua.1/opam
@@ -9,9 +9,8 @@ homepage: "http://www.lua.org/"
 license: "MIT"
 build: [["pkg-config" "lua"]]
 depexts: [
-  ["liblua5.2-dev"] {os-distribution = "debian"}
+  ["liblua5.2-dev"] {os-family = "debian"}
   ["liblua-devel"] {os-distribution = "mageia"}
-  ["liblua5.2-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on a Lua system installation"
 description:

--- a/packages/conf-lz4/conf-lz4.1.0.0/opam
+++ b/packages/conf-lz4/conf-lz4.1.0.0/opam
@@ -6,8 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 build: ["lz4" "-V"]
 depexts: [
-  ["liblz4-tool"] {os-distribution = "debian"}
-  ["liblz4-tool"] {os-distribution = "ubuntu"}
+  ["liblz4-tool"] {os-family = "debian"}
   ["lz4"] {os-distribution = "centos"}
   ["lz4"] {os-distribution = "rhel"}
   ["lz4"] {os-distribution = "fedora"}

--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -6,8 +6,7 @@ authors: "GNU Project"
 license: "GPL-3"
 build: [["sh" "-exc" "echo | m4"]]
 depexts: [
-  ["m4"] {os-distribution = "debian"}
-  ["m4"] {os-distribution = "ubuntu"}
+  ["m4"] {os-family = "debian"}
   ["m4"] {os-distribution = "fedora"}
   ["m4"] {os-distribution = "rhel"}
   ["m4"] {os-distribution = "centos"}

--- a/packages/conf-mariadb/conf-mariadb.1/opam
+++ b/packages/conf-mariadb/conf-mariadb.1/opam
@@ -10,8 +10,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libmariadbclient-dev"] {os-distribution = "debian"}
-  ["libmariadbclient-dev"] {os-distribution = "ubuntu"}
+  ["libmariadbclient-dev"] {os-family = "debian"}
   ["mariadb-devel"] {os-distribution = "centos"}
   ["mariadb-connector-c"] {os = "macos" & os-distribution = "homebrew"}
   ["mariadb-dev"] {os-distribution = "alpine"}

--- a/packages/conf-mpfr/conf-mpfr.1/opam
+++ b/packages/conf-mpfr/conf-mpfr.1/opam
@@ -8,8 +8,7 @@ build: [
   ["cc" "test.c" "-I/usr/local/include" "-L/usr/local/lib" "-lgmp" "-lmpfr"]
 ]
 depexts: [
-  ["libmpfr-dev"] {os-distribution = "debian"}
-  ["libmpfr-dev"] {os-distribution = "ubuntu"}
+  ["libmpfr-dev"] {os-family = "debian"}
   ["mpfr-devel"] {os-distribution = "fedora"}
   ["mpfr"] {os = "macos" & os-distribution = "homebrew"}
   ["mpfr"] {os = "freebsd"}

--- a/packages/conf-mpi/conf-mpi.1/opam
+++ b/packages/conf-mpi/conf-mpi.1/opam
@@ -6,8 +6,7 @@ bug-reports: "mailto:tim@tbrk.org"
 build: [["sh" "configure" os]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["mpi-default-dev"] {os-distribution = "debian"}
-  ["mpi-default-dev"] {os-distribution = "ubuntu"}
+  ["mpi-default-dev"] {os-family = "debian"}
   ["openmpi-devel"] {os-distribution = "centos"}
   ["openmpi-devel"] {os-distribution = "fedora"}
   ["openmpi"] {os-family = "suse"}

--- a/packages/conf-mysql/conf-mysql.1/opam
+++ b/packages/conf-mysql/conf-mysql.1/opam
@@ -7,8 +7,7 @@ dev-repo: "git+https://github.com/mysql/mysql-server.git"
 license: "GPL"
 build: [["mysql_config" "--include"]]
 depexts: [
-  ["libmysqlclient-dev"] {os-distribution = "debian"}
-  ["libmysqlclient-dev"] {os-distribution = "ubuntu"}
+  ["libmysqlclient-dev"] {os-family = "debian"}
   ["mysql-devel"] {os-distribution = "centos"}
   ["mysql-connector-c"] {os = "macos" & os-distribution = "homebrew"}
   ["mariadb-dev"] {os-distribution = "alpine"}

--- a/packages/conf-nanomsg/conf-nanomsg.0/opam
+++ b/packages/conf-nanomsg/conf-nanomsg.0/opam
@@ -5,8 +5,7 @@ homepage: "http://nanomsg.org/"
 license: "MIT/X11"
 build: [["pkg-config" "nanomsg"]]
 depexts: [
-  ["libnanomsg-dev"] {os-distribution = "ubuntu"}
-  ["libnanomsg-dev"] {os-distribution = "debian"}
+  ["libnanomsg-dev"] {os-family = "debian"}
   ["nanomsg"] {os-distribution = "arch"}
   ["nanomsg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -7,8 +7,7 @@ license: "MIT"
 build: ["pkg-config" "ncurses"] {os-distribution != "opensuse"}
 depends: ["conf-pkg-config" {build & os-distribution != "opensuse"}]
 depexts: [
-  ["ncurses-dev"] {os-distribution = "debian"}
-  ["ncurses-dev"] {os-distribution = "ubuntu"}
+  ["ncurses-dev"] {os-family = "debian"}
   ["ncurses"] {os-distribution = "nixos"}
   ["ncurses-dev"] {os-distribution = "alpine"}
   ["ncurses-devel"] {os-distribution = "fedora"}

--- a/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
+++ b/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
@@ -6,8 +6,7 @@ bug-reports: "https://www.github.com/stevebleazard/ocaml-conf-netsnmp/issues"
 license: "MIT"
 dev-repo: "git+https://www.github.com/stevebleazard/ocaml-conf-netsnmp.git"
 depexts: [
-  ["libsnmp-dev"] {os-distribution = "debian"}
-  ["libsnmp-dev"] {os-distribution = "ubuntu"}
+  ["libsnmp-dev"] {os-family = "debian"}
   ["net-snmp-libs" "net-snmp-devel"] {os-distribution = "centos"}
   ["net-snmp-libs" "net-snmp-devel"] {os-distribution = "fedora"}
   ["libsnmp30" "net-snmp-devel"] {os-family = "suse"}

--- a/packages/conf-npm/conf-npm.1/opam
+++ b/packages/conf-npm/conf-npm.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["nodejs"] {os-distribution = "alpine"}
   ["npm"] {os-distribution = "arch"}
   ["npm"] {os-distribution = "centos"}
-  ["npm"] {os-distribution = "debian"}
+  ["npm"] {os-family = "debian"}
   ["npm"] {os-distribution = "fedora"}
   ["npm"] {os = "freebsd"}
   ["nodejs"] {os-distribution = "gentoo"}
@@ -20,7 +20,6 @@ depexts: [
   ["nodejs"] {os = "netbsd"}
   ["node"] {os = "openbsd"}
   ["npm"] {os-family = "suse"}
-  ["npm"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on npm installation"
 flags: conf

--- a/packages/conf-numa/conf-numa.0.1.0/opam
+++ b/packages/conf-numa/conf-numa.0.1.0/opam
@@ -6,8 +6,7 @@ bug-reports: "https://www.github.com/stevebleazard/ocaml-conf-numa/issues"
 license: "MIT"
 dev-repo: "git+https://www.github.com/stevebleazard/ocaml-conf-numa.git"
 depexts: [
-  ["libnuma-dev"] {os-distribution = "debian"}
-  ["libnuma-dev"] {os-distribution = "ubuntu"}
+  ["libnuma-dev"] {os-family = "debian"}
   ["numactl-libs" "numactl-devel"] {os-distribution = "centos"}
   ["numactl-libs" "numactl-devel"] {os-distribution = "fedora"}
   ["libnuma-devel"] {os-family = "suse"}

--- a/packages/conf-ode/conf-ode.1/opam
+++ b/packages/conf-ode/conf-ode.1/opam
@@ -5,9 +5,8 @@ homepage: "http://www.ode.org/"
 license: "BSD-3-Clause, or LGPLv2.1+"
 build: [["pkg-config" "ode"]]
 depexts: [
-  ["libode-dev"] {os-distribution = "debian"}
+  ["libode-dev"] {os-family = "debian"}
   ["libode-devel"] {os-distribution = "mageia"}
-  ["libode-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on a ODE system installation"
 description:

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -16,8 +16,7 @@ build: [
   ] {os = "macos"}
 ]
 depexts: [
-  ["libopenbabel-dev"] {os-distribution = "debian"}
-  ["libopenbabel-dev"] {os-distribution = "ubuntu"}
+  ["libopenbabel-dev"] {os-family = "debian"}
   ["open-babel"] {os = "macos" & os-distribution = "homebrew"}
   ["openbabel-devel"] {os-distribution = "centos"}
 ]

--- a/packages/conf-opencc0/conf-opencc0.1/opam
+++ b/packages/conf-opencc0/conf-opencc0.1/opam
@@ -14,11 +14,9 @@ build: [
 ]
 
 depexts: [
-  ["libopencc1"] {os-distribution = "debian"}
-  ["libopencc1"] {os-distribution = "ubuntu"}
+  ["libopencc1"] {os-family = "debian"}
   ["libopencc1"] {os-family = "suse"}
 ]
-
 post-messages: [
   "If the libopencc0 library is not installed by the system package manager, make sure that the path of the directory containing libopencc.so.1 is included in env-var LD_LIBRARY_PATH(for ld) and LIBRARY_PATH(for cc)" {failure}
 ]

--- a/packages/conf-opencc1/conf-opencc1.1/opam
+++ b/packages/conf-opencc1/conf-opencc1.1/opam
@@ -14,8 +14,7 @@ build: [
 ]
 
 depexts: [
-  ["libopencc2"] {os-distribution = "debian"}
-  ["libopencc2"] {os-distribution = "ubuntu"}
+  ["libopencc2"] {os-family = "debian"}
   ["libopencc2"] {os-family = "suse"}
   ["opencc"] {os-distribution = "arch"}
   ["app-i18n/opencc"] {os-distribution = "gentoo"}
@@ -24,7 +23,6 @@ depexts: [
   ["opencc"] {os = "freebsd"}
   ["opencc"] {os = "macos" & os-distribution = "homebrew"}
 ]
-
 synopsis: "Virtual package relying on opencc v1 (libopencc.so.2) installation"
 description: "This package can install only if the libopencc v1 is available on the system"
 

--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -11,8 +11,7 @@ build: [
 ]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libssl-dev"] {os-distribution = "debian"}
-  ["libssl-dev"] {os-distribution = "ubuntu"}
+  ["libssl-dev"] {os-family = "debian"}
   ["openssl-devel"] {os-distribution = "centos"}
   ["openssl-devel"] {os-distribution = "ol"}
   ["openssl-devel"] {os-distribution = "fedora"}

--- a/packages/conf-pam/conf-pam.1/opam
+++ b/packages/conf-pam/conf-pam.1/opam
@@ -5,8 +5,7 @@ maintainer: "opensource@janestreet.com"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 
 depexts: [
-  ["libpam0g-dev"] {os-distribution = "debian"}
-  ["libpam0g-dev"] {os-distribution = "ubuntu"}
+  ["libpam0g-dev"] {os-family = "debian"}
   ["pam-devel"] {os-distribution = "centos"}
   ["pam-devel"] {os-distribution = "fedora"}
   ["linux-pam-dev"] {os-distribution = "alpine"}

--- a/packages/conf-pandoc/conf-pandoc.0.1/opam
+++ b/packages/conf-pandoc/conf-pandoc.0.1/opam
@@ -7,8 +7,7 @@ license:      "GPL-3"
 build:        ["sh" "-exc" "echo | pandoc"]
 
 depexts: [
-  ["pandoc"] {os-distribution = "debian"}
-  ["pandoc"] {os-distribution = "ubuntu"}
+  ["pandoc"] {os-family = "debian"}
   ["pandoc" "epel-release"] {os-distribution = "centos"}
   ["pandoc"] {os-distribution = "fedora"}
   ["pandoc"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-pango/conf-pango.1/opam
+++ b/packages/conf-pango/conf-pango.1/opam
@@ -9,8 +9,7 @@ license: "LGPL"
 build: [["pkg-config" "pango"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libpango1.0-dev"] {os-distribution = "debian"}
-  ["libpango1.0-dev"] {os-distribution = "ubuntu"}
+  ["libpango1.0-dev"] {os-family = "debian"}
   ["pango"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a Pango system installation"

--- a/packages/conf-perl/conf-perl.1/opam
+++ b/packages/conf-perl/conf-perl.1/opam
@@ -6,8 +6,7 @@ license: "GPL-1+"
 authors: "Larry Wall"
 build: [["perl" "--version"]]
 depexts: [
-  ["perl"] {os-distribution = "debian"}
-  ["perl"] {os-distribution = "ubuntu"}
+  ["perl"] {os-family = "debian"}
   ["perl"] {os-distribution = "alpine"}
   ["perl"] {os-distribution = "nixos"}
   ["perl"] {os-distribution = "arch"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.0/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.0/opam
@@ -8,8 +8,7 @@ build: [
   ["pkg-config" "--help"]
 ]
 depexts: [
-  ["pkg-config"] {os-distribution = "debian"}
-  ["pkg-config"] {os-distribution = "ubuntu"}
+  ["pkg-config"] {os-family = "debian"}
   ["pkg-config"] {os-distribution = "arch"}
   ["pkgconfig"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -17,8 +17,7 @@ post-messages: [
   "conf-pkg-config: A symlink to /usr/local/bin/pkgconf has been installed in the OPAM bin directory (%{bin}%) on your PATH as 'pkg-config'. This is necessary for correct operation." {os = "openbsd"}
 ]
 depexts: [
-  ["pkg-config"] {os-distribution = "debian"}
-  ["pkg-config"] {os-distribution = "ubuntu"}
+  ["pkg-config"] {os-family = "debian"}
   ["pkg-config"] {os-distribution = "arch"}
   ["pkgconfig"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos"}

--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -8,10 +8,9 @@ build: [["pg_config"]]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 
 depexts: [
-  ["libpq-dev"] {os-distribution = "debian"}
+  ["libpq-dev"] {os-family = "debian"}
   ["database/postgresql96-client"] {os-distribution = "freebsd"}
   ["database/postgresql96-client"] {os-distribution = "openbsd"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
@@ -20,7 +19,6 @@ depexts: [
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]
-
 synopsis: "Virtual package relying on a PostgreSQL system installation"
 description:
   "This package can only install if PostgreSQL is installed on the system."

--- a/packages/conf-ppl/conf-ppl.1/opam
+++ b/packages/conf-ppl/conf-ppl.1/opam
@@ -9,8 +9,7 @@ build: [
 	"cc test.c -I/usr/local/include -L/usr/local/lib -lppl_c -lppl" {os = "freebsd" | os = "openbsd"}]
 ]
 depexts: [
-  ["libppl-dev"] {os-distribution = "debian"}
-  ["libppl-dev"] {os-distribution = "ubuntu"}
+  ["libppl-dev"] {os-family = "debian"}
   ["ppl"] {os-distribution = "arch"}
   ["dev-libs/ppl"] {os-distribution = "gentoo"}
   ["libppl" "libppl-devel"] {os-distribution = "centos"}

--- a/packages/conf-python-2-7-dev/conf-python-2-7-dev.1.0/opam
+++ b/packages/conf-python-2-7-dev/conf-python-2-7-dev.1.0/opam
@@ -8,8 +8,7 @@ build: [
   ["cc" "test.c"]
 ]
 depexts: [
-  ["python2.7-dev"] {os-distribution = "debian"}
-  ["python2.7-dev"] {os-distribution = "ubuntu"}
+  ["python2.7-dev"] {os-family = "debian"}
   ["python27"] {os-distribution = "nixos"}
 ]
 synopsis:

--- a/packages/conf-python-2-7/conf-python-2-7.1.0/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.0/opam
@@ -6,8 +6,7 @@ license: "PSF"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: ["python2.7" "test.py"]
 depexts: [
-  ["python2.7"] {os-distribution = "debian"}
-  ["python2.7"] {os-distribution = "ubuntu"}
+  ["python2.7"] {os-family = "debian"}
   ["python27"] {os-distribution = "nixos"}
   ["python"] {os-distribution = "alpine"}
   ["python"] {os-distribution = "centos"}

--- a/packages/conf-python-3-dev/conf-python-3-dev.1/opam
+++ b/packages/conf-python-3-dev/conf-python-3-dev.1/opam
@@ -8,8 +8,7 @@ build: [
   [make]
 ]
 depexts: [
-  ["python3-dev"] {os-distribution = "debian"}
-  ["python3-dev"] {os-distribution = "ubuntu"}
+  ["python3-dev"] {os-family = "debian"}
   ["python3-devel"] {os-distribution = "fedora"}
   ["python3-dev"] {os-distribution = "alpine"}
   ["python3"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-python-3/conf-python-3.1.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.1.0.0/opam
@@ -6,8 +6,7 @@ license: "PSF"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: ["python3" "test.py"]
 depexts: [
-  ["python3"] {os-distribution = "debian"}
-  ["python3"] {os-distribution = "ubuntu"}
+  ["python3"] {os-family = "debian"}
   ["python3"] {os-distribution = "nixos"}
   ["python3"] {os-distribution = "alpine"}
   ["python36" "epel-release"] {os-distribution = "centos"}

--- a/packages/conf-r-mathlib/conf-r-mathlib.1/opam
+++ b/packages/conf-r-mathlib/conf-r-mathlib.1/opam
@@ -6,9 +6,8 @@ license: "GPL"
 build: [["pkg-config" "libRmath"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["r-mathlib"] {os-distribution = "debian"}
+  ["r-mathlib"] {os-family = "debian"}
   ["libRmath-devel"] {os-distribution = "mageia"}
-  ["r-mathlib"] {os-distribution = "ubuntu"}
   ["libRmath-devel"] {os-distribution = "centos"}
   ["libRmath-devel"] {os-distribution = "fedora"}
   ["libRmath-devel"] {os-distribution = "rhel"}

--- a/packages/conf-r/conf-r.1.0.0/opam
+++ b/packages/conf-r/conf-r.1.0.0/opam
@@ -8,8 +8,7 @@ build: ["R" "CMD" "BATCH" "check.r"]
 depexts: [
   ["r"] {os = "macos" & os-distribution = "homebrew"}
   ["r"] {os-distribution = "arch"}
-  ["r-base-core"] {os-distribution = "debian"}
-  ["r-base-core"] {os-distribution = "ubuntu"}
+  ["r-base-core"] {os-family = "debian"}
   ["R-core"] {os-family = "suse"}
   ["R"] {os-distribution = "alpine"}
   ["epel-release" "R"] {os-distribution = "centos"}

--- a/packages/conf-rocksdb/conf-rocksdb.1/opam
+++ b/packages/conf-rocksdb/conf-rocksdb.1/opam
@@ -6,8 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Apache-2.0"
 
 depexts: [
-  ["librocksdb-dev"] {os-distribution = "debian"}
-  ["librocksdb-dev"] {os-distribution = "ubuntu"}
+  ["librocksdb-dev"] {os-family = "debian"}
 ]
 build: [
   ["cc" "-lrocksdb" "main.c"]

--- a/packages/conf-ruby/conf-ruby.1.0.0/opam
+++ b/packages/conf-ruby/conf-ruby.1.0.0/opam
@@ -11,7 +11,7 @@ depexts: [
   ["ruby"] {os-distribution = "alpine"}
   ["ruby"] {os-distribution = "arch"}
   ["ruby"] {os-distribution = "centos"}
-  ["ruby"] {os-distribution = "debian"}
+  ["ruby"] {os-family = "debian"}
   ["ruby"] {os-distribution = "fedora"}
   ["dev-lang/ruby"] {os-distribution = "gentoo"}
   ["ruby"] {os-distribution = "homebrew" & os = "macos"}
@@ -20,7 +20,6 @@ depexts: [
   ["ruby"] {os = "openbsd"}
   ["ruby"] {os-family = "suse"}
   ["ruby"] {os-distribution = "ol"}
-  ["ruby"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on Ruby"
 description:

--- a/packages/conf-rust-2018/conf-rust-2018.1/opam
+++ b/packages/conf-rust-2018/conf-rust-2018.1/opam
@@ -15,8 +15,7 @@ depexts: [
   ["cargo"] {os-distribution = "centos"}
   ["cargo"] {os-distribution = "fedora"}
   ["cargo"] {os-family = "suse"}
-  ["cargo"] {os-distribution = "debian"}
-  ["cargo"] {os-distribution = "ubuntu"}
+  ["cargo"] {os-family = "debian"}
   ["cargo"] {os-distribution = "nixos"}
   ["cargo"] {os-distribution = "alpine"}
   ["rust"] {os-distribution = "arch"}

--- a/packages/conf-rust/conf-rust.0.1/opam
+++ b/packages/conf-rust/conf-rust.0.1/opam
@@ -13,8 +13,7 @@ depexts: [
   ["cargo"] {os-distribution = "centos"}
   ["cargo"] {os-distribution = "fedora"}
   ["cargo"] {os-family = "suse"}
-  ["cargo"] {os-distribution = "debian"}
-  ["cargo"] {os-distribution = "ubuntu"}
+  ["cargo"] {os-family = "debian"}
   ["cargo"] {os-distribution = "nixos"}
   ["cargo"] {os-distribution = "alpine"}
   ["rust"] {os-distribution = "arch"}

--- a/packages/conf-sdl-gfx/conf-sdl-gfx.1/opam
+++ b/packages/conf-sdl-gfx/conf-sdl-gfx.1/opam
@@ -4,8 +4,7 @@ homepage: "http://www.ferzkopp.net/joomla/software-mainmenu-14/4-ferzkopps-linux
 license: "LGPL 2.1"
 build: [["pkg-config" "SDL_gfx"]]
 depexts: [
-  ["libsdl-gfx1.2-dev"] {os-distribution = "debian"}
-  ["libsdl-gfx1.2-dev"] {os-distribution = "ubuntu"}
+  ["libsdl-gfx1.2-dev"] {os-family = "debian"}
   ["libSDL_gfx-devel"] {os-distribution = "mageia"}
   ["sdl_gfx"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-sdl-image/conf-sdl-image.1/opam
+++ b/packages/conf-sdl-image/conf-sdl-image.1/opam
@@ -5,10 +5,9 @@ license: "LGPL 2.1"
 build: [["pkg-config" "SDL_image"]]
 depexts: [
   ["sdl_image-dev"] {os-distribution = "alpine"}
-  ["libsdl-image1.2-dev"] {os-distribution = "debian"}
-  ["libsdl-image1.2-dev"] {os-distribution = "ubuntu"}
+  ["libsdl-image1.2-dev"] {os-family = "debian"}
   ["libSDL_image-devel"] {os-distribution = "mageia"}
-  ["sdl_image"] {os = "macos" & os-distribution = "homebrew"} 
+  ["sdl_image"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a sdl-image system installation"
 description:

--- a/packages/conf-sdl-mixer/conf-sdl-mixer.1/opam
+++ b/packages/conf-sdl-mixer/conf-sdl-mixer.1/opam
@@ -5,8 +5,7 @@ license: "LGPL 2.1"
 build: [["pkg-config" "SDL_mixer"]]
 depexts: [
   ["sdl_mixer-dev"] {os-distribution = "alpine"}
-  ["libsdl-mixer1.2-dev"] {os-distribution = "debian"}
-  ["libsdl-mixer1.2-dev"] {os-distribution = "ubuntu"}
+  ["libsdl-mixer1.2-dev"] {os-family = "debian"}
   ["libSDL_mixer-devel"] {os-distribution = "mageia"}
   ["sdl_mixer"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-sdl-net/conf-sdl-net.1/opam
+++ b/packages/conf-sdl-net/conf-sdl-net.1/opam
@@ -4,8 +4,7 @@ homepage: "http://www.libsdl.org/projects/SDL_net/release-1.2.html"
 license: "Zlib"
 build: [["pkg-config" "SDL_net"]]
 depexts: [
-  ["libsdl-net1.2-dev"] {os-distribution = "debian"}
-  ["libsdl-net1.2-dev"] {os-distribution = "ubuntu"}
+  ["libsdl-net1.2-dev"] {os-family = "debian"}
   ["libSDL_net-devel"] {os-distribution = "mageia"}
   ["sdl_net"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-sdl-ttf/conf-sdl-ttf.1/opam
+++ b/packages/conf-sdl-ttf/conf-sdl-ttf.1/opam
@@ -4,8 +4,7 @@ homepage: "http://www.libsdl.org/projects/SDL_ttf/release-1.2.html"
 license: "LGPL 2.1"
 build: [["pkg-config" "SDL_ttf"]]
 depexts: [
-  ["libsdl-ttf2.0-dev"] {os-distribution = "debian"}
-  ["libsdl-ttf2.0-dev"] {os-distribution = "ubuntu"}
+  ["libsdl-ttf2.0-dev"] {os-family = "debian"}
   ["libSDL_ttf-devel"] {os-distribution = "mageia"}
   ["sdl_ttf"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-sdl2-image/conf-sdl2-image.1/opam
+++ b/packages/conf-sdl2-image/conf-sdl2-image.1/opam
@@ -5,8 +5,7 @@ license: "Zlib"
 build: [["pkg-config" "SDL2_image"]]
 depexts: [
   ["sdl2_image-dev"] {os-distribution = "alpine"}
-  ["libsdl2-image-dev"] {os-distribution = "debian"}
-  ["libsdl2-image-dev"] {os-distribution = "ubuntu"}
+  ["libsdl2-image-dev"] {os-family = "debian"}
   ["libsdl2_image-devel"] {os-distribution = "mageia"}
 ]
 synopsis: "Virtual package relying on a sdl2-image system installation"

--- a/packages/conf-sdl2-mixer/conf-sdl2-mixer.1/opam
+++ b/packages/conf-sdl2-mixer/conf-sdl2-mixer.1/opam
@@ -5,8 +5,7 @@ license: "Zlib"
 build: [["pkg-config" "SDL2_mixer"]]
 depexts: [
   ["sdl2_mixer-dev"] {os-distribution = "alpine"}
-  ["libsdl2-mixer-dev"] {os-distribution = "debian"}
-  ["libsdl2-mixer-dev"] {os-distribution = "ubuntu"}
+  ["libsdl2-mixer-dev"] {os-family = "debian"}
   ["libsdl2_mixer-devel"] {os-distribution = "mageia"}
 ]
 synopsis: "Virtual package relying on a sdl2-mixer system installation"

--- a/packages/conf-sdl2-net/conf-sdl2-net.1/opam
+++ b/packages/conf-sdl2-net/conf-sdl2-net.1/opam
@@ -5,8 +5,7 @@ license: "Zlib"
 build: [["pkg-config" "SDL2_net"]]
 depexts: [
   ["sdl2_net-dev"] {os-distribution = "alpine"}
-  ["libsdl2-net-dev"] {os-distribution = "debian"}
-  ["libsdl2-net-dev"] {os-distribution = "ubuntu"}
+  ["libsdl2-net-dev"] {os-family = "debian"}
   ["libsdl2_net-devel"] {os-distribution = "mageia"}
 ]
 synopsis: "Virtual package relying on a sdl2-net system installation"

--- a/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
+++ b/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
@@ -5,8 +5,7 @@ license: "Zlib"
 build: [["pkg-config" "SDL2_ttf"]]
 depexts: [
   ["sdl2_ttf-dev"] {os-distribution = "alpine"}
-  ["libsdl2-ttf-dev"] {os-distribution = "debian"}
-  ["libsdl2-ttf-dev"] {os-distribution = "ubuntu"}
+  ["libsdl2-ttf-dev"] {os-family = "debian"}
   ["libsdl2_ttf-devel"] {os-distribution = "mageia"}
 ]
 synopsis: "Virtual package relying on a sdl2-ttf system installation"

--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -8,14 +8,13 @@ build: [["pkg-config" "sdl2"]]
 depexts: [
   ["sdl2-dev"] {os-distribution = "alpine"}
   ["sdl2"] {os-distribution = "arch"}
-  ["libsdl2-dev"] {os-distribution = "debian"}
+  ["libsdl2-dev"] {os-family = "debian"}
   ["SDL2-devel"] {os-distribution = "fedora"}
   ["sdl2"] {os = "freebsd"}
   ["sdl2"] {os = "macos" & os-distribution = "homebrew"}
   ["libsdl2-devel"] {os-distribution = "mageia"}
   ["sdl2"] {os = "openbsd"}
   ["sdl2"] {os-family = "suse"}
-  ["libsdl2-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on a SDL2 system installation"
 description:

--- a/packages/conf-sdpa/conf-sdpa.1/opam
+++ b/packages/conf-sdpa/conf-sdpa.1/opam
@@ -4,8 +4,7 @@ authors: "SDPA Project"
 homepage: "http://sdpa.sourceforge.net/"
 build: ["sh" "-exc" "command -v sdpa"]
 depexts: [
-  ["sdpa"] {os-distribution = "debian"}
-  ["sdpa"] {os-distribution = "ubuntu"}
+  ["sdpa"] {os-family = "debian"}
 ]
 synopsis: "Virtual package relying on a SDPA binary system installation"
 description:

--- a/packages/conf-sfml2/conf-sfml2.1/opam
+++ b/packages/conf-sfml2/conf-sfml2.1/opam
@@ -5,9 +5,8 @@ homepage: "http://sfml-dev.org/"
 license: "Zlib"
 build: [["pkg-config" "sfml-all"]]
 depexts: [
-  ["libsfml-dev"] {os-distribution = "debian"}
+  ["libsfml-dev"] {os-family = "debian"}
   ["sfml2-devel"] {os-distribution = "mageia"}
-  ["libsfml-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on a SFML2 system installation"
 description:

--- a/packages/conf-snappy/conf-snappy.1/opam
+++ b/packages/conf-snappy/conf-snappy.1/opam
@@ -6,8 +6,7 @@ build: [
   ["c++" "test.cpp" "-lsnappy"]
 ]
 depexts: [
-  ["libsnappy-dev"] {os-distribution = "debian"}
-  ["libsnappy-dev"] {os-distribution = "ubuntu"}
+  ["libsnappy-dev"] {os-family = "debian"}
   ["snappy"] {os = "macos" & os-distribution = "homebrew"}
   ["snappy-devel"] {os-distribution = "fedora"}
 ]

--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -13,10 +13,9 @@ depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 
 depexts: [
-  ["libsqlite3-dev"] {os-distribution = "debian"}
+  ["libsqlite3-dev"] {os-family = "debian"}
   ["database/sqlite3"] {os = "freebsd"}
   ["database/sqlite3"] {os = "openbsd"}
-  ["libsqlite3-dev"] {os-distribution = "ubuntu"}
   ["sqlite-devel"] {os-distribution = "centos"}
   ["sqlite-devel"] {os-distribution = "rhel"}
   ["sqlite-devel"] {os-distribution = "fedora"}

--- a/packages/conf-tcl/conf-tcl.1/opam
+++ b/packages/conf-tcl/conf-tcl.1/opam
@@ -6,8 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [["sh" "check.sh"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["tcl-dev"] {os-distribution = "debian"}
-  ["tcl-dev"] {os-distribution = "ubuntu"}
+  ["tcl-dev"] {os-family = "debian"}
   ["tcl"] {os-distribution = "nixos"}
   ["tcl-dev"] {os-family = "alpine"}
   ["tcl-devel"] {os-family = "rhel"}

--- a/packages/conf-tidy/conf-tidy.1/opam
+++ b/packages/conf-tidy/conf-tidy.1/opam
@@ -10,17 +10,15 @@ build: [
 ]
 
 depexts: [
-  ["libtidy-dev"] {os-distribution = "debian"}
-  ["libtidy-dev"] {os-distribution = "ubuntu"}
+  ["libtidy-dev"] {os-family = "debian"}
   ["libtidy-devel"] {os-distribution = "opensuse"}
   ["tidy"] {os-distribution = "arch"}
   ["app-text/tidy-html5"] {os-distribution = "gentoo"}
   ["libtidy-devel"] {os-distribution = "fedora"}
   ["libtidy-devel"] {os-distribution = "centos"}
   ["tidy-html5"] {os = "macos" & os-distribution = "homebrew"}
-  ["tidy-html5"] {os = "freebsd" }
+  ["tidy-html5"] {os = "freebsd"}
 ]
-
 synopsis: "Virtual package relying on libtidy installation"
 description: "This package can install only if the libtidy is available on the system"
 

--- a/packages/conf-time/conf-time.1/opam
+++ b/packages/conf-time/conf-time.1/opam
@@ -7,8 +7,7 @@ license: "GPL"
 build: [["which" "time"]]
 depends: ["conf-which" {build}]
 depexts: [
-  ["time"] {os-distribution = "debian"}
-  ["time"] {os-distribution = "ubuntu"}
+  ["time"] {os-family = "debian"}
   ["time"] {os-distribution = "centos"}
   ["time"] {os-distribution = "fedora"}
   ["time"] {os-distribution = "arch"}

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -6,8 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [["sh" "check.sh"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["tk-dev"] {os-distribution = "debian"}
-  ["tk-dev"] {os-distribution = "ubuntu"}
+  ["tk-dev"] {os-family = "debian"}
   ["tk"] {os-distribution = "nixos"}
   ["tk"] {os-family = "alpine"}
   ["tk-dev"] {os-family = "alpine"}

--- a/packages/conf-vim/conf-vim.1/opam
+++ b/packages/conf-vim/conf-vim.1/opam
@@ -5,8 +5,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "charityware"
 build: ["vim" "--version"]
 depexts: [
-  ["vim-nox"] {os-distribution = "debian"}
-  ["vim-nox"] {os-distribution = "ubuntu"}
+  ["vim-nox"] {os-family = "debian"}
   ["vim"] {os-distribution = "centos"}
   ["vim"] {os-distribution = "rhel"}
   ["vim"] {os-distribution = "fedora"}

--- a/packages/conf-wget/conf-wget.1/opam
+++ b/packages/conf-wget/conf-wget.1/opam
@@ -7,8 +7,7 @@ license: "GPL-2+"
 build: [["which" "wget"]]
 depends: ["conf-which" {build}]
 depexts: [
-  ["wget"] {os-distribution = "debian"}
-  ["wget"] {os-distribution = "ubuntu"}
+  ["wget"] {os-family = "debian"}
   ["wget"] {os-distribution = "fedora"}
   ["wget"] {os-distribution = "arch"}
   ["wget"] {os-distribution = "nixos"}

--- a/packages/conf-which/conf-which.1/opam
+++ b/packages/conf-which/conf-which.1/opam
@@ -9,8 +9,7 @@ depexts: [
   ["which"] {os-distribution = "centos"}
   ["which"] {os-distribution = "fedora"}
   ["which"] {os-family = "suse"}
-  ["debianutils"] {os-distribution = "debian"}
-  ["debianutils"] {os-distribution = "ubuntu"}
+  ["debianutils"] {os-family = "debian"}
   ["which"] {os-distribution = "nixos"}
   ["which"] {os-distribution = "arch"}
 ]

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -8,8 +8,7 @@ build: ["pkg-config" "zlib"] {os != "macos"}
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["zlib-dev"] {os-distribution = "alpine"}
-  ["zlib1g-dev"] {os-distribution = "debian"}
-  ["zlib1g-dev"] {os-distribution = "ubuntu"}
+  ["zlib1g-dev"] {os-family = "debian"}
   ["zlib-devel"] {os-distribution = "centos"}
   ["zlib-devel"] {os-distribution = "fedora"}
   ["zlib"] {os-distribution = "nixos"}

--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -8,8 +8,7 @@ build: [
   ["cc" "test.c" "-I/usr/local/include" "-L/usr/local/lib" "-lzmq"]
 ]
 depexts: [
-  ["libzmq3-dev"] {os-distribution = "debian"}
-  ["libzmq3-dev"] {os-distribution = "ubuntu"}
+  ["libzmq3-dev"] {os-family = "debian"}
   ["zeromq"] {os = "macos" & os-distribution = "homebrew"}
   ["zeromq-dev"] {os-distribution = "alpine"}
   ["zeromq-devel"] {os-distribution = "centos"}

--- a/packages/conf-zstd/conf-zstd.0.1/opam
+++ b/packages/conf-zstd/conf-zstd.0.1/opam
@@ -7,8 +7,7 @@ license: "BSD"
 build: [["pkg-config" "libzstd"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libzstd-dev"] {os-distribution = "debian"}
-  ["libzstd-dev"] {os-distribution = "ubuntu"}
+  ["libzstd-dev"] {os-family = "debian"}
   ["libzstd-devel"] {os-distribution = "centos"}
   ["libzstd-devel"] {os-distribution = "rhel"}
   ["libzstd-devel"] {os-distribution = "fedora"}

--- a/packages/conf-zstd/conf-zstd.1.3.8/opam
+++ b/packages/conf-zstd/conf-zstd.1.3.8/opam
@@ -10,8 +10,7 @@ build: [
 ]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libzstd-dev"] {os-distribution = "debian"}
-  ["libzstd-dev"] {os-distribution = "ubuntu"}
+  ["libzstd-dev"] {os-family = "debian"}
   ["libzstd-devel"] {os-distribution = "centos"}
   ["libzstd-devel"] {os-distribution = "rhel"}
   ["libzstd-devel"] {os-distribution = "fedora"}

--- a/packages/cryptokit/cryptokit.1.6/opam
+++ b/packages/cryptokit/cryptokit.1.6/opam
@@ -9,8 +9,7 @@ depends: [
   "num"
 ]
 depexts: [
-  ["zlib1g-dev"] {os-distribution = "debian"}
-  ["zlib1g-dev"] {os-distribution = "ubuntu"}
+  ["zlib1g-dev"] {os-family = "debian"}
   ["zlib-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/cryptokit/cryptokit.1.7/opam
+++ b/packages/cryptokit/cryptokit.1.7/opam
@@ -9,8 +9,7 @@ depends: [
   "num"
 ]
 depexts: [
-  ["zlib1g-dev"] {os-distribution = "debian"}
-  ["zlib1g-dev"] {os-distribution = "ubuntu"}
+  ["zlib1g-dev"] {os-family = "debian"}
   ["zlib-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/cryptokit/cryptokit.1.9/opam
+++ b/packages/cryptokit/cryptokit.1.9/opam
@@ -9,8 +9,7 @@ depends: [
   "num"
 ]
 depexts: [
-  ["zlib1g-dev"] {os-distribution = "debian"}
-  ["zlib1g-dev"] {os-distribution = "ubuntu"}
+  ["zlib1g-dev"] {os-family = "debian"}
   ["zlib-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/ctypes-foreign/ctypes-foreign.0.4.0/opam
+++ b/packages/ctypes-foreign/ctypes-foreign.0.4.0/opam
@@ -5,8 +5,7 @@ homepage: "https://github.com/ocamllabs/ocaml-ctypes"
 dev-repo: "git+http://github.com/ocamllabs/ocaml-ctypes.git"
 bug-reports: "http://github.com/ocamllabs/ocaml-ctypes/issues"
 depexts: [
-  ["libffi-dev"] {os-distribution = "debian"}
-  ["libffi-dev"] {os-distribution = "ubuntu"}
+  ["libffi-dev"] {os-family = "debian"}
   ["libffi"] {os = "macos" & os-distribution = "homebrew"}
   ["libffi"] {os = "macos" & os-distribution = "macports"}
   ["libffi-devel"] {os-distribution = "centos"}

--- a/packages/ctypes/ctypes.0.1.1/opam
+++ b/packages/ctypes/ctypes.0.1.1/opam
@@ -16,8 +16,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libffi-dev"] {os-distribution = "debian"}
-  ["libffi-dev"] {os-distribution = "ubuntu"}
+  ["libffi-dev"] {os-family = "debian"}
   ["libffi"] {os = "macos" & os-distribution = "homebrew"}
   ["libffi"] {os = "macos" & os-distribution = "macports"}
   ["libffi-devel"] {os-distribution = "centos"}

--- a/packages/ctypes/ctypes.0.2.3/opam
+++ b/packages/ctypes/ctypes.0.2.3/opam
@@ -12,8 +12,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libffi-dev"] {os-distribution = "debian"}
-  ["libffi-dev"] {os-distribution = "ubuntu"}
+  ["libffi-dev"] {os-family = "debian"}
   ["libffi"] {os = "macos" & os-distribution = "homebrew"}
   ["libffi"] {os = "macos" & os-distribution = "macports"}
   ["libffi-devel"] {os-distribution = "centos"}

--- a/packages/ctypes/ctypes.0.3.4/opam
+++ b/packages/ctypes/ctypes.0.3.4/opam
@@ -13,8 +13,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libffi-dev"] {os-distribution = "debian"}
-  ["libffi-dev"] {os-distribution = "ubuntu"}
+  ["libffi-dev"] {os-family = "debian"}
   ["libffi"] {os = "macos" & os-distribution = "homebrew"}
   ["libffi"] {os = "macos" & os-distribution = "macports"}
   ["libffi-devel"] {os-distribution = "centos"}

--- a/packages/cubicle/cubicle.1.0/opam
+++ b/packages/cubicle/cubicle.1.0/opam
@@ -17,8 +17,7 @@ depends: [
 ]
 depopts: ["functory"]
 depexts: [
-  ["graphviz"] {os-distribution = "debian"}
-  ["graphviz"] {os-distribution = "ubuntu"}
+  ["graphviz"] {os-family = "debian"}
 ]
 conflicts: [
   "functory" {< "0.5"}

--- a/packages/curses/curses.1.0.3/opam
+++ b/packages/curses/curses.1.0.3/opam
@@ -8,8 +8,7 @@ build: [
 remove: [["ocamlfind" "remove" "curses"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libncurses-dev"] {os-distribution = "ubuntu"}
-  ["libncurses-dev"] {os-distribution = "debian"}
+  ["libncurses-dev"] {os-family = "debian"}
 ]
 install: [make "OCAMLMAKEFILE=OCamlMakefile" "install"]
 synopsis: "Bindings to curses/ncurses"

--- a/packages/dbm/dbm.1.0/opam
+++ b/packages/dbm/dbm.1.0/opam
@@ -15,8 +15,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libgdbm-dev"] {os-distribution = "debian"}
-  ["libgdbm-dev"] {os-distribution = "ubuntu"}
+  ["libgdbm-dev"] {os-family = "debian"}
   ["gdbm"] {os-distribution = "nixos"}
   ["gdbm-devel"] {os-distribution = "centos"}
   ["gdbm-devel"] {os-distribution = "rhel"}

--- a/packages/dbm/dbm.1.1/opam
+++ b/packages/dbm/dbm.1.1/opam
@@ -15,8 +15,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libgdbm-dev"] {os-distribution = "debian"}
-  ["libgdbm-dev"] {os-distribution = "ubuntu"}
+  ["libgdbm-dev"] {os-family = "debian"}
   ["gdbm"] {os-distribution = "nixos"}
   ["gdbm-devel"] {os-distribution = "centos"}
   ["gdbm-devel"] {os-distribution = "rhel"}

--- a/packages/dlm/dlm.0.3.0/opam
+++ b/packages/dlm/dlm.0.3.0/opam
@@ -20,8 +20,7 @@ depends: [
   "uuidm"
 ]
 depexts: [
-  ["libdlm-dev"] {os-distribution = "debian"}
-  ["libdlm-dev"] {os-distribution = "ubuntu"}
+  ["libdlm-dev"] {os-family = "debian"}
   ["dlm-devel"] {os-distribution = "rhel"}
   ["dlm-devel"] {os-distribution = "centos"}
   ["dlm-devel"] {os-distribution = "fedora"}

--- a/packages/dssi/dssi.0.1.2/opam
+++ b/packages/dssi/dssi.0.1.2/opam
@@ -12,8 +12,7 @@ install: [
 remove: ["ocamlfind" "remove" "dssi"]
 depends: ["ocaml" "ocamlfind" "ladspa"]
 depexts: [
-  ["dssi-dev"] {os-distribution = "debian"}
-  ["dssi-dev"] {os-distribution = "ubuntu"}
+  ["dssi-dev"] {os-family = "debian"}
   ["dssi-devel"] {os-distribution = "centos"}
   ["dssi-devel"] {os-distribution = "fedora"}
   ["dssi-devel"] {os-family = "suse"}

--- a/packages/faad/faad.0.3.2/opam
+++ b/packages/faad/faad.0.3.2/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "faad"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libfaad-dev"] {os-distribution = "debian"}
-  ["libfaad-dev"] {os-distribution = "ubuntu"}
+  ["libfaad-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/faad/faad.0.3.3/opam
+++ b/packages/faad/faad.0.3.3/opam
@@ -20,8 +20,7 @@ install: [
 remove: ["ocamlfind" "remove" "faad"]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libfaad-dev"] {os-distribution = "debian"}
-  ["libfaad-dev"] {os-distribution = "ubuntu"}
+  ["libfaad-dev"] {os-family = "debian"}
   ["faad2"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-faad/issues"

--- a/packages/faad/faad.0.4.0/opam
+++ b/packages/faad/faad.0.4.0/opam
@@ -29,8 +29,7 @@ depexts: [
   ["faad2-devel"] {os-distribution = "centos"}
   ["faad2-devel"] {os-distribution = "fedora"}
   ["faad2-devel"] {os-family = "suse"}
-  ["libfaad-dev"] {os-distribution = "debian"}
-  ["libfaad-dev"] {os-distribution = "ubuntu"}
+  ["libfaad-dev"] {os-family = "debian"}
   ["faad2"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-faad/issues"

--- a/packages/farmhash/farmhash.0.3/opam
+++ b/packages/farmhash/farmhash.0.3/opam
@@ -20,8 +20,7 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["g++"] {os-distribution = "debian"}
-  ["g++"] {os-distribution = "ubuntu"}
+  ["g++"] {os-family = "debian"}
   ["gcc-c++"] {os-distribution = "fedora"}
 ]
 synopsis: "Bindings for Google's farmhash library"

--- a/packages/fdkaac/fdkaac.0.2.1/opam
+++ b/packages/fdkaac/fdkaac.0.2.1/opam
@@ -23,8 +23,7 @@ depexts: [
   ["fdk-aac-devel"] {os-distribution = "centos"}
   ["fdk-aac-devel"] {os-distribution = "fedora"}
   ["fdk-aac-devel"] {os-family = "suse"}
-  ["libfdk-aac-dev"] {os-distribution = "debian"}
-  ["libfdk-aac-dev"] {os-distribution = "ubuntu"}
+  ["libfdk-aac-dev"] {os-family = "debian"}
   ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Fraunhofer FDK AAC Codec Library"

--- a/packages/fdkaac/fdkaac.0.3.0/opam
+++ b/packages/fdkaac/fdkaac.0.3.0/opam
@@ -26,8 +26,7 @@ depexts: [
   ["fdk-aac-devel"] {os-distribution = "centos"}
   ["fdk-aac-devel"] {os-distribution = "fedora"}
   ["fdk-aac-devel"] {os-family = "suse"}
-  ["libfdk-aac-dev"] {os-distribution = "debian"}
-  ["libfdk-aac-dev"] {os-distribution = "ubuntu"}
+  ["libfdk-aac-dev"] {os-family = "debian"}
   ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Fraunhofer FDK AAC Codec Library"

--- a/packages/fftw3/fftw3.0.5.3/opam
+++ b/packages/fftw3/fftw3.0.5.3/opam
@@ -23,8 +23,7 @@ depends: [
 ]
 depopts: ["archimedes"]
 depexts: [
-  ["libfftw3-dev"] {os-distribution = "ubuntu"}
-  ["libfftw3-dev"] {os-distribution = "debian"}
+  ["libfftw3-dev"] {os-family = "debian"}
   ["math/fftw3"] {os = "freebsd"}
   ["math/fftw3"] {os = "openbsd"}
 ]

--- a/packages/fftw3/fftw3.0.6/opam
+++ b/packages/fftw3/fftw3.0.6/opam
@@ -26,8 +26,7 @@ depopts: [
   "lacaml"
 ]
 depexts: [
-  ["libfftw3-dev"] {os-distribution = "ubuntu"}
-  ["libfftw3-dev"] {os-distribution = "debian"}
+  ["libfftw3-dev"] {os-family = "debian"}
   ["math/fftw3"] {os = "freebsd"}
   ["math/fftw3"] {os = "openbsd"}
 ]

--- a/packages/fftw3/fftw3.0.7.1/opam
+++ b/packages/fftw3/fftw3.0.7.1/opam
@@ -32,8 +32,7 @@ depends: [
   "lacaml" {with-test}
 ]
 depexts: [
-  ["libfftw3-dev"] {os-distribution = "ubuntu"}
-  ["libfftw3-dev"] {os-distribution = "debian"}
+  ["libfftw3-dev"] {os-family = "debian"}
   ["fftw-devel"] {os-distribution = "centos"}
   ["math/fftw3"] {os = "freebsd"}
   ["math/fftw3"] {os = "openbsd"}

--- a/packages/fftw3/fftw3.0.7.2/opam
+++ b/packages/fftw3/fftw3.0.7.2/opam
@@ -37,8 +37,7 @@ depends: [
   "lacaml" {with-test}
 ]
 depexts: [
-  ["libfftw3-dev"] {os-distribution = "ubuntu"}
-  ["libfftw3-dev"] {os-distribution = "debian"}
+  ["libfftw3-dev"] {os-family = "debian"}
   ["fftw-devel"] {os-distribution = "centos"}
   ["math/fftw3"] {os = "freebsd"}
   ["math/fftw3"] {os = "openbsd"}

--- a/packages/fftw3/fftw3.0.7.3/opam
+++ b/packages/fftw3/fftw3.0.7.3/opam
@@ -54,8 +54,7 @@ depends: [
 ]
 depexts: [
   ["fftw-dev"] {os-distribution = "alpine"}
-  ["libfftw3-dev"] {os-distribution = "ubuntu"}
-  ["libfftw3-dev"] {os-distribution = "debian"}
+  ["libfftw3-dev"] {os-family = "debian"}
   ["fftw-devel"] {os-distribution = "centos"}
   ["math/fftw3"] {os = "freebsd"}
   ["math/fftw3"] {os = "openbsd"}

--- a/packages/fftw3/fftw3.0.7/opam
+++ b/packages/fftw3/fftw3.0.7/opam
@@ -30,8 +30,7 @@ depopts: [
   "lacaml"
 ]
 depexts: [
-  ["libfftw3-dev"] {os-distribution = "ubuntu"}
-  ["libfftw3-dev"] {os-distribution = "debian"}
+  ["libfftw3-dev"] {os-family = "debian"}
   ["math/fftw3"] {os = "freebsd"}
   ["math/fftw3"] {os = "openbsd"}
 ]

--- a/packages/fftw3/fftw3.0.8.1/opam
+++ b/packages/fftw3/fftw3.0.8.1/opam
@@ -32,8 +32,7 @@ depends: [
   "lacaml" {with-test}
 ]
 depexts: [
-  ["libfftw3-dev"] {os-distribution = "ubuntu"}
-  ["libfftw3-dev"] {os-distribution = "debian"}
+  ["libfftw3-dev"] {os-family = "debian"}
   ["fftw-devel"] {os-distribution = "centos"}
   ["fftw-dev"] {os-distribution = "alpine"}
   ["fftw-devel"] {os-distribution = "fedora"}

--- a/packages/fftw3/fftw3.0.8/opam
+++ b/packages/fftw3/fftw3.0.8/opam
@@ -33,8 +33,7 @@ depends: [
   "lacaml" {with-test}
 ]
 depexts: [
-  ["libfftw3-dev"] {os-distribution = "ubuntu"}
-  ["libfftw3-dev"] {os-distribution = "debian"}
+  ["libfftw3-dev"] {os-family = "debian"}
   ["fftw-devel"] {os-distribution = "centos"}
   ["math/fftw3"] {os = "freebsd"}
   ["math/fftw3"] {os = "openbsd"}

--- a/packages/flac/flac.0.1.2/opam
+++ b/packages/flac/flac.0.1.2/opam
@@ -27,8 +27,7 @@ depexts: [
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}
-  ["libflac-dev"] {os-distribution = "debian"}
-  ["libflac-dev"] {os-distribution = "ubuntu"}
+  ["libflac-dev"] {os-family = "debian"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-flac/issues"

--- a/packages/flac/flac.0.1.3/opam
+++ b/packages/flac/flac.0.1.3/opam
@@ -29,8 +29,7 @@ depexts: [
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}
-  ["libflac-dev"] {os-distribution = "debian"}
-  ["libflac-dev"] {os-distribution = "ubuntu"}
+  ["libflac-dev"] {os-family = "debian"}
   ["flac"] {os-distribution = "nixos"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/flac/flac.0.1.4/opam
+++ b/packages/flac/flac.0.1.4/opam
@@ -29,8 +29,7 @@ depexts: [
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}
-  ["libflac-dev"] {os-distribution = "debian"}
-  ["libflac-dev"] {os-distribution = "ubuntu"}
+  ["libflac-dev"] {os-family = "debian"}
   ["flac"] {os-distribution = "nixos"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/flac/flac.0.1.5/opam
+++ b/packages/flac/flac.0.1.5/opam
@@ -30,8 +30,7 @@ depexts: [
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}
-  ["libflac-dev"] {os-distribution = "debian"}
-  ["libflac-dev"] {os-distribution = "ubuntu"}
+  ["libflac-dev"] {os-family = "debian"}
   ["flac"] {os-distribution = "nixos"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/flowtype/flowtype.0.1.0/opam
+++ b/packages/flowtype/flowtype.0.1.0/opam
@@ -12,8 +12,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.10.0/opam
+++ b/packages/flowtype/flowtype.0.10.0/opam
@@ -12,8 +12,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.11.0/opam
+++ b/packages/flowtype/flowtype.0.11.0/opam
@@ -12,8 +12,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.13.1/opam
+++ b/packages/flowtype/flowtype.0.13.1/opam
@@ -13,8 +13,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.14.0/opam
+++ b/packages/flowtype/flowtype.0.14.0/opam
@@ -20,8 +20,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.15.0/opam
+++ b/packages/flowtype/flowtype.0.15.0/opam
@@ -20,8 +20,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.17.0/opam
+++ b/packages/flowtype/flowtype.0.17.0/opam
@@ -20,8 +20,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.19.0/opam
+++ b/packages/flowtype/flowtype.0.19.0/opam
@@ -20,8 +20,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.19.1/opam
+++ b/packages/flowtype/flowtype.0.19.1/opam
@@ -20,8 +20,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.20.0/opam
+++ b/packages/flowtype/flowtype.0.20.0/opam
@@ -20,8 +20,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.20.1/opam
+++ b/packages/flowtype/flowtype.0.20.1/opam
@@ -20,8 +20,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.21.0/opam
+++ b/packages/flowtype/flowtype.0.21.0/opam
@@ -20,8 +20,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.22.0/opam
+++ b/packages/flowtype/flowtype.0.22.0/opam
@@ -21,8 +21,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.22.1/opam
+++ b/packages/flowtype/flowtype.0.22.1/opam
@@ -21,8 +21,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.25.0/opam
+++ b/packages/flowtype/flowtype.0.25.0/opam
@@ -30,8 +30,7 @@ depends: [
 ]
 depexts: [
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
 ]
 post-messages: [
   "This package requires libelf to be installed on your system" {failure}

--- a/packages/flowtype/flowtype.0.26.0/opam
+++ b/packages/flowtype/flowtype.0.26.0/opam
@@ -29,8 +29,7 @@ depends: [
 ]
 depexts: [
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
 ]
 post-messages: [
   "This package requires libelf to be installed on your system" {failure}

--- a/packages/flowtype/flowtype.0.27.0/opam
+++ b/packages/flowtype/flowtype.0.27.0/opam
@@ -22,8 +22,7 @@ depends: [
 available: os != "linux"
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.29.0/opam
+++ b/packages/flowtype/flowtype.0.29.0/opam
@@ -21,8 +21,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.3.0/opam
+++ b/packages/flowtype/flowtype.0.3.0/opam
@@ -12,8 +12,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.30.0/opam
+++ b/packages/flowtype/flowtype.0.30.0/opam
@@ -21,8 +21,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.32.0/opam
+++ b/packages/flowtype/flowtype.0.32.0/opam
@@ -21,8 +21,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.35.0/opam
+++ b/packages/flowtype/flowtype.0.35.0/opam
@@ -21,8 +21,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.36.0/opam
+++ b/packages/flowtype/flowtype.0.36.0/opam
@@ -22,8 +22,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.38.0/opam
+++ b/packages/flowtype/flowtype.0.38.0/opam
@@ -22,8 +22,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.4.0/opam
+++ b/packages/flowtype/flowtype.0.4.0/opam
@@ -12,8 +12,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.40.0/opam
+++ b/packages/flowtype/flowtype.0.40.0/opam
@@ -22,8 +22,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.42.0/opam
+++ b/packages/flowtype/flowtype.0.42.0/opam
@@ -22,8 +22,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.43.0/opam
+++ b/packages/flowtype/flowtype.0.43.0/opam
@@ -22,8 +22,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.44.0/opam
+++ b/packages/flowtype/flowtype.0.44.0/opam
@@ -23,8 +23,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.45.0/opam
+++ b/packages/flowtype/flowtype.0.45.0/opam
@@ -23,8 +23,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.46.0/opam
+++ b/packages/flowtype/flowtype.0.46.0/opam
@@ -23,8 +23,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.47.0/opam
+++ b/packages/flowtype/flowtype.0.47.0/opam
@@ -23,8 +23,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.48.0/opam
+++ b/packages/flowtype/flowtype.0.48.0/opam
@@ -23,8 +23,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.5.0/opam
+++ b/packages/flowtype/flowtype.0.5.0/opam
@@ -12,8 +12,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.6.0/opam
+++ b/packages/flowtype/flowtype.0.6.0/opam
@@ -12,8 +12,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.7.0/opam
+++ b/packages/flowtype/flowtype.0.7.0/opam
@@ -12,8 +12,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.8.0/opam
+++ b/packages/flowtype/flowtype.0.8.0/opam
@@ -12,8 +12,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.9.1/opam
+++ b/packages/flowtype/flowtype.0.9.1/opam
@@ -12,8 +12,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/flowtype/flowtype.0.9.2/opam
+++ b/packages/flowtype/flowtype.0.9.2/opam
@@ -12,8 +12,7 @@ depends: [
 ]
 build: [ [ make ] ]
 depexts: [
-  ["libelf-dev"] {os-distribution = "debian"}
-  ["libelf-dev"] {os-distribution = "ubuntu"}
+  ["libelf-dev"] {os-family = "debian"}
   ["elfutils-libelf-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Flow is a static typechecker for JavaScript."

--- a/packages/freetds/freetds.0.5.2/opam
+++ b/packages/freetds/freetds.0.5.2/opam
@@ -26,9 +26,8 @@ depends: [
 depexts: [
   ["freetds-dev"] {os-distribution = "alpine"}
   ["freetds-devel"] {os-distribution = "centos"}
-  ["freetds-dev"] {os-distribution = "debian"}
+  ["freetds-dev"] {os-family = "debian"}
   ["freetds-devel"] {os-distribution = "fedora"}
-  ["freetds-dev"] {os-distribution = "ubuntu"}
   ["freetds"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Binding to the FreeTDS library"

--- a/packages/freetds/freetds.0.6/opam
+++ b/packages/freetds/freetds.0.6/opam
@@ -30,8 +30,7 @@ depends: [
 depexts: [
   ["freetds-dev"] {os-distribution = "alpine"}
   ["epel-release" "freetds-devel"] {os-distribution = "centos"}
-  ["freetds-dev"] {os-distribution = "debian"}
-  ["freetds-dev"] {os-distribution = "ubuntu"}
+  ["freetds-dev"] {os-family = "debian"}
   ["freetds-dev"] {os-distribution = "alpine"}
   ["freetds-devel"] {os-distribution = "fedora"}
   ["freetds-devel"] {os-distribution = "rhel"}

--- a/packages/freetds/freetds.0.7/opam
+++ b/packages/freetds/freetds.0.7/opam
@@ -27,8 +27,7 @@ depends: [
 depexts: [
   ["freetds-dev"] {os-distribution = "alpine"}
   ["epel-release" "freetds-devel"] {os-distribution = "centos"}
-  ["freetds-dev"] {os-distribution = "debian"}
-  ["freetds-dev"] {os-distribution = "ubuntu"}
+  ["freetds-dev"] {os-family = "debian"}
   ["freetds-dev"] {os-distribution = "alpine"}
   ["freetds-devel"] {os-distribution = "fedora"}
   ["freetds-devel"] {os-distribution = "rhel"}

--- a/packages/frei0r/frei0r.0.1.0/opam
+++ b/packages/frei0r/frei0r.0.1.0/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "frei0r"]]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config"]
 depexts: [
-  ["frei0r-plugins-dev"] {os-distribution = "debian"}
-  ["frei0r-plugins-dev"] {os-distribution = "ubuntu"}
+  ["frei0r-plugins-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Bindings for the frei0r API which provides video effects"

--- a/packages/frei0r/frei0r.0.1.1/opam
+++ b/packages/frei0r/frei0r.0.1.1/opam
@@ -17,8 +17,7 @@ depexts: [
   ["frei0r-devel"] {os-distribution = "fedora"}
   ["frei0r-devel"] {os-family = "suse"}
   ["frei0r"] {os = "macos" & os-distribution = "homebrew"}
-  ["frei0r-plugins-dev"] {os-distribution = "debian"}
-  ["frei0r-plugins-dev"] {os-distribution = "ubuntu"}
+  ["frei0r-plugins-dev"] {os-family = "debian"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-frei0r/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-frei0r.git"

--- a/packages/gammu/gammu.0.9.1/opam
+++ b/packages/gammu/gammu.0.9.1/opam
@@ -20,8 +20,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libgammu-dev"] {os-distribution = "ubuntu"}
-  ["libgammu-dev"] {os-distribution = "debian"}
+  ["libgammu-dev"] {os-family = "debian"}
   ["epel-release" "gammu-devel"] {os-distribution = "centos"}
   ["gammu-devel"] {os-distribution = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}

--- a/packages/gammu/gammu.0.9.2/opam
+++ b/packages/gammu/gammu.0.9.2/opam
@@ -22,8 +22,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libgammu-dev"] {os-distribution = "ubuntu"}
-  ["libgammu-dev"] {os-distribution = "debian"}
+  ["libgammu-dev"] {os-family = "debian"}
   ["epel-release" "gammu-devel"] {os-distribution = "centos"}
   ["gammu-devel"] {os-distribution = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}

--- a/packages/gammu/gammu.0.9.3/opam
+++ b/packages/gammu/gammu.0.9.3/opam
@@ -28,8 +28,7 @@ depopts: [
   "base-unix"
 ]
 depexts: [
-  ["libgammu-dev"] {os-distribution = "ubuntu"}
-  ["libgammu-dev"] {os-distribution = "debian"}
+  ["libgammu-dev"] {os-family = "debian"}
   ["epel-release" "gammu-devel"] {os-distribution = "centos"}
   ["gammu-devel"] {os-distribution = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}

--- a/packages/gammu/gammu.0.9.4/opam
+++ b/packages/gammu/gammu.0.9.4/opam
@@ -24,8 +24,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libgammu-dev"] {os-distribution = "ubuntu"}
-  ["libgammu-dev"] {os-distribution = "debian"}
+  ["libgammu-dev"] {os-family = "debian"}
   ["epel-release" "gammu-devel"] {os-distribution = "centos"}
   ["gammu-devel"] {os-distribution = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}

--- a/packages/gavl/gavl.0.1.5/opam
+++ b/packages/gavl/gavl.0.1.5/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "gavl"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libgavl-dev"] {os-distribution = "debian"}
-  ["libgavl-dev"] {os-distribution = "ubuntu"}
+  ["libgavl-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/gavl/gavl.0.1.6/opam
+++ b/packages/gavl/gavl.0.1.6/opam
@@ -16,8 +16,7 @@ depexts: [
   ["gavl-devel"] {os-distribution = "centos"}
   ["gavl-devel"] {os-distribution = "fedora"}
   ["gavl-devel"] {os-family = "suse"}
-  ["libgavl-dev"] {os-distribution = "debian"}
-  ["libgavl-dev"] {os-distribution = "ubuntu"}
+  ["libgavl-dev"] {os-family = "debian"}
   ["drfill/liquidsoap/libgavl"] {os = "macos" & os-distribution = "homebrew"}
   ["gavl"] {os-distribution = "arch"}
 ]

--- a/packages/gdal/gdal.0.0.1/opam
+++ b/packages/gdal/gdal.0.0.1/opam
@@ -18,8 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgdal-dev"] {os-distribution = "debian"}
-  ["libgdal-dev"] {os-distribution = "ubuntu"}
+  ["libgdal-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-gdal"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/gdal/gdal.0.1.0/opam
+++ b/packages/gdal/gdal.0.1.0/opam
@@ -18,8 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgdal-dev"] {os-distribution = "debian"}
-  ["libgdal-dev"] {os-distribution = "ubuntu"}
+  ["libgdal-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-gdal"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/gdal/gdal.0.1.1/opam
+++ b/packages/gdal/gdal.0.1.1/opam
@@ -18,8 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgdal-dev"] {os-distribution = "debian"}
-  ["libgdal-dev"] {os-distribution = "ubuntu"}
+  ["libgdal-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-gdal"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/gdal/gdal.0.2.0/opam
+++ b/packages/gdal/gdal.0.2.0/opam
@@ -18,8 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgdal-dev"] {os-distribution = "debian"}
-  ["libgdal-dev"] {os-distribution = "ubuntu"}
+  ["libgdal-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-gdal"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/gdal/gdal.0.3.0/opam
+++ b/packages/gdal/gdal.0.3.0/opam
@@ -19,8 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgdal-dev"] {os-distribution = "debian"}
-  ["libgdal-dev"] {os-distribution = "ubuntu"}
+  ["libgdal-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-gdal"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/gdal/gdal.0.4.0/opam
+++ b/packages/gdal/gdal.0.4.0/opam
@@ -19,8 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgdal-dev"] {os-distribution = "debian"}
-  ["libgdal-dev"] {os-distribution = "ubuntu"}
+  ["libgdal-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-gdal"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/gdal/gdal.0.5.0/opam
+++ b/packages/gdal/gdal.0.5.0/opam
@@ -19,8 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgdal-dev"] {os-distribution = "debian"}
-  ["libgdal-dev"] {os-distribution = "ubuntu"}
+  ["libgdal-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-gdal"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/gdal/gdal.0.6.0/opam
+++ b/packages/gdal/gdal.0.6.0/opam
@@ -19,8 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgdal-dev"] {os-distribution = "debian"}
-  ["libgdal-dev"] {os-distribution = "ubuntu"}
+  ["libgdal-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-gdal"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/gdal/gdal.0.6.1/opam
+++ b/packages/gdal/gdal.0.6.1/opam
@@ -19,8 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgdal-dev"] {os-distribution = "debian"}
-  ["libgdal-dev"] {os-distribution = "ubuntu"}
+  ["libgdal-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-gdal"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/gdal/gdal.0.8.0/opam
+++ b/packages/gdal/gdal.0.8.0/opam
@@ -23,8 +23,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgdal-dev"] {os-distribution = "debian"}
-  ["libgdal-dev"] {os-distribution = "ubuntu"}
+  ["libgdal-dev"] {os-family = "debian"}
 ]
 synopsis: "Bindings to the GDAL and OGR libraries"
 flags: light-uninstall

--- a/packages/gdal/gdal.0.9.0/opam
+++ b/packages/gdal/gdal.0.9.0/opam
@@ -23,8 +23,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgdal-dev"] {os-distribution = "debian"}
-  ["libgdal-dev"] {os-distribution = "ubuntu"}
+  ["libgdal-dev"] {os-family = "debian"}
   ["gdal"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Bindings to the GDAL and OGR libraries"

--- a/packages/geoip/geoip.0.0.2/opam
+++ b/packages/geoip/geoip.0.0.2/opam
@@ -18,8 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgeoip-dev"] {os-distribution = "ubuntu"}
-  ["libgeoip-dev"] {os-distribution = "debian"}
+  ["libgeoip-dev"] {os-family = "debian"}
   ["geoip"] {os = "macos" & os-distribution = "homebrew"}
   ["geoip-dev"] {os-distribution = "alpine"}
   ["GeoIP-devel"] {os-distribution = "centos"}

--- a/packages/geoip/geoip.0.0.3/opam
+++ b/packages/geoip/geoip.0.0.3/opam
@@ -18,8 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgeoip-dev"] {os-distribution = "ubuntu"}
-  ["libgeoip-dev"] {os-distribution = "debian"}
+  ["libgeoip-dev"] {os-family = "debian"}
   ["geoip"] {os = "macos" & os-distribution = "homebrew"}
   ["geoip-dev"] {os-distribution = "alpine"}
   ["GeoIP-devel"] {os-distribution = "centos"}

--- a/packages/glMLite/glMLite.0.03.51/opam
+++ b/packages/glMLite/glMLite.0.03.51/opam
@@ -10,8 +10,7 @@ depends: [
 ]
 install: [make "install" "PREFIX=%{lib}%/glMLite"]
 depexts: [
-  ["freeglut3-dev"] {os-distribution = "debian"}
-  ["freeglut3-dev"] {os-distribution = "ubuntu"}
+  ["freeglut3-dev"] {os-family = "debian"}
   ["homebrew/x11/freeglut"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "OpenGL bindings for OCaml"

--- a/packages/gles3/gles3.20160307.alpha/opam
+++ b/packages/gles3/gles3.20160307.alpha/opam
@@ -17,8 +17,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libgles2-mesa-dev"] {os-distribution = "debian"}
-  ["libgles2-mesa-dev"] {os-distribution = "ubuntu"}
+  ["libgles2-mesa-dev"] {os-family = "debian"}
   ["libmesaglesv2_2-devel"] {os-distribution = "mageia"}
   ["mesa-libGLES" "mesa-libGLES-devel"] {os-distribution = "centos"}
   ["mesa-libGLES-devel"] {os-distribution = "fedora"}

--- a/packages/gles3/gles3.20160505.alpha/opam
+++ b/packages/gles3/gles3.20160505.alpha/opam
@@ -18,8 +18,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libgles2-mesa-dev"] {os-distribution = "debian"}
-  ["libgles2-mesa-dev"] {os-distribution = "ubuntu"}
+  ["libgles2-mesa-dev"] {os-family = "debian"}
   ["libmesaglesv2_2-devel"] {os-distribution = "mageia"}
   ["mesa-libGLES" "mesa-libGLES-devel"] {os-distribution = "centos"}
   ["mesa-libGLES-devel"] {os-distribution = "fedora"}

--- a/packages/glpk/glpk.0.1.6/opam
+++ b/packages/glpk/glpk.0.1.6/opam
@@ -4,8 +4,7 @@ build: [make "byte" "opt"]
 remove: [["ocamlfind" "remove" "glpk"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libglpk-dev"] {os-distribution = "debian"}
-  ["libglpk-dev"] {os-distribution = "ubuntu"}
+  ["libglpk-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Bindings for glpk"

--- a/packages/glpk/glpk.0.1.7/opam
+++ b/packages/glpk/glpk.0.1.7/opam
@@ -12,8 +12,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libglpk-dev"] {os-distribution = "debian"}
-  ["libglpk-dev"] {os-distribution = "ubuntu"}
+  ["libglpk-dev"] {os-family = "debian"}
   ["homebrew/science/glpk"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install"]

--- a/packages/glpk/glpk.0.1.8/opam
+++ b/packages/glpk/glpk.0.1.8/opam
@@ -9,8 +9,7 @@ build: [make "byte" "opt"]
 remove: [["ocamlfind" "remove" "glpk"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libglpk-dev"] {os-distribution = "debian"}
-  ["libglpk-dev"] {os-distribution = "ubuntu"}
+  ["libglpk-dev"] {os-family = "debian"}
   ["homebrew/science/glpk"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install"]

--- a/packages/gperftools/gperftools.0.2/opam
+++ b/packages/gperftools/gperftools.0.2/opam
@@ -19,8 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libgoogle-perftools-dev"] {os-distribution = "debian"}
-  ["libgoogle-perftools-dev"] {os-distribution = "ubuntu"}
+  ["libgoogle-perftools-dev"] {os-family = "debian"}
   ["gperftools"] {os-distribution = "homebrew"}
   ["gperftools-devel"] {os-distribution = "centos"}
 ]

--- a/packages/gperftools/gperftools.0.3/opam
+++ b/packages/gperftools/gperftools.0.3/opam
@@ -20,8 +20,7 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["libgoogle-perftools-dev"] {os-distribution = "debian"}
-  ["libgoogle-perftools-dev"] {os-distribution = "ubuntu"}
+  ["libgoogle-perftools-dev"] {os-family = "debian"}
   ["gperftools"] {os-distribution = "homebrew"}
   ["gperftools-devel"] {os-distribution = "centos"}
 ]

--- a/packages/gstreamer/gstreamer.0.2.0/opam
+++ b/packages/gstreamer/gstreamer.0.2.0/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "gstreamer"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libgstreamer0.10-dev"] {os-distribution = "debian"}
-  ["libgstreamer0.10-dev"] {os-distribution = "ubuntu"}
+  ["libgstreamer0.10-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/hdf5/hdf5.0.1.2/opam
+++ b/packages/hdf5/hdf5.0.1.2/opam
@@ -15,8 +15,7 @@ remove: [
   ["ocamlfind" "remove" "hdf5_raw"]
 ]
 depexts: [
-  ["libhdf5-serial-dev"] {os-distribution = "ubuntu"}
-  ["libhdf5-serial-dev"] {os-distribution = "debian"}
+  ["libhdf5-serial-dev"] {os-family = "debian"}
   ["hdf5-dev"] {os-distribution = "alpine"}
   ["epel-release" "hdf5-devel"] {os-distribution = "centos"}
   ["homebrew/science/hdf5"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/hdf5/hdf5.0.1.3/opam
+++ b/packages/hdf5/hdf5.0.1.3/opam
@@ -23,9 +23,8 @@ depends: [
 depexts: [
   ["hdf5-dev"] {os-distribution = "alpine"}
   ["epel-release" "hdf5-devel"] {os-distribution = "centos"}
-  ["libhdf5-serial-dev"] {os-distribution = "debian"}
+  ["libhdf5-serial-dev"] {os-family = "debian"}
   ["homebrew/science/hdf5"] {os-distribution = "homebrew" & os = "macos"}
-  ["libhdf5-serial-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Manages HDF5 files used for storing large amounts of data"
 description:

--- a/packages/hdf5/hdf5.0.1.4/opam
+++ b/packages/hdf5/hdf5.0.1.4/opam
@@ -23,9 +23,8 @@ depends: [
 depexts: [
   ["hdf5"] {os-distribution = "alpine"}
   ["epel-release" "hdf5-devel"] {os-distribution = "centos"}
-  ["libhdf5-serial-dev"] {os-distribution = "debian"}
+  ["libhdf5-serial-dev"] {os-family = "debian"}
   ["homebrew/science/hdf5"] {os-distribution = "homebrew" & os = "macos"}
-  ["libhdf5-serial-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Manages HDF5 files used for storing large amounts of data"
 description:

--- a/packages/hdf5/hdf5.0.1.5/opam
+++ b/packages/hdf5/hdf5.0.1.5/opam
@@ -19,9 +19,8 @@ depends: [
 depexts: [
   ["hdf5"] {os-distribution = "alpine"}
   ["epel-release" "hdf5-devel"] {os-distribution = "centos"}
-  ["libhdf5-dev"] {os-distribution = "debian"}
+  ["libhdf5-dev"] {os-family = "debian"}
   ["hdf5"] {os-distribution = "homebrew"}
-  ["libhdf5-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Manages HDF5 files used for storing large amounts of data"
 description: "The library manages reading and writing to HDF5 files. HDF5 file

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.3/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.3/opam
@@ -19,8 +19,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libzmq3-dev"] {os-distribution = "debian"}
-  ["libzmq3-dev"] {os-distribution = "ubuntu"}
+  ["libzmq3-dev"] {os-family = "debian"}
   ["zeromq3-devel"] {os-distribution = "centos"}
 ]
 dev-repo: "git://github.com/andrewray/iocaml"

--- a/packages/iocaml-kernel/iocaml-kernel.0.4.4/opam
+++ b/packages/iocaml-kernel/iocaml-kernel.0.4.4/opam
@@ -20,8 +20,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libzmq3-dev"] {os-distribution = "debian"}
-  ["libzmq3-dev"] {os-distribution = "ubuntu"}
+  ["libzmq3-dev"] {os-family = "debian"}
   ["zeromq"] {os = "macos" & os-distribution = "homebrew"}
   ["zeromq3-devel"] {os-distribution = "centos"}
 ]

--- a/packages/jemalloc/jemalloc.0.1/opam
+++ b/packages/jemalloc/jemalloc.0.1/opam
@@ -25,8 +25,7 @@ depends: [
 ]
 depexts: [
   ["jemalloc-dev"] {os-distribution = "alpine"}
-  ["libjemalloc-dev"] {os-distribution = "debian"}
-  ["libjemalloc-dev"] {os-distribution = "ubuntu"}
+  ["libjemalloc-dev"] {os-family = "debian"}
   ["jemalloc-devel"] {os-distribution = "fedora"}
   ["jemalloc-devel"] {os-distribution = "mageia"}
   ["jemalloc-devel"] {os-distribution = "rhel"}

--- a/packages/kafka/kafka.0.2/opam
+++ b/packages/kafka/kafka.0.2/opam
@@ -21,8 +21,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["librdkafka-dev"] {os-distribution = "debian"}
-  ["librdkafka-dev"] {os-distribution = "ubuntu"}
+  ["librdkafka-dev"] {os-family = "debian"}
 ]
 synopsis:
   "Bindings for Apache Kafka - high-throughput distributed messaging system"

--- a/packages/kinetic-client/kinetic-client.0.0.1/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.1/opam
@@ -20,8 +20,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["protobuf-compiler"] {os-distribution = "debian"}
-  ["protobuf-compiler"] {os-distribution = "ubuntu"}
+  ["protobuf-compiler"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/CloudFounders/kinetic-ocaml-client"
 synopsis: "Client for Seagate's kinetic drives."

--- a/packages/kinetic-client/kinetic-client.0.0.3/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.3/opam
@@ -20,8 +20,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["protobuf-compiler"] {os-distribution = "debian"}
-  ["protobuf-compiler"] {os-distribution = "ubuntu"}
+  ["protobuf-compiler"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/CloudFounders/kinetic-ocaml-client"
 synopsis: "Client for Seagate's kinetic drives."

--- a/packages/kinetic-client/kinetic-client.0.0.4/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.4/opam
@@ -20,8 +20,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["protobuf-compiler"] {os-distribution = "debian"}
-  ["protobuf-compiler"] {os-distribution = "ubuntu"}
+  ["protobuf-compiler"] {os-family = "debian"}
   ["protobuf"] {os = "macos" & os-distribution = "homebrew"}
 ]
 dev-repo: "git://github.com/CloudFounders/kinetic-ocaml-client"

--- a/packages/kinetic-client/kinetic-client.0.0.5/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.5/opam
@@ -20,8 +20,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["protobuf-compiler"] {os-distribution = "debian"}
-  ["protobuf-compiler"] {os-distribution = "ubuntu"}
+  ["protobuf-compiler"] {os-family = "debian"}
   ["protobuf"] {os = "macos" & os-distribution = "homebrew"}
 ]
 dev-repo: "git://github.com/CloudFounders/kinetic-ocaml-client"

--- a/packages/kinetic-client/kinetic-client.0.0.6/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.6/opam
@@ -21,8 +21,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["protobuf-compiler"] {os-distribution = "debian"}
-  ["protobuf-compiler"] {os-distribution = "ubuntu"}
+  ["protobuf-compiler"] {os-family = "debian"}
   ["protobuf"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Client for Seagate's kinetic drives."

--- a/packages/kinetic-client/kinetic-client.0.0.9/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.9/opam
@@ -25,8 +25,7 @@ depends: [
   "cmdliner"
 ]
 depexts: [
-  ["protobuf-compiler"] {os-distribution = "debian"}
-  ["protobuf-compiler"] {os-distribution = "ubuntu"}
+  ["protobuf-compiler"] {os-family = "debian"}
   ["protobuf-compiler"] {os-distribution = "centos"}
   ["protobuf"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/krb5/krb5.109.38.alpha1/opam
+++ b/packages/krb5/krb5.109.38.alpha1/opam
@@ -11,8 +11,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libkrb5-dev"] {os-distribution = "debian"}
-  ["libkrb5-dev"] {os-distribution = "ubuntu"}
+  ["libkrb5-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Kerberos 5 bindings"

--- a/packages/kyotocabinet/kyotocabinet.0.1/opam
+++ b/packages/kyotocabinet/kyotocabinet.0.1/opam
@@ -24,8 +24,7 @@ depends: [
   "jbuilder" {build}
 ]
 depexts: [
-  ["libkyotocabinet-dev"] {os-distribution = "ubuntu"}
-  ["libkyotocabinet-dev"] {os-distribution = "debian"}
+  ["libkyotocabinet-dev"] {os-family = "debian"}
   ["kyotocabinet-devel"] {os-distribution = "fedora"}
   ["kyoto-cabinet"] {os = "macos" & os-distribution = "homebrew"}
   ["kyotocabinet"] {os = "macos" & os-distribution = "macports"}

--- a/packages/kyotocabinet/kyotocabinet.0.2/opam
+++ b/packages/kyotocabinet/kyotocabinet.0.2/opam
@@ -14,11 +14,10 @@ depends: [
   "jbuilder" {build}
 ]
 depexts: [
-  ["libkyotocabinet-dev"] {os-distribution = "debian"}
+  ["libkyotocabinet-dev"] {os-family = "debian"}
   ["kyotocabinet-devel"] {os-distribution = "fedora"}
   ["kyoto-cabinet"] {os-distribution = "homebrew" & os = "macos"}
   ["kyotocabinet"] {os-distribution = "macports" & os = "macos"}
-  ["libkyotocabinet-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "OCaml bindings for Kyoto Cabinet DBM"
 description: """

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta5/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta5/opam
@@ -28,15 +28,13 @@ depexts: [
   ["gtkspell3-dev"] {os-distribution = "alpine"}
   ["gtkspell3"] {os-distribution = "arch"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
-  ["libgtkspell3-3-dev"] {os-distribution = "debian"}
+  ["libgtkspell3-3-dev"] {os-family = "debian"}
   ["gtkspell3-devel"] {os-distribution = "fedora"}
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse"}
-  ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
   ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]
-
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
@@ -27,15 +27,13 @@ depexts: [
   ["gtkspell3-dev"] {os-distribution = "alpine"}
   ["gtkspell3"] {os-distribution = "archlinux"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
-  ["libgtkspell3-3-dev"] {os-distribution = "debian"}
+  ["libgtkspell3-3-dev"] {os-family = "debian"}
   ["gtkspell3-devel"] {os-distribution = "fedora"}
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse"}
-  ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
   ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]
-
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]

--- a/packages/labrys/labrys.0.1/opam
+++ b/packages/labrys/labrys.0.1/opam
@@ -24,8 +24,7 @@ depends: [
   "craml" {with-test}
 ]
 depexts: [
-  ["libgc-dev"] {os-distribution = "debian"}
-  ["libgc-dev"] {os-distribution = "ubuntu"}
+  ["libgc-dev"] {os-family = "debian"}
   ["gc-devel"] {os-distribution = "centos"}
   ["gc-devel"] {os-distribution = "fedora"}
   ["gc-devel"] {os-family = "suse"}

--- a/packages/ladspa/ladspa.0.1.4/opam
+++ b/packages/ladspa/ladspa.0.1.4/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "ladspa"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["ladspa-sdk"] {os-distribution = "debian"}
-  ["ladspa-sdk"] {os-distribution = "ubuntu"}
+  ["ladspa-sdk"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Bindings for the LADSPA API which provides audio effects"

--- a/packages/ladspa/ladspa.0.1.5/opam
+++ b/packages/ladspa/ladspa.0.1.5/opam
@@ -24,8 +24,7 @@ depexts: [
   ["ladspa-devel"] {os-distribution = "centos"}
   ["ladspa-devel"] {os-distribution = "fedora"}
   ["ladspa-devel"] {os-family = "suse"}
-  ["ladspa-sdk"] {os-distribution = "debian"}
-  ["ladspa-sdk"] {os-distribution = "ubuntu"}
+  ["ladspa-sdk"] {os-family = "debian"}
   ["drfill/liquidsoap/ladspa_header"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/lame/lame.0.3.1/opam
+++ b/packages/lame/lame.0.3.1/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "lame"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libmp3lame-dev"] {os-distribution = "debian"}
-  ["libmp3lame-dev"] {os-distribution = "ubuntu"}
+  ["libmp3lame-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/lame/lame.0.3.3/opam
+++ b/packages/lame/lame.0.3.3/opam
@@ -24,8 +24,7 @@ depexts: [
   ["lame-devel"] {os-distribution = "centos"}
   ["lame-devel"] {os-distribution = "fedora"}
   ["lame-devel"] {os-family = "suse"}
-  ["libmp3lame-dev"] {os-distribution = "debian"}
-  ["libmp3lame-dev"] {os-distribution = "ubuntu"}
+  ["libmp3lame-dev"] {os-family = "debian"}
   ["lame"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-lame/issues"

--- a/packages/lbfgs/lbfgs.0.8.3/opam
+++ b/packages/lbfgs/lbfgs.0.8.3/opam
@@ -25,8 +25,7 @@ patches: [
   "string.patch"
 ]
 depexts: [
-  ["gfortran"] {os-distribution = "debian"}
-  ["gfortran"] {os-distribution = "ubuntu"}
+  ["gfortran"] {os-family = "debian"}
   ["mingw64-x86_64-gcc-fortran"] {os = "cygwin"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/lbfgs/lbfgs.0.8.5/opam
+++ b/packages/lbfgs/lbfgs.0.8.5/opam
@@ -19,8 +19,7 @@ depends: [
 ]
 depopts: ["lacaml"]
 depexts: [
-  ["gfortran"] {os-distribution = "debian"}
-  ["gfortran"] {os-distribution = "ubuntu"}
+  ["gfortran"] {os-family = "debian"}
   ["mingw64-x86_64-gcc-fortran"] {os = "cygwin"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/lbfgs/lbfgs.0.8.6/opam
+++ b/packages/lbfgs/lbfgs.0.8.6/opam
@@ -27,8 +27,7 @@ depopts: [
   "lacaml"
 ]
 depexts: [
-  ["gfortran"] {os-distribution = "debian"}
-  ["gfortran"] {os-distribution = "ubuntu"}
+  ["gfortran"] {os-family = "debian"}
   ["mingw64-x86_64-gcc-fortran"] {os = "cygwin"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/lbfgs/lbfgs.0.8.7/opam
+++ b/packages/lbfgs/lbfgs.0.8.7/opam
@@ -44,8 +44,7 @@ depopts: [
   "lacaml"
 ]
 depexts: [
-  ["gfortran"] {os-distribution = "debian"}
-  ["gfortran"] {os-distribution = "ubuntu"}
+  ["gfortran"] {os-family = "debian"}
   ["mingw64-x86_64-gcc-fortran"] {os = "cygwin"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/lbfgs/lbfgs.0.8.8/opam
+++ b/packages/lbfgs/lbfgs.0.8.8/opam
@@ -42,8 +42,7 @@ depopts: [
   "lacaml"
 ]
 depexts: [
-  ["gfortran"] {os-distribution = "debian"}
-  ["gfortran"] {os-distribution = "ubuntu"}
+  ["gfortran"] {os-family = "debian"}
   ["mingw64-x86_64-gcc-fortran"] {os = "cygwin"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/lbfgs/lbfgs.0.9.1/opam
+++ b/packages/lbfgs/lbfgs.0.9.1/opam
@@ -22,8 +22,7 @@ depends: [
   "lacaml" {with-test}
 ]
 depexts: [
-  ["gfortran"] {os-distribution = "debian"}
-  ["gfortran"] {os-distribution = "ubuntu"}
+  ["gfortran"] {os-family = "debian"}
   ["gfortran"] {os-distribution = "alpine"}
   ["gcc-gfortran"] {os-distribution = "centos"}
   ["gcc-gfortran"] {os-distribution = "fedora"}

--- a/packages/lbfgs/lbfgs.0.9/opam
+++ b/packages/lbfgs/lbfgs.0.9/opam
@@ -25,8 +25,7 @@ depends: [
   "lacaml" {with-test}
 ]
 depexts: [
-  ["gfortran"] {os-distribution = "debian"}
-  ["gfortran"] {os-distribution = "ubuntu"}
+  ["gfortran"] {os-family = "debian"}
   ["gfortran"] {os-distribution = "alpine"}
   ["gcc-gfortran"] {os-distribution = "centos"}
   ["gcc-gfortran"] {os-distribution = "fedora"}

--- a/packages/leveldb/leveldb.1.2.0/opam
+++ b/packages/leveldb/leveldb.1.2.0/opam
@@ -20,8 +20,7 @@ depends: [
   "conf-leveldb"
 ]
 depexts: [
-  ["libsnappy-dev"] {os-distribution = "debian"}
-  ["libsnappy-dev"] {os-distribution = "ubuntu"}
+  ["libsnappy-dev"] {os-family = "debian"}
   ["snappy-devel"] {os-distribution = "centos"}
 ]
 synopsis: "OCaml bindings for Google's LevelDB library."

--- a/packages/libevent/libevent.0.7.0/opam
+++ b/packages/libevent/libevent.0.7.0/opam
@@ -23,9 +23,8 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["libevent-dev"] {os-distribution = "alpine"}
   ["libevent-devel"] {os-distribution = "centos"}
-  ["libevent-dev"] {os-distribution = "debian"}
+  ["libevent-dev"] {os-family = "debian"}
   ["libevent-devel"] {os-distribution = "fedora"}
-  ["libevent-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "OCaml wrapper for the libevent API"
 description: """

--- a/packages/libevent/libevent.0.8.0/opam
+++ b/packages/libevent/libevent.0.8.0/opam
@@ -27,9 +27,8 @@ depends: [
 depexts: [
   ["libevent-dev"] {os-distribution = "alpine"}
   ["libevent-devel"] {os-distribution = "centos"}
-  ["libevent-dev"] {os-distribution = "debian"}
+  ["libevent-dev"] {os-family = "debian"}
   ["libevent-devel"] {os-distribution = "fedora"}
-  ["libevent-dev"] {os-distribution = "ubuntu"}
 ]
 available: os != "macos"
 synopsis: "OCaml wrapper for the libevent API"

--- a/packages/libevent/libevent.0.8.1/opam
+++ b/packages/libevent/libevent.0.8.1/opam
@@ -29,8 +29,7 @@ depends: [
   "ounit" {with-test}
 ]
 depexts: [
-  ["libevent-dev"] {os-distribution = "debian"}
-  ["libevent-dev"] {os-distribution = "ubuntu"}
+  ["libevent-dev"] {os-family = "debian"}
   ["libevent-devel"] {os-distribution = "fedora"}
   ["libevent-devel"] {os-distribution = "centos"}
   ["libevent-dev"] {os-distribution = "alpine"}

--- a/packages/libssh/libssh.0.1/opam
+++ b/packages/libssh/libssh.0.1/opam
@@ -26,9 +26,8 @@ depends: [
 ]
 depexts: [
   ["libssh-devel"] {os-distribution = "centos"}
-  ["libssh-dev"] {os-distribution = "debian"}
+  ["libssh-dev"] {os-family = "debian"}
   ["libssh"] {os-distribution = "homebrew" & os = "macos"}
-  ["libssh-dev"] {os-distribution = "ubuntu"}
 ]
 post-messages: [
   "This package requires libssh https://www.libssh.org on your system"

--- a/packages/libsvm/libsvm.0.8.3/opam
+++ b/packages/libsvm/libsvm.0.8.3/opam
@@ -24,8 +24,7 @@ patches: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 depexts: [
-  ["libsvm-dev"] {os-distribution = "ubuntu"}
-  ["libsvm-dev"] {os-distribution = "debian"}
+  ["libsvm-dev"] {os-family = "debian"}
 ]
 synopsis: "LIBSVM bindings"
 description:

--- a/packages/libsvm/libsvm.0.9.0/opam
+++ b/packages/libsvm/libsvm.0.9.0/opam
@@ -22,8 +22,7 @@ conflicts: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 depexts: [
-  ["libsvm-dev"] {os-distribution = "ubuntu"}
-  ["libsvm-dev"] {os-distribution = "debian"}
+  ["libsvm-dev"] {os-family = "debian"}
 ]
 synopsis: "LIBSVM Bindings for OCaml"
 description: """

--- a/packages/libsvm/libsvm.0.9.1/opam
+++ b/packages/libsvm/libsvm.0.9.1/opam
@@ -21,8 +21,7 @@ conflicts: [
   "sexplib" {>= "113.24.00"}
 ]
 depexts: [
-  ["libsvm-dev"] {os-distribution = "ubuntu"}
-  ["libsvm-dev"] {os-distribution = "debian"}
+  ["libsvm-dev"] {os-family = "debian"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "LIBSVM Bindings for OCaml"

--- a/packages/libsvm/libsvm.0.9.2/opam
+++ b/packages/libsvm/libsvm.0.9.2/opam
@@ -24,8 +24,7 @@ conflicts: [
   "sexplib" {>= "113.24.00"}
 ]
 depexts: [
-  ["libsvm-dev"] {os-distribution = "ubuntu"}
-  ["libsvm-dev"] {os-distribution = "debian"}
+  ["libsvm-dev"] {os-family = "debian"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "LIBSVM Bindings for OCaml"

--- a/packages/libsvm/libsvm.0.9.3/opam
+++ b/packages/libsvm/libsvm.0.9.3/opam
@@ -33,8 +33,7 @@ depopts: [
 ]
 available: os != "macos"
 depexts: [
-  ["libsvm-dev"] {os-distribution = "ubuntu"}
-  ["libsvm-dev"] {os-distribution = "debian"}
+  ["libsvm-dev"] {os-family = "debian"}
 ]
 synopsis: "LIBSVM bindings for OCaml"
 description: """

--- a/packages/libvirt/libvirt.0.6.1.2/opam
+++ b/packages/libvirt/libvirt.0.6.1.2/opam
@@ -24,8 +24,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libvirt-dev"] {os-distribution = "debian"}
-  ["libvirt-dev"] {os-distribution = "ubuntu"}
+  ["libvirt-dev"] {os-family = "debian"}
   ["libvirt"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install-opt"]

--- a/packages/libvirt/libvirt.0.6.1.4/opam
+++ b/packages/libvirt/libvirt.0.6.1.4/opam
@@ -27,8 +27,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libvirt-dev"] {os-distribution = "debian"}
-  ["libvirt-dev"] {os-distribution = "ubuntu"}
+  ["libvirt-dev"] {os-family = "debian"}
   ["libvirt"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis:

--- a/packages/lmdb/lmdb.0.1/opam
+++ b/packages/lmdb/lmdb.0.1/opam
@@ -26,8 +26,7 @@ depends: [
 ]
 
 depexts: [
-  ["liblmdb-dev"] {os-distribution = "debian"}
-  ["liblmdb-dev"] {os-distribution = "ubuntu"}
+  ["liblmdb-dev"] {os-family = "debian"}
   ["lmdb"] {os = "macos" & os-distribution = "homebrew"}
   ["lmdb"] {os = "macos" & os-distribution = "macports"}
   ["lmdb-devel"] {os-distribution = "fedora"}

--- a/packages/lo/lo.0.1.0/opam
+++ b/packages/lo/lo.0.1.0/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "lo"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["liblo-dev"] {os-distribution = "ubuntu"}
-  ["liblo-dev"] {os-distribution = "debian"}
+  ["liblo-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/lo/lo.0.1.1/opam
+++ b/packages/lo/lo.0.1.1/opam
@@ -20,8 +20,7 @@ install: [
 remove: ["ocamlfind" "remove" "lo"]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["liblo-dev"] {os-distribution = "ubuntu"}
-  ["liblo-dev"] {os-distribution = "debian"}
+  ["liblo-dev"] {os-family = "debian"}
   ["liblo"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-lo/issues"

--- a/packages/lo/lo.0.1.2/opam
+++ b/packages/lo/lo.0.1.2/opam
@@ -19,8 +19,7 @@ install: [
 ]
 depends: ["ocaml" "ocamlfind" {build}]
 depexts: [
-  ["liblo-dev"] {os-distribution = "ubuntu"}
-  ["liblo-dev"] {os-distribution = "debian"}
+  ["liblo-dev"] {os-family = "debian"}
   ["liblo"] {os = "macos" & os-distribution = "homebrew"}
   ["liblo-dev"] {os-distribution = "alpine"}
   ["liblo"] {os-distribution = "arch"}

--- a/packages/lwt-zmq/lwt-zmq.1.0-beta3/opam
+++ b/packages/lwt-zmq/lwt-zmq.1.0-beta3/opam
@@ -15,8 +15,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libzmq-dev"] {os-distribution = "debian"}
-  ["libzmq-dev"] {os-distribution = "ubuntu"}
+  ["libzmq-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/lwt-zmq"
 install: [make "install"]

--- a/packages/lwt-zmq/lwt-zmq.1.0-beta4/opam
+++ b/packages/lwt-zmq/lwt-zmq.1.0-beta4/opam
@@ -11,8 +11,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libzmq-dev"] {os-distribution = "debian"}
-  ["libzmq-dev"] {os-distribution = "ubuntu"}
+  ["libzmq-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/lwt-zmq"
 install: [make "install"]

--- a/packages/lzo/lzo.0.0.1/opam
+++ b/packages/lzo/lzo.0.0.1/opam
@@ -23,8 +23,7 @@ depends: [
   "base-bytes"
 ]
 depexts: [
-  ["liblzo2-dev"] {os-distribution = "debian"}
-  ["liblzo2-dev"] {os-distribution = "ubuntu"}
+  ["liblzo2-dev"] {os-family = "debian"}
   ["lzo"] {os-distribution = "homebrew"}
   ["lzo-dev"] {os-distribution = "alpine"}
   ["lzo-devel"] {os-distribution = "centos"}

--- a/packages/lzo/lzo.0.0.2/opam
+++ b/packages/lzo/lzo.0.0.2/opam
@@ -23,8 +23,7 @@ depends: [
   "base-bytes"
 ]
 depexts: [
-  ["liblzo2-dev"] {os-distribution = "debian"}
-  ["liblzo2-dev"] {os-distribution = "ubuntu"}
+  ["liblzo2-dev"] {os-family = "debian"}
   ["lzo"] {os-distribution = "homebrew"}
   ["lzo-dev"] {os-distribution = "alpine"}
   ["lzo-devel"] {os-distribution = "centos"}

--- a/packages/mad/mad.0.4.4/opam
+++ b/packages/mad/mad.0.4.4/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "mad"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libmad0-dev"] {os-distribution = "debian"}
-  ["libmad0-dev"] {os-distribution = "ubuntu"}
+  ["libmad0-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/mad/mad.0.4.5/opam
+++ b/packages/mad/mad.0.4.5/opam
@@ -17,8 +17,7 @@ depexts: [
   ["libmad-devel"] {os-distribution = "centos"}
   ["libmad-devel"] {os-distribution = "fedora"}
   ["libmad-devel"] {os-family = "suse"}
-  ["libmad0-dev"] {os-distribution = "debian"}
-  ["libmad0-dev"] {os-distribution = "ubuntu"}
+  ["libmad0-dev"] {os-family = "debian"}
   ["libmad"] {os-distribution = "nixos"}
   ["mad"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/magic/magic.0.7.3/opam
+++ b/packages/magic/magic.0.7.3/opam
@@ -14,8 +14,7 @@ depexts: [
   ["file-devel"] {os-distribution = "centos"}
   ["file-devel"] {os-distribution = "fedora"}
   ["file-devel"] {os-family = "suse"}
-  ["libmagic-dev"] {os-distribution = "debian"}
-  ["libmagic-dev"] {os-distribution = "ubuntu"}
+  ["libmagic-dev"] {os-family = "debian"}
   ["libmagic"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install"]

--- a/packages/milter/milter.1.0.0/opam
+++ b/packages/milter/milter.1.0.0/opam
@@ -14,8 +14,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libmilter-dev"] {os-distribution = "debian"}
-  ["libmilter-dev"] {os-distribution = "ubuntu"}
+  ["libmilter-dev"] {os-family = "debian"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml libmilter bindings"

--- a/packages/milter/milter.1.0.1/opam
+++ b/packages/milter/milter.1.0.1/opam
@@ -15,8 +15,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libmilter-dev"] {os-distribution = "debian"}
-  ["libmilter-dev"] {os-distribution = "ubuntu"}
+  ["libmilter-dev"] {os-family = "debian"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml libmilter bindings"

--- a/packages/milter/milter.1.0.2/opam
+++ b/packages/milter/milter.1.0.2/opam
@@ -18,8 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libmilter-dev"] {os-distribution = "debian"}
-  ["libmilter-dev"] {os-distribution = "ubuntu"}
+  ["libmilter-dev"] {os-family = "debian"}
 ]
 synopsis: "OCaml libmilter bindings"
 description: """

--- a/packages/milter/milter.1.0.4/opam
+++ b/packages/milter/milter.1.0.4/opam
@@ -18,11 +18,10 @@ depexts: [
   ["libmilter"] {os = "freebsd"}
   ["libmilter"] {os-distribution = "gentoo"}
   ["libmilter"] {os-distribution = "macports"}
-  ["libmilter-dev"] {os-distribution = "debian"}
+  ["libmilter-dev"] {os-family = "debian"}
   ["sendmail-devel"] {os-distribution = "mageia"}
   ["sendmail-devel"] {os-family = "suse"}
   ["libmilter"] {os = "netbsd"}
-  ["libmilter-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "OCaml libmilter bindings"
 description: """

--- a/packages/mindstorm/mindstorm.0.5.3/opam
+++ b/packages/mindstorm/mindstorm.0.5.3/opam
@@ -28,8 +28,7 @@ depopts: [
   "base-threads"
 ]
 depexts: [
-  ["libbluetooth-dev"] {os-distribution = "debian"}
-  ["libbluetooth-dev"] {os-distribution = "ubuntu"}
+  ["libbluetooth-dev"] {os-family = "debian"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Drive Lego Mindstorm bricks from OCaml"

--- a/packages/mindstorm/mindstorm.0.5.4/opam
+++ b/packages/mindstorm/mindstorm.0.5.4/opam
@@ -31,8 +31,7 @@ depopts: [
   "base-threads"
 ]
 depexts: [
-  ["libbluetooth-dev"] {os-distribution = "debian"}
-  ["libbluetooth-dev"] {os-distribution = "ubuntu"}
+  ["libbluetooth-dev"] {os-family = "debian"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Drive Lego Mindstorms bricks from OCaml"

--- a/packages/mindstorm/mindstorm.0.6.1/opam
+++ b/packages/mindstorm/mindstorm.0.6.1/opam
@@ -31,8 +31,7 @@ depends: [
   "ocamlfind" {build & >= "1.5"}
 ]
 depexts: [
-  ["libbluetooth-dev"] {os-distribution = "debian"}
-  ["libbluetooth-dev"] {os-distribution = "ubuntu"}
+  ["libbluetooth-dev"] {os-family = "debian"}
 ]
 synopsis: "Drive Lego Mindstorms bricks from OCaml"
 description: """

--- a/packages/mindstorm/mindstorm.0.6/opam
+++ b/packages/mindstorm/mindstorm.0.6/opam
@@ -31,8 +31,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libbluetooth-dev"] {os-distribution = "debian"}
-  ["libbluetooth-dev"] {os-distribution = "ubuntu"}
+  ["libbluetooth-dev"] {os-family = "debian"}
 ]
 synopsis: "Drive Lego Mindstorms bricks from OCaml"
 description: """

--- a/packages/mirage-block-unix/mirage-block-unix.2.10.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.10.0/opam
@@ -32,8 +32,7 @@ depends: [
   "ppx_type_conv" {with-test}
 ]
 depexts: [
-  ["linux-libc-dev"] {os-distribution = "debian"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["linux-glibc-devel"] {os-family = "suse"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["kernel-headers"] {os-distribution = "centos"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.4/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.4/opam
@@ -28,8 +28,7 @@ depends: [
   "fmt" {with-test}
 ]
 depexts: [
-  ["linux-libc-dev"] {os-distribution = "debian"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["linux-glibc-devel"] {os-family = "suse"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["kernel-headers"] {os-distribution = "centos"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.9.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.9.0/opam
@@ -28,8 +28,7 @@ depends: [
   "fmt" {with-test}
 ]
 depexts: [
-  ["linux-libc-dev"] {os-distribution = "debian"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["linux-glibc-devel"] {os-family = "suse"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["kernel-headers"] {os-distribution = "centos"}

--- a/packages/misuja/misuja.0.0.0/opam
+++ b/packages/misuja/misuja.0.0.0/opam
@@ -14,8 +14,7 @@ depends: [
   "base-unix"
 ]
 depexts: [
-  ["libjack-jackd2-dev"] {os-distribution = "ubuntu"}
-  ["libjack-jackd2-dev"] {os-distribution = "debian"}
+  ["libjack-jackd2-dev"] {os-family = "debian"}
   ["jack-dev"] {os-distribution = "alpine"}
   ["jack-audio-connection-kit-devel"] {os-distribution = "fedora"}
   ["epel-release" "jack-audio-connection-kit-devel"]

--- a/packages/mldonkey/mldonkey.3.1.5/opam
+++ b/packages/mldonkey/mldonkey.3.1.5/opam
@@ -12,8 +12,7 @@ depends: [
   "num"
 ]
 depexts: [
-  ["zlib1g-dev"] {os-distribution = "ubuntu"}
-  ["zlib1g-dev"] {os-distribution = "debian"}
+  ["zlib1g-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Cross-platform multi-network peer-to-peer daemon"

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -22,8 +22,7 @@ depends: [
   "oasis"
 ]
 depexts: [
-  ["libmpfr-dev"] {os-distribution = "ubuntu"}
-  ["libmpfr-dev"] {os-distribution = "debian"}
+  ["libmpfr-dev"] {os-family = "debian"}
 ]
 post-messages: [
   "Make sure you had MPFR version 3.1.6 installed on your system.

--- a/packages/mlmpfr/mlmpfr.4.0.0/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.0/opam
@@ -22,8 +22,7 @@ depends: [
   "oasis"
 ]
 depexts: [
-  ["libmpfr-dev"] {os-distribution = "ubuntu"}
-  ["libmpfr-dev"] {os-distribution = "debian"}
+  ["libmpfr-dev"] {os-family = "debian"}
 ]
 post-messages: [
   "Make sure you had MPFR version 4.0.0 installed on your system." {failure}

--- a/packages/mlmpfr/mlmpfr.4.0.1/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.1/opam
@@ -22,8 +22,7 @@ depends: [
   "oasis"
 ]
 depexts: [
-  ["libmpfr-dev"] {os-distribution = "ubuntu"}
-  ["libmpfr-dev"] {os-distribution = "debian"}
+  ["libmpfr-dev"] {os-family = "debian"}
 ]
 post-messages: [
   "Make sure you had MPFR version 4.0.1 installed on your system." {failure}

--- a/packages/mlmpfr/mlmpfr.4.0.2/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.2/opam
@@ -22,8 +22,7 @@ depends: [
   "oasis"
 ]
 depexts: [
-  ["libmpfr-dev"] {os-distribution = "ubuntu"}
-  ["libmpfr-dev"] {os-distribution = "debian"}
+  ["libmpfr-dev"] {os-family = "debian"}
 ]
 post-messages: [
   "Make sure you had MPFR version 4.0.2 installed on your system." {failure}

--- a/packages/mysql/mysql.1.0.4/opam
+++ b/packages/mysql/mysql.1.0.4/opam
@@ -17,8 +17,7 @@ depends: [
   "camlp4"
 ]
 depexts: [
-  ["libmysqlclient-dev"] {os-distribution = "debian"}
-  ["libmysqlclient-dev"] {os-distribution = "ubuntu"}
+  ["libmysqlclient-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Provides access to mysql databases"

--- a/packages/mysql/mysql.1.1.1/opam
+++ b/packages/mysql/mysql.1.1.1/opam
@@ -19,8 +19,7 @@ depends: [
   "camlp4"
 ]
 depexts: [
-  ["libmysqlclient-dev"] {os-distribution = "debian"}
-  ["libmysqlclient-dev"] {os-distribution = "ubuntu"}
+  ["libmysqlclient-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Provides access to mysql databases"

--- a/packages/mysql/mysql.1.1.2/opam
+++ b/packages/mysql/mysql.1.1.2/opam
@@ -21,8 +21,7 @@ depends: [
   "camlp4"
 ]
 depexts: [
-  ["libmysqlclient-dev"] {os-distribution = "debian"}
-  ["libmysqlclient-dev"] {os-distribution = "ubuntu"}
+  ["libmysqlclient-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Bindings to libmysqlclient for interacting with mysql databases"

--- a/packages/mysql/mysql.1.1.3/opam
+++ b/packages/mysql/mysql.1.1.3/opam
@@ -29,8 +29,7 @@ depends: [
   "camlp4"
 ]
 depexts: [
-  ["libmysqlclient-dev"] {os-distribution = "debian"}
-  ["libmysqlclient-dev"] {os-distribution = "ubuntu"}
+  ["libmysqlclient-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Bindings to libmysqlclient for interacting with mysql databases"

--- a/packages/mysql/mysql.1.2.0/opam
+++ b/packages/mysql/mysql.1.2.0/opam
@@ -20,8 +20,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libmysqlclient-dev"] {os-distribution = "debian"}
-  ["libmysqlclient-dev"] {os-distribution = "ubuntu"}
+  ["libmysqlclient-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Bindings to libmysqlclient for interacting with mysql databases"

--- a/packages/nlopt-ocaml/nlopt-ocaml.0.4/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.4/opam
@@ -15,8 +15,7 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["libnlopt-dev"] {os-distribution = "debian"}
-  ["libnlopt-dev"] {os-distribution = "ubuntu"}
+  ["libnlopt-dev"] {os-family = "debian"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml bindings to the NLOpt optimization library"

--- a/packages/nlopt-ocaml/nlopt-ocaml.0.5/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.5/opam
@@ -15,8 +15,7 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["libnlopt-dev"] {os-distribution = "debian"}
-  ["libnlopt-dev"] {os-distribution = "ubuntu"}
+  ["libnlopt-dev"] {os-family = "debian"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml bindings to the NLOpt optimization library"

--- a/packages/ocaml-buddy/ocaml-buddy.0.6.1/opam
+++ b/packages/ocaml-buddy/ocaml-buddy.0.6.1/opam
@@ -11,8 +11,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libbdd-dev"] {os-distribution = "debian"}
-  ["libbdd-dev"] {os-distribution = "ubuntu"}
+  ["libbdd-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/abate/ocaml-buddy"
 install: [make "install"]

--- a/packages/ocaml-expat/ocaml-expat.0.9.1/opam
+++ b/packages/ocaml-expat/ocaml-expat.0.9.1/opam
@@ -12,8 +12,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libexpat1-dev"] {os-distribution = "debian"}
-  ["libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libexpat1-dev"] {os-family = "debian"}
   ["expat"] {os = "macos" & os-distribution = "homebrew"}
 ]
 patches: [ "Makefile.patch" ]

--- a/packages/ocaml-expat/ocaml-expat.1.0.0/opam
+++ b/packages/ocaml-expat/ocaml-expat.1.0.0/opam
@@ -14,8 +14,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libexpat1-dev"] {os-distribution = "debian"}
-  ["libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libexpat1-dev"] {os-family = "debian"}
   ["expat"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install"]

--- a/packages/ocaml-expat/ocaml-expat.1.1.0/opam
+++ b/packages/ocaml-expat/ocaml-expat.1.1.0/opam
@@ -14,8 +14,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libexpat1-dev"] {os-distribution = "debian"}
-  ["libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libexpat1-dev"] {os-family = "debian"}
   ["expat"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install"]

--- a/packages/ocaml-lua/ocaml-lua.1.0/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.0/opam
@@ -22,8 +22,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["liblua5.1-0-dev"] {os-distribution = "debian"}
-  ["liblua5.1-0-dev"] {os-distribution = "ubuntu"}
+  ["liblua5.1-0-dev"] {os-family = "debian"}
   ["lua-dev"] {os-distribution = "alpine"}
   ["lua51-devel"] {os-family = "suse"}
 ]

--- a/packages/ocaml-lua/ocaml-lua.1.1/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.1/opam
@@ -32,8 +32,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["liblua5.1-0-dev"] {os-distribution = "debian"}
-  ["liblua5.1-0-dev"] {os-distribution = "ubuntu"}
+  ["liblua5.1-0-dev"] {os-family = "debian"}
   ["lua-dev"] {os-distribution = "alpine"}
   ["lua51-devel"] {os-family = "suse"}
 ]

--- a/packages/ocaml-lua/ocaml-lua.1.2/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.2/opam
@@ -32,8 +32,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["liblua5.1-0-dev"] {os-distribution = "debian"}
-  ["liblua5.1-0-dev"] {os-distribution = "ubuntu"}
+  ["liblua5.1-0-dev"] {os-family = "debian"}
   ["lua-dev"] {os-distribution = "alpine"}
   ["lua51-devel"] {os-family = "suse"}
 ]

--- a/packages/ocaml-lua/ocaml-lua.1.3/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.3/opam
@@ -32,8 +32,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["liblua5.1-0-dev"] {os-distribution = "debian"}
-  ["liblua5.1-0-dev"] {os-distribution = "ubuntu"}
+  ["liblua5.1-0-dev"] {os-family = "debian"}
   ["compat-lua-devel"] {os-distribution = "fedora"}
   ["lua-devel"] {os-distribution = "centos"}
   ["lua-dev"] {os-distribution = "alpine"}

--- a/packages/ocaml-lua/ocaml-lua.1.4/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.4/opam
@@ -32,8 +32,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["liblua5.1-0-dev"] {os-distribution = "debian"}
-  ["liblua5.1-0-dev"] {os-distribution = "ubuntu"}
+  ["liblua5.1-0-dev"] {os-family = "debian"}
   ["compat-lua-devel"] {os-distribution = "fedora"}
   ["lua-devel"] {os-distribution = "centos"}
   ["lua51"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ocaml-lua/ocaml-lua.1.5/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.5/opam
@@ -32,8 +32,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["liblua5.1-0-dev"] {os-distribution = "debian"}
-  ["liblua5.1-0-dev"] {os-distribution = "ubuntu"}
+  ["liblua5.1-0-dev"] {os-family = "debian"}
   ["compat-lua-devel"] {os-distribution = "fedora"}
   ["lua-devel"] {os-distribution = "centos"}
   ["lua51"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ocaml-lua/ocaml-lua.1.6/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.6/opam
@@ -32,8 +32,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["liblua5.1-0-dev"] {os-distribution = "debian"}
-  ["liblua5.1-0-dev"] {os-distribution = "ubuntu"}
+  ["liblua5.1-0-dev"] {os-family = "debian"}
   ["compat-lua-devel"] {os-distribution = "fedora"}
   ["lua-devel"] {os-distribution = "centos"}
   ["lua51"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ocaml-lua/ocaml-lua.1.7/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.7/opam
@@ -32,8 +32,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["liblua5.1-0-dev"] {os-distribution = "debian"}
-  ["liblua5.1-0-dev"] {os-distribution = "ubuntu"}
+  ["liblua5.1-0-dev"] {os-family = "debian"}
   ["compat-lua-devel"] {os-distribution = "fedora"}
   ["lua-devel"] {os-distribution = "centos"}
   ["lua51"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ocaml-r/ocaml-r.0.0.1/opam
+++ b/packages/ocaml-r/ocaml-r.0.0.1/opam
@@ -27,8 +27,7 @@ depends: [
   "menhir"
 ]
 depexts: [
-  ["r-mathlib"] {os-distribution = "debian"}
-  ["r-mathlib"] {os-distribution = "ubuntu"}
+  ["r-mathlib"] {os-family = "debian"}
   ["R"] {os-distribution = "alpine"}
   ["epel-release" "R"] {os-distribution = "centos"}
 ]

--- a/packages/ocaml-systemd/ocaml-systemd.1.1/opam
+++ b/packages/ocaml-systemd/ocaml-systemd.1.1/opam
@@ -17,8 +17,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libsystemd-dev"] {os-distribution = "debian"}
-  ["libsystemd-dev"] {os-distribution = "ubuntu"}
+  ["libsystemd-dev"] {os-family = "debian"}
   ["systemd-devel"] {os-distribution = "centos"}
 ]
 synopsis: "OCaml module for native access to the systemd facilities"

--- a/packages/ocaml-systemd/ocaml-systemd.1.2/opam
+++ b/packages/ocaml-systemd/ocaml-systemd.1.2/opam
@@ -17,8 +17,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libsystemd-dev"] {os-distribution = "debian"}
-  ["libsystemd-dev"] {os-distribution = "ubuntu"}
+  ["libsystemd-dev"] {os-family = "debian"}
   ["systemd-devel"] {os-distribution = "centos"}
   ["systemd-devel"] {os-distribution = "fedora"}
 ]

--- a/packages/ocaml-zmq/ocaml-zmq.0/opam
+++ b/packages/ocaml-zmq/ocaml-zmq.0/opam
@@ -8,8 +8,7 @@ build: [
 remove: [["ocamlfind" "remove" "ZMQ"]]
 depends: ["ocaml" "ocamlfind" "ounit" "uint"]
 depexts: [
-  ["libzmq3-dev"] {os-distribution = "debian"}
-  ["libzmq3-dev"] {os-distribution = "ubuntu"}
+  ["libzmq3-dev"] {os-family = "debian"}
   ["zeromq-devel"] {os-distribution = "centos"}
   ["zeromq-devel"] {os-distribution = "rhel"}
 ]

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs/opam
@@ -18,8 +18,7 @@ depends: [
   "camlidl"
 ]
 depexts: [
-  ["libfuse-dev"] {os-distribution = "debian"}
-  ["libfuse-dev"] {os-distribution = "ubuntu"}
+  ["libfuse-dev"] {os-family = "debian"}
 ]
 available: os != "macos"
 synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs2/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs2/opam
@@ -21,8 +21,7 @@ depends: [
   "camlidl"
 ]
 depexts: [
-  ["libfuse-dev"] {os-distribution = "debian"}
-  ["libfuse-dev"] {os-distribution = "ubuntu"}
+  ["libfuse-dev"] {os-family = "debian"}
 ]
 available: os != "macos"
 synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs3/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs3/opam
@@ -22,8 +22,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libfuse-dev"] {os-distribution = "debian"}
-  ["libfuse-dev"] {os-distribution = "ubuntu"}
+  ["libfuse-dev"] {os-family = "debian"}
 ]
 available: os != "macos"
 synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs4/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs4/opam
@@ -22,8 +22,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libfuse-dev"] {os-distribution = "debian"}
-  ["libfuse-dev"] {os-distribution = "ubuntu"}
+  ["libfuse-dev"] {os-family = "debian"}
   ["fuse-dev"] {os-distribution = "alpine"}
   ["fuse-devel"] {os-distribution = "centos"}
   ["fuse-devel"] {os-distribution = "fedora"}

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs5/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs5/opam
@@ -22,8 +22,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libfuse-dev"] {os-distribution = "debian"}
-  ["libfuse-dev"] {os-distribution = "ubuntu"}
+  ["libfuse-dev"] {os-family = "debian"}
   ["fuse-dev"] {os-distribution = "alpine"}
   ["fuse-devel"] {os-distribution = "centos"}
   ["fuse-devel"] {os-distribution = "fedora"}

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs6/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs6/opam
@@ -17,8 +17,7 @@ depends: [
   "dune" {build}
 ]
 depexts: [
-  ["libfuse-dev"] {os-distribution = "debian"}
-  ["libfuse-dev"] {os-distribution = "ubuntu"}
+  ["libfuse-dev"] {os-family = "debian"}
   ["fuse-dev"] {os-distribution = "alpine"}
   ["fuse-devel"] {os-distribution = "centos"}
   ["fuse-devel"] {os-distribution = "fedora"}

--- a/packages/ocamlsdl/ocamlsdl.0.9.1/opam
+++ b/packages/ocamlsdl/ocamlsdl.0.9.1/opam
@@ -18,8 +18,7 @@ depopts: [
   "conf-sdl-ttf"
 ]
 depexts: [
-  ["libsdl1.2-dev"] {os-distribution = "debian"}
-  ["libsdl1.2-dev"] {os-distribution = "ubuntu"}
+  ["libsdl1.2-dev"] {os-family = "debian"}
   ["sdl"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install"]

--- a/packages/ocsigen-start/ocsigen-start.1.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.0.0/opam
@@ -18,13 +18,9 @@ depends: [
   "yojson"
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["npm"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Skeleton for building client-server Eliom applications"

--- a/packages/ocsigen-start/ocsigen-start.1.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.0/opam
@@ -22,15 +22,10 @@ depends: [
   "js_of_ocaml" {< "3.3.0"}
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
-  ["npm"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
+  ["postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Skeleton for building client-server Eliom applications"

--- a/packages/ocsigen-start/ocsigen-start.1.2.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.2.0/opam
@@ -24,15 +24,10 @@ depends: [
   "resource-pooling" {>= "0.5.2"}
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
-  ["npm"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
+  ["postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {

--- a/packages/ocsigen-start/ocsigen-start.1.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.3.0/opam
@@ -24,15 +24,10 @@ depends: [
   "resource-pooling" {>= "0.5.2"}
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
-  ["npm"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
+  ["postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {

--- a/packages/ocsigen-start/ocsigen-start.1.4.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.4.0/opam
@@ -24,15 +24,10 @@ depends: [
   "resource-pooling" {>= "0.5.2"}
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
-  ["npm"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
+  ["postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {

--- a/packages/ocsigen-start/ocsigen-start.1.5.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.5.0/opam
@@ -24,15 +24,10 @@ depends: [
   "resource-pooling" {>= "0.5.2"}
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
-  ["npm"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
+  ["postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {

--- a/packages/ocsigen-start/ocsigen-start.1.6.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.6.0/opam
@@ -23,15 +23,10 @@ depends: [
   "resource-pooling" {>= "0.5.2"}
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
-  ["npm"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
+  ["postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {

--- a/packages/ocsigen-start/ocsigen-start.1.7.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.7.0/opam
@@ -23,15 +23,10 @@ depends: [
   "resource-pooling" {>= "0.5.2"}
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
-  ["npm"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
+  ["postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {

--- a/packages/ocsigen-start/ocsigen-start.1.8.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.8.0/opam
@@ -23,15 +23,10 @@ depends: [
   "resource-pooling" {>= "0.5.2"}
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
-  ["npm"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
+  ["postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {

--- a/packages/ocurl/ocurl.0.5.4/opam
+++ b/packages/ocurl/ocurl.0.5.4/opam
@@ -10,8 +10,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libcurl4-gnutls-dev"] {os-distribution = "debian"}
-  ["libcurl4-gnutls-dev"] {os-distribution = "ubuntu"}
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/ocurl/ocurl.0.5.5/opam
+++ b/packages/ocurl/ocurl.0.5.5/opam
@@ -10,8 +10,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libcurl4-gnutls-dev"] {os-distribution = "debian"}
-  ["libcurl4-gnutls-dev"] {os-distribution = "ubuntu"}
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/ocurl/ocurl.0.5.6/opam
+++ b/packages/ocurl/ocurl.0.5.6/opam
@@ -10,8 +10,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libcurl4-gnutls-dev"] {os-distribution = "debian"}
-  ["libcurl4-gnutls-dev"] {os-distribution = "ubuntu"}
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/ocurl/ocurl.0.6.0/opam
+++ b/packages/ocurl/ocurl.0.6.0/opam
@@ -11,8 +11,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libcurl4-gnutls-dev"] {os-distribution = "debian"}
-  ["libcurl4-gnutls-dev"] {os-distribution = "ubuntu"}
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Bindings to libcurl"

--- a/packages/ocurl/ocurl.0.6.1/opam
+++ b/packages/ocurl/ocurl.0.6.1/opam
@@ -11,8 +11,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libcurl4-gnutls-dev"] {os-distribution = "debian"}
-  ["libcurl4-gnutls-dev"] {os-distribution = "ubuntu"}
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/ocurl/ocurl.0.7.0/opam
+++ b/packages/ocurl/ocurl.0.7.0/opam
@@ -16,8 +16,7 @@ depends: [
 ]
 depopts: ["lwt"]
 depexts: [
-  ["libcurl4-gnutls-dev"] {os-distribution = "debian"}
-  ["libcurl4-gnutls-dev"] {os-distribution = "ubuntu"}
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/ocurl/ocurl.0.7.1/opam
+++ b/packages/ocurl/ocurl.0.7.1/opam
@@ -21,8 +21,7 @@ conflicts: [
   "lwt" {>= "4.0.0"}
 ]
 depexts: [
-  ["libcurl4-gnutls-dev"] {os-distribution = "debian"}
-  ["libcurl4-gnutls-dev"] {os-distribution = "ubuntu"}
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
 ]
 install: [make "install"]

--- a/packages/ocurl/ocurl.0.7.2/opam
+++ b/packages/ocurl/ocurl.0.7.2/opam
@@ -26,8 +26,7 @@ conflicts: [
   "lwt" {>= "4.0.0"}
 ]
 depexts: [
-  ["libcurl4-gnutls-dev"] {os-distribution = "debian"}
-  ["libcurl4-gnutls-dev"] {os-distribution = "ubuntu"}
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
 ]
 synopsis: "Bindings to libcurl"

--- a/packages/odbc/odbc.3.0/opam
+++ b/packages/odbc/odbc.3.0/opam
@@ -15,8 +15,7 @@ remove: [
 ]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["unixodbc-dev"] {os-distribution = "ubuntu"}
-  ["unixodbc-dev"] {os-distribution = "debian"}
+  ["unixodbc-dev"] {os-family = "debian"}
   ["unixodbc"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "findlib_install"]

--- a/packages/ogg/ogg.0.4.3/opam
+++ b/packages/ogg/ogg.0.4.3/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "ogg"]]
 depends: ["ocaml" {< "4.06.0"} "ocamlfind" "conf-pkg-config" {build}]
 depexts: [
-  ["libogg-dev"] {os-distribution = "ubuntu"}
-  ["libogg-dev"] {os-distribution = "debian"}
+  ["libogg-dev"] {os-family = "debian"}
   ["libogg"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install"]

--- a/packages/ogg/ogg.0.5.0/opam
+++ b/packages/ogg/ogg.0.5.0/opam
@@ -14,8 +14,7 @@ depends: ["ocaml" {< "4.06.0"} "ocamlfind" "conf-pkg-config" {build}]
 depexts: [
   ["libogg-dev"] {os-distribution = "alpine"}
   ["libogg"] {os-distribution = "arch"}
-  ["libogg-dev"] {os-distribution = "debian"}
-  ["libogg-dev"] {os-distribution = "ubuntu"}
+  ["libogg-dev"] {os-family = "debian"}
   ["libogg-devel"] {os-distribution = "centos"}
   ["libogg-devel"] {os-distribution = "fedora"}
   ["libogg-devel"] {os-family = "suse"}

--- a/packages/ogg/ogg.0.5.1/opam
+++ b/packages/ogg/ogg.0.5.1/opam
@@ -14,8 +14,7 @@ depends: ["ocaml" {< "4.06.0"} "ocamlfind" "conf-pkg-config" {build}]
 depexts: [
   ["libogg-dev"] {os-distribution = "alpine"}
   ["libogg"] {os-distribution = "arch"}
-  ["libogg-dev"] {os-distribution = "debian"}
-  ["libogg-dev"] {os-distribution = "ubuntu"}
+  ["libogg-dev"] {os-family = "debian"}
   ["libogg-devel"] {os-distribution = "centos"}
   ["libogg-devel"] {os-distribution = "fedora"}
   ["libogg-devel"] {os-family = "suse"}

--- a/packages/ogg/ogg.0.5.2/opam
+++ b/packages/ogg/ogg.0.5.2/opam
@@ -18,8 +18,7 @@ depends: [
 depexts: [
   ["libogg-dev"] {os-distribution = "alpine"}
   ["libogg"] {os-distribution = "arch"}
-  ["libogg-dev"] {os-distribution = "debian"}
-  ["libogg-dev"] {os-distribution = "ubuntu"}
+  ["libogg-dev"] {os-family = "debian"}
   ["libogg-devel"] {os-distribution = "centos"}
   ["libogg-devel"] {os-distribution = "fedora"}
   ["libogg-devel"] {os-family = "suse"}

--- a/packages/opencc/opencc.0.4.3-0.1.1/opam
+++ b/packages/opencc/opencc.0.4.3-0.1.1/opam
@@ -21,8 +21,7 @@ depends: [
   "ctypes-foreign"
 ]
 depexts: [
-  ["libopencc-dev"] {os-distribution = "debian"}
-  ["libopencc-dev"] {os-distribution = "ubuntu"}
+  ["libopencc-dev"] {os-family = "debian"}
   ["opencc"] {os-distribution = "arch"}
 ]
 post-messages: [

--- a/packages/opus/opus.0.1.2/opam
+++ b/packages/opus/opus.0.1.2/opam
@@ -18,8 +18,7 @@ depends: [
 depexts: [
   ["opus-dev"] {os-distribution = "alpine"}
   ["opus"] {os-distribution = "arch"}
-  ["libopus-dev"] {os-distribution = "debian"}
-  ["libopus-dev"] {os-distribution = "ubuntu"}
+  ["libopus-dev"] {os-family = "debian"}
   ["opus-devel"] {os-distribution = "centos"}
   ["opus-devel"] {os-distribution = "fedora"}
   ["opus-devel"] {os-family = "suse"}

--- a/packages/oqamldebug/oqamldebug.0.9.1/opam
+++ b/packages/oqamldebug/oqamldebug.0.9.1/opam
@@ -16,8 +16,7 @@ remove: [
   [make "uninstall"]
 ]
 depexts: [
-  ["qt4-qmake"] {os-distribution = "debian"}
-  ["qt4-qmake"] {os-distribution = "ubuntu"}
+  ["qt4-qmake"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Graphical front-end to ocamldebug"

--- a/packages/oqamldebug/oqamldebug.0.9.2/opam
+++ b/packages/oqamldebug/oqamldebug.0.9.2/opam
@@ -16,8 +16,7 @@ remove: [
   [make "uninstall"]
 ]
 depexts: [
-  ["qt4-qmake"] {os-distribution = "debian"}
-  ["qt4-qmake"] {os-distribution = "ubuntu"}
+  ["qt4-qmake"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Graphical front-end to ocamldebug"

--- a/packages/ordma/ordma.0.0.1/opam
+++ b/packages/ordma/ordma.0.0.1/opam
@@ -15,8 +15,7 @@ depends: [
   "lwt" {>= "2.5.1" & < "4.0.0"}
 ]
 depexts: [
-  ["librdmacm-dev"] {os-distribution = "ubuntu"}
-  ["librdmacm-dev"] {os-distribution = "debian"}
+  ["librdmacm-dev"] {os-family = "debian"}
 ]
 available: os = "linux"
 synopsis: "ordma provides ocaml bindings to librdmacm (rsocket)"

--- a/packages/ordma/ordma.0.0.2/opam
+++ b/packages/ordma/ordma.0.0.2/opam
@@ -20,8 +20,7 @@ depends: [
 ]
 available: os = "linux"
 depexts: [
-  ["librdmacm-dev"] {os-distribution = "ubuntu"}
-  ["librdmacm-dev"] {os-distribution = "debian"}
+  ["librdmacm-dev"] {os-family = "debian"}
 ]
 synopsis: "ordma provides ocaml bindings to librdmacm (rsocket)"
 url {

--- a/packages/papi/papi.0.1.1/opam
+++ b/packages/papi/papi.0.1.1/opam
@@ -17,12 +17,10 @@ depends: [
   "fmt" {with-test} ]
 
 depexts: [
-  ["libpapi-dev"] {os-distribution = "debian"}
-  ["libpapi-dev"] {os-distribution = "ubuntu"}
+  ["libpapi-dev"] {os-family = "debian"}
   ["papi-devel"] {os-distribution = "centos"}
   ["papi"] {os-distribution = "arch"}
 ]
-
 description: """
 Papi provides OCaml bindings to PAPI, a C library for portable access to
 hardware performance counters.

--- a/packages/parmap/parmap.1.0-rc1/opam
+++ b/packages/parmap/parmap.1.0-rc1/opam
@@ -30,8 +30,7 @@ depends: [
   "conf-aclocal"
 ]
 depexts: [
-  ["autoconf"] {os-distribution = "ubuntu"}
-  ["autoconf"] {os-distribution = "debian"}
+  ["autoconf"] {os-family = "debian"}
 ]
 synopsis: "Minimalistic library allowing to exploit multicore architecture"
 description: """

--- a/packages/parmap/parmap.1.0-rc2/opam
+++ b/packages/parmap/parmap.1.0-rc2/opam
@@ -30,8 +30,7 @@ depends: [
   "conf-aclocal"
 ]
 depexts: [
-  ["autoconf"] {os-distribution = "ubuntu"}
-  ["autoconf"] {os-distribution = "debian"}
+  ["autoconf"] {os-family = "debian"}
 ]
 synopsis: "Minimalistic library allowing to exploit multicore architecture"
 description: """

--- a/packages/parmap/parmap.1.0-rc3/opam
+++ b/packages/parmap/parmap.1.0-rc3/opam
@@ -30,8 +30,7 @@ depends: [
   "conf-aclocal"
 ]
 depexts: [
-  ["autoconf"] {os-distribution = "ubuntu"}
-  ["autoconf"] {os-distribution = "debian"}
+  ["autoconf"] {os-family = "debian"}
 ]
 synopsis: "Minimalistic library allowing to exploit multicore architecture"
 description: """

--- a/packages/pci/pci.0.2.0/opam
+++ b/packages/pci/pci.0.2.0/opam
@@ -21,8 +21,7 @@ depends: [
 ]
 available: os = "linux"
 depexts: [
-  ["libpci-dev"] {os-distribution = "debian"}
-  ["libpci-dev"] {os-distribution = "ubuntu"}
+  ["libpci-dev"] {os-family = "debian"}
   ["pciutils-devel"] {os-distribution = "centos"}
 ]
 post-messages: [

--- a/packages/perf/perf.1.0/opam
+++ b/packages/perf/perf.1.0/opam
@@ -11,8 +11,7 @@ build: [
 ]
 available: [ os = "linux" ]
 depexts: [
-  ["linux-libc-dev"] {os-distribution = "debian"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+  ["linux-libc-dev"] {os-family = "debian"}
 ]
 remove: [ "ocamlfind" "remove" "perf" ]
 depends: [

--- a/packages/plasma/plasma.0.6.1/opam
+++ b/packages/plasma/plasma.0.6.1/opam
@@ -15,8 +15,7 @@ depends: [
   "xstrp4"
 ]
 depexts: [
-  ["libpq-dev"] {os-distribution = "debian"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
+  ["libpq-dev"] {os-family = "debian"}
 ]
 install: ["omake" "install"]
 synopsis: "Distributed filesystem for large files, implemented in user space"

--- a/packages/plasma/plasma.0.6.2/opam
+++ b/packages/plasma/plasma.0.6.2/opam
@@ -15,8 +15,7 @@ depends: [
   "xstrp4"
 ]
 depexts: [
-  ["libpq-dev"] {os-distribution = "debian"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
+  ["libpq-dev"] {os-family = "debian"}
 ]
 install: ["omake" "install"]
 synopsis: "Distributed filesystem for large files, implemented in user space"

--- a/packages/portaudio/portaudio.0.2.1/opam
+++ b/packages/portaudio/portaudio.0.2.1/opam
@@ -14,8 +14,7 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["portaudio-dev"] {os-distribution = "alpine"}
   ["portaudio"] {os = "macos" & os-distribution = "homebrew"}
-  ["portaudio19-dev"] {os-distribution = "debian"}
-  ["portaudio19-dev"] {os-distribution = "ubuntu"}
+  ["portaudio19-dev"] {os-family = "debian"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-portaudio/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-portaudio.git"

--- a/packages/portia/portia.0.1/opam
+++ b/packages/portia/portia.0.1/opam
@@ -18,8 +18,7 @@ depends: [
   "batteries"
 ]
 depexts: [
-  ["asciidoc"] {os-distribution = "debian"}
-  ["asciidoc"] {os-distribution = "ubuntu"}
+  ["asciidoc"] {os-family = "debian"}
 ]
 post-messages: [
   "This package requires asciidoc to build the doc." {failure}

--- a/packages/portia/portia.1.0/opam
+++ b/packages/portia/portia.1.0/opam
@@ -18,8 +18,7 @@ depends: [
   "batteries"
 ]
 depexts: [
-  ["asciidoc"] {os-distribution = "debian"}
-  ["asciidoc"] {os-distribution = "ubuntu"}
+  ["asciidoc"] {os-family = "debian"}
 ]
 post-messages: [
   "This package requires asciidoc to build the doc." {failure}

--- a/packages/portia/portia.1.1/opam
+++ b/packages/portia/portia.1.1/opam
@@ -21,8 +21,7 @@ depends: [
   "qtest" {with-test}
 ]
 depexts: [
-  ["asciidoc"] {os-distribution = "debian"}
-  ["asciidoc"] {os-distribution = "ubuntu"}
+  ["asciidoc"] {os-family = "debian"}
 ]
 post-messages: [
   "This package requires asciidoc to build the doc." {failure}

--- a/packages/postgresql/postgresql.3.2.1/opam
+++ b/packages/postgresql/postgresql.3.2.1/opam
@@ -45,8 +45,7 @@ depopts: [
   "lablgtk"
 ]
 depexts: [
-  ["libpq-dev"] {os-distribution = "debian"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
+  ["libpq-dev"] {os-family = "debian"}
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-libs"] {os-distribution = "arch"}
   ["postgresql-dev"] {os-distribution = "alpine"}

--- a/packages/postgresql/postgresql.4.0.0/opam
+++ b/packages/postgresql/postgresql.4.0.0/opam
@@ -45,8 +45,7 @@ depopts: [
   "lablgtk" {build}
 ]
 depexts: [
-  ["libpq-dev"] {os-distribution = "debian"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
+  ["libpq-dev"] {os-family = "debian"}
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-libs"] {os-distribution = "arch"}
   ["postgresql-dev"] {os-distribution = "alpine"}

--- a/packages/postgresql/postgresql.4.0.1/opam
+++ b/packages/postgresql/postgresql.4.0.1/opam
@@ -45,8 +45,7 @@ depopts: [
   "lablgtk" {build}
 ]
 depexts: [
-  ["libpq-dev"] {os-distribution = "debian"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
+  ["libpq-dev"] {os-family = "debian"}
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-libs"] {os-distribution = "arch"}
   ["postgresql-dev"] {os-distribution = "alpine"}

--- a/packages/postgresql/postgresql.4.1.0/opam
+++ b/packages/postgresql/postgresql.4.1.0/opam
@@ -26,10 +26,9 @@ depends: [
 ]
 depexts: [
   ["postgresql-libs"] {os-distribution = "arch"}
-  ["libpq-dev"] {os-distribution = "debian"}
+  ["libpq-dev"] {os-family = "debian"}
   ["database/postgresql96-client"] {os = "freebsd"}
   ["database/postgresql96-client"] {os = "openbsd"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}

--- a/packages/postgresql/postgresql.4.2.0/opam
+++ b/packages/postgresql/postgresql.4.2.0/opam
@@ -26,10 +26,9 @@ depends: [
 ]
 depexts: [
   ["postgresql-libs"] {os-distribution = "arch"}
-  ["libpq-dev"] {os-distribution = "debian"}
+  ["libpq-dev"] {os-family = "debian"}
   ["database/postgresql96-client"] {os = "freebsd"}
   ["database/postgresql96-client"] {os = "openbsd"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}

--- a/packages/postgresql/postgresql.4.2.1/opam
+++ b/packages/postgresql/postgresql.4.2.1/opam
@@ -26,10 +26,9 @@ depends: [
 ]
 depexts: [
   ["postgresql-libs"] {os-distribution = "arch"}
-  ["libpq-dev"] {os-distribution = "debian"}
+  ["libpq-dev"] {os-family = "debian"}
   ["database/postgresql96-client"] {os = "freebsd"}
   ["database/postgresql96-client"] {os = "openbsd"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}

--- a/packages/postgresql/postgresql.4.3.0/opam
+++ b/packages/postgresql/postgresql.4.3.0/opam
@@ -26,10 +26,9 @@ depends: [
 ]
 depexts: [
   ["postgresql-libs"] {os-distribution = "arch"}
-  ["libpq-dev"] {os-distribution = "debian"}
+  ["libpq-dev"] {os-family = "debian"}
   ["database/postgresql96-client"] {os = "freebsd"}
   ["database/postgresql96-client"] {os = "openbsd"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}

--- a/packages/postgresql/postgresql.4.4.0/opam
+++ b/packages/postgresql/postgresql.4.4.0/opam
@@ -25,10 +25,9 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
 ]
 depexts: [
-  ["libpq-dev"] {os-distribution = "debian"}
+  ["libpq-dev"] {os-family = "debian"}
   ["database/postgresql96-client"] {os = "freebsd"}
   ["database/postgresql96-client"] {os = "openbsd"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}

--- a/packages/postgresql/postgresql.4.4.1/opam
+++ b/packages/postgresql/postgresql.4.4.1/opam
@@ -25,10 +25,9 @@ depends: [
 ]
 
 depexts: [
-  ["libpq-dev"] {os-distribution = "debian"}
+  ["libpq-dev"] {os-family = "debian"}
   ["database/postgresql96-client"] {os-distribution = "freebsd"}
   ["database/postgresql96-client"] {os-distribution = "openbsd"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
@@ -37,7 +36,6 @@ depexts: [
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]
-
 synopsis: "Bindings to the PostgreSQL library"
 
 description: """

--- a/packages/postgresql/postgresql.4.4.2/opam
+++ b/packages/postgresql/postgresql.4.4.2/opam
@@ -25,10 +25,9 @@ depends: [
 ]
 
 depexts: [
-  ["libpq-dev"] {os-distribution = "debian"}
+  ["libpq-dev"] {os-family = "debian"}
   ["database/postgresql96-client"] {os-distribution = "freebsd"}
   ["database/postgresql96-client"] {os-distribution = "openbsd"}
-  ["libpq-dev"] {os-distribution = "ubuntu"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
@@ -37,7 +36,6 @@ depexts: [
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]
-
 synopsis: "Bindings to the PostgreSQL library"
 
 description: """

--- a/packages/proj4/proj4.0.9.1/opam
+++ b/packages/proj4/proj4.0.9.1/opam
@@ -18,8 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libproj-dev"] {os-distribution = "debian"}
-  ["libproj-dev"] {os-distribution = "ubuntu"}
+  ["libproj-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/proj4ml"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/proj4/proj4.0.9.2/opam
+++ b/packages/proj4/proj4.0.9.2/opam
@@ -18,8 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libproj-dev"] {os-distribution = "debian"}
-  ["libproj-dev"] {os-distribution = "ubuntu"}
+  ["libproj-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/proj4ml"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/pulseaudio/pulseaudio.0.1.3/opam
+++ b/packages/pulseaudio/pulseaudio.0.1.3/opam
@@ -17,8 +17,7 @@ depexts: [
   ["pulseaudio-libs-devel"] {os-distribution = "fedora"}
   ["pulseaudio-libs-devel"] {os-family = "suse"}
   ["pulseaudio"] {os = "macos" & os-distribution = "homebrew"}
-  ["libpulse-dev"] {os-distribution = "debian"}
-  ["libpulse-dev"] {os-distribution = "ubuntu"}
+  ["libpulse-dev"] {os-family = "debian"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-pulseaudio/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-pulseaudio.git"

--- a/packages/py/py.1.0/opam
+++ b/packages/py/py.1.0/opam
@@ -17,8 +17,7 @@ depends: [
   "ctypes-foreign" {>= "0.4.0"}
 ]
 depexts: [
-  ["python3-dev"] {os-distribution = "debian"}
-  ["python3-dev"] {os-distribution = "ubuntu"}
+  ["python3-dev"] {os-family = "debian"}
   ["python3-devel"] {os-distribution = "fedora"}
   ["python3-dev"] {os-distribution = "alpine"}
 ]

--- a/packages/radare2/radare2.0.0.1/opam
+++ b/packages/radare2/radare2.0.0.1/opam
@@ -25,9 +25,8 @@ depends: [
   ("yojson" {>= "1.3.2"} | "yojson-android" {>= "1.3.2"})
 ]
 depexts: [
-  ["radare2"] {os-distribution = "debian"}
+  ["radare2"] {os-family = "debian"}
   ["radare2"] {os-distribution = "homebrew" & os = "macos"}
-  ["radare2"] {os-distribution = "ubuntu"}
 ]
 messages: [
   "You need to have r2 (radare2) installed and in your path"

--- a/packages/radare2/radare2.0.0.2/opam
+++ b/packages/radare2/radare2.0.0.2/opam
@@ -12,8 +12,7 @@ build: [
 	["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depexts: [
-  ["radare2"] {os-distribution = "debian"}
-  ["radare2"] {os-distribution = "ubuntu"}
+  ["radare2"] {os-family = "debian"}
   ["radare2"] {os-distribution = "fedora"}
   ["radare2"] {os-distribution = "arch"}
   ["radare2"] {os-distribution = "gentoo"}

--- a/packages/riak-pb/riak-pb.1.0.0/opam
+++ b/packages/riak-pb/riak-pb.1.0.0/opam
@@ -12,8 +12,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["protobuf-compiler"] {os-distribution = "ubuntu"}
-  ["protobuf-compiler"] {os-distribution = "debian"}
+  ["protobuf-compiler"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/metadave/riak-ocaml-pb"
 install: [make "install"]

--- a/packages/riakc/riakc.0.0.0/opam
+++ b/packages/riakc/riakc.0.0.0/opam
@@ -10,8 +10,7 @@ depends: [
   "protobuf"
 ]
 depexts: [
-  ["protobuf-compiler"] {os-distribution = "debian"}
-  ["protobuf-compiler"] {os-distribution = "ubuntu"}
+  ["protobuf-compiler"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/orbitz/ocaml-riakc"
 install: [make "install"]

--- a/packages/riakc/riakc.1.0.0/opam
+++ b/packages/riakc/riakc.1.0.0/opam
@@ -10,8 +10,7 @@ depends: [
   "protobuf"
 ]
 depexts: [
-  ["protobuf-compiler"] {os-distribution = "debian"}
-  ["protobuf-compiler"] {os-distribution = "ubuntu"}
+  ["protobuf-compiler"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/orbitz/ocaml-riakc"
 install: [make "install"]

--- a/packages/riakc/riakc.2.0.0/opam
+++ b/packages/riakc/riakc.2.0.0/opam
@@ -10,8 +10,7 @@ depends: [
   "protobuf"
 ]
 depexts: [
-  ["protobuf-compiler"] {os-distribution = "debian"}
-  ["protobuf-compiler"] {os-distribution = "ubuntu"}
+  ["protobuf-compiler"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/orbitz/ocaml-riakc"
 install: [make "install"]

--- a/packages/samplerate/samplerate.0.1.2/opam
+++ b/packages/samplerate/samplerate.0.1.2/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "samplerate"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libsamplerate0-dev"] {os-distribution = "debian"}
-  ["libsamplerate0-dev"] {os-distribution = "ubuntu"}
+  ["libsamplerate0-dev"] {os-family = "debian"}
   ["libsamplerate"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install"]

--- a/packages/samplerate/samplerate.0.1.3/opam
+++ b/packages/samplerate/samplerate.0.1.3/opam
@@ -12,8 +12,7 @@ install: [
 remove: ["ocamlfind" "remove" "samplerate"]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libsamplerate0-dev"] {os-distribution = "debian"}
-  ["libsamplerate0-dev"] {os-distribution = "ubuntu"}
+  ["libsamplerate0-dev"] {os-family = "debian"}
   ["libsamplerate"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-samplerate/issues"

--- a/packages/samplerate/samplerate.0.1.4/opam
+++ b/packages/samplerate/samplerate.0.1.4/opam
@@ -16,8 +16,7 @@ depexts: [
   ["libsamplerate-devel"] {os-distribution = "fedora"}
   ["libsamplerate-devel"] {os-family = "suse"}
   ["libsamplerate-dev"] {os-distribution = "alpine"}
-  ["libsamplerate0-dev"] {os-distribution = "debian"}
-  ["libsamplerate0-dev"] {os-distribution = "ubuntu"}
+  ["libsamplerate0-dev"] {os-family = "debian"}
   ["libsamplerate"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-samplerate/issues"

--- a/packages/sanlock/sanlock.0.0.9/opam
+++ b/packages/sanlock/sanlock.0.0.9/opam
@@ -23,8 +23,7 @@ depends: [
 ]
 available: os = "linux"
 depexts: [
-  ["libsanlock-dev"] {os-distribution = "debian"}
-  ["libsanlock-dev"] {os-distribution = "ubuntu"}
+  ["libsanlock-dev"] {os-family = "debian"}
   ["sanlock-devel"] {os-distribution = "centos"}
 ]
 post-messages: [

--- a/packages/schroedinger/schroedinger.0.1.0/opam
+++ b/packages/schroedinger/schroedinger.0.1.0/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "schroedinger"]]
 depends: ["ocaml" "ocamlfind" "ogg"]
 depexts: [
-  ["libschroedinger-dev"] {os-distribution = "ubuntu"}
-  ["libschroedinger-dev"] {os-distribution = "debian"}
+  ["libschroedinger-dev"] {os-family = "debian"}
   ["schroedinger"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install"]

--- a/packages/schroedinger/schroedinger.0.1.1/opam
+++ b/packages/schroedinger/schroedinger.0.1.1/opam
@@ -20,8 +20,7 @@ install: [
 remove: ["ocamlfind" "remove" "schroedinger"]
 depends: ["ocaml" "ocamlfind" "ogg"]
 depexts: [
-  ["libschroedinger-dev"] {os-distribution = "ubuntu"}
-  ["libschroedinger-dev"] {os-distribution = "debian"}
+  ["libschroedinger-dev"] {os-family = "debian"}
   ["schroedinger"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-schroedinger/issues"

--- a/packages/shine/shine.0.2.1/opam
+++ b/packages/shine/shine.0.2.1/opam
@@ -22,8 +22,7 @@ depexts: [
   ["libshine-devel"] {os-distribution = "centos"}
   ["libshine-devel"] {os-distribution = "fedora"}
   ["libshine-devel"] {os-family = "suse"}
-  ["libshine-dev"] {os-distribution = "debian"}
-  ["libshine-dev"] {os-distribution = "ubuntu"}
+  ["libshine-dev"] {os-family = "debian"}
   ["drfill/liquidsoap/libshine"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.0/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.0/opam
@@ -15,10 +15,9 @@ remove: [make "opam-hvt-uninstall" "PREFIX=%{prefix}%"]
 depends: "conf-pkg-config"
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: [
   "solo5-bindings-genode"

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.1/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.1/opam
@@ -15,10 +15,9 @@ remove: [make "opam-hvt-uninstall" "PREFIX=%{prefix}%"]
 depends: "conf-pkg-config"
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: [
   "solo5-bindings-genode"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.1.1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.1.1/opam
@@ -18,10 +18,9 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: "solo5-kernel-virtio"
 available: arch = "x86_64" & os = "linux"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.1/opam
@@ -18,10 +18,9 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: "solo5-kernel-virtio"
 available: arch = "x86_64" & os = "linux"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2-1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2-1/opam
@@ -18,10 +18,9 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: "solo5-kernel-virtio"
 available: arch = "x86_64" & os = "linux"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2/opam
@@ -18,10 +18,9 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: "solo5-kernel-virtio"
 available: arch = "x86_64" & os = "linux"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/opam
@@ -18,10 +18,9 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: [
   "solo5-kernel-virtio"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.1/opam
@@ -18,10 +18,9 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: [
   "solo5-kernel-virtio"

--- a/packages/soundtouch/soundtouch.0.1.7/opam
+++ b/packages/soundtouch/soundtouch.0.1.7/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "soundtouch"]]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config"]
 depexts: [
-  ["libsoundtouch0-dev"] {os-distribution = "debian"}
-  ["libsoundtouch0-dev"] {os-distribution = "ubuntu"}
+  ["libsoundtouch0-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/soundtouch/soundtouch.0.1.8/opam
+++ b/packages/soundtouch/soundtouch.0.1.8/opam
@@ -16,8 +16,7 @@ depexts: [
   ["soundtouch-devel"] {os-distribution = "centos"}
   ["soundtouch-devel"] {os-distribution = "fedora"}
   ["soundtouch-devel"] {os-family = "suse"}
-  ["libsoundtouch-dev"] {os-distribution = "debian"}
-  ["libsoundtouch-dev"] {os-distribution = "ubuntu"}
+  ["libsoundtouch-dev"] {os-family = "debian"}
   ["drfill/homebrew-liquidsoap/soundtouch"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/speex/speex.0.2.0/opam
+++ b/packages/speex/speex.0.2.0/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "speex"]]
 depends: ["ocaml" "ocamlfind" "ogg"]
 depexts: [
-  ["libspeex-dev"] {os-distribution = "ubuntu"}
-  ["libspeex-dev"] {os-distribution = "debian"}
+  ["libspeex-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/speex/speex.0.2.1/opam
+++ b/packages/speex/speex.0.2.1/opam
@@ -24,8 +24,7 @@ depexts: [
   ["speex-devel"] {os-distribution = "centos"}
   ["speex-devel"] {os-distribution = "fedora"}
   ["speex-devel"] {os-family = "suse"}
-  ["libspeex-dev"] {os-distribution = "ubuntu"}
-  ["libspeex-dev"] {os-distribution = "debian"}
+  ["libspeex-dev"] {os-family = "debian"}
   ["speex"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-speex/issues"

--- a/packages/spf/spf.1.0.0/opam
+++ b/packages/spf/spf.1.0.0/opam
@@ -11,8 +11,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libspf2-dev"] {os-distribution = "debian"}
-  ["libspf2-dev"] {os-distribution = "ubuntu"}
+  ["libspf2-dev"] {os-family = "debian"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml bindings for libspf2"

--- a/packages/spf/spf.1.0.1/opam
+++ b/packages/spf/spf.1.0.1/opam
@@ -11,8 +11,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libspf2-dev"] {os-distribution = "debian"}
-  ["libspf2-dev"] {os-distribution = "ubuntu"}
+  ["libspf2-dev"] {os-family = "debian"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml bindings for libspf2"

--- a/packages/spf/spf.2.0.2/opam
+++ b/packages/spf/spf.2.0.2/opam
@@ -14,7 +14,7 @@ depexts: [
   ["libspf2-dev"] {os-distribution = "alpine"}
   ["libspf2"] {os-distribution = "arch"}
   ["epel-release" "libspf2-devel"] {os-distribution = "centos"}
-  ["libspf2-dev"] {os-distribution = "debian"}
+  ["libspf2-dev"] {os-family = "debian"}
   ["libspf2-devel"] {os-distribution = "fedora"}
   ["libspf2"] {os = "freebsd"}
   ["libspf2"] {os-distribution = "gentoo"}
@@ -22,7 +22,6 @@ depexts: [
   ["libspf2"] {os = "netbsd"}
   ["libspf2"] {os = "openbsd"}
   ["libspf2-devel"] {os-family = "suse"}
-  ["libspf2-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "OCaml bindings for libspf2"
 description: "OCaml-SPF provides C bindings for OCaml programs."

--- a/packages/ssl/ssl.0.4.6/opam
+++ b/packages/ssl/ssl.0.4.6/opam
@@ -15,8 +15,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libssl-dev"] {os-distribution = "debian"}
-  ["libssl-dev"] {os-distribution = "ubuntu"}
+  ["libssl-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Bindings for the libssl"

--- a/packages/ssl/ssl.0.4.6a/opam
+++ b/packages/ssl/ssl.0.4.6a/opam
@@ -16,8 +16,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libssl-dev"] {os-distribution = "debian"}
-  ["libssl-dev"] {os-distribution = "ubuntu"}
+  ["libssl-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Bindings for the libssl"

--- a/packages/ssl/ssl.0.4.7/opam
+++ b/packages/ssl/ssl.0.4.7/opam
@@ -15,8 +15,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libssl-dev"] {os-distribution = "debian"}
-  ["libssl-dev"] {os-distribution = "ubuntu"}
+  ["libssl-dev"] {os-family = "debian"}
   ["openssl-devel"] {os-distribution = "centos"}
   ["openssl-devel"] {os-distribution = "fedora"}
 ]

--- a/packages/ssl/ssl.0.5.0/opam
+++ b/packages/ssl/ssl.0.5.0/opam
@@ -16,8 +16,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["libssl-dev"] {os-distribution = "debian"}
-  ["libssl-dev"] {os-distribution = "ubuntu"}
+  ["libssl-dev"] {os-family = "debian"}
   ["openssl-devel"] {os-distribution = "centos"}
   ["openssl-devel"] {os-distribution = "fedora"}
 ]

--- a/packages/sundialsml/sundialsml.2.5.0p0/opam
+++ b/packages/sundialsml/sundialsml.2.5.0p0/opam
@@ -30,8 +30,7 @@ depopts: [
     "mpi"
 ]
 depexts: [
-  ["libsundials-serial-dev"] {os-distribution = "debian"}
-  ["libsundials-serial-dev"] {os-distribution = "ubuntu"}
+  ["libsundials-serial-dev"] {os-family = "debian"}
   ["sundials"] {os = "macos" & os-distribution = "homebrew"}
   ["sundials"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/sundialsml/sundialsml.2.5.0p1/opam
+++ b/packages/sundialsml/sundialsml.2.5.0p1/opam
@@ -30,8 +30,7 @@ depopts: [
     "mpi"
 ]
 depexts: [
-  ["libsundials-serial-dev"] {os-distribution = "debian"}
-  ["libsundials-serial-dev"] {os-distribution = "ubuntu"}
+  ["libsundials-serial-dev"] {os-family = "debian"}
   ["sundials"] {os = "macos" & os-distribution = "homebrew"}
   ["sundials"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/sundialsml/sundialsml.2.5.0p2/opam
+++ b/packages/sundialsml/sundialsml.2.5.0p2/opam
@@ -30,8 +30,7 @@ depopts: [
     "mpi"
 ]
 depexts: [
-  ["libsundials-serial-dev"] {os-distribution = "debian"}
-  ["libsundials-serial-dev"] {os-distribution = "ubuntu"}
+  ["libsundials-serial-dev"] {os-family = "debian"}
   ["homebrew/science/sundials"] {os = "macos" & os-distribution = "homebrew"}
   ["sundials"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/sundialsml/sundialsml.2.6.2p0/opam
+++ b/packages/sundialsml/sundialsml.2.6.2p0/opam
@@ -40,8 +40,7 @@ depopts: [
     "mpi"
 ]
 depexts: [
-  ["libsundials-serial-dev"] {os-distribution = "debian"}
-  ["libsundials-serial-dev"] {os-distribution = "ubuntu"}
+  ["libsundials-serial-dev"] {os-family = "debian"}
   ["lapack-devel" "sundials-devel"] {os-distribution = "fedora"}
   ["epel-release" "lapack-devel" "sundials-devel"]
     {os-distribution = "centos"}

--- a/packages/sundialsml/sundialsml.2.6.2p1/opam
+++ b/packages/sundialsml/sundialsml.2.6.2p1/opam
@@ -40,8 +40,7 @@ depopts: [
     "mpi"
 ]
 depexts: [
-  ["libsundials-serial-dev"] {os-distribution = "debian"}
-  ["libsundials-serial-dev"] {os-distribution = "ubuntu"}
+  ["libsundials-serial-dev"] {os-family = "debian"}
   ["lapack-devel" "sundials-devel"] {os-distribution = "fedora"}
   ["epel-release" "lapack-devel" "sundials-devel"]
     {os-distribution = "centos"}

--- a/packages/sundialsml/sundialsml.2.7.0p0/opam
+++ b/packages/sundialsml/sundialsml.2.7.0p0/opam
@@ -40,8 +40,7 @@ depopts: [
     "mpi"
 ]
 depexts: [
-  ["libsundials-serial-dev"] {os-distribution = "debian"}
-  ["libsundials-serial-dev"] {os-distribution = "ubuntu"}
+  ["libsundials-serial-dev"] {os-family = "debian"}
   ["lapack-devel" "sundials-devel"] {os-distribution = "fedora"}
   ["epel-release" "lapack-devel" "sundials-devel"]
     {os-distribution = "centos"}

--- a/packages/sundialsml/sundialsml.3.1.1p0/opam
+++ b/packages/sundialsml/sundialsml.3.1.1p0/opam
@@ -40,8 +40,7 @@ depopts: [
     "mpi"
 ]
 depexts: [
-  ["libsundials-serial-dev"] {os-distribution = "debian"}
-  ["libsundials-serial-dev"] {os-distribution = "ubuntu"}
+  ["libsundials-serial-dev"] {os-family = "debian"}
   ["lapack-devel" "sundials-devel"] {os-distribution = "fedora"}
   [
     "epel-release"

--- a/packages/taglib/taglib.0.2.0/opam
+++ b/packages/taglib/taglib.0.2.0/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "taglib"]]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config"]
 depexts: [
-  ["libtag1-dev"] {os-distribution = "debian"}
-  ["libtag1-dev"] {os-distribution = "ubuntu"}
+  ["libtag1-dev"] {os-family = "debian"}
   ["taglib"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install"]

--- a/packages/taglib/taglib.0.3.0/opam
+++ b/packages/taglib/taglib.0.3.0/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "taglib"]]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config"]
 depexts: [
-  ["libtag1-dev"] {os-distribution = "debian"}
-  ["libtag1-dev"] {os-distribution = "ubuntu"}
+  ["libtag1-dev"] {os-family = "debian"}
   ["taglib"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install"]

--- a/packages/taglib/taglib.0.3.2/opam
+++ b/packages/taglib/taglib.0.3.2/opam
@@ -13,8 +13,7 @@ remove: ["ocamlfind" "remove" "taglib"]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config"]
 depexts: [
   ["taglib-devel"] {os-distribution = "centos"}
-  ["libtag1-dev"] {os-distribution = "debian"}
-  ["libtag1-dev"] {os-distribution = "ubuntu"}
+  ["libtag1-dev"] {os-family = "debian"}
   ["taglib"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-taglib/issues"

--- a/packages/taglib/taglib.0.3.3/opam
+++ b/packages/taglib/taglib.0.3.3/opam
@@ -16,8 +16,7 @@ depexts: [
   ["gcc-c++" "taglib-devel"] {os-family = "suse"}
   ["gcc-c++" "taglib-devel"] {os-distribution = "fedora"}
   ["gcc-c++" "taglib-devel"] {os-distribution = "centos"}
-  ["libtag1-dev"] {os-distribution = "debian"}
-  ["libtag1-dev"] {os-distribution = "ubuntu"}
+  ["libtag1-dev"] {os-family = "debian"}
   ["taglib"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-taglib/issues"

--- a/packages/termbox/termbox.0.1.0/opam
+++ b/packages/termbox/termbox.0.1.0/opam
@@ -9,8 +9,7 @@ remove: [
 ]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["python"] {os-distribution = "ubuntu"}
-  ["python"] {os-distribution = "debian"}
+  ["python"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/testsimple/testsimple.0.3.1/opam
+++ b/packages/testsimple/testsimple.0.3.1/opam
@@ -17,8 +17,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["perl"] {os-distribution = "debian"}
-  ["perl"] {os-distribution = "ubuntu"}
+  ["perl"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-testsimple"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/theora/theora.0.3.0/opam
+++ b/packages/theora/theora.0.3.0/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "theora"]]
 depends: ["ocaml" "ocamlfind" "ogg"]
 depexts: [
-  ["libtheora-dev"] {os-distribution = "ubuntu"}
-  ["libtheora-dev"] {os-distribution = "debian"}
+  ["libtheora-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/theora/theora.0.3.1/opam
+++ b/packages/theora/theora.0.3.1/opam
@@ -17,8 +17,7 @@ depexts: [
   ["libtheora-devel"] {os-distribution = "fedora"}
   ["libtheora-devel"] {os-family = "suse"}
   ["theora"] {os = "macos" & os-distribution = "homebrew"}
-  ["libtheora-dev"] {os-distribution = "ubuntu"}
-  ["libtheora-dev"] {os-distribution = "debian"}
+  ["libtheora-dev"] {os-family = "debian"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-theora/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-theora.git"

--- a/packages/tidy/tidy.0-2009-0.1.1/opam
+++ b/packages/tidy/tidy.0-2009-0.1.1/opam
@@ -22,8 +22,7 @@ depends: [
   "core_kernel" {< "v0.13"}
 ]
 depexts: [
-  ["libtidy-dev"] {os-distribution = "debian"}
-  ["libtidy-dev"] {os-distribution = "ubuntu"}
+  ["libtidy-dev"] {os-family = "debian"}
   ["tidyhtml"] {os-distribution = "arch"}
 ]
 post-messages: [

--- a/packages/tidy/tidy.1-4.9.30-0.1.1/opam
+++ b/packages/tidy/tidy.1-4.9.30-0.1.1/opam
@@ -22,8 +22,7 @@ depends: [
   "core_kernel" {< "v0.13"}
 ]
 depexts: [
-  ["libtidy-dev"] {os-distribution = "debian"}
-  ["libtidy-dev"] {os-distribution = "ubuntu"}
+  ["libtidy-dev"] {os-family = "debian"}
   ["tidyhtml"] {os-distribution = "arch"}
 ]
 post-messages: [

--- a/packages/traildb/traildb.0.1/opam
+++ b/packages/traildb/traildb.0.1/opam
@@ -16,9 +16,8 @@ depends: [
   "ounit" {with-test}
 ]
 depexts: [
-  ["libtraildb-dev"] {os-distribution = "debian"}
+  ["libtraildb-dev"] {os-family = "debian"}
   ["traildb"] {os-distribution = "homebrew"}
-  ["libtraildb-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "OCaml bindings for TrailDB."
 description: "TrailDB is a file format for time-series."

--- a/packages/travis-opam/travis-opam.1.1.0/opam
+++ b/packages/travis-opam/travis-opam.1.1.0/opam
@@ -16,12 +16,11 @@ depends: [
 depexts: [
   ["jq"] {os-distribution = "alpine"}
   ["jq"] {os-distribution = "centos"}
-  ["jq"] {os-distribution = "debian"}
+  ["jq"] {os-family = "debian"}
   ["jq"] {os-distribution = "fedora"}
   ["jq"] {os-distribution = "homebrew" & os = "macos"}
   ["jq"] {os-family = "suse"}
   ["jq"] {os-distribution = "ol"}
-  ["jq"] {os-distribution = "ubuntu"}
 ]
 build: [make]
 synopsis: "Travis CI (Continuous Integration) helpers"

--- a/packages/tsdl-image/tsdl-image.0.1.1/opam
+++ b/packages/tsdl-image/tsdl-image.0.1.1/opam
@@ -21,9 +21,8 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["libsdl2-image-dev"] {os-distribution = "debian"}
+  ["libsdl2-image-dev"] {os-family = "debian"}
   ["sdl2_image"] {os-distribution = "homebrew" & os = "macos"}
-  ["libsdl2-image-dev"] {os-distribution = "ubuntu"}
   ["sdl2_image"] {os-distribution = "arch"}
 ]
 synopsis: "SDL2_Image bindings to go with Tsdl"

--- a/packages/tsdl-image/tsdl-image.0.1.2/opam
+++ b/packages/tsdl-image/tsdl-image.0.1.2/opam
@@ -22,9 +22,8 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["libsdl2-image-dev"] {os-distribution = "debian"}
+  ["libsdl2-image-dev"] {os-family = "debian"}
   ["sdl2_image"] {os-distribution = "homebrew" & os = "macos"}
-  ["libsdl2-image-dev"] {os-distribution = "ubuntu"}
   ["sdl2_image"] {os-distribution = "arch"}
 ]
 synopsis: "SDL2_Image bindings to go with Tsdl"

--- a/packages/tsdl-image/tsdl-image.0.1/opam
+++ b/packages/tsdl-image/tsdl-image.0.1/opam
@@ -22,9 +22,8 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libsdl2-image-dev"] {os-distribution = "debian"}
+  ["libsdl2-image-dev"] {os-family = "debian"}
   ["sdl2_image"] {os-distribution = "homebrew" & os = "macos"}
-  ["libsdl2-image-dev"] {os-distribution = "ubuntu"}
   ["sdl2_image"] {os-distribution = "arch"}
 ]
 synopsis: "SDL2_Image bindings to go with Tsdl"

--- a/packages/tsdl-image/tsdl-image.0.2.0/opam
+++ b/packages/tsdl-image/tsdl-image.0.2.0/opam
@@ -22,9 +22,8 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["libsdl2-image-dev"] {os-distribution = "debian"}
+  ["libsdl2-image-dev"] {os-family = "debian"}
   ["sdl2_image"] {os-distribution = "homebrew" & os = "macos"}
-  ["libsdl2-image-dev"] {os-distribution = "ubuntu"}
   ["sdl2_image"] {os-distribution = "arch"}
 ]
 synopsis: "SDL2_Image bindings to go with Tsdl"

--- a/packages/tsdl-mixer/tsdl-mixer.0.2/opam
+++ b/packages/tsdl-mixer/tsdl-mixer.0.2/opam
@@ -22,9 +22,8 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["libsdl2-mixer-dev"] {os-distribution = "debian"}
+  ["libsdl2-mixer-dev"] {os-family = "debian"}
   ["sdl2_mixer"] {os-distribution = "homebrew" & os = "macos"}
-  ["libsdl2-mixer-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "SDL2_mixer bindings to go with Tsdl"
 description: """

--- a/packages/tsdl-ttf/tsdl-ttf.0.2/opam
+++ b/packages/tsdl-ttf/tsdl-ttf.0.2/opam
@@ -24,9 +24,8 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["libsdl2-ttf-dev"] {os-distribution = "debian"}
+  ["libsdl2-ttf-dev"] {os-family = "debian"}
   ["sdl2_ttf"] {os-distribution = "homebrew" & os = "macos"}
-  ["libsdl2-ttf-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "SDL2_ttf bindings to go with Tsdl"
 description:

--- a/packages/usb/usb.1.3.0/opam
+++ b/packages/usb/usb.1.3.0/opam
@@ -16,8 +16,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libusb-1.0-0-dev"] {os-distribution = "debian"}
-  ["libusb-1.0-0-dev"] {os-distribution = "ubuntu"}
+  ["libusb-1.0-0-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "OCaml bindings for libusb-1.0"

--- a/packages/usbmux/usbmux.0.9/opam
+++ b/packages/usbmux/usbmux.0.9/opam
@@ -26,8 +26,7 @@ depends: [
   "yojson"
 ]
 depexts: [
-  ["usbmuxd"] {os-distribution = "debian"}
-  ["usbmuxd"] {os-distribution = "ubuntu"}
+  ["usbmuxd"] {os-family = "debian"}
 ]
 post-messages: [
   "Now you can ssh into your jailbroken iDevice using the CLI, gandalf."

--- a/packages/usbmux/usbmux.1.0/opam
+++ b/packages/usbmux/usbmux.1.0/opam
@@ -26,8 +26,7 @@ depends: [
   "yojson"
 ]
 depexts: [
-  ["usbmuxd"] {os-distribution = "debian"}
-  ["usbmuxd"] {os-distribution = "ubuntu"}
+  ["usbmuxd"] {os-family = "debian"}
 ]
 post-messages: [
   "Now you can ssh into your jailbroken iDevice using the CLI, gandalf."

--- a/packages/usbmux/usbmux.1.1.0/opam
+++ b/packages/usbmux/usbmux.1.1.0/opam
@@ -28,8 +28,7 @@ depends: [
   "yojson"
 ]
 depexts: [
-  ["usbmuxd"] {os-distribution = "debian"}
-  ["usbmuxd"] {os-distribution = "ubuntu"}
+  ["usbmuxd"] {os-family = "debian"}
 ]
 post-messages: [
   "Now you can ssh into your jailbroken iDevice using the CLI, gandalf."

--- a/packages/usbmux/usbmux.1.1.1/opam
+++ b/packages/usbmux/usbmux.1.1.1/opam
@@ -28,8 +28,7 @@ depends: [
   "yojson"
 ]
 depexts: [
-  ["usbmuxd"] {os-distribution = "debian"}
-  ["usbmuxd"] {os-distribution = "ubuntu"}
+  ["usbmuxd"] {os-family = "debian"}
 ]
 post-messages: [
   "Now you can ssh into your jailbroken iDevice using the CLI, gandalf."

--- a/packages/usbmux/usbmux.1.2.0/opam
+++ b/packages/usbmux/usbmux.1.2.0/opam
@@ -28,8 +28,7 @@ depends: [
   "yojson"
 ]
 depexts: [
-  ["usbmuxd"] {os-distribution = "debian"}
-  ["usbmuxd"] {os-distribution = "ubuntu"}
+  ["usbmuxd"] {os-family = "debian"}
 ]
 post-messages: [
   "Now you can ssh into your jailbroken iDevice using the CLI, gandalf."

--- a/packages/usbmux/usbmux.1.3.1/opam
+++ b/packages/usbmux/usbmux.1.3.1/opam
@@ -29,8 +29,7 @@ depends: [
   "yojson"
 ]
 depexts: [
-  ["usbmuxd"] {os-distribution = "debian"}
-  ["usbmuxd"] {os-distribution = "ubuntu"}
+  ["usbmuxd"] {os-family = "debian"}
 ]
 post-messages: [
   "Now you can ssh into your jailbroken iDevice using the CLI, gandalf."

--- a/packages/usbmux/usbmux.1.3.2/opam
+++ b/packages/usbmux/usbmux.1.3.2/opam
@@ -32,8 +32,7 @@ depends: [
   "yojson" {>= "1.3.2"}
 ]
 depexts: [
-  ["usbmuxd"] {os-distribution = "debian"}
-  ["usbmuxd"] {os-distribution = "ubuntu"}
+  ["usbmuxd"] {os-family = "debian"}
 ]
 post-messages: [
   "

--- a/packages/voaacenc/voaacenc.0.1.1/opam
+++ b/packages/voaacenc/voaacenc.0.1.1/opam
@@ -12,8 +12,7 @@ install: [
 remove: ["ocamlfind" "remove" "voaacenc"]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config"]
 depexts: [
-  ["libvo-aacenc-dev"] {os-distribution = "debian"}
-  ["libvo-aacenc-dev"] {os-distribution = "ubuntu"}
+  ["libvo-aacenc-dev"] {os-family = "debian"}
   ["libvo-aacenc"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-voaacenc/issues"

--- a/packages/vorbis/vorbis.0.6.1/opam
+++ b/packages/vorbis/vorbis.0.6.1/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "vorbis"]]
 depends: ["ocaml" "ocamlfind" "ogg"]
 depexts: [
-  ["libvorbis-dev"] {os-distribution = "debian"}
-  ["libvorbis-dev"] {os-distribution = "ubuntu"}
+  ["libvorbis-dev"] {os-family = "debian"}
   ["libvorbis"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: [make "install"]

--- a/packages/vorbis/vorbis.0.6.2/opam
+++ b/packages/vorbis/vorbis.0.6.2/opam
@@ -19,8 +19,7 @@ depexts: [
   ["libvorbis-devel"] {os-distribution = "centos"}
   ["libvorbis-devel"] {os-distribution = "fedora"}
   ["libvorbis-devel"] {os-family = "suse"}
-  ["libvorbis-dev"] {os-distribution = "debian"}
-  ["libvorbis-dev"] {os-distribution = "ubuntu"}
+  ["libvorbis-dev"] {os-family = "debian"}
   ["libvorbis"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-vorbis/issues"

--- a/packages/vorbis/vorbis.0.7.0/opam
+++ b/packages/vorbis/vorbis.0.7.0/opam
@@ -20,8 +20,7 @@ depexts: [
   ["libvorbis-devel"] {os-distribution = "centos"}
   ["libvorbis-devel"] {os-distribution = "fedora"}
   ["libvorbis-devel"] {os-family = "suse"}
-  ["libvorbis-dev"] {os-distribution = "debian"}
-  ["libvorbis-dev"] {os-distribution = "ubuntu"}
+  ["libvorbis-dev"] {os-family = "debian"}
   ["libvorbis"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-vorbis/issues"

--- a/packages/xapi-libs-transitional/xapi-libs-transitional.1.0.1/opam
+++ b/packages/xapi-libs-transitional/xapi-libs-transitional.1.0.1/opam
@@ -42,8 +42,7 @@ depends: [
   "ezxenstore" {= "0.1.1"}
 ]
 depexts: [
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
 ]

--- a/packages/xen-evtchn-unix/xen-evtchn-unix.2.0.0/opam
+++ b/packages/xen-evtchn-unix/xen-evtchn-unix.2.0.0/opam
@@ -22,8 +22,7 @@ depends: [
 ]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xenstore"] {os-distribution = "arch"}

--- a/packages/xen-evtchn-unix/xen-evtchn-unix.2.1.0/opam
+++ b/packages/xen-evtchn-unix/xen-evtchn-unix.2.1.0/opam
@@ -22,8 +22,7 @@ build: [
 ]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xenstore"] {os-distribution = "arch"}

--- a/packages/xen-evtchn/xen-evtchn.1.0.1/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.1/opam
@@ -22,8 +22,7 @@ depends: [
 depopts: ["xenctrl"]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xenstore"] {os-distribution = "arch"}

--- a/packages/xen-evtchn/xen-evtchn.1.0.3/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.3/opam
@@ -22,8 +22,7 @@ depends: [
 depopts: ["xenctrl"]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xenstore"] {os-distribution = "arch"}

--- a/packages/xen-evtchn/xen-evtchn.1.0.4/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.4/opam
@@ -22,8 +22,7 @@ depends: [
 depopts: ["xenctrl"]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xenstore"] {os-distribution = "arch"}

--- a/packages/xen-evtchn/xen-evtchn.1.0.5/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.5/opam
@@ -22,8 +22,7 @@ depends: [
 depopts: ["xenctrl"]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xenstore"] {os-distribution = "arch"}

--- a/packages/xen-evtchn/xen-evtchn.1.0.6/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.6/opam
@@ -22,8 +22,7 @@ depends: [
 depopts: ["xenctrl"]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xenstore"] {os-distribution = "arch"}

--- a/packages/xen-evtchn/xen-evtchn.1.0.7/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.7/opam
@@ -20,8 +20,7 @@ depends: [
 ]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xenstore"] {os-distribution = "arch"}

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.0.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.0.0/opam
@@ -19,8 +19,7 @@ depends: [
 ]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xenstore"] {os-distribution = "arch"}

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.0.1/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.0.1/opam
@@ -19,8 +19,7 @@ depends: [
 ]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xenstore"] {os-distribution = "arch"}

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.1.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.1.0/opam
@@ -22,8 +22,7 @@ build: [
 ]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xenstore"] {os-distribution = "archlinux"}

--- a/packages/xen-gnt-unix/xen-gnt-unix.4.0.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.4.0.0/opam
@@ -22,8 +22,7 @@ build: [
 ]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xenstore"] {os-distribution = "archlinux"}

--- a/packages/xen-gnt/xen-gnt.0.9.9/opam
+++ b/packages/xen-gnt/xen-gnt.0.9.9/opam
@@ -14,8 +14,7 @@ depends: [
   "lwt" {< "4.0.0"}
 ]
 depexts: [
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/xapi-project/ocaml-gnt"
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/xen-gnt/xen-gnt.1.0.0/opam
+++ b/packages/xen-gnt/xen-gnt.1.0.0/opam
@@ -15,8 +15,7 @@ depends: [
   "cmdliner"
 ]
 depexts: [
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/xapi-project/ocaml-gnt"
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/xen-gnt/xen-gnt.1.0.1/opam
+++ b/packages/xen-gnt/xen-gnt.1.0.1/opam
@@ -15,8 +15,7 @@ depends: [
   "cmdliner"
 ]
 depexts: [
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/mirage/ocaml-gnt"
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/xen-gnt/xen-gnt.1.0.2/opam
+++ b/packages/xen-gnt/xen-gnt.1.0.2/opam
@@ -15,8 +15,7 @@ depends: [
   "cmdliner"
 ]
 depexts: [
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/mirage/ocaml-gnt"
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/xen-gnt/xen-gnt.1.0.3/opam
+++ b/packages/xen-gnt/xen-gnt.1.0.3/opam
@@ -15,8 +15,7 @@ depends: [
   "cmdliner"
 ]
 depexts: [
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/mirage/ocaml-gnt"
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/xen-gnt/xen-gnt.2.0.0/opam
+++ b/packages/xen-gnt/xen-gnt.2.0.0/opam
@@ -16,8 +16,7 @@ depends: [
   "cmdliner"
 ]
 depexts: [
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/mirage/ocaml-gnt"
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/xen-gnt/xen-gnt.2.1.0/opam
+++ b/packages/xen-gnt/xen-gnt.2.1.0/opam
@@ -19,8 +19,7 @@ depends: [
   "mirage-profile" {>= "0.3"}
 ]
 depexts: [
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
 ]
 install: [make "PREFIX=%{prefix}%" "install"]
 synopsis: "Xen grant table bindings"

--- a/packages/xen-gnt/xen-gnt.2.2.0/opam
+++ b/packages/xen-gnt/xen-gnt.2.2.0/opam
@@ -21,8 +21,7 @@ depends: [
 ]
 depopts: ["xenctrl"]
 depexts: [
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
 ]
 synopsis: "Xen grant table bindings"
 description: """

--- a/packages/xen-gnt/xen-gnt.2.2.1/opam
+++ b/packages/xen-gnt/xen-gnt.2.2.1/opam
@@ -21,8 +21,7 @@ depends: [
 ]
 depopts: ["xenctrl"]
 depexts: [
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
 ]
 synopsis: "Xen grant table bindings"
 description: """

--- a/packages/xen-gnt/xen-gnt.2.2.3/opam
+++ b/packages/xen-gnt/xen-gnt.2.2.3/opam
@@ -26,8 +26,7 @@ depends: [
   "mirage-profile" {>= "0.3"}
 ]
 depexts: [
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev"] {os-family = "debian"}
 ]
 synopsis: "Xen grant table bindings"
 description: """

--- a/packages/yajl/yajl.0.7.0/opam
+++ b/packages/yajl/yajl.0.7.0/opam
@@ -8,8 +8,7 @@ depends: [
   "conf-ruby" {build}
 ]
 depexts: [
-  ["cmake"] {os-distribution = "debian"}
-  ["cmake"] {os-distribution = "ubuntu"}
+  ["cmake"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "bindings to the YAJL streaming JSON library"

--- a/packages/yajl/yajl.0.7.1/opam
+++ b/packages/yajl/yajl.0.7.1/opam
@@ -7,8 +7,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["cmake"] {os-distribution = "debian"}
-  ["cmake"] {os-distribution = "ubuntu"}
+  ["cmake"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "bindings to the YAJL streaming JSON library"

--- a/packages/yajl/yajl.0.7.2/opam
+++ b/packages/yajl/yajl.0.7.2/opam
@@ -7,8 +7,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["cmake"] {os-distribution = "debian"}
-  ["cmake"] {os-distribution = "ubuntu"}
+  ["cmake"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "bindings to the YAJL streaming JSON library"

--- a/packages/yajl/yajl.0.7.3/opam
+++ b/packages/yajl/yajl.0.7.3/opam
@@ -7,8 +7,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["cmake"] {os-distribution = "debian"}
-  ["cmake"] {os-distribution = "ubuntu"}
+  ["cmake"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "bindings to the YAJL streaming JSON library"

--- a/packages/yara/yara.0.1/opam
+++ b/packages/yara/yara.0.1/opam
@@ -20,9 +20,8 @@ depends: [
   "ctypes-foreign"
 ]
 depexts: [
-  ["libyara-dev"] {os-distribution = "debian"}
+  ["libyara-dev"] {os-family = "debian"}
   ["libyara-dev"] {os-distribution = "alpine"}
-  ["libyara-dev"] {os-distribution = "ubuntu"}
   ["epel-release" "yara-devel"] {os-distribution = "centos"}
   ["yara-devel"] {os-distribution = "fedora"}
   ["yara"] {os-distribution = "arch"}

--- a/packages/zbar/zbar.0.9/opam
+++ b/packages/zbar/zbar.0.9/opam
@@ -18,8 +18,7 @@ depends: [
 ]
 depopts: ["ctypes" "ctypes-foreign"]
 depexts: [
-  ["libzbar-dev"] {os-distribution = "ubuntu"}
-  ["libzbar-dev"] {os-distribution = "debian"}
+  ["libzbar-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/vbmithr/ocaml-zbar"
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/zmq/zmq.3.2-0/opam
+++ b/packages/zmq/zmq.3.2-0/opam
@@ -16,8 +16,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libzmq3-dev"] {os-distribution = "debian"}
-  ["libzmq3-dev"] {os-distribution = "ubuntu"}
+  ["libzmq3-dev"] {os-family = "debian"}
 ]
 conflicts: ["ocaml-zmq"]
 dev-repo: "git://github.com/issuu/ocaml-zmq"

--- a/packages/zmq/zmq.3.2-1/opam
+++ b/packages/zmq/zmq.3.2-1/opam
@@ -17,8 +17,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libzmq3-dev"] {os-distribution = "debian"}
-  ["libzmq3-dev"] {os-distribution = "ubuntu"}
+  ["libzmq3-dev"] {os-family = "debian"}
 ]
 conflicts: ["ocaml-zmq"]
 dev-repo: "git://github.com/issuu/ocaml-zmq"

--- a/packages/zmq/zmq.3.2-2/opam
+++ b/packages/zmq/zmq.3.2-2/opam
@@ -17,8 +17,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libzmq3-dev"] {os-distribution = "debian"}
-  ["libzmq3-dev"] {os-distribution = "ubuntu"}
+  ["libzmq3-dev"] {os-family = "debian"}
 ]
 conflicts: ["ocaml-zmq"]
 dev-repo: "git://github.com/issuu/ocaml-zmq"


### PR DESCRIPTION
We've had one case of a user whose `os-distribution` was `raspbian` but `os-family` is `debian`. If both `debian` and `ubuntu` depexts are the same then there's no reason to not use `os-family = "debian"` instead, which is what this PR does.