### PR TITLE
Package ocsigen-start.2.4.0

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.2.4.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.4.0/opam
@@ -27,14 +27,7 @@ depends: [
   "lwt_camlp4"
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
+  ["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {

--- a/packages/ocsigen-start/ocsigen-start.2.4.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.4.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+authors: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"
+description: "Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom). It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users. Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management. This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users. The goal is to enable the programmer to concentrate on the core of the app, and not on user management."
+homepage: "https://ocsigen.org/ocsigen-start/"
+bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "pgocaml" {>= "3.1"}
+  "macaque" {>= "0.7.4"}
+  "safepass" {>= "3.0"}
+  "ocsigen-i18n" {>= "3.1.0"}
+  "eliom" {>= "6.4.0"}
+  "ocsigen-toolkit" {>= "2.3.1"}
+  "js_of_ocaml" {>= "3.4.0"}
+  "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "yojson" {>= "1.4.1"}
+  "resource-pooling" {>= "0.5.2"}
+  "cohttp-lwt-unix"
+  "conf-npm" {>= "1"}
+  "ocamlnet"
+  "lwt_camlp4"
+]
+depexts: [
+  ["imagemagick"] {os-distribution = "debian"}
+  ["ruby-sass"] {os-distribution = "debian"}
+  ["postgresql"] {os-distribution = "debian"}
+  ["postgresql-common"] {os-distribution = "debian"}
+  ["imagemagick"] {os-distribution = "ubuntu"}
+  ["ruby-sass"] {os-distribution = "ubuntu"}
+  ["postgresql"] {os-distribution = "ubuntu"}
+  ["postgresql-common"] {os-distribution = "ubuntu"}
+  ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
+]
+url {
+  src: "https://github.com/jrochel/ocsigen-start/archive/2.4.0.tar.gz"
+  checksum: [
+    "md5=d06baef4915ae084235ef0dea5201dc1"
+    "sha512=a3935112cb37e84acc2b2fb6d75ab11a31acc25ead694afe26cf28b2b95ca2046d665e195ff2902457fdb0e5a6449d7b4f3b7be3108bfdb76be4ed5477aeee73"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-start.2.4.0`
An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc
Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom). It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users. Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management. This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users. The goal is to enable the programmer to concentrate on the core of the app, and not on user management.



---
* Homepage: https://ocsigen.org/ocsigen-start/
* Source repo: git+https://github.com/ocsigen/ocsigen-start.git
* Bug tracker: https://github.com/ocsigen/ocsigen-start/issues

---
:camel: Pull-request generated by opam-publish v2.0.0