### PR TITLE
Package coq-flocq-quickchick.1.0.0

### DIFF
--- a/packages/coq-flocq-quickchick/coq-flocq-quickchick.1.0.0/opam
+++ b/packages/coq-flocq-quickchick/coq-flocq-quickchick.1.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Flocq binary_float generators for QuickChick testing framework"
+maintainer: "Yaroslav Kogevnikov <ykozhevnikov@codeminders.com>"
+authors: "Yaroslav Kogevnikov <ykozhevnikov@codeminders.com>"
+license: "MIT"
+homepage: "https://github.com/digamma-ai/flocq-quickchick"
+bug-reports: "https://github.com/digamma-ai/flocq-quickchick/issues"
+depends: [
+  "coq" {>= "8.8.2"}
+  "coq-quickchick" {>= "1.0.2"}
+  "coq-flocq" {>= "3.1.0"}
+]
+build: [
+  ["coq_makefile" "-f" "_CoqProject"  "-o" "Makefile"]
+  [make]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/digamma-ai/flocq-quickchick.git"
+url {
+  src: "https://github.com/digamma-ai/flocq-quickchick/archive/1.0.1.tar.gz"
+  checksum: [
+    "md5=ced088829a344c127cff792047855168"
+    "sha512=2f85ae20e7be379deec197b5044d5567ca6fefbe128978999cbc560c51da468ac224cbd3e8475167cdae07322739e1d9ad852bb1c628ca7749ff701f49ec1080"
+  ]
+}


### PR DESCRIPTION
### `coq-flocq-quickchick.1.0.0`
Flocq binary_float generators for QuickChick testing framework



---
* Homepage: https://github.com/digamma-ai/flocq-quickchick
* Source repo: git+https://github.com/digamma-ai/flocq-quickchick.git
* Bug tracker: https://github.com/digamma-ai/flocq-quickchick/issues

---
:camel: Pull-request generated by opam-publish v2.0.0