### PR TITLE
Package taglib.0.3.6

### DIFF
--- a/packages/taglib/taglib.0.3.6/opam
+++ b/packages/taglib/taglib.0.3.6/opam
@@ -6,8 +6,9 @@ bug-reports: "https://github.com/savonet/ocaml-taglib/issues"
 synopsis:
   "Bindings for the taglib library which provides functions for reading tags in headers of audio files"
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
+  "conf-pkg-config" {build}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/taglib/taglib.0.3.6/opam
+++ b/packages/taglib/taglib.0.3.6/opam
@@ -17,7 +17,6 @@ build: [
   [make]
 ]
 install: [make "install"]
-remove: ["ocamlfind" "remove" "taglib"]
 depexts: [
   ["taglib-dev"] {os-distribution = "alpine"}
   ["gcc-c++" "taglib-devel"] {os-family = "suse"}

--- a/packages/taglib/taglib.0.3.6/opam
+++ b/packages/taglib/taglib.0.3.6/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-taglib"
+bug-reports: "https://github.com/savonet/ocaml-taglib/issues"
+synopsis:
+  "Bindings for the taglib library which provides functions for reading tags in headers of audio files"
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+]
+build: [
+  ["./bootstrap"] {dev}
+  ["./configure" "--prefix" prefix]
+  [make "clean"] {dev}
+  [make]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "taglib"]
+depexts: [
+  ["taglib-dev"] {os-distribution = "alpine"}
+  ["gcc-c++" "taglib-devel"] {os-family = "suse"}
+  ["gcc-c++" "taglib-devel"] {os-distribution = "fedora"}
+  ["gcc-c++" "taglib-devel"] {os-distribution = "centos"}
+  ["libtag1-dev"] {os-family = "debian"}
+  ["taglib"] {os = "macos" & os-distribution = "homebrew"}
+]
+dev-repo: "git+https://github.com/savonet/ocaml-taglib.git"
+url {
+  src:
+    "https://github.com/savonet/ocaml-taglib/releases/download/0.3.6/ocaml-taglib-0.3.6.tar.gz"
+  checksum: [
+    "md5=093d19f2b26cc97fa12b22ddc46a0466"
+    "sha512=b5744b57beb63761cd5ad1a6d9824e1d3e5da2e94649544217264441a9e561f722b31359df02457465eacf168ff162e5bf524df1c239a98d1277466aa887518a"
+  ]
+}


### PR DESCRIPTION
### `taglib.0.3.6`
Bindings for the taglib library which provides functions for reading tags in headers of audio files



---
* Homepage: https://github.com/savonet/ocaml-taglib
* Source repo: git+https://github.com/savonet/ocaml-taglib.git
* Bug tracker: https://github.com/savonet/ocaml-taglib/issues

---
:camel: Pull-request generated by opam-publish v2.0.0