### PR TITLE
zed, lambda-term and utop

### DIFF
--- a/packages/lambda-term/lambda-term.2.0.2/opam
+++ b/packages/lambda-term/lambda-term.2.0.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml-community/lambda-term"
+bug-reports: "https://github.com/ocaml-community/lambda-term/issues"
+dev-repo: "git://github.com/ocaml-community/lambda-term.git"
+license: "BSD3"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "lwt"   {>= "4.0.0"}
+  "lwt_log"
+  "react"
+  "zed"   {>= "2.0.3" & < "3.0"}
+  "camomile" {>= "1.0.1"}
+  "lwt_react"
+  "dune" {>= "1.0.0"}
+]
+synopsis: "Terminal manipulation library for OCaml"
+description: """
+Lambda-term is a cross-platform library for manipulating the terminal. It
+provides an abstraction for keys, mouse events, colors, as well as a set of
+widgets to write curses-like applications. The main objective of lambda-term is
+to provide a higher level functional interface to terminal manipulation than,
+for example, ncurses, by providing a native OCaml interface instead of bindings
+to a C library. Lambda-term integrates with zed to provide text edition
+facilities in console applications."""
+url {
+  src: "https://github.com/ocaml-community/lambda-term/releases/download/2.0.2/lambda-term-2.0.2.tbz"
+  checksum: "md5=4602aa4355705909e406513322b4b27e"
+}

--- a/packages/utop/utop.2.4.1/opam
+++ b/packages/utop/utop.2.4.1/opam
@@ -1,0 +1,38 @@
+version: "2.4.1"
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: "Jérémie Dimino"
+license: "BSD3"
+homepage: "https://github.com/ocaml-community/utop"
+bug-reports: "https://github.com/ocaml-community/utop/issues"
+doc: "https://ocaml-community.github.io/utop/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-unix"
+  "base-threads"
+  "ocamlfind" {>= "1.7.2"}
+  "lambda-term" {>= "2.0" & < "3.0"}
+  "lwt"
+  "lwt_react"
+  "camomile"
+  "react" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.2"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocaml-community/utop.git"
+synopsis: "Universal toplevel for OCaml"
+description: """
+utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for
+OCaml.  It can run in a terminal or in Emacs. It supports line
+edition, history, real-time and context sensitive completion, colors,
+and more.  It integrates with the Tuareg mode in Emacs.
+"""
+url {
+  src: "https://github.com/ocaml-community/utop/releases/download/2.4.1/utop-2.4.1.tbz"
+  checksum: "md5=d51936e2180e42c812c91ec35a7de02a"
+}

--- a/packages/zed/zed.2.0.3/opam
+++ b/packages/zed/zed.2.0.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml-community/zed"
+bug-reports: "https://github.com/ocaml-community/zed/issues"
+dev-repo: "git://github.com/ocaml-community/zed.git"
+license: "BSD3"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.1.0"}
+  "base-bytes"
+  "camomile" {>= "1.0.1"}
+  "react"
+  "charInfo_width" {>= "1.1.0" & < "2.0~"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Abstract engine for text edition in OCaml"
+description: """
+Zed is an abstract engine for text edition. It can be used to write text
+editors, edition widgets, readlines, ... Zed uses Camomile to fully support the
+Unicode specification, and implements an UTF-8 encoded string type with
+validation, and a rope datastructure to achieve efficient operations on large
+Unicode buffers. Zed also features a regular expression search on ropes. To
+support efficient text edition capabilities, Zed provides macro recording and
+cursor management facilities."""
+url {
+  src: "https://github.com/ocaml-community/zed/releases/download/2.0.3/zed-2.0.3.tbz"
+  checksum: "878123c9114bf3c0bd18a19fb1af73cd"
+}


### PR DESCRIPTION
This PR will resolve https://github.com/ocaml-community/utop/issues/295

* zed
  2.0.3 (2019-08-09)
  ------------------

  * Zed\_string
    * `exception Invalid of string * string` raised when an invalid Zed\_char sequence is encounted
    * `next_ofs : t -> int -> int` returns the offset of the next zchar in `t`
    * `prev_ofs : t -> int -> int` returns the offset of the prev zchar in `t`

* lambda-term
  2.0.2 (2019-08-09)
  ------------------

  LTerm\_history: catch and log `Zed_string.Invalid` exception

* utop
  2.4.1 (2019-08-09)
  ------------------

  ### General

  * Remove camlp4 remnants (@XVilka, ocaml-community/utop#290) (@kandu, ocaml-community/utop#293)
  * Allow to statically link utop (@diml, ocaml-community/utop#285) (@hongchangwu, ocaml-community/utop#286)

  ### Misc

  * Remove broken elisp (m-plamann, ocaml-community/utop#292)
  * Add OCaml 4.08 build in Travis CI (XVilka, ocaml-community/utop#291)