### PR TITLE
Fix description and synopsis of pythonlib.v0.12.0

### DIFF
--- a/packages/pythonlib/pythonlib.v0.12.0/opam
+++ b/packages/pythonlib/pythonlib.v0.12.0/opam
@@ -19,9 +19,9 @@ depends: [
   "ppxlib"     {>= "0.7.0" & < "0.9.0"}
   "pyml"       {>= "20190626"}
 ]
-synopsis: "[@@deriving] plugin to generate Python conversion functions"
+synopsis: "A library to help writing wrappers around ocaml code for python"
 description: "
-Part of the Jane Street's PPX rewriters collection.
+This library helps exposing ocaml functions to python. The python runtime interaction is handled by pyml.
 "
 url {
   src: "https://github.com/janestreet/pythonlib/archive/v0.12.0.tar.gz"


### PR DESCRIPTION
(Another case of copy/paste gone wrong.)