### PR TITLE
Prepare split of `ppx_yojson_conv`

### DIFF
--- a/packages/ppx_yojson_conv/ppx_yojson_conv.v0.12.0/opam
+++ b/packages/ppx_yojson_conv/ppx_yojson_conv.v0.12.0/opam
@@ -16,6 +16,9 @@ depends: [
   "ppxlib"   {>= "0.7.0" & < "0.9.0"}
   "yojson"   {>= "1.7.0"}
 ]
+conflicts:[
+  "ppx_yojson_conv_lib"
+]
 synopsis: "[@@deriving] plugin to generate Yojson conversion functions"
 description: "
 Part of the Jane Street's PPX rewriters collection.


### PR DESCRIPTION
`ppx_yojson_conv_lib` is about to be released as a standalone package,
so that it can be used by other projects without inheriting all the dependencies
of `ppx_yojson_conv`. Future versions of `ppx_yojson_conv` will depend
on `ppx_yojson_conv_lib`, but old versions are not co-installable with the
upcoming package.

cc @trefis, who did the split