### PR TITLE
Fix flowtype.0.94.0 dependency on sedlex.

### DIFF
--- a/packages/flowtype/flowtype.0.94.0/opam
+++ b/packages/flowtype/flowtype.0.94.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "core_kernel" {= "v0.11.1"}
-  "sedlex" {>= "1.99.4"}
+  "sedlex" {= "1.99.4"}
   "lwt" {>= "3.3.0"}
   "lwt_log" {= "1.0.0"}
   "lwt_ppx" {>= "1.1.0"}


### PR DESCRIPTION
flowtype 0.94.0 doesn't seem to build with sedlex 2.0 or above:
```
#=== ERROR while compiling flowtype.0.94.0 ====================================#
# context     2.0.5 | macos/x86_64 | ocaml-base-compiler.4.05.0 | https://opam.ocaml.org#83d66f60
# path        ~/.opam/4.05.0/.opam-switch/build/flowtype.0.94.0
# command     ~/.opam/opam-init/hooks/sandbox.sh build env FLOW_RELEASE=1 make
# exit-code   2
# env-file    ~/.opam/log/flowtype-66637-ffb3fd.env
# output-file ~/.opam/log/flowtype-66637-ffb3fd.out
### output ###
# [...]
# ocamlfind: [WARNING] Package `threads': Linking problems may arise because of the missing -thread or -vmthread switch
# ocamlfind ocamlc -c -safe-string -w A -warn-error A -w a -package core_kernel -package lwt -package lwt.unix -package lwt_ppx -package lwt_log -package unix -package str -package bigarray -package ppx_gen_rec -package ppx_deriving.show -package sedlex -package wtf8 -w -39 -w -4-6-29-35-44-48-50 -package ppx_deriving -package dtoa -I src/parser -I src/parsing -I src/commands -I src/flowlib -I [...]
# + ocamlfind ocamlc -c -safe-string -w A -warn-error A -w a -package core_kernel -package lwt -package lwt.unix -package lwt_ppx -package lwt_log -package unix -package str -package bigarray -package ppx_gen_rec -package ppx_deriving.show -package sedlex -package wtf8 -w -39 -w -4-6-29-35-44-48-50 -package ppx_deriving -package dtoa -I src/parser -I src/parsing -I src/commands -I src/flowlib -[...]
# ocamlfind: [WARNING] Package `threads': Linking problems may arise because of the missing -thread or -vmthread switch
# ocamlfind ocamldep -package core_kernel -package lwt -package lwt.unix -package lwt_ppx -package lwt_log -package unix -package str -package bigarray -package ppx_gen_rec -package ppx_deriving.show -package sedlex -package wtf8 -package ppx_deriving -package dtoa -modules src/parser/pattern_cover.ml > src/parser/pattern_cover.ml.depends
# ocamlfind ocamlc -c -safe-string -w A -warn-error A -w a -package core_kernel -package lwt -package lwt.unix -package lwt_ppx -package lwt_log -package unix -package str -package bigarray -package ppx_gen_rec -package ppx_deriving.show -package sedlex -package wtf8 -w -39 -w -4-6-29-35-44-48-50 -package ppx_deriving -package dtoa -I src/parser -I src/parsing -I src/commands -I src/flowlib -I [...]
# + ocamlfind ocamlc -c -safe-string -w A -warn-error A -w a -package core_kernel -package lwt -package lwt.unix -package lwt_ppx -package lwt_log -package unix -package str -package bigarray -package ppx_gen_rec -package ppx_deriving.show -package sedlex -package wtf8 -w -39 -w -4-6-29-35-44-48-50 -package ppx_deriving -package dtoa -I src/parser -I src/parsing -I src/commands -I src/flowlib -[...]
# ocamlfind: [WARNING] Package `threads': Linking problems may arise because of the missing -thread or -vmthread switch
# File "src/parser/flow_lexer.ml", line 16, characters 15-28:
# Error: Uninterpreted extension 'sedlex.regexp'.
# Command exited with code 2.
# make: *** [build-flow] Error 10
```