### PR TITLE
Package gremlin.0.1.0

### DIFF
--- a/packages/gremlin/gremlin.0.1.0/opam
+++ b/packages/gremlin/gremlin.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Bramford Horton <bram.horton@gmail.com>"
+homepage: "https://github.com/bramford/ocaml-gremlin"
+bug-reports: "https://github.com/bramford/ocaml-gremlin/issues"
+dev-repo: "git+https://github.com/bramford/ocaml-gremlin"
+doc: "https://bramford.github.io/ocaml-gremlin/doc"
+license: "ISC"
+build: [ "dune" "build" "-j" jobs "-p" name ]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "dune" {build & >= "1.10.0"}
+  "lwt" {>= "4.2.1"}
+  "containers" {>= "2.6"}
+  "lwt_ppx" {>= "1.2.2"}
+  "conduit-lwt-unix" {>= "1.4.0"}
+  "yojson" {>= "1.7.0"}
+  "core" {>= "0.12.3"}
+  "ppx_let" {>= "0.12.0"}
+]
+synopsis: "Gremlin Client Library"
+description: """
+This is an Apache Tinkerpop3 Gremlin client library.
+
+See the official tinkerpop3 and gremlin docs:
+- http://tinkerpop.apache.org/docs/current/
+
+This client library is implemented following the driver provider requirements:
+- http://tinkerpop.apache.org/docs/current/dev/provider/#_graph_driver_provider_requirements
+"""
+authors: "Bramford Horton <bram.horton@gmail.com>"
+url {
+  src: "https://github.com/bramford/ocaml-gremlin/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=25305ca5e5c682638a17986b0f602ec2"
+    "sha512=234a3b87152ae35d34cd249dcfb0ba85eb7d14361bb5101420fadfadb3a9ce564a9f8851027f3bf5af129c34f78e4c2243427ca747deecdd9d33a6082ac88868"
+  ]
+}


### PR DESCRIPTION
### `gremlin.0.1.0`
Gremlin Client Library
This is an Apache Tinkerpop3 Gremlin client library.

See the official tinkerpop3 and gremlin docs:
- http://tinkerpop.apache.org/docs/current/

This client library is implemented following the driver provider requirements:
- http://tinkerpop.apache.org/docs/current/dev/provider/#_graph_driver_provider_requirements



---
* Homepage: https://github.com/bramford/ocaml-gremlin
* Source repo: git+https://github.com/bramford/ocaml-gremlin
* Bug tracker: https://github.com/bramford/ocaml-gremlin/issues

---
:camel: Pull-request generated by opam-publish v2.0.0