### PR TITLE
[new release] datakit-github, datakit-bridge-local-git, datakit-client-git, datakit-client, datakit, datakit-bridge-github, datakit-server-9p, datakit-client-9p, datakit-ci and datakit-server (1.0.0)

### DIFF
--- a/packages/datakit-bridge-github/datakit-bridge-github.1.0.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.1.0.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Leonard" "Magnus Skjegstad" "David Scott" "Thomas Gazagnaire"
+]
+license: "Apache"
+homepage: "https://github.com/moby/datakit"
+doc: "https://docker.github.io/datakit/"
+bug-reports: "https://github.com/moby/datakit/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "cmdliner"
+  "lwt" {>= "3.0.0"}
+  "datakit-github" {>= "0.12.0"}
+  "datakit-client" {>= "0.12.0"}
+  "datakit-client-9p" {>= "0.12.0"}
+  "datakit-client-git" {>= "0.12.0"}
+  "logs"
+  "fmt"
+  "mtime" {>= "1.0.0"}
+  "asl"
+  "win-eventlog"
+  "uri" {>= "2.0.0"}
+  "hvsock" {>= "0.8.1"}
+  "hex"
+  "nocrypto"
+  "prometheus-app"
+  "protocol-9p-unix" {>= "0.11.0"}
+  "github-hooks-unix" {>= "0.2.0"}
+  "github" {>= "2.1.0"}
+  "alcotest" {with-test}
+  "datakit" {with-test & >= "0.12.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "tests/%{name}%"] {with-test}
+]
+dev-repo: "git+https://github.com/moby/datakit.git"
+synopsis: "A bidirectional bridge between the GitHub API and Datakit"
+description: """
+The package provides a bi-directional bridge between the GitHub API
+and Datakit, so you can talk to the GitHub API using filesystem and
+Git-like commands only. The `datakit-github` programs can start a
+webhook server to listen for GitHub events in real time, and project
+it into a Git repository. It also monitors that Git repository for
+user-provided changes, and translate them into GitHub API calls.
+"""
+url {
+  src:
+    "https://github.com/moby/datakit/releases/download/v1.0.0/datakit-v1.0.0.tbz"
+  checksum: [
+    "sha256=e5b36c9db8ce40dd828166ddeb35b197766d782fb39d1cbc90628a43c69c34d5"
+    "sha512=af3e973be41bcbda95bdf2722e3040607cbfd5cffcd026046eba027da9cabe072c0ecb4cd7edef4aedb4ee0f68e7cec5c273f666c5fd66dd7e0ee19ed5d90c0a"
+  ]
+}

