### PR TITLE
Fix some old warnings 24

### DIFF
--- a/packages/ocp-indent/ocp-indent.0.1.0/opam
+++ b/packages/ocp-indent/ocp-indent.0.1.0/opam
@@ -20,3 +20,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/0.1.0.tar.gz"
   checksum: "md5=d8f4050700a12f77c0d157ac931cac5f"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.0.6.0/opam
+++ b/packages/ocp-indent/ocp-indent.0.6.0/opam
@@ -22,3 +22,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/0.6.0.tar.gz"
   checksum: "md5=4727770e9ff7f85974fcacd53a3fe4fb"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.0.6.1/opam
+++ b/packages/ocp-indent/ocp-indent.0.6.1/opam
@@ -25,3 +25,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/0.6.1.tar.gz"
   checksum: "md5=daa738345f34eaa433e31112a7ff77b1"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.0.6.2/opam
+++ b/packages/ocp-indent/ocp-indent.0.6.2/opam
@@ -22,3 +22,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/0.6.2.tar.gz"
   checksum: "md5=05c597215d3cf44c48a0136e2baa1d67"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.0.9.0/opam
+++ b/packages/ocp-indent/ocp-indent.0.9.0/opam
@@ -23,3 +23,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/0.9.0.tar.gz"
   checksum: "md5=054542583c9a1f1d5a9bea4d66109813"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.0.9.2/opam
+++ b/packages/ocp-indent/ocp-indent.0.9.2/opam
@@ -21,3 +21,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/0.9.2.tar.gz"
   checksum: "md5=181a410fdc6645acf63df2513f9a7ab3"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.1.0.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.0.0/opam
@@ -23,3 +23,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/1.0.0.tar.gz"
   checksum: "md5=44689a88b81b7f36541e280c6dc53327"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.1.0.1/opam
+++ b/packages/ocp-indent/ocp-indent.1.0.1/opam
@@ -25,3 +25,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/1.0.1.tar.gz"
   checksum: "md5=69da0934353b8b1263d46d92cb68de1a"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.1.0.2/opam
+++ b/packages/ocp-indent/ocp-indent.1.0.2/opam
@@ -21,3 +21,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/1.0.2.tar.gz"
   checksum: "md5=88ecedbc240c9d34bd13381ec1c45807"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.1.1.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.1.0/opam
@@ -21,3 +21,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/1.1.0.tar.gz"
   checksum: "md5=11160a54f9f3e1a73f8ef141015ba79d"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.1.2.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.2.0/opam
@@ -25,3 +25,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/1.2.0.tar.gz"
   checksum: "md5=f9ba5ac9099a5b3a7f90af9ecf557e00"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.1.2.1/opam
+++ b/packages/ocp-indent/ocp-indent.1.2.1/opam
@@ -23,3 +23,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/1.2.1.tar.gz"
   checksum: "md5=c402edc8f91a6f0535f605d1e0fefe16"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.1.2.2/opam
+++ b/packages/ocp-indent/ocp-indent.1.2.2/opam
@@ -23,3 +23,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/1.2.2.tar.gz"
   checksum: "md5=1069e54f8f2ef9f4f9cc40605ceb4825"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.1.3.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.3.0/opam
@@ -23,3 +23,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/1.3.0.tar.gz"
   checksum: "md5=506c9f461b954d1df561c10588a50e85"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.1.3.1/opam
+++ b/packages/ocp-indent/ocp-indent.1.3.1/opam
@@ -23,3 +23,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/1.3.1.tar.gz"
   checksum: "md5=c26e582072e555b6cd9a741157c78205"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.1.3.2/opam
+++ b/packages/ocp-indent/ocp-indent.1.3.2/opam
@@ -23,3 +23,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/1.3.2.tar.gz"
   checksum: "md5=2cbf6c2615e75fd6f963db35004a3f61"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-indent/ocp-indent.1.4.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.4.0/opam
@@ -38,3 +38,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-indent/archive/1.4.0.tar.gz"
   checksum: "md5=f447438ce86c3456110e0f07633758d1"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-index/ocp-index.0.1.0/opam
+++ b/packages/ocp-index/ocp-index.0.1.0/opam
@@ -26,3 +26,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-index/archive/0.1.0.tar.gz"
   checksum: "md5=c10966ef3847bc24c898741eafd467e5"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-index/ocp-index.0.2.0/opam
+++ b/packages/ocp-index/ocp-index.0.2.0/opam
@@ -26,3 +26,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-index/archive/0.2.0.tar.gz"
   checksum: "md5=b198abbebceb256c611dd4ccb22e82f3"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-index/ocp-index.0.3.0/opam
+++ b/packages/ocp-index/ocp-index.0.3.0/opam
@@ -27,3 +27,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-index/archive/0.3.0.tar.gz"
   checksum: "md5=04c932570f1d43f3a780edc2d532aa8c"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-index/ocp-index.1.0.0/opam
+++ b/packages/ocp-index/ocp-index.1.0.0/opam
@@ -43,3 +43,4 @@ url {
   src: "https://github.com/OCamlPro/ocp-index/archive/1.0.0.tar.gz"
   checksum: "md5=4dca1473e9f88542321565d2ecd50599"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocp-pack-split/ocp-pack-split.1.0.1/opam
+++ b/packages/ocp-pack-split/ocp-pack-split.1.0.1/opam
@@ -17,3 +17,4 @@ url {
   src: "http://www.ocamlpro.com//files/ocp-pack-1.0.1.tar.gz"
   checksum: "md5=9122bc296089330db082965152164ce7"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocplib-endian/ocplib-endian.0.2/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.2/opam
@@ -26,3 +26,4 @@ url {
   src: "https://github.com/OCamlPro/ocplib-endian/archive/0.2.tar.gz"
   checksum: "md5=0b298747d03b8f5751107705cab0d9f2"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocplib-endian/ocplib-endian.0.3/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.3/opam
@@ -26,3 +26,4 @@ url {
   src: "https://github.com/OCamlPro/ocplib-endian/archive/0.3.tar.gz"
   checksum: "md5=28ad3fd680a59e3341d68315bc7b79a3"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocplib-endian/ocplib-endian.0.4/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.4/opam
@@ -26,3 +26,4 @@ url {
   src: "https://github.com/OCamlPro/ocplib-endian/archive/0.4.tar.gz"
   checksum: "md5=58d84c036a92d2e327ac8ad8dfe775d8"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocplib-endian/ocplib-endian.0.6/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.6/opam
@@ -28,3 +28,4 @@ url {
   src: "https://github.com/OCamlPro/ocplib-endian/archive/0.6.tar.gz"
   checksum: "md5=e8a3bab148db6fe46b17796900228209"
 }
+tags: ["org:ocamlpro"]

--- a/packages/ocplib-endian/ocplib-endian.0.7/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.7/opam
@@ -28,3 +28,4 @@ url {
   src: "https://github.com/OCamlPro/ocplib-endian/archive/0.7.tar.gz"
   checksum: "md5=c5d7ddb431dc10b01718fe303e642491"
 }
+tags: ["org:ocamlpro"]


### PR DESCRIPTION
Done with

    for f in $(opam admin lint 24 -l); do opam-ed -if "packages/${f%%.*}/$f/opam" 'prepend tags "org:ocamlpro"'; done

(and checking that all the packages started with `ocp`)
Note that this warning is now obsolete and could be removed (since no non-ocp packages hit it anymore).