### PR TITLE
Make unavailable uninstallable old versions

### DIFF
--- a/packages/lablqml/lablqml.0.5/opam
+++ b/packages/lablqml/lablqml.0.5/opam
@@ -6,6 +6,8 @@ bug-reports:  "https://github.com/kakadu/lablqml/issues"
 dev-repo: "git+https://github.com/Kakadu/lablqml.git"
 tags: [ "gui" "ui" "qt" ]
 
+available: [false]
+
 build: [
   ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH ./configure"] {os-distribution = "alpine"}
   ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH make"]        {os-distribution = "alpine"}

--- a/packages/lablqt/lablqt.0.2/opam
+++ b/packages/lablqt/lablqt.0.2/opam
@@ -4,6 +4,9 @@ authors:      "kakadu.hafanana@gmail.com"
 homepage:     "http://kakadu.github.io/lablqt/"
 bug-reports:  "https://github.com/kakadu/lablqt/issues"
 dev-repo: "git+https://github.com/Kakadu/lablqt.git"
+
+available: [false]
+
 build: [
   ["./configure"]
   [make "generator"]
@@ -24,7 +27,7 @@ depends: [
   "conf-qt" {>= "5.2"}
   "ocamlbuild" {build}
 ]
-synopsis: "Tool for interfacing QtQuick with OCaml."
+synopsis: "Tool for interfacing QtQuick with OCaml"
 description: "Versions <= 0.4 are known as `lablqt`, >0.5 -- as `lablqml`."
 flags: light-uninstall
 url {


### PR DESCRIPTION
They don't have reverse dependencies so it is safe.

Discussed at https://discuss.ocaml.org/t/question-when-it-is-ok-to-remove-some-packages-versions-from-opam/4321