### PR TITLE
5 packages from owlbarn/owl at 0.6.0

### DIFF
--- a/packages/owl-base/owl-base.0.6.0/opam
+++ b/packages/owl-base/owl-base.0.6.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "base-bigarray"
-  "dune" {build}
+  "dune"
 ]
 url {
   src: "https://github.com/owlbarn/owl/archive/0.6.0.tar.gz"

--- a/packages/owl-base/owl-base.0.6.0/opam
+++ b/packages/owl-base/owl-base.0.6.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/"
+synopsis: "OCaml Scientific and Engineering Computing - Base"
+description: "Owl is an OCaml scientific library."
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "base-bigarray"
+  "dune" {build}
+]
+url {
+  src: "https://github.com/owlbarn/owl/archive/0.6.0.tar.gz"
+  checksum: [
+    "md5=b78de667bc02e232beb321e0d7e11347"
+    "sha512=0bb8dbeef6f762660f1bf5eaf9e4b96a9af3956fadf15a8000f99d9a676a0b6e32870d29d74bc4a87eab6967cc27ecfca82d42b9d9e682b1937dc15121f8f298"
+  ]
+}

--- a/packages/owl-plplot/owl-plplot.0.6.0/opam
+++ b/packages/owl-plplot/owl-plplot.0.6.0/opam
@@ -22,7 +22,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build}
+  "dune"
   "owl" {>= "0.5.0"}
   "plplot"
 ]

--- a/packages/owl-plplot/owl-plplot.0.6.0/opam
+++ b/packages/owl-plplot/owl-plplot.0.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/owl/"
+synopsis: "OCaml Scientific and Engineering Computing"
+description: """
+Owl: OCaml Scientific and Engineering Computing
+
+Owl is an OCaml numerical library.
+It supports N-dimensional arrays, both dense and sparse matrix operations, linear algebra, regressions, fast Fourier transforms, and many advanced mathematical and statistical functions (such as Markov chain Monte Carlo methods).
+Recently, Owl has implemented algorithmic differentiation which essentially makes developing machine learning and neural network algorithms trivial.
+"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "owl" {>= "0.5.0"}
+  "plplot"
+]
+url {
+  src: "https://github.com/owlbarn/owl/archive/0.6.0.tar.gz"
+  checksum: [
+    "md5=b78de667bc02e232beb321e0d7e11347"
+    "sha512=0bb8dbeef6f762660f1bf5eaf9e4b96a9af3956fadf15a8000f99d9a676a0b6e32870d29d74bc4a87eab6967cc27ecfca82d42b9d9e682b1937dc15121f8f298"
+  ]
+}

--- a/packages/owl-top/owl-top.0.6.0/opam
+++ b/packages/owl-top/owl-top.0.6.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/"
+synopsis: "OCaml Scientific and Engineering Computing - Top"
+description: "Owl is an OCaml scientific library."
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "ocaml-compiler-libs"
+  "owl" {>= version}
+  "owl-zoo"
+]
+url {
+  src: "https://github.com/owlbarn/owl/archive/0.6.0.tar.gz"
+  checksum: [
+    "md5=b78de667bc02e232beb321e0d7e11347"
+    "sha512=0bb8dbeef6f762660f1bf5eaf9e4b96a9af3956fadf15a8000f99d9a676a0b6e32870d29d74bc4a87eab6967cc27ecfca82d42b9d9e682b1937dc15121f8f298"
+  ]
+}

--- a/packages/owl-top/owl-top.0.6.0/opam
+++ b/packages/owl-top/owl-top.0.6.0/opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build}
+  "dune"
   "ocaml-compiler-libs"
   "owl" {>= version}
   "owl-zoo"

--- a/packages/owl-zoo/owl-zoo.0.6.0/opam
+++ b/packages/owl-zoo/owl-zoo.0.6.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/"
+synopsis: "OCaml Scientific and Engineering Computing - Zoo"
+description: """
+Owl's Zoo System
+
+The Zoo System is Owl's customised toplevel.
+It is used for scripting numerical applications and sharing small code snippets via gist among users.
+The Zoo system introduces a zoo directive into toplevel, the referred gist id will be automatically downloaded and imported as a module in the script.
+The nested zoo reference is also supported.
+"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "ocaml-compiler-libs"
+  "owl" {>= version}
+]
+url {
+  src: "https://github.com/owlbarn/owl/archive/0.6.0.tar.gz"
+  checksum: [
+    "md5=b78de667bc02e232beb321e0d7e11347"
+    "sha512=0bb8dbeef6f762660f1bf5eaf9e4b96a9af3956fadf15a8000f99d9a676a0b6e32870d29d74bc4a87eab6967cc27ecfca82d42b9d9e682b1937dc15121f8f298"
+  ]
+}

--- a/packages/owl-zoo/owl-zoo.0.6.0/opam
+++ b/packages/owl-zoo/owl-zoo.0.6.0/opam
@@ -23,7 +23,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build}
+  "dune"
   "ocaml-compiler-libs"
   "owl" {>= version}
 ]

--- a/packages/owl/owl.0.6.0/opam
+++ b/packages/owl/owl.0.6.0/opam
@@ -28,7 +28,7 @@ depends: [
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
   "ctypes"
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
   "eigen" {>= "0.1.0"}
   "owl-base" {>= version}
   "stdio" {build}

--- a/packages/owl/owl.0.6.0/opam
+++ b/packages/owl/owl.0.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/owl/"
+synopsis: "OCaml Scientific and Engineering Computing"
+description: """
+Owl: OCaml Scientific and Engineering Computing
+
+Owl is an OCaml numerical library.
+It supports N-dimensional arrays, both dense and sparse matrix operations, linear algebra, regressions, fast Fourier transforms, and many advanced mathematical and statistical functions (such as Markov chain Monte Carlo methods).
+Recently, Owl has implemented algorithmic differentiation which essentially makes developing machine learning and neural network algorithms trivial.
+"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "alcotest" {with-test}
+  "base" {build}
+  "base-bigarray"
+  "conf-openblas" {>= "0.2.0"}
+  "ctypes"
+  "dune" {build & >= "1.2.1"}
+  "eigen" {>= "0.1.0"}
+  "owl-base" {>= version}
+  "stdio" {build}
+]
+url {
+  src: "https://github.com/owlbarn/owl/archive/0.6.0.tar.gz"
+  checksum: [
+    "md5=b78de667bc02e232beb321e0d7e11347"
+    "sha512=0bb8dbeef6f762660f1bf5eaf9e4b96a9af3956fadf15a8000f99d9a676a0b6e32870d29d74bc4a87eab6967cc27ecfca82d42b9d9e682b1937dc15121f8f298"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`owl.0.6.0`: OCaml Scientific and Engineering Computing
-`owl-base.0.6.0`: OCaml Scientific and Engineering Computing - Base
-`owl-plplot.0.6.0`: OCaml Scientific and Engineering Computing
-`owl-top.0.6.0`: OCaml Scientific and Engineering Computing - Top
-`owl-zoo.0.6.0`: OCaml Scientific and Engineering Computing - Zoo



---
* Homepage: https://github.com/owlbarn/owl
* Source repo: git+https://github.com/owlbarn/owl.git
* Bug tracker: https://github.com/owlbarn/owl/issues

---
:camel: Pull-request generated by opam-publish v2.0.0