### PR TITLE
Don't disable dynlink in -static switches

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.01.0+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+musl+static/opam
@@ -28,7 +28,6 @@ build: [
     "-no-tk"
     "-no-curses"
     "-no-graph"
-    "-no-shared-libs"
   ]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+musl+static/opam
@@ -27,7 +27,6 @@ build: [
     "-static"
     "-no-curses"
     "-no-graph"
-    "-no-shared-libs"
   ]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+musl+static/opam
@@ -27,7 +27,6 @@ build: [
     "-static"
     "-no-curses"
     "-no-graph"
-    "-no-shared-libs"
   ]
   [make "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+musl+flambda/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Official 4.05.0 release compiled with musl-clang and with flambda activated"
+description:
+  "Requires musl-clang to be installed (package musl on Arch Linux or musl-tools on Debian)"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.05.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-flambda"
+    "-cc"
+    "musl-clang -Os"
+    "-aspp"
+    "musl-clang -c"
+    "-no-curses"
+    "-no-graph"
+  ]
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.05.0.tar.gz"
+  checksum: "md5=7e0079162134336a24b9028349c756bb"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+musl+static+flambda/opam
@@ -28,7 +28,6 @@ build: [
     "-static"
     "-no-curses"
     "-no-graph"
-    "-no-shared-libs"
   ]
   [make "world"]
   [make "world.opt"]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+musl+flambda/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Official 4.06.0 release compiled with musl-clang and with flambda activated"
+description:
+  "Requires musl-clang to be installed (package musl on Arch Linux or musl-tools on Debian)"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.06.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-flambda"
+    "-cc"
+    "musl-clang -Os"
+    "-aspp"
+    "musl-clang -c"
+    "-no-curses"
+    "-no-graph"
+  ]
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.06.0.tar.gz"
+  checksum: "md5=4f3906e581181c5435078ffe3e485e3f"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+musl+static+flambda/opam
@@ -28,7 +28,6 @@ build: [
     "-static"
     "-no-curses"
     "-no-graph"
-    "-no-shared-libs"
   ]
   [make "world"]
   [make "world.opt"]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+musl+flambda/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Official 4.06.1 release compiled with musl-clang and with flambda activated"
+description:
+  "Requires musl-clang to be installed (package musl on Arch Linux or musl-tools on Debian)"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.06.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-flambda"
+    "-cc"
+    "musl-clang -Os"
+    "-aspp"
+    "musl-clang -c"
+    "-no-curses"
+    "-no-graph"
+  ]
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+  checksum: "md5=d02eb67b828de22c3f97d94b3c46acba"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
@@ -28,7 +28,6 @@ build: [
     "-static"
     "-no-curses"
     "-no-graph"
-    "-no-shared-libs"
   ]
   [make "world"]
   [make "world.opt"]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis:
+  "Official 4.07.1 release compiled with musl-gcc and with flambda activated"
+description:
+  "Requires musl-gcc to be installed (package musl on Arch Linux or musl-tools on Debian)"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.07.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-flambda"
+    "-cc"
+    "musl-gcc -Os"
+    "-aspp"
+    "musl-gcc -c"
+    "-no-curses"
+    "-no-graph"
+  ]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"
+  checksum: "md5=352fe8d46cb238a26aa10c38bad6ecb6"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
@@ -30,7 +30,6 @@ build: [
     "-static"
     "-no-curses"
     "-no-graph"
-    "-no-shared-libs"
   ]
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+flambda/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.08.0, compiled with musl-gcc and with flambda activated"
+description:
+  "Requires musl-gcc to be installed (package musl on Arch Linux or musl-tools on Debian)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=musl-gcc -Os"
+    "ASPP=musl-gcc -c"
+    "--enable-flambda"
+    "--disable-graph-lib"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
+  checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
@@ -28,7 +28,6 @@ build: [
     "--enable-flambda"
     "LIBS=-static"
     "--disable-graph-lib"
-    "--disable-shared"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+flambda/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.08.1, compiled with musl-gcc and with flambda activated"
+description:
+  "Requires musl-gcc to be installed (package musl on Arch Linux or musl-tools on Debian)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.08.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "archlinux"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=musl-gcc -Os"
+    "ASPP=musl-gcc -c"
+    "--enable-flambda"
+    "--disable-graph-lib"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.1.tar.gz"
+  checksum: "md5=723b6bfe8cf5abcbccc6911143f71055"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
@@ -32,7 +32,6 @@ build: [
     "--enable-flambda"
     "LIBS=-static"
     "--disable-graph-lib"
-    "--disable-shared"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]


### PR DESCRIPTION
This removes the `-no-shared-libs` flag from the configuration of static switches.  Note that this switch doesn't produce static binaries by default, only when `-ccopt -static` is passed to `ocamlopt`.

This fixes #14663 and https://github.com/backtracking/ocamlgraph/issues/80 (verified by running `opam install ppx_deriving ocamlgraph`). It's also related to #3608.

One downside of this change is that it replace a compile-time error (`Dynlink` isn't built when `-no-shared-libs` is configured) with a run-time error (`Failure "Dynamic loading not supported"`). This only affects executables compiled with `-ccopt -static`.

cc @etanol 