### PR TITLE
[new release] dropbox_lwt_unix and dropbox (0.2)

### DIFF
--- a/packages/dropbox/dropbox.0.2/opam
+++ b/packages/dropbox/dropbox.0.2/opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "dune"
+  "dune" {>= "1.1"}
   "atdgen" {>= "1.5.0"}
   "yojson" {>= "1.6.0"}
   "base-bytes"

--- a/packages/dropbox/dropbox.0.2/opam
+++ b/packages/dropbox/dropbox.0.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>" ]
+tags: ["dropbox" "sync"]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-dropbox"
+dev-repo: "git+https://github.com/Chris00/ocaml-dropbox.git"
+bug-reports: "https://github.com/Chris00/ocaml-dropbox/issues"
+doc: "https://Chris00.github.io/ocaml-dropbox/doc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "atdgen" {>= "1.5.0"}
+  "yojson" {>= "1.6.0"}
+  "base-bytes"
+  "base-unix" {with-test}
+  "cohttp"
+  "cohttp-lwt" {>= "2.0.0"}
+  "lwt"
+  ("tls" | "ssl")
+]
+synopsis: "Binding to the Dropbox Remote API"
+description: """
+Pure OCaml library to access Dropbox.  Lwt and Async backends are
+supported.  In particular, this library can be used from a mirage
+unikernel."""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-dropbox/releases/download/0.2/dropbox-0.2.tbz"
+  checksum: [
+    "sha256=3a317ff6963c453fe74d955e24b23721d5ab44f22969db106a1ab64328f1d8c7"
+    "sha512=170d74a2652f90c59108c4155ac31367ef38a0184a49d4a8657731da181695a249f2eab3bf6b460804aa07eb7dbcb165e895eca2f231662b15c74d98f65a948f"
+  ]
+}

--- a/packages/dropbox_lwt_unix/dropbox_lwt_unix.0.2/opam
+++ b/packages/dropbox_lwt_unix/dropbox_lwt_unix.0.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>" ]
+tags: ["dropbox" "sync"]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-dropbox"
+dev-repo: "git+https://github.com/Chris00/ocaml-dropbox.git"
+bug-reports: "https://github.com/Chris00/ocaml-dropbox/issues"
+doc: "https://Chris00.github.io/ocaml-dropbox/doc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "dropbox" {= version}
+  "cohttp-lwt-unix" {>= "0.99.0"}
+]
+synopsis: "Binding to the Dropbox Remote API (Unix)"
+description: """
+Pure OCaml library to access Dropbox.  Lwt-unix backend."""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-dropbox/releases/download/0.2/dropbox-0.2.tbz"
+  checksum: [
+    "sha256=3a317ff6963c453fe74d955e24b23721d5ab44f22969db106a1ab64328f1d8c7"
+    "sha512=170d74a2652f90c59108c4155ac31367ef38a0184a49d4a8657731da181695a249f2eab3bf6b460804aa07eb7dbcb165e895eca2f231662b15c74d98f65a948f"
+  ]
+}

--- a/packages/dropbox_lwt_unix/dropbox_lwt_unix.0.2/opam
+++ b/packages/dropbox_lwt_unix/dropbox_lwt_unix.0.2/opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "dune"
+  "dune" {>= "1.1"}
   "dropbox" {= version}
   "cohttp-lwt-unix" {>= "0.99.0"}
 ]


### PR DESCRIPTION
Binding to the Dropbox Remote API (Unix)

- Project page: <a href="https://github.com/Chris00/ocaml-dropbox">https://github.com/Chris00/ocaml-dropbox</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-dropbox/doc">https://Chris00.github.io/ocaml-dropbox/doc</a>

##### CHANGES:


