### PR TITLE
[new release] merlin (3.3.2)

### DIFF
--- a/packages/merlin/merlin.3.3.2/opam
+++ b/packages/merlin/merlin.3.3.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.1" & < "4.09"}
-  "dune" {build & >= "1.8.0"}
+  "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
   "yojson"
   "mdx" {with-test & >= "1.3.0"}

--- a/packages/merlin/merlin.3.3.2/opam
+++ b/packages/merlin/merlin.3.3.2/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+name:         "merlin"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.1" & < "4.09"}
+  "dune" {build & >= "1.8.0"}
+  "ocamlfind" {>= "1.5.2"}
+  "yojson"
+  "mdx" {with-test & >= "1.3.0"}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam config var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v3.3.2/merlin-v3.3.2.tbz"
+  checksum: [
+    "sha256=1d1c71e663b1e58acf19069cebd1e8d18f7dbe513c6065347d162cdd2c2de801"
+    "sha512=3ae021669808a40b4449f1cbdaca40b605ea5779a6204addd8b0ee4af9f14f528d55ca43a8dd3c7d547fb8e4cb256c09a9151d5559ef24dad83b5ab05aa146a2"
+  ]
+}

--- a/packages/merlin/merlin.3.3.2/opam
+++ b/packages/merlin/merlin.3.3.2/opam
@@ -8,7 +8,6 @@ dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.1" & < "4.09"}


### PR DESCRIPTION
CHANGES:

Mon Jul 15 11:10:35 CEST 2019

  + backend
    - `**` globbing in .merlin won't look into hidden directories
      (starting with a '.') (by Daniel Bünzl, ocaml/merlin#990)
    - fallback to "/dev/null" configuration for findlib
    - better 4.08 support:
      + support for letop (let+, and+, ...) (ocaml/merlin#986)
      + fix parsing recovery for 4.08 constructions (ocaml/merlin#987)
      + catch an exception raised by 4.08 Printtyp trying to rename a
        persistent identifier (ocaml/merlin#991)
    - locate: treat local locations differently from external locations (coming
      from a cmi), this fixes "jump to definition" on mutually recursive
      bindings (ocaml/merlin#984)
    - when completing an infix operator in a sub-module, wrap with () (ocaml/merlin#992)
    - disable arity checks on externals (for Bucklescript compatibility)
    - remove parser preprocessing (simplify compilation for OCaml < 4.08) (ocaml/merlin#997)
  + editor modes
    - emacs
      + fix position computation in presence of tabs or multi-byte characters (ocaml/merlin#981)
      + log arguments in "merlin-debug-last-commands" (ocaml/merlin#981)
    - vim
      + install reason.vim file (by Hezekiah M. Carty, ocaml/merlin#974)