### PR TITLE
[DO NOT MERGE] Test reverse dependencies for ocsigen/lwt#603

### DIFF
--- a/packages/lwt/lwt.4.2.2/opam
+++ b/packages/lwt/lwt.4.2.2/opam
@@ -63,6 +63,6 @@ a single thread by default. This reduces the need for locks or other
 synchronization primitives. Code can be run in parallel on an opt-in basis."
 
 url {
-  src: "https://github.com/aantron/lwt-branches/archive/5.0.0.20190820.tar.gz"
-  checksum: "md5=fe50996bcec69f676db165359cba64d8"
+  src: "https://github.com/aantron/lwt-branches/archive/5.0.0.201908202.tar.gz"
+  checksum: "md5=619bbef14f00716be4f743a591c78c0c"
 }

--- a/packages/lwt/lwt.5.0.0/opam
+++ b/packages/lwt/lwt.5.0.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+
+version: "4.2.2"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.7.0"}
+  "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0"}
+  "ocplib-endian"
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  "bisect_ppx" {dev & >= "1.5.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+pin-depends: [
+  ["bisect_ppx.git" "git+https://github.com/aantron/bisect_ppx.git"]
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+post-messages: [
+  "Lwt 5.0.0 will make some breaking changes in November 2019. See
+  https://github.com/ocsigen/lwt/issues/584"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+
+url {
+  src: "https://github.com/aantron/lwt-branches/archive/5.0.0.20190820.tar.gz"
+  checksum: "md5=fe50996bcec69f676db165359cba64d8"
+}


### PR DESCRIPTION
See https://github.com/ocsigen/lwt/issues/603. Triggering a revdeps build is the only practical way to find users of `Lwt.async` that might be affected by that change.

We did this previously in https://github.com/ocaml/opam-repository/pull/12409, but that was over a year ago. This is part of the preparation of announcements for the Lwt 5.0.0 release.