### PR TITLE
Package bogue.1907.11

### DIFF
--- a/packages/bogue/bogue.1907.11/opam
+++ b/packages/bogue/bogue.1907.11/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Vu Ngoc San <san.vu-ngoc@laposte.net>"]
+authors: ["Vu Ngoc San <san.vu-ngoc@laposte.net>"]
+bug-reports: "https://github.com/sanette/bogue/issues"
+homepage: "https://github.com/sanette/bogue"
+doc: "http://sanette.github.io/bogue/Bogue.html"
+license: "ISC"
+dev-repo: "git+https://github.com/sanette/bogue.git"
+synopsis: "GUI library for ocaml, with animations, based on SDL2"
+description: """
+bogue is a GUI library for ocaml, with animations, based on SDL2.
+
+This library can be used for games or for adding GUI elements to any
+ocaml program.
+
+It uses the SDL2 renderer library, which makes it quite fast.
+
+It is themable, and does not try to look like your desktop. Instead,
+it will look the same on every platform.
+
+Graphics output is scalable, and hence easily adapts to Hi-DPI
+displays.
+
+Programming with bogue is easy if you're used to GUIs with widgets,
+layouts, callbacks, and of course it has a functional flavor. ​It uses
+Threads when non-blocking reactions are needed."""
+depends: [
+  "tsdl-image" {build}
+  "tsdl-ttf" {build}
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "tsdl" {>= "0.9.0"}
+]

--- a/packages/bogue/bogue.1907.11/opam
+++ b/packages/bogue/bogue.1907.11/opam
@@ -34,6 +34,6 @@ depends: [
   "tsdl-image" {build}
   "tsdl-ttf" {build}
   "ocaml" {>= "4.03.0"}
-  "ocamlfind" {build}
+  "dune" {>= "1.10"}
   "tsdl" {>= "0.9.0"}
 ]


### PR DESCRIPTION
### `bogue.1907.11`
GUI library for ocaml, with animations, based on SDL2
bogue is a GUI library for ocaml, with animations, based on SDL2.

This library can be used for games or for adding GUI elements to any
ocaml program.

It uses the SDL2 renderer library, which makes it quite fast.

It is themable, and does not try to look like your desktop. Instead,
it will look the same on every platform.

Graphics output is scalable, and hence easily adapts to Hi-DPI
displays.

Programming with bogue is easy if you're used to GUIs with widgets,
layouts, callbacks, and of course it has a functional flavor. ​It uses
Threads when non-blocking reactions are needed.



---
* Homepage: https://github.com/sanette/bogue
* Source repo: git+https://github.com/sanette/bogue.git
* Bug tracker: https://github.com/sanette/bogue/issues

---
:camel: Pull-request generated by opam-publish v2.0.0