### PR TITLE
Markup.ml 0.8.1: standards-compliant HTML5 parser

### DIFF
--- a/packages/markup/markup.0.8.1/opam
+++ b/packages/markup/markup.0.8.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+
+synopsis: "Error-recovering functional HTML5 and XML parsers and writers"
+
+version: "0.8.1"
+license: "BSD"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/markup.ml.git"
+
+depends: [
+  "dune" {build}
+  "uchar"
+  "uutf" {>= "1.0.0"}
+
+  "bisect_ppx" {dev & >= "1.3.0"}
+  "ounit" {dev}
+]
+# Markup.ml implicitly requires OCaml 4.02.3, as this is a contraint of Dune.
+# Without that, Markup.ml implicitly requires OCaml 4.01.0, as this is a
+# constraint of Uutf. Without *that*, Markup.ml works on OCaml 3.11 or earlier.
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: """
+Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
+a simple interface: they are functions that transform byte streams to parsing
+signal streams. Streams can be manipulated in various ways, such as processing
+by fold, filter, and map, assembly into DOM tree structures, or serialization
+back to HTML or XML.
+
+Both parsers are based on their respective standards. The HTML parser, in
+particular, is based on the state machines defined in HTML5.
+
+The parsers are error-recovering by default, and accept fragments. This makes it
+very easy to get a best-effort parse of some input. The parsers can, however, be
+easily configured to be strict, and to accept only full documents.
+
+Apart from this, the parsers are streaming (do not build up a document in
+memory), non-blocking (can be used with threading libraries), lazy (do not
+consume input unless the signal stream is being read), and process the input in
+a single pass. They automatically detect the character encoding of the input
+stream, and convert everything to UTF-8."""
+
+url {
+  src: "https://github.com/aantron/markup.ml/archive/0.8.1.tar.gz"
+  checksum: "md5=1d9cd1bdd9ee5d65af7d36ad5900cc0e2"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/markup.ml/releases/tag/0.8.1):

> Additions
>
> - Ability to optionally pass custom escaping functions to `Markup.write_html` (aantron/markup.ml#42, Julien Sagot).
>
> Bugs fixed
>
> - `Markup.html5` and `Markup.xhtml` filtered their inputs incorrectly (aantron/markup.ml#41).
> - XML parser placed unnecessary restrictions on attribute names (aantron/markup.ml#43, @jeffa5).
> - HTML parser dropped characters in URL query parameter names (aantron/markup.ml#44, Julien Sagot).