### PR TITLE
Package uint.2.0.0

### DIFF
--- a/packages/ocaml-zmq/ocaml-zmq.0/opam
+++ b/packages/ocaml-zmq/ocaml-zmq.0/opam
@@ -5,8 +5,13 @@ build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
-remove: [["ocamlfind" "remove" "ZMQ"]]
-depends: ["ocaml" "ocamlfind" "ounit" "uint"]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+  "ounit"
+  "uint" {< "2.0.0"}
+  "base-unsafe-string"
+]
 depexts: [
   ["libzmq3-dev"] {os-family = "debian"}
   ["zeromq-devel"] {os-distribution = "centos"}
@@ -15,7 +20,6 @@ depexts: [
 conflicts: ["zmq"]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml bindings for ZMQ 2.1"
-flags: light-uninstall
 url {
   src: "https://github.com/issuu/ocaml-zmq/tarball/67586823edd"
   checksum: "md5=32db494bfaaeb15ee536644090ee0b2b"

--- a/packages/uint/uint.2.0.0/opam
+++ b/packages/uint/uint.2.0.0/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "@doc" "-p" name ] {with-doc}
 ]
 depends: [
-  "dune" {build}
+  "dune" {>= "1.11"}
   "ocamlfind" {>= "1.5"}
   "ocaml" {>= "4.07.0"}
   "stdint" {>= "0.5.0"}

--- a/packages/uint/uint.2.0.0/opam
+++ b/packages/uint/uint.2.0.0/opam
@@ -17,6 +17,7 @@ depends: [
   "dune" {build}
   "ocamlfind" {>= "1.5"}
   "ocaml" {>= "4.07.0"}
+  "stdint" {>= "0.5.0"}
 ]
 url {
   src: "https://github.com/andrenth/ocaml-uint/archive/2.0.0.tar.gz"

--- a/packages/uint/uint.2.0.0/opam
+++ b/packages/uint/uint.2.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Andre Nathan <andre@digirati.com.br>"
+authors: [
+  "Andre Nathan <andre@digirati.com.br>"
+  "Jeff Shaw <shawjef3@msu.edu>"
+]
+license: "MIT"
+homepage: "https://github.com/andrenth/ocaml-uint"
+dev-repo: "git+https://github.com/andrenth/ocaml-uint.git"
+bug-reports: "https://github.com/andrenth/ocaml-uint/issues"
+synopsis: "Deprecated: An unsigned integer library"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+]
+depends: [
+  "dune" {build}
+  "ocamlfind" {>= "1.5"}
+  "ocaml" {>= "4.07.0"}
+]
+url {
+  src: "https://github.com/andrenth/ocaml-uint/archive/2.0.0.tar.gz"
+  checksum: [
+    "md5=b54e959aae09b2ed9b3e7bb54d1de5e7"
+    "sha512=fbb4057519138d0aea8e1af30e854d3c789ef867bd57175398b311c6579eecba6c5a1469e54ca63b67ebae1421f1b7848d95166192c3dd1478e8eeef0ce56c2b"
+  ]
+}

--- a/packages/zmq/zmq.3.2-0/opam
+++ b/packages/zmq/zmq.3.2-0/opam
@@ -6,12 +6,11 @@ build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
-remove: [["ocamlfind" "remove" "ZMQ"]]
 depends: [
   "ocaml"
-  "ocamlfind"
+  "ocamlfind" {build}
   "ounit"
-  "uint"
+  "uint" {< "2.0.0"}
   "oasis"
   "ocamlbuild" {build}
 ]
@@ -22,7 +21,6 @@ conflicts: ["ocaml-zmq"]
 dev-repo: "git://github.com/issuu/ocaml-zmq"
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml bindings for ZeroMQ 3.2"
-flags: light-uninstall
 url {
   src: "https://github.com/issuu/ocaml-zmq/archive/3.2-0.tar.gz"
   checksum: "md5=4728a8cc3475cf42bde10c0df503fe6f"

--- a/packages/zmq/zmq.3.2-1/opam
+++ b/packages/zmq/zmq.3.2-1/opam
@@ -6,13 +6,12 @@ build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
-remove: [["ocamlfind" "remove" "ZMQ"]]
 depends: [
   "ocaml"
-  "ocamlfind"
+  "ocamlfind" {build}
   "base-unix"
   "ounit"
-  "uint"
+  "uint" {< "2.0.0"}
   "oasis"
   "ocamlbuild" {build}
 ]
@@ -23,7 +22,6 @@ conflicts: ["ocaml-zmq"]
 dev-repo: "git://github.com/issuu/ocaml-zmq"
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml bindings for ZeroMQ 3.2"
-flags: light-uninstall
 url {
   src: "https://github.com/issuu/ocaml-zmq/archive/3.2-1.tar.gz"
   checksum: "md5=05f9d04dbb93b2c9ac07108aefb5f768"

--- a/packages/zmq/zmq.3.2-2/opam
+++ b/packages/zmq/zmq.3.2-2/opam
@@ -6,13 +6,12 @@ build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
-remove: [["ocamlfind" "remove" "ZMQ"]]
 depends: [
   "ocaml"
-  "ocamlfind"
+  "ocamlfind" {build}
   "base-unix"
   "ounit"
-  "uint"
+  "uint" {< "2.0.0"}
   "oasis"
   "ocamlbuild" {build}
 ]
@@ -23,7 +22,6 @@ conflicts: ["ocaml-zmq"]
 dev-repo: "git://github.com/issuu/ocaml-zmq"
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml bindings for ZeroMQ 3.2"
-flags: light-uninstall
 url {
   src: "https://github.com/issuu/ocaml-zmq/archive/3.2-2.tar.gz"
   checksum: "md5=e806e5507d41e3416be1a42b0a4a2098"


### PR DESCRIPTION
### `uint.2.0.0`
Deprecated: An unsigned integer library



---
* Homepage: https://github.com/andrenth/ocaml-uint
* Source repo: git+https://github.com/andrenth/ocaml-uint.git
* Bug tracker: https://github.com/andrenth/ocaml-uint/issues

---
:camel: Pull-request generated by opam-publish v2.0.0