### PR TITLE
[new release] dns-lwt, dns, dns-async, dns-lwt-unix and mirage-dns (1.1.3)

### DIFF
--- a/packages/dns-async/dns-async.1.1.3/opam
+++ b/packages/dns-async/dns-async.1.1.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+synopsis: "DNS implementation using the Async concurrency framework"
+description: """
+This is an implementation of the DNS protocol and a client
+and server resolver using the Jane Street Async library.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "dns"
+  "async" {>= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.3/dns-v1.1.3.tbz"
+  checksum: [
+    "sha256=17a3b507d7c1848f14ba213397bcc5df3967bbb9792ec6c650ea5dd9feb5456a"
+    "sha512=cd13ea4c92c018dc884fcce7eb62d2f3f1ef76c3a51c11bb3fe722d72b90e4070f1d0f939cd9faa93c710a4d2dee9761d89557f8086c9fb4ca75c6f1a467fbf3"
+  ]
+}

--- a/packages/dns-async/dns-async.1.1.3/opam
+++ b/packages/dns-async/dns-async.1.1.3/opam
@@ -22,7 +22,7 @@ doc: "https://mirage.github.io/ocaml-dns/"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "1.2"}
   "dns" {=version}
   "async" {>= "v0.9.0"}
 ]

--- a/packages/dns-async/dns-async.1.1.3/opam
+++ b/packages/dns-async/dns-async.1.1.3/opam
@@ -22,8 +22,8 @@ doc: "https://mirage.github.io/ocaml-dns/"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
-  "dns"
+  "dune"
+  "dns" {=version}
   "async" {>= "v0.9.0"}
 ]
 build: [

--- a/packages/dns-lwt-unix/dns-lwt-unix.1.1.3/opam
+++ b/packages/dns-lwt-unix/dns-lwt-unix.1.1.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+synopsis: "DNS implementation for Unix and Windows using Lwt_unix"
+description: """
+This is an implementation of the DNS protocol and a client
+and server resolver using the `Lwt_unix` concurrency framework.
+Despite the name, the library should work on both Unix and Windows
+(as supported by Lwt_unix upstream).
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "dns-lwt"
+  "base-unix"
+  "cmdliner"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.3/dns-v1.1.3.tbz"
+  checksum: [
+    "sha256=17a3b507d7c1848f14ba213397bcc5df3967bbb9792ec6c650ea5dd9feb5456a"
+    "sha512=cd13ea4c92c018dc884fcce7eb62d2f3f1ef76c3a51c11bb3fe722d72b90e4070f1d0f939cd9faa93c710a4d2dee9761d89557f8086c9fb4ca75c6f1a467fbf3"
+  ]
+}

--- a/packages/dns-lwt-unix/dns-lwt-unix.1.1.3/opam
+++ b/packages/dns-lwt-unix/dns-lwt-unix.1.1.3/opam
@@ -24,7 +24,7 @@ doc: "https://mirage.github.io/ocaml-dns/"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "1.2"}
   "dns-lwt" {=version}
   "base-unix"
   "cmdliner"

--- a/packages/dns-lwt-unix/dns-lwt-unix.1.1.3/opam
+++ b/packages/dns-lwt-unix/dns-lwt-unix.1.1.3/opam
@@ -24,8 +24,8 @@ doc: "https://mirage.github.io/ocaml-dns/"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
-  "dns-lwt"
+  "dune"
+  "dns-lwt" {=version}
   "base-unix"
   "cmdliner"
 ]

--- a/packages/dns-lwt/dns-lwt.1.1.3/opam
+++ b/packages/dns-lwt/dns-lwt.1.1.3/opam
@@ -25,7 +25,7 @@ doc: "https://mirage.github.io/ocaml-dns/"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "1.2"}
   "mirage-profile" {>= "0.8.0"}
   "lwt" {>= "3.0.0"}
   "dns" {=version}

--- a/packages/dns-lwt/dns-lwt.1.1.3/opam
+++ b/packages/dns-lwt/dns-lwt.1.1.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+license: "ISC"
+synopsis: "DNS implementation in portable Lwt"
+description: """
+This is an implementation of the DNS protocol and a client
+and server resolver using the portable Lwt concurrency framework.
+You can find a Unix version of this library in the `dns-lwt-unix`
+opam package, and in theory you could compile this one to JavaScript
+as well using js_of_ocaml.
+"""
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "mirage-profile" {>= "0.8.0"}
+  "lwt" {>= "3.0.0"}
+  "dns"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.3/dns-v1.1.3.tbz"
+  checksum: [
+    "sha256=17a3b507d7c1848f14ba213397bcc5df3967bbb9792ec6c650ea5dd9feb5456a"
+    "sha512=cd13ea4c92c018dc884fcce7eb62d2f3f1ef76c3a51c11bb3fe722d72b90e4070f1d0f939cd9faa93c710a4d2dee9761d89557f8086c9fb4ca75c6f1a467fbf3"
+  ]
+}

--- a/packages/dns-lwt/dns-lwt.1.1.3/opam
+++ b/packages/dns-lwt/dns-lwt.1.1.3/opam
@@ -25,10 +25,10 @@ doc: "https://mirage.github.io/ocaml-dns/"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "mirage-profile" {>= "0.8.0"}
   "lwt" {>= "3.0.0"}
