### PR TITLE
[new release] diet (0.4)

### DIFF
--- a/packages/diet/diet.0.4/opam
+++ b/packages/diet/diet.0.4/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: "David Scott"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-diet"
+doc: "https://mirage.github.io/ocaml-diet/"
+bug-reports: "https://github.com/mirage/ocaml-diet/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "stdlib-shims"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-diet.git"
+synopsis: "Discrete Interval Encoding Trees"
+description: """
+This data structure is based on the
+[Functional Pearls: Diets for Fat Sets](https://web.engr.oregonstate.edu/~erwig/papers/Diet_JFP98.pdf)
+by Martin Erwig."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-diet/releases/download/v0.4/diet-v0.4.tbz"
+  checksum: [
+    "sha256=96acac2e4fdedb5f47dd8ad2562e723d85ab59cd1bd85554df21ec907b071741"
+    "sha512=88ab26a898ace0fa97bb521b8715ad9e122782c9be212e2162d2d3695208dbb3d296409446dfa4c1b84e6cdf8fd9a1922989046db3c7ad01db57940ced4b0c17"
+  ]
+}


### PR DESCRIPTION
Discrete Interval Encoding Trees

- Project page: <a href="https://github.com/mirage/ocaml-diet">https://github.com/mirage/ocaml-diet</a>
- Documentation: <a href="https://mirage.github.io/ocaml-diet/">https://mirage.github.io/ocaml-diet/</a>

##### CHANGES:

- support OCaml 4.08 deprecations by using Stdlib (@avsm)
