### PR TITLE
Package eliom.6.8.0

### DIFF
--- a/packages/eliom/eliom.6.8.0/opam
+++ b/packages/eliom/eliom.6.8.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: "Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppx_tools" {>= "0.99.3"}
+  "js_of_ocaml" {>= "3.3"}
+  "js_of_ocaml-lwt" {>= "3.3"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-ppx_deriving_json" {>= "3.3"}
+  "js_of_ocaml-tyxml" {>= "3.3"}
+  "lwt_log"
+  "lwt_ppx"
+  "tyxml" {>= "4.3.0"}
+  "ocsigenserver" {>= "2.10"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+]
+url {
+  src: "https://github.com/jrochel/eliom/archive/6.8.0.tar.gz"
+  checksum: [
+    "md5=065bcce57a52e0d8b224b29f1e8bf441"
+    "sha512=9bd335c60765f8f1fa129d30306cafe079269737ffb2d50f142958523eecf877d8cfd1f841691da49530a506b8a3735c6a885ed3ff7904160f2ef12fd3f6b922"
+  ]
+}


### PR DESCRIPTION
### `eliom.6.8.0`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0