### PR TITLE
Fix lablqml.0.6.2

### DIFF
--- a/packages/lablqml/lablqml.0.6.2/opam
+++ b/packages/lablqml/lablqml.0.6.2/opam
@@ -9,29 +9,17 @@ tags: [ "gui" "ui" "qt" ]
 build: [
   ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH ./configure"]
       {os-distribution = "alpine" | os-distribution = "centos" | os-distribution = "fedora" }
-  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH make"]
-      {os-distribution = "alpine" | os-distribution = "centos" | os-distribution = "fedora" }
-  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH make demos"]
-      { (os-distribution = "alpine"  | os-distribution = "centos" | os-distribution = "fedora") & with-test }
-
   ["./configure"]
       { os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" }
-  ["dune" "build" "-p" "lablqml,ppx_qt"]
-      { os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" }
+  ["dune" "build" "-p" "lablqml,ppx_qt" "-j" jobs]
   [make "demos"]
-      { with-test & os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" }
 ]
-install: [
-  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH make install"]
-      { os-distribution  = "alpine" | os-distribution  = "centos" | os-distribution  = "fedora" }
-  [make "install"]
-      { os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" }
-]
+install: [make "install"]
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "ocamlfind" {build & with-test }
-  "dune"
+  "ocamlfind" {with-test}
+  "dune" {>= "1.0"}
   "configurator" {build & < "v0.13"}
   "conf-qt" {>= "5.2.1"}
   "ppxlib"  {<= "0.9.0"}

--- a/packages/lablqml/lablqml.0.6.2/opam
+++ b/packages/lablqml/lablqml.0.6.2/opam
@@ -12,7 +12,7 @@ build: [
   ["./configure"]
       { os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" }
   ["dune" "build" "-p" "lablqml,ppx_qt" "-j" jobs]
-  [make "demos"]
+  [make "demos"] {with-test}
 ]
 install: [make "install"]
 


### PR DESCRIPTION
cc @Kakadu @mseri 

This PR fixes several flaws with `lablqml.0.6.2`:
* The command prefixed by `PATH` shouldn't be needed outside of the configure part. I had a look at it and if discover (https://github.com/Kakadu/lablqml/blob/master/lib/config/discover.ml) fails with this PATH, the other commands will do to.
* `dune build -p` was missing for the case with `PATH`
* `build & with-test` is redundant I think (or does nothing, I'm not quite sure)

There are several things I'm not happy with. The package doesn't use dune the correct way:
* lablqml and ppx_qt should be either two separate packages or ppx_qt should have been `lablqml.ppx` or something. Currently this packages calls `dune install` which shouldn't be the case. opam files should be in the root directory, install files shouldn't be in the repository, there shouldn't be any `dune-project` in subdirectories. If it was done that way, dune install could have been avoided and opam would have just taken the install files generated in the root directory.
* In my opinion the PATH differentiation should be done by `discover.ml` and not by opam. It's a huge pain to read and a duplication which can leads to bugs (and there was since on one side make was called and on the other `dune build -p` was called.
* Are you sure ppxlib <= 0.9.0 is required? What if they made a micro release?