### PR TITLE
Flac conflicts with old Liquidsoap versions.

### DIFF
--- a/packages/flac/flac.0.1.5/opam
+++ b/packages/flac/flac.0.1.5/opam
@@ -35,6 +35,9 @@ depexts: [
   ["flac"] {os-distribution = "nixos"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}
 ]
+conflicts: [
+  "liquidsoap" {<= "1.3.7"}
+]
 bug-reports: "https://github.com/savonet/ocaml-flac/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-flac.git"
 synopsis: "Interface for the Free Lossless Audio Codec otherwise known as FLAC"


### PR DESCRIPTION
An user of Liquidsoap was recently hit by this incompatibility of latest version of flac with old Liquidsoap versions: https://github.com/savonet/liquidsoap/issues/881.