### PR TITLE
[new release] csv, csvtool and csv-lwt (2.3)

### DIFF
--- a/packages/csv-lwt/csv-lwt.2.3/opam
+++ b/packages/csv-lwt/csv-lwt.2.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Richard Jones"
+          "Christophe Troestler"]
+tags: ["csv" "database" "science"]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-csv"
+dev-repo: "git+https://github.com/Chris00/ocaml-csv.git"
+bug-reports: "https://github.com/Chris00/ocaml-csv/issues"
+doc: "https://Chris00.github.io/ocaml-csv/doc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "csv"
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "lwt"
+]
+synopsis: "A pure OCaml library to read and write CSV files, LWT version"
+description: """
+This is a pure OCaml library to read and write CSV files, including
+all extensions used by Excel — e.g. quotes, newlines, 8 bit characters
+in fields, \"0 etc. A special representation of rows of CSV files with
+a header is provided. This version can be used with the monadic
+concurrency library LWT."""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-csv/releases/download/2.3/csv-2.3.tbz"
+  checksum: [
+    "sha256=2b90f22ef36279a4e1249d6784a4fb3e3e3f16394018ffdabae21ba71d4f759b"
+    "sha512=70ab5d0f5829c118e278942914632abdd6b626a543d3de6c11572e93aa7c869be9a03565255651d787b881fa2e9f11a933aaed70d07eed4261376e8f01dc29a4"
+  ]
+}

--- a/packages/csv/csv.2.3/opam
+++ b/packages/csv/csv.2.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Richard Jones"
+           "Christophe Troestler" ]
+tags: ["csv" "database" "science"]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-csv"
+dev-repo: "git+https://github.com/Chris00/ocaml-csv.git"
+bug-reports: "https://github.com/Chris00/ocaml-csv/issues"
+doc: "https://Chris00.github.io/ocaml-csv/doc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-bytes"
+  "base-unix"
+]
+synopsis: "A pure OCaml library to read and write CSV files"
+description: """
+This is a pure OCaml library to read and write CSV files, including
+all extensions used by Excel — e.g. quotes, newlines, 8 bit characters
+in fields, \"0 etc. A special representation of rows of CSV files with
+a header is provided."""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-csv/releases/download/2.3/csv-2.3.tbz"
+  checksum: [
+    "sha256=2b90f22ef36279a4e1249d6784a4fb3e3e3f16394018ffdabae21ba71d4f759b"
+    "sha512=70ab5d0f5829c118e278942914632abdd6b626a543d3de6c11572e93aa7c869be9a03565255651d787b881fa2e9f11a933aaed70d07eed4261376e8f01dc29a4"
+  ]
+}

--- a/packages/csvtool/csvtool.2.3/opam
+++ b/packages/csvtool/csvtool.2.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Richard Jones"
+           "Christophe Troestler" ]
+tags: ["csv" "database" "science"]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-csv"
+dev-repo: "git+https://github.com/Chris00/ocaml-csv.git"
+bug-reports: "https://github.com/Chris00/ocaml-csv/issues"
+doc: "https://Chris00.github.io/ocaml-csv/doc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "csv" {= version}
+  "uutf"
+]
+synopsis: "Command line tool for handling CSV files"
+description: """
+This is a handy command line tool for handling CSV files from shell
+scripts based on the library `csv`."""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-csv/releases/download/2.3/csv-2.3.tbz"
+  checksum: [
+    "sha256=2b90f22ef36279a4e1249d6784a4fb3e3e3f16394018ffdabae21ba71d4f759b"
+    "sha512=70ab5d0f5829c118e278942914632abdd6b626a543d3de6c11572e93aa7c869be9a03565255651d787b881fa2e9f11a933aaed70d07eed4261376e8f01dc29a4"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- Be compatible with OCaml ≥ 4.08 (fixes Chris00/ocaml-csv#28).
- Put `csvtool` in its own package.
- Use UTF-8 to determine column widths for the "readable" format
  (fixes Chris00/ocaml-csv#21).
- Add deprecation attributes.
- Fix alignment in `csvtool` usage message.
- Small improvements to the documentation.