### PR TITLE
release ott 0.29

### DIFF
--- a/packages/ott/ott.0.29/opam
+++ b/packages/ott/ott.0.29/opam
@@ -5,7 +5,7 @@ license: "part BSD3, part LGPL 2.1"
 homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
 bug-reports: "https://github.com/ott-lang/ott/issues"
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.02.0"}
 ]
 build: [make "world"]
 dev-repo: "git+https://github.com/ott-lang/ott.git"

--- a/packages/ott/ott.0.29/opam
+++ b/packages/ott/ott.0.29/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Peter Sewell" "Francesco Zappa Nardelli" "Scott Owens"]
+license: "part BSD3, part LGPL 2.1"
+homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
+bug-reports: "https://github.com/ott-lang/ott/issues"
+depends: [
+  "ocaml" {>= "4.00.0"}
+]
+build: [make "world"]
+dev-repo: "git+https://github.com/ott-lang/ott.git"
+synopsis: "A tool for writing definitions of programming languages and calculi"
+description: """
+Ott takes as input a definition of a language syntax and semantics, in a
+concise and readable ASCII notation that is close to what one would write in
+informal mathematics.  It generates output:
+- a LaTeX source file that defines commands to build a typeset version of the definition;
+- a Coq version of the definition;
+- a HOL version of the definition;
+- an Isabelle/HOL version of the definition;
+- a Lem version of the definition;
+- an OCaml version of the syntax of the definition.
+Additionally, it can be run as a filter, taking a
+LaTeX/Coq/Isabelle/HOL/Lem/OCaml source file
+with embedded (symbolic) terms of the defined language, parsing them and
+replacing them by typeset terms.
+"""
+url {
+  src: "https://github.com/ott-lang/ott/archive/0.29.tar.gz"
+  checksum: "md5=6284382d02bd01ed00fe0e09fe3b777f"
+}


### PR DESCRIPTION
CHANGES:
2018-04 @palmskog Coq 8.8 compatibility
2018-05 @alastairreid add -generate_aux_rules false when generating PDF
2019-08 @dstolfa support for comments in Isabelle 2018
2019-08 @JoeyEremondi fix list bounds when subrules are present
2019-08 @JoeyEremondi make error messages consistently formatted with locations
2019-08 @buggymcbugfix explin OTT comment syntax in documentation
2019-08 @rafoo replace `` by $() and add LaTeX packages required by pandoc
2019-08 @Vertmo improvement on generation of lexer and parser (metavars at end, sort tokens, precise OCaml type, update location nl)
2019-08 @rmn30 install menhir_library_extra.mly
2019-08 @hannesm update opam file to 2.0