### PR TITLE
Coq 8.8.1 doesn't compile with OCaml 4.08.0

### DIFF
--- a/packages/coq/coq.8.8.1/opam
+++ b/packages/coq/coq.8.8.1/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
   "camlp5"
   "num"


### PR DESCRIPTION
Here's the error message when trying to compile Coq 8.8.1 with OCaml 4.08.0:
```
#=== ERROR while compiling coq.8.8.1 ==========================================#
# context     2.0.5 | linux/x86_64 | ocaml-base-compiler.4.08.0 | pinned(https://github.com/coq/coq/archive/V8.8.1.tar.gz)
# path        ~/.opam/4.08.0/.opam-switch/build/coq.8.8.1
# command     ~/.opam/opam-init/hooks/sandbox.sh build make -j7
# exit-code   2
# env-file    ~/.opam/log/coq-13555-af57d6.env
# output-file ~/.opam/log/coq-13555-af57d6.out
### output ###
# 59 |     open Hashset.Combine
# [...]
# Error: Unbound module Hashset
# Hint: Did you mean Hashtbl?
# make[1]: *** [Makefile.build:668: clib/cSet.cmx] Error 2
# File "clib/hashset.ml", line 1:
# Error: Could not find the .cmi file for interface clib/hashset.mli.
# File "clib/cObj.ml", line 1:
# Error: Could not find the .cmi file for interface clib/cObj.mli.
# make[1]: *** [Makefile.build:668: clib/hashset.cmx] Error 2
# make[1]: *** [Makefile.build:668: clib/cObj.cmx] Error 2
# make[1]: Leaving directory '/home/hritcu/.opam/4.08.0/.opam-switch/build/coq.8.8.1'
# make: *** [Makefile:191: submake] Error 2
```

This error doesn't occur with OCaml 4.07.1, so I propose setting an upper bound.