### PR TITLE
Package jemalloc.0.2

### DIFF
--- a/packages/devkit/devkit.0.6/opam
+++ b/packages/devkit/devkit.0.6/opam
@@ -39,7 +39,7 @@ depends: [
 ]
 depopts: [
   "gperftools"
-  "jemalloc"
+  "jemalloc" {<= "0.1"}
 ]
 synopsis: "development kit - general purpose library"
 flags: light-uninstall

--- a/packages/devkit/devkit.0.7/opam
+++ b/packages/devkit/devkit.0.7/opam
@@ -39,7 +39,7 @@ depends: [
 ]
 depopts: [
   "gperftools"
-  "jemalloc"
+  "jemalloc" {<= "0.1"}
 ]
 synopsis: "development kit - general purpose library"
 flags: light-uninstall

--- a/packages/devkit/devkit.1.0/opam
+++ b/packages/devkit/devkit.1.0/opam
@@ -33,7 +33,7 @@ depends: [
 ]
 depopts: [
   "gperftools"
-  "jemalloc"
+  "jemalloc" {<= "0.1"}
 ]
 url {
   src: "https://github.com/ahrefs/devkit/archive/1.0.tar.gz"

--- a/packages/devkit/devkit.1.2/opam
+++ b/packages/devkit/devkit.1.2/opam
@@ -32,7 +32,7 @@ depends: [
 ]
 depopts: [
   "gperftools"
-  "jemalloc"
+  "jemalloc" {<= "0.1"}
 ]
 url {
   src: "https://github.com/ahrefs/devkit/archive/1.2.tar.gz"

--- a/packages/jemalloc/jemalloc.0.2/opam
+++ b/packages/jemalloc/jemalloc.0.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "joris.giovannangeli@ahrefs.com"
+authors: "joris giovannangeli"
+homepage: "https://github.com/ahrefs/ocaml-jemalloc"
+bug-reports: "https://github.com/ahrefs/ocaml-jemalloc/issues"
+license: "MIT"
+tags: ["org:ahrefs" "clib:jemalloc"]
+dev-repo: "git://github.com/ahrefs/ocaml-jemalloc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs
+   "@install"]
+]
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune"
+]
+depexts: [
+  ["jemalloc-dev"] {os-distribution = "alpine"}
+  ["libjemalloc-dev"] {os-family = "debian"}
+  ["jemalloc-devel"] {os-distribution = "fedora"}
+  ["jemalloc-devel"] {os-distribution = "mageia"}
+  ["jemalloc-devel"] {os-distribution = "rhel"}
+  ["jemalloc-devel"] {os-distribution = "centos"}
+  ["jemalloc"] {os = "macos"}
+]
+synopsis: "Bindings to jemalloc mallctl api"
+description:
+  "Exposes helpers to access jemalloc control api, retrieve allocator statistics and change allocator settings."
+url {
+  src: "https://github.com/ahrefs/ocaml-jemalloc/archive/0.2.tar.gz"
+  checksum: "md5=2a315381e5a1265a0ec05d0fd8721c2c"
+}


### PR DESCRIPTION
### `jemalloc.0.2`
Bindings to jemalloc mallctl api
Exposes helpers to access jemalloc control api, retrieve allocator statistics and change allocator settings.



---
* Homepage: https://github.com/ahrefs/ocaml-jemalloc
* Source repo: git://github.com/ahrefs/ocaml-jemalloc
* Bug tracker: https://github.com/ahrefs/ocaml-jemalloc/issues

---
:camel: Pull-request generated by opam-publish v2.0.0