### PR TITLE
+conduit.1.5.0

### DIFF
--- a/packages/conduit-async/conduit-async.1.5.0/opam
+++ b/packages/conduit-async/conduit-async.1.5.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "core"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "conduit" {=version}
+  "async" {>= "v0.10.0"}
+  "ipaddr" {>= "3.0.0"}
+]
+depopts: ["async_ssl"]
+conflicts: [
+  "async_ssl" {< "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Async"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v1.5.0/conduit-v1.5.0.tbz"
+  checksum: [
+    "sha256=06b6476ba4d8caf4cbfccbf7fd181cb2e5fe459e5e8e4992617fd2d7bebcbfd1"
+    "sha512=8bddae1a238d58d1b59520afb4f627c4beaf9b5355cacc4087e6667e678392cbc681777e32874ee033ffe40da8a7f0d3bab38eed64f25d201294a9c3e3476978"
+  ]
+}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.4.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.4.0/opam
@@ -15,7 +15,7 @@ depends: [
   "conduit-lwt" {>="1.4.0"}
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.9.4"}
-  "ipaddr" {>= "3.0.0"}
+  "ipaddr" {>= "3.0.0" & < "4.0.0"}
 ]
 depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.5.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.5.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "conduit-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+depopts: ["tls" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls" {< "0.8.0"}
+  "ssl" {< "0.5.9"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v1.5.0/conduit-v1.5.0.tbz"
+  checksum: [
+    "sha256=06b6476ba4d8caf4cbfccbf7fd181cb2e5fe459e5e8e4992617fd2d7bebcbfd1"
+    "sha512=8bddae1a238d58d1b59520afb4f627c4beaf9b5355cacc4087e6667e678392cbc681777e32874ee033ffe40da8a7f0d3bab38eed64f25d201294a9c3e3476978"
+  ]
+}

--- a/packages/conduit-lwt/conduit-lwt.1.5.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.1.5.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "conduit" {=version}
+  "lwt" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v1.5.0/conduit-v1.5.0.tbz"
+  checksum: [
+    "sha256=06b6476ba4d8caf4cbfccbf7fd181cb2e5fe459e5e8e4992617fd2d7bebcbfd1"
+    "sha512=8bddae1a238d58d1b59520afb4f627c4beaf9b5355cacc4087e6667e678392cbc681777e32874ee033ffe40da8a7f0d3bab38eed64f25d201294a9c3e3476978"
+  ]
+}

--- a/packages/conduit/conduit.1.5.0/opam
+++ b/packages/conduit/conduit.1.5.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "astring"
+  "uri"
+  "logs" {>= "0.5.0"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for 
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `mirage-conduit`: the MirageOS compatible implementation
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v1.5.0/conduit-v1.5.0.tbz"
+  checksum: [
+    "sha256=06b6476ba4d8caf4cbfccbf7fd181cb2e5fe459e5e8e4992617fd2d7bebcbfd1"
+    "sha512=8bddae1a238d58d1b59520afb4f627c4beaf9b5355cacc4087e6667e678392cbc681777e32874ee033ffe40da8a7f0d3bab38eed64f25d201294a9c3e3476978"
+  ]
+}

--- a/packages/mirage-conduit/mirage-conduit.1.5.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.1.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "cstruct" {>= "3.0.0"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-time-lwt" {>= "1.1.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-dns" {>= "3.0.0"}
+  "conduit-lwt"
+  "vchan" {>= "3.0.0"}
+  "xenstore"
+  "tls" {>= "0.8.0"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "MirageOS interface to network connections"
+description: """
+The `conduit` library takes care of establishing and listening for 
+TCP and SSL/TLS connections for MirageOS unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v1.5.0/conduit-v1.5.0.tbz"
+  checksum: [
+    "sha256=06b6476ba4d8caf4cbfccbf7fd181cb2e5fe459e5e8e4992617fd2d7bebcbfd1"
+    "sha512=8bddae1a238d58d1b59520afb4f627c4beaf9b5355cacc4087e6667e678392cbc681777e32874ee033ffe40da8a7f0d3bab38eed64f25d201294a9c3e3476978"
+  ]
+}

--- a/packages/mirage-conduit/mirage-conduit.3.2.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "mirage-time-lwt" {>= "1.1.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-dns" {>= "3.0.0"}
-  "conduit-lwt"
+  "conduit-lwt" {>="1.5.0"}
   "vchan" {>= "3.0.0"}
   "xenstore"
   "tls" {>= "0.8.0"}


### PR DESCRIPTION
* lwt-unix: Do not close file descriptors more than once, which led to a lot of
  log spam due to EBADF (#294 @hcarty @avsm)
* lwt-unix: Always close channels after handling an event (#283 @hcarty)
* Allow TCP to be established from existing file descriptors
  (for example, an inherited systemd socket) (#144 @SGrondin #282 @timbertson)
* async: add `Conduit_async.V3` which provides convenience functions for
  resolving URIs to addresses (#287 @vbmithr)
* `Lwt_ssl`: Enable certification validation (#291 @vouillon)
* `Async_ssl`: fix exception raised when other side disconnects
  due to sharing underlying fd (#295 @bogdan2412)
