### PR TITLE
Package ocsigenserver.2.12.0

### DIFF
--- a/packages/ocsigenserver/ocsigenserver.2.12.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.12.0/opam
@@ -37,11 +37,6 @@ build: [
   [make]
 ]
 install: [make "install"]
-remove: [
-  ["rm" "-rf" "%{lib}%/ocsigenserver"]
-  ["rm" "-rf" "%{doc}%/ocsigenserver"]
-  ["rm" "-f" "%{man}%/man1/ocsigenserver.1"]
-]
 depends: [
   "ocaml" {>= "4.06.1"}
   "ocamlfind"
@@ -66,7 +61,6 @@ conflicts: [
   "camlzip" {< "1.04"}
   "pgocaml" {< "2.2"}
 ]
-flags: light-uninstall
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.12.0.tar.gz"
   checksum: [

--- a/packages/ocsigenserver/ocsigenserver.2.12.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "dev@ocsigen.org"
-synopsis: "A full-featured and extensible Web server."
+synopsis: "A full-featured and extensible Web server"
 description: "Ocsigen Server implements most features of the HTTP protocol, and has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc."
 authors: "dev@ocsigen.org"
 homepage: "http://ocsigen.org/ocsigenserver/"
@@ -68,7 +68,7 @@ conflicts: [
 ]
 flags: light-uninstall
 url {
-  src: "https://github.com/jrochel/ocsigenserver/archive/2.12.0.tar.gz"
+  src: "https://github.com/ocsigen/ocsigenserver/archive/2.12.0.tar.gz"
   checksum: [
     "md5=0fdc5619e56a2dae59d6c5c3283aa9a1"
     "sha512=bf699257e4881b5c3173142eea6163a5c85726bbaca98f144a664e595d8a893d47b9419fb3ecea9b8ab3c058d2764edbadd83fea803198c81ce09bd412a1b6bb"

--- a/packages/ocsigenserver/ocsigenserver.2.12.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.12.0/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "A full-featured and extensible Web server."
+description: "Ocsigen Server implements most features of the HTTP protocol, and has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc."
+authors: "dev@ocsigen.org"
+homepage: "http://ocsigen.org/ocsigenserver/"
+bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+build: [
+  [
+    "sh"
+    "configure"
+    "--prefix"
+    "%{prefix}%"
+    "--ocsigen-user"
+    "%{user}%"
+    "--ocsigen-group"
+    "%{group}%"
+    "--commandpipe"
+    "%{lib}%/ocsigenserver/var/run/ocsigenserver_command"
+    "--logdir"
+    "%{lib}%/ocsigenserver/var/log/ocsigenserver"
+    "--mandir"
+    "%{man}%/man1"
+    "--docdir"
+    "%{lib}%/ocsigenserver/share/doc/ocsigenserver"
+    "--commandpipe"
+    "%{lib}%/ocsigenserver/var/run/ocsigenserver_command"
+    "--staticpagesdir"
+    "%{lib}%/ocsigenserver/var/www"
+    "--datadir"
+    "%{lib}%/ocsigenserver/var/lib/ocsigenserver"
+    "--sysconfdir"
+    "%{lib}%/ocsigenserver/etc/ocsigenserver"
+  ]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["rm" "-rf" "%{lib}%/ocsigenserver"]
+  ["rm" "-rf" "%{doc}%/ocsigenserver"]
+  ["rm" "-f" "%{man}%/man1/ocsigenserver.1"]
+]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind"
+  "base-unix"
+  "base-threads"
+  "react"
+  "ssl" {>= "0.5.8"}
+  "lwt" {>= "3.0.0"}
+  "lwt_ssl"
+  "lwt_react"
+  "lwt_log"
+  "ocamlnet" {>= "4.0.2"}
+  "pcre"
+  "cryptokit"
+  "tyxml" {>= "4.0.0"}
+  "dbm" | "sqlite3" | "pgocaml"
+  "ipaddr" {>= "2.1"}
+  "xml-light"
+]
+depopts: "camlzip"
+conflicts: [
+  "camlzip" {< "1.04"}
+  "pgocaml" {< "2.2"}
+]
+flags: light-uninstall
+url {
+  src: "https://github.com/jrochel/ocsigenserver/archive/2.12.0.tar.gz"
+  checksum: [
+    "md5=0fdc5619e56a2dae59d6c5c3283aa9a1"
+    "sha512=bf699257e4881b5c3173142eea6163a5c85726bbaca98f144a664e595d8a893d47b9419fb3ecea9b8ab3c058d2764edbadd83fea803198c81ce09bd412a1b6bb"
+  ]
+}


### PR DESCRIPTION
### `ocsigenserver.2.12.0`
A full-featured and extensible Web server.
Ocsigen Server implements most features of the HTTP protocol, and has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc.



---
* Homepage: http://ocsigen.org/ocsigenserver/
* Source repo: git+https://github.com/ocsigen/ocsigenserver.git
* Bug tracker: https://github.com/ocsigen/ocsigenserver/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0