### PR TITLE
Lwt_log 1.1.1

### DIFF
--- a/packages/lwt_log/lwt_log.1.1.1/opam
+++ b/packages/lwt_log/lwt_log.1.1.1/opam
@@ -16,7 +16,7 @@ maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 dev-repo: "git+https://github.com/ocsigen/lwt_log.git"
 
 depends: [
-  "dune" {build}
+  "dune" {>= "1.0"}
   "lwt" {>= "4.0.0"}
 ]
 

--- a/packages/lwt_log/lwt_log.1.1.1/opam
+++ b/packages/lwt_log/lwt_log.1.1.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+
+synopsis: "Lwt logging library (deprecated)"
+
+version: "1.1.1"
+license: "LGPL"
+homepage: "https://github.com/ocsigen/lwt_log"
+doc: "https://github.com/ocsigen/lwt_log/blob/master/src/core/lwt_log_core.mli"
+bug-reports: "https://github.com/ocsigen/lwt_log/issues"
+
+authors: [
+  "Shawn Wagner"
+  "Jérémie Dimino"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/ocsigen/lwt_log.git"
+
+depends: [
+  "dune" {build}
+  "lwt" {>= "4.0.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/lwt_log/archive/1.1.1.tar.gz"
+  checksum: "md5=02e93be62288037870ae5b1ce099fe59"
+}


### PR DESCRIPTION
[Changelog](https://github.com/ocsigen/lwt_log/releases/tag/1.1.1):

> - Upgrade from Jbuilder to Dune (ocsigen/lwt_log#3, Rudi Grinberg).
> - Update license headers (ocsigen/lwt_log#2, Ben Rosser).