### PR TITLE
ocaml-freestanding: restrict to < 4.08.1

### DIFF
--- a/packages/ocaml-freestanding/ocaml-freestanding.0.4.5/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.4.5/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")
-  "ocaml" {>= "4.05.0" & < "4.09.0"}
+  "ocaml" {>= "4.05.0" & < "4.08.1"}
 ]
 substs: [
   "flags/cflags.tmp"


### PR DESCRIPTION
due to `off_t` expected in `sys/types.h`, see https://github.com/mirage/ocaml-freestanding/pull/61/commits/7857bfba3a0692761f7d3fb3a50bf77fb507486f for an upstream fix (release pending, merged into master https://github.com/mirage/ocaml-freestanding/pull/61) //cc @mato