### PR TITLE
allow compilation of coq 8.9 with ocaml 4.08

### DIFF
--- a/packages/coq/coq.8.9.1/files/ocaml408_compat.patch
+++ b/packages/coq/coq.8.9.1/files/ocaml408_compat.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.build b/Makefile.build
+index ed29e21c82..02a92cd404 100644
+--- a/Makefile.build
++++ b/Makefile.build
+@@ -262,7 +262,7 @@ endef
+ CAMLP5DEPS:=grammar/grammar.cma
+ CAMLP5USE=pa_extend.cmo q_MLast.cmo pa_macro.cmo -D$(CAMLVERSION)
+ 
+-PR_O := $(if $(READABLE_ML4),pr_o.cmo,pr_dump.cmo)
++PR_O := $(if $(READABLE_ML4),pr_o.cmo,)
+ 
+ # Main packages linked by Coq.
+ SYSMOD:=-package num,str,unix,dynlink,threads

--- a/packages/coq/coq.8.9.1/opam
+++ b/packages/coq/coq.8.9.1/opam
@@ -33,6 +33,7 @@ install: [
   [make "install-byte"]
 ]
 extra-files: ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"]
+patches: ["ocaml408_compat.patch" "md5=372b00769425baabc8bdc70b7c4fa8ae"]
 
 url {
   src: "https://github.com/coq/coq/archive/V8.9.1.tar.gz"

--- a/packages/coq/coq.8.9.1/opam
+++ b/packages/coq/coq.8.9.1/opam
@@ -8,7 +8,7 @@ license: "LGPL-2.1"
 synopsis: "Formal proof management system"
 
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" <= "4.08.0"}
   "ocamlfind" {build}
   "camlp5"
   "num"

--- a/packages/coq/coq.8.9.1/opam
+++ b/packages/coq/coq.8.9.1/opam
@@ -35,7 +35,7 @@ install: [
 patches: ["ocaml408_compat.patch"]
 extra-files: [
    ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"]
-   ["ocaml408_compat.patch" "md5=372b00769425baabc8bdc70b7c4fa8ae"] {ocaml:version >= "4.08.0"}
+   ["ocaml408_compat.patch" "md5=372b00769425baabc8bdc70b7c4fa8ae"]
 ]
 
 url {

--- a/packages/coq/coq.8.9.1/opam
+++ b/packages/coq/coq.8.9.1/opam
@@ -35,7 +35,7 @@ install: [
 patches: ["ocaml408_compat.patch"]
 extra-files: [
    ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"]
-   ["ocaml408_compat.patch" "md5=372b00769425baabc8bdc70b7c4fa8ae"]
+   ["ocaml408_compat.patch" "md5=372b00769425baabc8bdc70b7c4fa8ae"] {ocaml:version >= "4.08.0"}
 ]
 
 url {

--- a/packages/coq/coq.8.9.1/opam
+++ b/packages/coq/coq.8.9.1/opam
@@ -34,7 +34,7 @@ install: [
 ]
 patches: ["ocaml408_compat.patch"]
 extra-files: [
-   ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"
+   ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"]
    ["ocaml408_compat.patch" "md5=372b00769425baabc8bdc70b7c4fa8ae"]
 ]
 

--- a/packages/coq/coq.8.9.1/opam
+++ b/packages/coq/coq.8.9.1/opam
@@ -8,7 +8,7 @@ license: "LGPL-2.1"
 synopsis: "Formal proof management system"
 
 depends: [
-  "ocaml" {>= "4.02.3" <= "4.08.0"}
+  "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "camlp5"
   "num"

--- a/packages/coq/coq.8.9.1/opam
+++ b/packages/coq/coq.8.9.1/opam
@@ -32,8 +32,11 @@ install: [
   [make "install"]
   [make "install-byte"]
 ]
-extra-files: ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"]
-patches: ["ocaml408_compat.patch" "md5=372b00769425baabc8bdc70b7c4fa8ae"]
+patches: ["ocaml408_compat.patch"]
+extra-files: [
+   ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"
+   ["ocaml408_compat.patch" "md5=372b00769425baabc8bdc70b7c4fa8ae"]
+]
 
 url {
   src: "https://github.com/coq/coq/archive/V8.9.1.tar.gz"


### PR DESCRIPTION
Coq 8.9.1 doesn't compiler with ocaml 4.08 due to an incompatibility in dynamic loading when calling camlp5.
This patch fixes that.