### PR TITLE
[new release] git-http, git, git-unix and git-mirage (2.1.0)

### DIFF
--- a/packages/git-http/git-http.2.1.0/opam
+++ b/packages/git-http/git-http.2.1.0/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml"        {>= "4.03.0"}
   "dune"         {build}
-  "git"          {>= "2.0.0"}
+  "git"          {= version}
   "cohttp"       {>= "1.0.0"}
   "cohttp-lwt"   {>= "1.0.0"}
 ]

--- a/packages/git-http/git-http.2.1.0/opam
+++ b/packages/git-http/git-http.2.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "Client implementation of the \"Smart\" HTTP Git protocol in pure OCaml"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"        {>= "4.03.0"}
+  "dune"         {build}
+  "git"          {>= "2.0.0"}
+  "cohttp"       {>= "1.0.0"}
+  "cohttp-lwt"   {>= "1.0.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.0/git-2.1.0.tbz"
+  checksum: [
+    "sha256=2a64446ac45b38e6830dc907d5321c0902310562dae3ba1bfb9ed70c0b3b9c7c"
+    "sha512=7ac19137197a0620f4a1398e325895a37bc1d52d9e32ed756488e01b55ae95f37f930c80d11bc29203b30ee6becf49b67826afd31c1389eb37e2c7f892b40864"
+  ]
+}

--- a/packages/git-mirage/git-mirage.2.1.0/opam
+++ b/packages/git-mirage/git-mirage.2.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-channel-lwt"
   "mirage-conduit"   {>= "3.0.0"}
   "git-http"         {=version}
-  "git"              {>= "2.0.0"}
+  "git"              {=version}
   "alcotest"         {with-test & >= "0.8.1"}
   "mtime"            {with-test & >= "1.0.0"}
   "mirage-fs-unix"   {with-test & >= "1.3.0"}

--- a/packages/git-mirage/git-mirage.2.1.0/opam
+++ b/packages/git-mirage/git-mirage.2.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-flow-lwt"
   "mirage-channel-lwt"
   "mirage-conduit"   {>= "3.0.0"}
-  "git-http"         {>= "2.0.0"}
+  "git-http"         {=version}
   "git"              {>= "2.0.0"}
   "alcotest"         {with-test & >= "0.8.1"}
   "mtime"            {with-test & >= "1.0.0"}

--- a/packages/git-mirage/git-mirage.2.1.0/opam
+++ b/packages/git-mirage/git-mirage.2.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "MirageOS backend for the Git protocol(s)"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"            {>= "4.03.0"}
+  "dune"             {build}
+  "cohttp-mirage"    {>= "1.0.0"}
+  "mirage-flow-lwt"
+  "mirage-channel-lwt"
+  "mirage-conduit"   {>= "3.0.0"}
+  "git-http"         {>= "2.0.0"}
+  "git"              {>= "2.0.0"}
+  "alcotest"         {with-test & >= "0.8.1"}
+  "mtime"            {with-test & >= "1.0.0"}
+  "mirage-fs-unix"   {with-test & >= "1.3.0"}
+  "nocrypto"         {with-test & >= "0.5.4"}
+  "tls"              {with-test}
+  "io-page"          {with-test & >= "1.6.1"}
+  "tcpip"            {with-test & >= "3.3.0"}
+  "io-page-unix"     {with-test}
+  "mirage-stack-lwt" {with-test & >= "1.3.0"}
+  "mirage-time-unix"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.0/git-2.1.0.tbz"
+  checksum: [
+    "sha256=2a64446ac45b38e6830dc907d5321c0902310562dae3ba1bfb9ed70c0b3b9c7c"
+    "sha512=7ac19137197a0620f4a1398e325895a37bc1d52d9e32ed756488e01b55ae95f37f930c80d11bc29203b30ee6becf49b67826afd31c1389eb37e2c7f892b40864"
+  ]
+}

