### PR TITLE
[new release] decompress (0.9.0)

### DIFF
--- a/packages/decompress/decompress.0.9.0/opam
+++ b/packages/decompress/decompress.0.9.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name:         "decompress"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib in OCaml"
+description: """Decompress is an implementation of Zlib in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {build}
+  "base-bytes"
+  "base-bigarray"
+  "mmap"
+  "optint"
+  "checkseum"
+  "camlzip"    {with-test & >= "1.07"}
+  "re"         {with-test & >= "1.7.2"}
+  "alcotest"   {with-test}
+  "bos"        {with-test}
+  "cmdliner"
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v0.9.0/decompress-v0.9.0.tbz"
+  checksum: [
+    "sha256=70dd782b258a51a37c3971b9bd96c656b161876d781e168a626e9bb437833e3b"
+    "sha512=34033405c8dca30f67c39cad8f50875e255644d0e0b88019091d59932aaf90d87445070228291b1d3d1c07a98ce97aeca11554daf1a8f3b04d043b4f6c1ab83c"
+  ]
+}

--- a/packages/rfc1951/rfc1951.0.8.1/opam
+++ b/packages/rfc1951/rfc1951.0.8.1/opam
@@ -26,7 +26,7 @@ depends: [
   "base-bigarray"
   "optint"
   "checkseum"
-  "decompress"
+  "decompress" {= version}
   "camlzip"    {with-test}
   "re"         {with-test & >= "1.7.2"}
   "alcotest"   {with-test}

--- a/packages/rfc1951/rfc1951.0.9.0/opam
+++ b/packages/rfc1951/rfc1951.0.9.0/opam
@@ -13,11 +13,8 @@ description: """This package provide an implementation of RFC1951 in OCaml.
 We provide a pure non-blocking interface to inflate and deflate data flow.
 """
 
-build: [
-  [ "dune" "subst" ]
-  [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
-]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+runt-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"      {>= "4.03.0"}
@@ -26,7 +23,7 @@ depends: [
   "base-bigarray"
   "optint"
   "checkseum"
-  "decompress"
+  "decompress" {= version}
   "camlzip"    {with-test}
   "re"         {with-test & >= "1.7.2"}
   "alcotest"   {with-test}

--- a/packages/rfc1951/rfc1951.0.9.0/opam
+++ b/packages/rfc1951/rfc1951.0.9.0/opam
@@ -14,7 +14,7 @@ We provide a pure non-blocking interface to inflate and deflate data flow.
 """
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
-runt-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"      {>= "4.03.0"}


### PR DESCRIPTION
Implementation of Zlib in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

* Add support of 4.07 and 4.08 in Travis (@XVilka, @dinosaure, mirage/decompress#70, mirage/decompress#71)
* Use `mmap` (@XVilka, @dinosaure, @hannesm, mirage/decompress#68, mirage/decompress#69, mirage/decompress#71)
* Update documentation (@yurug, @dinosaure, mirage/decompress#65, mirage/decompress#66)
* Micro-optimization about specialization (@dinosaure, mirage/decompress#64)
* Re-organize internals of `decompress` (@dinosaure, mirage/decompress#63) 
* GZIP support (@clecat, review by @dinosaure, @cfcs, @hannesm, mirage/decompress#60)
 - fix mirage/decompress#58 (@dinosaure)
