### PR TITLE
[new release] irmin-indexeddb (0.5)

### DIFF
--- a/packages/irmin-indexeddb/irmin-indexeddb.0.5/opam
+++ b/packages/irmin-indexeddb/irmin-indexeddb.0.5/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name: "irmin-indexeddb"
+synopsis: "Irmin backend using the web-browser's IndexedDB store"
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "ISC"
+homepage: "https://github.com/talex5/irmin-indexeddb"
+bug-reports: "https://github.com/talex5/irmin-indexeddb/issues"
+depends: [
+  "ocaml"
+  "base64" {>= "3.0.0"}
+  "irmin" {>= "0.10.0" & < "0.11.0"}
+  "cstruct" {>= "1.7.0"}
+  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "lwt"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+dev-repo: "git+https://github.com/talex5/irmin-indexeddb.git"
+description: """
+This is an Irmin backend that stores the data in the web-browser's IndexedDB store.
+For more information, see <http://roscidus.com/blog/blog/2015/06/22/cuekeeper-internals-irmin/>
+"""
+url {
+  src:
+    "https://github.com/talex5/irmin-indexeddb/releases/download/v0.5/irmin-indexeddb-v0.5.tbz"
+  checksum: [
+    "sha256=68e0e89dd34a10f1066e81a01634866131945d8222a6b7ab6dd66385a1e39edd"
+    "sha512=49c37b185dbdd583eda934e0bd6a8e4a6d3af34f6a444cb296d538dbef2a39360a8dc8fc3a40488f949fe76a5ecbca52c0fc17a30a918577385b65e42b6fc0d3"
+  ]
+}


### PR DESCRIPTION
Irmin backend using the web-browser's IndexedDB store

- Project page: <a href="https://github.com/talex5/irmin-indexeddb">https://github.com/talex5/irmin-indexeddb</a>

##### CHANGES:

Note: this release still uses Irmin 0.10.x, which is very out-of-date now.
However, this is a first step towards fixing the bit-rot.

- Update `js_of_ocaml` 2 -> 3.
- Update `base64` 2 -> 3.
- Upgrade opam 1 -> 2.
- Convert from oasis to dune.
