### PR TITLE
Lwt_glib 1.1.1

### DIFF
--- a/packages/lwt_glib/lwt_glib.1.1.1/opam
+++ b/packages/lwt_glib/lwt_glib.1.1.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+
+synopsis: "GLib integration for Lwt"
+
+version: "1.1.1"
+license: "LGPL"
+homepage: "https://github.com/ocsigen/lwt_glib"
+doc: "https://github.com/ocsigen/lwt_glib/blob/master/src/lwt_glib.mli"
+bug-reports: "https://github.com/ocsigen/lwt_glib/issues"
+
+authors: "Jérémie Dimino"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/ocsigen/lwt_glib.git"
+
+depends: [
+  "base-unix"
+  "conf-glib-2" {build}
+  "conf-pkg-config" {build}
+  "dune"
+  "lwt" {>= "3.0.0"}
+  "ocaml"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocsigen/lwt_glib/archive/1.1.1.tar.gz"
+  checksum: "md5=9453631043b3e5b50f8d5bc5d443464e"
+}


### PR DESCRIPTION
[Changelog](https://github.com/ocsigen/lwt_glib/releases/tag/1.1.1):

> - Move Lwt_glib to a separate repo.
> - Fix internal helper (ocsigen/lwt_glib#1, Frédéric Bour).
> - Upgrade from Jbuilder to Dune (ocsigen/lwt_glib@f8269a1).
> - Fix deprecation warnings due to OCaml 4.08 and Lwt development (ocsigen/lwt_glib@9f50a15).