### PR TITLE
[new release] arp and arp-mirage (2.1.0)

### DIFF
--- a/packages/arp-mirage/arp-mirage.2.0.0/opam
+++ b/packages/arp-mirage/arp-mirage.2.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "mirage-protocols-lwt" {>= "2.0.0"}
   "lwt"
   "duration"
-  "arp" {>= "2.0.0"}
+  "arp" {= version}
   "mirage-profile" {>= "0.5"}
   "logs"
   "cstruct" {>= "2.2.0"}

--- a/packages/arp-mirage/arp-mirage.2.1.0/opam
+++ b/packages/arp-mirage/arp-mirage.2.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/arp"
+doc: "https://mirage.github.io/arp/"
+dev-repo: "git+https://github.com/mirage/arp.git"
+bug-reports: "https://github.com/mirage/arp/issues"
+license: "ISC"
+synopsis: "Address Resolution Protocol for MirageOS"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-time-lwt"
+  "mirage-protocols-lwt" {>= "2.0.0"}
+  "lwt"
+  "duration"
+  "arp" {= version}
+  "mirage-profile" {>= "0.5"}
+  "logs"
+  "cstruct" {>= "2.2.0"}
+  "ethernet" {with-test & >= "2.0.0"}
+  "fmt" {with-test}
+  "mirage-vnetif" {with-test}
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+  "mirage-random" {with-test}
+  "mirage-random-test" {with-test}
+  "mirage-unix" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/arp/releases/download/v2.1.0/arp-v2.1.0.tbz"
+  checksum: [
+    "sha256=ac2c004d500237ea2416ddf2a70b804df1aeeec894e58272aff7890410c8495d"
+    "sha512=7add4366202d671bf9e3013eedf699450611229bbd938d1dced449308c25a3afd5f6f53ec3a5969c756c95400cceb95cadb145ac04d2983db4a23e07801c86d5"
+  ]
+}

--- a/packages/arp-mirage/arp-mirage.2.1.0/opam
+++ b/packages/arp-mirage/arp-mirage.2.1.0/opam
@@ -9,7 +9,7 @@ license: "ISC"
 synopsis: "Address Resolution Protocol for MirageOS"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-time-lwt"
   "mirage-protocols-lwt" {>= "2.0.0"}
   "lwt"

--- a/packages/arp/arp.2.1.0/opam
+++ b/packages/arp/arp.2.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/arp"
+doc: "https://mirage.github.io/arp/"
+dev-repo: "git+https://github.com/mirage/arp.git"
+bug-reports: "https://github.com/mirage/arp/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"
+  "cstruct" {>= "2.2.0"}
+  "ipaddr" {>= "4.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "logs"
+  "mirage-random" {with-test}
+  "mirage-random-test" {with-test}
+  "bisect_ppx" {with-test}
+  "alcotest" {with-test}
+]
+conflicts: [
+  "arp-mirage" {< "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Address Resolution Protocol purely in OCaml"
+description: """
+ARP is an implementation of the address resolution protocol (RFC826) purely in
+OCaml.  It handles IPv4 protocol addresses and Ethernet hardware addresses only.
+"""
+url {
+  src:
+    "https://github.com/mirage/arp/releases/download/v2.1.0/arp-v2.1.0.tbz"
+  checksum: [
+    "sha256=ac2c004d500237ea2416ddf2a70b804df1aeeec894e58272aff7890410c8495d"
+    "sha512=7add4366202d671bf9e3013eedf699450611229bbd938d1dced449308c25a3afd5f6f53ec3a5969c756c95400cceb95cadb145ac04d2983db4a23e07801c86d5"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Update to ipaddr.4.0.0 interfaces (mirage/arp#16 @avsm)