### PR TITLE
ppxlib.0.9.0

### DIFF
--- a/packages/ppxlib/ppxlib.0.9.0/opam
+++ b/packages/ppxlib/ppxlib.0.9.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.06" & ocaml:version < "4.09" }
+]
+depends: [
+  "ocaml"                   {>= "4.04.1"}
+  "base"                    {>= "v0.11.0"}
+  "dune"
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "1.3.1"}
+  "ppx_derivers"            {>= "1.0"}
+  "stdio"                   {>= "v0.11.0"}
+  "ocamlfind"               {with-test}
+]
+synopsis: "Base library and tools for ppx rewriters"
+description: """
+A comprehensive toolbox for ppx development. It features:
+- a OCaml AST / parser / pretty-printer snapshot,to create a full
+   frontend independent of the version of OCaml;
+- a library for library for ppx rewriters in general, and type-driven
+  code generators in particular;
+- a feature-full driver for OCaml AST transformers;
+- a quotation mechanism allowing  to write values representing the
+   OCaml AST in the OCaml syntax;
+- a generator of open recursion classes from type definitions.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/archive/0.9.0.tar.gz"
+  checksum: [
+    "sha256=d269f882a31ff75095a80793082f7481884ca75ef867c8c409f26ad36f9a0a54"
+    "sha512=b903b0386739e17107f89fb9d7c861e95232c0deebbceeacad2d54f1ef771eb942a63e6057d2e3828f4c299c896c6488b6fd351bc150fd4e49d5a48bef84d8a8"
+  ]
+}


### PR DESCRIPTION
This release bumps the AST version from 4.07 to 4.08,
and it thus likely to break reverse dependencies.

For this reason, constraints have been added to said
reverse dependencies (https://github.com/ocaml/opam-repository/pull/14208 and https://github.com/ocaml/opam-repository/pull/14623).

This goes without saying, but this pull request should
only be merged after https://github.com/ocaml/opam-repository/pull/14623 is.