### PR TITLE
+ppx_cstubs.0.2.1

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.2.1/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.2.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://github.com/fdopen/ppx_cstubs"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+doc: "https://fdopen.github.io/ppx_cstubs/"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ctypes" {>= "0.13.0" & < "0.16.0"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.02.3" & < "4.10.0"}
+  "ocaml-migrate-parsetree"
+  "ocamlfind" # not only a build dependency, it depends on findlib.top
+  "dune" {>= "1.6"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: """
+Preprocessor for quick and dirty stub generation
+"""
+
+description: """
+ppx_cstubs is a ppx-based preprocessor for quick and dirty stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file with c stub
+code and an OCaml file with all additional boilerplate code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.2.1.tar.gz"
+  checksum: [
+    "md5=36ae3b715484d0b6a1abced4caad2f56"
+    "sha512=2665cb20122a48fdfb5613694ea4dfea5b6f09c6bf5291fe93e4c8231ab7ccd09e59c47ae8f27ac8d721421ba740625e12665bb72a63ee6adf2c66a292e7f8b3"
+  ]
+}


### PR DESCRIPTION
- support OCaml 4.09.0+beta1 and ctypes 0.15

- bump internally used AST version from 4.06 to 4.08