### PR TITLE
conf-openblas: add Arch Linux support

### DIFF
--- a/packages/conf-openblas/conf-openblas.0.2.0/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.0/opam
@@ -12,8 +12,10 @@ build: [
     "-exc"
     "cc $CFLAGS -I/usr/local/opt/openblas/include test.c -L/usr/local/opt/openblas/lib -lopenblas"
   ] {os = "macos" & os-distribution = "homebrew"}
+  ["sh" "-exc" "cc $CFLAGS test.c -lcblas"]
+    {os-distribution = "arch"}
   ["sh" "-exc" "cc $CFLAGS test.c -lopenblas"]
-    {os-distribution != "fedora" & os-distribution != "centos" & os-family != "suse" & os != "macos"}
+    {os-distribution != "fedora" & os-distribution != "centos" & os-family != "suse" & os != "macos" & os-distribution != "arch"}
 ]
 depexts: [
   ["libc-dev" "openblas-dev"] {os-distribution = "alpine"}
@@ -22,6 +24,7 @@ depexts: [
   ["libopenblas-dev" "liblapacke-dev"] {os-distribution = "ubuntu"}
   ["openblas-devel"] {os-distribution = "fedora"}
   ["openblas-devel"] {os-family = "suse"}
+  ["openblas" "lapacke" "cblas"] {os-distribution = "arch"}
   ["openblas"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package to install OpenBLAS and LAPACKE"


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam-repository/issues/12989 for `os-distribution = "arch"`

This is the cause: https://bugs.archlinux.org/task/59046