### PR TITLE
Package ocp-indent.1.8.0

### DIFF
--- a/packages/ocp-indent/ocp-indent.1.8.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.8.0/opam
@@ -27,7 +27,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [
-  ["dune" "runtest" "-p" name]
+  ["dune" "runtest" "-p" name "-j" jobs]
 ]
 depends: [
   "ocaml"

--- a/packages/ocp-indent/ocp-indent.1.8.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.8.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "contact@ocamlpro.com"
+synopsis: "A simple tool to indent OCaml programs"
+description: """
+Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack
+machine ; this is much faster and more reliable than using regexps. Presets and
+configuration options available, with the possibility to set them project-wide.
+Supports most common syntax extensions, and extensible for others.
+
+Includes:
+- An indentor program, callable from the command-line or from within editors
+- Bindings for popular editors
+- A library that can be directly used by editor writers, or just for
+  fault-tolerant/approximate parsing.
+"""
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Jun Furuse"
+]
+homepage: "http://www.typerex.org/ocp-indent.html"
+bug-reports: "https://github.com/OCamlPro/ocp-indent/issues"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+tags: ["org:ocamlpro" "org:typerex"]
+dev-repo: "git+https://github.com/OCamlPro/ocp-indent.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name]
+]
+depends: [
+  "ocaml"
+  "dune" {build}
+  "cmdliner" {>= "1.0.0"}
+  "ocamlfind"
+  "base-bytes"
+]
+post-messages: [
+  "This package requires additional configuration for use in editors. Install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path \"%{share}%/emacs/site-lisp\")
+  (require 'ocp-indent)
+
+* for Vim, add this line to ~/.vimrc:
+  set rtp^=\"%{share}%/ocp-indent/vim\"
+"
+  {success & !user-setup:installed}
+]
+url {
+  src: "https://github.com/OCamlPro/ocp-indent/archive/1.8.0.tar.gz"
+  checksum: [
+    "md5=d4d11e1aaedd7d3268ac7d5813de43ca"
+    "sha512=246a97f04b44371900a6f39eab34d9b674d6afa9026e78fce2ef171b5d28fcca0b49f353b2de9d09cb5529b896e47c253acc3074618060862e8a7debd9289afc"
+  ]
+}

--- a/packages/ocp-indent/ocp-indent.1.8.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.8.0/opam
@@ -31,7 +31,7 @@ run-test: [
 ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune" {>= "1.0"}
   "cmdliner" {>= "1.0.0"}
   "ocamlfind"
   "base-bytes"


### PR DESCRIPTION
### `ocp-indent.1.8.0`
A simple tool to indent OCaml programs
Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack
machine ; this is much faster and more reliable than using regexps. Presets and
configuration options available, with the possibility to set them project-wide.
Supports most common syntax extensions, and extensible for others.

Includes:
- An indentor program, callable from the command-line or from within editors
- Bindings for popular editors
- A library that can be directly used by editor writers, or just for
  fault-tolerant/approximate parsing.



---
* Homepage: http://www.typerex.org/ocp-indent.html
* Source repo: git+https://github.com/OCamlPro/ocp-indent.git
* Bug tracker: https://github.com/OCamlPro/ocp-indent/issues

---
:camel: Pull-request generated by opam-publish v2.0.0