### PR TITLE
Package ppx_tools_versioned.5.2.3

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.1.3.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.3.1/opam
@@ -38,7 +38,7 @@ post-messages: [
 
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name] {with-test}
+  ["jbuilder" "runtest" "-p" name] {with-test & ocaml:version < "4.08.0"}
 ]
 synopsis: "Code coverage for OCaml"
 description: """

--- a/packages/bisect_ppx/bisect_ppx.1.3.2/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.3.2/opam
@@ -38,7 +38,7 @@ post-messages: [
 
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name] {with-test}
+  ["jbuilder" "runtest" "-p" name] {with-test & ocaml:version < "4.08.0"}
 ]
 synopsis: "Code coverage for OCaml"
 description: """

--- a/packages/bisect_ppx/bisect_ppx.1.3.3/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.3.3/opam
@@ -38,7 +38,6 @@ post-messages: [
 
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 synopsis: "Code coverage for OCaml"
 description: """

--- a/packages/bisect_ppx/bisect_ppx.1.3.4/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.3.4/opam
@@ -29,7 +29,6 @@ conflicts: [
 # it. 4.02.0 is the natural constraint of Bisect_ppx.
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 synopsis: "Code coverage for OCaml"
 description: """

--- a/packages/ppx_cstruct/ppx_cstruct.4.0.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.4.0.0/opam
@@ -13,7 +13,7 @@ tags: [ "org:mirage" "org:ocamllabs" ]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.08.0"}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_cstruct/ppx_cstruct.5.0.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.5.0.0/opam
@@ -13,7 +13,7 @@ tags: [ "org:mirage" "org:ocamllabs" ]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.08.0"}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_tools_versioned/ppx_tools_versioned.5.2.3/opam
+++ b/packages/ppx_tools_versioned/ppx_tools_versioned.5.2.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Alain Frisch <alain.frisch@lexifi.com>"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_tools_versioned"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools_versioned/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools_versioned.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.0"}
+  "ocaml-migrate-parsetree" {>= "1.4.0"}
+]
+synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.3.tar.gz"
+  checksum: [
+    "md5=b1455e5a4a1bcd9ddbfcf712ccbd4262"
+    "sha512=af20aa0031b9c638537bcdb52c75de95f316ae8fd455a38672a60da5c7c6895cca9dbecd5d56a88c3c40979c6a673a047d986b5b41e1e84b528b7df5d905b9b1"
+  ]
+}


### PR DESCRIPTION
### `ppx_tools_versioned.5.2.3`
A variant of ppx_tools based on ocaml-migrate-parsetree



---
* Homepage: https://github.com/ocaml-ppx/ppx_tools_versioned
* Source repo: git://github.com/ocaml-ppx/ppx_tools_versioned.git
* Bug tracker: https://github.com/ocaml-ppx/ppx_tools_versioned/issues

---
:camel: Pull-request generated by opam-publish v2.0.0