### PR TITLE
Package mutf8.0.2

### DIFF
--- a/packages/mutf8/mutf8.0.2/opam
+++ b/packages/mutf8/mutf8.0.2/opam
@@ -5,10 +5,10 @@ authors: "Wim Lewis <wiml@hhhh.org>"
 license: "BSD"
 depends: [
   "ocaml" { >= "4.07.0" }
-  "dune" { build & >= "1.0.0" }
+  "dune" { >= "1.0.0" }
   "batteries" { >= "2.0.0" }
 ]
-build: [ "dune" "build" "-p" "mutf8" ]
+build: [ "dune" "build" "-p" name ]
 dev-repo: "git+https://github.com/wiml/ocaml-mutf8.git"
 bug-reports: "https://github.com/wiml/ocaml-mutf8/issues"
 homepage: "https://github.com/wiml/ocaml-mutf8"

--- a/packages/mutf8/mutf8.0.2/opam
+++ b/packages/mutf8/mutf8.0.2/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+synopsis: "The Modified UTF-8 encoding used by Java and related systems"
+maintainer: "Wim Lewis <wiml@hhhh.org>"
+authors: "Wim Lewis <wiml@hhhh.org>"
+license: "BSD"
+depends: [
+  "ocaml" { >= "4.07.0" }
+  "dune" { build & >= "1.0.0" }
+  "batteries" { >= "2.0.0" }
+]
+build: [ "dune" "build" "-p" "mutf8" ]
+dev-repo: "git+https://github.com/wiml/ocaml-mutf8.git"
+bug-reports: "https://github.com/wiml/ocaml-mutf8/issues"
+homepage: "https://github.com/wiml/ocaml-mutf8"
+url {
+  src: "http://github.com/wiml/ocaml-mutf8/archive/v0.2.tar.gz"
+  checksum: "sha512=595c25f2ffc8e5bc544d3c80c9491ee6d5a490a8995cba44e72c03e750e7d20a5b3c21c016cf1ffce44c273752b40f6f07482b6ceabe9e9851ad3759ac4dde8b"
+}


### PR DESCRIPTION
### `mutf8.0.2`
The Modified UTF-8 encoding used by Java and related systems



---
* Homepage: https://github.com/wiml/ocaml-mutf8
* Source repo: git+https://github.com/wiml/ocaml-mutf8.git
* Bug tracker: https://github.com/wiml/ocaml-mutf8/issues

---
:camel: Pull-request generated by opam-publish v2.0.0