### PR TITLE
Package ISO8601.0.2.6

### DIFF
--- a/packages/ISO8601/ISO8601.0.2.6/opam
+++ b/packages/ISO8601/ISO8601.0.2.6/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "ISO 8601 and RFC 3999 date parsing for OCaml"
+maintainer: ["c-cube" "ocaml-community"]
+authors: "Julien Sagot"
+homepage: "http://github.com/ocaml-community/ISO8601.ml/"
+doc: "http://ocaml-community.github.io/ISO8601.ml/"
+bug-reports: "https://github.com/ocaml-community/ISO8601.ml/issues"
+depends: [
+  "dune" {>= "1.0"}
+  "base-unix"
+  "ocaml" {>= "3.12.1"}
+  "odoc" {with-doc}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/ocaml-community/ISO8601.ml.git"
+url {
+  src: "https://github.com/ocaml-community/ISO8601.ml/archive/0.2.6.tar.gz"
+  checksum: [
+    "md5=c9921e30f7f7ed80d805adbb7d690dfd"
+    "sha512=bfd4efb67b6d41dabda874e8238ee6a65780afbe6bb16cd0fea96ca9507f1c600af919e7a03078c950e3ed6c2ff36f4ef78f038bb07263adccdc18eea91ff100"
+  ]
+}


### PR DESCRIPTION
### `ISO8601.0.2.6`
ISO 8601 and RFC 3999 date parsing for OCaml



---
* Homepage: http://github.com/ocaml-community/ISO8601.ml/
* Source repo: git+https://github.com/ocaml-community/ISO8601.ml.git
* Bug tracker: https://github.com/ocaml-community/ISO8601.ml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0