### PR TITLE
irrlicht: add bound on OCaml version

### DIFF
--- a/packages/irrlicht/irrlicht.0.0.5/opam
+++ b/packages/irrlicht/irrlicht.0.0.5/opam
@@ -29,7 +29,7 @@ This version of the binding was tested with Irrlicht version 1.8.4
 """
 
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "4.09"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
`irrlicht.0.0.5` is not compatible with OCaml 4.09 because of the new `const` qualifier on the return type of `caml_named_value`. Upstream fix proposed: https://github.com/fccm/OCaml-Irrlicht/pulls

cc @fccm 
