### PR TITLE
Package mtime.1.2.0

### DIFF
--- a/packages/mtime/mtime.1.2.0/opam
+++ b/packages/mtime/mtime.1.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The mtime programmers" ]
+homepage: "https://erratique.ch/software/mtime"
+doc: "https://erratique.ch/software/mtime"
+dev-repo: "git+https://erratique.ch/repos/mtime.git"
+bug-reports: "https://github.com/dbuenzli/mtime/issues"
+tags: [ "time" "monotonic" "system" "org:erratique" ]
+license: "ISC"
+depends:
+[
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+]
+depopts: [ "js_of_ocaml" ]
+conflicts: ["js_of_ocaml" {<= "3.3.0"} ]
+build: [[
+   "ocaml" "pkg/pkg.ml" "build"
+   "--pinned" "%{pinned}%"
+   "--with-js_of_ocaml" "%{js_of_ocaml:installed}%" ]]
+
+synopsis: """Monotonic wall-clock time for OCaml"""
+description: """\
+
+Mtime has platform independent support for monotonic wall-clock time
+in pure OCaml. This time increases monotonically and is not subject to
+operating system calendar time adjustments. The library has types to
+represent nanosecond precision timestamps and time spans.
+
+The additional Mtime_clock library provide access to a system
+monotonic clock.
+
+Mtime has a no dependency. Mtime_clock depends on your system library.
+The optional JavaScript support depends on [js_of_ocaml][jsoo]. Mtime
+and its libraries are distributed under the ISC license.
+
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+"""
+url {
+archive: "https://erratique.ch/software/mtime/releases/mtime-1.2.0.tbz"
+checksum: "f3f4c1333c0f74fc27b05c35b9c0dab9"
+}


### PR DESCRIPTION
### `mtime.1.2.0`
Monotonic wall-clock time for OCaml
Mtime has platform independent support for monotonic wall-clock time
in pure OCaml. This time increases monotonically and is not subject to
operating system calendar time adjustments. The library has types to
represent nanosecond precision timestamps and time spans.

The additional Mtime_clock library provide access to a system
monotonic clock.

Mtime has a no dependency. Mtime_clock depends on your system library.
The optional JavaScript support depends on [js_of_ocaml][jsoo]. Mtime
and its libraries are distributed under the ISC license.

[jsoo]: http://ocsigen.org/js_of_ocaml/



---
* Homepage: https://erratique.ch/software/mtime
* Source repo: git+https://erratique.ch/repos/mtime.git
* Bug tracker: https://github.com/dbuenzli/mtime/issues

---
v1.2.0 2019-07-19 Zagreb
------------------------

* Add support for node.js. Thanks to Fabian (@copy) for the patch.
* Support for js_of_ocaml 3.4.0.
* Add MTIME_OS environment variable for specifying the OS at build time.

---
:camel: Pull-request generated by opam-publish v2.0.0