### PR TITLE
[WIP] yojson 3.5.1 release preparation

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/whitequark/ppx_deriving_yojson"
+bug-reports: "https://github.com/whitequark/ppx_deriving_yojson/issues"
+dev-repo: "git://github.com/whitequark/ppx_deriving_yojson.git"
+tags: [ "syntax" "json" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0" & < "4.09.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
+  "result"
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_tools"    {build}
+  "ppxfind"      {build}
+  "dune"         {>= "1.2"}
+  "cppo"         {build}
+  "ounit"        {with-test & >= "2.0.0"}
+]
+conflicts: [
+  "ppx_deriving" {= "4.2"}
+]
+synopsis: "JSON codec generator for OCaml"
+description: """
+ppx_deriving_yojson is a ppx_deriving plugin that provides
+a JSON codec generator."""
+url {
+  src: "https://github.com/gasche/ppx_deriving_yojson/archive/prepare-release-3.5.1.tar.gz"
+  checksum: "sha256=dc3c60df272737d5db47adbd10268f4156c6c1b9fbef88c0d77edf2a6c126f1a"
+}


### PR DESCRIPTION
* Two bugfixes when using [%to_json ], [%of_json ] extensions
  (error with polymorphic variables, unbound value 'safe_map')
  (ocaml-ppx/ppx_deriving_yojson#100, ocaml-ppx/ppx_deriving_yojson#101)
  Gabriel Scherer, report by Matt Windsor