### PR TITLE
[DO NOT MERGE] Move ocaml-variants.4.09.0+trunk to ocaml-variants.4.09.1+trunk

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+afl/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-synopsis: "latest 4.09 development, with flambda activated"
+synopsis: "latest 4.09 development, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 depends: [
-  "ocaml" {= "4.09.0" & post}
+  "ocaml" {= "4.09.1" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -12,14 +12,14 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
+  ["./configure" "--prefix=%{prefix}%" "--with-afl" ]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "--enable-flambda"
     "CC=cc"
     "ASPP=cc -c"
+    "--with-afl"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+default-unsafe-string/opam
@@ -1,8 +1,12 @@
 opam-version: "2.0"
-synopsis: "latest 4.09 development, with afl-fuzz instrumentation"
+synopsis: "latest 4.09 development, without safe strings by default"
 maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {= "4.09.0" & post}
+  "ocaml" {= "4.09.1" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -12,14 +16,19 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--with-afl" ]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "DEFAULT_STRING=unsafe"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "DEFAULT_STRING=unsafe"
     "CC=cc"
     "ASPP=cc -c"
-    "--with-afl"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+flambda/opam
@@ -1,12 +1,8 @@
 opam-version: "2.0"
-synopsis: "latest 4.09.0 development, without safe strings by default"
+synopsis: "latest 4.09 development, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
-authors: "Xavier Leroy and many contributors"
-homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
-dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {= "4.09.0" & post}
+  "ocaml" {= "4.09.1" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -16,17 +12,12 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "--disable-force-safe-string"
-    "DEFAULT_STRING=unsafe"
-  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
-  [
-    "./configure"
-    "--prefix=%{prefix}%"
-    "--disable-force-safe-string"
-    "DEFAULT_STRING=unsafe"
+    "--enable-flambda"
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+fp+flambda/opam
@@ -1,12 +1,12 @@
 opam-version: "2.0"
-synopsis: "latest 4.09 development, with frame pointers"
+synopsis: "latest 4.09 development, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/ocaml/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {= "4.09.0" & post}
+  "ocaml" {= "4.09.1" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -20,11 +20,13 @@ build: [
     "./configure"
     "--prefix=%{prefix}%"
     "--enable-frame-pointers"
+    "--enable-flambda"
   ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "--enable-frame-pointers"
+    "--enable-flambda"
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+fp/opam
@@ -1,8 +1,12 @@
 opam-version: "2.0"
-synopsis: "latest 4.09 development"
+synopsis: "latest 4.09 development, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {= "4.09.0" & post}
+  "ocaml" {= "4.09.1" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -12,11 +16,15 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk/opam
@@ -1,12 +1,8 @@
 opam-version: "2.0"
-synopsis: "latest 4.09.0 development, with frame-pointers and flambda activated"
+synopsis: "latest 4.09 development"
 maintainer: "platform@lists.ocaml.org"
-authors: "Xavier Leroy and many contributors"
-homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
-dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {= "4.09.0" & post}
+  "ocaml" {= "4.09.1" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -16,17 +12,11 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "--enable-frame-pointers"
-    "--enable-flambda"
-  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
-  [
-    "./configure"
-    "--prefix=%{prefix}%"
-    "--enable-frame-pointers"
-    "--enable-flambda"
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}

--- a/packages/ocaml/ocaml.4.09.1/opam
+++ b/packages/ocaml/ocaml.4.09.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-config"
+  "ocaml-base-compiler" {= "4.09.1"} |
+  "ocaml-variants" {>= "4.09.1" & < "4.09.2~"} |
+  "ocaml-system" {>= "4.09.1" & < "4.09.2~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: CAML_LD_LIBRARY_PATH = ""
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]


### PR DESCRIPTION
Following the release of OCaml 4.09.0, the package `ocaml-4.09.0+trunk` (and other +trunk variants for 4.09.0) is not valid anymore and needs to be moved to 4.09.1 as of https://github.com/ocaml/ocaml/commit/6207460e793f8c5538bfd8164fa3078f7300b57a

cc @talex5 @avsm 