### PR TITLE
Package javalib.3.1.1

### DIFF
--- a/packages/javalib/javalib.3.1.1/opam
+++ b/packages/javalib/javalib.3.1.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Nicolas Barré <nicolas.barre@irisa.fr>"
+authors: "Javalib Development team"
+homepage: "https://javalib-team.github.io/javalib/"
+bug-reports: "https://github.com/javalib-team/javalib/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/javalib-team/javalib.git"
+build: [
+  ["./configure.sh"]
+  [make]
+]
+install: [make "install"]
+depends: [
+  "ocaml" {>= "4.04"}
+  "conf-which" {build}
+  "ocamlfind" {build}
+  "camlzip" {>= "1.05"}
+  "extlib"
+]
+
+synopsis: "Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files"
+
+description: """
+Thus it stands for a good starting point for people who want to
+develop static analyses for Java byte-code programs, benefiting from
+the strength of OCaml language.
+"""
+url {
+  src: "https://github.com/javalib-team/javalib/archive/v3.1.1.tar.gz"
+  checksum: [
+    "md5=26dd16bdfb8b0bc28e466670569782b2"
+    "sha512=5488d1bf6cb426104dc0ad7b60e69414897b53b04111c387329ad531ccb8733f9ef279edd4abd77b0c1d32ad6bef5c98f8f57de1fdc30a34cf51a6f799b39b7f"
+  ]
+}


### PR DESCRIPTION
### `javalib.3.1.1`
Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files
Thus it stands for a good starting point for people who want to
develop static analyses for Java byte-code programs, benefiting from
the strength of OCaml language.



---
* Homepage: https://javalib-team.github.io/javalib/
* Source repo: git+https://github.com/javalib-team/javalib.git
* Bug tracker: https://github.com/javalib-team/javalib/issues

---
:camel: Pull-request generated by opam-publish v2.0.0