### PR TITLE
Package mariadb.1.1.4

### DIFF
--- a/packages/mariadb/mariadb.1.1.4/opam
+++ b/packages/mariadb/mariadb.1.1.4/opam
@@ -13,10 +13,6 @@ build: [
   [make]
 ]
 install: [make "install"]
-remove: [
-  ["ocamlfind" "remove" "mariadb"]
-  ["ocamlfind" "remove" "mariadb_bindings"]
-]
 depends: [
   "ocaml" {>= "4.07.0"}
   "ocamlfind" {build}
@@ -28,7 +24,6 @@ depexts: [
   ["libmariadb-dev"] {os-distribution = "debian"}
   ["libmariadb-dev"] {os-distribution = "ubuntu"}
 ]
-flags: light-uninstall
 url {
   src: "https://github.com/andrenth/ocaml-mariadb/archive/1.1.4.tar.gz"
   checksum: [

--- a/packages/mariadb/mariadb.1.1.4/opam
+++ b/packages/mariadb/mariadb.1.1.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Andre Nathan <andrenth@gmail.com>"
+authors: "Andre Nathan <andrenth@gmail.com>"
+homepage: "https://github.com/andrenth/ocaml-mariadb"
+bug-reports: "https://github.com/andrenth/ocaml-mariadb/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/andrenth/ocaml-mariadb.git"
+synopsis: "OCaml bindings for MariaDB"
+description: "OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its nonblocking API."
+
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "mariadb"]
+  ["ocamlfind" "remove" "mariadb_bindings"]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ctypes" {>= "0.7.0"}
+  "ctypes-foreign" {>= "0.4.0"}
+]
+depexts: [
+  ["libmariadb-dev"] {os-distribution = "debian"}
+  ["libmariadb-dev"] {os-distribution = "ubuntu"}
+]
+flags: light-uninstall
+url {
+  src: "https://github.com/andrenth/ocaml-mariadb/archive/1.1.4.tar.gz"
+  checksum: [
+    "md5=ffbce0267be1fa60df1f623eb72cb2a1"
+    "sha512=2ca1fd613abe060d21e95e265d7a1e2699a2b78918a940757fcf0925c0b6dabfeea655b17dfa12610f8a1d5fa475a69ba767cd4572391e21e34c95581407c37f"
+  ]
+}


### PR DESCRIPTION
### `mariadb.1.1.4`
OCaml bindings for MariaDB
OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its nonblocking API.



---
* Homepage: https://github.com/andrenth/ocaml-mariadb
* Source repo: git+https://github.com/andrenth/ocaml-mariadb.git
* Bug tracker: https://github.com/andrenth/ocaml-mariadb/issues

---
:camel: Pull-request generated by opam-publish v2.0.0