### PR TITLE
Package ppx_cstubs.0.2.0

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.2.0/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://github.com/fdopen/ppx_cstubs"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+doc: "https://fdopen.github.io/ppx_cstubs/"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ctypes" {>= "0.13.0" & < "0.15.0"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.02.3" & < "4.09.0"}
+  "ocaml-migrate-parsetree"
+  "ocamlfind" # not only a build dependency, it depends on findlib.top
+  "dune" {>= "1.6"}
+  "ppx_tools_versioned" {>= "5.0.1"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: """
+Preprocessor for quick and dirty stub generation
+"""
+
+description: """
+ppx_cstubs is a ppx-based preprocessor for quick and dirty stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file with c stub
+code and an OCaml file with all additional boilerplate code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=10da28b219eb97232f0e0ee7da12b0f1"
+    "sha512=dddcacd97c097ab6e1288a0910db0bd297039766ac682730f3fec2a83b3f276e949ba536db87dc397abc20578f803bad7e65dbf418e333430ca2576a12762c16"
+  ]
+}


### PR DESCRIPTION
### `ppx_cstubs.0.2.0`
Preprocessor for quick and dirty stub generation
ppx_cstubs is a ppx-based preprocessor for quick and dirty stub generation with
ctypes. ppx_cstubs creates two files from a single ml file: a file with c stub
code and an OCaml file with all additional boilerplate code.



---
* Homepage: https://github.com/fdopen/ppx_cstubs
* Source repo: git+https://github.com/fdopen/ppx_cstubs.git
* Bug tracker: https://github.com/fdopen/ppx_cstubs/issues

---
:camel: Pull-request generated by opam-publish v2.0.0