### PR TITLE
bitstring: make ocaml migrate parsetree a runtime dependency

### DIFF
--- a/packages/bitstring/bitstring.3.0.0/opam
+++ b/packages/bitstring/bitstring.3.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build}
   "ppx_tools_versioned"
-  "ocaml-migrate-parsetree" {build & >= "1.0.5"}
+  "ocaml-migrate-parsetree" {>= "1.0.5"}
   "ounit" {with-test}
 ]
 conflicts: [

--- a/packages/bitstring/bitstring.3.1.0/opam
+++ b/packages/bitstring/bitstring.3.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build}
   "ppx_tools_versioned" {build}
-  "ocaml-migrate-parsetree" {build & >= "1.0.5"}
+  "ocaml-migrate-parsetree" {>= "1.0.5"}
   "ounit" {with-test}
 ]
 conflicts: [


### PR DESCRIPTION
Fixes #14522
cc @jorisgio @xguerin 