### PR TITLE
Add an upper bounds to ppxlib reverse dependencies (again).

### DIFF
--- a/packages/clangml/clangml.4.0.0/opam
+++ b/packages/clangml/clangml.4.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "conf-zlib"
   "ocamlfind" {build & >= "1.8.0"}
   "dune" {>= "1.10.0"}
-  "ppxlib" {>= "0.6.0"}
+  "ppxlib" {>= "0.6.0" & < "0.9.0"}
   "stdcompat" {>= "10"}
   "ppx_show" {>= "0.1.0"}
   "ppx_compare" {>= "v0.12.0"}

--- a/packages/genprint/genprint.0.1/opam
+++ b/packages/genprint/genprint.0.1/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.02.0" }
   "dune"
   "stdlib-shims"
-  "ppxlib" {build}
+  "ppxlib" {build & < "0.9.0"}
 ]
 
 url {

--- a/packages/genprint/genprint.0.2/opam
+++ b/packages/genprint/genprint.0.2/opam
@@ -20,7 +20,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0" }
   "dune"
-  "ppxlib"
+  "ppxlib" {< "0.9.0"}
   "cppo" {build}
   "stdlib-shims"
 ]

--- a/packages/obus/obus.1.2.0/opam
+++ b/packages/obus/obus.1.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "lwt_log"
   "lwt_react"
   "ocaml-migrate-parsetree"
-  "ppxlib"
+  "ppxlib" {< "0.9.0"}
 ]
 
 url {

--- a/packages/override/override.0.1.0/opam
+++ b/packages/override/override.0.1.0/opam
@@ -9,7 +9,7 @@ license: "BSD"
 dev-repo: "git+https://gitlab.inria.fr/tmartine/override.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "dune" "ppxlib" "stdcompat" "ppx_tools"
+  "dune" "ppxlib" {< "0.9.0"} "stdcompat" "ppx_tools"
   "ocaml" {>= "4.04.1" & < "4.08.0"}] # no ppxlib for OCaml <4.04.1
 url {
   src: "https://gitlab.inria.fr/tmartine/override/-/archive/0.1.0/override-0.1.0.tar.gz"

--- a/packages/override/override.0.2.0/opam
+++ b/packages/override/override.0.2.0/opam
@@ -19,7 +19,7 @@ and change module interfaces.
 """
 depends: [
   "dune" {>= "1.10.0"}
-  "ppxlib" {>= "0.6.0"}
+  "ppxlib" {>= "0.6.0" & < "0.9.0"}
   "stdcompat" {>= "9"}
   "ppx_show" {>= "0.1.0"}
   "ppx_compare" {>= "v0.12.0"}

--- a/packages/override/override.0.2.1/opam
+++ b/packages/override/override.0.2.1/opam
@@ -19,7 +19,7 @@ and change module interfaces.
 """
 depends: [
   "dune" {>= "1.10.0"}
-  "ppxlib" {>= "0.6.0"}
+  "ppxlib" {>= "0.6.0" & < "0.9.0"}
   "stdcompat" {>= "9"}
   "ppx_show" {>= "0.1.0"}
   "ppx_compare" {>= "v0.12.0"}

--- a/packages/ppx_bsx/ppx_bsx.2.0.0/opam
+++ b/packages/ppx_bsx/ppx_bsx.2.0.0/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" { = "4.06.1" }
   "markup"
-  "ppxlib"
+  "ppxlib" {< "0.9.0"}
   "dune" {>= "1.9"}
 ]
 url {

--- a/packages/ppx_enum/ppx_enum.0.0.2/opam
+++ b/packages/ppx_enum/ppx_enum.0.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "dune"
   "ocaml" {>= "4.07.0" & < "4.08.0"}
   "ounit" {with-test & >= "2.0.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.9.0"}
   "ppx_deriving" {with-test}
 ]
 tags: ["org:cryptosense"]

--- a/packages/ppx_import/ppx_import.1.6.2/opam
+++ b/packages/ppx_import/ppx_import.1.6.2/opam
@@ -13,7 +13,7 @@ synopsis: "A syntax extension for importing declarations from interface files"
 depends: [
   "ocaml"                   {              >= "4.04.2" & < "4.08.0" }
   "dune"                    { >= "1.2.0"  }
-  "ppxlib"                  {              >= "0.3.1"  }
+  "ppxlib"                  {              >= "0.3.1"  & < "0.9.0" }
   "ppx_tools_versioned"     {              >= "5.2.1"  }
   "ocaml-migrate-parsetree" {              >= "1.1.0"  }
   "ounit"                   { with-test                }

--- a/packages/ppx_show/ppx_show.0.1.0/opam
+++ b/packages/ppx_show/ppx_show.0.1.0/opam
@@ -14,7 +14,7 @@ license: "BSD"
 dev-repo: "git+https://gitlab.inria.fr/tmartine/ppx_show"
 synopsis: "OCaml PPX deriver for deriving show based on ppxlib"
 depends: [
-  "ppxlib" {>= "0.8.0"}
+  "ppxlib" {>= "0.8.0" & < "0.9.0"}
   "stdcompat" {>= "9"}
 ]
 url {


### PR DESCRIPTION
Basically a follow-up of https://github.com/ocaml/opam-repository/pull/14208, original message:

> The next release of ppxlib (0.9.0) will change the selected
> AST from 4.07 to 4.08. It will hence break a lot of code.
> 
> This pull request adds an upper bounds to all reverse
> dependencies, so that the next version can be released
> safely.