### PR TITLE
Release clangml.4.0.0

### DIFF
--- a/packages/clangml/clangml.4.0.0/opam
+++ b/packages/clangml/clangml.4.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "conf-libclang"
   "conf-ncurses"
   "conf-zlib"
-  "ocamlfind" {>= "1.8.0"}
+  "ocamlfind" {build & >= "1.8.0"}
   "dune" {>= "1.10.0"}
   "ppxlib" {>= "0.6.0"}
   "stdcompat" {>= "10"}

--- a/packages/clangml/clangml.4.0.0/opam
+++ b/packages/clangml/clangml.4.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_show" {>= "0.1.0"}
   "ppx_compare" {>= "v0.12.0"}
   "override" {>= "0.1.0"}
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & != "4.05.0" }
 ]
 build: [
   ["./configure" "--prefix=%{prefix}%"]

--- a/packages/clangml/clangml.4.0.0/opam
+++ b/packages/clangml/clangml.4.0.0/opam
@@ -27,6 +27,6 @@ build: [
   ["./configure" "--prefix=%{prefix}%"]
   ["dune" "build" "-p" name "-j" jobs]]
 url {
-  src: "https://gitlab.inria.fr/memcad/clangml/-/archive/4.0.0/clangml-4.0.0.tar.gz"
-  checksum: "sha512=1e23f40db2f9d0e1861b3c6ce7b0d6840658f10bd1367239c4d828419285575fbfcebb177b2f7832c4ec2f4bb5ec2e371692477d721d8377d3c7841cbaa9049d"
+  src: "https://gitlab.inria.fr/memcad/clangml/-/archive/v4.0.0/clangml-v4.0.0.tar.gz"
+  checksum: "sha512=eb6d83b2692f40ddb724ec899220b4264e8844f23b5d6d216cce801fbc9586692a871a37d32dea9db83dbcd5b5e0607c73ca20d037fb51ec56c83d1f9f31e485"
 }

--- a/packages/clangml/clangml.4.0.0/opam
+++ b/packages/clangml/clangml.4.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+bug-reports: "https://gitlab.inria.fr/memcad/clangml"
+homepage: "https://gitlab.inria.fr/memcad/clangml"
+doc: "https://gitlab.inria.fr/memcad/clangml"
+license: "BSD"
+dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
+synopsis: "OCaml bindings for Clang API"
+description: """
+clangml provides bindings to call the Clang API from OCaml.
+"""
+depends: [
+  "conf-libclang"
+  "conf-ncurses"
+  "conf-zlib"
+  "ocamlfind" {>= "1.8.0"}
+  "dune" {>= "1.10.0"}
+  "ppxlib" {>= "0.6.0"}
+  "stdcompat" {>= "10"}
+  "ppx_show" {>= "0.1.0"}
+  "ppx_compare" {>= "v0.12.0"}
+  "override" {>= "0.1.0"}
+  "ocaml" {>= "4.04.0"}
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  ["dune" "build" "-p" name "-j" jobs]]
+url {
+  src: "https://gitlab.inria.fr/memcad/clangml/-/archive/4.0.0/clangml-4.0.0.tar.gz"
+  checksum: "sha512=1e23f40db2f9d0e1861b3c6ce7b0d6840658f10bd1367239c4d828419285575fbfcebb177b2f7832c4ec2f4bb5ec2e371692477d721d8377d3c7841cbaa9049d"
+}


### PR DESCRIPTION
- C++ support: all the code examples from C++14 and C++17 norms are covered
  by the AST.

- AST pretty-printers, comparators and lifters are now defined in sub-libraries
  (clangml.show, clangml.ord, clangml.lift). Visitors are no longer derived by
  default (`override` PPX library can be used to derive visitors from the AST
  if needed.)

- A very limited C/C++ pretty-printer is provided in the sub-library
  clangml.printer. It should be extended in next releases.

- Compatible with OCaml 4.08

- Bug fixes

- Flag dune as a build dependency
  (suggested by @kit-ty-kate in
   https://github.com/ocaml/opam-repository/pull/13434)