### PR TITLE
Fmt.0.8.7: fix rev deps.

### DIFF
--- a/packages/dune-release/dune-release.0.1.0/opam
+++ b/packages/dune-release/dune-release.0.1.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "jbuilder" {build}
-  "fmt"
+  "fmt" {< "0.8.7"}
   "bos"
   "cmdliner"
   "webbrowser"

--- a/packages/dune-release/dune-release.0.2.0/opam
+++ b/packages/dune-release/dune-release.0.2.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "jbuilder" {build}
-  "fmt"
+  "fmt" {< "0.8.7"}
   "bos"
   "cmdliner"
   "re"

--- a/packages/dune-release/dune-release.0.3.0/opam
+++ b/packages/dune-release/dune-release.0.3.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "jbuilder" {build}
-  "fmt"
+  "fmt" {< "0.8.7"}
   "bos"
   "cmdliner"
   "re"

--- a/packages/dune-release/dune-release.1.0.0/opam
+++ b/packages/dune-release/dune-release.1.0.0/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/samoht/dune-release/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune"
-  "fmt"
+  "fmt" {< "0.8.7"}
   "bos"
   "cmdliner"
   "re"

--- a/packages/dune-release/dune-release.1.0.1/opam
+++ b/packages/dune-release/dune-release.1.0.1/opam
@@ -19,7 +19,7 @@ run-test: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune"
-  "fmt"
+  "fmt" {< "0.8.7"}
   "bos"
   "cmdliner"
   "re"

--- a/packages/electrod/electrod.0.1.4/opam
+++ b/packages/electrod/electrod.0.1.4/opam
@@ -16,7 +16,7 @@ depends: [
   "ppxfind" {build}
   "cmdliner" {>= "1.0.2"}
   "containers" {>= "2.0"}
-  "fmt"
+  "fmt" {< "0.8.7"}
   "gen"
   "hashcons"
   "logs"

--- a/packages/electrod/electrod.0.1.6/opam
+++ b/packages/electrod/electrod.0.1.6/opam
@@ -15,7 +15,7 @@ depends: [
   "ppxfind" {build}
   "cmdliner" {>= "1.0.2"}
   "containers" {>= "2.0"}
-  "fmt"
+  "fmt" {< "0.8.7"}
   "gen"
   "hashcons"
   "logs"

--- a/packages/electrod/electrod.0.1.7/opam
+++ b/packages/electrod/electrod.0.1.7/opam
@@ -15,7 +15,7 @@ depends: [
   "ppxfind" {build}
   "cmdliner" {>= "1.0.2"}
   "containers" {>= "2.0"}
-  "fmt"
+  "fmt" {< "0.8.7"}
   "gen"
   "hashcons"
   "logs"

--- a/packages/graphql_parser/graphql_parser.0.12.2/opam
+++ b/packages/graphql_parser/graphql_parser.0.12.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"
   "menhir" {build}
   "alcotest" {with-test & >= "0.8.1"}
-  "fmt"
+  "fmt" {< "0.8.7"}
   "re" {>= "1.5.0"}
 ]
 

--- a/packages/graphql_parser/graphql_parser.0.9.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.9.0/opam
@@ -17,7 +17,7 @@ depends: [
   "menhir" {build}
   "alcotest" {with-test & >= "0.8.1"}
   "result"
-  "fmt"
+  "fmt" {< "0.8.7"}
 ]
 
 synopsis: "Library for parsing GraphQL queries"

--- a/packages/topkg-care/topkg-care.0.9.0/opam
+++ b/packages/topkg-care/topkg-care.0.9.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild"
   "topkg" {= "0.9.0"}
   "result"
-  "fmt"
+  "fmt" {< "0.8.7"}
   "logs"
   "bos" {>= "0.1.5"}
   "cmdliner" {>= "1.0.0"}

--- a/packages/topkg-care/topkg-care.0.9.1/opam
+++ b/packages/topkg-care/topkg-care.0.9.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild"
   "topkg" {= "0.9.1"}
   "result"
-  "fmt"
+  "fmt" {< "0.8.7"}
   "logs"
   "bos" {>= "0.1.5"}
   "cmdliner" {>= "1.0.0"}

--- a/packages/topkg-care/topkg-care.1.0.0/opam
+++ b/packages/topkg-care/topkg-care.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild"
   "topkg" {= "1.0.0"}
   "result"
-  "fmt"
+  "fmt" {< "0.8.7"}
   "logs"
   "bos" {>= "0.1.5"}
   "cmdliner" {>= "1.0.0"}


### PR DESCRIPTION
Fixing revdeps failures of https://github.com/ocaml/opam-repository/pull/14564 that seem to be due to the new release.