### PR TITLE
Fix travis when a test dependency is not available

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -58,7 +58,7 @@ function build_one {
   echo "build one: $pkg"
   # test for installability
   echo "Checking for availability..."
-  if ! opam install $pkg --dry-run; then
+  if ! opam install -t $pkg --dry-run; then
       echo "Package unavailable."
       if opam show $pkg; then
           echo "Package is unavailable on this configuration, skipping:"


### PR DESCRIPTION
This should fix Travis in the presence of packages not installable with their test dependencies