### PR TITLE
Package prepare.3.1

### DIFF
--- a/packages/prepare/prepare.3.1/opam
+++ b/packages/prepare/prepare.3.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Nicolas Barré <nicolas.barre@irisa.fr>"
+authors: "Javalib Development team"
+homepage: "https://javalib-team.github.io/javalib/"
+bug-reports: "https://github.com/javalib-team/javalib/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/javalib-team/javalib.git"
+build: [
+  ["./configure.sh"]
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "javalib"]
+depends: [
+  "ocaml" {>= "4.04"}
+  "conf-which" {build}
+  "ocamlfind" {build}
+  "camlzip" {>= "1.05"}
+  "camlp4"
+  "extlib"
+]
+
+synopsis: "Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files"
+
+description: """
+Thus it stands for a good starting point for people who want to
+develop static analyses for Java byte-code programs, benefiting from
+the strength of OCaml language.
+"""
+url {
+  src: "https://github.com/javalib-team/javalib/archive/v3.1.tar.gz"
+  checksum: [
+    "md5=515e890d06a9b3c6b57e5112a491ef24"
+    "sha512=74edd09168766a0bb30c442951d69aad7199efd39f1fe54f2335d439bae10ab95ccd0d2429ac336268a7ecddc8c2a35c8fbb168d6ef2b43b6177a0200f6336b6"
+  ]
+}

--- a/packages/prepare/prepare.3.1/opam
+++ b/packages/prepare/prepare.3.1/opam
@@ -10,7 +10,6 @@ build: [
   [make]
 ]
 install: [make "install"]
-remove: ["ocamlfind" "remove" "javalib"]
 depends: [
   "ocaml" {>= "4.04"}
   "conf-which" {build}


### PR DESCRIPTION
### `prepare.3.1`
Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files
Thus it stands for a good starting point for people who want to
develop static analyses for Java byte-code programs, benefiting from
the strength of OCaml language.



---
* Homepage: https://javalib-team.github.io/javalib/
* Source repo: git+https://github.com/javalib-team/javalib.git
* Bug tracker: https://github.com/javalib-team/javalib/issues

---
:camel: Pull-request generated by opam-publish v2.0.0