### PR TITLE
Package logs.0.7.0

### DIFF
--- a/packages/logs/logs.0.7.0/opam
+++ b/packages/logs/logs.0.7.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The logs programmers"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+dev-repo: "git+https://erratique.ch/repos/logs.git"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mtime" {with-test} ]
+depopts: [
+  "js_of_ocaml"
+  "fmt"
+  "cmdliner"
+  "lwt"
+  "base-threads"
+]
+conflicts: [
+  "js_of_ocaml" { < "3.3.0" } ]
+
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+          "--with-fmt" "%{fmt:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+          "--with-lwt" "%{lwt:installed}%"
+          "--with-base-threads" "%{base-threads:installed}%"
+]]
+
+synopsis: """Logging infrastructure for OCaml"""
+description: """\
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+"""
+url {
+archive: "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz"
+checksum: "2bf021ca13331775e33cf34ab60246f7"
+}


### PR DESCRIPTION
### `logs.0.7.0`
Logging infrastructure for OCaml
Logs provides a logging infrastructure for OCaml. Logging is performed
on sources whose reporting level can be set independently. Log message
report is decoupled from logging and is handled by a reporter.

A few optional log reporters are distributed with the base library and
the API easily allows to implement your own.

`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
formatters depends on [Fmt][fmt].  The optional `Logs_browser`
reporter that reports to the web browser console depends on
[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
command line support for controlling Logs depends on
[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
Lwt logging functions depends on [`Lwt`][lwt]

Logs and its reporters are distributed under the ISC license.

[fmt]: http://erratique.ch/software/fmt
[jsoo]: http://ocsigen.org/js_of_ocaml/
[cmdliner]: http://erratique.ch/software/cmdliner
[lwt]: http://ocsigen.org/lwt/



---
* Homepage: https://erratique.ch/software/logs
* Source repo: git+https://erratique.ch/repos/logs.git
* Bug tracker: https://github.com/dbuenzli/logs/issues

---
v0.7.0 2019-08-09 Zagreb
------------------------

Support for thread safe logging, thanks to Jules Aguillon for the
work.

* Add `Logs.set_reporter_mutex` for installing mutual exclusion
  primitives to access the reporter.
* Add `Logs_threaded.enable` to install mutual exclusion
  primitives for OCaml threads.

---
:camel: Pull-request generated by opam-publish v2.0.0