--- a/packages/datakit-bridge-local-git/datakit-bridge-local-git.1.0.0/opam
+++ b/packages/datakit-bridge-local-git/datakit-bridge-local-git.1.0.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "thomas.leonard@docker.com"
+authors: "Thomas Leonard"
+license: "Apache"
+homepage: "https://github.com/moby/datakit"
+doc: "https://docker.github.io/datakit/"
+bug-reports: "https://github.com/moby/datakit/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "cmdliner"
+  "irmin-watcher"
+  "irmin" {>= "1.2.0"}
+  "irmin-unix" {>= "1.2.0"}
+  "lwt" {>= "3.0.0"}
+  "logs"
+  "fmt"
+  "protocol-9p-unix" {>= "0.11.0"}
+  "datakit-client" {>= "0.12.0"}
+  "datakit-client-9p" {>= "0.12.0"}
+  "datakit-github" {>= "0.12.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/moby/datakit.git"
+synopsis: "DataKit Local-Git bridge"
+description: """
+This service is a drop-in replacement for the DataKit-GitHub bridge
+that instead just monitors a local Git repository. It is useful for
+testing a new DataKitCI configuration without having to configure
+GitHub integration first.
+
+The local bridge monitors the state of one or more local Git
+repositories, writing the current head of each branch to
+DataKit. DataKitCI can be configured to run the CI tests against the
+project each time a commit is made.
+
+Once you are happy with the way the CI is working, you can replace
+this service with the GitHub bridge service to have the CI test a
+project hosted on GitHub instead.
+
+Unlike the GitHub bridge, this service:
+
+- only reports on branches, not tags or pull requests;
+- does not report build statuses from other CI systems; and
+- does not push the statuses set by the CI anywhere.
+"""
+url {
+  src:
+    "https://github.com/moby/datakit/releases/download/v1.0.0/datakit-v1.0.0.tbz"
+  checksum: [
+    "sha256=e5b36c9db8ce40dd828166ddeb35b197766d782fb39d1cbc90628a43c69c34d5"
+    "sha512=af3e973be41bcbda95bdf2722e3040607cbfd5cffcd026046eba027da9cabe072c0ecb4cd7edef4aedb4ee0f68e7cec5c273f666c5fd66dd7e0ee19ed5d90c0a"
+  ]
+}

--- a/packages/datakit-ci/datakit-ci.1.0.0/opam
+++ b/packages/datakit-ci/datakit-ci.1.0.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas© Leonard" "Anil Madhavapeddy" "Dave Tucker" "Thomas Gazagnaire"
+]
+license: "Apache"
+homepage: "https://github.com/moby/datakit"
+doc: "https://docker.github.io/datakit/"
+bug-reports: "https://github.com/moby/datakit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "multipart-form-data"
+  "datakit-client" {>= "0.12.0"}
+  "datakit-client-9p" {>= "0.12.0"}
+  "datakit-github" {>= "0.12.0"}
+  "protocol-9p-unix" {>= "0.11.0"}
+  "astring"
+  "cmdliner"
+  "fmt"
+  "cstruct" {>="4.0.0"}
+  "cstruct-sexp"
+  "logs"
+  "tyxml" {>= "4.0.0"}
+  "tls" {>= "0.9.0"}
+  "conduit-lwt-unix" {>= "1.0.0"}
+  "io-page"
+  "pbkdf"
+  "webmachine" {>= "0.4.0"}
+  "session-redis-lwt" {>= "0.4.0"}
+  "session-webmachine" {>= "0.4.0"}
+  "redis-lwt"
+  "asetmap"
+  "github-unix" {>= "3.0.0"}
+  "prometheus-app"
+  "lwt" {>= "3.0.0"}
+  "ppx_sexp_conv" {build & >="v0.9.0"}
+  "crunch" {build}
+  "datakit" {with-test & >= "0.12.0"}
+  "irmin-unix" {with-test & >= "1.2.0"}
+  "alcotest" {with-test}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "base64" {>="3.1.0"}
+  "uri" {>="3.0.0"}
+  "yojson" {>="1.7.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "ci/tests"] {with-test}
+]
+dev-repo: "git+https://github.com/moby/datakit.git"
+synopsis: "Continuous Integration service using DataKit"
+description: """
+DataKitCI is a continuous integration service that monitors your
+GitHub project and tests each branch, tag and pull request. It
+displays the test results as status indicators in the GitHub UI. It
+keeps all of its state and logs in DataKit, rather than a traditional
+relational database, allowing review with the usual Git tools.
+"""
+url {
+  src:
+    "https://github.com/moby/datakit/releases/download/v1.0.0/datakit-v1.0.0.tbz"
+  checksum: [
+    "sha256=e5b36c9db8ce40dd828166ddeb35b197766d782fb39d1cbc90628a43c69c34d5"
+    "sha512=af3e973be41bcbda95bdf2722e3040607cbfd5cffcd026046eba027da9cabe072c0ecb4cd7edef4aedb4ee0f68e7cec5c273f666c5fd66dd7e0ee19ed5d90c0a"
+  ]
+}

