### PR TITLE
[new release] js_of_ocaml, js_of_ocaml-ocamlbuild, js_of_ocaml-ppx_deriving_json, js_of_ocaml-tyxml, js_of_ocaml-ppx, js_of_ocaml-lwt, js_of_ocaml-compiler and js_of_ocaml-toplevel (3.5.0-2-g3f00ff176)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.0-2-g3f00ff176/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.0-2-g3f00ff176/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.org/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.2"}
+  "ppx_expect" {with-test & >= "0.12.0"}
+  "cmdliner"
+  "ocaml-migrate-parsetree"
+  "yojson" # It's optional, but we want users to be able to use source-map without pain.
+]
+
+depopts: [ "ocamlfind" ]
+
+conflicts: [
+  "ocamlfind"   {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+url {
+  src:
+    "http://ocsigen.org/js_of_ocaml/releases/js_of_ocaml-3.5.0-2-g3f00ff176.tbz"
+  checksum: [
+    "sha256=7de4c5317d06b33903fea1a439153f0b8893f2ea2501c0a704a82c0f9d9442dd"
+    "sha512=2d3de57c572aa469c203de67cc28e5a0345d098beae8003b7034f25ce70a1d36db1975de4dd3f6f98ff594745a0f4d9f0e981ae82c997fbbb600822f407732de"
+  ]
+}

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.0-2-g3f00ff176/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.0-2-g3f00ff176/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.org/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.2"}
+  "lwt" {>= "2.4.4"}
+  "js_of_ocaml" {>= "3.2"}
+  "js_of_ocaml-ppx"
+]
+depopts: [ "graphics" "lwt_log" ]
+url {
+  src:
+    "http://ocsigen.org/js_of_ocaml/releases/js_of_ocaml-3.5.0-2-g3f00ff176.tbz"
+  checksum: [
+    "sha256=7de4c5317d06b33903fea1a439153f0b8893f2ea2501c0a704a82c0f9d9442dd"
+    "sha512=2d3de57c572aa469c203de67cc28e5a0345d098beae8003b7034f25ce70a1d36db1975de4dd3f6f98ff594745a0f4d9f0e981ae82c997fbbb600822f407732de"
+  ]
+}

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.0-2-g3f00ff176/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.0-2-g3f00ff176/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.org/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "dune" {build}
+  "ocamlbuild"
+]
+url {
+  src:
+    "http://ocsigen.org/js_of_ocaml/releases/js_of_ocaml-3.5.0-2-g3f00ff176.tbz"
+  checksum: [
+    "sha256=7de4c5317d06b33903fea1a439153f0b8893f2ea2501c0a704a82c0f9d9442dd"
+    "sha512=2d3de57c572aa469c203de67cc28e5a0345d098beae8003b7034f25ce70a1d36db1975de4dd3f6f98ff594745a0f4d9f0e981ae82c997fbbb600822f407732de"
+  ]
+}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.0-2-g3f00ff176/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.0-2-g3f00ff176/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.org/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.2"}
+  "ocaml-migrate-parsetree" {>= "1.4"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "js_of_ocaml" {>= "3.0"}
+]
+url {
+  src:
+    "http://ocsigen.org/js_of_ocaml/releases/js_of_ocaml-3.5.0-2-g3f00ff176.tbz"
+  checksum: [
+    "sha256=7de4c5317d06b33903fea1a439153f0b8893f2ea2501c0a704a82c0f9d9442dd"
+    "sha512=2d3de57c572aa469c203de67cc28e5a0345d098beae8003b7034f25ce70a1d36db1975de4dd3f6f98ff594745a0f4d9f0e981ae82c997fbbb600822f407732de"
+  ]
+}

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.0-2-g3f00ff176/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.0-2-g3f00ff176/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.org/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {build & >= "1.2"}
+  "js_of_ocaml"
+  "ocaml-migrate-parsetree"
+  "ppxlib"
+]
+url {
+  src:
+    "http://ocsigen.org/js_of_ocaml/releases/js_of_ocaml-3.5.0-2-g3f00ff176.tbz"
+  checksum: [
+    "sha256=7de4c5317d06b33903fea1a439153f0b8893f2ea2501c0a704a82c0f9d9442dd"
+    "sha512=2d3de57c572aa469c203de67cc28e5a0345d098beae8003b7034f25ce70a1d36db1975de4dd3f6f98ff594745a0f4d9f0e981ae82c997fbbb600822f407732de"
+  ]
+}

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.0-2-g3f00ff176/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.0-2-g3f00ff176/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.org/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.2"}
+  "ocamlfind" {>= "1.5.1"}
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml" {>= "3.0"}
+]
+url {
+  src:
+    "http://ocsigen.org/js_of_ocaml/releases/js_of_ocaml-3.5.0-2-g3f00ff176.tbz"
+  checksum: [
+    "sha256=7de4c5317d06b33903fea1a439153f0b8893f2ea2501c0a704a82c0f9d9442dd"
+    "sha512=2d3de57c572aa469c203de67cc28e5a0345d098beae8003b7034f25ce70a1d36db1975de4dd3f6f98ff594745a0f4d9f0e981ae82c997fbbb600822f407732de"
+  ]
+}

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.0-2-g3f00ff176/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.0-2-g3f00ff176/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.org/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.2"}
+  "tyxml" {>= "4.3"}
+  "reactiveData" {>= "0.2"}
+  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml-ppx"
+]
+conflicts: [
+  "js_of_ocaml"             {<"3.0"}
+]
+url {
+  src:
+    "http://ocsigen.org/js_of_ocaml/releases/js_of_ocaml-3.5.0-2-g3f00ff176.tbz"
+  checksum: [
+    "sha256=7de4c5317d06b33903fea1a439153f0b8893f2ea2501c0a704a82c0f9d9442dd"
+    "sha512=2d3de57c572aa469c203de67cc28e5a0345d098beae8003b7034f25ce70a1d36db1975de4dd3f6f98ff594745a0f4d9f0e981ae82c997fbbb600822f407732de"
+  ]
+}

