### PR TITLE
[new release] ke (0.4)

### DIFF
--- a/packages/ke/ke.0.4/opam
+++ b/packages/ke/ke.0.4/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name:         "ke"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ke"
+bug-reports:  "https://github.com/mirage/ke/issues"
+dev-repo:     "git+https://github.com/mirage/ke.git"
+doc:          "https://mirage.github.io/ke/"
+license:      "MIT"
+synopsis:     "Queue implementation"
+description:  """Queue implementation in OCaml (functional and imperative queue)"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {build}
+  "fmt"
+  "bigarray-compat"
+  "alcotest" {with-test}
+  "bigstringaf" {with-test}
+]
+url {
+  src: "https://github.com/mirage/ke/releases/download/v0.4/ke-v0.4.tbz"
+  checksum: [
+    "sha256=ddf60f66569b77c35c664087beb8934b3e43df1f70bccb6d4d02d70d8cef898d"
+    "sha512=3e4b9a30d2eb8af842b7953ba04ba64aadeafad807e098c203234924301e1b020b0fdf5f4f46e688c23058dacf5de86deae2c29e6874f4672cf990564cb9b8d3"
+  ]
+}


### PR DESCRIPTION
Queue implementation

- Project page: <a href="https://github.com/mirage/ke">https://github.com/mirage/ke</a>
- Documentation: <a href="https://mirage.github.io/ke/">https://mirage.github.io/ke/</a>

##### CHANGES:

* Call `dune subst` only when we _pin_ `ke`
* Update documentation (@dinosaure, @Drup)
  - Typography
  - Documentation about `Fke.tail{,_exn}`
  - Documentation about `Fke.rev_iter`
* Add `Fke.tail{,_exn}` (@dinosaure, mirage/ke#8)
* Add `Fke.rev_iter` (@dinosaure, mirage/ke#9)
* Compatible with `mirage`, dependance with `bigarray-compat` (@dinosaure, @TheLortex, mirage/ke#8)
* Update OPAM file (@dinosaure)
