### PR TITLE
Packages chartjs.0.2.2, chartjs-annotation.0.2.2, chartjs-colorschemes.0.2.2, chartjs-datalabels.0.2.2 and chartjs-streaming.0.2.2

### DIFF
--- a/packages/chartjs-annotation/chartjs-annotation.0.2.1/opam
+++ b/packages/chartjs-annotation/chartjs-annotation.0.2.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "sashayanin@gmail.com"
+authors: ["Alexander Yanin"]
+homepage: "https://github.com/monstasat/chartjs-ocaml"
+dev-repo: "git+https://github.com/monstasat/chartjs-ocaml.git"
+bug-reports: "https://github.com/monstasat/chartjs-ocaml/issues"
+license: "MIT"
+        
+synopsis: "OCaml bindigns for Chart.js annotation plugin"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
+  "chartjs"
+]

--- a/packages/chartjs-colorschemes/chartjs-colorschemes.0.2.1/opam
+++ b/packages/chartjs-colorschemes/chartjs-colorschemes.0.2.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "sashayanin@gmail.com"
+authors: ["Alexander Yanin"]
+homepage: "https://github.com/monstasat/chartjs-ocaml"
+dev-repo: "git+https://github.com/monstasat/chartjs-ocaml.git"
+bug-reports: "https://github.com/monstasat/chartjs-ocaml/issues"
+license: "MIT"
+synopsis: "OCaml bindigns for Chart.js colorschemes plugin"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
+  "chartjs"
+]

--- a/packages/chartjs-datalabels/chartjs-datalabels.0.2.1/opam
+++ b/packages/chartjs-datalabels/chartjs-datalabels.0.2.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "sashayanin@gmail.com"
+authors: ["Alexander Yanin"]
+homepage: "https://github.com/monstasat/chartjs-ocaml"
+dev-repo: "git+https://github.com/monstasat/chartjs-ocaml.git"
+bug-reports: "https://github.com/monstasat/chartjs-ocaml/issues"
+license: "MIT"
+synopsis: "OCaml bindigns for Chart.js datalabels plugin"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
+  "chartjs"
+]

--- a/packages/chartjs-streaming/chartjs-streaming.0.2.1/opam
+++ b/packages/chartjs-streaming/chartjs-streaming.0.2.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "sashayanin@gmail.com"
+authors: ["Alexander Yanin"]
+homepage: "https://github.com/monstasat/chartjs-ocaml"
+dev-repo: "git+https://github.com/monstasat/chartjs-ocaml.git"
+bug-reports: "https://github.com/monstasat/chartjs-ocaml/issues"
+license: "MIT"
+synopsis: "OCaml bindings for Chart.js streaming plugin"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
+  "chartjs"
+]

--- a/packages/chartjs/chartjs.0.2.1/opam
+++ b/packages/chartjs/chartjs.0.2.1/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "sashayanin@gmail.com"
+authors: ["Alexander Yanin"]
+homepage: "https://github.com/monstasat/chartjs-ocaml"
+dev-repo: "git+https://github.com/monstasat/chartjs-ocaml.git"
+bug-reports: "https://github.com/monstasat/chartjs-ocaml/issues"
+license: "MIT"
+synopsis: "OCaml bindings for Chart.js"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
+]


### PR DESCRIPTION
This pull-request concerns:
-`chartjs.0.2.1`: OCaml bindings for Chart.js
-`chartjs-annotation.0.2.1`: OCaml bindigns for Chart.js annotation plugin
-`chartjs-colorschemes.0.2.1`: OCaml bindigns for Chart.js colorschemes plugin
-`chartjs-datalabels.0.2.1`: OCaml bindigns for Chart.js datalabels plugin
-`chartjs-streaming.0.2.1`: OCaml bindings for Chart.js streaming plugin



---
* Homepage: https://github.com/monstasat/chartjs-ocaml
* Source repo: git+https://github.com/monstasat/chartjs-ocaml.git
* Bug tracker: https://github.com/monstasat/chartjs-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0