### PR TITLE
[new release] conduit, conduit-lwt, conduit-async, conduit-mirage and conduit-lwt-unix (2.0.0)

### DIFF
--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.0.99.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.0.99.0/opam
@@ -22,7 +22,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "conduit-lwt-unix"
+  "conduit-lwt-unix" {< "2.0.0"}
   "cmdliner"
   "logs"
   "fmt"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.0.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.0.0/opam
@@ -22,7 +22,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "conduit-lwt-unix"
+  "conduit-lwt-unix" {< "2.0.0"}
   "cmdliner"
   "magic-mime"
   "logs"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.0.2/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.0.2/opam
@@ -21,7 +21,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "conduit-lwt-unix" {>= "1.0.3"}
+  "conduit-lwt-unix" {>= "1.0.3" & < "2.0.0"}
   "cmdliner"
   "magic-mime"
   "logs"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.1.1/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.1.1/opam
@@ -16,12 +16,12 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.1.0"}
-  "conduit-lwt-unix" {>= "1.0.3"}
+  "conduit-lwt-unix" {>= "1.0.3" & < "2.0.0"}
   "cmdliner"
   "magic-mime"
   "logs"
   "fmt" {>= "0.8.2"}
-  "cohttp-lwt" {="1.1.1"}
+  "cohttp-lwt" {= "1.1.1"}
   "lwt" {>= "3.0.0"}
   "base-unix"
   "ounit" {with-test}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.2.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.1.2.0/opam
@@ -43,12 +43,12 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.1.0"}
-  "conduit-lwt-unix" {>= "1.0.3"}
+  "conduit-lwt-unix" {>= "1.0.3" & < "2.0.0"}
   "cmdliner"
   "magic-mime"
   "logs"
   "fmt" {>= "0.8.2"}
-  "cohttp-lwt" {="1.2.0"}
+  "cohttp-lwt" {= "1.2.0"}
   "lwt" {>= "3.0.0"}
   "base-unix"
   "ounit" {with-test}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.0.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.0.0/opam
@@ -27,7 +27,7 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.1.0"}
-  "conduit-lwt-unix" {>= "1.0.3"}
+  "conduit-lwt-unix" {>= "1.0.3" & < "2.0.0"}
   "cmdliner"
   "magic-mime"
   "logs"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.1.3/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.1.3/opam
@@ -27,7 +27,7 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.1.0"}
-  "conduit-lwt-unix" {>= "1.0.3"}
+  "conduit-lwt-unix" {>= "1.0.3" & < "2.0.0"}
   "cmdliner"
   "magic-mime"
   "logs"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.2.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.2.0/opam
@@ -27,12 +27,12 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.1.0"}
-  "conduit-lwt-unix" {>= "1.0.3"}
+  "conduit-lwt-unix" {>= "1.0.3" & < "2.0.0"}
   "cmdliner"
   "magic-mime"
   "logs"
   "fmt" {>= "0.8.2"}
-  "cohttp-lwt" {=version}
+  "cohttp-lwt" {= version}
   "lwt" {>= "3.0.0"}
   "base-unix"
   "ounit" {with-test}

--- a/packages/conduit-async/conduit-async.2.0.0/opam
+++ b/packages/conduit-async/conduit-async.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "core"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "conduit" {=version}
+  "async" {>= "v0.10.0"}
+  "ipaddr" {>= "3.0.0"}
+]
+depopts: ["async_ssl"]
+conflicts: [
+  "async_ssl" {< "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Async"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.0/conduit-v2.0.0.tbz"
+  checksum: [
+    "sha256=d973a5c3b49b2529d50016daa9cc9c35413c75f1d9c62f363ae416e51e3a8aa5"
+    "sha512=ae80a1f0593d8a8fef9c5f7d794f2312f9665459ebbc94f68c957cedaf93100320f9e8f373af95d4b9c34780b34744683ab08c5544f1f8efc355e557f6c9ad9d"
+  ]
+}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "conduit-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+depopts: ["tls" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls" {< "0.8.0"}
+  "ssl" {< "0.5.9"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.0/conduit-v2.0.0.tbz"
+  checksum: [
+    "sha256=d973a5c3b49b2529d50016daa9cc9c35413c75f1d9c62f363ae416e51e3a8aa5"
+    "sha512=ae80a1f0593d8a8fef9c5f7d794f2312f9665459ebbc94f68c957cedaf93100320f9e8f373af95d4b9c34780b34744683ab08c5544f1f8efc355e557f6c9ad9d"
+  ]
+}

--- a/packages/conduit-lwt/conduit-lwt.2.0.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "conduit" {=version}
+  "lwt" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.0/conduit-v2.0.0.tbz"
+  checksum: [
+    "sha256=d973a5c3b49b2529d50016daa9cc9c35413c75f1d9c62f363ae416e51e3a8aa5"
+    "sha512=ae80a1f0593d8a8fef9c5f7d794f2312f9665459ebbc94f68c957cedaf93100320f9e8f373af95d4b9c34780b34744683ab08c5544f1f8efc355e557f6c9ad9d"
+  ]
+}

