### PR TITLE
Package herdtools7.7.54

### DIFF
--- a/packages/herdtools7/herdtools7.7.54/files/chatouille.patch
+++ b/packages/herdtools7/herdtools7.7.54/files/chatouille.patch
@@ -1,0 +1,13 @@
+diff --git a/dune-defs.sh b/dune-defs.sh
+index 400faf5..7ba15be 100644
+--- a/dune-defs.sh
++++ b/dune-defs.sh
+@@ -5,7 +5,7 @@ for d
+ do
+   awk \
+     '/names/ { ok = 1 ; getline ;  }\
+-    /)/ { ok = 0 ; }\
++    /[)]/ { ok = 0 ; }\
+         { if (ok) print $0; }' $d/dune |\
+    while read line
+    do

--- a/packages/herdtools7/herdtools7.7.54/opam
+++ b/packages/herdtools7/herdtools7.7.54/opam
@@ -15,7 +15,7 @@ install: ["./dune-install.sh" "%{prefix}%"]
 # @todo Add "build-doc" field
 # @todo Add "build-test" field
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.05.0"}
   "dune"
 ]
 url {

--- a/packages/herdtools7/herdtools7.7.54/opam
+++ b/packages/herdtools7/herdtools7.7.54/opam
@@ -25,3 +25,4 @@ url {
     "sha512=63ebe937b8a651ec9918a8c4a70a41cba611fa8528a20b246732e0ec1bdb6e852e5936b8860f566d4973a9945cd44d1df6eb87c4e5c7704073565c07c8f75f20"
   ]
 }
+patches: ["chatouille.patch"]

--- a/packages/herdtools7/herdtools7.7.54/opam
+++ b/packages/herdtools7/herdtools7.7.54/opam
@@ -14,7 +14,6 @@ build: ["./dune-build.sh" "%{prefix}%"]
 install: ["./dune-install.sh" "%{prefix}%"]
 # @todo Add "build-doc" field
 # @todo Add "build-test" field
-remove: ["./dune-uninstall.sh" "%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune"

--- a/packages/herdtools7/herdtools7.7.54/opam
+++ b/packages/herdtools7/herdtools7.7.54/opam
@@ -17,7 +17,7 @@ install: ["./dune-install.sh" "%{prefix}%"]
 remove: ["./dune-uninstall.sh" "%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build}
+  "dune"
 ]
 url {
   src: "https://github.com/herd/herdtools7/archive/7.54.tar.gz"

--- a/packages/herdtools7/herdtools7.7.54/opam
+++ b/packages/herdtools7/herdtools7.7.54/opam
@@ -10,8 +10,8 @@ homepage: "http://diy.inria.fr/"
 bug-reports: "http://github.com/herd/herdtools7/issues/"
 doc: "http://diy.inria.fr/doc/index.html"
 dev-repo: "git+https://github.com/herd/herdtools7.git"
-build: ["./dune-build.sh" "%{prefix}%"]
-install: ["./dune-install.sh" "%{prefix}%"]
+build: ["sh -x ./dune-build.sh" "%{prefix}%"]
+install: ["sh -x ./dune-install.sh" "%{prefix}%"]
 # @todo Add "build-doc" field
 # @todo Add "build-test" field
 depends: [

--- a/packages/herdtools7/herdtools7.7.54/opam
+++ b/packages/herdtools7/herdtools7.7.54/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "The herdtools suite for simulating and studying weak memory models"
+maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
+authors: [
+  "Luc Maranget <Luc.Maranget@inria.fr>"
+  "Jade Alglave <j.alglave@ucl.ac.uk>"
+  "Vincent Jacques <vincent@russian-dolls-sunflowers.com>"
+]
+homepage: "http://diy.inria.fr/"
+bug-reports: "http://github.com/herd/herdtools7/issues/"
+doc: "http://diy.inria.fr/doc/index.html"
+dev-repo: "git+https://github.com/herd/herdtools7.git"
+build: ["./dune-build.sh" "%{prefix}%"]
+install: ["./dune-install.sh" "%{prefix}%"]
+# @todo Add "build-doc" field
+# @todo Add "build-test" field
+remove: ["./dune-uninstall.sh" "%{prefix}%"]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build}
+]
+url {
+  src: "https://github.com/herd/herdtools7/archive/7.54.tar.gz"
+  checksum: [
+    "md5=ffc58bca7f8c8c5ba1d3c65881d737b4"
+    "sha512=63ebe937b8a651ec9918a8c4a70a41cba611fa8528a20b246732e0ec1bdb6e852e5936b8860f566d4973a9945cd44d1df6eb87c4e5c7704073565c07c8f75f20"
+  ]
+}

--- a/packages/herdtools7/herdtools7.7.54/opam
+++ b/packages/herdtools7/herdtools7.7.54/opam
@@ -10,8 +10,8 @@ homepage: "http://diy.inria.fr/"
 bug-reports: "http://github.com/herd/herdtools7/issues/"
 doc: "http://diy.inria.fr/doc/index.html"
 dev-repo: "git+https://github.com/herd/herdtools7.git"
-build: ["sh -x ./dune-build.sh" "%{prefix}%"]
-install: ["sh -x ./dune-install.sh" "%{prefix}%"]
+build: ["sh" "-x" "./dune-build.sh" "%{prefix}%"]
+install: ["sh" "-x" "./dune-install.sh" "%{prefix}%"]
 # @todo Add "build-doc" field
 # @todo Add "build-test" field
 depends: [

--- a/packages/herdtools7/herdtools7.7.54/opam
+++ b/packages/herdtools7/herdtools7.7.54/opam
@@ -10,8 +10,8 @@ homepage: "http://diy.inria.fr/"
 bug-reports: "http://github.com/herd/herdtools7/issues/"
 doc: "http://diy.inria.fr/doc/index.html"
 dev-repo: "git+https://github.com/herd/herdtools7.git"
-build: ["sh" "-x" "./dune-build.sh" "%{prefix}%"]
-install: ["sh" "-x" "./dune-install.sh" "%{prefix}%"]
+build: ["sh" "./dune-build.sh" "%{prefix}%"]
+install: ["sh" "./dune-install.sh" "%{prefix}%"]
 # @todo Add "build-doc" field
 # @todo Add "build-test" field
 depends: [


### PR DESCRIPTION
### `herdtools7.7.54`
The herdtools suite for simulating and studying weak memory models



---
* Homepage: http://diy.inria.fr/
* Source repo: git+https://github.com/herd/herdtools7.git
* Bug tracker: http://github.com/herd/herdtools7/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0