### PR TITLE
Speed up re-configuring OCaml sources

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
@@ -18,6 +18,7 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
+    "-C"
     "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
   ]
@@ -29,6 +30,7 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
@@ -15,14 +15,12 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "CC=cc"
-    "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+    "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ]
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
@@ -15,14 +15,12 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "CC=cc"
-    "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+    "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ]
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
@@ -18,6 +18,7 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
+    "-C"
     "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
   ]
@@ -29,6 +30,7 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.1.tar.gz"
   checksum: "md5=723b6bfe8cf5abcbccc6911143f71055"
 }
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).


### PR DESCRIPTION
The `graphics` package has to re-`configure` the OCaml source tree when the package is added to a compiler which was built without it.

The `configure` script takes a bit longer in OCaml 4.08.0 but, since it is built with GNU autoconf, there is a solution which is the `-C` parameter to `configure` (with thanks to @stedolan for originally bringing to my attention just how much faster it makes things!). This creates a file `config.cache` which is used in subsequent invocations to prevent probing the system again.

This alters `ocaml-base-compiler.4.08.0` to have the `-C` switch which has no effect on the build other than to cause `config.cache` to be created when `configure` is run and then this file is installed to `share/ocaml/config.cache` in the switch.

It makes a considerable difference installing graphics.4.08.0, knocking 20 seconds off the package's build time!

This would obviously also be wanted in ocaml-base-compiler.4.08.1 when it comes out. I don't propose doing this for `ocaml-variants`. Obviously the `graphics` package is entirely standalone from OCaml 4.09.0 onwards, but I'd propose keeping this tweak in ocaml-base-compiler.4.09.0 as well, since at some point there are other packages I'd like to be able to build from the source tree, so I anticipate other packages which will want to re-`configure` the tree.