### PR TITLE
checkseum / digestif: with variants: conflict with mirage-runtime < 4.0.0

### DIFF
--- a/packages/checkseum/checkseum.0.1.0/opam
+++ b/packages/checkseum/checkseum.0.1.0/opam
@@ -40,7 +40,8 @@ depopts: [
 
 conflicts: [
   "mirage-xen-posix" {< "3.1.0"}
-  "ocaml-freestanding" {< "0.4.1"}
+  "ocaml-freestanding" {< "0.4.3"}
+  "mirage-runtime" {< "4.0.0"}
 ]
 url {
   src:

--- a/packages/digestif/digestif.0.7.2/opam
+++ b/packages/digestif/digestif.0.7.2/opam
@@ -50,8 +50,9 @@ depopts: [
 
 conflicts: [
   "mirage-xen-posix" {< "3.1.0"}
-  "ocaml-freestanding" {< "0.4.1"}
+  "ocaml-freestanding" {< "0.4.3"}
   "eqaf" {= "0.3"}
+  "mirage-runtime" {< "4.0.0"}
 ]
 url {
   src:

--- a/packages/digestif/digestif.0.7.3/opam
+++ b/packages/digestif/digestif.0.7.3/opam
@@ -47,7 +47,8 @@ depopts: [
 
 conflicts: [
   "mirage-xen-posix" {< "3.1.0"}
-  "ocaml-freestanding" {< "0.4.1"}
+  "ocaml-freestanding" {< "0.4.3"}
+  "mirage-runtime" {< "4.0.0"}
 ]
 url {
   src:


### PR DESCRIPTION
require ocaml-freestanding at least 0.4.3 (the first one to install cflags et al).

//cc @dinosaure 