### PR TITLE
ocveralls will not be compatible with Bisect_ppx 1.5.0

### DIFF
--- a/packages/ocveralls/ocveralls.0.3.2/opam
+++ b/packages/ocveralls/ocveralls.0.3.2/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "ezjsonm" {build & >= "0.4.0"}
-  ("bisect" | "bisect_ppx" {build})
+  ("bisect" | "bisect_ppx" {build & < "1.5.0"})
 ]
 synopsis:
   "Generate JSON for http://coveralls.io from bisect code coverage data."

--- a/packages/ocveralls/ocveralls.0.3.3/opam
+++ b/packages/ocveralls/ocveralls.0.3.3/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "ezjsonm" {build & >= "0.4.0"}
-  ("bisect" | "bisect_ppx" {build})
+  ("bisect" | "bisect_ppx" {build & < "1.5.0"})
 ]
 synopsis:
   "Generate JSON for http://coveralls.io from bisect code coverage data."

--- a/packages/ocveralls/ocveralls.0.3.4/opam
+++ b/packages/ocveralls/ocveralls.0.3.4/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "ezjsonm" {build & >= "0.4.0"}
-  ("bisect" | "bisect_ppx" {build})
+  ("bisect" | "bisect_ppx" {build & < "1.5.0"})
 ]
 synopsis:
   "Generate JSON for http://coveralls.io from bisect code coverage data."


### PR DESCRIPTION
[ocveralls](https://github.com/sagotch/ocveralls) is deprecated. Its functionality was incorporated directly into Bisect_ppx in aantron/bisect_ppx#176.

Bisect_ppx will change in 1.5.0 in a way that will break existing ocveralls releases, so this PR adds the needed constraints.