### PR TITLE
4 packages from c-cube/qcheck at 0.10

### DIFF
--- a/packages/qcheck-alcotest/qcheck-alcotest.0.10/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.10/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Alcotest backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {>= "0.9"}
+  "alcotest"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+run-test: ["dune" "runtest" "-p" name]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.10.tar.gz"
+  checksum: [
+    "md5=de3599bfa7ad2a4981c289affeb9bf6e"
+    "sha512=250d7934012455d29d95b710f5b42bbe3ea42e6ec1b5781dba807781ac9d5a66ca39dc4535667fd9b00bfcc566e11dbdb3f7306dde1d8f0e9f90d1447cdc4d97"
+  ]
+}

--- a/packages/qcheck-core/qcheck-core.0.10/opam
+++ b/packages/qcheck-core/qcheck-core.0.10/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Core qcheck library"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+run-test: ["dune" "runtest" "-p" name]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.10.tar.gz"
+  checksum: [
+    "md5=de3599bfa7ad2a4981c289affeb9bf6e"
+    "sha512=250d7934012455d29d95b710f5b42bbe3ea42e6ec1b5781dba807781ac9d5a66ca39dc4535667fd9b00bfcc566e11dbdb3f7306dde1d8f0e9f90d1447cdc4d97"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.10/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.10/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "OUnit backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {>= "0.9"}
+  "ounit" {>= "2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+run-test: ["dune" "runtest" "-p" name]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.10.tar.gz"
+  checksum: [
+    "md5=de3599bfa7ad2a4981c289affeb9bf6e"
+    "sha512=250d7934012455d29d95b710f5b42bbe3ea42e6ec1b5781dba807781ac9d5a66ca39dc4535667fd9b00bfcc566e11dbdb3f7306dde1d8f0e9f90d1447cdc4d97"
+  ]
+}

--- a/packages/qcheck/qcheck.0.10/opam
+++ b/packages/qcheck/qcheck.0.10/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Compatibility package for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {>= "0.9"}
+  "qcheck-ounit" {>= "0.9"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+run-test: ["dune" "runtest" "-p" name]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.10.tar.gz"
+  checksum: [
+    "md5=de3599bfa7ad2a4981c289affeb9bf6e"
+    "sha512=250d7934012455d29d95b710f5b42bbe3ea42e6ec1b5781dba807781ac9d5a66ca39dc4535667fd9b00bfcc566e11dbdb3f7306dde1d8f0e9f90d1447cdc4d97"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`qcheck.0.10`: Compatibility package for qcheck
-`qcheck-alcotest.0.10`: Alcotest backend for qcheck
-`qcheck-core.0.10`: Core qcheck library
-`qcheck-ounit.0.10`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.0.0