### PR TITLE
Package archsat.1.1

### DIFF
--- a/packages/archsat/archsat.1.1/opam
+++ b/packages/archsat/archsat.1.1/opam
@@ -19,19 +19,6 @@ install:[
     "SHAREDIR=%{archsat:share}%"
     "install_dk"] { dedukti:installed }
 ]
-remove: [
-  [make
-    "MANDIR=%{man}%"
-    "BINDIR=%{archsat:bin}%"
-    "SHAREDIR=%{archsat:share}%"
-    "uninstall"]
-  [make
-    "-C" "static"
-    "MANDIR=%{man}%"
-    "BINDIR=%{archsat:bin}%"
-    "SHAREDIR=%{archsat:share}%"
-    "uninstall"]
-]
 depends: [
   "ocaml"       { >= "4.07.0" }
   "ocamlfind"   { build }

--- a/packages/archsat/archsat.1.1/opam
+++ b/packages/archsat/archsat.1.1/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
+license: "BSD-2-clauses"
+build: [
+  [make "bin"]
+  [make "test"] { with-test }
+  [make "static"] { dedukti:installed }
+]
+install:[
+  [make
+    "MANDIR=%{man}%"
+    "BINDIR=%{archsat:bin}%"
+    "SHAREDIR=%{archsat:share}%"
+    "install"]
+  [make
+    "-C" "static"
+    "MANDIR=%{man}%"
+    "BINDIR=%{archsat:bin}%"
+    "SHAREDIR=%{archsat:share}%"
+    "install_dk"] { dedukti:installed }
+]
+remove: [
+  [make
+    "MANDIR=%{man}%"
+    "BINDIR=%{archsat:bin}%"
+    "SHAREDIR=%{archsat:share}%"
+    "uninstall"]
+  [make
+    "-C" "static"
+    "MANDIR=%{man}%"
+    "BINDIR=%{archsat:bin}%"
+    "SHAREDIR=%{archsat:share}%"
+    "uninstall"]
+]
+depends: [
+  "ocaml"       { >= "4.07.0" }
+  "ocamlfind"   { build }
+  "ocamlbuild"  { build }
+  "qcheck"      { with-test & >= "0.8" }
+  "dolmen"      { >= "0.4" }
+  "msat"        { >= "0.7" & < "0.8" }
+  "containers"  { >= "2.0" }
+  "cmdliner"    { >= "0.9.8" }
+  "zarith"
+  "ocamlgraph"
+  "gen"
+  "mtime"
+  "iter"        { >= "0.5" }
+  "spelll"      { >= "0.3" }
+  "uucp"
+  "uutf"        { >= "1.0" }
+]
+depopts: [
+  "dedukti"
+]
+tags: [ "sat" "smt" "solver" "theorem prover" "tptp" "logic" "smtlib" "dimacs" ]
+homepage: "https://gforge.inria.fr/projects/archsat/"
+dev-repo: "git+https://scm.gforge.inria.fr/anonscm/git/archsat/archsat.git"
+bug-reports: "https://gforge.inria.fr/tracker/?atid=14153&group_id=7473"
+synopsis: "A first-order theorem prover with formal proof output"
+description:
+"Archsat is an experimental SMT/McSat solver, aimed at solving first-order problems.
+Archsat integrates Tableau theory, superposition, and Rewriting into an McSat core.
+
+Archsat currently features builtin support for equality, uninterpreted functions
+and predicates, as well as rewriting. Additionally, whenever it finds a proof, it is
+able to export that proof to various formal proof formats: coq proof script, coq proof term,
+dedukti proof term.
+"
+authors: "Guillaume Bury"
+url {
+  src: "https://github.com/Gbury/archsat/archive/v1.1.tar.gz"
+  checksum: [
+    "md5=14a97e6f88adc863d2f208b5563209f6"
+    "sha512=d1a2aa3b29de82b9954f926ef8771d391e5028c254b8a63d6ca7472cc063becd6adca2056f9599e6ae176d2364a0efeed082858a97cd6bcb1ebbb818d2ffba7b"
+  ]
+}


### PR DESCRIPTION
### `archsat.1.1`
A first-order theorem prover with formal proof output
Archsat is an experimental SMT/McSat solver, aimed at solving first-order problems.
Archsat integrates Tableau theory, superposition, and Rewriting into an McSat core.

Archsat currently features builtin support for equality, uninterpreted functions
and predicates, as well as rewriting. Additionally, whenever it finds a proof, it is
able to export that proof to various formal proof formats: coq proof script, coq proof term,
dedukti proof term.



---
* Homepage: https://gforge.inria.fr/projects/archsat/
* Source repo: git+https://scm.gforge.inria.fr/anonscm/git/archsat/archsat.git
* Bug tracker: https://gforge.inria.fr/tracker/?atid=14153&group_id=7473

---
:camel: Pull-request generated by opam-publish v2.0.0