--- a/packages/datakit-client-9p/datakit-client-9p.1.0.0/opam
+++ b/packages/datakit-client-9p/datakit-client-9p.1.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Leonard" "Magnus Skjegstad" "David Scott" "Thomas Gazagnaire"
+]
+license: "Apache"
+homepage: "https://github.com/moby/datakit"
+doc: "https://docker.github.io/datakit/"
+bug-reports: "https://github.com/moby/datakit/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "astring"
+  "logs"
+  "fmt"
+  "cstruct" {> "2.2.0"}
+  "datakit-client" {>= "0.12.0"}
+  "protocol-9p-unix" {>= "0.11.0"}
+  "cmdliner"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/moby/datakit.git"
+synopsis: "A library for Datakit clients over 9P"
+description: """
+Connect to DataKit clients using the 9P filesystem protocol.
+"""
+url {
+  src:
+    "https://github.com/moby/datakit/releases/download/v1.0.0/datakit-v1.0.0.tbz"
+  checksum: [
+    "sha256=e5b36c9db8ce40dd828166ddeb35b197766d782fb39d1cbc90628a43c69c34d5"
+    "sha512=af3e973be41bcbda95bdf2722e3040607cbfd5cffcd026046eba027da9cabe072c0ecb4cd7edef4aedb4ee0f68e7cec5c273f666c5fd66dd7e0ee19ed5d90c0a"
+  ]
+}

--- a/packages/datakit-client-git/datakit-client-git.1.0.0/opam
+++ b/packages/datakit-client-git/datakit-client-git.1.0.0/opam
@@ -12,9 +12,9 @@ depends: [
   "dune" {build}
   "datakit-client" {>= "0.12.0"}
   "irmin-git" {>= "1.2.0"}
-  "io-page-unix"
   "irmin-watcher"
   "git-unix"
+  "io-page-unix" {with-test}
   "alcotest" {with-test}
   "irmin-mem" {with-test}
   "irmin-git" {with-test}

--- a/packages/datakit-client-git/datakit-client-git.1.0.0/opam
+++ b/packages/datakit-client-git/datakit-client-git.1.0.0/opam
@@ -12,6 +12,7 @@ depends: [
   "dune" {build}
   "datakit-client" {>= "0.12.0"}
   "irmin-git" {>= "1.2.0"}
+  "io-page-unix"
   "irmin-watcher"
   "git-unix"
   "alcotest" {with-test}

--- a/packages/datakit-client-git/datakit-client-git.1.0.0/opam
+++ b/packages/datakit-client-git/datakit-client-git.1.0.0/opam
@@ -18,6 +18,7 @@ depends: [
   "alcotest" {with-test}
   "irmin-mem" {with-test}
   "irmin-git" {with-test}
+  "mirage-flow-lwt" {with-test}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/datakit-client-git/datakit-client-git.1.0.0/opam
+++ b/packages/datakit-client-git/datakit-client-git.1.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Leonard" "Magnus Skjegstad" "David Scott" "Thomas Gazagnaire"
+]
+license: "Apache"
+homepage: "https://github.com/moby/datakit"
+doc: "https://docker.github.io/datakit/"
+bug-reports: "https://github.com/moby/datakit/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "datakit-client" {>= "0.12.0"}
+  "irmin-git" {>= "1.2.0"}
+  "irmin-watcher"
+  "git-unix"
+  "alcotest" {with-test}
+  "irmin-mem" {with-test}
+  "irmin-git" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "tests/datakit-git"] {with-test}
+]
+dev-repo: "git+https://github.com/moby/datakit.git"
+synopsis: "A library for connecting Datakit client using Git"
+description: """
+This library allows for creating DataKit clients that
+use the Git protocol for communication.
+"""
+url {
+  src:
+    "https://github.com/moby/datakit/releases/download/v1.0.0/datakit-v1.0.0.tbz"
+  checksum: [
+    "sha256=e5b36c9db8ce40dd828166ddeb35b197766d782fb39d1cbc90628a43c69c34d5"
+    "sha512=af3e973be41bcbda95bdf2722e3040607cbfd5cffcd026046eba027da9cabe072c0ecb4cd7edef4aedb4ee0f68e7cec5c273f666c5fd66dd7e0ee19ed5d90c0a"
+  ]
+}

