### PR TITLE
[new release] capnp-rpc-lwt, capnp-rpc-mirage, capnp-rpc and capnp-rpc-unix (0.3.3)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.3/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.3/opam
@@ -29,7 +29,7 @@ depends: [
   "ptime"
   "asn1-combinators" {>= "0.2.0"}
   "x509" {>= "0.7.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.3/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.0.0"}
+  "capnp-rpc" {>= "0.3"}
+  "lwt"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "mirage-flow-lwt"
+  "tls" {>= "0.8.0"}
+  "mirage-kv-lwt"
+  "mirage-clock"
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "0.7.0"}
+  "dune" {build & >= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.3.3/capnp-rpc-v0.3.3.tbz"
+  checksum: [
+    "sha256=5a3277f970e25486d1acc5bdcfd4e42c049d680eee23521a20603904b887eef1"
+    "sha512=bcfe12cbd27bdaa13e3e3550b31083c5241f3006b9d38fd86fa0b3d6ee86ced0d7cd74755cc132843362e41ef2dd3b1546aee46a958e2bb12e66c199babbe80f"
+  ]
+}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.3/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp" {>= "3.1.0"}
+  "capnp-rpc-lwt" {>= "0.3"}
+  "astring"
+  "fmt"
+  "logs"
+  "arp-mirage"
+  "mirage-dns"
+  "mirage-stack-lwt"
+  "base64" {>= "3.0.0"}
+  "alcotest-lwt" {with-test}
+  "io-page-unix" {with-test}
+  "tcpip" {with-test}
+  "mirage-vnetif" {with-test}
+  "dune" {build & >= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.3.3/capnp-rpc-v0.3.3.tbz"
+  checksum: [
+    "sha256=5a3277f970e25486d1acc5bdcfd4e42c049d680eee23521a20603904b887eef1"
+    "sha512=bcfe12cbd27bdaa13e3e3550b31083c5241f3006b9d38fd86fa0b3d6ee86ced0d7cd74755cc132843362e41ef2dd3b1546aee46a958e2bb12e66c199babbe80f"
+  ]
+}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.3/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.3/opam
@@ -24,7 +24,7 @@ depends: [
   "io-page-unix" {with-test}
   "tcpip" {with-test}
   "mirage-vnetif" {with-test}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.3/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.3/opam
@@ -18,6 +18,7 @@ depends: [
   "astring"
   "fmt" {>= "0.8.4"}
   "logs"
+  "base64" {>= "3.0.0"}
   "dune" {build & >= "1.0"}
   "alcotest-lwt" {with-test & >= "0.8.0"}
 ]

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.3/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.3/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.4"}
   "logs"
   "base64" {>= "3.0.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "alcotest-lwt" {with-test & >= "0.8.0"}
 ]
 build: [

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.3/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp-rpc-lwt" {>= "0.3"}
+  "mirage-flow-unix"
+  "cmdliner"
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.4"}
+  "logs"
+  "dune" {build & >= "1.0"}
+  "alcotest-lwt" {with-test & >= "0.8.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.3.3/capnp-rpc-v0.3.3.tbz"
+  checksum: [
+    "sha256=5a3277f970e25486d1acc5bdcfd4e42c049d680eee23521a20603904b887eef1"
+    "sha512=bcfe12cbd27bdaa13e3e3550b31083c5241f3006b9d38fd86fa0b3d6ee86ced0d7cd74755cc132843362e41ef2dd3b1546aee46a958e2bb12e66c199babbe80f"
+  ]
+}

--- a/packages/capnp-rpc/capnp-rpc.0.1/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "uint"
+  "uint" {< "2.0.0"}
   "astring"
   "fmt"
   "logs"
@@ -19,6 +19,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "alcotest" {with-test}
   "afl-persistent" {with-test}
+  "capnp" {with-test & >= "3.3.0"}
 ]
 synopsis:
   "Cap'n Proto is a capability-based RPC system with bindings for many languages."

--- a/packages/capnp-rpc/capnp-rpc.0.2/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "uint"
+  "uint" {< "2.0.0"}
   "astring"
   "fmt"
   "logs"

--- a/packages/capnp-rpc/capnp-rpc.0.3.1/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.3.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "uint"
+  "uint" {< "2.0.0"}
   "astring"
   "fmt"
   "logs"

--- a/packages/capnp-rpc/capnp-rpc.0.3.2/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.3.2/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "uint"
+  "uint" {< "2.0.0"}
   "astring"
   "fmt"
   "logs"

--- a/packages/capnp-rpc/capnp-rpc.0.3.3/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.3.3/opam
@@ -18,7 +18,7 @@ depends: [
   "fmt"
   "logs"
   "asetmap"
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "alcotest" {with-test}
   "afl-persistent" {with-test}
 ]

--- a/packages/capnp-rpc/capnp-rpc.0.3.3/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.3.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "uint"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "dune" {build & >= "1.0"}
+  "alcotest" {with-test}
+  "afl-persistent" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.3.3/capnp-rpc-v0.3.3.tbz"
+  checksum: [
+    "sha256=5a3277f970e25486d1acc5bdcfd4e42c049d680eee23521a20603904b887eef1"
+    "sha512=bcfe12cbd27bdaa13e3e3550b31083c5241f3006b9d38fd86fa0b3d6ee86ced0d7cd74755cc132843362e41ef2dd3b1546aee46a958e2bb12e66c199babbe80f"
+  ]
+}

--- a/packages/capnp-rpc/capnp-rpc.0.3/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "uint"
+  "uint" {< "2.0.0"}
   "astring"
   "fmt"
   "logs"


### PR DESCRIPTION
CHANGES:

- Update uint.uint32 to uint (@Cjen1, mirage/capnp-rpc#159).
- Update to new x509 API (@talex5, mirage/capnp-rpc#158).
- Require base64 >= 3.0.0 for capnp-rpc-mirage too (@talex5, mirage/capnp-rpc#157).
- Put test sockets in temporary directory (@talex5, mirage/capnp-rpc#156).