### PR TITLE
Package ocsigen-toolkit.2.3.2

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.2/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.2/opam
@@ -16,7 +16,7 @@ depends: [
   "calendar"
 ]
 url {
-  src: "https://github.com/jrochel/ocsigen-toolkit/archive/2.3.2.tar.gz"
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.3.2.tar.gz"
   checksum: [
     "md5=29b7ea4872504a6e4067c380fe471a66"
     "sha512=971cf4175c1c5b3243d3959f3db51825fc08530c731eb6fbdea5ac34f33c9050cc315aa0b13c0cc95158631e9f1da1dc98d4f3cce426c6e59e62566905aab645"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.2/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.2/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.7.0"}
+  "calendar"
+]
+url {
+  src: "https://github.com/jrochel/ocsigen-toolkit/archive/2.3.2.tar.gz"
+  checksum: [
+    "md5=29b7ea4872504a6e4067c380fe471a66"
+    "sha512=971cf4175c1c5b3243d3959f3db51825fc08530c731eb6fbdea5ac34f33c9050cc315aa0b13c0cc95158631e9f1da1dc98d4f3cce426c6e59e62566905aab645"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.3.2`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0