### PR TITLE
[new release] conduit, conduit-lwt, conduit-async, conduit-mirage and conduit-lwt-unix (2.0.1)

### DIFF
--- a/packages/conduit-async/conduit-async.2.0.1/opam
+++ b/packages/conduit-async/conduit-async.2.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "core"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "conduit" {=version}
+  "async" {>= "v0.10.0"}
+  "ipaddr" {>= "3.0.0"}
+]
+depopts: ["async_ssl"]
+conflicts: [
+  "async_ssl" {< "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Async"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.1/conduit-v2.0.1.tbz"
+  checksum: [
+    "sha256=faf9c1a74bb9f7e0c97637a96968c5198a9344b1dfccbbc2d124d74ac3bedfbb"
+    "sha512=af30cb72ca65e619eb3f38ab3633c1f0ab28dbd7eedd10bcb80f449db9c9b7c433b8553adcb05ac1590ece1797e55bbe5e915255b1ad2fa2dff461a2bfc488aa"
+  ]
+}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.0/opam
@@ -22,6 +22,7 @@ depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [
   "tls" {< "0.8.0"}
   "ssl" {< "0.5.9"}
+  "lwt_ssl" # due to a build bug fixed in conduit 2.0.1
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.1/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "conduit-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+depopts: ["tls" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls" {< "0.8.0"}
+  "ssl" {< "0.5.9"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.1/conduit-v2.0.1.tbz"
+  checksum: [
+    "sha256=faf9c1a74bb9f7e0c97637a96968c5198a9344b1dfccbbc2d124d74ac3bedfbb"
+    "sha512=af30cb72ca65e619eb3f38ab3633c1f0ab28dbd7eedd10bcb80f449db9c9b7c433b8553adcb05ac1590ece1797e55bbe5e915255b1ad2fa2dff461a2bfc488aa"
+  ]
+}

--- a/packages/conduit-lwt/conduit-lwt.2.0.1/opam
+++ b/packages/conduit-lwt/conduit-lwt.2.0.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "conduit" {=version}
+  "lwt" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.1/conduit-v2.0.1.tbz"
+  checksum: [
+    "sha256=faf9c1a74bb9f7e0c97637a96968c5198a9344b1dfccbbc2d124d74ac3bedfbb"
+    "sha512=af30cb72ca65e619eb3f38ab3633c1f0ab28dbd7eedd10bcb80f449db9c9b7c433b8553adcb05ac1590ece1797e55bbe5e915255b1ad2fa2dff461a2bfc488aa"
+  ]
+}

--- a/packages/conduit-mirage/conduit-mirage.2.0.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "cstruct" {>= "3.0.0"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-time-lwt" {>= "1.1.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0"}
+  "dns-client" {>= "4.0.0"}
+  "conduit-lwt"
+  "vchan" {>= "3.0.0"}
+  "xenstore"
+  "tls" {>= "0.8.0"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+
+  #these are required for tls.mirage, which conduit-mirage depends on
+  "mirage-kv-lwt" {>= "2.0.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "ptime"
+]
+conflicts: [
+  "mirage-conduit"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.1/conduit-v2.0.1.tbz"
+  checksum: [
+    "sha256=faf9c1a74bb9f7e0c97637a96968c5198a9344b1dfccbbc2d124d74ac3bedfbb"
+    "sha512=af30cb72ca65e619eb3f38ab3633c1f0ab28dbd7eedd10bcb80f449db9c9b7c433b8553adcb05ac1590ece1797e55bbe5e915255b1ad2fa2dff461a2bfc488aa"
+  ]
+}

--- a/packages/conduit/conduit.2.0.1/opam
+++ b/packages/conduit/conduit.2.0.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "astring"
+  "uri"
+  "logs" {>= "0.5.0"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for 
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.1/conduit-v2.0.1.tbz"
+  checksum: [
+    "sha256=faf9c1a74bb9f7e0c97637a96968c5198a9344b1dfccbbc2d124d74ac3bedfbb"
+    "sha512=af30cb72ca65e619eb3f38ab3633c1f0ab28dbd7eedd10bcb80f449db9c9b7c433b8553adcb05ac1590ece1797e55bbe5e915255b1ad2fa2dff461a2bfc488aa"
+  ]
+}


### PR DESCRIPTION
A network connection establishment library

- Project page: <a href="https://github.com/mirage/ocaml-conduit">https://github.com/mirage/ocaml-conduit</a>
- Documentation: <a href="https://mirage.github.io/ocaml-conduit/">https://mirage.github.io/ocaml-conduit/</a>

##### CHANGES:

* lwt-unix: fix compilation with `lwt_ssl` and fix tests to correctly exercise this
  part of the codepath (mirage/ocaml-conduit#304 @avsm).
