### PR TITLE
[new release] uri and uri-sexp (3.0.0)

### DIFF
--- a/packages/async_js/async_js.v0.12.0/opam
+++ b/packages/async_js/async_js.v0.12.0/opam
@@ -10,18 +10,16 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"            {>= "4.07.0"}
-  "async_kernel"     {>= "v0.12" & < "v0.13"}
+  "ocaml" {>= "4.07.0"}
+  "async_kernel" {>= "v0.12" & < "v0.13"}
   "async_rpc_kernel" {>= "v0.12" & < "v0.13"}
-  "ppx_jane"         {>= "v0.12" & < "v0.13"}
-  "dune"             {build & >= "1.5.1"}
-  "js_of_ocaml"      {>= "3.2.1"}
+  "ppx_jane" {>= "v0.12" & < "v0.13"}
+  "dune" {build & >= "1.5.1"}
+  "js_of_ocaml" {>= "3.2.1"}
   "js_of_ocaml-ppx"
-  "uri"              {>= "2.0.0"}
+  "uri" {>= "2.0.0" & < "3.0.0"}
 ]
 synopsis: "A small library that provide Async support for JavaScript platforms"
-description: "
-"
 url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/async_js-v0.12.0.tar.gz"
   checksum: "md5=444eab0508755820f499811d8082746e"

