### PR TITLE
Update eqaf.0.5 with optional dependencies

### DIFF
--- a/packages/eqaf/eqaf.0.5/opam
+++ b/packages/eqaf/eqaf.0.5/opam
@@ -21,7 +21,7 @@ depends: [
   "alcotest"       {with-test}
   "crowbar"        {with-test}
 ]
-depotps: [
+depopts: [
   "cstruct" {>= "4.0.0"}
   "bigarray-compat"
 ]

--- a/packages/eqaf/eqaf.0.5/opam
+++ b/packages/eqaf/eqaf.0.5/opam
@@ -13,7 +13,7 @@ This package provides an equal function on string in constant-time to avoid timi
 """
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
-runtest: [ "dune" "runtest" "-p" name "-j" "1" "--no-buffer" "--verbose" ]
+run-test: [ "dune" "runtest" "-p" name "-j" "1" "--no-buffer" "--verbose" ]
 
 depends: [
   "ocaml"          {>= "4.03.0"}

--- a/packages/eqaf/eqaf.0.5/opam
+++ b/packages/eqaf/eqaf.0.5/opam
@@ -12,17 +12,18 @@ description: """
 This package provides an equal function on string in constant-time to avoid timing-attack with crypto stuff.
 """
 
-build: [
-  [ "dune" "subst" ] {pinned}
-  [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name "-j" "1" "--no-buffer" "--verbose" ] {with-test}
-]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+runtest: [ "dune" "runtest" "-p" name "-j" "1" "--no-buffer" "--verbose" ]
 
 depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"
   "alcotest"       {with-test}
   "crowbar"        {with-test}
+]
+depotps: [
+  "cstruct" {>= "4.0.0"}
+  "bigarray-compat"
 ]
 url {
   src: "https://github.com/mirage/eqaf/releases/download/v0.5/eqaf-v0.5.tbz"


### PR DESCRIPTION
Add depopts to `eqaf.0.5` to be able to provide `eqaf.cstruct` if `cstruct` will be/is available.