### PR TITLE
Tag some packages as accepting CI failures on Debian Sid

### DIFF
--- a/packages/aacplus/aacplus.0.2.1/opam
+++ b/packages/aacplus/aacplus.0.2.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["libaacplus"] {os-distribution = "gentoo"}
   ["libaacplus"] {os = "freebsd"}
 ]
+x-ci-accept-failures: ["debian-unstable"]
 install: [make "install"]
 synopsis:
   "Bindings for the aacplus library which provides functions for decoding AAC audio files"

--- a/packages/aacplus/aacplus.0.2.2/opam
+++ b/packages/aacplus/aacplus.0.2.2/opam
@@ -16,6 +16,7 @@ depexts: [
   ["libaacplus"] {os-distribution = "gentoo"}
   ["libaacplus"] {os = "freebsd"}
 ]
+x-ci-accept-failures: ["debian-unstable"]
 bug-reports: "https://github.com/savonet/ocaml-aacplus/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-aacplus.git"
 synopsis:

--- a/packages/ahrocksdb/ahrocksdb.0.2.0/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.0/opam
@@ -40,6 +40,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest"] {with-test}
 ]
+x-ci-accept-failures: ["debian-unstable"]
 dev-repo: "git+https://github.com/ahrefs/ocaml-ahrocksdb.git"
 url {
   src:

--- a/packages/ahrocksdb/ahrocksdb.0.2.1/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.1/opam
@@ -38,6 +38,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest"] {with-test}
 ]
+x-ci-accept-failures: ["debian-unstable"]
 dev-repo: "git+https://github.com/ahrefs/ocaml-ahrocksdb.git"
 url {
   src:

--- a/packages/conf-ida/conf-ida.0.1/opam
+++ b/packages/conf-ida/conf-ida.0.1/opam
@@ -17,6 +17,7 @@ depends: [
 ]
 substs: [ "find-ida.ml" ]
 flags: [ conf ]
+x-ci-accept-failures: ["debian-unstable"]
 
 synopsis: "Checks that IDA Pro is installed"
 description: """

--- a/packages/conf-ida/conf-ida.0.2/opam
+++ b/packages/conf-ida/conf-ida.0.2/opam
@@ -17,6 +17,7 @@ depends: [
 ]
 substs: [ "find-ida.ml" ]
 flags: [ conf ]
+x-ci-accept-failures: ["debian-unstable"]
 
 synopsis: "Checks that IDA Pro is installed"
 description: """

--- a/packages/hdfs/hdfs.0.1/opam
+++ b/packages/hdfs/hdfs.0.1/opam
@@ -24,6 +24,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.5"}
 ]
+x-ci-accept-failures: ["debian-unstable"]
 post-messages: [
   "
   This package depends on C compiler being able to find libhdfs header and library files.

--- a/packages/hdfs/hdfs.0.2/opam
+++ b/packages/hdfs/hdfs.0.2/opam
@@ -24,6 +24,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.5"}
 ]
+x-ci-accept-failures: ["debian-unstable"]
 post-messages: [
   "
   This package depends on C compiler being able to find libhdfs header and library files.

--- a/packages/ocamlyices/ocamlyices.0.7.0/opam
+++ b/packages/ocamlyices/ocamlyices.0.7.0/opam
@@ -8,6 +8,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "ocamlyices"]]
 depends: ["ocaml" "ocamlfind" "camlidl" "num"]
+x-ci-accept-failures: ["debian-unstable"]
 dev-repo: "git://github.com/polazarus/ocamlyices"
 install: [make "install"]
 synopsis: "Yices SMT solver binding"

--- a/packages/ocamlyices/ocamlyices.0.7.1/opam
+++ b/packages/ocamlyices/ocamlyices.0.7.1/opam
@@ -8,6 +8,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "ocamlyices"]]
 depends: ["ocaml" "ocamlfind" "camlidl" "num"]
+x-ci-accept-failures: ["debian-unstable"]
 dev-repo: "git://github.com/polazarus/ocamlyices"
 install: [make "install"]
 synopsis: "Yices SMT solver binding"

--- a/packages/proj4/proj4.0.9.1/opam
+++ b/packages/proj4/proj4.0.9.1/opam
@@ -20,6 +20,7 @@ depends: [
 depexts: [
   ["libproj-dev"] {os-family = "debian"}
 ]
+x-ci-accept-failures: ["debian-unstable"]
 dev-repo: "git://github.com/hcarty/proj4ml"
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Bindings to the PROJ.4 projection library"

--- a/packages/proj4/proj4.0.9.2/opam
+++ b/packages/proj4/proj4.0.9.2/opam
@@ -20,6 +20,7 @@ depends: [
 depexts: [
   ["libproj-dev"] {os-family = "debian"}
 ]
+x-ci-accept-failures: ["debian-unstable"]
 dev-repo: "git://github.com/hcarty/proj4ml"
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Bindings to the PROJ.4 projection library"

--- a/packages/srs/srs.1.0.0/opam
+++ b/packages/srs/srs.1.0.0/opam
@@ -10,6 +10,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
+x-ci-accept-failures: ["debian-unstable"]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml bindings for libsrs2"
 flags: light-uninstall

--- a/packages/srs/srs.2.0.0/opam
+++ b/packages/srs/srs.2.0.0/opam
@@ -10,6 +10,7 @@ depends: [
   "ocaml"
   "jbuilder" {build}
 ]
+x-ci-accept-failures: ["debian-unstable"]
 synopsis: "OCaml bindings for libsrs2"
 description: "OCaml-SRS provides C bindings to libsrs2 for OCaml"
 url {

--- a/packages/wiringpi/wiringpi.0.0.1/opam
+++ b/packages/wiringpi/wiringpi.0.0.1/opam
@@ -14,6 +14,7 @@ depends: [
   "ocamlfind"
   "ocamlbuild" {build}
 ]
+x-ci-accept-failures: ["debian-unstable"]
 post-messages: [
   "
   This package requires WiringPi development files installed.


### PR DESCRIPTION
Some packages will always fail in CI because either they need some specific version of a package or because some external dependency is not installable in the CI.

My proposal (implemented in `opam-health-check` via the following two commits: https://github.com/kit-ty-kate/opam-health-check/commit/721699fe2beddcce21c830071f2ab25bbda4176c https://github.com/kit-ty-kate/opam-health-check/commit/3462fa92818e8d20151748712101f38f6050e345), is to tag the irredeemable packages to accept the failures, changing them from an hard failure to an internal failure. This change simplifies and cleans the view in [ci.ocamllabs.io](http://check.ocamllabs.io) and allows us to see which packages really fail. `opam-health-check` only uses Debian Sid so that's why only debian-sid is tagged.

For now this is only a handful of packages because checking whether or not the failure can be skipped is a time consuming process in some cases but I'll add more of them in the future.

Does anyone have any thoughts on this? cc @mseri @avsm @dra27 @samoht @AltGr @rjbou @hannesm 