### PR TITLE
[WIP] ppx_deriving.4.4 release preparation branch

### DIFF
--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.1.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.1.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "jbuilder" {build & >= "1.0+beta17"}
   "js_of_ocaml"
   "ppx_tools"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.2.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.2.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "jbuilder" {build & >= "1.0+beta17"}
   "js_of_ocaml"
   "ppx_tools"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.3.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "dune" {build & >= "1.2"}
   "js_of_ocaml"
   "ppx_tools"

--- a/packages/nocrypto/nocrypto.0.5.4-1/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-1/opam
@@ -37,6 +37,7 @@ conflicts: [
   "ocb-stubblr" {<"0.1.0"}
   "mirage-xen" {<"2.2.0"}
   "sexplib" {="v0.9.0"}
+  "ocaml" {= "4.08.0"}
 ]
 
 patches: [

--- a/packages/ppx_deriving/ppx_deriving.4.4/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.4/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version >= "4.03"}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune"     {build >= "1.6.3"}
+  "cppo"     {build}
+  "ppxfind"  {build}
+  "ocaml-migrate-parsetree"
+  "ppx_derivers"
+  "ppx_tools"  {>= "4.02.3"}
+  "result"
+  "ounit"      {with-test}
+  "ocaml" {>= "4.02" & < "4.09.0"}
+]
+synopsis: "Type-driven code generation for OCaml >=4.02.2"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src: "https://github.com/ocaml-ppx/ppx_deriving/archive/v4.4.tar.gz"
+  checksum: "sha256=c2d85af4cb65a1f163f624590fb0395a164bbfd0d05082092526b669e66bcc34"}

--- a/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.4/opam
+++ b/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.4/opam
@@ -16,7 +16,7 @@ build: [
   ]
   [
     "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test.byte" "--"
-  ] {with-test}
+  ] {with-test & ppx_deriving:version < "4.3"}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
@@ -25,7 +25,7 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "ocaml-migrate-parsetree"
-  "ppx_deriving" {>= "3.2" & < "4.3"}
+  "ppx_deriving" {>= "3.2" & < "5.0"}
   "ppx_derivers"
   "result" {with-test}
   "ounit" {with-test}

--- a/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.4/opam
+++ b/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.4/opam
@@ -25,7 +25,7 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "ocaml-migrate-parsetree"
-  "ppx_deriving" {>= "3.2" & < "5.0"}
+  "ppx_deriving" {>= "3.2" & < "4.3"}
   "ppx_derivers"
   "result" {with-test}
   "ounit" {with-test}

--- a/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.5/opam
+++ b/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.5/opam
@@ -16,7 +16,7 @@ build: [
   ]
   [
     "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test.byte" "--"
-  ] {with-test}
+  ] {with-test & ppx_deriving:version < "4.3"}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
@@ -25,7 +25,7 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "ocaml-migrate-parsetree"
-  "ppx_deriving" {>= "3.2" & < "4.3"}
+  "ppx_deriving" {>= "3.2" & < "5.0"}
   "ppx_derivers"
   "result" {with-test}
   "ounit" {with-test}

--- a/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.5/opam
+++ b/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.5/opam
@@ -25,7 +25,7 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "ocaml-migrate-parsetree"
-  "ppx_deriving" {>= "3.2" & < "5.0"}
+  "ppx_deriving" {>= "3.2" & < "4.3"}
   "ppx_derivers"
   "result" {with-test}
   "ounit" {with-test}

--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.6/opam
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.6/opam
@@ -25,7 +25,7 @@ build: [
   [make "doc"] {with-doc}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "cppo" {build}

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.5.9.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.5.9.0/opam
@@ -14,7 +14,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.08.0"}
   "jbuilder" {build}
   "cppo" {build}
   "rpclib" {>= "5.0.0"}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.3/opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.08.0"}
   "yojson" {< "1.6.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.4/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.4/opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.08.0"}
   "yojson" {>= "1.6.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}

--- a/packages/visitors/visitors.20171124/opam
+++ b/packages/visitors/visitors.20171124/opam
@@ -16,7 +16,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.02.2"}
+  "ocaml" {>= "4.02.2" & < "4.08.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "cppo" {build}

--- a/packages/visitors/visitors.20180306/opam
+++ b/packages/visitors/visitors.20180306/opam
@@ -16,7 +16,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.02.2"}
+  "ocaml" {>= "4.02.2" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cppo" {build}

--- a/packages/visitors/visitors.20180513/opam
+++ b/packages/visitors/visitors.20180513/opam
@@ -16,7 +16,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.02.2"}
+  "ocaml" {>= "4.02.2" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cppo" {build}


### PR DESCRIPTION
* Restore support for OCaml 4.02.3
  ocaml-ppx/ppx_deriving#188
  (ELLIOTTCABLE)
* workaround Location.input_filename being empty
  when using reason-language-server
  ocaml-ppx/ppx_deriving#196
  (Ryan Artecona)
* Add support for OCaml 4.08.0
  ocaml-ppx/ppx_deriving#193, ocaml-ppx/ppx_deriving#197, ocaml-ppx/ppx_deriving#200
  (Gabriel Scherer)