--- a/packages/cohttp-async/cohttp-async.1.2.0/opam
+++ b/packages/cohttp-async/cohttp-async.1.2.0/opam
@@ -56,7 +56,7 @@ depends: [
   "sexplib0" {< "v0.12"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.12"}
   "ounit" {with-test}
-  "uri" {>= "2.0.0"}
+  "uri" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/cohttp-async/cohttp-async.2.0.0/opam
+++ b/packages/cohttp-async/cohttp-async.2.0.0/opam
@@ -31,14 +31,14 @@ depends: [
   "base" {>= "v0.11.0" & < "v0.12"}
   "core" {with-test & < "v0.12"}
   "cohttp"
-  "conduit-async" {>="1.2.0"}
+  "conduit-async" {>= "1.2.0"}
   "magic-mime"
   "logs"
   "fmt" {>= "0.8.2"}
   "sexplib0" {< "v0.12"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.12"}
   "ounit" {with-test}
-  "uri" {>= "2.0.0"}
+  "uri" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/cohttp-async/cohttp-async.2.1.1/opam
+++ b/packages/cohttp-async/cohttp-async.2.1.1/opam
@@ -31,14 +31,14 @@ depends: [
   "base" {>= "v0.11.0"}
   "core" {with-test}
   "cohttp"
-  "conduit-async" {>="1.2.0"}
+  "conduit-async" {>= "1.2.0"}
   "magic-mime"
   "logs"
   "fmt" {>= "0.8.2"}
   "sexplib0"
   "ppx_sexp_conv" {>= "v0.9.0"}
   "ounit" {with-test}
-  "uri" {>= "2.0.0"}
+  "uri" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/cohttp/cohttp.1.2.0/opam
+++ b/packages/cohttp/cohttp.1.2.0/opam
@@ -44,7 +44,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {build & >= "1.1.0"}
   "re" {>= "1.7.2"}
-  "uri" {>= "2.0.0"}
+  "uri" {>= "2.0.0" & < "3.0.0"}
   "fieldslib" {< "v0.13"}
   "sexplib0" {< "v0.13"}
   "ppx_fields_conv" {>= "v0.9.0" & < "v0.13"}

--- a/packages/cohttp/cohttp.2.0.0/opam
+++ b/packages/cohttp/cohttp.2.0.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {build & >= "1.1.0"}
   "re" {>= "1.7.2"}
-  "uri" {>= "2.0.0"}
+  "uri" {>= "2.0.0" & < "3.0.0"}
   "fieldslib" {< "v0.13"}
   "sexplib0" {< "v0.13"}
   "ppx_fields_conv" {>= "v0.9.0" & < "v0.13"}

--- a/packages/cohttp/cohttp.2.1.2/opam
+++ b/packages/cohttp/cohttp.2.1.2/opam
@@ -35,7 +35,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {build & >= "1.1.0"}
   "re" {>= "1.7.2"}
-  "uri" {>= "2.0.0"}
+  "uri" {>= "2.0.0" & < "3.0.0"}
   "fieldslib"
   "sexplib0"
   "ppx_fields_conv" {>= "v0.9.0"}

--- a/packages/mechaml/mechaml.0.1/opam
+++ b/packages/mechaml/mechaml.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind" {build}
   "cohttp" {>= "0.21.0" & < "0.99"}
   "lwt"
-  "uri"
+  "uri" {< "3.0.0"}
   "lambdasoup" {< "0.7.0"}
   "alcotest" {with-test & < "0.8.0"}
 ]

--- a/packages/mechaml/mechaml.1.0.0/opam
+++ b/packages/mechaml/mechaml.1.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "cohttp-lwt"
   "cohttp-lwt-unix"
   "lwt"
-  "uri"
+  "uri" {< "3.0.0"}
   "lambdasoup" {< "0.7.0"}
   "alcotest" {with-test & >= "0.8.0"}
 ]

--- a/packages/mechaml/mechaml.1.1.0/opam
+++ b/packages/mechaml/mechaml.1.1.0/opam
@@ -82,7 +82,7 @@ depends: [
   "cohttp-lwt"
   "cohttp-lwt-unix"
   "lwt"
-  "uri"
+  "uri" {< "3.0.0"}
   "lambdasoup" {< "0.7.0"}
   "alcotest" {with-test & >= "0.8.0"}
   "ocaml" {>= "4.03.0"}
@@ -98,3 +98,4 @@ url {
     "https://github.com/yannham/mechaml/releases/download/v1.1.0/mechaml-v1.1.0.tbz"
   checksum: "md5=6ce800fbcdd8bdb53c84fb5e4bfb0329"
 }
+synopsis: ""

--- a/packages/satyrographos/satyrographos.0.0.1.4/opam
+++ b/packages/satyrographos/satyrographos.0.0.1.4/opam
@@ -22,8 +22,7 @@ depends: [
   "ppx_deriving" {build}
   "ppx_inline_test" {build & < "v0.12"}
   "ppx_jane" {build & < "v0.12"}
-  (* "satysfi" {>= "0.0.3" & < "0.0.4"} *)
-  "uri" {>= "2.0.0"}
+  "uri" {>= "2.0.0" & < "3.0.0"}
   "yojson"
 ]
 synopsis: "A naive package manager for SATySFi"

--- a/packages/satyrographos/satyrographos.0.0.1.5/opam
+++ b/packages/satyrographos/satyrographos.0.0.1.5/opam
@@ -21,7 +21,7 @@ depends: [
   "json-derivers"
   "ppx_deriving"
   "ppx_jane" {< "v0.12"}
-  "uri" {>= "2.0.0"}
+  "uri" {>= "2.0.0" & < "3.0.0"}
   "yojson"
 ]
 synopsis: "A naive package manager for SATySFi"

--- a/packages/satyrographos/satyrographos.0.0.1.7/opam
+++ b/packages/satyrographos/satyrographos.0.0.1.7/opam
@@ -20,7 +20,7 @@ depends: [
   "json-derivers"
   "ppx_deriving"
   "ppx_jane" {< "v0.13"}
-  "uri" {>= "2.0.0"}
+  "uri" {>= "2.0.0" & < "3.0.0"}
   "yojson"
 ]
 synopsis: "A package manager for SATySFi"

--- a/packages/uri-sexp/uri-sexp.3.0.0/opam
+++ b/packages/uri-sexp/uri-sexp.3.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+ocaml-uri with sexp support
+"""
+depends: [
+  "uri" {= version}
+  "dune" {build & >= "1.2.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v3.0.0/uri-v3.0.0.tbz"
+  checksum: [
+    "sha256=8fb334fba6ebbf879e2e82d80d6adee8bdaf6cec3bb3da248110d805477d19fa"
+    "sha512=553c18032a7c96cccdc8e37f497ce34e821b9dd089cfc8685783b7ade1d4dfa422722e4724abcba8b1171b51fa91a2bee297396fc7c349118069b6352e07881e"
+  ]
+}

--- a/packages/uri/uri.3.0.0/opam
+++ b/packages/uri/uri.3.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification 
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build & >= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "re" {>= "1.9.0"}
+  "stringext" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v3.0.0/uri-v3.0.0.tbz"
+  checksum: [
+    "sha256=8fb334fba6ebbf879e2e82d80d6adee8bdaf6cec3bb3da248110d805477d19fa"
+    "sha512=553c18032a7c96cccdc8e37f497ce34e821b9dd089cfc8685783b7ade1d4dfa422722e4724abcba8b1171b51fa91a2bee297396fc7c349118069b6352e07881e"
+  ]
+}


### PR DESCRIPTION
An RFC3986 URI/URL parsing library

- Project page: <a href="https://github.com/mirage/ocaml-uri">https://github.com/mirage/ocaml-uri</a>
- Documentation: <a href="https://mirage.github.io/ocaml-uri/">https://mirage.github.io/ocaml-uri/</a>

##### CHANGES:

* Complete the migration of making sexp an optional dependency that was
  started in 2.0.0. We now remove the `uri.sexp` ocamlfind package and
  have `uri` and `uri-sexp` for both the ocamlfind and opam packages.
  Code that was formerly using `uri.sexp` in its build will now need to
  move to `uri-sexp` instead (mirage/ocaml-uri#134 @Julow @dinosaure).

* Remove the deprecated `Uri_re` module. All code should be using the
  `Uri.Re` module instead (@avsm @Julow).

* Remove the `uri.top` library, since we install the toplevel printer
  automatically since 2.2.0 via an attribute.
