### PR TITLE
Package ocolor.1.2.1

### DIFF
--- a/packages/ocolor/ocolor.1.2.1/opam
+++ b/packages/ocolor/ocolor.1.2.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Print with style in your terminal using Format's semantic tags"
+maintainer: "Marc Chevalier <ocolor@marc-chevalier.com>"
+authors: "Marc Chevalier <ocolor@marc-chevalier.com>"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build & >= "1.6.3"}
+  "cppo" {build & >= "1.6.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+homepage: "https://github.com/marc-chevalier/ocolor"
+bug-reports: "https://github.com/marc-chevalier/ocolor/issues"
+dev-repo: "git+https://github.com/marc-chevalier/ocolor.git"
+license: "MIT"
+description: """
+This package provides a nice way to use ANSI escape codes thanks to Format's
+semantic tags. This mode is compositional: ending a style restore the previous
+one, instead of destroying everything.
+This package also allows using directly ANSI escape codes (with Printf).
+
+Note that this library does not intend to handle anything else than ANSI escape
+codes (in particular, not the old Windows style of styling). Moreover, it aims
+to be as pure as possible, so insensitive to the environment. As a consequence,
+there is no mechanism to detect terminal's settings. However, some configuration
+is possible, but must be done manually.
+"""
+url {
+  src: "https://github.com/marc-chevalier/ocolor/archive/1.2.1.tar.gz"
+  checksum: [
+    "md5=b0ee5aebb9233f6ec301c8acfff649a9"
+    "sha512=bd313217e648a767790bdcce5998e1989d060f71b5dd35fe6193c630ebbdb52257e898729a58198b4dea4799068a2b724d47b0b0c3fce6e275e153e2a72d4a39"
+  ]
+}


### PR DESCRIPTION
### `ocolor.1.2.1`
Print with style in your terminal using Format's semantic tags
This package provides a nice way to use ANSI escape codes thanks to Format's
semantic tags. This mode is compositional: ending a style restore the previous
one, instead of destroying everything.
This package also allows using directly ANSI escape codes (with Printf).

Note that this library does not intend to handle anything else than ANSI escape
codes (in particular, not the old Windows style of styling). Moreover, it aims
to be as pure as possible, so insensitive to the environment. As a consequence,
there is no mechanism to detect terminal's settings. However, some configuration
is possible, but must be done manually.



---
* Homepage: https://github.com/marc-chevalier/ocolor
* Source repo: git+https://github.com/marc-chevalier/ocolor.git
* Bug tracker: https://github.com/marc-chevalier/ocolor/issues

---
:camel: Pull-request generated by opam-publish v2.0.0