### PR TITLE
[new release] dockerfile-opam, dockerfile and dockerfile-cmd (6.3.0)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.6.3.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.6.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL - generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "dockerfile-opam" {>= "3.0.0"}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "ppx_sexp_conv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.3.0/dockerfile-v6.3.0.tbz"
+  checksum: [
+    "sha256=56d37a41dd05f4dd8a82d195a60d610d24667b71fa0b763d24453e70b311bb26"
+    "sha512=98b314110f0661bb14bef71e5bf04d5995de97821dac596ec4a439e15ef9517a0ce40dec10b91f3c21fd4d593bde01c37f0ce6fa998acaecfaf6b991d24538b9"
+  ]
+}

--- a/packages/dockerfile-cmd/dockerfile-cmd.6.3.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.6.3.0/opam
@@ -16,7 +16,7 @@ doc: "https://avsm.github.io/ocaml-dockerfile/doc"
 bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build}
+  "dune"
   "dockerfile-opam" {>= "3.0.0"}
   "cmdliner"
   "fmt"

--- a/packages/dockerfile-opam/dockerfile-opam.6.3.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.6.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution
+support for generating dockerfiles."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "dockerfile" {= version}
+  "ocaml-version" {>= "1.0.0"}
+  "cmdliner"
+  "astring"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.3.0/dockerfile-v6.3.0.tbz"
+  checksum: [
+    "sha256=56d37a41dd05f4dd8a82d195a60d610d24667b71fa0b763d24453e70b311bb26"
+    "sha512=98b314110f0661bb14bef71e5bf04d5995de97821dac596ec4a439e15ef9517a0ce40dec10b91f3c21fd4d593bde01c37f0ce6fa998acaecfaf6b991d24538b9"
+  ]
+}

--- a/packages/dockerfile-opam/dockerfile-opam.6.3.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.6.3.0/opam
@@ -16,7 +16,7 @@ doc: "https://avsm.github.io/ocaml-dockerfile/"
 bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build}
+  "dune"
   "dockerfile" {= version}
   "ocaml-version" {>= "1.0.0"}
   "cmdliner"

--- a/packages/dockerfile/dockerfile.6.3.0/opam
+++ b/packages/dockerfile/dockerfile.6.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.3.0/dockerfile-v6.3.0.tbz"
+  checksum: [
+    "sha256=56d37a41dd05f4dd8a82d195a60d610d24667b71fa0b763d24453e70b311bb26"
+    "sha512=98b314110f0661bb14bef71e5bf04d5995de97821dac596ec4a439e15ef9517a0ce40dec10b91f3c21fd4d593bde01c37f0ce6fa998acaecfaf6b991d24538b9"
+  ]
+}

--- a/packages/dockerfile/dockerfile.6.3.0/opam
+++ b/packages/dockerfile/dockerfile.6.3.0/opam
@@ -13,7 +13,7 @@ doc: "https://avsm.github.io/ocaml-dockerfile/doc"
 bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build}
+  "dune"
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
   "fmt"


### PR DESCRIPTION
Dockerfile eDSL -- opam support

- Project page: <a href="https://github.com/avsm/ocaml-dockerfile">https://github.com/avsm/ocaml-dockerfile</a>
- Documentation: <a href="https://avsm.github.io/ocaml-dockerfile/">https://avsm.github.io/ocaml-dockerfile/</a>

##### CHANGES:

- Add `?chown` option for `copy` and `add` Dockerfile
  functions (avsm/ocaml-dockerfile#12 @talex5)
- add beta repository for switches if there is a dev release
  in any of the compilers for that switch (@avsm).
- Demote Debian 9 to a Tier 2 now that Debian 10 is stable (@avsm).
- Create `opam` group on all Linux distributions (avsm/ocaml-dockerfile#11 @talex5)
