### PR TITLE
[new release] mirage-profile, mirage-profile-xen and mirage-profile-unix (0.9.1)

### DIFF
--- a/packages/mirage-profile-unix/mirage-profile-unix.0.9.1/opam
+++ b/packages/mirage-profile-unix/mirage-profile-unix.0.9.1/opam
@@ -14,7 +14,6 @@ depends: [
   "ocplib-endian"
 ]
 build: [
-  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/mirage-profile.git"

--- a/packages/mirage-profile-unix/mirage-profile-unix.0.9.1/opam
+++ b/packages/mirage-profile-unix/mirage-profile-unix.0.9.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Collect runtime profiling information in CTF format"
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mirage/mirage-profile"
+doc: "https://mirage.github.io/mirage-profile/"
+bug-reports: "https://github.com/mirage/mirage-profile/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build & >= "1.0"}
+  "mirage-profile" {>= "0.8.0"}
+  "mtime" {>= "1.0.0"}
+  "ocplib-endian"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-profile.git"
+description: """
+This library can be used to trace execution of OCaml/Lwt programs (such as
+Mirage unikernels) at the level of Lwt threads.  The traces can be viewed using
+JavaScript or GTK viewers provided by [mirage-trace-viewer][] or processed by
+tools supporting the [Common Trace Format (CTF)][ctf].
+
+This backend adds a Unix collector.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-profile/releases/download/v0.9.1/mirage-profile-v0.9.1.tbz"
+  checksum: [
+    "sha256=2bb6cf03c73c6f45dedc34365c9131b8bdda62390b04d26eb76793a6422a0352"
+    "sha512=23cc4a2a62f5cc05b48d626bd6c8171a442fd46490da6810b1c507fcd7661c7fcd901d8328cddf687af4144136bf0d34b63f8484e32550077ab63d23e6eaea2b"
+  ]
+}

--- a/packages/mirage-profile-xen/mirage-profile-xen.0.9.1/opam
+++ b/packages/mirage-profile-xen/mirage-profile-xen.0.9.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Collect runtime profiling information in CTF format"
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mirage/mirage-profile"
+doc: "https://mirage.github.io/mirage-profile/"
+bug-reports: "https://github.com/mirage/mirage-profile/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build & >= "1.0"}
+  "mirage-profile" {=version}
+  "io-page-xen"
+  "io-page"
+  "mirage-xen-minios"
+  "ocplib-endian"
+  "mirage-xen" {>= "4.0.0"}
+  "xenstore"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-profile.git"
+description: """
+This library can be used to trace execution of OCaml/Lwt programs (such as
+Mirage unikernels) at the level of Lwt threads.  The traces can be viewed using
+JavaScript or GTK viewers provided by [mirage-trace-viewer][] or processed by
+tools supporting the [Common Trace Format (CTF)][ctf].
+
+This library adds a Xen MirageOS backend collector.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-profile/releases/download/v0.9.1/mirage-profile-v0.9.1.tbz"
+  checksum: [
+    "sha256=2bb6cf03c73c6f45dedc34365c9131b8bdda62390b04d26eb76793a6422a0352"
+    "sha512=23cc4a2a62f5cc05b48d626bd6c8171a442fd46490da6810b1c507fcd7661c7fcd901d8328cddf687af4144136bf0d34b63f8484e32550077ab63d23e6eaea2b"
+  ]
+}

--- a/packages/mirage-profile-xen/mirage-profile-xen.0.9.1/opam
+++ b/packages/mirage-profile-xen/mirage-profile-xen.0.9.1/opam
@@ -18,7 +18,6 @@ depends: [
   "xenstore"
 ]
 build: [
-  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/mirage-profile.git"

--- a/packages/mirage-profile/mirage-profile.0.9.1/opam
+++ b/packages/mirage-profile/mirage-profile.0.9.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Collect runtime profiling information in CTF format"
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mirage/mirage-profile"
+doc: "https://mirage.github.io/mirage-profile/"
+bug-reports: "https://github.com/mirage/mirage-profile/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "ppx_cstruct" {build}
+  "ocplib-endian"
+  "lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-profile.git"
+description: """
+This library can be used to trace execution of OCaml/Lwt programs (such as
+Mirage unikernels) at the level of Lwt threads.  The traces can be viewed using
+JavaScript or GTK viewers provided by [mirage-trace-viewer][] or processed by
+tools supporting the [Common Trace Format (CTF)][ctf].  Some example traces can
+be found in the blog post [Visualising an Asynchronous
+Monad](http://roscidus.com/blog/blog/2014/10/27/visualising-an-asynchronous-monad/).
+
+Libraries can use the functions mirage-profile provides to annotate the traces
+with extra information.  When compiled against a normal version of Lwt,
+mirage-profile's functions are null-ops (or call the underlying untraced
+operation, as appropriate) and OCaml's cross-module inlining will optimise
+these calls away, meaning there should be no overhead in the non-profiling
+case.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-profile/releases/download/v0.9.1/mirage-profile-v0.9.1.tbz"
+  checksum: [
+    "sha256=2bb6cf03c73c6f45dedc34365c9131b8bdda62390b04d26eb76793a6422a0352"
+    "sha512=23cc4a2a62f5cc05b48d626bd6c8171a442fd46490da6810b1c507fcd7661c7fcd901d8328cddf687af4144136bf0d34b63f8484e32550077ab63d23e6eaea2b"
+  ]
+}

--- a/packages/mirage-profile/mirage-profile.0.9.1/opam
+++ b/packages/mirage-profile/mirage-profile.0.9.1/opam
@@ -15,7 +15,6 @@ depends: [
   "lwt"
 ]
 build: [
-  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/mirage-profile.git"


### PR DESCRIPTION
Collect runtime profiling information in CTF format

- Project page: <a href="https://github.com/mirage/mirage-profile">https://github.com/mirage/mirage-profile</a>
- Documentation: <a href="https://mirage.github.io/mirage-profile/">https://mirage.github.io/mirage-profile/</a>

##### CHANGES:

- update for mirage-xen 4.0.0 (@talex5).
