### PR TITLE
Package fmt.0.8.7

### DIFF
--- a/packages/fmt/fmt.0.8.7/opam
+++ b/packages/fmt/fmt.0.8.7/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The fmt programmers" ]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt"
+dev-repo: "git+https://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  # Can be removed once ocaml >= 4.07
+  "seq"
+  "stdlib-shims"
+]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-base-unix" "%{base-unix:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """OCaml Format pretty-printer combinators"""
+description: """\
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner
+"""
+url {
+archive: "https://erratique.ch/software/fmt/releases/fmt-0.8.7.tbz"
+checksum: "c317aa285fe13732cd1f27674f974357"
+}


### PR DESCRIPTION
### `fmt.0.8.7`
OCaml Format pretty-printer combinators
Fmt exposes combinators to devise `Format` pretty-printing functions.

Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
library that allows to setup formatters for terminal color output
depends on the Unix library. The optional `Fmt_cli` library that
provides command line support for Fmt depends on [`Cmdliner`][cmdliner].

Fmt is distributed under the ISC license.

[cmdliner]: http://erratique.ch/software/cmdliner



---
* Homepage: https://erratique.ch/software/fmt
* Source repo: git+https://erratique.ch/repos/fmt.git
* Bug tracker: https://github.com/dbuenzli/fmt/issues

```
v0.8.7 2019-07-21 Zagreb
------------------------

* Require OCaml 4.05.
* Add `Fmt.hex` and friends. Support for hex dumping.
  Thanks to David Kaloper Meršinjak for the design and implementation..
* Add `Fmt.si_size` to format integer magnitudes using SI prefixes.
* Add `Fmt.uint64_ns_span` to format time spans.
* Add `Fmt.truncated` to truncate your long strings.
* Add `Fmt.flush`, has the effect of `Format.pp_print_flush`.
* Add `Fmt.[Dump.]{field,record}` for records (#9).
* Add `Fmt.concat` to apply a list of formatters to a value.
* Add `Fmt.{semi,sps}`, separators.
* Add `Fmt.{error,error_msg}` to format `result` values.
* Add `Fmt.failwith_notrace`.
* Add `Fmt.( ++ )`, alias for `Fmt.append`.
* Add `Fmt.Dump.string`.
* Add more ANSI tty formatting styles and make them composable.
* Change `Fmt.{const,comma,cut,sp}`, generalize signature.
* Change `Fmt.append`, incompatible signature. Use `Fmt.(pair ~sep:nop)` if 
  you were using it (backward compatible with earlier versions of `Fmt`).
* Deprecate `Fmt.{strf,kstrf,strf_like}` in favor of `Fmt.{str,kstr,str_like}`.
* Deprecate `Fmt.{always,unit}` in favor of `Fmt.any`.
* Deprecate `Fmt.{prefix,suffix}` (specializes Fmt.( ++ )).
* Deprecate `Fmt.styled_unit`.
* No longer subvert the `Format` tag system to do dirty things.
  Thanks to David Kaloper Meršinjak for the work.
```
---
:camel: Pull-request generated by opam-publish v2.0.0