### PR TITLE
Fix dune version for sedlex.2.1

### DIFF
--- a/packages/sedlex/sedlex.2.1/opam
+++ b/packages/sedlex/sedlex.2.1/opam
@@ -23,7 +23,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {>= "1.0"}
+  "dune" {>= "1.8"}
   "ppx_tools_versioned"
   "ocaml-migrate-parsetree"
   "gen"


### PR DESCRIPTION
This is the same fix as ocaml-community/sedlex#82. The `dune` files for this package now use `promote-until-clean` which was only introduced starting with dune 1.8 and seems to not be handled correctly with earlier versions.