### PR TITLE
Update bisect_ppx-ocamlbuild metadata

### DIFF
--- a/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.1/opam
+++ b/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.1/opam
@@ -8,9 +8,9 @@ authors: [
   "Anton Bachin <antonbachin@yahoo.com>"
 ]
 license: "Public Domain"
-homepage: "https://github.com/aantron/bisect_ppx"
-bug-reports: "https://github.com/aantron/bisect_ppx/issues"
-dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+homepage: "https://github.com/aantron/bisect_ppx-ocamlbuild"
+bug-reports: "https://github.com/aantron/bisect_ppx-ocamlbuild/issues"
+dev-repo: "git+https://github.com/aantron/bisect_ppx-ocamlbuild.git"
 depends: [
   "ocaml"
   "bisect_ppx" {>= "1.0.0"}


### PR DESCRIPTION
The package has moved to [aantron/bisect_ppx-ocamlbuild](https://github.com/aantron/bisect_ppx-ocamlbuild). See aantron/bisect_ppx#201.