-  "dns"
+  "dns" {=version}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/dns/dns.1.1.3/opam
+++ b/packages/dns/dns.1.1.3/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+license: "ISC"
+synopsis: "DNS client and server implementation in pure OCaml"
+description: """
+This is a pure OCaml implementation of the DNS protocol.  It is intended to be
+a reasonably high-performance implementation, but clarity is preferred rather
+than low-level performance hacks.
+
+There are several concrete implementations using this package that you probably
+want to use for practical purposes:
+
+- dns-lwt for the Lwt concurrency library
+- dns-lwt-unix using the Lwt_unix bindings
+- dns-async using the Jane Street Async library
+- mirage-dns for the MirageOS unikernel framework
+"""
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "cstruct" {>= "3.0.2"}
+  "ppx_cstruct"
+  "re" {>="1.7.2"}
+  "ipaddr" {>= "2.6.0"}
+  "uri" {>= "1.7.0"}
+  "domain-name" {>="0.3.0"}
+  "base64" {>= "3.0.0"}
+  "hashcons"
+  "result"
+  "mmap" {with-test}
+  "bigarray-compat" {with-test}
+  "pcap-format" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.3/dns-v1.1.3.tbz"
+  checksum: [
+    "sha256=17a3b507d7c1848f14ba213397bcc5df3967bbb9792ec6c650ea5dd9feb5456a"
+    "sha512=cd13ea4c92c018dc884fcce7eb62d2f3f1ef76c3a51c11bb3fe722d72b90e4070f1d0f939cd9faa93c710a4d2dee9761d89557f8086c9fb4ca75c6f1a467fbf3"
+  ]
+}

--- a/packages/dns/dns.1.1.3/opam
+++ b/packages/dns/dns.1.1.3/opam
@@ -31,7 +31,7 @@ doc: "https://mirage.github.io/ocaml-dns/"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "1.2"}
   "cstruct" {>= "3.0.2"}
   "ppx_cstruct"
   "re" {>="1.7.2"}

--- a/packages/dns/dns.1.1.3/opam
+++ b/packages/dns/dns.1.1.3/opam
@@ -35,7 +35,7 @@ depends: [
   "cstruct" {>= "3.0.2"}
   "ppx_cstruct"
   "re" {>="1.7.2"}
-  "ipaddr" {>= "2.6.0"}
+  "ipaddr" {>= "4.0.0"}
   "uri" {>= "1.7.0"}
   "domain-name" {>="0.3.0"}
   "base64" {>= "3.0.0"}

--- a/packages/mirage-dns/mirage-dns.1.1.3/opam
+++ b/packages/mirage-dns/mirage-dns.1.1.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+synopsis: "DNS implementation for the MirageOS unikernel framework"
+description: """
+This is an implementation of a DNS server and client resolver
+for the [MirageOS unikernel framework](https://mirage.io).
+"""
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build}
+  "dns-lwt"
+  "duration"
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-kv-lwt" {>= "2.0.0"}
+  "mirage-time-lwt"
+  "mirage-profile" {>= "0.8.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.3/dns-v1.1.3.tbz"
+  checksum: [
+    "sha256=17a3b507d7c1848f14ba213397bcc5df3967bbb9792ec6c650ea5dd9feb5456a"
+    "sha512=cd13ea4c92c018dc884fcce7eb62d2f3f1ef76c3a51c11bb3fe722d72b90e4070f1d0f939cd9faa93c710a4d2dee9761d89557f8086c9fb4ca75c6f1a467fbf3"
+  ]
+}

--- a/packages/mirage-dns/mirage-dns.3.1.2/opam
+++ b/packages/mirage-dns/mirage-dns.3.1.2/opam
@@ -20,7 +20,7 @@ for the [MirageOS unikernel framework](https://mirage.io).
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune"
-  "dns-lwt"
+  "dns-lwt" {>="1.1.2"}
   "duration"
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-kv-lwt" {>= "2.0.0"}

--- a/packages/mirage-dns/mirage-dns.3.1.3/opam
+++ b/packages/mirage-dns/mirage-dns.3.1.3/opam
@@ -19,8 +19,8 @@ for the [MirageOS unikernel framework](https://mirage.io).
 """
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune" {build}
-  "dns-lwt"
+  "dune"
+  "dns-lwt" {>="1.1.3"}
   "duration"
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-kv-lwt" {>= "2.0.0"}

--- a/packages/mirage-dns/mirage-dns.3.1.3/opam
+++ b/packages/mirage-dns/mirage-dns.3.1.3/opam
@@ -19,7 +19,7 @@ for the [MirageOS unikernel framework](https://mirage.io).
 """
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune"
+  "dune" {>= "1.2"}
   "dns-lwt" {>="1.1.3"}
   "duration"
   "mirage-stack-lwt" {>= "1.3.0"}


### PR DESCRIPTION
DNS implementation in portable Lwt

- Project page: <a href="https://github.com/mirage/ocaml-dns">https://github.com/mirage/ocaml-dns</a>
- Documentation: <a href="https://mirage.github.io/ocaml-dns/">https://mirage.github.io/ocaml-dns/</a>

##### CHANGES:

* Support domain-name.0.3.0 interface, which bumps the minimum
  OCaml version supported to 4.04 due to that dependency (@avsm)
* Fix tests with recent OCaml (use mmap/bigarray-compat) (@avsm)
