### PR TITLE
[new release] optint (0.0.3)

### DIFF
--- a/packages/optint/optint.0.0.3/opam
+++ b/packages/optint/optint.0.0.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   [ "romain.calascibetta@gmail.com" ]
+authors:      "Romain Calascibetta"
+license:      "ISC"
+homepage:     "https://github.com/mirage/optint"
+bug-reports:  "https://github.com/mirage/optint/issues"
+dev-repo:     "git+https://github.com/mirage/optint.git"
+doc:          "https://mirage.github.io/optint/"
+synopsis:     "Abstract type on integer between x64 and x86 architecture"
+description: """
+This library provide an abstract type which represents at least a 32-bits integer.
+On x64, this library use a native unboxed integer (63 bits).
+On x86, this library use a boxed int32.
+
+Implementation depends on target architecture.
+"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "crowbar" {with-test}
+  "fmt" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/optint/releases/download/v0.0.3/optint-v0.0.3.tbz"
+  checksum: [
+    "sha256=9279d910f0b49eef4e6c7201a2e6189a4866b12d42ce677b9c3d51458d1ef930"
+    "sha512=c696a4cee26666a1868a6d0ea5b441d6292468fd51c233b3d2036ee6df7a0cba9200747ba7287b8181ca29afce80433c2919fe84f5d7c9debcd5ce8c192e4ac4"
+  ]
+}


### PR DESCRIPTION
Abstract type on integer between x64 and x86 architecture

- Project page: <a href="https://github.com/mirage/optint">https://github.com/mirage/optint</a>
- Documentation: <a href="https://mirage.github.io/optint/">https://mirage.github.io/optint/</a>

##### CHANGES:

- Avoid partial application of function (mirage/optint#2, @dinosaure)
- Add `[@immediate]` tag (mirage/optint#4, @dinosaure)
- Fix `select.ml` in 32bit (mirage/optint#5, @IndiscriminateCoding)
- Fix typo (mirage/optint#6, @hannesm)
- Add fuzzer (mirage/optint#8, @dinosaure)
- Fix `lsr` and `asr` in 64bit (mirage/optint#8, @cfcs, @dinosaure)
- Optimization on `of_int` function (64bit) (mirage/optint#8, @cfcs, @dinosaure)
- Optimization on `abs` function (64bit) (mirage/optint#8, @cfcs, @dinosaure)
- Fix 32bit architecture, keep bit-sign in the same place (mirage/optint#8, @dinosaure, review @cfcs)
