### PR TITLE
Add ocamlfind.1.8.1

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.8.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.8.0/opam
@@ -45,7 +45,7 @@ remove: [
   ["rm" "-f" "%{bin}%/ocaml"] {ocaml:preinstalled}
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "4.09.0"}
   "conf-m4" {build}
 ]
 synopsis: "A library manager for OCaml"

--- a/packages/ocamlfind/ocamlfind.1.8.1/files/ocaml-stub
+++ b/packages/ocamlfind/ocamlfind.1.8.1/files/ocaml-stub
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+BINDIR=$(dirname "$(command -v ocamlc)")
+"$BINDIR/ocaml" -I "$OCAML_TOPLEVEL_PATH" "$@"

--- a/packages/ocamlfind/ocamlfind.1.8.1/files/ocamlfind.install
+++ b/packages/ocamlfind/ocamlfind.1.8.1/files/ocamlfind.install
@@ -1,0 +1,6 @@
+bin: [
+  "src/findlib/ocamlfind" {"ocamlfind"}
+  "?src/findlib/ocamlfind_opt" {"ocamlfind"}
+  "?tools/safe_camlp4"
+]
+toplevel: ["src/findlib/topfind"]

--- a/packages/ocamlfind/ocamlfind.1.8.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.8.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A library manager for OCaml"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage: "http://projects.camlcity.org/projects/findlib.html"
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+description: """
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts.
+"""
+build: [
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-sitelib"
+    lib
+    "-mandir"
+    man
+    "-config"
+    "%{lib}%/findlib.conf"
+    "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "all"]
+  [make "opt"] {ocaml:native}
+]
+install: [
+  [make "install"]
+  ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
+]
+depends: [
+  "ocaml" {>= "4.00.0"}
+  "conf-m4" {build}
+]
+extra-files: [
+  ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+  ["ocaml-stub" "md5=181f259c9e0bad9ef523e7d4abfdf87a"]
+]
+url {
+  src: "http://download.camlcity.org/download/findlib-1.8.1.tar.gz"
+  checksum: "md5=18ca650982c15536616dea0e422cbd8c"
+  mirrors: "http://download2.camlcity.org/download/findlib-1.8.1.tar.gz"
+}


### PR DESCRIPTION
OCamlfind 1.8.1 has just been released. This release adds support for OCaml >= 4.09