### PR TITLE
[new release] fftw3 (0.8.3)

### DIFF
--- a/packages/fftw3/fftw3.0.8.3/opam
+++ b/packages/fftw3/fftw3.0.8.3/opam
@@ -17,7 +17,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "1.1"}
   "cppo" {build}
   "lacaml" {with-test & os = "linux"}
   "conf-fftw3"

--- a/packages/fftw3/fftw3.0.8.3/opam
+++ b/packages/fftw3/fftw3.0.8.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+maintainer: "Christophe.Troestler@umons.ac.be"
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/fftw-ocaml"
+dev-repo: "git+https://github.com/Chris00/fftw-ocaml.git"
+bug-reports: "https://github.com/Chris00/fftw-ocaml/issues"
+doc: "https://Chris00.github.io/fftw-ocaml/doc"
+tags: ["FFT"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs] {os != "macos"}
+  ["env" "FFTW3_CFLAGS=-I /usr/local/include -L /usr/local/lib -I /usr/local/include -L /usr/local/lib"
+   "dune" "build" "-p" name "-j" jobs
+  ] {os = "macos"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "cppo" {build}
+  "lacaml" {with-test & os = "linux"}
+  "conf-fftw3"
+]
+synopsis: "Binding to the Fast Fourier Transform library FFTW"
+description: """
+Library binding the seminal library FFTW."""
+url {
+  src:
+    "https://github.com/Chris00/fftw-ocaml/releases/download/0.8.3/fftw3-0.8.3.tbz"
+  checksum: [
+    "sha256=99e46004ca02ddff9f2a1f1213426ccab4fbfcc687f1a436df56f52200a2afff"
+    "sha512=3a48d0b8243f3c14c845f68b40617d199940339c5aa9b92bf3103406e917ef8b44c707db2698142e1c485645a2cd656d020e6064bc7e938ec8891d49ee90b6d7"
+  ]
+}


### PR DESCRIPTION
Binding to the Fast Fourier Transform library FFTW

- Project page: <a href="https://github.com/Chris00/fftw-ocaml">https://github.com/Chris00/fftw-ocaml</a>
- Documentation: <a href="https://Chris00.github.io/fftw-ocaml/doc">https://Chris00.github.io/fftw-ocaml/doc</a>

##### CHANGES:

- Compatibility with OCaml 4.08 and the newer `Bigarray` code.
- Upgrade to OPAM 2.
- Remove conditionals to support older versions of OCaml.
