### PR TITLE
hardcaml 1.1.1 and 1.2.0 are not compatible with 4.08

### DIFF
--- a/packages/hardcaml/hardcaml.1.1.1/opam
+++ b/packages/hardcaml/hardcaml.1.1.1/opam
@@ -6,7 +6,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind"
   "base-bytes"
   "camlp4"

--- a/packages/hardcaml/hardcaml.1.2.0/opam
+++ b/packages/hardcaml/hardcaml.1.2.0/opam
@@ -14,7 +14,7 @@ build: [
   ] 
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "camlp4"


### PR DESCRIPTION
(Because they use `map_file` from `Bigarray`.)