### PR TITLE
[new release] elpi (1.6.0)

### DIFF
--- a/packages/elpi/elpi.1.6.0/opam
+++ b/packages/elpi/elpi.1.6.0/opam
@@ -1,0 +1,85 @@
+opam-version: "2.0"
+name: "elpi"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Claudio Sacerdoti Coen" "Enrico Tassi" ]
+license: "LGPL 2.1+"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  [make "tests"] {with-test & os != "macos"}
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "camlp5"
+  "ppx_tools_versioned"
+  "ppx_deriving"
+  "ocaml-migrate-parsetree"
+  "re" {>= "1.7.2"}
+  "ANSITerminal" {with-test}
+  "cmdliner" {with-test}
+  "dune" {build}
+  "conf-time" {with-test}
+]
+synopsis: "ELPI - Embeddable λProlog Interpreter"
+description: """
+ELPI implements a variant of λProlog enriched with Constraint Handling Rules,
+a programming language well suited to manipulate syntax trees with binders.
+
+ELPI is designed to be embedded into larger applications written in OCaml as
+an extension language. It comes with an API to drive the interpreter and 
+with an FFI for defining built-in predicates and data types, as well as
+quotations and similar goodies that are handy to adapt the language to the host
+application.
+
+This package provides both a command line interpreter (elpi) and a library to
+be linked in other applications (eg by passing -package elpi to ocamlfind).
+
+The ELPI programming language has the following features:
+
+- Native support for variable binding and substitution, via an Higher Order
+  Abstract Syntax (HOAS) embedding of the object language. The programmer needs
+  not to care about De Bruijn indexes.
+
+- Native support for hypothetical context. When moving under a binder one can
+  attach to the bound variable extra information that is collected when the
+  variable gets out of scope. For example when writing a type-checker the
+  programmer needs not to care about managing the typing context.
+
+- Native support for higher order unification variables, again via HOAS.
+  Unification variables of the meta-language (λProlog) can be reused to
+  represent the unification variables of the object language. The programmer
+  does not need to care about the unification-variable assignment map and
+  cannot assign to a unification variable a term containing variables out of
+  scope, or build a circular assignment.
+
+- Native support for syntactic constraints and their meta-level handling rules.
+  The generative semantics of Prolog can be disabled by turning a goal into a
+  syntactic constraint (suspended goal). A syntactic constraint is resumed as
+  soon as relevant variables gets assigned. Syntactic constraints can be
+  manipulated by constraint handling rules (CHR).
+
+- Native support for backtracking. To ease implementation of search.
+
+- The constraint store is extensible.  The host application can declare
+  non-syntactic constraints and use custom constraint solvers to check their
+  consistency.
+
+- Clauses are graftable. The user is free to extend an existing program by
+  inserting/removing clauses, both at runtime (using implication) and at
+  "compilation" time by accumulating files.
+
+ELPI is free software released under the terms of LGPL 2.1 or above."""
+url {
+  src:
+    "https://github.com/LPCIC/elpi/releases/download/v1.6.0/elpi-v1.6.0.tbz"
+  checksum: [
+    "sha256=6fadd66727e9e3c4eaa30d5f401965020d814cf8cda816b7fe8c78252cc4113e"
+    "sha512=612e2f097609b7c6af73794b63d0e2d73da9ee43b59378a067b32af0093f69ecae82cb3a83c54a2809c3a4af7331d940c3cd77789af974a4da79d5a2991c1a35"
+  ]
+}

--- a/packages/elpi/elpi.1.6.0/opam
+++ b/packages/elpi/elpi.1.6.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "elpi"
 maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
 authors: [ "Claudio Sacerdoti Coen" "Enrico Tassi" ]
 license: "LGPL 2.1+"
@@ -23,7 +22,7 @@ depends: [
   "re" {>= "1.7.2"}
   "ANSITerminal" {with-test}
   "cmdliner" {with-test}
-  "dune" {build}
+  "dune"
   "conf-time" {with-test}
 ]
 synopsis: "ELPI - Embeddable λProlog Interpreter"


### PR DESCRIPTION
CHANGES:

- Builtin:
  - `same_term` (infix `==`) for Prolog's non-logical comparison (without
    instantiation).
  - `set` and `map A` (`A` only allowed to be a closed term) on
    `string`, `int` and `loc` keys.

- Compiler:
  - provide line number on error about duplicate mode declaration
  - elpi-checker is faster and bails out after 10 seconds

- FFI:
  - allow `AlgebraicData` declarations to mix `M` and `MS` constructors
  - `Conversion.t` for closed terms (no unification variable and no variables
    bound by the program)

- Tests:
  - typecheck all tests and measure type checking time