### PR TITLE
Lwt_ssl 1.1.3

### DIFF
--- a/packages/lwt_ssl/lwt_ssl.1.1.3/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.1.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+
+synopsis: "OpenSSL binding with concurrent I/O"
+
+version: "1.1.3"
+license: "LGPL with OpenSSL linking exception"
+homepage: "https://github.com/ocsigen/lwt_ssl"
+doc: "https://github.com/ocsigen/lwt_ssl/blob/master/src/lwt_ssl.mli"
+bug-reports: "https://github.com/ocsigen/lwt_ssl/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/ocsigen/lwt_ssl.git"
+
+depends: [
+  "base-unix"
+  "dune"
+  "lwt" {>= "3.0.0"}
+  "ocaml"
+  "ssl" {>= "0.5.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocsigen/lwt_ssl/archive/1.1.3.tar.gz"
+  checksum: "md5=b18414b2ef71ededa07666dfc467f10a"
+}


### PR DESCRIPTION
[Changelog](https://github.com/ocsigen/lwt_ssl/releases/tag/1.1.3):

> - Upgrade from Jbuilder to Dune (ocsigen/lwt_ssl@3b5782c).