### PR TITLE
Add depext for capnproto on Alpine Linux

### DIFF
--- a/packages/conf-capnproto/conf-capnproto.0/opam
+++ b/packages/conf-capnproto/conf-capnproto.0/opam
@@ -13,6 +13,7 @@ build: [
   ["capnpc" "--version"]
 ]
 depexts: [
+  ["capnproto-dev@testing"] {os-distribution = "alpine"}
   ["capnproto"] {os-distribution = "arch"}
   ["capnproto"] {os-distribution = "centos"}
   ["capnproto" "libcapnp-dev"] {os-distribution = "debian"}


### PR DESCRIPTION
Note: this requires the "testing" repository to be configured first. See https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management. The Docker images at e.g. `ocurrent/opam:alpine-3.10-ocaml-4.08` now have this added automatically.
