### PR TITLE
Package dolmen.0.4.1

### DIFF
--- a/packages/dolmen/dolmen.0.4.1/opam
+++ b/packages/dolmen/dolmen.0.4.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "guillaume.bury@gmail.com"
+license: "BSD-2-clauses"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "menhir" {>= "20151005"}
+  "dune" {build}
+]
+tags: [ "parser" "tptp" "logic" "smtlib" "dimacs" ]
+homepage: "https://github.com/Gbury/dolmen"
+doc: "http://gbury.github.io/dolmen"
+bug-reports: "https://github.com/Gbury/dolmen/issues"
+dev-repo: "git+https://github.com/Gbury/dolmen.git"
+authors: "Guillaume Bury"
+synopsis: "A parser library"
+description:
+"Dolmen is a parser library. It currently targets languages used in automated theorem provers,
+but may be extended ot other domains.
+
+Dolmen provides functors that takes as arguments a representation of terms and statements,
+and returns a module that can parse files (or streams of tokens) into the provided representation
+of terms or statements. This is meant so that Dolmen can be used as a drop-in replacement of existing
+parser, in order to factorize parsers among projects.
+
+Additionally, Dolmen also provides a standard implementation of terms and statements that cna be
+used ot instantiate its parsers."
+url {
+  src: "https://github.com/Gbury/dolmen/archive/v0.4.1.tar.gz"
+  checksum: [
+    "md5=55a97ff61dd8398e38570272ae7e3964"
+    "sha512=83f71037eb568d5449ff2d968cb50a0b105c9712e0bd29497d1f95683698f394860a11d4dee2a2a41163504e395ef068c3974901fca11894d671684fe438fc51"
+  ]
+}

--- a/packages/dolmen/dolmen.0.4.1/opam
+++ b/packages/dolmen/dolmen.0.4.1/opam
@@ -8,7 +8,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "menhir" {>= "20151005"}
-  "dune" {build}
+  "dune" {>= "1.5.0"}
 ]
 tags: [ "parser" "tptp" "logic" "smtlib" "dimacs" ]
 homepage: "https://github.com/Gbury/dolmen"


### PR DESCRIPTION
### `dolmen.0.4.1`
A parser library
Dolmen is a parser library. It currently targets languages used in automated theorem provers,
but may be extended ot other domains.

Dolmen provides functors that takes as arguments a representation of terms and statements,
and returns a module that can parse files (or streams of tokens) into the provided representation
of terms or statements. This is meant so that Dolmen can be used as a drop-in replacement of existing
parser, in order to factorize parsers among projects.

Additionally, Dolmen also provides a standard implementation of terms and statements that cna be
used ot instantiate its parsers.



---
* Homepage: https://github.com/Gbury/dolmen
* Source repo: git+https://github.com/Gbury/dolmen.git
* Bug tracker: https://github.com/Gbury/dolmen/issues

---
:camel: Pull-request generated by opam-publish v2.0.0