### PR TITLE
Package ocolor.1.2

### DIFF
--- a/packages/ocolor/ocolor.1.2/opam
+++ b/packages/ocolor/ocolor.1.2/opam
@@ -8,7 +8,6 @@ depends: [
   "cppo" {build & >= "1.6.5"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 homepage: "https://github.com/marc-chevalier/ocolor"

--- a/packages/ocolor/ocolor.1.2/opam
+++ b/packages/ocolor/ocolor.1.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Print with style in your terminal using Format's semantic tags"
+maintainer: "Marc Chevalier <ocolor@marc-chevalier.com>"
+authors: "Marc Chevalier <ocolor@marc-chevalier.com>"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build & >= "1.6.3"}
+  "cppo" {build & >= "1.6.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+homepage: "https://github.com/marc-chevalier/ocolor"
+bug-reports: "https://github.com/marc-chevalier/ocolor/issues"
+dev-repo: "git+https://github.com/marc-chevalier/ocolor.git"
+license: "MIT"
+description: """
+This package provides a nice way to use ANSI escape codes thanks to Format's
+semantic tags. This mode is compositional: ending a style restore the previous
+one, instead of destroying everything.
+This package also allows using directly ANSI escape codes (with Printf).
+
+Note that this library does not intend to handle anything else than ANSI escape
+codes (in particular, not the old Windows style of styling). Moreover, it aims
+to be as pure as possible, so insensitive to the environment. As a consequence,
+there is no mechanism to detect terminal's settings. However, some configuration
+is possible, but must be done manually.
+"""
+url {
+  src: "https://github.com/marc-chevalier/ocolor/archive/1.2.tar.gz"
+  checksum: [
+    "md5=28b04a0cd1b8bbec795fe098913dff9b"
+    "sha512=420b6fbd8d18eb8e326dd23910fab3ea691e5e5044cf531d958f6bcd5dabb223075c31269873c5c5e5e273b8e391c0cdc20296c1ba4568819888e44bfef150be"
+  ]
+}


### PR DESCRIPTION
### `ocolor.1.2`
Print with style in your terminal using Format's semantic tags
This package provides a nice way to use ANSI escape codes thanks to Format's
semantic tags. This mode is compositional: ending a style restore the previous
one, instead of destroying everything.
This package also allows using directly ANSI escape codes (with Printf).

Note that this library does not intend to handle anything else than ANSI escape
codes (in particular, not the old Windows style of styling). Moreover, it aims
to be as pure as possible, so insensitive to the environment. As a consequence,
there is no mechanism to detect terminal's settings. However, some configuration
is possible, but must be done manually.



---
* Homepage: https://github.com/marc-chevalier/ocolor
* Source repo: git+https://github.com/marc-chevalier/ocolor.git
* Bug tracker: https://github.com/marc-chevalier/ocolor/issues

---
:camel: Pull-request generated by opam-publish v2.0.0