### PR TITLE
Tag various packages incompatible with OCaml >= 4.08 (Dynlink change)

### DIFF
--- a/packages/deriving-yojson/deriving-yojson.0.2/opam
+++ b/packages/deriving-yojson/deriving-yojson.0.2/opam
@@ -12,13 +12,12 @@ remove: [
   ["ocamlfind" "remove" "deriving-yojson"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "deriving"
   "oasis"
   "ocamlfind"
   "yojson"
   "ocamlbuild" {build}
-  "camlp4" {< "4.08"}
 ]
 dev-repo: "git://github.com/hhugo/deriving-yojson"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/deriving-yojson/deriving-yojson.0.3.1/opam
+++ b/packages/deriving-yojson/deriving-yojson.0.3.1/opam
@@ -12,13 +12,12 @@ remove: [
   ["ocamlfind" "remove" "deriving-yojson"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "deriving"
   "oasis"
   "ocamlfind"
   "yojson"
   "ocamlbuild" {build}
-  "camlp4" {< "4.08"}
 ]
 dev-repo: "git://github.com/hhugo/deriving-yojson"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/deriving-yojson/deriving-yojson.0.3/opam
+++ b/packages/deriving-yojson/deriving-yojson.0.3/opam
@@ -12,13 +12,12 @@ remove: [
   ["ocamlfind" "remove" "deriving-yojson"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "deriving"
   "oasis"
   "ocamlfind"
   "yojson"
   "ocamlbuild" {build}
-  "camlp4" {< "4.08"}
 ]
 dev-repo: "git://github.com/hhugo/deriving-yojson"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/sqlgg/sqlgg.0.2.4/opam
+++ b/packages/sqlgg/sqlgg.0.2.4/opam
@@ -3,14 +3,13 @@ maintainer: "ygrek@autistici.org"
 homepage: "http://ygrek.org.ua/p/sqlgg/"
 build: [[make "-C" "src"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind"
   "menhir"
   "deriving"
   ("extlib" | "extlib-compat")
   "ounit" {< "2.0.0"}
   "ocamlbuild" {build}
-  "camlp4" {< "4.08"}
 ]
 synopsis: "SQL Guided (code) Generator"
 description: """

--- a/packages/sqlgg/sqlgg.0.2.5/opam
+++ b/packages/sqlgg/sqlgg.0.2.5/opam
@@ -3,14 +3,13 @@ maintainer: "ygrek@autistici.org"
 homepage: "http://ygrek.org.ua/p/sqlgg/"
 build: [[make "-C" "src"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind"
   "menhir"
   "deriving"
   ("extlib" | "extlib-compat")
   "ounit"
   "ocamlbuild" {build}
-  "camlp4" {< "4.08"}
 ]
 synopsis: "SQL Guided (code) Generator"
 description: """

--- a/packages/sqlgg/sqlgg.0.3.0/opam
+++ b/packages/sqlgg/sqlgg.0.3.0/opam
@@ -12,14 +12,13 @@ remove: [
   ["rm" "-f" "%{bin}%/sqlgg" "%{bin}%/sqlgg.exe"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "ocamlfind"
   "menhir"
   "deriving"
   ("extlib" | "extlib-compat")
   "ounit"
   "ocamlbuild" {build}
-  "camlp4" {< "4.08"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "SQL Guided (code) Generator"

--- a/packages/sqlgg/sqlgg.0.4.3/opam
+++ b/packages/sqlgg/sqlgg.0.4.3/opam
@@ -28,7 +28,7 @@ remove: [
   ["rm" "-f" "%{bin}%/sqlgg" "%{bin}%/sqlgg.exe"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "mybuild" {build}
@@ -37,7 +37,6 @@ depends: [
   ("extlib" | "extlib-compat")
   "base-unix"
   "ounit"
-  "camlp4" {< "4.08"}
 ]
 depopts: [
   "mysql"

--- a/packages/webdav/webdav.1.1.5/opam
+++ b/packages/webdav/webdav.1.1.5/opam
@@ -9,7 +9,7 @@ build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "webdav"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "omake" {build}
   "ocamlnet" {>= "4.1.0"}


### PR DESCRIPTION
As per this comment (https://github.com/ocaml/opam-repository/pull/14766#issuecomment-527347072), some packages fail due to a change in the compiler (and not from camlp4). Those packages have to be fixed accordingly.

cc @gerdstolpmann for `webdav`. Your package still relies on `camlp4` and is not going to be maintained any further. The latest version of OCaml, webdav is compatible with is currently 4.07.