### PR TITLE
BER MetaOCaml N101 (4.01.0+BER)

### DIFF
--- a/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.base/opam
+++ b/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.base/opam
@@ -20,7 +20,7 @@ synopsis: "Findlib toolchain configuration for MetaOCaml"
 depends: [
   "ocaml"
   "ocaml-variants"
-    {= "4.02.1+BER" | = "4.02.1+modular-implicits-ber" | = "4.04.0+BER" | = "4.07.1+BER"}
+    {= "4.01.0+BER" | = "4.02.1+BER" | = "4.02.1+modular-implicits-ber" | = "4.04.0+BER" | = "4.07.1+BER"}
 ]
 flags: light-uninstall
 extra-files: [

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+BER/opam
@@ -26,19 +26,14 @@ install: [
   ["%{make}%" "-C" "ber-metaocaml-101" "install"]
 ]
 patches: [
-  "ber-101.patch"
   "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
 ]
 url {
-  src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
-  checksum: "md5=04dfdd7da189462a4f10ec6530359cef"
-}
-extra-source "ber-101.patch" {
-  src: "http://pim.happyleptic.org/~rixed/metaocaml-opam/ber-101.patch"
-  checksum: "md5=ff90d48d21044f1aa14544479a61fe37"
+  src: "https://github.com/metaocaml/ber-metaocaml/archive/ber-n101.tar.gz"
+  checksum: "md5=6a366887562dee1b9ea34a43c8d6413a"
 }
 extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
   src:
     "https://github.com/diml/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
-  checksum: "md5=a8c6dd8e547a7b766138f7ca3eb1cbfd"
+  checksum: "md5=faccda3b3ab092fa9ac7d5d4d8beb004"
 }


### PR DESCRIPTION
Fixes so that BER MetaOCaml N101 works again:
* Since the patch on http://pim.happyleptic.org is no longer available, retrieve the code from the repository at https://github.com/metaocaml/ber-metaocaml/ instead
* Add 4.01.0+BER to the OCaml version constraints in base-metaocaml-ocamlfind
* Fix the checksum for the clang patch