### PR TITLE
Package oseq.0.3

### DIFF
--- a/packages/oseq/oseq.0.3/opam
+++ b/packages/oseq/oseq.0.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis:
+  "Simple list of suspensions, as a composable lazy iterator that behaves like a value"
+description:
+  "Extends the new standard library's `Seq` module with many useful combinators."
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+license: "BSD-2-clauses"
+tags: ["sequence" "iterator" "seq" "pure" "list"]
+homepage: "https://github.com/c-cube/oseq/"
+doc: "https://c-cube.github.io/oseq/"
+bug-reports: "https://github.com/c-cube/oseq/issues"
+depends: [
+  "dune" {build}
+  "qcheck" {with-test}
+  "qtest" {with-test}
+  "gen" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+  "seq"
+]
+build: [
+  ["dune" "build" "-p" name]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/oseq.git"
+url {
+  src: "https://github.com/c-cube/oseq/archive/0.3.tar.gz"
+  checksum: [
+    "md5=67102af593f844217357a1c082d318ca"
+    "sha512=0f36b50cecf5f18df427a532fbe29851999574ea0a87f1e5b4c05332aab7a794c63237cee65ba90217ecdee131a1c118b8954d6fe610f60ba3e94c446b71b596"
+  ]
+}


### PR DESCRIPTION
### `oseq.0.3`
Simple list of suspensions, as a composable lazy iterator that behaves like a value
Extends the new standard library's `Seq` module with many useful combinators.



---
* Homepage: https://github.com/c-cube/oseq/
* Source repo: git+https://github.com/c-cube/oseq.git
* Bug tracker: https://github.com/c-cube/oseq/issues

---
:camel: Pull-request generated by opam-publish v2.0.0