### PR TITLE
bigstringaf.0.5.2: Untag dune a build dependency

### DIFF
--- a/packages/bigstringaf/bigstringaf.0.5.2/opam
+++ b/packages/bigstringaf/bigstringaf.0.5.2/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "dune" {build}
+  "dune"
   "alcotest" {with-test}
   "base-bigarray"
   "ocaml" {>= "4.03.0"}


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/pull/14497 was merged in between https://github.com/ocaml/opam-repository/pull/14266 and was missing the fix

cc @seliopou could you change that upstream?