### PR TITLE
Package prepare.1.1.3

### DIFF
--- a/packages/prepare/prepare.1.1.3/opam
+++ b/packages/prepare/prepare.1.1.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Andre Nathan <andrenth@gmail.com>"
+authors: "Andre Nathan <andrenth@gmail.com>"
+homepage: "https://github.com/andrenth/ocaml-mariadb"
+bug-reports: "https://github.com/andrenth/ocaml-mariadb/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/andrenth/ocaml-mariadb.git"
+synopsis: "OCaml bindings for MariaDB"
+description: "OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its nonblocking API."
+
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "mariadb"]
+  ["ocamlfind" "remove" "mariadb_bindings"]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ctypes" {>= "0.7.0"}
+  "ctypes-foreign" {>= "0.4.0"}
+]
+depexts: [
+  ["libmariadb-dev"] {os-distribution = "debian"}
+  ["libmariadb-dev"] {os-distribution = "ubuntu"}
+]
+flags: light-uninstall
+url {
+  src: "https://github.com/andrenth/ocaml-mariadb/archive/1.1.3.tar.gz"
+  checksum: [
+    "md5=0bd46e67c71f8b3df7cb449bc4d068a0"
+    "sha512=177663b456a17cb4f20ad2b67c021c1edaf9fc85d5b0e288e1edfd2342024db8be9bc8a7682be395678dd9e9ee1cf99a9b85934fc296e4fcdf3dcb41be7451e0"
+  ]
+}


### PR DESCRIPTION
### `prepare.1.1.3`
OCaml bindings for MariaDB
OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its nonblocking API.



---
* Homepage: https://github.com/andrenth/ocaml-mariadb
* Source repo: git+https://github.com/andrenth/ocaml-mariadb.git
* Bug tracker: https://github.com/andrenth/ocaml-mariadb/issues

---
:camel: Pull-request generated by opam-publish v2.0.0