### PR TITLE
3 packages from andersfugmann/amqp-client at 2.2.0

### DIFF
--- a/packages/amqp-client-async/amqp-client-async.2.2.0/opam
+++ b/packages/amqp-client-async/amqp-client-async.2.2.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune" {>= "1.1"}
   "xml-light" {build}
   "amqp-client" {= "2.2.0"}
   "ocplib-endian" {>= "0.6"}

--- a/packages/amqp-client-async/amqp-client-async.2.2.0/opam
+++ b/packages/amqp-client-async/amqp-client-async.2.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: [ "Anders Fugmann" ]
+homepage: "https://github.com/andersfugmann/amqp-client"
+bug-reports: "https://github.com/andersfugmann/amqp-client/issues"
+dev-repo: "git+https://github.com/andersfugmann/amqp-client.git"
+doc: "https://andersfugmann.github.io/amqp-client/amqp-client-async/Amqp_client_async/"
+license: "BSD3"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "xml-light" {build}
+  "amqp-client" {= "2.2.0"}
+  "ocplib-endian" {>= "0.6"}
+  "async" {>= "v0.10.0"}
+  "uri"
+]
+synopsis: "Amqp client library, async version"
+url {
+  src: "https://github.com/andersfugmann/amqp-client/archive/2.2.0.tar.gz"
+  checksum: [
+    "md5=7b669f71063296444ffa6103e472f298"
+    "sha512=bf2d11fc39f85fea0f8ba510fc91c57d253bcff1407433839a930c0b0392c38829150a08e7c2809bd0d770b4282b101f1b29a46ea6f229305ca9eb6f882b9203"
+  ]
+}

--- a/packages/amqp-client-lwt/amqp-client-lwt.2.2.0/opam
+++ b/packages/amqp-client-lwt/amqp-client-lwt.2.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: [ "Anders Fugmann" ]
+homepage: "https://github.com/andersfugmann/amqp-client"
+bug-reports: "https://github.com/andersfugmann/amqp-client/issues"
+dev-repo: "git+https://github.com/andersfugmann/amqp-client.git"
+doc: "https://andersfugmann.github.io/amqp-client/amqp-client-lwt/Amqp_client_lwt/"
+license: "BSD3"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "xml-light" {build}
+  "amqp-client" {= "2.2.0"}
+  "ocplib-endian" {>= "0.6"}
+  "lwt" {>= "2.4.6"}
+  "lwt_log"
+  "uri"
+]
+synopsis: "Amqp client library, lwt version"
+url {
+  src: "https://github.com/andersfugmann/amqp-client/archive/2.2.0.tar.gz"
+  checksum: [
+    "md5=7b669f71063296444ffa6103e472f298"
+    "sha512=bf2d11fc39f85fea0f8ba510fc91c57d253bcff1407433839a930c0b0392c38829150a08e7c2809bd0d770b4282b101f1b29a46ea6f229305ca9eb6f882b9203"
+  ]
+}

--- a/packages/amqp-client-lwt/amqp-client-lwt.2.2.0/opam
+++ b/packages/amqp-client-lwt/amqp-client-lwt.2.2.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune" {>= "1.1"}
   "xml-light" {build}
   "amqp-client" {= "2.2.0"}
   "ocplib-endian" {>= "0.6"}

--- a/packages/amqp-client/amqp-client.2.2.0/opam
+++ b/packages/amqp-client/amqp-client.2.2.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune" {>= "1.1"}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
   "async" {with-test}

--- a/packages/amqp-client/amqp-client.2.2.0/opam
+++ b/packages/amqp-client/amqp-client.2.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: [ "Anders Fugmann" ]
+homepage: "https://github.com/andersfugmann/amqp-client"
+bug-reports: "https://github.com/andersfugmann/amqp-client/issues"
+dev-repo: "git+https://github.com/andersfugmann/amqp-client.git"
+doc: "https://andersfugmann.github.io/amqp-client/"
+license: "BSD3"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "xml-light" {build}
+  "ocplib-endian" {>= "0.6"}
+  "async" {with-test}
+  "lwt" {with-test}
+]
+synopsis: "Amqp client base library"
+description: """
+This library provides high level client bindings for amqp. The library
+is tested with rabbitmq, but should work with other amqp
+servers. The library is written in pure OCaml.
+
+This is the base library required by lwt/async versions.
+You should install either amqp-client-async or amqp-client-lwt
+for actual client functionality."""
+url {
+  src: "https://github.com/andersfugmann/amqp-client/archive/2.2.0.tar.gz"
+  checksum: [
+    "md5=7b669f71063296444ffa6103e472f298"
+    "sha512=bf2d11fc39f85fea0f8ba510fc91c57d253bcff1407433839a930c0b0392c38829150a08e7c2809bd0d770b4282b101f1b29a46ea6f229305ca9eb6f882b9203"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`amqp-client.2.2.0`: Amqp client base library
-`amqp-client-async.2.2.0`: Amqp client library, async version
-`amqp-client-lwt.2.2.0`: Amqp client library, lwt version



---
* Homepage: https://github.com/andersfugmann/amqp-client
* Source repo: git+https://github.com/andersfugmann/amqp-client.git
* Bug tracker: https://github.com/andersfugmann/amqp-client/issues

---
:camel: Pull-request generated by opam-publish v2.0.0