### PR TITLE
Package eigen.0.1.4

### DIFF
--- a/packages/eigen/eigen.0.1.4/opam
+++ b/packages/eigen/eigen.0.1.4/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.04"}
   "ctypes" {>= "0.14.0"}
   "ctypes-foreign"
-  "dune" {>= "1.1.0"}
+  "dune" {>= "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "eigen_cpp/libeigen_cpp_stubs.a"]

--- a/packages/eigen/eigen.0.1.4/opam
+++ b/packages/eigen/eigen.0.1.4/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/owlbarn/eigen"
 doc: "https://owlbarn.github.io/eigen/eigen"
 bug-reports: "https://github.com/owlbarn/eigen/issues"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.04"}
   "ctypes" {>= "0.14.0"}
   "ctypes-foreign"
   "dune" {>= "1.1.0"}

--- a/packages/eigen/eigen.0.1.4/opam
+++ b/packages/eigen/eigen.0.1.4/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Owl's OCaml interface to Eigen3 C++ library"
+description:
+  "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: "Liang Wang"
+license: "MIT"
+homepage: "https://github.com/owlbarn/eigen"
+doc: "https://owlbarn.github.io/eigen/eigen"
+bug-reports: "https://github.com/owlbarn/eigen/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "ctypes" {>= "0.14.0"}
+  "ctypes-foreign"
+  "dune" {>= "1.1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "eigen_cpp/libeigen_cpp_stubs.a"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/owlbarn/eigen.git"
+url {
+  src: "https://github.com/owlbarn/eigen/archive/0.1.4.tar.gz"
+  checksum: [
+    "md5=4e2e8cc068cc4b5f00597f2e14b4d80d"
+    "sha512=1bde5688c3aa6f8feddc750386dc66aa2423ad69361272a7c3115b8823f621231b22505c071b03f5bd11252d0b7ebc22e42a2e8915152fba680f4470b3e829db"
+  ]
+}


### PR DESCRIPTION
### `eigen.0.1.4`
Owl's OCaml interface to Eigen3 C++ library
Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations.



---
* Homepage: https://github.com/owlbarn/eigen
* Source repo: git+https://github.com/owlbarn/eigen.git
* Bug tracker: https://github.com/owlbarn/eigen/issues

---
:camel: Pull-request generated by opam-publish v2.0.0