### PR TITLE
Package uint.2.0.1

### DIFF
--- a/packages/uint/uint.2.0.1/opam
+++ b/packages/uint/uint.2.0.1/opam
@@ -11,11 +11,10 @@ bug-reports: "https://github.com/andrenth/ocaml-uint/issues"
 synopsis: "Deprecated: An unsigned integer library"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
   "dune" {>= "1.11"}
-  "ocamlfind" {>= "1.5"}
   "ocaml" {>= "4.07.0"}
   "stdint" {>= "0.5.0"}
 ]

--- a/packages/uint/uint.2.0.1/opam
+++ b/packages/uint/uint.2.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Andre Nathan <andre@digirati.com.br>"
+authors: [
+  "Andre Nathan <andre@digirati.com.br>"
+  "Jeff Shaw <shawjef3@msu.edu>"
+]
+license: "MIT"
+homepage: "https://github.com/andrenth/ocaml-uint"
+dev-repo: "git+https://github.com/andrenth/ocaml-uint.git"
+bug-reports: "https://github.com/andrenth/ocaml-uint/issues"
+synopsis: "Deprecated: An unsigned integer library"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+]
+depends: [
+  "dune" {>= "1.11"}
+  "ocamlfind" {>= "1.5"}
+  "ocaml" {>= "4.07.0"}
+  "stdint" {>= "0.5.0"}
+]
+url {
+  src: "https://github.com/andrenth/ocaml-uint/archive/2.0.1.tar.gz"
+  checksum: [
+    "md5=3cec2efa58139a94dbc74366281d8e38"
+    "sha512=6ecb73813b6636c631a1ea4aa8994f3285e8b5e22e35f33828534b05b1f6f9d54f1f38f822a3512e95bbdba92cc8ee98df472fcbeb9884aeeefc73c038d9084a"
+  ]
+}


### PR DESCRIPTION
### `uint.2.0.1`
Deprecated: An unsigned integer library



---
* Homepage: https://github.com/andrenth/ocaml-uint
* Source repo: git+https://github.com/andrenth/ocaml-uint.git
* Bug tracker: https://github.com/andrenth/ocaml-uint/issues

---
:camel: Pull-request generated by opam-publish v2.0.0