### PR TITLE
[new release] dns, dns-certify, dns-mirage, dns-resolver, dns-client, dns-server, dns-tsig and dns-cli (4.0.0)

### DIFF
--- a/packages/dns-certify/dns-certify.4.0.0/opam
+++ b/packages/dns-certify/dns-certify.4.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD2"
 
 depends: [
-  "dune" {build & >= "1.2.0"}
+  "dune" {>= "1.2.0"}
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-tsig" {= version}

--- a/packages/dns-certify/dns-certify.4.0.0/opam
+++ b/packages/dns-certify/dns-certify.4.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {build & >= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "0.7.1"}
+  "lwt" {>= "4.2.1"}
+  "tls" {>= "0.10.3"}
+  "mirage-random" {>= "1.2.0"}
+  "mirage-time-lwt" {>= "1.3.0"}
+  "mirage-clock-lwt" {>= "2.0.0"}
+  "mirage-stack-lwt" {>= "1.4.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.0.0/dns-v4.0.0.tbz"
+  checksum: [
+    "sha256=19e856bd3205e3f0294a89501f06d1fb5ee1afd4a4ef26c1b56af866ac254c6a"
+    "sha512=62df40202c67632f1f7381f6c6d919d5dcca80ccddb2141c5879ad089a9432df69cfe6245da1b3101139b449463fe0c2d7165f8fec42d325e17f5e4553384a12"
+  ]
+}

--- a/packages/dns-cli/dns-cli.4.0.0/opam
+++ b/packages/dns-cli/dns-cli.4.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD2"
 
 depends: [
-  "dune" {build & >= "1.2.0"}
+  "dune" {>= "1.2.0"}
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-tsig" {= version}

--- a/packages/dns-cli/dns-cli.4.0.0/opam
+++ b/packages/dns-cli/dns-cli.4.0.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {build & >= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-client" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "rresult" {>= "0.6.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "0.7.1"}
+  "nocrypto" {>= "0.5.4"}
+  "hex" {>= "1.4.0"}
+  "ptime" {>= "0.8.5"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.0.0/dns-v4.0.0.tbz"
+  checksum: [
+    "sha256=19e856bd3205e3f0294a89501f06d1fb5ee1afd4a4ef26c1b56af866ac254c6a"
+    "sha512=62df40202c67632f1f7381f6c6d919d5dcca80ccddb2141c5879ad089a9432df69cfe6245da1b3101139b449463fe0c2d7165f8fec42d325e17f5e4553384a12"
+  ]
+}

--- a/packages/dns-client/dns-client.4.0.0/opam
+++ b/packages/dns-client/dns-client.4.0.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build & >="1.5.1"}
+  "dune" {>="1.5.1"}
   "ocaml" {>= "4.07.0"}
   "cstruct" {>= "4.0.0"}
   "fmt" {>= "0.8.8"}

--- a/packages/dns-client/dns-client.4.0.0/opam
+++ b/packages/dns-client/dns-client.4.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns-client/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD2"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {build & >="1.5.1"}
+  "ocaml" {>= "4.07.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt" {>= "0.8.8"}
+  "logs" {>= "0.6.3"}
+  "dns" {= version}
+  "rresult" {>= "0.6.0"}
+  "randomconv" {>= "0.1.2"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack-lwt" {>= "1.4.0"}
+  "mirage-random" {>= "1.2.0"}
+]
+synopsis: "Pure DNS resolver API"
+description: """
+A pure resolver implementation using uDNS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.0.0/dns-v4.0.0.tbz"
+  checksum: [
+    "sha256=19e856bd3205e3f0294a89501f06d1fb5ee1afd4a4ef26c1b56af866ac254c6a"
+    "sha512=62df40202c67632f1f7381f6c6d919d5dcca80ccddb2141c5879ad089a9432df69cfe6245da1b3101139b449463fe0c2d7165f8fec42d325e17f5e4553384a12"
+  ]
+}

--- a/packages/dns-mirage/dns-mirage.4.0.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD2"
 
 depends: [
-  "dune" {build & >= "1.2.0"}
+  "dune" {>= "1.2.0"}
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "ipaddr" {>= "4.0.0"}

--- a/packages/dns-mirage/dns-mirage.4.0.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {build & >= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack-lwt" {>= "1.4.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  In a similar vein, wildcard records are _not_ supported, and it is
+unlikely they'll ever be in this library.  Truncated hmac in `TSIG` are not
+supported (always the full length of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.0.0/dns-v4.0.0.tbz"
+  checksum: [
+    "sha256=19e856bd3205e3f0294a89501f06d1fb5ee1afd4a4ef26c1b56af866ac254c6a"
+    "sha512=62df40202c67632f1f7381f6c6d919d5dcca80ccddb2141c5879ad089a9432df69cfe6245da1b3101139b449463fe0c2d7165f8fec42d325e17f5e4553384a12"
+  ]
+}

--- a/packages/dns-resolver/dns-resolver.4.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD2"
 
 depends: [
-  "dune" {build & >= "1.2.0"}
+  "dune" {>= "1.2.0"}
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-server" {= version}

--- a/packages/dns-resolver/dns-resolver.4.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {build & >= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time-lwt" {>= "1.3.0"}
+  "mirage-clock-lwt" {>= "2.0.0"}
+  "mirage-random" {>= "1.2.0"}
+  "mirage-stack-lwt" {>= "1.4.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.0.0/dns-v4.0.0.tbz"
+  checksum: [
+    "sha256=19e856bd3205e3f0294a89501f06d1fb5ee1afd4a4ef26c1b56af866ac254c6a"
+    "sha512=62df40202c67632f1f7381f6c6d919d5dcca80ccddb2141c5879ad089a9432df69cfe6245da1b3101139b449463fe0c2d7165f8fec42d325e17f5e4553384a12"
+  ]
+}

--- a/packages/dns-server/dns-server.4.0.0/opam
+++ b/packages/dns-server/dns-server.4.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD2"
 
 depends: [
-  "dune" {build & >= "1.2.0"}
+  "dune" {>= "1.2.0"}
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}

--- a/packages/dns-server/dns-server.4.0.0/opam
+++ b/packages/dns-server/dns-server.4.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {build & >= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time-lwt" {>= "1.3.0"}
+  "mirage-clock-lwt" {>= "2.0.0"}
+  "mirage-stack-lwt" {>= "1.4.0"}
+  "nocrypto" {with-test}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.0.0/dns-v4.0.0.tbz"
+  checksum: [
+    "sha256=19e856bd3205e3f0294a89501f06d1fb5ee1afd4a4ef26c1b56af866ac254c6a"
+    "sha512=62df40202c67632f1f7381f6c6d919d5dcca80ccddb2141c5879ad089a9432df69cfe6245da1b3101139b449463fe0c2d7165f8fec42d325e17f5e4553384a12"
+  ]
+}

--- a/packages/dns-tsig/dns-tsig.4.0.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD2"
 
 depends: [
-  "dune" {build & > "1.2.0"}
+  "dune" {> "1.2.0"}
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "nocrypto" {>= "0.5.4"}

--- a/packages/dns-tsig/dns-tsig.4.0.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {build & > "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "nocrypto" {>= "0.5.4"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.0.0/dns-v4.0.0.tbz"
+  checksum: [
+    "sha256=19e856bd3205e3f0294a89501f06d1fb5ee1afd4a4ef26c1b56af866ac254c6a"
+    "sha512=62df40202c67632f1f7381f6c6d919d5dcca80ccddb2141c5879ad089a9432df69cfe6245da1b3101139b449463fe0c2d7165f8fec42d325e17f5e4553384a12"
+  ]
+}

--- a/packages/dns/dns.4.0.0/opam
+++ b/packages/dns/dns.4.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD2"
 
 depends: [
-  "dune" {build & >= "1.2.0"}
+  "dune" {>= "1.2.0"}
   "ocaml" {>= "4.07.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}

--- a/packages/dns/dns.4.0.0/opam
+++ b/packages/dns/dns.4.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {build & >= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "rresult" "astring" "fmt" "logs" "ptime"
+  "domain-name" {>= "0.3.0"}
+  "gmap" {>= "0.3.0"}
+  "cstruct" {>= "3.2.0"}
+  "ipaddr" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  In a similar vein, wildcard records are _not_ supported, and it is
+unlikely they'll ever be in this library.  Truncated hmac in `TSIG` are not
+supported (always the full length of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.0.0/dns-v4.0.0.tbz"
+  checksum: [
+    "sha256=19e856bd3205e3f0294a89501f06d1fb5ee1afd4a4ef26c1b56af866ac254c6a"
+    "sha512=62df40202c67632f1f7381f6c6d919d5dcca80ccddb2141c5879ad089a9432df69cfe6245da1b3101139b449463fe0c2d7165f8fec42d325e17f5e4553384a12"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Switch to uDNS implementation, developed from scratch since 2017, primarily
  focusing on a recursive caching resolver. The server part supports dynamic
  updates (RFC 2135), transaction authentication with HMAC (RFC 2845), zone
  transfer (RFC 5936), incremental zone transfer (RFC 1995), change
  notifications (RFC 1996) amongst others.
* The core library uses a GADT for resource record sets, where the key (resource
  record type) specifies the value type.
* The API does not leak exceptions, but uses the result type where appropriate.
* TCP transport is well supported and used widely (client uses it by default)
* Naming: client is a DNS client, resolver is the recursive resolver library
* The DNS library is split into the following opam packages and sublibraries:
  - `dns` - the core library
  - `dns-tsig` - transaction signatures
  - `dns-zone` - zone file parser (mostly taken from the 1.x series)
  - `dns-cli` - command line utilities (odig, onotify, ..)
  - `dns-client` - pure client implementation
    - `.unix` - DNS client using the Unix module for communication
    - `.lwt` - DNS client using Lwt_unix for communication
    - `.mirage` - DNS client using MirageOS for communication
  - `dns-certify` - helpers for let's encrypt provisioning
    - `.mirage` - certificate provisioning with MirageOS
  - `dns-mirage` - generic MirageOS communication layer
  - `dns-server` - pure server implementation
    - `.mirage` - MirageOS primary and secondary server
  - `dns-resolver` - pure recursive resolver implementation
    - `.mirage` - MirageOS recursive resolver
* Only OCaml 4.07.0 and above are supported
* Multicast DNS has been dropped for now
* A client using async from JS has not been implemented yet