### PR TITLE
Package nice_parser.1.0.0

### DIFF
--- a/packages/nice_parser/nice_parser.1.0.0/opam
+++ b/packages/nice_parser/nice_parser.1.0.0/opam
@@ -17,7 +17,7 @@ description:
   "Nice_parser wraps your {menhir, ocamlyacc}-generated parser in a sane interface, eliminating boilerplate code."
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune" {build & >= "1.10"}
+  "dune" {>= "1.10"}
   "menhir" {build}
   "stdio" {!= "0"}
   "base" {!= "0"}

--- a/packages/nice_parser/nice_parser.1.0.0/opam
+++ b/packages/nice_parser/nice_parser.1.0.0/opam
@@ -18,7 +18,7 @@ description:
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.10"}
-  "menhir" {build}
+  "menhir" {with-test}
   "stdio"
   "base" {with-test}
   "ppx_jane" {with-test}

--- a/packages/nice_parser/nice_parser.1.0.0/opam
+++ b/packages/nice_parser/nice_parser.1.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.10"}
   "menhir" {build}
-  "stdio" {!= "0"}
+  "stdio"
   "base" {!= "0"}
   "ppx_jane" {with-test}
   "ppx_inline_test" {with-test}

--- a/packages/nice_parser/nice_parser.1.0.0/opam
+++ b/packages/nice_parser/nice_parser.1.0.0/opam
@@ -3,7 +3,7 @@ build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-  ["dune" "build" "-p" name "@doc"] {with-doc}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
 ]
 maintainer: ["Steffen Smolka <smolka@cs.cornell.edu>"]
 authors: ["Steffen Smolka <smolka@cs.cornell.edu>"]

--- a/packages/nice_parser/nice_parser.1.0.0/opam
+++ b/packages/nice_parser/nice_parser.1.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Steffen Smolka <smolka@cs.cornell.edu>"]
+authors: ["Steffen Smolka <smolka@cs.cornell.edu>"]
+bug-reports: "https://github.com/smolkaj/ocaml-parsing/issues"
+homepage: "https://github.com/smolkaj/ocaml-parsing"
+doc: "https://smolkaj.github.io/ocaml-parsing/nice_parser/"
+license: "MIT"
+dev-repo: "git+https://github.com/smolkaj/ocaml-parsing.git"
+synopsis: "Nice parsers without the boilerplate"
+description:
+  "Nice_parser wraps your {menhir, ocamlyacc}-generated parser in a sane interface, eliminating boilerplate code."
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build & >= "1.10"}
+  "menhir" {build}
+  "stdio" {!= "0"}
+  "base" {!= "0"}
+  "ppx_jane" {with-test}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/smolkaj/ocaml-parsing/archive/1.0.0.tar.gz"
+  checksum: [
+    "md5=9ac52ebf61b297e0eed7821e714efa23"
+    "sha512=ad72f446fd42fe43ea1fe754d2f15c25fc46f235402012a3d45d3121bb9bd44151e864ea0221432d4e80606a2b0421bccee42d98bff7ac21a20718ea0353f890"
+  ]
+}

--- a/packages/nice_parser/nice_parser.1.0.0/opam
+++ b/packages/nice_parser/nice_parser.1.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.10"}
   "menhir" {build}
   "stdio"
-  "base" {!= "0"}
+  "base" {with-test}
   "ppx_jane" {with-test}
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}


### PR DESCRIPTION
### `nice_parser.1.0.0`
Nice parsers without the boilerplate
Nice_parser wraps your {menhir, ocamlyacc}-generated parser in a sane interface, eliminating boilerplate code.



---
* Homepage: https://github.com/smolkaj/ocaml-parsing
* Source repo: git+https://github.com/smolkaj/ocaml-parsing.git
* Bug tracker: https://github.com/smolkaj/ocaml-parsing/issues

---
:camel: Pull-request generated by opam-publish v2.0.0