--- a/packages/datakit-client/datakit-client.1.0.0/opam
+++ b/packages/datakit-client/datakit-client.1.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Leonard" "Magnus Skjegstad" "David Scott" "Thomas Gazagnaire"
+]
+license: "Apache"
+homepage: "https://github.com/moby/datakit"
+doc: "https://docker.github.io/datakit/"
+bug-reports: "https://github.com/moby/datakit/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "astring"
+  "result"
+  "fmt"
+  "lwt"
+  "cstruct" {> "2.2.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/moby/datakit.git"
+synopsis: "A library to construct Datakit clients"
+description: """
+The library currently only provides only a 9p client to talk to
+Datakit, but other filesystem protocols will be available in the
+future.
+"""
+url {
+  src:
+    "https://github.com/moby/datakit/releases/download/v1.0.0/datakit-v1.0.0.tbz"
+  checksum: [
+    "sha256=e5b36c9db8ce40dd828166ddeb35b197766d782fb39d1cbc90628a43c69c34d5"
+    "sha512=af3e973be41bcbda95bdf2722e3040607cbfd5cffcd026046eba027da9cabe072c0ecb4cd7edef4aedb4ee0f68e7cec5c273f666c5fd66dd7e0ee19ed5d90c0a"
+  ]
+}

--- a/packages/datakit-github/datakit-github.1.0.0/opam
+++ b/packages/datakit-github/datakit-github.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Leonard" "Magnus Skjegstad" "David Scott" "Thomas Gazagnaire"
+]
+license: "Apache"
+homepage: "https://github.com/moby/datakit"
+doc: "https://docker.github.io/datakit/"
+bug-reports: "https://github.com/moby/datakit/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "cmdliner"
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.8.0"}
+  "asetmap"
+  "logs"
+  "fmt"
+  "result"
+  "datakit-client-9p" {>= "0.12.0"}
+  "datakit-client-git" {>= "0.12.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/moby/datakit.git"
+synopsis: "Abstraction of the GitHub API, suitable for DataKit clients"
+description: """
+This library exposes the GitHub REST API over the
+DataKit filesystem layer.
+"""
+url {
+  src:
+    "https://github.com/moby/datakit/releases/download/v1.0.0/datakit-v1.0.0.tbz"
+  checksum: [
+    "sha256=e5b36c9db8ce40dd828166ddeb35b197766d782fb39d1cbc90628a43c69c34d5"
+    "sha512=af3e973be41bcbda95bdf2722e3040607cbfd5cffcd026046eba027da9cabe072c0ecb4cd7edef4aedb4ee0f68e7cec5c273f666c5fd66dd7e0ee19ed5d90c0a"
+  ]
+}

--- a/packages/datakit-server-9p/datakit-server-9p.1.0.0/opam
+++ b/packages/datakit-server-9p/datakit-server-9p.1.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Leonard" "Magnus Skjegstad" "David Scott" "Thomas Gazagnaire"
+]
+license: "Apache"
+homepage: "https://github.com/moby/datakit"
+doc: "https://docker.github.io/datakit/"
+bug-reports: "https://github.com/moby/datakit/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "datakit-server" {>= "0.12.0"}
+  "mirage-flow-lwt"
+  "protocol-9p" {>= "0.11.0"}
+  "sexplib"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/moby/datakit.git"
+synopsis: "Build Datakit servers using the 9P filesystem protocol"
+description: """
+This library allows for the construction of DataKit servers
+that can be accessed over the 9P filesystem protocol.
+"""
+url {
+  src:
+    "https://github.com/moby/datakit/releases/download/v1.0.0/datakit-v1.0.0.tbz"
+  checksum: [
+    "sha256=e5b36c9db8ce40dd828166ddeb35b197766d782fb39d1cbc90628a43c69c34d5"
+    "sha512=af3e973be41bcbda95bdf2722e3040607cbfd5cffcd026046eba027da9cabe072c0ecb4cd7edef4aedb4ee0f68e7cec5c273f666c5fd66dd7e0ee19ed5d90c0a"
+  ]
+}

