### PR TITLE
vchan: older versions cannot use mirage-xen>4

### DIFF
--- a/packages/vchan/vchan.2.0.0/opam
+++ b/packages/vchan/vchan.2.0.0/opam
@@ -33,6 +33,7 @@ conflicts: [
   "xen-evtchn" {< "1.0.3"}
   "xen-evtchn" {>= "2.0.0"}
   "xen-gnt"    {>= "2.0.0"}
+  "mirage-xen" {>= "4.0.0"}
 ]
 synopsis: "Xen Vchan implementation"
 description: """

--- a/packages/vchan/vchan.2.0.1/opam
+++ b/packages/vchan/vchan.2.0.1/opam
@@ -33,6 +33,7 @@ conflicts: [
   "xen-evtchn" {< "1.0.3"}
   "xen-evtchn" {>= "2.0.0"}
   "xen-gnt"    {>= "2.0.0"}
+  "mirage-xen" {>= "4.0.0"}
 ]
 synopsis: "Xen Vchan implementation"
 description: """

--- a/packages/vchan/vchan.2.0.2/opam
+++ b/packages/vchan/vchan.2.0.2/opam
@@ -33,6 +33,7 @@ conflicts: [
   "xen-evtchn" {< "1.0.3"}
   "xen-evtchn" {>= "2.0.0"}
   "xen-gnt"    {>= "2.0.0"}
+  "mirage-xen" {>= "4.0.0"}
 ]
 synopsis: "Xen Vchan implementation"
 description: """

--- a/packages/vchan/vchan.2.0.3/opam
+++ b/packages/vchan/vchan.2.0.3/opam
@@ -38,6 +38,7 @@ conflicts: [
   "xen-evtchn" {< "1.0.3"}
   "xen-evtchn" {>= "2.0.0"}
   "xen-gnt"    {>= "2.0.0"}
+  "mirage-xen" {>= "4.0.0"}
 ]
 depexts: [
   ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}

--- a/packages/vchan/vchan.2.1.0/opam
+++ b/packages/vchan/vchan.2.1.0/opam
@@ -26,7 +26,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.13"}
-  "io-page"
+  "io-page" {<"2.0.0"}
   "mirage-types-lwt" {< "3.0.0"}
   "xenstore" {>= "1.2.2"}
   "xenstore_transport"

--- a/packages/vchan/vchan.2.1.0/opam
+++ b/packages/vchan/vchan.2.1.0/opam
@@ -39,6 +39,7 @@ conflicts: [
   "xen-evtchn" {< "1.0.3"}
   "xen-evtchn" {>= "2.0.0"}
   "xen-gnt"    {>= "2.0.0"}
+  "mirage-xen" {>= "4.0.0"}
 ]
 depexts: [
   ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}

--- a/packages/vchan/vchan.2.2.0/opam
+++ b/packages/vchan/vchan.2.2.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.13"}
-  "io-page"
+  "io-page" {<"2.0.0"}
   "mirage-types-lwt" {< "3.0.0"}
   "xenstore" {>= "1.2.2"}
   "xenstore_transport"

--- a/packages/vchan/vchan.2.2.0/opam
+++ b/packages/vchan/vchan.2.2.0/opam
@@ -44,6 +44,7 @@ conflicts: [
   "xen-evtchn" {< "1.0.3"}
   "xen-evtchn" {>= "2.0.0"}
   "xen-gnt" {>= "2.0.0"}
+  "mirage-xen" {>= "4.0.0"}
 ]
 depexts: [
   ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}

--- a/packages/vchan/vchan.2.3.0/opam
+++ b/packages/vchan/vchan.2.3.0/opam
@@ -29,6 +29,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.03.0" & with-test}
   "ocamlfind" {build}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0" & <"3.4.0"} 

--- a/packages/vchan/vchan.2.3.0/opam
+++ b/packages/vchan/vchan.2.3.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.13"}
-  "io-page"
+  "io-page" {<"2.0.0"}
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}
   "xenstore_transport"

--- a/packages/vchan/vchan.2.3.0/opam
+++ b/packages/vchan/vchan.2.3.0/opam
@@ -53,7 +53,9 @@ conflicts: [
  "xen-evtchn" {< "1.0.3"}
  "xen-evtchn" {>= "2.0.0"}
  "xen-gnt"    {>= "2.0.0"}
- ]
+ "mirage-xen" {>= "4.0.0"}
+]
+
 depexts: [
   ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
   ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}

--- a/packages/vchan/vchan.2.3.1/opam
+++ b/packages/vchan/vchan.2.3.1/opam
@@ -49,6 +49,9 @@ depopts: [
   "xen-gnt-unix"
   "mirage-xen"
 ]
+conflicts: [
+  "mirage-xen" {>="4.0.0"}
+]
 depexts: [
   ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
   ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}

--- a/packages/vchan/vchan.2.3.1/opam
+++ b/packages/vchan/vchan.2.3.1/opam
@@ -29,6 +29,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.03.0" & with-test}
   "ocamlfind" {build}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0" & < "3.4.0"}

--- a/packages/vchan/vchan.2.3.1/opam
+++ b/packages/vchan/vchan.2.3.1/opam
@@ -35,7 +35,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.13"}
-  "io-page"
+  "io-page" {<"2.0.0"}
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}
   "xenstore_transport"


### PR DESCRIPTION
due to Os_xen change