### PR TITLE
[new release] ocaml-version (2.3.0)

### DIFF
--- a/packages/ocaml-version/ocaml-version.2.3.0/opam
+++ b/packages/ocaml-version/ocaml-version.2.3.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/avsm/ocaml-version"
+doc: "https://avsm.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/avsm/ocaml-version/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune"
+  "result"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-version.git"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+Browse the [API documentation](http://anil-code.recoil.org/ocaml-version/ocaml-version/Ocaml_version/index.html) for more
+details.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/avsm/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+url {
+  src:
+    "https://github.com/avsm/ocaml-version/releases/download/v2.3.0/ocaml-version-v2.3.0.tbz"
+  checksum: [
+    "sha256=1682c775b03000d70f7f72e0331ad4a3fee465843b8399148dbd0cea220de130"
+    "sha512=094b33164c4c853e2389825ce6cafc064a0fd27dd6e9b014f42c55ff6c3e11169822fde73eb8d3ffbad0fcf015919c629463ec02b5daadf792fbe2b090f27ee4"
+  ]
+}


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/avsm/ocaml-version">https://github.com/avsm/ocaml-version</a>
- Documentation: <a href="https://avsm.github.io/ocaml-version/doc">https://avsm.github.io/ocaml-version/doc</a>

##### CHANGES:

* Support OCaml 4.02.3, which brings back a dependency on
  the `result` library.
