### PR TITLE
Package satyrographos.0.0.2.1

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.2.1/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.1/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "core" {< "v0.13"}
-  "dune" {build}
+  "dune" {>= "1.4"}
   "fileutils"
   "json-derivers"
   "ppx_deriving"

--- a/packages/satyrographos/satyrographos.0.0.2.1/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL3+"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "core" {< "v0.13"}
+  "dune" {build}
+  "fileutils"
+  "json-derivers"
+  "ppx_deriving"
+  "ppx_jane" {< "v0.13"}
+  "opam-format" {>= "2.0" & < "2.1"}
+  "uri" {>= "3.0.0"}
+  "uri-sexp" {>= "3.0.0"}
+  "shexp" {< "v0.13"}
+  "yojson"
+]
+synopsis: "A package manager for SATySFi"
+description: """
+Satyrographos is a package manager for [SATySFi].
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src: "https://github.com/na4zagin3/satyrographos/archive/v0.0.2.1.tar.gz"
+  checksum: [
+    "md5=fc8607a885fb05369e8125584beee7da"
+    "sha512=923f9dbbfb23d675696ba000231ea6590c90e18c84fd167247b77131b05e4ee3a6371d8b5384a25fc4ec9d92de2c423e4c6fa8d93e346b668de252cdf4cb9e02"
+  ]
+}


### PR DESCRIPTION
### `satyrographos.0.0.2.1`
A package manager for SATySFi
Satyrographos is a package manager for [SATySFi].

Satyrographos is distributed under the LGPL-3.0 license.


  [SATySFi]: https://github.com/gfngfn/SATySFi
  [Satyrographos]: https://github.com/na4zagin3/satyrographos



---
* Homepage: https://github.com/na4zagin3/satyrographos
* Source repo: git+https://github.com/na4zagin3/satyrographos.git
* Bug tracker: https://github.com/na4zagin3/satyrographos/issues

---
:camel: Pull-request generated by opam-publish v2.0.0