### PR TITLE
[new release] integration1d (0.5.1)

### DIFF
--- a/packages/integration1d/integration1d.0.5.1/opam
+++ b/packages/integration1d/integration1d.0.5.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+tags: ["science" "numerics"]
+license: "ISC"
+homepage: "https://github.com/Chris00/integration1d"
+dev-repo: "git+https://github.com/Chris00/integration1d.git"
+bug-reports: "https://github.com/Chris00/integration1d/issues"
+doc: "https://Chris00.github.io/integration1d/doc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune"
+  "cppo" {build}
+]
+synopsis: "Collection of 1D numerical integration routines"
+description: """
+One dimensional integration routines modeled after QUADPACK."""
+url {
+  src:
+    "https://github.com/Chris00/integration1d/releases/download/0.5.1/integration1d-0.5.1.tbz"
+  checksum: [
+    "sha256=b92ca26c4d817f16b9f248d73ac4b1c9f6006baee3ab93bf83e3dea9f8abf70a"
+    "sha512=5ecd95cfa8b54f0b68c72d52cbab2a3aef8cf5ff5f139f89181f08ccb8d52f15baaf889682dd12eff157d979662dcd10adb7dce1a65e232b1ca086e6be4f1465"
+  ]
+}


### PR DESCRIPTION
Collection of 1D numerical integration routines

- Project page: <a href="https://github.com/Chris00/integration1d">https://github.com/Chris00/integration1d</a>
- Documentation: <a href="https://Chris00.github.io/integration1d/doc">https://Chris00.github.io/integration1d/doc</a>

##### CHANGES:

- Replace the deprecated Camlp4 by cppo.
- Use `dune` to compile.
- Upgrade to OPAM 2.
