### PR TITLE
Package tsdl.0.9.7

### DIFF
--- a/packages/tsdl/tsdl.0.9.7/opam
+++ b/packages/tsdl/tsdl.0.9.7/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The tsdl programmers"]
+homepage: "https://erratique.ch/software/tsdl"
+doc: "https://erratique.ch/software/tsdl/doc/Tsdl"
+dev-repo: "git+https://erratique.ch/repos/tsdl.git"
+bug-reports: "https://github.com/dbuenzli/tsdl/issues"
+tags: [ "audio" "bindings" "graphics" "media" "opengl" "input" "hci"
+        "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "conf-sdl2"
+  "ctypes" {>= "0.9.0"}
+  "ctypes-foreign" ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+           "--pinned" "%{pinned}%"
+]]
+
+synopsis: """Thin bindings to SDL for OCaml"""
+description: """\
+
+Tsdl is an OCaml library providing thin bindings to the cross-platform
+SDL C library.
+
+Tsdl depends on the [SDL 2.0.6][sdl] C library (or later),
+[ocaml-ctypes][ctypes] and the `result` compatibility package.
+Tsdl is distributed under the ISC license.
+
+[sdl]: http://www.libsdl.org/
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes
+"""
+url {
+archive: "https://erratique.ch/software/tsdl/releases/tsdl-0.9.7.tbz"
+checksum: "22a93b45950a044792107b961ef7ca47"
+}


### PR DESCRIPTION
### `tsdl.0.9.7`
Thin bindings to SDL for OCaml
Tsdl is an OCaml library providing thin bindings to the cross-platform
SDL C library.

Tsdl depends on the [SDL 2.0.6][sdl] C library (or later),
[ocaml-ctypes][ctypes] and the `result` compatibility package.
Tsdl is distributed under the ISC license.

[sdl]: http://www.libsdl.org/
[ctypes]: https://github.com/ocamllabs/ocaml-ctypes



---
* Homepage: https://erratique.ch/software/tsdl
* Source repo: git+https://erratique.ch/repos/tsdl.git
* Bug tracker: https://github.com/dbuenzli/tsdl/issues

---
v0.9.7 2019-07-19 Zagreb
------------------------

- Add support for `SDL_{Sensor,Display}Event`. Thanks to Florent
  Monnier for the patches.
- Require OCaml 4.03 and handle stdlib deprecations.
- Drop `result` depency.
- Drop `ocb-stubblr` dependency

---
:camel: Pull-request generated by opam-publish v2.0.0