### PR TITLE
2 packages from sapristi/easy_logging at 0.5

### DIFF
--- a/packages/easy_logging/easy_logging.0.5/opam
+++ b/packages/easy_logging/easy_logging.0.5/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Module to log messages. Aimed at being both powerful and easy to use"
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "GPL"
+homepage: "https://sapristi.github.io/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.8"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "src/examples"] {with-test}
+]
+
+description: """Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages printf style, or [string] or [string lazy_t]
+   * tree logging architecture for light configuration
+   * handlers associated to each logger will format, filter and treat the message independantly.
+   * use the infrastructure with your own handlers with the [MakeLogging] functor.
+   * use tags to add contextual information to log messages
+"""
+url {
+  src: "https://github.com/sapristi/easy_logging/tarball/v0.5"
+  checksum: [
+    "md5=12fb8044e96ea1ace1cc465c766cde7e"
+    "sha512=17ab30169c54a13f3aff8605bd1acaffb911c6882fa3a0c7ad6c14b2dcbd3c08b0f2568fb0ec500ae6e741be926a49fb73954d2ccfedcd274463ffed20149b02"
+  ]
+}

--- a/packages/easy_logging_yojson/easy_logging_yojson.0.5/opam
+++ b/packages/easy_logging_yojson/easy_logging_yojson.0.5/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Configuration loader for easy_logging with yojson backend"
+
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "GPL"
+homepage: "https://sapristi.github.io/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.8"}
+  "ppx_deriving"{>= "4.0" & < "5.0"}
+  "ppx_deriving_yojson"
+  "easy_logging" {>= "0.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "conf_loader_modules/yojson"] {with-test}
+]
+
+description: """Provides deserialisation of logging configuration 
+(loggers instantation and handlers parameters) from json,
+using ppx_deriving_yojson.
+
+-------
+
+     Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages printf style, or [string] or [string lazy_t]
+   * tree logging architecture for light configuration
+   * handlers associated to each logger will format, filter and treat the message independantly.
+   * use the infrastructure with your own handlers with the [MakeLogging] functor.
+   * use tags to add contextual information to log messages
+"""
+url {
+  src: "https://github.com/sapristi/easy_logging/tarball/v0.5"
+  checksum: [
+    "md5=12fb8044e96ea1ace1cc465c766cde7e"
+    "sha512=17ab30169c54a13f3aff8605bd1acaffb911c6882fa3a0c7ad6c14b2dcbd3c08b0f2568fb0ec500ae6e741be926a49fb73954d2ccfedcd274463ffed20149b02"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`easy_logging.0.5`: Module to log messages. Aimed at being both powerful and easy to use
-`easy_logging_yojson.0.5`: Configuration loader for easy_logging with yojson backend



---
* Homepage: https://sapristi.github.io/easy_logging/
* Source repo: git+https://github.com/sapristi/easy_logging.git
* Bug tracker: https://github.com/sapristi/easy_logging/issues

---
:camel: Pull-request generated by opam-publish v2.0.0