### PR TITLE
[new release] mirage, mirage-runtime, mirage-types-lwt and mirage-types (3.5.2)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.5.2/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.5.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build & >= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria-runtime"  {>= "2.2.2"}
+  "fmt"
+  "logs"
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.5.2/mirage-v3.5.2.tbz"
+  checksum: [
+    "sha256=5d8afad75900edd69fcd7c8e77662e9281884358bac4e85c411b37093f6838e0"
+    "sha512=a4933b9834ea83c7b21a82d97e3e3869f652f946bf8af878ff972f673e8155ee65df345740afbd11a43d23851970c74c5b552d295e5418b2e06b5467b4a8decc"
+  ]
+}

--- a/packages/mirage-runtime/mirage-runtime.3.5.2/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.5.2/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune" {build & >= "1.1.0"}
+  "dune" {>= "1.1.0"}
   "ipaddr"             {>= "3.0.0"}
   "functoria-runtime"  {>= "2.2.2"}
   "fmt"

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.5.2/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.5.2/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends:   [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build & >= "1.1.0"}
+  "lwt"
+  "cstruct" {>="3.2.1"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-types" {>= "3.5.0"}
+  "mirage-clock-lwt" {>= "2.0.0"}
+  "mirage-time-lwt" {>= "1.1.0"}
+  "mirage-random" {>= "1.2.0"}
+  "mirage-flow-lwt" {>= "1.5.0"}
+  "mirage-protocols-lwt" {>= "2.0.0"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-console-lwt" {>= "2.3.5"}
+  "mirage-block-lwt" {>= "1.1.0"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "mirage-fs-lwt" {>= "2.0.0"}
+  "mirage-kv-lwt" {>= "2.0.0"}
+  "mirage-channel-lwt" {>= "3.1.0"}
+]
+
+synopsis: "Lwt module type definitions for MirageOS applications"
+description: """
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.5.2/mirage-v3.5.2.tbz"
+  checksum: [
+    "sha256=5d8afad75900edd69fcd7c8e77662e9281884358bac4e85c411b37093f6838e0"
+    "sha512=a4933b9834ea83c7b21a82d97e3e3869f652f946bf8af878ff972f673e8155ee65df345740afbd11a43d23851970c74c5b552d295e5418b2e06b5467b4a8decc"
+  ]
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.5.2/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.5.2/opam
@@ -16,7 +16,7 @@ build: [
 
 depends:   [
   "ocaml" {>= "4.05.0"}
-  "dune" {build & >= "1.1.0"}
+  "dune" {>= "1.1.0"}
   "lwt"
   "cstruct" {>="3.2.1"}
   "ipaddr" {>= "3.0.0"}

--- a/packages/mirage-types/mirage-types.3.5.2/opam
+++ b/packages/mirage-types/mirage-types.3.5.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build & >= "1.1.0"}
+  "mirage-device" {>= "1.1.0"}
+  "mirage-time" {>= "1.1.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-random" {>= "1.2.0"}
+  "mirage-flow" {>= "1.5.0"}
+  "mirage-console" {>= "2.3.5"}
+  "mirage-protocols" {>= "2.0.0"}
+  "mirage-stack" {>= "1.3.0"}
+  "mirage-block" {>= "1.1.0"}
+  "mirage-net" {>= "2.0.0"}
+  "mirage-fs" {>= "2.0.0"}
+  "mirage-kv" {>= "2.0.0"}
+  "mirage-channel" {>= "3.1.0"}
+]
+synopsis: "Module type definitions for MirageOS applications"
+description: """
+Module type definitions for MirageOS applications
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.5.2/mirage-v3.5.2.tbz"
+  checksum: [
+    "sha256=5d8afad75900edd69fcd7c8e77662e9281884358bac4e85c411b37093f6838e0"
+    "sha512=a4933b9834ea83c7b21a82d97e3e3869f652f946bf8af878ff972f673e8155ee65df345740afbd11a43d23851970c74c5b552d295e5418b2e06b5467b4a8decc"
+  ]
+}

--- a/packages/mirage-types/mirage-types.3.5.2/opam
+++ b/packages/mirage-types/mirage-types.3.5.2/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune" {build & >= "1.1.0"}
+  "dune" {>= "1.1.0"}
   "mirage-device" {>= "1.1.0"}
   "mirage-time" {>= "1.1.0"}
   "mirage-clock" {>= "2.0.0"}

--- a/packages/mirage/mirage.3.5.2/opam
+++ b/packages/mirage/mirage.3.5.2/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune" {build & >= "1.1.0"}
+  "dune" {>= "1.1.0"}
   "ipaddr"             {>= "3.0.0"}
   "functoria"          {>= "2.2.3"}
   "bos"

--- a/packages/mirage/mirage.3.5.2/opam
+++ b/packages/mirage/mirage.3.5.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build & >= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria"          {>= "2.2.3"}
+  "bos"
+  "astring"
+  "logs"
+  "mirage-runtime"     {>= "3.5.0"}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.5.2/mirage-v3.5.2.tbz"
+  checksum: [
+    "sha256=5d8afad75900edd69fcd7c8e77662e9281884358bac4e85c411b37093f6838e0"
+    "sha512=a4933b9834ea83c7b21a82d97e3e3869f652f946bf8af878ff972f673e8155ee65df345740afbd11a43d23851970c74c5b552d295e5418b2e06b5467b4a8decc"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Adapt to conduit 2.0.0 release, including dns 4.0.0 (mirage/mirage#996, by @hannesm)
* Adjust mirage-xen constraints to < 5.0.0 (mirage/mirage#995, by @reynir)