### PR TITLE
odoc 1.4.2: documentation generator

### DIFF
--- a/packages/odoc/odoc.1.4.2/opam
+++ b/packages/odoc/odoc.1.4.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+
+version: "1.4.2"
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://github.com/ocaml/odoc#readme"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+
+depends: [
+  "astring" {build}
+  "cmdliner" {build & >= "1.0.0"}
+  "cppo" {build}
+  "dune"
+  "fpath" {build}
+  "ocaml" {>= "4.02.0"}
+  "result" {build}
+  "tyxml" {build & >= "4.3.0"}
+
+  "alcotest" {dev & >= "0.8.3"}
+  "markup" {dev & >= "0.8.0"}
+  "ocamlfind" {dev}
+  "sexplib" {dev & >= "113.33.00"}
+
+  "bisect_ppx" {with-test & >= "1.3.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocaml/odoc/archive/1.4.2.tar.gz"
+  checksum: "md5=d75ce63539040cd199d22203d46fc5f3"
+}


### PR DESCRIPTION
Bugs fixed

- Build on OCaml 4.09 (ocaml/odoc#383, Anil Madhavapeddy).
- Handle OCaml 4.08 type and module substitutions (ocaml/odoc#381, Jon Ludlam).
- Parser: better trimming of leading whitespace in code blocks (ocaml/odoc#370, Jules Aguillon).
- Parser: allow references to operators containing `:` characters (ocaml/odoc#384, reported Sylvain Le Gall).
- HTML: emit `<meta generator>` again (ocaml/odoc#378, Daniel Bünzli).
- CLI: `odoc html-targets` was ignoring deeply nested modules (ocaml/odoc#379, Daniel Bünzli).
- Fix bad internal usage of `List.iter2` (ocaml/odoc#376, Yotam Barnoy).