### PR TITLE
Add General.0.7.0

### DIFF
--- a/packages/General/General.0.7.0/opam
+++ b/packages/General/General.0.7.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Rich functionality for built-in and basic OCaml types"
+maintainer: "Vincent Jacques <vincent@vincent-jacques.net>"
+authors: "Vincent Jacques <vincent@vincent-jacques.net>"
+license: "MIT"
+homepage: "https://jacquev6.github.io/General/"
+doc: "https://jacquev6.github.io/General/"
+bug-reports: "http://github.com/jacquev6/General/issues/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "cppo" {build & >= "1.3.0"}
+  "num"
+  "js_of_ocaml-compiler" {with-test}
+  "conf-npm" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/jacquev6/General.git"
+url {
+  src: "https://github.com/jacquev6/General/archive/0.7.0.tar.gz"
+  checksum: "md5=168ab930a45d0210a949bc221d8dd39d"
+}

--- a/packages/General/General.0.7.0/opam
+++ b/packages/General/General.0.7.0/opam
@@ -8,7 +8,7 @@ doc: "https://jacquev6.github.io/General/"
 bug-reports: "http://github.com/jacquev6/General/issues/"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build}
+  "dune"
   "cppo" {build & >= "1.3.0"}
   "num"
   "js_of_ocaml-compiler" {with-test}


### PR DESCRIPTION
`General.0.6.0` was not compatible with OCaml 4.08 (#13895). `General.0.7.0` is :-)