### PR TITLE
mirage-dns: remove an unnecessary constraint

### DIFF
--- a/packages/mirage-dns/mirage-dns.3.1.2/opam
+++ b/packages/mirage-dns/mirage-dns.3.1.2/opam
@@ -20,7 +20,7 @@ for the [MirageOS unikernel framework](https://mirage.io).
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune"
-  "dns-lwt" {>="1.1.2"}
+  "dns-lwt"
   "duration"
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-kv-lwt" {>= "2.0.0"}


### PR DESCRIPTION
This caused co-instability issues:

```
$ opam install dns.1.1.1 mirage-kv-lwt.2.0.0 mirage-dns
The following dependencies couldn't be met:
...
```

Without that constraint the package can co-install without issues.