### PR TITLE
[new release] qrencode (0.2)

### DIFF
--- a/packages/qrencode/qrencode.0.2/opam
+++ b/packages/qrencode/qrencode.0.2/opam
@@ -1,0 +1,33 @@
+version: "0.2"
+opam-version: "2.0"
+maintainer: "vb@luminar.eu.org"
+authors: ["Vincent Bernardoff"]
+homepage: "https://github.com/vbmithr/qrencode-ocaml"
+build: ["dune" "build" "-p" name "-j" jobs]
+
+depends: [
+  "dune" {>= "1.10"}
+  "ocaml"
+]
+depexts: [
+  ["pkg-config" "libqrencode-dev" "libpng-dev"] {os-family = "debian"}
+  ["pkg-config" "qrencode" "libpng"] {os-distribution = "arch"}
+]
+dev-repo: "git+https://github.com/vbmithr/qrencode-ocaml"
+bug-reports: "https://github.com/vbmithr/qrencode-ocaml/issues"
+synopsis: "Binding to libqrencode (QR-code encoding library)"
+doc:"https://vbmithr.github.io/qrencode-ocaml"
+description:"""
+Libqrencode is a fast and compact library for encoding data in a QR
+Code symbol, a 2D symbology that can be scanned by handy terminals
+such as a mobile phone with CCD. The capacity of QR Code is up to 7000
+digits or 4000 characters and has high robustness."
+"""
+url {
+  src:
+    "https://github.com/vbmithr/qrencode-ocaml/releases/download/0.2/qrencode-0.2.tbz"
+  checksum: [
+    "sha256=2058669f169bace743f09ce03ce0227e49548e6e77a1d3852aebab287bab721b"
+    "sha512=7fabfe4c9e03af13a0d296014416c740c66f6a57498f984294b83348e4d0e98e00261711d862a568c7b5e6803d5ed40ff02e4c57ea08ee66075c02686c004b29"
+  ]
+}


### PR DESCRIPTION
Binding to libqrencode (QR-code encoding library)

- Project page: <a href="https://github.com/vbmithr/qrencode-ocaml">https://github.com/vbmithr/qrencode-ocaml</a>
- Documentation: <a href="https://vbmithr.github.io/qrencode-ocaml">https://vbmithr.github.io/qrencode-ocaml</a>

##### CHANGES:

* Build: Port to dune
