### PR TITLE
[new release] emile (0.5)

### DIFF
--- a/packages/emile/emile.0.5/opam
+++ b/packages/emile/emile.0.5/opam
@@ -19,7 +19,7 @@ pin-depends: [
 
 depends: [
   "ocaml"    {>= "4.03.0"}
-  "dune"     {build}
+  "dune"     {>= "1.0"}
   "angstrom" {>= "0.9.0"}
   "ipaddr"   {>= "2.7.0"}
   "base64"   {>= "3.0.0"}

--- a/packages/emile/emile.0.5/opam
+++ b/packages/emile/emile.0.5/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name:         "emile"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/emile"
+bug-reports:  "https://github.com/dinosaure/emile/issues"
+dev-repo:     "git+https://github.com/dinosaure/emile.git"
+doc:          "https://dinosaure.github.io/emile/"
+license:      "MIT"
+synopsis:     "Parser of email address according RFC 822"
+description:  """Parser of email address according RFC 822"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+
+pin-depends: [
+  [ "mrmime.dev" "git+https://github.com/mirage/mrmime.git" ]
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {build}
+  "angstrom" {>= "0.9.0"}
+  "ipaddr"   {>= "2.7.0"}
+  "base64"   {>= "3.0.0"}
+  "pecu"
+  "uutf"
+  "fmt"
+  "alcotest" {with-test}
+]
+depopts: [
+  "mrmime"
+]
+url {
+  src:
+    "https://github.com/dinosaure/emile/releases/download/v0.5/emile-v0.5.tbz"
+  checksum: [
+    "sha256=58698e8ff6797090a9ee472e3eea216e81d69910aba49c1f06f6ed1fd70fee76"
+    "sha512=407c7465c5ade34fb30668d91ad8ee0a0b6554f8b7b763378f369cd27b056b76d63b9c41fcae4fed651586bdf021ab5b15d3e8c0e432647cfb8c3055933294b6"
+  ]
+}


### PR DESCRIPTION
Parser of email address according RFC 822

- Project page: <a href="https://github.com/dinosaure/emile">https://github.com/dinosaure/emile</a>
- Documentation: <a href="https://dinosaure.github.io/emile/">https://dinosaure.github.io/emile/</a>

##### CHANGES:

- Add helpers about [mrmime](https://github.com/mirage/mrmime.git) (@dinosaure)
- Add CI about optional sub-package `emile.mrmime`
- Update OPAM file (@dinosaure)
