### PR TITLE
Package sedlex.2.1

### DIFF
--- a/packages/sedlex/sedlex.2.1/opam
+++ b/packages/sedlex/sedlex.2.1/opam
@@ -17,13 +17,12 @@ homepage: "https://github.com/ocaml-community/sedlex"
 dev-repo: "git+https://github.com/ocaml-community/sedlex.git"
 bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 build: [
-  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {build & >= "4.02.3"}
+  "ocaml" {>= "4.02.3"}
   "dune" {build & >= "1.0"}
   "ppx_tools_versioned"
   "ocaml-migrate-parsetree"

--- a/packages/sedlex/sedlex.2.1/opam
+++ b/packages/sedlex/sedlex.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "An OCaml lexer generator for Unicode"
+description: "
+sedlex is a lexer generator for OCaml. It is similar to ocamllex, but supports
+Unicode. Unlike ocamllex, sedlex allows lexer specifications within regular
+OCaml source files. Lexing specific constructs are provided via a ppx syntax
+extension.
+"
+license: "MIT"
+doc: "https://ocaml-community.github.io/sedlex/index.html"
+maintainer: "Alain Frisch <alain.frisch@lexifi.com>"
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "https://github.com/ocaml-community/sedlex/graphs/contributors"
+]
+homepage: "https://github.com/ocaml-community/sedlex"
+dev-repo: "git+https://github.com/ocaml-community/sedlex.git"
+bug-reports: "https://github.com/ocaml-community/sedlex/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {build & >= "4.02.3"}
+  "dune" {build & >= "1.0"}
+  "ppx_tools_versioned"
+  "ocaml-migrate-parsetree"
+  "gen"
+  "uchar"
+]
+url {
+  src: "https://github.com/ocaml-community/sedlex/archive/v2.1.zip"
+  checksum: [
+    "md5=30fdddb1c9d8301bad3d5b3d2cbbefbf"
+    "sha512=7c937c5ed234ac6f97aacec5e9f185c4490ab8cc953d071b1bbb93983e5518c4c0fb96782a43348631270c7b4f3e0c5dc312777644724adf955f9a58070b3f12"
+  ]
+}


### PR DESCRIPTION
### `sedlex.2.1`
An OCaml lexer generator for Unicode
sedlex is a lexer generator for OCaml. It is similar to ocamllex, but supports
Unicode. Unlike ocamllex, sedlex allows lexer specifications within regular
OCaml source files. Lexing specific constructs are provided via a ppx syntax
extension.



---
* Homepage: https://github.com/ocaml-community/sedlex
* Source repo: git+https://github.com/ocaml-community/sedlex.git
* Bug tracker: https://github.com/ocaml-community/sedlex/issues

---
:camel: Pull-request generated by opam-publish v2.0.0