### PR TITLE
Lo is not available on alpine.

### DIFF
--- a/packages/lo/lo.0.1.2/opam
+++ b/packages/lo/lo.0.1.2/opam
@@ -22,7 +22,6 @@ depexts: [
   ["liblo-dev"] {os-distribution = "ubuntu"}
   ["liblo-dev"] {os-distribution = "debian"}
   ["liblo"] {os = "macos" & os-distribution = "homebrew"}
-  ["liblo-dev"] {os-distribution = "alpine"}
   ["liblo"] {os-distribution = "arch"}
   ["liblo-devel"] {os-distribution = "centos"}
   ["liblo-devel"] {os-distribution = "fedora"}


### PR DESCRIPTION
An user informed us that lo-dev is not available on alpine. See https://github.com/savonet/ocaml-lo/issues/1.