### PR TITLE
2 packages from sapristi/easy_logging at 0.5.1

### DIFF
--- a/packages/easy_logging/easy_logging.0.5.1/opam
+++ b/packages/easy_logging/easy_logging.0.5.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Module to log messages. Aimed at being both powerful and easy to use"
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "GPL"
+homepage: "https://sapristi.github.io/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.8"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "src/examples"] {with-test}
+]
+
+description: """Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages printf style, or [string] or [string lazy_t]
+   * tree logging architecture for light configuration
+   * handlers associated to each logger will format, filter and treat the message independantly.
+   * use the infrastructure with your own handlers with the [MakeLogging] functor.
+   * use tags to add contextual information to log messages
+"""
+url {
+  src: "https://github.com/sapristi/easy_logging/tarball/v0.5.1"
+  checksum: [
+    "md5=0b619809b404cdee0cfe896b0a1eb041"
+    "sha512=94d944114c105b07512ddf3bf0028827286edc3ee6a13eb6175ff39707ff041aebd46a75bd44aa520ff1712bd00aaeee09b62722cb1ba39ed56fbee2fe69e843"
+  ]
+}

--- a/packages/easy_logging_yojson/easy_logging_yojson.0.5.1/opam
+++ b/packages/easy_logging_yojson/easy_logging_yojson.0.5.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Configuration loader for easy_logging with yojson backend"
+
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "GPL"
+homepage: "https://sapristi.github.io/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.8"}
+  "ppx_deriving"{>= "4.0" & < "5.0"}
+  "ppx_deriving_yojson"
+  "easy_logging" {>= "0.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "conf_loader_modules/yojson"] {with-test}
+]
+
+description: """Provides deserialisation of logging configuration 
+(loggers instantation and handlers parameters) from json,
+using ppx_deriving_yojson.
+
+-------
+
+     Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages printf style, or [string] or [string lazy_t]
+   * tree logging architecture for light configuration
+   * handlers associated to each logger will format, filter and treat the message independantly.
+   * use the infrastructure with your own handlers with the [MakeLogging] functor.
+   * use tags to add contextual information to log messages
+"""
+url {
+  src: "https://github.com/sapristi/easy_logging/tarball/v0.5.1"
+  checksum: [
+    "md5=0b619809b404cdee0cfe896b0a1eb041"
+    "sha512=94d944114c105b07512ddf3bf0028827286edc3ee6a13eb6175ff39707ff041aebd46a75bd44aa520ff1712bd00aaeee09b62722cb1ba39ed56fbee2fe69e843"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`easy_logging.0.5.1`: Module to log messages. Aimed at being both powerful and easy to use
-`easy_logging_yojson.0.5.1`: Configuration loader for easy_logging with yojson backend



---
* Homepage: https://sapristi.github.io/easy_logging/
* Source repo: git+https://github.com/sapristi/easy_logging.git
* Bug tracker: https://github.com/sapristi/easy_logging/issues

---
:camel: Pull-request generated by opam-publish v2.0.0