### PR TITLE
[new release] mirage, mirage-runtime, mirage-types-lwt and mirage-types (3.5.1)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.5.1/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.5.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build & >= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria-runtime"  {>= "2.2.2"}
+  "fmt"
+  "logs"
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.5.1/mirage-v3.5.1.tbz"
+  checksum: [
+    "sha256=2ff147901b46be2226660b0038fe3a1f3f8ffb8a72eecea9bc5fb2937e4cd23e"
+    "sha512=d4b5f49e147d42d5a696232dc5e2336db2459a5b1e9c5702ed46c5870596e8d7dc69e799d50554b8e8edc637a21ed4f374a26eb53f0bc8d54ba11819fe5c742d"
+  ]
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.5.1/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.5.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends:   [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build & >= "1.1.0"}
+  "lwt"
+  "cstruct" {>="3.2.1"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-types" {>= "3.5.0"}
+  "mirage-clock-lwt" {>= "2.0.0"}
+  "mirage-time-lwt" {>= "1.1.0"}
+  "mirage-random" {>= "1.2.0"}
+  "mirage-flow-lwt" {>= "1.5.0"}
+  "mirage-protocols-lwt" {>= "2.0.0"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-console-lwt" {>= "2.3.5"}
+  "mirage-block-lwt" {>= "1.1.0"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "mirage-fs-lwt" {>= "2.0.0"}
+  "mirage-kv-lwt" {>= "2.0.0"}
+  "mirage-channel-lwt" {>= "3.1.0"}
+]
+
+synopsis: "Lwt module type definitions for MirageOS applications"
+description: """
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.5.1/mirage-v3.5.1.tbz"
+  checksum: [
+    "sha256=2ff147901b46be2226660b0038fe3a1f3f8ffb8a72eecea9bc5fb2937e4cd23e"
+    "sha512=d4b5f49e147d42d5a696232dc5e2336db2459a5b1e9c5702ed46c5870596e8d7dc69e799d50554b8e8edc637a21ed4f374a26eb53f0bc8d54ba11819fe5c742d"
+  ]
+}

--- a/packages/mirage-types/mirage-types.3.5.1/opam
+++ b/packages/mirage-types/mirage-types.3.5.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build & >= "1.1.0"}
+  "mirage-device" {>= "1.1.0"}
+  "mirage-time" {>= "1.1.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-random" {>= "1.2.0"}
+  "mirage-flow" {>= "1.5.0"}
+  "mirage-console" {>= "2.3.5"}
+  "mirage-protocols" {>= "2.0.0"}
+  "mirage-stack" {>= "1.3.0"}
+  "mirage-block" {>= "1.1.0"}
+  "mirage-net" {>= "2.0.0"}
+  "mirage-fs" {>= "2.0.0"}
+  "mirage-kv" {>= "2.0.0"}
+  "mirage-channel" {>= "3.1.0"}
+]
+synopsis: "Module type definitions for MirageOS applications"
+description: """
+Module type definitions for MirageOS applications
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.5.1/mirage-v3.5.1.tbz"
+  checksum: [
+    "sha256=2ff147901b46be2226660b0038fe3a1f3f8ffb8a72eecea9bc5fb2937e4cd23e"
+    "sha512=d4b5f49e147d42d5a696232dc5e2336db2459a5b1e9c5702ed46c5870596e8d7dc69e799d50554b8e8edc637a21ed4f374a26eb53f0bc8d54ba11819fe5c742d"
+  ]
+}

--- a/packages/mirage/mirage.3.5.1/opam
+++ b/packages/mirage/mirage.3.5.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build & >= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria"          {>= "2.2.3"}
+  "bos"
+  "astring"
+  "logs"
+  "mirage-runtime"     {>= "3.5.0"}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.5.1/mirage-v3.5.1.tbz"
+  checksum: [
+    "sha256=2ff147901b46be2226660b0038fe3a1f3f8ffb8a72eecea9bc5fb2937e4cd23e"
+    "sha512=d4b5f49e147d42d5a696232dc5e2336db2459a5b1e9c5702ed46c5870596e8d7dc69e799d50554b8e8edc637a21ed4f374a26eb53f0bc8d54ba11819fe5c742d"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Adapt to new tracing API (mirage/mirage#985, by @talex5)
* Remove stubs for qrexec and qubes gui (qubes 3 is end of life, qubes 4 makes it configurable) (mirage/mirage#984, by @linse & @yomimono)
* Update mirage-logs and charrua-client-mirage version constraints (mirage/mirage#982, by @hannesm)
* Remove unused dockerfile, travis updates (mirage/mirage#982 mirage/mirage#990, by @hannesm)