### PR TITLE
Fix hdf5.0.1.5

### DIFF
--- a/packages/hdf5/hdf5.0.1.5/opam
+++ b/packages/hdf5/hdf5.0.1.5/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/vbrankov/hdf5-ocaml/issues"
 license: "MIT"
 dev-repo: "git+https://github.com/vbrankov/hdf5-ocaml.git"
 build: [
-  ["dune" "build" "-p" "hdf5-ocaml" "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "cppo"
@@ -30,7 +30,7 @@ arrays of records."
 url {
   src: "https://github.com/vbrankov/hdf5-ocaml/archive/v0.1.5.tar.gz"
   checksum: [
-    "md5=f1509ae61a4f1fce48076515e0bdb8a0"
-    "sha512=7efdaa6f83d3c328c625bb6daf4ed3a7aaa9e90ff3f8427a61cd723b1073c36dcd77c3350f601b2845b10758f8ed2b584b0e7eea86128e3fefc8998edcc06df7"
+    "md5=5e42f0b3f28a7ed8ba84998ee30ff8e7"
+    "sha512=17eea72e38f70f92a3b01cd10e0cae8839d8d214b5fa6507f9d435530afe17c88fbdd349157a12eead205e1cf66225d6282199404a3c26841366a57f5c69ff23"
   ]
 }


### PR DESCRIPTION
hdf5.0.1.5 is was still broken: I tried installing it and although the install doesn't raise any errors, I installs nothing.  I'm trying a new attempt at fixing it by renaming the library to hdf5 so that the package name and the library name are the same.

See:
https://github.com/ocaml/opam-repository/pull/14417
https://github.com/ocaml/opam-repository/pull/14356