### PR TITLE
Set an upper bound on merlin-extend for Reason < 3.5.0

### DIFF
--- a/packages/reason-parser/reason-parser.1.13.5/opam
+++ b/packages/reason-parser/reason-parser.1.13.5/opam
@@ -19,18 +19,10 @@ build: [
     "--native-dynlink"
     "%{ocaml:native-dynlink}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_reason.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
   "ocamlfind" {build}
-  "ocamlbuild" {build & < "0.14"}
   "menhir" {= "20170418"}
   "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}

--- a/packages/reason-parser/reason-parser.1.13.5/opam
+++ b/packages/reason-parser/reason-parser.1.13.5/opam
@@ -31,7 +31,7 @@ depends: [
   "ocaml" {>= "4.02" & < "4.05"}
   "ocamlfind" {build}
   "menhir" {= "20170418"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "topkg" {= "0.8.1"}
   "ocaml-migrate-parsetree"

--- a/packages/reason-parser/reason-parser.1.13.5/opam
+++ b/packages/reason-parser/reason-parser.1.13.5/opam
@@ -30,6 +30,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
   "ocamlfind" {build}
+  "ocamlbuild" {build & < "0.14"}
   "menhir" {= "20170418"}
   "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}

--- a/packages/reason/reason.1.11.0/opam
+++ b/packages/reason/reason.1.11.0/opam
@@ -34,7 +34,7 @@ depends: [
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "menhir" {>= "20160303" & <= "20170101"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "topkg" {= "0.8.1"}
   "ocaml-migrate-parsetree"

--- a/packages/reason/reason.1.11.0/opam
+++ b/packages/reason/reason.1.11.0/opam
@@ -31,6 +31,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
+  "ocamlbuild" {build & < "0.14"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "menhir" {>= "20160303" & <= "20170101"}

--- a/packages/reason/reason.1.11.0/opam
+++ b/packages/reason/reason.1.11.0/opam
@@ -21,17 +21,9 @@ build: [
     "--utop"
     "%{utop:installed}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_reason.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
-  "ocamlbuild" {build & < "0.14"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "menhir" {>= "20160303" & <= "20170101"}

--- a/packages/reason/reason.1.13.0/opam
+++ b/packages/reason/reason.1.13.0/opam
@@ -32,6 +32,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
+  "ocamlbuild" {build & < "0.14"}
   "ocamlfind" {build}
   "utop" {>= "1.17"}
   "merlin-extend" {>= "0.3" & < "0.4"}

--- a/packages/reason/reason.1.13.0/opam
+++ b/packages/reason/reason.1.13.0/opam
@@ -22,17 +22,9 @@ build: [
     "--utop"
     "%{utop:installed}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_reason.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
-  "ocamlbuild" {build & < "0.14"}
   "ocamlfind" {build}
   "utop" {>= "1.17"}
   "merlin-extend" {>= "0.3" & < "0.4"}

--- a/packages/reason/reason.1.13.0/opam
+++ b/packages/reason/reason.1.13.0/opam
@@ -34,7 +34,7 @@ depends: [
   "ocaml" {>= "4.02" & < "4.05"}
   "ocamlfind" {build}
   "utop" {>= "1.17"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "topkg" {= "0.8.1"}
   "ocaml-migrate-parsetree"

--- a/packages/reason/reason.1.13.2/opam
+++ b/packages/reason/reason.1.13.2/opam
@@ -30,6 +30,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
+  "ocamlbuild" {build & < "0.14"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "merlin-extend" {>= "0.3" & < "0.4"}

--- a/packages/reason/reason.1.13.2/opam
+++ b/packages/reason/reason.1.13.2/opam
@@ -32,7 +32,7 @@ depends: [
   "ocaml" {>= "4.02" & < "4.05"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "topkg" {= "0.8.1"}
   "ocaml-migrate-parsetree"

--- a/packages/reason/reason.1.13.2/opam
+++ b/packages/reason/reason.1.13.2/opam
@@ -20,17 +20,9 @@ build: [
     "--utop"
     "%{utop:installed}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_reason.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
-  "ocamlbuild" {build & < "0.14"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "merlin-extend" {>= "0.3" & < "0.4"}

--- a/packages/reason/reason.1.13.3/opam
+++ b/packages/reason/reason.1.13.3/opam
@@ -30,6 +30,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
+  "ocamlbuild" {build & < "0.14"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "merlin-extend" {>= "0.3" & < "0.4"}

--- a/packages/reason/reason.1.13.3/opam
+++ b/packages/reason/reason.1.13.3/opam
@@ -32,7 +32,7 @@ depends: [
   "ocaml" {>= "4.02" & < "4.05"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "topkg" {= "0.8.1"}
   "ocaml-migrate-parsetree"

--- a/packages/reason/reason.1.13.3/opam
+++ b/packages/reason/reason.1.13.3/opam
@@ -20,17 +20,9 @@ build: [
     "--utop"
     "%{utop:installed}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_reason.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
-  "ocamlbuild" {build & < "0.14"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "merlin-extend" {>= "0.3" & < "0.4"}

--- a/packages/reason/reason.1.13.4/opam
+++ b/packages/reason/reason.1.13.4/opam
@@ -30,6 +30,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
+  "ocamlbuild" {build & < "0.14"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "merlin-extend" {>= "0.3" & < "0.4"}

--- a/packages/reason/reason.1.13.4/opam
+++ b/packages/reason/reason.1.13.4/opam
@@ -32,7 +32,7 @@ depends: [
   "ocaml" {>= "4.02" & < "4.05"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "topkg" {>= "0.8.1" & < "0.9"}
   "ocaml-migrate-parsetree"

--- a/packages/reason/reason.1.13.4/opam
+++ b/packages/reason/reason.1.13.4/opam
@@ -20,17 +20,9 @@ build: [
     "--utop"
     "%{utop:installed}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_reason.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
-  "ocamlbuild" {build & < "0.14"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "merlin-extend" {>= "0.3" & < "0.4"}

--- a/packages/reason/reason.1.13.5/opam
+++ b/packages/reason/reason.1.13.5/opam
@@ -20,18 +20,10 @@ build: [
     "--utop"
     "%{utop:installed}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_reason.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
   "ocamlfind" {build}
-  "ocamlbuild" {build & < "0.14"}
   "utop" {>= "1.17" & < "2.0"}
   "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}

--- a/packages/reason/reason.1.13.5/opam
+++ b/packages/reason/reason.1.13.5/opam
@@ -32,7 +32,7 @@ depends: [
   "ocaml" {>= "4.02" & < "4.05"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "topkg" {>= "0.8.1" & < "0.9"}
   "ocaml-migrate-parsetree"

--- a/packages/reason/reason.1.13.5/opam
+++ b/packages/reason/reason.1.13.5/opam
@@ -31,6 +31,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02" & < "4.05"}
   "ocamlfind" {build}
+  "ocamlbuild" {build & < "0.14"}
   "utop" {>= "1.17" & < "2.0"}
   "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}

--- a/packages/reason/reason.1.13.6/opam
+++ b/packages/reason/reason.1.13.6/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.02" & < "4.05"}
   "ocamlfind" {build}
   "utop" {>= "1.17"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "topkg" {>= "0.8.1" & < "0.9"}
   "ocaml-migrate-parsetree"

--- a/packages/reason/reason.1.13.7/opam
+++ b/packages/reason/reason.1.13.7/opam
@@ -30,7 +30,7 @@ depends: [
   "ocamlfind" {build}
   "menhir" {>= "20170418" & <= "20170712"}
   "utop" {>= "1.17"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "topkg" {>= "0.8.1"}
   "ocaml-migrate-parsetree"

--- a/packages/reason/reason.1.3.0/opam
+++ b/packages/reason/reason.1.3.0/opam
@@ -17,13 +17,6 @@ build: [
     "native-dynlink=%{ocaml:native-dynlink}%"
     "utop=%{utop:installed}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_reason.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml" {= "4.02.3"}

--- a/packages/reason/reason.1.3.0/opam
+++ b/packages/reason/reason.1.3.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "BetterErrors" {>= "0.0.1"}
-  "menhir" {>= "20160303" & > "20170418"}
+  "menhir" {>= "20160303" & < "20170418"}
   "merlin" {>= "2.5.0"}
   "merlin-extend" {>= "0.3" & < "0.4"}
   "re" {>= "1.5.0"}

--- a/packages/reason/reason.1.3.0/opam
+++ b/packages/reason/reason.1.3.0/opam
@@ -33,7 +33,7 @@ depends: [
   "BetterErrors" {>= "0.0.1"}
   "menhir" {>= "20160303"}
   "merlin" {>= "2.5.0"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "re" {>= "1.5.0"}
 ]
 conflicts: [

--- a/packages/reason/reason.1.3.0/opam
+++ b/packages/reason/reason.1.3.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "BetterErrors" {>= "0.0.1"}
-  "menhir" {>= "20160303"}
+  "menhir" {>= "20160303" & > "20170418"}
   "merlin" {>= "2.5.0"}
   "merlin-extend" {>= "0.3" & < "0.4"}
   "re" {>= "1.5.0"}

--- a/packages/reason/reason.1.4.0/opam
+++ b/packages/reason/reason.1.4.0/opam
@@ -17,13 +17,6 @@ build: [
     "native-dynlink=%{ocaml:native-dynlink}%"
     "utop=%{utop:installed}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_reason.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml" {= "4.02.3"}

--- a/packages/reason/reason.1.4.0/opam
+++ b/packages/reason/reason.1.4.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "BetterErrors" {>= "0.0.1"}
-  "menhir" {>= "20160303" & > "20170418"}
+  "menhir" {>= "20160303" & < "20170418"}
   "merlin" {>= "2.5.0"}
   "merlin-extend" {>= "0.3" & < "0.4"}
   "re" {>= "1.5.0"}

--- a/packages/reason/reason.1.4.0/opam
+++ b/packages/reason/reason.1.4.0/opam
@@ -33,7 +33,7 @@ depends: [
   "BetterErrors" {>= "0.0.1"}
   "menhir" {>= "20160303"}
   "merlin" {>= "2.5.0"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "re" {>= "1.5.0"}
 ]
 conflicts: [

--- a/packages/reason/reason.1.4.0/opam
+++ b/packages/reason/reason.1.4.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "BetterErrors" {>= "0.0.1"}
-  "menhir" {>= "20160303"}
+  "menhir" {>= "20160303" & > "20170418"}
   "merlin" {>= "2.5.0"}
   "merlin-extend" {>= "0.3" & < "0.4"}
   "re" {>= "1.5.0"}

--- a/packages/reason/reason.1.7.4/opam
+++ b/packages/reason/reason.1.7.4/opam
@@ -17,13 +17,6 @@ build: [
     "native-dynlink=%{ocaml:native-dynlink}%"
     "utop=%{utop:installed}%"
   ]
-  [
-    "ocamlbuild"
-    "-classic-display"
-    "-use-ocamlfind"
-    "src_test/test_reason.byte"
-    "--"
-  ] {with-test}
 ]
 depends: [
   "ocaml" {= "4.02.3"}

--- a/packages/reason/reason.1.7.4/opam
+++ b/packages/reason/reason.1.7.4/opam
@@ -29,7 +29,7 @@ depends: [
   "ocaml" {= "4.02.3"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
-  "menhir" {>= "20160303" & > "20170418"}
+  "menhir" {>= "20160303" & < "20170418"}
   "merlin-extend" {>= "0.3" & < "0.4"}
 ]
 conflicts: [

--- a/packages/reason/reason.1.7.4/opam
+++ b/packages/reason/reason.1.7.4/opam
@@ -29,7 +29,7 @@ depends: [
   "ocaml" {= "4.02.3"}
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
-  "menhir" {>= "20160303"}
+  "menhir" {>= "20160303" & > "20170418"}
   "merlin-extend" {>= "0.3" & < "0.4"}
 ]
 conflicts: [

--- a/packages/reason/reason.1.7.4/opam
+++ b/packages/reason/reason.1.7.4/opam
@@ -30,7 +30,7 @@ depends: [
   "ocamlfind" {build}
   "utop" {>= "1.17" & < "2.0"}
   "menhir" {>= "20160303"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
 ]
 conflicts: [
   "utop" {< "1.17"}

--- a/packages/reason/reason.2.0.0/opam
+++ b/packages/reason/reason.2.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.02" & < "4.05"}
   "ocamlfind" {build}
   "utop" {>= "1.17"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "topkg" {>= "0.8.1" & < "0.9"}
   "ocaml-migrate-parsetree"

--- a/packages/reason/reason.3.0.0/opam
+++ b/packages/reason/reason.3.0.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocamlfind" {build}
   "menhir" {>= "20170418" & <= "20170712"}
   "utop" {>= "1.17"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "topkg" {>= "0.9.1"}
   "ocaml-migrate-parsetree"

--- a/packages/reason/reason.3.0.3/opam
+++ b/packages/reason/reason.3.0.3/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "menhir" {>= "20170418" & <= "20171013"}
   "utop" {>= "1.17"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "ocaml-migrate-parsetree"
 ]

--- a/packages/reason/reason.3.0.4/opam
+++ b/packages/reason/reason.3.0.4/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "menhir" {>= "20170418" & <= "20171013"}
   "utop" {>= "1.17"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result" {= "1.2"}
   "ocaml-migrate-parsetree"
 ]

--- a/packages/reason/reason.3.2.0/opam
+++ b/packages/reason/reason.3.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "jbuilder" {build}
   "ocamlfind" {build}
   "menhir" {>= "20170418" & <= "20171013"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result"
   "ocaml-migrate-parsetree"
 ]

--- a/packages/reason/reason.3.3.5/opam
+++ b/packages/reason/reason.3.3.5/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"          {>= "1.4"}
   "ocamlfind"     {build}
   "menhir"        {>= "20170418"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result"
   "ocaml-migrate-parsetree"
 ]

--- a/packages/reason/reason.3.3.7/opam
+++ b/packages/reason/reason.3.3.7/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"          {>= "1.4"}
   "ocamlfind"     {build}
   "menhir"        {>= "20170418"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result"
   "ocaml-migrate-parsetree"
 ]

--- a/packages/reason/reason.3.4.0/opam
+++ b/packages/reason/reason.3.4.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"          {>= "1.4"}
   "ocamlfind"     {build}
   "menhir"        {>= "20170418"}
-  "merlin-extend" {>= "0.3"}
+  "merlin-extend" {>= "0.3" & < "0.4"}
   "result"
   "ocaml-migrate-parsetree"
 ]


### PR DESCRIPTION
`merlin-extend` changed the dune library name in 0.4 from `merlin_extend` to `merlin-extend`, and Reason has only adapted to this change since 3.5.0