### PR TITLE
Package cry.0.6.4

### DIFF
--- a/packages/cry/cry.0.6.4/opam
+++ b/packages/cry/cry.0.6.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-cry"
+bug-reports: "https://github.com/savonet/ocaml-cry/issues"
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+]
+depopts: [
+  "ssl" {>= "0.5.9"}
+  "osx-secure-transport"
+]
+build: [
+  ["./bootstrap"] {dev}
+  ["./configure" "--prefix" prefix]
+  [make "clean"] {dev}
+  [make]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/savonet/ocaml-cry.git"
+synopsis:
+  "The cry library is an implementation of the shout protocol to connect to audio diffusion servers such as icecast"
+url {
+  src:
+    "https://github.com/savonet/ocaml-cry/releases/download/0.6.4/ocaml-cry-0.6.2.tar.gz"
+  checksum: [
+    "md5=c98e10381f571f599c5b6da0fe7aefdc"
+    "sha512=f7ace78f15e2c97aed8a95a082cb8d168771b2d2bcf397d98364cceb6270ae39524697ce6099831bc5b2c4736b93793aa1904dbe1dbca4675f93ae6e87002e9e"
+  ]
+}

--- a/packages/cry/cry.0.6.4/opam
+++ b/packages/cry/cry.0.6.4/opam
@@ -4,7 +4,7 @@ authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-cry"
 bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.01"}
   "ocamlfind" {build}
 ]
 depopts: [


### PR DESCRIPTION
### `cry.0.6.4`
The cry library is an implementation of the shout protocol to connect to audio diffusion servers such as icecast



---
* Homepage: https://github.com/savonet/ocaml-cry
* Source repo: git+https://github.com/savonet/ocaml-cry.git
* Bug tracker: https://github.com/savonet/ocaml-cry/issues

---
:camel: Pull-request generated by opam-publish v2.0.0