### PR TITLE
[new release] fiat-p256 (0.2.0)

### DIFF
--- a/packages/fiat-p256/fiat-p256.0.2.0/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "benchmark" {with-test}
   "bigarray-compat"
   "cstruct" {>= "3.5.0"}
-  "dune" {build & >= "1.6.0"}
+  "dune" {>= "1.6.0"}
   "hex"
   "ppx_deriving_yojson" {with-test}
   "rresult" {with-test}

--- a/packages/fiat-p256/fiat-p256.0.2.0/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.0/opam
@@ -16,7 +16,7 @@ tags: ["org:mirage"]
 build: [
  ["dune" "subst"] {pinned}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "alcotest" {with-test}

--- a/packages/fiat-p256/fiat-p256.0.2.0/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Etienne Millon <me@emillon.org>"
+license: "MIT"
+authors: [
+    "Etienne Millon <me@emillon.org>"
+    "Andres Erbsen <andreser@mit.edu>"
+    "Google Inc."
+    "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+    "Massachusetts Institute of Technology"
+]
+homepage: "https://github.com/mirage/fiat"
+bug-reports: "https://github.com/mirage/fiat/issues"
+dev-repo: "git+https://github.com/mirage/fiat.git"
+doc: "https://mirage.github.io/fiat/doc"
+tags: ["org:mirage"]
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "alcotest" {with-test}
+  "asn1-combinators" {with-test}
+  "benchmark" {with-test}
+  "bigarray-compat"
+  "cstruct" {>= "3.5.0"}
+  "dune" {build & >= "1.6.0"}
+  "hex"
+  "ppx_deriving_yojson" {with-test}
+  "rresult" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+]
+synopsis: "Primitives for Elliptic Curve Cryptography taken from Fiat"
+description: """
+This is an implementation of the ECDH over P-256 key exchange algorithm, using
+code from Fiat (<https://github.com/mit-plv/fiat-crypto>).
+
+Cryptographic primitives should not be used in end applications, they are better
+used as part of a cryptographic library.
+"""
+url {
+  src:
+    "https://github.com/mirage/fiat/releases/download/v0.2.0/fiat-p256-v0.2.0.tbz"
+  checksum: [
+    "sha256=b2854ca46b2522248521440dcd5b17accfc8d3bfc754ff0f7e907ba40f513a30"
+    "sha512=47a1b5583b614069c278e6f6253cb9d873b3f100060708b178cce0d617398ee317cd0aa1c2ac49d748b452f8ab92004256820201729fa391c6c0a33f840d04f5"
+  ]
+}


### PR DESCRIPTION
Primitives for Elliptic Curve Cryptography taken from Fiat

- Project page: <a href="https://github.com/mirage/fiat">https://github.com/mirage/fiat</a>
- Documentation: <a href="https://mirage.github.io/fiat/doc">https://mirage.github.io/fiat/doc</a>

##### CHANGES:

*2019-07-23*

### Fixed

- Fix a bug in `generate_key` where it would never actually work when used with
  a proper `rng` function (mirage/fiat#44, @NathanReb)
- Fix benchmark executable. It is now built (but not executed) as part of tests
  (mirage/fiat#45, @emillon)

### Changed

- Use `alcotest` instead of `ppx_expect` for tests (mirage/fiat#43, @emillon)
