### PR TITLE
[new release] mirage-net-macosx (1.7.0)

### DIFF
--- a/packages/mirage-net-macosx/mirage-net-macosx.1.7.0/opam
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.7.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:  "Anil Madhavapeddy <anil@recoil.org>"
+authors:     "Anil Madhavapeddy <anil@recoil.org>"
+homepage:    "https://github.com/mirage/mirage-net-macosx"
+bug-reports: "https://github.com/mirage/mirage-net-macosx/issues"
+dev-repo:    "git+https://github.com/mirage/mirage-net-macosx.git"
+doc:         "https://mirage.github.io/mirage-net-macosx/"
+
+license: "ISC"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "1.4.0"}
+  "macaddr"
+  "sexplib"
+  "logs"
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "vmnet" {>= "1.5.1"}
+]
+tags: "org:mirage"
+
+synopsis: "MacOS implementation of the Mirage_net_lwt interface"
+description: """
+This interface exposes raw Ethernet frames using the
+[Vmnet](https://github.com/mirage/ocaml-vmnet) framework that
+is available on MacOS X Yosemite onwards.  It is suitable for
+use with an OCaml network stack such as the one found at
+<https://github.com/mirage/mirage-tcpip>.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-macosx/releases/download/v1.7.0/mirage-net-macosx-v1.7.0.tbz"
+  checksum: [
+    "sha256=9c3360560c46a7e511d261361f19644f3f0db03be01fd2b2d46012cdf56a6479"
+    "sha512=46501c457c45c4631144915543436fdf791724244d4665d1d5847655a7f82106d58e3d93fb705e4af9de623e379f567ce4cc8953b6d5f538402148eabbf66986"
+  ]
+}


### PR DESCRIPTION
MacOS implementation of the Mirage_net_lwt interface

- Project page: <a href="https://github.com/mirage/mirage-net-macosx">https://github.com/mirage/mirage-net-macosx</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-macosx/">https://mirage.github.io/mirage-net-macosx/</a>

##### CHANGES:

- Use max_buffer_size as buffer length as required by Vmnet (@magnuss)
- Update to use latest ocaml-vmnet to improve error handling (@magnuss)
