### PR TITLE
Package prepare.7.53

### DIFF
--- a/packages/prepare/prepare.7.53/opam
+++ b/packages/prepare/prepare.7.53/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "The herdtools suite for simulating and studying weak memory models"
+maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
+authors: [
+  "Luc Maranget <Luc.Maranget@inria.fr>"
+  "Jade Alglave <j.alglave@ucl.ac.uk>"
+  "Vincent Jacques <vincent@russian-dolls-sunflowers.com>"
+]
+homepage: "http://diy.inria.fr/"
+bug-reports: "http://github.com/herd/herdtools7/issues/"
+doc: "http://diy.inria.fr/doc/index.html"
+dev-repo: "git+https://github.com/herd/herdtools7.git"
+build: ["./dune-build.sh" "%{prefix}%"]
+install: ["./dune-install.sh" "%{prefix}%"]
+# @todo Add "build-doc" field
+# @todo Add "build-test" field
+remove: ["./dune-uninstall.sh" "%{prefix}%"]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build}
+]
+url {
+  src: "https://github.com/herd/herdtools7/archive/7.53.tar.gz"
+  checksum: [
+    "md5=d63f495d2235b14e621b616088f8e072"
+    "sha512=22e3deed749cd7cc0390b08b5e2cebb240b289ace4c21288e19791986287e32b8132e765c3655625d154daee25f388f404db1ce9d23cfcad208a298f2f86302f"
+  ]
+}


### PR DESCRIPTION
### `prepare.7.53`
The herdtools suite for simulating and studying weak memory models



---
* Homepage: http://diy.inria.fr/
* Source repo: git+https://github.com/herd/herdtools7.git
* Bug tracker: http://github.com/herd/herdtools7/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0