### PR TITLE
[new release] tuntap (1.8.1)

### DIFF
--- a/packages/tuntap/tuntap.1.8.1/opam
+++ b/packages/tuntap/tuntap.1.8.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "vb@luminar.eu.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-tuntap"
+doc: "https://mirage.github.io/ocaml-tuntap/"
+bug-reports: "https://github.com/mirage/ocaml-tuntap/issues"
+synopsis: "OCaml library for handling TUN/TAP devices"
+description: """
+This is an OCaml library for handling TUN/TAP devices.  TUN refers to layer 3
+virtual interfaces whereas TAP refers to layer 2 Ethernet ones.
+
+See <http://en.wikipedia.org/wiki/TUN/TAP> for more information.
+
+Linux, FreeBSD, OpenBSD and macOS should all be supported.  You will need
+to install the third-party <http://tuntaposx.sourceforge.net/> on macOS before
+using this library.
+"""
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"
+  "ipaddr" {>= "4.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "cmdliner"
+  "ounit" {with-test}
+  "lwt" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+dev-repo: "git+https://github.com/mirage/ocaml-tuntap.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tuntap/releases/download/v1.8.1/tuntap-v1.8.1.tbz"
+  checksum: [
+    "sha256=e7bb3134ce5cde3c2f202fb202600f0177d817f70c5cdf7d801f596d7d3d2393"
+    "sha512=fc839959864e1a95250e83dd3eb7192da175a921c9fcd1e381be52875cbece126750aa7d0512341e2d6e252ba65a9b986434b3cbf9bd81b154f4aed6b42fed3f"
+  ]
+}


### PR DESCRIPTION
OCaml library for handling TUN/TAP devices

- Project page: <a href="https://github.com/mirage/ocaml-tuntap">https://github.com/mirage/ocaml-tuntap</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tuntap/">https://mirage.github.io/ocaml-tuntap/</a>

##### CHANGES:

* Use ipaddr.4.0.0 interface (mirage/ocaml-tuntap#33 @avsm)
