### PR TITLE
[new release] checkseum (0.0.9)

### DIFF
--- a/packages/checkseum/checkseum.0.0.9/opam
+++ b/packages/checkseum/checkseum.0.0.9/opam
@@ -38,7 +38,7 @@ depopts: [
 conflicts: [
   "mirage-xen-posix" {< "3.1.0"}
   "ocaml-freestanding" {< "0.4.1"}
-  "mirage-runtime" {< "4.0.0"}
+  "mirage-runtime" {>= "4.0.0"}
 ]
 url {
   src:

--- a/packages/checkseum/checkseum.0.0.9/opam
+++ b/packages/checkseum/checkseum.0.0.9/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+name:         "checkseum"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/dinosaure/checkseum"
+bug-reports:  "https://github.com/dinosaure/checkseum/issues"
+dev-repo:     "git+https://github.com/dinosaure/checkseum.git"
+doc:          "https://dinosaure.github.io/checkseum/"
+license:      "MIT"
+synopsis:     "Adler-32, CRC32 and CRC32-C implementation in C and OCaml"
+description: """
+Checkseum is a library to provide implementation of Adler-32, CRC32 and CRC32-C in C and OCaml.
+
+This library use the linking trick to choose between the C implementation (checkseum.c) or the OCaml implementation (checkseum.ocaml).
+This library is on top of optint to get the best representation of an int32.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"         {>= "4.03.0"}
+  "dune"          {>= "1.9.2"}
+  "optint"
+  "base-bytes"
+  "bigarray-compat"
+  "fmt"
+  "rresult"
+  "cmdliner"
+  "alcotest"      {with-test}
+]
+
+depopts: [
+  "ocaml-freestanding"
+  "mirage-xen-posix"
+]
+
+conflicts: [
+  "mirage-xen-posix" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+  "mirage-runtime" {< "4.0.0"}
+]
+url {
+  src:
+    "https://github.com/dinosaure/checkseum/releases/download/0.0.9/checkseum-0.0.9.tbz"
+  checksum: [
+    "sha256=4e0e57a5cb4e6462cda037c358b9f298fe589c1ccc4278d6f8bd0f704a56d12e"
+    "sha512=0c37505abe2ffc0a4e7f4d8a4f1c473f9948b3cd2b41deca96bcb6ef3cfe95809905cf16d6f3febd9dff551e2f81f3b2c0cbba1d6b4ec36565ec1dc13dbeb600"
+  ]
+}

--- a/packages/checkseum/checkseum.0.0.9/opam
+++ b/packages/checkseum/checkseum.0.0.9/opam
@@ -42,7 +42,7 @@ conflicts: [
 ]
 url {
   src:
-    "https://github.com/dinosaure/checkseum/releases/download/0.0.9/checkseum-0.0.9.tbz"
+    "https://github.com/mirage/checkseum/releases/download/v0.0.9/checkseum-v0.0.9.tbz"
   checksum: [
     "sha256=4e0e57a5cb4e6462cda037c358b9f298fe589c1ccc4278d6f8bd0f704a56d12e"
     "sha512=0c37505abe2ffc0a4e7f4d8a4f1c473f9948b3cd2b41deca96bcb6ef3cfe95809905cf16d6f3febd9dff551e2f81f3b2c0cbba1d6b4ec36565ec1dc13dbeb600"

--- a/packages/checkseum/checkseum.0.0.9/opam
+++ b/packages/checkseum/checkseum.0.0.9/opam
@@ -45,6 +45,6 @@ url {
     "https://github.com/mirage/checkseum/releases/download/v0.0.9/checkseum-v0.0.9.tbz"
   checksum: [
     "sha256=02aad775eece3a04911d4a4552b5f0fdcebfc3e2569b61e23d2c7ce33865967f"
-    "sha512=0c37505abe2ffc0a4e7f4d8a4f1c473f9948b3cd2b41deca96bcb6ef3cfe95809905cf16d6f3febd9dff551e2f81f3b2c0cbba1d6b4ec36565ec1dc13dbeb600"
+    "sha512=7bdef1d2bcb92acecfe2bcad03aebb27762a5d674c99d3f683c253e744879bd01c612ae29cf03cd85f1edad9aa3032f668d176cda833ef7c0a2e2a3687cff1e2"
   ]
 }

--- a/packages/checkseum/checkseum.0.0.9/opam
+++ b/packages/checkseum/checkseum.0.0.9/opam
@@ -44,7 +44,7 @@ url {
   src:
     "https://github.com/mirage/checkseum/releases/download/v0.0.9/checkseum-v0.0.9.tbz"
   checksum: [
-    "sha256=4e0e57a5cb4e6462cda037c358b9f298fe589c1ccc4278d6f8bd0f704a56d12e"
+    "sha256=02aad775eece3a04911d4a4552b5f0fdcebfc3e2569b61e23d2c7ce33865967f"
     "sha512=0c37505abe2ffc0a4e7f4d8a4f1c473f9948b3cd2b41deca96bcb6ef3cfe95809905cf16d6f3febd9dff551e2f81f3b2c0cbba1d6b4ec36565ec1dc13dbeb600"
   ]
 }


### PR DESCRIPTION
CHANGES:

- Mirage 3 compatibility

NOTE: old/new release to be able to compile some _unikernels_ without pin. `checkseum` will not change significantly before the release of Mirage 4 so it's mostly an helper to avoid `pin` on some MirageOS 3 projects.