--- a/packages/datakit-server/datakit-server.1.0.0/opam
+++ b/packages/datakit-server/datakit-server.1.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Leonard" "Magnus Skjegstad" "David Scott" "Thomas Gazagnaire"
+]
+license: "Apache"
+homepage: "https://github.com/moby/datakit"
+doc: "https://docker.github.io/datakit/"
+bug-reports: "https://github.com/moby/datakit/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "astring"
+  "logs"
+  "rresult"
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "cstruct" {>= "2.2.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/moby/datakit.git"
+synopsis: "A library to write Datakit servers"
+description: """
+The library exposes a VFS interface, that servers can use to write
+introspection libraries -- for instance to expose runtime parameters
+over 9p. The library does not depend on Irmin so is relatively
+lightweight to embed in any application.
+"""
+url {
+  src:
+    "https://github.com/moby/datakit/releases/download/v1.0.0/datakit-v1.0.0.tbz"
+  checksum: [
+    "sha256=e5b36c9db8ce40dd828166ddeb35b197766d782fb39d1cbc90628a43c69c34d5"
+    "sha512=af3e973be41bcbda95bdf2722e3040607cbfd5cffcd026046eba027da9cabe072c0ecb4cd7edef4aedb4ee0f68e7cec5c273f666c5fd66dd7e0ee19ed5d90c0a"
+  ]
+}

--- a/packages/datakit/datakit.1.0.0/opam
+++ b/packages/datakit/datakit.1.0.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Leonard" "Magnus Skjegstad" "David Scott" "Thomas Gazagnaire"
+]
+license: "Apache"
+homepage: "https://github.com/moby/datakit"
+doc: "https://docker.github.io/datakit/"
+bug-reports: "https://github.com/moby/datakit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "cmdliner"
+  "rresult"
+  "astring"
+  "fmt"
+  "asetmap"
+  "git" {>= "1.11.5"}
+  "uri" {>="2.0.0"}
+  "irmin" {>="1.4.0"}
+  "irmin-mem" {>= "1.2.0"}
+  "irmin-git" {>= "1.2.0"}
+  "cstruct" {>= "2.2"}
+  "result"
+  "lwt" {>= "3.0.0"}
+  "conduit-lwt-unix" {>= "1.0.0"}
+  "mirage-flow"
+  "named-pipe" {>= "0.4.0"}
+  "hvsock" {>= "0.8.1"}
+  "logs" {>= "0.5.0"}
+  "win-eventlog"
+  "asl" {>= "0.10"}
+  "mtime" {>= "1.0.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "prometheus-app"
+  "protocol-9p-unix" {>= "0.11.0"}
+  "datakit-server-9p" {>= "0.12.0"}
+  "datakit-client-9p" {with-test & >= "0.12.0"}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "tests/datakit"] {with-test}
+  ["dune" "runtest" "tests/datakit-9p"] {with-test}
+]
+dev-repo: "git+https://github.com/moby/datakit.git"
+synopsis: "Orchestrate applications using a Git-like dataflow"
+description: """
+DataKit is a tool to orchestrate applications using a Git-like dataflow. It
+revisits the UNIX pipeline concept, with a modern twist: streams of
+tree-structured data instead of raw text. DataKit allows you to define complex
+build pipelines over version-controlled data.
+
+DataKit is currently used as the coordination
+layer for [HyperKit](http://github.com/docker/hyperkit), the
+hypervisor component of
+[Docker for Mac and Windows](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/), and
+for the DataKitCI continuous integration system.
+"""
+url {
+  src:
+    "https://github.com/moby/datakit/releases/download/v1.0.0/datakit-v1.0.0.tbz"
+  checksum: [
+    "sha256=e5b36c9db8ce40dd828166ddeb35b197766d782fb39d1cbc90628a43c69c34d5"
+    "sha512=af3e973be41bcbda95bdf2722e3040607cbfd5cffcd026046eba027da9cabe072c0ecb4cd7edef4aedb4ee0f68e7cec5c273f666c5fd66dd7e0ee19ed5d90c0a"
+  ]
+}


### PR DESCRIPTION
Abstraction of the GitHub API, suitable for DataKit clients

- Project page: <a href="https://github.com/moby/datakit">https://github.com/moby/datakit</a>
- Documentation: <a href="https://docker.github.io/datakit/">https://docker.github.io/datakit/</a>

##### CHANGES:

- format source code using ocamlformat 0.10 and the `conventional`
  profile (@avsm).
- support uri>=3.0.0 (@avsm)
