### PR TITLE
Package prepare.1.0.0

### DIFF
--- a/packages/prepare/prepare.1.0.0/opam
+++ b/packages/prepare/prepare.1.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Steffen Smolka <smolka@cs.cornell.edu>"]
+authors: ["Steffen Smolka <smolka@cs.cornell.edu>"]
+bug-reports: "https://github.com/netkat-lang/ocaml-parsing/issues"
+homepage: "https://github.com/netkat-lang/ocaml-parsing"
+doc: "https://smolkaj.github.io/ocaml-parsing/nice_parser/"
+license: "MIT"
+dev-repo: "git+https://github.com/netkat-lang/ocaml-parsing.git"
+synopsis: "Nice parsers without the boilerplate"
+description:
+  "Nice_parser wraps your {menhir, ocamlyacc}-generated parser in a sane interface, eliminating boilerplate code."
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.10"}
+  "menhir" {build}
+  "stdio" {!= "0"}
+  "base" {!= "0"}
+  "ppx_jane" {dev & with-test}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+]


### PR DESCRIPTION
### `prepare.1.0.0`
Nice parsers without the boilerplate
Nice_parser wraps your {menhir, ocamlyacc}-generated parser in a sane interface, eliminating boilerplate code.



---
* Homepage: https://github.com/netkat-lang/ocaml-parsing
* Source repo: git+https://github.com/netkat-lang/ocaml-parsing.git
* Bug tracker: https://github.com/netkat-lang/ocaml-parsing/issues

---
:camel: Pull-request generated by opam-publish v2.0.0