--- a/packages/git-unix/git-unix.2.1.0/opam
+++ b/packages/git-unix/git-unix.2.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "Virtual package to install and configure ocaml-git's Unix backend"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+
+depends: [
+  "ocaml"           {>= "4.03.0"}
+  "dune"            {build}
+  "mmap"            {>= "1.1.0"}
+  "cmdliner"
+  "git-http"
+  "cohttp"          {>= "1.0.0"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "mtime"           {>= "1.0.0"}
+  "base-unix"
+  "alcotest"        {with-test & >= "0.8.1"}
+  "nocrypto"        {with-test & >= "0.5.4"}
+  "tls"             {with-test}
+  "io-page"         {with-test & >= "1.6.1"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.0/git-2.1.0.tbz"
+  checksum: [
+    "sha256=2a64446ac45b38e6830dc907d5321c0902310562dae3ba1bfb9ed70c0b3b9c7c"
+    "sha512=7ac19137197a0620f4a1398e325895a37bc1d52d9e32ed756488e01b55ae95f37f930c80d11bc29203b30ee6becf49b67826afd31c1389eb37e2c7f892b40864"
+  ]
+}

--- a/packages/git-unix/git-unix.2.1.0/opam
+++ b/packages/git-unix/git-unix.2.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "dune"            {build}
   "mmap"            {>= "1.1.0"}
   "cmdliner"
-  "git-http"
+  "git-http" {=version}
   "cohttp"          {>= "1.0.0"}
   "cohttp-lwt-unix" {>= "1.0.0"}
   "mtime"           {>= "1.0.0"}

--- a/packages/git/git.2.1.0/opam
+++ b/packages/git/git.2.1.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "Git format and protocol in pure OCaml"
+description: """
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {build}
+  "uri"        {>= "1.9.0"}
+  "lwt"        {>= "2.4.7"}
+  "angstrom"   {>= "0.9.0"}
+  "fpath"      {>= "0.7.0"}
+  "digestif"   {>= "0.7.2"}
+  "lru"        {>= "0.3.0"}
+  "decompress" {>= "0.9.0"}
+  "checkseum"  {>= "0.1.0"}
+  "ke"
+  "encore"
+  "duff"
+  "hex"
+  "ocplib-endian"
+  "rresult"
+  "logs"
+  "fmt"
+  "astring"
+  "cstruct"
+  "ocamlgraph"
+  "alcotest" {with-test & >= "0.8.1"}
+  "nocrypto" {with-test & >= "0.5.4"}
+  "tls"      {with-test}
+  "mtime"    {with-test & >= "1.0.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.0/git-2.1.0.tbz"
+  checksum: [
+    "sha256=2a64446ac45b38e6830dc907d5321c0902310562dae3ba1bfb9ed70c0b3b9c7c"
+    "sha512=7ac19137197a0620f4a1398e325895a37bc1d52d9e32ed756488e01b55ae95f37f930c80d11bc29203b30ee6becf49b67826afd31c1389eb37e2c7f892b40864"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- Move to the last version of `decompress` (@dinosaure, mirage/ocaml-git#366)
- Check order of entries in a tree object (bug found by @samoht, fixed by @dinosaure, mirage/ocaml-git#365)
- Use `mmap` package (@dinosaure, mirage/ocaml-git#347, mirage/ocaml-git#360)
- Update README.md (@tcoopman, @dinosaure, mirage/ocaml-git#337, mirage/ocaml-git#359)
- `trim` the window used to pack (@pqwy, @dinosaure, mirage/ocaml-git#357, mirage/ocaml-git#358)
- Use lastest version of `lru.0.3.0` (@pqwy, @dinosaure, mirage/ocaml-git#352, mirage/ocaml-git#356)
- Fix smart protocol (fixed by @clecat and @dinosaure, feedbacks from @hannesm)
 * Pull-request mirage/ocaml-git#351, mirage/ocaml-git#350, mirage/ocaml-git#338
 * Issues mirage/ocaml-git#335, mirage/ocaml-git#342, mirage/ocaml-git#346

   + regression tests was added (@dinosaure)
   + semantics about negociation was explained (@clecat)
   + end-to-end tests partially done (@hannesm)

- Remove `sexplib` dependency (@samoht, mirage/ocaml-git#349)
- Fix smart protocol to accept empty response from `ls-remote` (bug found by @hannesm, fixed by @dinosaure, mirage/ocaml-git#348)
- Add `io-page-unix` as dependency to tests `git-mirage` (@dinosaure, mirage/ocaml-git#345)
- Remove deprecated `Cstruct.add_len` (replaced by `ke`) (@dinosaure, mirage/ocaml-git#345)
- Use `Uri.user_info` to be able to be authentified by a service like GitHub (@linse, review by @dinosaure, mirage/ocaml-git#341, mirage/ocaml-git#343)
- avoid clash between `digestif.c` and `digestif.ocaml` implementation (same for `checkseum`)
 * remove implementation dependencies on `git-unix` and `git-mirage` (bug found by @hannesm and @linse, fixed by @dinosaure, mirage/ocaml-git#339)

   This update should be fixed by `dune`'s variants and `>= digestif.0.7.2` and `>= checkseum.0.1.0`

- **breaking-change** add `etmp` as already-allocated buffer to encode Git object (@dinosaure, mirage/ocaml-git#336)
 * add `ke.0.3` as new dependency
- consumed inputs for every entries in a tree (bug found by @zspicko, fixed by @dinosaure, mirage/ocaml-git#334)