### PR TITLE
codept: 0.10.3 is fine with OCaml 4.09

### DIFF
--- a/packages/codept/codept.0.10.3/opam
+++ b/packages/codept/codept.0.10.3/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "dune"
   "menhir" {build}
-  "ocaml" {>="4.03" & < "4.09"}
+  "ocaml" {>="4.03" & < "4.10"}
 ]
 synopsis: "Alternative ocaml dependency analyzer"
 description:"""


### PR DESCRIPTION
This PR adjusts codept's upper bound for compatible OCaml version to 4.10 excluded .