### PR TITLE
Package oseq.0.3

### DIFF
--- a/packages/oseq/oseq.0.3/opam
+++ b/packages/oseq/oseq.0.3/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/c-cube/oseq/"
 doc: "https://c-cube.github.io/oseq/"
 bug-reports: "https://github.com/c-cube/oseq/issues"
 depends: [
-  "dune" {build}
+  "dune" {>= "1.0"}
   "qcheck" {with-test}
   "qtest" {with-test}
   "gen" {with-test}
@@ -20,9 +20,9 @@ depends: [
   "seq"
 ]
 build: [
-  ["dune" "build" "-p" name]
-  ["dune" "build" "@doc" "-p" name] {with-doc}
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/c-cube/oseq.git"
 url {

--- a/packages/oseq/oseq.0.3/opam
+++ b/packages/oseq/oseq.0.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis:
+  "Simple list of suspensions, as a composable lazy iterator that behaves like a value"
+description:
+  "Extends the new standard library's `Seq` module with many useful combinators."
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+license: "BSD-2-clauses"
+tags: ["sequence" "iterator" "seq" "pure" "list"]
+homepage: "https://github.com/c-cube/oseq/"
+doc: "https://c-cube.github.io/oseq/"
+bug-reports: "https://github.com/c-cube/oseq/issues"
+depends: [
+  "dune" {build}
+  "qcheck" {with-test}
+  "qtest" {with-test}
+  "gen" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+  "seq"
+]
+build: [
+  ["dune" "build" "-p" name]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/oseq.git"
+url {
+  src: "https://github.com/c-cube/oseq/archive/0.3.tar.gz"
+  checksum: [
+    "md5=ef0503fdbade1cb70186da5459af5c04"
+    "sha512=7b8c8128f275fbfd8be2e351b9993603701aa0175bd1b7f754911603b4fbd21972bc4e88a1e2814391d3db635a1f801257fe33ea738994567b5ceea3b92ae58b"
+  ]
+}


### PR DESCRIPTION
### `oseq.0.3`
Simple list of suspensions, as a composable lazy iterator that behaves like a value
Extends the new standard library's `Seq` module with many useful combinators.



---
* Homepage: https://github.com/c-cube/oseq/
* Source repo: git+https://github.com/c-cube/oseq.git
* Bug tracker: https://github.com/c-cube/oseq/issues

---
:camel: Pull-request generated by opam-publish v2.0.0