--- a/packages/conduit-mirage/conduit-mirage.2.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "cstruct" {>= "3.0.0"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-time-lwt" {>= "1.1.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0"}
+  "dns-client" {>= "4.0.0"}
+  "conduit-lwt"
+  "vchan" {>= "3.0.0"}
+  "xenstore"
+  "tls" {>= "0.8.0"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+
+  #these are required for tls.mirage, which conduit-mirage depends on
+  "mirage-kv-lwt" {>= "2.0.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "ptime"
+]
+conflicts: [
+  "mirage-conduit"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.0/conduit-v2.0.0.tbz"
+  checksum: [
+    "sha256=d973a5c3b49b2529d50016daa9cc9c35413c75f1d9c62f363ae416e51e3a8aa5"
+    "sha512=ae80a1f0593d8a8fef9c5f7d794f2312f9665459ebbc94f68c957cedaf93100320f9e8f373af95d4b9c34780b34744683ab08c5544f1f8efc355e557f6c9ad9d"
+  ]
+}

--- a/packages/conduit/conduit.2.0.0/opam
+++ b/packages/conduit/conduit.2.0.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "astring"
+  "uri"
+  "logs" {>= "0.5.0"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for 
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.0/conduit-v2.0.0.tbz"
+  checksum: [
+    "sha256=d973a5c3b49b2529d50016daa9cc9c35413c75f1d9c62f363ae416e51e3a8aa5"
+    "sha512=ae80a1f0593d8a8fef9c5f7d794f2312f9665459ebbc94f68c957cedaf93100320f9e8f373af95d4b9c34780b34744683ab08c5544f1f8efc355e557f6c9ad9d"
+  ]
+}

--- a/packages/github-hooks-unix/github-hooks-unix.0.2.0/opam
+++ b/packages/github-hooks-unix/github-hooks-unix.0.2.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {build & >= "1.0+beta9"}
   "github-unix" {>= "3.0.1"}
-  "conduit-lwt-unix" {>= "1.0.0"}
+  "conduit-lwt-unix" {>= "1.0.0" & <"2.0.0"}
   "github-hooks" {>= "0.2.0"}
   "cohttp-lwt-unix" {>= "0.99.0"}
 ]

--- a/packages/github-hooks-unix/github-hooks-unix.0.4.0/opam
+++ b/packages/github-hooks-unix/github-hooks-unix.0.4.0/opam
@@ -45,7 +45,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune"
   "github-unix" {>= "3.0.1"}
-  "conduit-lwt-unix" {>= "1.0.0"}
+  "conduit-lwt-unix" {>= "1.0.0" & <"2.0.0"}
   "github-hooks" {>= "0.3.0"}
   "cohttp-lwt-unix" {>= "0.99.0"}
 ]

--- a/packages/github-hooks/github-hooks.0.3.0/opam
+++ b/packages/github-hooks/github-hooks.0.3.0/opam
@@ -26,6 +26,7 @@ depends: [
   "logs"
   "lwt" {< "4.0.0"}
   "cohttp-lwt" {>= "0.99.0"}
+  "conduit-lwt" {<"1.5.0"}
   "github" {>= "3.0.1"}
   "nocrypto"
   "cstruct"

--- a/packages/github-hooks/github-hooks.0.4.0/opam
+++ b/packages/github-hooks/github-hooks.0.4.0/opam
@@ -48,6 +48,7 @@ depends: [
   "logs"
   "lwt"
   "cohttp-lwt" {>= "0.99.0"}
+  "conduit-lwt" {<"1.5.0"}
   "github" {>= "3.0.1"}
   "nocrypto"
   "cstruct"

--- a/packages/hiredis/hiredis.0.4/opam
+++ b/packages/hiredis/hiredis.0.4/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "conduit-lwt-unix" {>= "1.0.0"}
+  "conduit-lwt-unix" {>= "1.0.0" & <"2.0.0"}
 ]
 synopsis: "Redis tools based on the Hiredis C library"
 description:

--- a/packages/hiredis/hiredis.0.6/opam
+++ b/packages/hiredis/hiredis.0.6/opam
@@ -18,6 +18,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "lwt" {>= "3.3.0"}
+  "conduit-lwt-unix" {<"2.0.0"}
 ]
 synopsis: "Redis tools based on the Hiredis C library"
 description:

--- a/packages/hiredis/hiredis.0.7.1/opam
+++ b/packages/hiredis/hiredis.0.7.1/opam
@@ -18,6 +18,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "lwt" {>= "3.3.0"}
+  "conduit-lwt-unix" {<"2.0.0"}
 ]
 synopsis: "Redis tools based on the Hiredis C library"
 description:

--- a/packages/hiredis/hiredis.0.8/opam
+++ b/packages/hiredis/hiredis.0.8/opam
@@ -15,6 +15,7 @@ depends: [
   "jbuilder" {build}
   "lwt" {>= "3.3.0"}
   "hiredis-value" {>= "0.8"}
+  "conduit-lwt-unix" {<"2.0.0"}
 ]
 synopsis: "Redis tools based on the Hiredis C library"
 description:

--- a/packages/prof_spacetime/prof_spacetime.0.2.0/opam
+++ b/packages/prof_spacetime/prof_spacetime.0.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "cohttp" {>= "0.99.0" & < "1.0"}
   "cohttp-lwt-unix" {< "1.0"}
   "conduit"
-  "conduit-lwt-unix"
+  "conduit-lwt-unix" {< "2.0.0"}
   "yojson"
   "lwt"
   "lambda-term" {< "2.0"}

--- a/packages/prof_spacetime/prof_spacetime.0.3.0/opam
+++ b/packages/prof_spacetime/prof_spacetime.0.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "cohttp" {>= "1.0.0"}
   "cohttp-lwt-unix"
   "conduit"
-  "conduit-lwt-unix"
+  "conduit-lwt-unix" {< "2.0.0"}
   "yojson"
   "lwt"
   "lambda-term"

--- a/packages/resp-server/resp-server.0.2/opam
+++ b/packages/resp-server/resp-server.0.2/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "jbuilder" {build}
   "hiredis" {<= "0.7"}
-  "conduit-lwt-unix" {>= "1.0"}
+  "conduit-lwt-unix" {>= "1.0" & <"2.0.0"}}
 ]
 build: [
   ["jbuilder" "build" "-p" name]

--- a/packages/resp-server/resp-server.0.2/opam
+++ b/packages/resp-server/resp-server.0.2/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "jbuilder" {build}
   "hiredis" {<= "0.7"}
-  "conduit-lwt-unix" {>= "1.0" & <"2.0.0"}}
+  "conduit-lwt-unix" {>= "1.0" & <"2.0.0"}
 ]
 build: [
   ["jbuilder" "build" "-p" name]

--- a/packages/resp-server/resp-server.0.3/opam
+++ b/packages/resp-server/resp-server.0.3/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "jbuilder" {build}
   "hiredis-value" {>= "0.8"}
-  "conduit-lwt-unix" {>= "1.0"}
+  "conduit-lwt-unix" {>= "1.0" & <"2.0.0"}
 ]
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]

--- a/packages/resp-server/resp-server.0.9.1/opam
+++ b/packages/resp-server/resp-server.0.9.1/opam
@@ -12,6 +12,7 @@ depends:
     "dune"
     "resp" {>= "0.9.1"}
     "resp-client" {>= "0.9.1"}
+    "conduit-lwt-unix" {>="1.0.0" & <"2.0.0"}
 ]
 
 build:

--- a/packages/resp-server/resp-server.0.9/opam
+++ b/packages/resp-server/resp-server.0.9/opam
@@ -12,6 +12,7 @@ depends:
     "dune"
     "resp" {>= "0.9"}
     "resp-client" {>= "0.9"}
+    "conduit-lwt-unix" {>="1.0.0" & <"2.0.0"}
 ]
 
 build:


### PR DESCRIPTION
A network connection establishment library

- Project page: <a href="https://github.com/mirage/ocaml-conduit">https://github.com/mirage/ocaml-conduit</a>
- Documentation: <a href="https://mirage.github.io/ocaml-conduit/">https://mirage.github.io/ocaml-conduit/</a>

##### CHANGES:

* lwt-unix: obtain client IP correctly when using TLS connections (mirage/ocaml-conduit#277 @victorgomes)
* lwt-unix: replace the dune/ocaml file with a `(select)` build form.
  This avoids invoking `ocamlfind` from the build, and fits in with the
  rest of dune builds much more naturally (@avsm).
* lwt-unix: force callers to give a custom callback `on_exn` in case of exceptions
  to avoid random crashes (mirage/ocaml-conduit#261 @kit-ty-kate)
* mirage: use `dns-client>=4.0.0` which is the `udns` implementation (mirage/ocaml-conduit#290 @hannesm)
* mirage: rename `mirage-conduit` to `conduit-mirage` to fit the naming structure
  of this library suite more.  All new users of Mirage should use `conduit-mirage`,
  and migrating should involve simply swapping the name in your `dune` and `opam`
  files (mirage/ocaml-conduit#302 @hannesm @avsm)
* async: expose `verify_mode` correctly in `Conduit_async` (mirage/ocaml-conduit#298 @brendanlong)
