### PR TITLE
owl-ode, owl-ode-sundials: release 0.1.0

### DIFF
--- a/packages/owl-ode-sundials/owl-ode-sundials.0.1.0/opam
+++ b/packages/owl-ode-sundials/owl-ode-sundials.0.1.0/opam
@@ -8,14 +8,12 @@ bug-reports: "https://github.com/owlbarn/owl_ode/issues"
 doc: "https://owlbarn.github.io/owl_ode/ode"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "exec" "examples/van_der_pol.exe"] {with-test & ocaml:version < "4.08.0"}
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
   "owl" {>= "0.6.0"}
   "dune" {>= "1.5.0"}
   "owl-ode" {>="0.1.0"}
-  "owl-plplot" {with-test}
   "sundialsml"
 ]
 synopsis: "Owl's ODE solvers, interface with SundialsML"

--- a/packages/owl-ode-sundials/owl-ode-sundials.0.1.0/opam
+++ b/packages/owl-ode-sundials/owl-ode-sundials.0.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/owlbarn/owl_ode/issues"
 doc: "https://owlbarn.github.io/owl_ode/ode"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "exec" "examples/van_der_pol.exe"] {with-test}
+  ["dune" "exec" "examples/van_der_pol.exe"] {with-test & ocaml:version < "4.08.0"}
 ]
 depends: [
   "ocaml" {>= "4.06.0"}

--- a/packages/owl-ode-sundials/owl-ode-sundials.0.1.0/opam
+++ b/packages/owl-ode-sundials/owl-ode-sundials.0.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "owlbarn"
+authors: [ "Marcello Seri" "Ta-Chu Calvin Kao" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl_ode"
+dev-repo: "git+https://github.com/owlbarn/owl_ode.git"
+bug-reports: "https://github.com/owlbarn/owl_ode/issues"
+doc: "https://owlbarn.github.io/owl_ode/ode"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "exec" "examples/van_der_pol.exe"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "owl" {>= "0.6.0"}
+  "dune" {>= "1.5.0"}
+  "owl-ode" {>="0.1.0"}
+  "owl-plplot" {with-test}
+  "sundialsml"
+]
+synopsis: "Owl's ODE solvers, interface with SundialsML"
+url {
+  src: "https://github.com/owlbarn/owl_ode/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=4e46481a58735ccbc5f9ca0978862553"
+    "sha512=0cbbaec0520e9efd7578d1a46760a9c5e0ecbc1dc62d11fc1ad63402f2b6e1dfe42be64a089d371c85248c3ba7393ae32999a56b0af45ca790caaf82049c3c8f"
+  ]
+}

--- a/packages/owl-ode/owl-ode.0.1.0/opam
+++ b/packages/owl-ode/owl-ode.0.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/owlbarn/owl_ode/issues"
 doc: "https://owlbarn.github.io/owl_ode/owl-ode"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.08.0"}
 ]
 depends: [
   "ocaml" {>= "4.06.0"}

--- a/packages/owl-ode/owl-ode.0.1.0/opam
+++ b/packages/owl-ode/owl-ode.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "owlbarn"
+authors: [ "Marcello Seri" "Ta-Chu Calvin Kao" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl_ode"
+dev-repo: "git+https://github.com/owlbarn/owl_ode.git"
+bug-reports: "https://github.com/owlbarn/owl_ode/issues"
+doc: "https://owlbarn.github.io/owl_ode/owl-ode"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.5.0"}
+  "owl" {>= "0.6.0"}
+  "owl-plplot" {with-test}
+  "alcotest" {with-test}
+]
+synopsis: "Owl's ODE solvers"
+url {
+  src: "https://github.com/owlbarn/owl_ode/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=4e46481a58735ccbc5f9ca0978862553"
+    "sha512=0cbbaec0520e9efd7578d1a46760a9c5e0ecbc1dc62d11fc1ad63402f2b6e1dfe42be64a089d371c85248c3ba7393ae32999a56b0af45ca790caaf82049c3c8f"
+  ]
+}

--- a/packages/sundialsml/sundialsml.3.1.1p0-1/opam
+++ b/packages/sundialsml/sundialsml.3.1.1p0-1/opam
@@ -1,0 +1,87 @@
+opam-version: "2.0"
+name: "sundialsml"
+maintainer: "tim@tbrk.org"
+authors: [
+    "Timothy Bourke <tim@tbrk.org>"
+    "Jun Inoue <Jun.Lambda@gmail.com>"
+    "Marc Pouzet <Marc.Pouzet@ens.fr>"
+]
+homepage: "http://inria-parkas.github.io/sundialsml/"
+bug-reports: "https://github.com/inria-parkas/sundialsml/issues"
+dev-repo: "git://github.com/inria-parkas/sundialsml"
+doc: "http://inria-parkas.github.io/sundialsml/"
+tags: [
+    "numerical"
+    "simulation"
+    "mathematics"
+    "science"
+]
+license: "BSD3"
+build: [
+  [
+    "./configure"
+    "--stubdir=%{stublibs}%/"
+    "--libdir=%{lib}%/"
+    "--docdir=%{doc}%/"
+  ]
+  [make "doc"] {with-doc}
+]
+install: [
+  [make "install-findlib"]
+  [make "install-doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "base-bigarray"
+  "ocamlfind" {build}
+]
+depopts: [
+    "mpi"
+]
+depexts: [
+  ["libsundials-dev"] {os-family = "debian"}
+  ["lapack-devel" "sundials-devel"] {os-distribution = "fedora"}
+  [
+    "epel-release"
+    "lapack-devel"
+    "suitesparse-devel"
+    "SuperLUMT-devel"
+    "sundials-devel"
+  ] {os-distribution = "centos"}
+  ["sundials"] {os = "macos" & os-distribution = "homebrew"}
+  ["sundials"] {os = "macos" & os-distribution = "macports"}
+]
+synopsis: "Interface to the Sundials suite of numerical solvers"
+description: """
+Sundials is a collection of six numerical solvers: CVODE, CVODES, IDA, IDAS,
+ARKODE, and KINSOL. This interface provides access to all features of the
+underlying library except the Hypre and PETSC nvectors.
+
+The structure of the OCaml interface mostly follows that of the original
+library, both for ease of reading the existing documentation and for
+converting existing source code, but several changes have been made for
+programming convenience and to increase safety, namely:
+
+- solver sessions are mostly configured via algebraic data types rather than
+  multiple function calls;
+
+- errors are signalled by exceptions not return codes (also from
+  user-supplied callback routines);
+
+- user data is shared between callback routines via closures (partial
+  applications of functions);
+
+- vectors are checked for compatibility with a session (using a combination
+  of static and dynamic checks), and;
+
+- explicit free commands are not necessary since OCaml is a
+  garbage-collected language.
+
+The detailed OCaml documentation contains cross-links to the original
+documentation. OCaml versions of the standard examples usually have an
+overhead of about 30% compared to the original C versions, and only rarely
+more than 50%."""
+url {
+  src: "https://github.com/inria-parkas/sundialsml/archive/v3.1.1p0.zip"
+  checksum: "md5=0c35080ac75baf6ce1cd9e5056f5e639"
+}


### PR DESCRIPTION
This pull-request concerns:
-`owl-ode.0.1.0`: Owl's ODE solvers
-`owl-ode-sundials.0.1.0`: Owl's ODE solvers, interface with SundialsML



---
* Homepage: https://github.com/owlbarn/owl_ode
* Source repo: git+https://github.com/owlbarn/owl_ode.git
* Bug tracker: https://github.com/owlbarn/owl_ode/issues

---
:camel: Pull-request generated by opam-publish v2.0.0