### PR TITLE
Package cmarker.0.3.0

### DIFF
--- a/packages/cmarker/cmarker.0.3.0/opam
+++ b/packages/cmarker/cmarker.0.3.0/opam
@@ -6,7 +6,7 @@ synopsis: "Bindings for a local installation of CMark"
 bug-reports: "https://github.com/pablo-meier/ocaml-cmark/issues"
 license: "BSD 2-Clause"
 dev-repo: "git+https://github.com/pablo-meier/ocaml-cmark.git"
-build: [ "dune" "build" "-p" name]
+build: [ "dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
   "dune"

--- a/packages/cmarker/cmarker.0.3.0/opam
+++ b/packages/cmarker/cmarker.0.3.0/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/pablo-meier/ocaml-cmark.git"
 build: [ "dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "dune"
+  "dune" {>= "1.11"}
   "ctypes" {>= "0.4.1"}
   "ctypes-foreign" {>= "0.4.0"}
   "utop" {= "2.4.0"}

--- a/packages/cmarker/cmarker.0.3.0/opam
+++ b/packages/cmarker/cmarker.0.3.0/opam
@@ -8,6 +8,8 @@ license: "BSD 2-Clause"
 dev-repo: "git+https://github.com/pablo-meier/ocaml-cmark.git"
 build: [ "dune" "build" "-p" name]
 depends: [
+  "ocaml"
+  "dune"
   "ctypes" {>= "0.4.1"}
   "ctypes-foreign" {>= "0.4.0"}
   "utop" {= "2.4.0"}

--- a/packages/cmarker/cmarker.0.3.0/opam
+++ b/packages/cmarker/cmarker.0.3.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Pablo Meier <pablo.a.meier@gmail.com>"
+authors: "Jonathan Chan <jyc@fastmail.fm>"
+homepage: "https://github.com/pablo-meier/ocaml-cmark"
+synopsis: "Bindings for a local installation of CMark"
+bug-reports: "https://github.com/pablo-meier/ocaml-cmark/issues"
+license: "BSD 2-Clause"
+dev-repo: "git+https://github.com/pablo-meier/ocaml-cmark.git"
+build: [ "dune" "build" "-p" name]
+depends: [
+  "ctypes" {>= "0.4.1"}
+  "ctypes-foreign" {>= "0.4.0"}
+  "utop" {= "2.4.0"}
+  "ocamlformat" {= "0.11.0"}
+]
+depexts: [
+  [["homebrew" "osx"] ["cmark"]]
+]
+url {
+  src: "https://github.com/pablo-meier/ocaml-cmark/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=f0f55cf211f95beb3b61932fb50aaca4"
+    "sha512=db23078e35176edab5c13704414feb89a8d4885f73dc20e55a87ed9e346c5ae9c792c87c8c95033e9cc99c878b48598275cd9032ec139a67455caef94c067e66"
+  ]
+}

--- a/packages/cmarker/cmarker.0.3.0/opam
+++ b/packages/cmarker/cmarker.0.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "1.11"}
   "ctypes" {>= "0.4.1"}
   "ctypes-foreign" {>= "0.4.0"}
-  "utop" {= "2.4.0"}
+  "utop"
 ]
 depexts: [
   [["homebrew" "osx"] ["cmark"]]

--- a/packages/cmarker/cmarker.0.3.0/opam
+++ b/packages/cmarker/cmarker.0.3.0/opam
@@ -13,7 +13,6 @@ depends: [
   "ctypes" {>= "0.4.1"}
   "ctypes-foreign" {>= "0.4.0"}
   "utop" {= "2.4.0"}
-  "ocamlformat" {= "0.11.0"}
 ]
 depexts: [
   [["homebrew" "osx"] ["cmark"]]


### PR DESCRIPTION
### `cmarker.0.3.0`
Bindings for a local installation of CMark



---
* Homepage: https://github.com/pablo-meier/ocaml-cmark
* Source repo: git+https://github.com/pablo-meier/ocaml-cmark.git
* Bug tracker: https://github.com/pablo-meier/ocaml-cmark/issues

---
:camel: Pull-request generated by opam-publish v2.0.0