### PR TITLE
frama-c: remove constraint on alt-ergo 2.3.0

### DIFF
--- a/packages/frama-c/frama-c.19.0/opam
+++ b/packages/frama-c/frama-c.19.0/opam
@@ -88,7 +88,7 @@ depends: [
   ( ( "lablgtk" { >= "2.18.2" } & "conf-gnomecanvas" )
   | ( "lablgtk3" { >= "3.0.beta4" & os!="macos" } & "lablgtk3-sourceview3" ))
   "conf-gtksourceview"
-  ( "alt-ergo-free" | "alt-ergo" { <= "2.2.0" } )
+  ( "alt-ergo-free" | "alt-ergo" )
   "conf-graphviz" { post }
   "yojson"
 ]


### PR DESCRIPTION
Remove constraint to allow using alt-ergo 2.3.0 (which produces better results overall), despite the fact that in a few rare cases the result may be worse. This is a net gain overall.