### PR TITLE
archsat.1.0: add missing lower bound on sequence

### DIFF
--- a/packages/archsat/archsat.1.0/opam
+++ b/packages/archsat/archsat.1.0/opam
@@ -45,7 +45,7 @@ depends: [
   "ocamlgraph"
   "gen"
   "mtime"
-  "sequence"
+  "sequence" {>= "0.5"}
   "spelll" { <= "0.2" }
   "uucp"
   "uutf"        { >= "1.0" }


### PR DESCRIPTION
Should fix the revdeps error in https://github.com/ocaml/opam-repository/pull/14767
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>