### PR TITLE
[new release] mirage-xen (4.0.1)

### DIFF
--- a/packages/mirage-xen/mirage-xen.4.0.1/opam
+++ b/packages/mirage-xen/mirage-xen.4.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "subst" ] {pinned}
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "xen-evtchn" {>= "0.9.9"}
+  "conf-pkg-config"
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "mirage-xen-ocaml" {>= "3.3.1"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen-minios" {>= "0.7.0"}
+  "logs"
+  "fmt"
+]
+conflicts: [
+  "dune" {= "1.9.1"}
+]
+available: [ os = "linux" ]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v4.0.1/mirage-xen-v4.0.1.tbz"
+  checksum: [
+    "sha256=0a05ea73d9bf336621b6014db15a6066266972f0b28d3bd05e4647df8179df92"
+    "sha512=14a8524433f4cb240b20ad165f67c4650aa855a5bdcead57c25f1431ada9eea8a14f8636cd24a4e20a60d711c21476304b2352654d54e5c66620d60211c40964"
+  ]
+}


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* Fix mirage-xen pkg-config file to reflect correct location of
  the bindings (@avsm)
