### PR TITLE
Travis: Use OCaml 4.09 and remove all redundant tests with mirage-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,25 +8,9 @@ matrix:
   include:
   - os: osx
     osx_image: xcode10.1
-    env: OCAML_VERSION=4.07 OPAM_VERSION=2.0
-  - os: linux
     env: OCAML_VERSION=4.08 OPAM_VERSION=2.0
   - os: linux
-    env: OCAML_VERSION=4.07 OPAM_VERSION=2.0
-  - os: linux
-    env: OCAML_VERSION=4.06 OPAM_VERSION=2.0 INSTALL_LOCAL=1
-  - os: linux
-    env: OCAML_VERSION=4.05 OPAM_VERSION=2.0
-  - os: linux
-    env: OCAML_VERSION=4.04 OPAM_VERSION=2.0
-  - os: linux
-    env: OCAML_VERSION=4.03 OPAM_VERSION=2.0
-  - os: linux
-    env: OCAML_VERSION=4.02 OPAM_VERSION=2.0
-  - os: linux
-    env: OCAML_VERSION=4.01 OPAM_VERSION=2.0
-  - os: linux
-    env: OCAML_VERSION=4.00 OPAM_VERSION=2.0
+    env: OCAML_VERSION=4.09 OPAM_VERSION=2.0 INSTALL_LOCAL=1
 notifications:
   email:
   - opam-commits@lists.ocaml.org


### PR DESCRIPTION
This PR makes use of OCaml 4.09 (added into ocaml-ci-scripts in https://github.com/ocaml/ocaml-ci-scripts/pull/311) and also removes every switches that are already tested by https://github.com/avsm/mirage-ci. Apart from MacOS, the only recent one that is not tested is the one with the ocaml compiler locally installed. Pre 4.02 compliers have also been removed.

This is a first step towards the complete removal of Travis from the CI of opam-repository.

cc @avsm 