### PR TITLE
Release Links 0.9 (Burghmuirhead).

### DIFF
--- a/packages/links-postgresql/links-postgresql.0.9/opam
+++ b/packages/links-postgresql/links-postgresql.0.9/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Simon Fowler <simon.fowler@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "Postgresql database driver for the Links Programming Language"
+description: "Postgresql database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-2"
+
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "postgresql"
+  "links"
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9/links-0.9.tbz"
+  checksum: [
+    "sha256=f49f509d215bdb9ba2a190d734d49863ac6c9a0140425e092ce2f47177aa9c5b"
+    "sha512=7bed99e82246e8c954e5759284d3a21fc464b9fb1ccb3544c9edb6b590c3c3ea66193f44bcc08ee6d9b3940768668d94b03b979f71f302923896c091934092cb"
+  ]
+}

--- a/packages/links-postgresql/links-postgresql.0.9/opam
+++ b/packages/links-postgresql/links-postgresql.0.9/opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build}
+  "dune" {>= "1.10"}
   "postgresql"
   "links"
 ]

--- a/packages/links-sqlite3/links-sqlite3.0.9/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jan Stolarek <jan.stolarek@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "SQLite database driver for the Links Programming Language"
+description: "SQLite database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-2"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "sqlite3"
+  "links"
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9/links-0.9.tbz"
+  checksum: [
+    "sha256=f49f509d215bdb9ba2a190d734d49863ac6c9a0140425e092ce2f47177aa9c5b"
+    "sha512=7bed99e82246e8c954e5759284d3a21fc464b9fb1ccb3544c9edb6b590c3c3ea66193f44bcc08ee6d9b3940768668d94b03b979f71f302923896c091934092cb"
+  ]
+}

--- a/packages/links-sqlite3/links-sqlite3.0.9/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build}
+  "dune" {>= "1.10"}
   "sqlite3"
   "links"
 ]

--- a/packages/links/links.0.9/opam
+++ b/packages/links/links.0.9/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Simon Fowler <simon.fowler@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "The Links Programming Language"
+description: "Links is a functional programming language designed to make web programming easier."
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-2"
+version: "0.9"
+
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "exec" "preinstall/preinstall.exe" "--" "-libdir" _:lib ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.3"}
+  "base64"
+  "linenoise"
+  "ANSITerminal"
+  "lwt" {>= "3.1.0"}
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit-lwt-unix"
+  "uri"
+  "websocket"
+  "websocket-lwt-unix"
+  "safepass"
+  "result"
+  "ocamlfind"
+  "menhir"
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9/links-0.9.tbz"
+  checksum: [
+    "sha256=f49f509d215bdb9ba2a190d734d49863ac6c9a0140425e092ce2f47177aa9c5b"
+    "sha512=7bed99e82246e8c954e5759284d3a21fc464b9fb1ccb3544c9edb6b590c3c3ea66193f44bcc08ee6d9b3940768668d94b03b979f71f302923896c091934092cb"
+  ]
+}

--- a/packages/links/links.0.9/opam
+++ b/packages/links/links.0.9/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build}
+  "dune" {>= "1.10"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}
   "base64"


### PR DESCRIPTION
0.9 Changelog:

Version 0.9 (Burghmuirhead) presents multiple major new features, bugfixes, as
well as significant changes and improvements to the Links internals.

Links now includes a Model-View-Update library for writing client code, as
pioneered by the Elm programming langauge. More can be found on
[the Wiki page](https://github.com/links-lang/links/wiki/Model-View-Update-(Elm-Architecture)).

The implementation of relational lenses has been extended to support _dynamic_
predicates in `select` queries. Additionally, much work has been done in order
to allow better typechecking of relational lenses.

Mutually-recursive functions and types should now be enclosed in a `mutual`
block:

```
mutual {
  typename Even = [| Z | SuccE:Odd |];
  typename Odd = [| SuccO:Even |];

  sig three : () -> Odd
  fun three() {
    SuccO(SuccE(SuccO(Z)))
  }
}
```

This leads to significant improvements with the performance of the typechecker
when considering mutually-recursive types, simplifies the code, and solves
multiple bugs.

FreezeML is a new approach to integrating first-class, System F-style
polymorphism with ML-style type inference. The system relies on not guessing
polymorphism, and the ability to "freeze" variables in order to suppress
instantiation. See the [TyDe abstract](http://tydeworkshop.org/2019-abstracts/paper19.pdf) for more details.

Version 0.9 includes an implementation of FreezeML:

  - Frozen variables (i.e., variables which are not instantiated) are written
    `~e`
  - Frozen lets (i.e., function definitions which never generalise their types)
    are written `~fun f(x) { x }`
  - Explicit function generalisation is written `$(fun(x) { x }` and produces a
    term of type `forall a::Any,b::Row. (a) -b-> a`
  - Explicit instantiation is written using `@`

The previous work on "explicit quantification" has been removed.

If the `effect_sugar` flag is set, there are many improvements which decrease
the number of times where explicit effect variables are required.

  - Fresh effect variables are no longer generated by the parser
  - Higher-order functions share an effect variable with their calling context: for example,
    `map : ((a) -e-> b, [a]) -e-> [b]` can be written as `map : ((a) -> b, [a]) -> [b]`.
  - Type names can now be written with an implicit effect variable, for example
    `typename Comp(a) = () ~> a` can be written insetad of `Comp(a, e::Eff) = () ~e~> a, and
    `forever : Comp(()) ~> ()` can be written instead of `forever : Comp((), e) ~e~> ()`
  - Presence variables can be omitted from effects. As an example, we can
    write
      ```
      sig evalState : (s) ->
                    (Comp(a, {Get:s,Put:(s) {}-> () |_})) ->
                     Comp(a, {                      |_})
      ```
      instead of
      ```
      sig evalState : (s) ->
                    (Comp(a, {Get:s,Put:(s) {}-> () |_})) ->
                     Comp(a, {Get{_},Put{_}         |_})
      ```

Much work on 0.9 has concentrated on significant non-user-visible changes. In
particular:

  - Desugaring passes which occur after the typechecker are now type-preserving
  - Changes to internal representation of types
  - Many internal refactorings

 - Modules now work better on the REPL

 - `import` is now used to allow a module to be used in the current file,
   whereas `open` brings it into the global scope. To get the previous
   behaviour, use `open import X` for a module `X`. (breaking change)

 - Many behind-the-scenes improvements and bugfixes

 - Compilation on OCaml 4.08 now supported
 - `select` queries now printed when debugging enabled
 - Query shredding now supported in SQLite
 - The `End` session type is now linear, and must be eliminated using `close`.
   This solves a class of memory leaks with session-typed applications.
 - Record field punning is now supported. For example, instead of writing
   `var hello = "hi"; (hello = hello, world="universe")`, it is now possible to
   write `var hello = "hi"; (=hello, world="universe")`.
 - `lines`, `unlines`, `partition`, and `span` added to prelude
 - Hyphenated HTML attributes are now allowed
 - "Primed" variables such as `x'` are now allowed
 - Initial (hacky) support for null integers in the database. If
   the `coerce_null_integers` setting is set to `true`, then `null_integer`
   (default -1) will be used instead of crashing at runtime.
 - Fix draggable list (sessions), draggable cropping frame examples