### PR TITLE
[new release] digestif (0.7.4)

### DIFF
--- a/packages/digestif/digestif.0.7.4/opam
+++ b/packages/digestif/digestif.0.7.4/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "digestif"
 maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
                 "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"

--- a/packages/digestif/digestif.0.7.4/opam
+++ b/packages/digestif/digestif.0.7.4/opam
@@ -31,7 +31,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"          {>= "4.03.0"}
-  "dune"           {build & >= "1.9.2"}
+  "dune"           {>= "1.9.2"}
   "eqaf"
   "base-bytes"
   "bigarray-compat"

--- a/packages/digestif/digestif.0.7.4/opam
+++ b/packages/digestif/digestif.0.7.4/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+name:         "digestif"
+maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/digestif"
+bug-reports:  "https://github.com/mirage/digestif/issues"
+dev-repo:     "git+https://github.com/mirage/digestif.git"
+doc:          "https://mirage.github.io/digestif/"
+license:      "MIT"
+synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+description: """
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {build & >= "1.9.2"}
+  "eqaf"
+  "base-bytes"
+  "bigarray-compat"
+  "fmt"            {with-test}
+  "alcotest"       {with-test}
+]
+
+depopts: [
+  "ocaml-freestanding"
+  "mirage-xen-posix"
+]
+
+conflicts: [
+  "mirage-xen-posix" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+  "mirage-runtime"{< "4.0.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/digestif/releases/download/v0.7.4/digestif-v0.7.4.tbz"
+  checksum: [
+    "sha256=af7cc1cccaf0a1dd572e666a0a9a2ab73f00bf5b469f664f728c767fa13025de"
+    "sha512=921a1e0e311231683093d8772da10eefac8f78fc928a4cbe8e0944ead3bba430324b39173fea387ddf6488b48f4be59291951838ee8c6db60837a481f4ec8a71"
+  ]
+}


### PR DESCRIPTION
Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)

- Project page: <a href="https://github.com/mirage/digestif">https://github.com/mirage/digestif</a>
- Documentation: <a href="https://mirage.github.io/digestif/">https://mirage.github.io/digestif/</a>

##### CHANGES:

- Compatibility version with MirageOS 3
