### PR TITLE
Mark package namespaces as deprecated

### DIFF
--- a/packages/namespaces/namespaces.0.5.1/opam
+++ b/packages/namespaces/namespaces.0.5.1/opam
@@ -15,8 +15,10 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-synopsis: "Turn directories into OCaml modules"
+synopsis: "Turn directories into OCaml modules (deprecated)"
 description: """
+Deprecated in favor of the built-in mechanism in Dune.
+
 An Ocamlbuild plugin that turns directories tagged with "namespace" into a
 nested module hierarchy. Each directory becomes a module. Filenames become
 scoped, so you can have the same filename in multiple directories. So, if you


### PR DESCRIPTION
Follow-on to https://github.com/ocaml/opam-repository/pull/14737#issuecomment-525128746.

lwt_camlp4 and lwt_log are already marked.