### PR TITLE
bitstring: make ocaml migrate parsetree a runtime dependency

### DIFF
--- a/packages/bitstring/bitstring.3.1.1/opam
+++ b/packages/bitstring/bitstring.3.1.1/opam
@@ -1,0 +1,34 @@
+authors      : [ "Richard W.M. Jones" "Xavier R. Guérin" ]
+bug-reports  : "https://bitbucket.org/thanatonauts/bitstring/issues"
+dev-repo: "git+https://bitbucket.org/thanatonauts/bitstring.git"
+doc          : "https://bitstring.software"
+homepage     : "https://bitstring.software"
+license      : "LGPLv2+ with exceptions and GPLv2+"
+maintainer   : "Xavier R. Guérin <ghub@applepine.org>"
+opam-version: "2.0"
+version      : "3.1.1"
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "ocaml-migrate-parsetree" {>= "1.0.5"}
+  "jbuilder" {build}
+  "ppx_tools_versioned" {build}
+  "ounit" {with-test}
+]
+conflicts: [
+  "ppx_bitstring"
+]
+
+synopsis: "bitstrings and bitstring matching for OCaml"
+description: """
+The ocaml-bitstring project adds Erlang-style bitstrings and matching over bitstrings as a syntax extension and library for OCaml. 
+You can use this module to both parse and generate binary formats, files and protocols. 
+Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
+url {
+  src: "https://bitbucket.org/thanatonauts/bitstring/get/v3.1.0.tar.gz"
+  checksum: "md5=22807a9517ede34823ebdb36d6bacef8"
+}


### PR DESCRIPTION
OMP has a runtime lib, and upgrading omp breaks ppx_bitstring as it is not rebuilt to match interface change. 