### PR TITLE
Fix ocaml-cry source

### DIFF
--- a/packages/cry/cry.0.6.4/opam
+++ b/packages/cry/cry.0.6.4/opam
@@ -23,9 +23,9 @@ synopsis:
   "The cry library is an implementation of the shout protocol to connect to audio diffusion servers such as icecast"
 url {
   src:
-    "https://github.com/savonet/ocaml-cry/releases/download/0.6.4/ocaml-cry-0.6.2.tar.gz"
+    "https://github.com/savonet/ocaml-cry/releases/download/0.6.4/ocaml-cry-0.6.4.tar.gz"
   checksum: [
-    "md5=c98e10381f571f599c5b6da0fe7aefdc"
-    "sha512=f7ace78f15e2c97aed8a95a082cb8d168771b2d2bcf397d98364cceb6270ae39524697ce6099831bc5b2c4736b93793aa1904dbe1dbca4675f93ae6e87002e9e"
+    "md5=e4a5af88832a0b3045870baeabee58b5"
+    "sha512=443e83db0bf0e8342a67476ffb3729ff486283ec65e2872c186d32255ae5d1df71b5c860a1f4db2ee9222409a4bf539e4d4a64d48242f417d066bfc291d36b2d"
   ]
 }


### PR DESCRIPTION
Sorry y'all, there was another issue with the cry tarball.. Forgot to re-run the autoconf so it got tagged with the wrong version.. This PR fixes the source.