### PR TITLE
[new release] certify (0.3.0)

### DIFF
--- a/packages/certify/certify.0.3.0/opam
+++ b/packages/certify/certify.0.3.0/opam
@@ -11,7 +11,7 @@ authors: [
 tags: ["org:mirage"]
 
 build: [
-  [ "dune" "build" ]
+  [ "dune" "build" "-p" name "-j" jobs ]
   [ "test/test.sh" ] {with-test}
 ]
 depends: [

--- a/packages/certify/certify.0.3.0/opam
+++ b/packages/certify/certify.0.3.0/opam
@@ -15,7 +15,7 @@ build: [
   [ "test/test.sh" ] {with-test}
 ]
 depends: [
-  "dune" {build}
+  "dune" {>= "1.0"}
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.7.0"}
   "cstruct" {>= "3.2.0"}

--- a/packages/certify/certify.0.3.0/opam
+++ b/packages/certify/certify.0.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:  ["maintenance@identity-function.com"]
+homepage:     "https://github.com/yomimono/ocaml-certify"
+dev-repo:     "git+https://github.com/yomimono/ocaml-certify.git"
+bug-reports:  "https://github.com/yomimono/ocaml-certify/issues"
+doc:          "https://yomimono.github.io/ocaml-certify/doc"
+synopsis:     "CLI utilities for simple X509 certificate manipulation"
+authors: [
+  "Mindy Preston"
+]
+tags: ["org:mirage"]
+
+build: [
+  [ "dune" "build" ]
+  [ "test/test.sh" ] {with-test}
+]
+depends: [
+  "dune" {build}
+  "nocrypto" {>= "0.5.4"}
+  "x509" {>= "0.7.0"}
+  "cstruct" {>= "3.2.0"}
+  "ptime"
+  "ocaml" {>= "4.04.2"}
+  "cmdliner" {>= "1.0.0"}
+  "conf-openssl" {with-test}
+]
+description: """
+`certify` is a small selection of useful utilities for manipulating X509 certificates and public keys.  It uses the mirleft organization's x509, tls, and nocrypto libraries.
+
+Three subcommands to `certify` are provided:
+* `certify csr`: make a certificate signing request
+* `certify selfsign`: make a self-signed certificate
+* `certify sign`: sign a certificate
+"""
+url {
+  src:
+    "https://github.com/yomimono/ocaml-certify/releases/download/v0.3.0/certify-v0.3.0.tbz"
+  checksum: [
+    "sha256=67b0bb89be2fe42c0901ad18f8cd7d78cb7cc54ad7391054fa0f521e9940bd35"
+    "sha512=e7b4ee48330e03f2a83019f54244ec467649c3c69c836892f36a53e1249fe809787cf43681b0e9c2cb2066805d53aaf82ac26cd58251100461a203da6e08d1aa"
+  ]
+}


### PR DESCRIPTION
CLI utilities for simple X509 certificate manipulation

- Project page: <a href="https://github.com/yomimono/ocaml-certify">https://github.com/yomimono/ocaml-certify</a>
- Documentation: <a href="https://yomimono.github.io/ocaml-certify/doc">https://yomimono.github.io/ocaml-certify/doc</a>

##### CHANGES:

* breaking change: `sign`, `selfsign`, and `csr` are now subcommands of a `certify` binary.  To update your workflow, simply prepend `certify` to any command you previously ran. (@reynir)
* improvements: allow --key for key filename in `sign`; write to csr.pem by default in `csr`. (@yomimono)
* maintenance: use newer x509 (v.0.7.0); make opam 2.0-compliant; use dune instead of topkg/ocamlfind; fix tests for some platforms. (@hannesm, @yomimono)
