### PR TITLE
2 packages from toots/ocaml-sys-socket at 1.0.0

### DIFF
--- a/packages/sys-socket-unix/sys-socket-unix.1.0.0/opam
+++ b/packages/sys-socket-unix/sys-socket-unix.1.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis:
+  "Ctypes bindings to unix-specific low-level socket structure and data-types"
+description: """
+This module provides OCaml ctypes bindings to system-specific low-level socket
+structure and data-types.
+
+The interface is implemented using ocaml-ctypes and in intended to exposed the
+machine-specific, low-level details of the most important parts of socket
+implementations.
+
+This package provides the part of the API that is specific to Unix systems."""
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "Romain Beauxis <toots@rastageeks.org>"
+license: "MIT"
+homepage: "https://github.com/toots/ocaml-sys-socket"
+bug-reports: "https://github.com/toots/ocaml-sys-socket/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.10"}
+  "ctypes"
+  "unix-errno"
+  "sys-socket"
+]
+available: os != "win32"
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/toots/ocaml-sys-socket.git"
+url {
+  src: "https://github.com/toots/ocaml-sys-socket/archive/1.0.0.tar.gz"
+  checksum: [
+    "md5=2ecd4e009ed19e4d961d9b8a4a09f546"
+    "sha512=2fbfd846baebd259a8486be2af856569ee6f056298e8cf5874ba76f5c207626cc5854abe2e091d670f9bb605eeb19a416e47b3c8474b8cbc5957f6293b3ccddb"
+  ]
+}

--- a/packages/sys-socket/sys-socket.1.0.0/opam
+++ b/packages/sys-socket/sys-socket.1.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis:
+  "Ctypes bindings to system-specific low-level socket structure and data-types"
+description: """
+This module provides OCaml ctypes bindings to system-specific low-level socket
+structure and data-types.
+
+The interface is implemented using ocaml-ctypes and in intended to exposed the
+machine-specific, low-level details of the most important parts of socket
+implementations.
+
+This package provides the part of the API that is compatible with both
+Unix and Win32 systems."""
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "Romain Beauxis <toots@rastageeks.org>"
+license: "MIT"
+homepage: "https://github.com/toots/ocaml-sys-socket"
+bug-reports: "https://github.com/toots/ocaml-sys-socket/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.10"}
+  "ctypes"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/toots/ocaml-sys-socket.git"
+url {
+  src: "https://github.com/toots/ocaml-sys-socket/archive/1.0.0.tar.gz"
+  checksum: [
+    "md5=2ecd4e009ed19e4d961d9b8a4a09f546"
+    "sha512=2fbfd846baebd259a8486be2af856569ee6f056298e8cf5874ba76f5c207626cc5854abe2e091d670f9bb605eeb19a416e47b3c8474b8cbc5957f6293b3ccddb"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`sys-socket.1.0.0`: Ctypes bindings to system-specific low-level socket structure and data-types
-`sys-socket-unix.1.0.0`: Ctypes bindings to unix-specific low-level socket structure and data-types



---
* Homepage: https://github.com/toots/ocaml-sys-socket
* Source repo: git+https://github.com/toots/ocaml-sys-socket.git
* Bug tracker: https://github.com/toots/ocaml-sys-socket/issues

---
:camel: Pull-request generated by opam-publish v2.0.0