--- a/packages/js_of_ocaml/js_of_ocaml.3.5.0-2-g3f00ff176/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.5.0-2-g3f00ff176/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.org/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+name: "js_of_ocaml"
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.2"}
+  "ocaml-migrate-parsetree" {>= "1.4"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "uchar"
+  "js_of_ocaml-compiler"
+]
+url {
+  src:
+    "http://ocsigen.org/js_of_ocaml/releases/js_of_ocaml-3.5.0-2-g3f00ff176.tbz"
+  checksum: [
+    "sha256=7de4c5317d06b33903fea1a439153f0b8893f2ea2501c0a704a82c0f9d9442dd"
+    "sha512=2d3de57c572aa469c203de67cc28e5a0345d098beae8003b7034f25ce70a1d36db1975de4dd3f6f98ff594745a0f4d9f0e981ae82c997fbbb600822f407732de"
+  ]
+}


### PR DESCRIPTION
Compiler from OCaml bytecode to Javascript

- Project page: <a href="http://ocsigen.org/js_of_ocaml">http://ocsigen.org/js_of_ocaml</a>

##### CHANGES:

## Features/Changes
* Compiler: Improve testing of the compiler (Ty Overby)
* Compiler: Add several macros for making the runtime easier to maintain (js_of_ocaml/releases#771) (Ty Overby)
* Compiler: Allow to emit one javascript per compilation unit (js_of_ocaml/releases#783)
* Compiler: refactoring (js_of_ocaml/releases#781, js_of_ocaml/releases#782, js_of_ocaml/releases#787, js_of_ocaml/releases#795, js_of_ocaml/releases#802)
* Compiler: more source map location for the javascript runtime (js_of_ocaml/releases#795)
* Compiler: tune variable naming (js_of_ocaml/releases#838)
* Runtime: support sharing when marshaling (js_of_ocaml/releases#814)
* Ppx: switch ppx rewriter to the OCaml 4.08 ast
* Misc: Improve CI speed
* Misc: remove ppx_deriving dependency
* Misc: remove cppo dependency
* Misc: remove ppx_tools_versioned dependency in ppx_deriving_json
* Misc: support for ocaml 4.09
* Misc: switch to ocamlformat.0.10
* Lib: Use expect tests
* Lib: Add support for 'addEventListener' with options (js_of_ocaml/releases#807)

## Bug fixes
* Compiler: don't generate source if no-source-map passed (js_of_ocaml/releases#780)
* Compiler: Fix compilation of [Array.set] to return [unit]/0 (js_of_ocaml/releases#792)
* Compiler: Fix assertion failure (js_of_ocaml/releases#828)
* Compiler: Fix compilation of exception handlers (js_of_ocaml/releases#830)
* Misc: Fix install on windows (js_of_ocaml/releases#794)
* Lib: Fix Dom_svg.createForeignObject (js_of_ocaml/releases#756)
* Runtime: Fix caml_obj_tag, causing miscompilation with lazy value (js_of_ocaml/releases#772)
* Runtime: Fix caml_ml_seek_out, caml_ml_pos_out (js_of_ocaml/releases#779) (Shachar Itzhaky)
* Runtime: caml_parse_sign_and_base to support unsigned syntax (js_of_ocaml/releases#792) (Shachar Itzhaky)
* Runtime: fix encoding when printing to stdout (js_of_ocaml/releases#800)
* Runtime: Handle browserfs in fs_node detection logic (js_of_ocaml/releases#831)
* Runtime: fix Obj.tag (js_of_ocaml/releases#832)
