### PR TITLE
Package janus-js.dev

### DIFF
--- a/packages/janus-js/janus-js.dev/opam
+++ b/packages/janus-js/janus-js.dev/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+maintainer: "sashayanin@gmail.com"
+authors: "Alexander Yanin"
+homepage: "https://github.com/monstasat/janus-ocaml"
+dev-repo: "git+https://github.com/monstasat/janus-ocaml.git"
+bug-reports: "https://github.com/monstasat/janus-ocaml/issues"
+license: "MIT"
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {build}
+  "js_of_ocaml" {>= "3.3.0"}
+  "js_of_ocaml-lwt"
+]
+
+synopsis: "Library for Janus WebRTC server manipulation from browser"


### PR DESCRIPTION
### `janus-js.dev`
Library for Janus WebRTC server manipulation from browser



---
* Homepage: https://github.com/monstasat/janus-ocaml
* Source repo: git+https://github.com/monstasat/janus-ocaml.git
* Bug tracker: https://github.com/monstasat/janus-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0