### PR TITLE
Package gremlin.0.1.1

### DIFF
--- a/packages/gremlin/gremlin.0.1.1/opam
+++ b/packages/gremlin/gremlin.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name: "gremlin"
+author: "Bramford Horton <bram.horton@gmail.com>"
+maintainer: "Bramford Horton <bram.horton@gmail.com>"
+homepage: "https://github.com/bramford/ocaml-gremlin"
+bug-reports: "https://github.com/bramford/ocaml-gremlin/issues"
+dev-repo: "git+https://github.com/bramford/ocaml-gremlin"
+doc: "https://bramford.github.io/ocaml-gremlin/doc"
+license: "ISC"
+build: [ "dune" "build" "-j" jobs "-p" name ]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "conduit-lwt-unix" {>= "1.4.0"}
+  "containers" {>= "2.6"}
+  "core" {>= "v0.12.3"}
+  "dune" {>= "1.10.0"}
+  "lwt" {>= "4.2.1"}
+  "lwt_ppx" {>= "1.2.2"}
+  "ppx_let" {>= "v0.12.0"}
+  "yojson" {>= "1.7.0"}
+  "websocket" {>= "2.13"}
+  "websocket-lwt-unix" {>= "2.13"}
+]
+synopsis: "Gremlin Client Library"
+description: """
+This is an Apache Tinkerpop3 Gremlin client library.
+
+See the official tinkerpop3 and gremlin docs:
+- http://tinkerpop.apache.org/docs/current/
+
+This client library is implemented following the driver provider requirements:
+- http://tinkerpop.apache.org/docs/current/dev/provider/#_graph_driver_provider_requirements
+"""
+authors: "Bramford Horton <bram.horton@gmail.com>"
+url {
+  src: "https://github.com/bramford/ocaml-gremlin/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=d6d34be20f43e9ff4c6b18159e99ea2c"
+    "sha512=42b39f19eb57d1f30b8e078457078e0d2dda35e538cc7fc28bc65d4cac6ebe8ad08f81fcd5f5e7e151c3cbfcd4ab9f9b09cba1608682fdda08eab0b5761b0bbe"
+  ]
+}

--- a/packages/gremlin/gremlin.0.1.1/opam
+++ b/packages/gremlin/gremlin.0.1.1/opam
@@ -31,7 +31,6 @@ See the official tinkerpop3 and gremlin docs:
 This client library is implemented following the driver provider requirements:
 - http://tinkerpop.apache.org/docs/current/dev/provider/#_graph_driver_provider_requirements
 """
-authors: "Bramford Horton <bram.horton@gmail.com>"
 url {
   src: "https://github.com/bramford/ocaml-gremlin/archive/0.1.1.tar.gz"
   checksum: [


### PR DESCRIPTION
### `gremlin.0.1.1`
Gremlin Client Library
This is an Apache Tinkerpop3 Gremlin client library.

See the official tinkerpop3 and gremlin docs:
- http://tinkerpop.apache.org/docs/current/

This client library is implemented following the driver provider requirements:
- http://tinkerpop.apache.org/docs/current/dev/provider/#_graph_driver_provider_requirements



---
* Homepage: https://github.com/bramford/ocaml-gremlin
* Source repo: git+https://github.com/bramford/ocaml-gremlin
* Bug tracker: https://github.com/bramford/ocaml-gremlin/issues

---
:camel: Pull-request generated by opam-publish v2.0.0