### PR TITLE
[new release] mirage-protocols-lwt and mirage-protocols (3.0.0)

### DIFF
--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.2.0.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.2.0.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build & >= "1.0"}
-  "mirage-protocols" {>= "2.0.0"}
+  "mirage-protocols" {="2.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"
   "lwt"

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.3.0.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.3.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-protocols" {>= "2.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "lwt"
+  "cstruct" {>= "1.9.0"}
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols-lwt provides a set of module types specialized to lwt which
+libraries intended to be used as MirageOS network implementations should
+implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v3.0.0/mirage-protocols-v3.0.0.tbz"
+  checksum: [
+    "sha256=b83352a91bb7a693ef7a2022539e789b869903946bbe374bac2df078d60b93e2"
+    "sha512=041c16ee3749562a3900762ef1c179f3d97efb856ec79346223083399cfb13b0e22d2041fb4208b98a557ae5ddf561d79c14362a8ce32dd08fe006b45e4b1c3e"
+  ]
+}

--- a/packages/mirage-protocols/mirage-protocols.3.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.3.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
+  "mirage-net" {>= "2.0.0"}
+  "fmt"
+  "duration"
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to
+be used as MirageOS network implementations should implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v3.0.0/mirage-protocols-v3.0.0.tbz"
+  checksum: [
+    "sha256=b83352a91bb7a693ef7a2022539e789b869903946bbe374bac2df078d60b93e2"
+    "sha512=041c16ee3749562a3900762ef1c179f3d97efb856ec79346223083399cfb13b0e22d2041fb4208b98a557ae5ddf561d79c14362a8ce32dd08fe006b45e4b1c3e"
+  ]
+}

--- a/packages/tcpip/tcpip.3.7.1/opam
+++ b/packages/tcpip/tcpip.3.7.1/opam
@@ -21,7 +21,7 @@ build: [
 depopts: ["mirage-xen-ocaml"]
 
 depends: [
-  "dune"     {build & >= "1.0"}
+  "dune" {build & >= "1.0"}
   "configurator" {build}
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
@@ -32,8 +32,8 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
-  "mirage-protocols" {>= "2.0.0"}
-  "mirage-protocols-lwt" {>= "2.0.0"}
+  "mirage-protocols" {>= "2.0.0" & < "3.0.0"}
+  "mirage-protocols-lwt" {>= "2.0.0" & < "3.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "2.0.0"}
   "mirage-flow" {with-test & >= "1.2.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >="0.7.0"}
+  "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.2/opam
+++ b/packages/tcpip/tcpip.3.7.2/opam
@@ -21,7 +21,7 @@ build: [
 depopts: ["mirage-xen-ocaml"]
 
 depends: [
-  "dune"     {build & >= "1.0"}
+  "dune" {build & >= "1.0"}
   "configurator" {build}
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
@@ -32,8 +32,8 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
-  "mirage-protocols" {>= "2.0.0"}
-  "mirage-protocols-lwt" {>= "2.0.0"}
+  "mirage-protocols" {>= "2.0.0" & < "3.0.0"}
+  "mirage-protocols-lwt" {>= "2.0.0" & < "3.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "2.0.0"}
   "mirage-flow" {with-test & >= "1.2.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >="0.7.0"}
+  "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.3/opam
+++ b/packages/tcpip/tcpip.3.7.3/opam
@@ -21,7 +21,7 @@ build: [
 depopts: ["mirage-xen-ocaml"]
 
 depends: [
-  "dune"     {build & >= "1.0"}
+  "dune" {build & >= "1.0"}
   "configurator" {build}
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
@@ -32,8 +32,8 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
-  "mirage-protocols" {>= "2.0.0"}
-  "mirage-protocols-lwt" {>= "2.0.0"}
+  "mirage-protocols" {>= "2.0.0" & < "3.0.0"}
+  "mirage-protocols-lwt" {>= "2.0.0" & < "3.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "2.0.0"}
   "mirage-flow" {with-test & >= "1.2.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >="0.7.0"}
+  "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.4/opam
+++ b/packages/tcpip/tcpip.3.7.4/opam
@@ -21,7 +21,7 @@ build: [
 depopts: ["mirage-xen-ocaml"]
 
 depends: [
-  "dune"     {build & >= "1.0"}
+  "dune" {build & >= "1.0"}
   "configurator" {build}
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
@@ -32,8 +32,8 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
-  "mirage-protocols" {>= "2.0.0"}
-  "mirage-protocols-lwt" {>= "2.0.0"}
+  "mirage-protocols" {>= "2.0.0" & < "3.0.0"}
+  "mirage-protocols-lwt" {>= "2.0.0" & < "3.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "2.0.0"}
   "mirage-flow" {with-test & >= "1.2.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >="0.7.0"}
+  "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.5/opam
+++ b/packages/tcpip/tcpip.3.7.5/opam
@@ -20,7 +20,7 @@ build: [
 
 depopts: ["mirage-xen-ocaml"]
 depends: [
-  "dune"     {build & >= "1.0"}
+  "dune" {build & >= "1.0"}
   "configurator" {build}
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
@@ -31,8 +31,8 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
-  "mirage-protocols" {>= "2.0.0"}
-  "mirage-protocols-lwt" {>= "2.0.0"}
+  "mirage-protocols" {>= "2.0.0" & < "3.0.0"}
+  "mirage-protocols-lwt" {>= "2.0.0" & < "3.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"
@@ -46,7 +46,7 @@ depends: [
   "ethernet" {>= "2.0.0"}
   "mirage-flow" {with-test & >= "1.2.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >="0.7.0"}
+  "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}


### PR DESCRIPTION
MirageOS signatures for network protocols

- Project page: <a href="https://github.com/mirage/mirage-protocols">https://github.com/mirage/mirage-protocols</a>
- Documentation: <a href="https://mirage.github.io/mirage-protocols/">https://mirage.github.io/mirage-protocols/</a>

##### CHANGES:

- replace `uipaddr` with `pp_ipaddr`, since the only use is to print
  human-readable IP addresses (mirage/mirage-protocols#18 @yomimono @linse)
- port to dune from jbuilder (mirage/mirage-protocols#17 @hannesm)
