### PR TITLE
datakit-ci: fix x509 version constraint

### DIFF
--- a/packages/datakit-ci/datakit-ci.0.12.4/opam
+++ b/packages/datakit-ci/datakit-ci.0.12.4/opam
@@ -23,6 +23,7 @@ depends: [
   "logs"
   "tyxml" {>= "4.0.0"}
   "tls" {>= "0.9.0"}
+  "x509" {< "0.7.0"}
   "conduit-lwt-unix" {>= "1.0.0"}
   "io-page"
   "pbkdf"

--- a/packages/datakit-ci/datakit-ci.1.0.0/opam
+++ b/packages/datakit-ci/datakit-ci.1.0.0/opam
@@ -23,6 +23,7 @@ depends: [
   "logs"
   "tyxml" {>= "4.0.0"}
   "tls" {>= "0.9.0"}
+  "x509" {< "0.7.0"}
   "conduit-lwt-unix" {>= "1.0.0"}
   "io-page"
   "pbkdf"


### PR DESCRIPTION
Otherwise, fail with:

    File "ci/src/cI_secrets.ml", line 41, characters 4-49:
    Error: Unbound module X509.Encoding

See http://check.ocamllabs.io/log/1565886141-3b8d9354a7fccbb21bc721da69b7c2649fbc6e7c/4.07.1/bad/datakit-ci.1.0.0