### PR TITLE
Package ocsigenserver.2.13.0

### DIFF
--- a/packages/ocsigenserver/ocsigenserver.2.13.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.13.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "A full-featured and extensible Web server"
+description: "Ocsigen Server implements most features of the HTTP protocol, and has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc."
+authors: "dev@ocsigen.org"
+homepage: "http://ocsigen.org/ocsigenserver/"
+bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+build: [
+  [
+    "sh"
+    "configure"
+    "--prefix"
+    "%{prefix}%"
+    "--ocsigen-user"
+    "%{user}%"
+    "--ocsigen-group"
+    "%{group}%"
+    "--commandpipe"
+    "%{lib}%/ocsigenserver/var/run/ocsigenserver_command"
+    "--logdir"
+    "%{lib}%/ocsigenserver/var/log/ocsigenserver"
+    "--mandir"
+    "%{man}%/man1"
+    "--docdir"
+    "%{lib}%/ocsigenserver/share/doc/ocsigenserver"
+    "--commandpipe"
+    "%{lib}%/ocsigenserver/var/run/ocsigenserver_command"
+    "--staticpagesdir"
+    "%{lib}%/ocsigenserver/var/www"
+    "--datadir"
+    "%{lib}%/ocsigenserver/var/lib/ocsigenserver"
+    "--sysconfdir"
+    "%{lib}%/ocsigenserver/etc/ocsigenserver"
+  ]
+  [make]
+]
+install: [make "install"]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind"
+  "base-unix"
+  "base-threads"
+  "react"
+  "ssl" {>= "0.5.8"}
+  "lwt" {>= "3.0.0"}
+  "lwt_ssl"
+  "lwt_react"
+  "lwt_log"
+  "ocamlnet" {>= "4.0.2"}
+  "pcre"
+  "cryptokit"
+  "tyxml" {>= "4.0.0"}
+  "dbm" | "sqlite3" | "pgocaml"
+  "ipaddr" {>= "2.1"}
+  "xml-light"
+]
+depopts: "camlzip"
+conflicts: [
+  "camlzip" {< "1.04"}
+  "pgocaml" {< "2.2"}
+]
+url {
+  src: "https://github.com/jrochel/ocsigenserver/archive/2.13.0.tar.gz"
+  checksum: [
+    "md5=516f92554d27d396c1ae28ea1b101705"
+    "sha512=609231587a7dcd59197ab85bb9b6875145ec75396d5cb5645634d68c386a0b5a3866540ef13d4697df3fa1797ee8825fc30d834156b8c027ab34511447c0227f"
+  ]
+}

--- a/packages/ocsigenserver/ocsigenserver.2.13.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.13.0/opam
@@ -62,7 +62,7 @@ conflicts: [
   "pgocaml" {< "2.2"}
 ]
 url {
-  src: "https://github.com/jrochel/ocsigenserver/archive/2.13.0.tar.gz"
+  src: "https://github.com/ocsigen/ocsigenserver/archive/2.13.0.tar.gz"
   checksum: [
     "md5=516f92554d27d396c1ae28ea1b101705"
     "sha512=609231587a7dcd59197ab85bb9b6875145ec75396d5cb5645634d68c386a0b5a3866540ef13d4697df3fa1797ee8825fc30d834156b8c027ab34511447c0227f"


### PR DESCRIPTION
### `ocsigenserver.2.13.0`
A full-featured and extensible Web server
Ocsigen Server implements most features of the HTTP protocol, and has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc.



---
* Homepage: http://ocsigen.org/ocsigenserver/
* Source repo: git+https://github.com/ocsigen/ocsigenserver.git
* Bug tracker: https://github.com/ocsigen/ocsigenserver/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0