### PR TITLE
[new release] mirage-net-solo5 (0.4.3)

### DIFF
--- a/packages/mirage-net-solo5/mirage-net-solo5.0.4.3/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.4.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-net-solo5"
+bug-reports:   "https://github.com/mirage/mirage-net-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-solo5.git"
+doc:           "https://mirage.github.io/mirage-net-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune"
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "macaddr" { >= "4.0.0"}
+  "mirage-solo5" {>= "0.5.0" & < "0.6.0"}
+  "logs" {>= "0.6.0"}
+  "fmt"
+]
+synopsis: "Solo5 implementation of MirageOS network interface"
+description:
+  "This library implements the MirageOS network interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-net-solo5/releases/download/v0.4.3/mirage-net-solo5-v0.4.3.tbz"
+  checksum: [
+    "sha256=f3e571078729802766315dba3dd3f663578d76e9cf8bfcaa9ec41d05bb77657a"
+    "sha512=e66109798faae1237d9de70e977c6032f553cc1341a7647b8ae99da9232018c053df6af3a41eed81ba968cd650378c57bfb95b1a9625bd28e0d1733085bd69e1"
+  ]
+}


### PR DESCRIPTION
Solo5 implementation of MirageOS network interface

- Project page: <a href="https://github.com/mirage/mirage-net-solo5">https://github.com/mirage/mirage-net-solo5</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-solo5/">https://mirage.github.io/mirage-net-solo5/</a>

##### CHANGES:

* Adjust to macaddr version 4.0.0 API (@yomimono, mirage/mirage-net-solo5#33)
* Port to Dune (@pascutto, mirage/mirage-net-solo5#29)
