### PR TITLE
ssl.0.5.9: Unflag dune as a build dependency

### DIFF
--- a/packages/ssl/ssl.0.5.9/opam
+++ b/packages/ssl/ssl.0.5.9/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
   "base-unix"
   "conf-openssl"
 ]


### PR DESCRIPTION
Fixing https://github.com/ocaml/opam-repository/pull/14508

cc @smimram Dune should not be flagged as a build dependency anymore (see #14266)
cc @avsm don't forget to check for build flags on dune