### PR TITLE
Lwt 4.3.0 - concurrency library

### DIFF
--- a/packages/lwt/lwt.4.3.0/opam
+++ b/packages/lwt/lwt.4.3.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+
+version: "4.3.0"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.7.0"}
+  "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0"}
+  "ocplib-endian"
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  "bisect_ppx" {dev & >= "1.3.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+post-messages: [
+  "Lwt 5.0.0 will make some breaking changes in November 2019. See
+  https://github.com/ocsigen/lwt/issues/584"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.3.0.tar.gz"
+  checksum: "md5=1a72b5ae4245707c12656632a25fc18c"
+}

--- a/packages/lwt_ppx/lwt_ppx.1.2.3/opam
+++ b/packages/lwt_ppx/lwt_ppx.1.2.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "PPX syntax for Lwt, providing something similar to async/await from JavaScript"
+
+version: "1.2.3"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Ppx_lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Gabriel Radanne"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune"
+  "lwt"
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree" {>= "1.3.0"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.3.0.tar.gz"
+  checksum: "md5=1a72b5ae4245707c12656632a25fc18c"
+}

--- a/packages/lwt_react/lwt_react.1.1.3/opam
+++ b/packages/lwt_react/lwt_react.1.1.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+
+synopsis: "Helpers for using React with Lwt"
+
+version: "1.1.3"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Lwt_react"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune"
+  "lwt" {>= "3.0.0"}
+  "ocaml"
+  "react" {>= "1.0.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.3.0.tar.gz"
+  checksum: "md5=1a72b5ae4245707c12656632a25fc18c"
+}

--- a/packages/ocurl/ocurl.0.7.10/opam
+++ b/packages/ocurl/ocurl.0.7.10/opam
@@ -20,6 +20,7 @@ depends: [
   "ocaml"
   "ocamlfind" {build}
   "base-unix"
+  "base-unsafe-string"
   "conf-libcurl"
 ]
 depopts: ["lwt"]

--- a/packages/ocurl/ocurl.0.7.10/opam
+++ b/packages/ocurl/ocurl.0.7.10/opam
@@ -23,6 +23,9 @@ depends: [
   "conf-libcurl"
 ]
 depopts: ["lwt"]
+conflicts: [
+  "lwt" {>= "4.0.0"}
+]
 synopsis: "Bindings to libcurl"
 description: """
 Client-side URL transfer library, supporting HTTP and a multitude of

--- a/packages/ocurl/ocurl.0.8.0/opam
+++ b/packages/ocurl/ocurl.0.8.0/opam
@@ -24,6 +24,9 @@ depends: [
   "conf-libcurl"
 ]
 depopts: ["lwt"]
+conflicts: [
+  "lwt" {>= "4.0.0"}
+]
 synopsis: "Bindings to libcurl"
 description: """
 Client-side URL transfer library, supporting HTTP and a multitude of


### PR DESCRIPTION
[Changelog](https://github.com/ocsigen/lwt/releases/tag/4.3.0):

<br>

Planned to break in 5.0.0

*For general discussion of breakage in Lwt 5.0.0, see ocsigen/lwt#584. See ocsigen/lwt#293 about how Lwt announces and does breaking changes.*

- The signature of [`Lwt.async`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/core/lwt.mli#L792) will change from `(unit -> 'a Lwt.t) -> unit` to `(unit -> unit Lwt.t) -> unit` (ocsigen/lwt#603, prompted @cfcs).
- [`Lwt_unix.send_msg`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/unix/lwt_unix.cppo.mli#L947) and [`Lwt_unix.recv_msg`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/unix/lwt_unix.cppo.mli#L930) will be changed to take [`Lwt_unix.IO_vectors.t`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/unix/lwt_unix.cppo.mli#L319) instead of [`Lwt_unix.io_vector`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/unix/lwt_unix.cppo.mli#L921)s (ocsigen/lwt#702, prompted Marcello Seri).
- Nesting calls to [`Lwt_main.run`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/unix/lwt_main.mli#L10) will be forbidden, and will raise an `Failure`. Most programs don't do this (ocsigen/lwt#609, prompted François-René Rideau).
- `configure.ml` will be removed in favor of an improved `discover.ml` This affects only users who are configuring Lwt as part of a manual installation (i.e., not users of opam or esy). See [`discover.ml`](https://github.com/ocsigen/lwt/blob/294b72acd3717b1678dd2667db9eb604ef6ffe81/src/unix/config/discover.ml#L27-L49) for usage (ocsigen/lwt#700).
- [`Lwt_unix.async_method`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/unix/lwt_unix.cppo.mli#L1228) will have no effect. In practice, it already does nothing, and has almost no users (ocsigen/lwt#572).

*The following planned breaking changes have already been [announced](https://github.com/ocsigen/lwt/releases/tag/4.0.0):*

- [`Lwt.pick`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/core/lwt.mli#L961) will raise `Invalid_argument` on the empty list, instead of returning a forever-pending promise. Also applies to [`Lwt.choose`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/core/lwt.mli#L1001), [`Lwt.npick`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/core/lwt.mli#L1005), [`Lwt.nchoose`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/core/lwt.mli#L1014), and [`Lwt.nchoose_split`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/core/lwt.mli#L1018) (ocsigen/lwt#562, Tim Reinke, prompted Hezekiah Carty).
- Remove translation of `[%lwt ...]` to `Lwt.catch` from the PPX (ocsigen/lwt#527).
- Remove `-no-debug` option from the PPX (ocsigen/lwt#528).
- Remove `Lwt_log` support from the PPX (ocsigen/lwt#520).

Additions

- [`Lwt_process`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/unix/lwt_process.mli#L6): allow setting working directory for new processes (ocsigen/lwt#694, Thomas Leonard).
- PPX: use OCaml 4.08 ASTs to support latest features (ocsigen/lwt#697).
- [`Lwt_io.NumberIO`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/unix/lwt_io.mli#L635): use compiler intrinsics for better performance (ocsigen/lwt#178, requested Mauricio Fernandez).

Bugs fixed

- Race condition in [`Lwt_react.S.limit`](https://github.com/ocsigen/lwt/blob/705a206ad64149be6cc93bb1447ce22fd14017ca/src/react/lwt_react.mli#L136) (ocsigen/lwt@4e592eb).
- Use `fallback` rule during configuration (ocsigen/lwt#693, Hongchang Wu).
- Fix typos (ocsigen/lwt#688, #692, @Fourchaux).