### PR TITLE
Label ocveralls and bisect as deprecated

### DIFF
--- a/packages/bisect/bisect.1.3.1/opam
+++ b/packages/bisect/bisect.1.3.1/opam
@@ -18,8 +18,10 @@ depends: [
   "camlp4"
   "ocamlbuild" {build}
 ]
-synopsis: "Code coverage tool for the OCaml language"
+synopsis: "Code coverage tool for the OCaml language (deprecated)"
 description: """
+Bisect is deprecated in favor of package bisect_ppx.
+
 Bisect is a code coverage tool for the OCaml language. It is a
 camlp4-based tool that allows to instrument your application before
 running tests. After application execution, it is possible to generate

--- a/packages/ocveralls/ocveralls.0.3.4/opam
+++ b/packages/ocveralls/ocveralls.0.3.4/opam
@@ -17,8 +17,8 @@ depends: [
   ("bisect" | "bisect_ppx" {build & < "1.5.0"})
 ]
 synopsis:
-  "Generate JSON for http://coveralls.io from bisect code coverage data."
-description: "Also support automatic upload of generated data."
+  "Generate JSON for http://coveralls.io from bisect code coverage data (deprecated)."
+description: "ocveralls has been integrated into package bisect_ppx."
 authors: "Julien Sagot ju.sagot@gmail.com"
 flags: light-uninstall
 url {


### PR DESCRIPTION
...in favor of package `bisect_ppx`.

- `ocveralls` is [archived](https://github.com/sagotch/ocveralls). Its functionality was integrated into Bisect_ppx in https://github.com/aantron/bisect_ppx/pull/176.
- `bisect` is the original source of `bisect_ppx`, but it is [now deprecated](https://github.com/gasche/bisect#deprecation) in favor of the latter. See also https://github.com/gasche/bisect/issues/2#issuecomment-506602009.

I did `opam search coverage`, and it would have helped to settle on `bisect_ppx` faster if these packages had been marked deprecated in the synopsis.

cc @gasche, @sagotch