### PR TITLE
Add a dependency on dune-configurator for all packages that use dune.configurator

### DIFF
--- a/packages/ahrocksdb/ahrocksdb.0.2.0/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.0/opam
@@ -25,6 +25,7 @@ bug-reports: "https://github.com/ahrefs/ocaml-ahrocksdb/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune"
+  "dune-configurator"
   "base" {build & < "v0.13"}
   "stdio" {build & < "v0.13"}
   "ctypes" {>= "0.12.0"}

--- a/packages/ahrocksdb/ahrocksdb.0.2.1/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.1/opam
@@ -25,6 +25,7 @@ bug-reports: "https://github.com/ahrefs/ocaml-ahrocksdb/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune"
+  "dune-configurator"
   "ctypes" {>= "0.12.0"}
   "astring"
   "conf-rocksdb"

--- a/packages/ahrocksdb/ahrocksdb.0.2.2/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.2/opam
@@ -25,6 +25,7 @@ bug-reports: "https://github.com/ahrefs/ocaml-ahrocksdb/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune"
+  "dune-configurator"
   "ctypes" {>= "0.12.0"}
   "astring"
   "conf-rocksdb"

--- a/packages/async_ssl/async_ssl.v0.12.0/opam
+++ b/packages/async_ssl/async_ssl.v0.12.0/opam
@@ -20,6 +20,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
   "dune"           {>= "1.5.1"}
+  "dune-configurator"
 ]
 synopsis: "An Async-pipe-based interface with OpenSSL"
 description: "

--- a/packages/base/base.v0.12.1/opam
+++ b/packages/base/base.v0.12.1/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml"             {>= "4.04.2" & < "4.08.0"}
   "sexplib0"          {>= "v0.12" & < "v0.13"}
   "dune"              {>= "1.5.1"}
+  "dune-configurator"
 ]
 depopts: [
   "base-native-int63"

--- a/packages/base/base.v0.12.2/opam
+++ b/packages/base/base.v0.12.2/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml"             {>= "4.04.2" & < "4.10.0"}
   "sexplib0"          {>= "v0.12" & < "v0.13"}
   "dune"              {>= "1.5.1"}
+  "dune-configurator"
 ]
 depopts: [
   "base-native-int63"

--- a/packages/bwrap/bwrap.0.1/opam
+++ b/packages/bwrap/bwrap.0.1/opam
@@ -18,6 +18,7 @@ run-test: [
 depends: [
   "ocaml" {>= "4.03"}
   "dune"
+  "dune-configurator"
   "cppo" {build}
   "base-unix"
   "base-bytes"

--- a/packages/cairo2/cairo2.0.6.1/opam
+++ b/packages/cairo2/cairo2.0.6.1/opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "base-bigarray"
   "dune"
+  "dune-configurator"
   "conf-cairo"
 ]
 depopts: [

--- a/packages/cairo2/cairo2.0.6/opam
+++ b/packages/cairo2/cairo2.0.6/opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "base-bigarray"
   "dune"
+  "dune-configurator"
   "conf-cairo"
 ]
 depopts: [

--- a/packages/containers/containers.2.4.1/opam
+++ b/packages/containers/containers.2.4.1/opam
@@ -9,6 +9,7 @@ doc: "https://c-cube.github.io/ocaml-containers"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
 depends: [
   "dune"
+  "dune-configurator"
   "result"
   "uchar"
   "qtest" {with-test}

--- a/packages/containers/containers.2.4/opam
+++ b/packages/containers/containers.2.4/opam
@@ -9,6 +9,7 @@ doc: "https://c-cube.github.io/ocaml-containers"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
 depends: [
   "dune"
+  "dune-configurator"
   "result"
   "uchar"
   "qtest" {with-test}

--- a/packages/containers/containers.2.5/opam
+++ b/packages/containers/containers.2.5/opam
@@ -9,6 +9,7 @@ doc: "https://c-cube.github.io/ocaml-containers"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
 depends: [
   "dune"
+  "dune-configurator"
   "result"
   "uchar"
   "qtest" {with-test}

--- a/packages/containers/containers.2.6.1/opam
+++ b/packages/containers/containers.2.6.1/opam
@@ -9,6 +9,7 @@ doc: "https://c-cube.github.io/ocaml-containers"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
 depends: [
   "dune"
+  "dune-configurator"
   "result"
   "uchar"
   "qtest" {with-test}

--- a/packages/containers/containers.2.6/opam
+++ b/packages/containers/containers.2.6/opam
@@ -9,6 +9,7 @@ doc: "https://c-cube.github.io/ocaml-containers"
 bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
 depends: [
   "dune"
+  "dune-configurator"
   "result"
   "uchar"
   "qtest" {with-test}

--- a/packages/crlibm/crlibm.0.3/opam
+++ b/packages/crlibm/crlibm.0.3/opam
@@ -14,6 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "dune"
+  "dune-configurator"
   "base-bytes" {build}
   "benchmark" {with-test}
 ]

--- a/packages/crlibm/crlibm.0.4/opam
+++ b/packages/crlibm/crlibm.0.4/opam
@@ -15,6 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "dune"
+  "dune-configurator"
   "base-bytes" {build}
   "benchmark" {with-test}
 ]

--- a/packages/dune-configurator/dune-configurator.1.0.0/opam
+++ b/packages/dune-configurator/dune-configurator.1.0.0/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+maintainer: "Jérémie Dimino"
+description: """
+dune.configurator library distributed with Dune 1.x
+"""
+depends: ["dune" {<"2.0.0"}]

--- a/packages/dune-configurator/dune-configurator.1.0.0/opam
+++ b/packages/dune-configurator/dune-configurator.1.0.0/opam
@@ -1,4 +1,7 @@
 opam-version: "2.0"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
 maintainer: "Jérémie Dimino"
 description: """
 dune.configurator library distributed with Dune 1.x

--- a/packages/fftw3/fftw3.0.8.2/opam
+++ b/packages/fftw3/fftw3.0.8.2/opam
@@ -14,7 +14,6 @@ build: [
     "env"
     "FFTW3_CFLAGS=-I /usr/local/include -L /usr/local/lib -I /usr/local/include -L /usr/local/lib"
     "dune"
-  "dune-configurator"
     "build"
     "-p"
     name

--- a/packages/fftw3/fftw3.0.8.2/opam
+++ b/packages/fftw3/fftw3.0.8.2/opam
@@ -14,6 +14,7 @@ build: [
     "env"
     "FFTW3_CFLAGS=-I /usr/local/include -L /usr/local/lib -I /usr/local/include -L /usr/local/lib"
     "dune"
+  "dune-configurator"
     "build"
     "-p"
     name
@@ -25,6 +26,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
+  "dune-configurator"
   "cppo" {build}
   "lacaml" {with-test}
   "conf-fftw3"

--- a/packages/fftw3/fftw3.0.8.3/opam
+++ b/packages/fftw3/fftw3.0.8.3/opam
@@ -18,6 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.1"}
+  "dune-configurator"
   "cppo" {build}
   "lacaml" {with-test & os = "linux"}
   "conf-fftw3"

--- a/packages/fiat-p256/fiat-p256.0.1.0/opam
+++ b/packages/fiat-p256/fiat-p256.0.1.0/opam
@@ -25,6 +25,7 @@ depends: [
   "bigarray-compat"
   "cstruct" {>= "3.5.0"}
   "dune" {>= "1.6.0"}
+  "dune-configurator"
   "hex"
   "ppx_deriving_yojson" {with-test}
   "ppx_expect"

--- a/packages/fiat-p256/fiat-p256.0.2.0/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.0/opam
@@ -25,6 +25,7 @@ depends: [
   "bigarray-compat"
   "cstruct" {>= "3.5.0"}
   "dune" {>= "1.6.0"}
+  "dune-configurator"
   "hex"
   "ppx_deriving_yojson" {with-test}
   "rresult" {with-test}

--- a/packages/freetds/freetds.0.7/opam
+++ b/packages/freetds/freetds.0.7/opam
@@ -20,6 +20,7 @@ build: [
 ]
 depends: [
   "dune" {>= "1.4.0"}
+  "dune-configurator"
   "cppo" {build}
   "ounit" {with-test & >= "2.0.0"}
   "ocaml" {>= "4.06.0"}

--- a/packages/glfw-ocaml/glfw-ocaml.3.2.1-1/opam
+++ b/packages/glfw-ocaml/glfw-ocaml.3.2.1-1/opam
@@ -9,6 +9,7 @@ depends: [
   "conf-glfw3"
   "base-bigarray"
   "dune" {>= "1.0"}
+  "dune-configurator"
   "conf-pkg-config" {build}
   "ocaml" {>= "4.02.0"}
 ]

--- a/packages/glfw-ocaml/glfw-ocaml.3.2.1-2/opam
+++ b/packages/glfw-ocaml/glfw-ocaml.3.2.1-2/opam
@@ -9,6 +9,7 @@ depends: [
   "conf-glfw3"
   "base-bigarray"
   "dune" {>= "1.0"}
+  "dune-configurator"
   "conf-pkg-config" {build}
   "ocaml" {>= "4.02.0"}
 ]

--- a/packages/gsl/gsl.1.24.0/opam
+++ b/packages/gsl/gsl.1.24.0/opam
@@ -18,6 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4.0"}
+  "dune-configurator"
   "conf-gsl" {build}
   "conf-pkg-config" {build}
   "base" {build & < "v0.13"}

--- a/packages/hdf5/hdf5.0.1.5/opam
+++ b/packages/hdf5/hdf5.0.1.5/opam
@@ -11,6 +11,7 @@ build: [
 depends: [
   "cppo"
   "dune" {>= "1.1.0"}
+  "dune-configurator"
   "ocaml" {>= "4.04"}
   "ppx_inline_test"
   "ppx_tools_versioned"

--- a/packages/hidapi/hidapi.1.1.1/opam
+++ b/packages/hidapi/hidapi.1.1.1/opam
@@ -11,6 +11,7 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.8.2"}
+  "dune-configurator"
   "conf-hidapi" {build}
   "bigstring" {>= "0.2"}
 ]

--- a/packages/hidapi/hidapi.1.1/opam
+++ b/packages/hidapi/hidapi.1.1/opam
@@ -12,6 +12,7 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.8.2"}
+  "dune-configurator"
   "conf-hidapi" {build}
   "bigstring" {>= "0.2"}
 ]

--- a/packages/interval_base/interval_base.1.5.1/opam
+++ b/packages/interval_base/interval_base.1.5.1/opam
@@ -17,6 +17,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "dune"
+  "dune-configurator"
 ]
 synopsis: "An interval library for OCaml (base package)"
 description: "

--- a/packages/interval_base/interval_base.1.5/opam
+++ b/packages/interval_base/interval_base.1.5/opam
@@ -17,6 +17,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "dune"
+  "dune-configurator"
 ]
 synopsis: "An interval library for OCaml (base package)"
 description: "

--- a/packages/interval_crlibm/interval_crlibm.1.5.1/opam
+++ b/packages/interval_crlibm/interval_crlibm.1.5.1/opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "interval_base" {= version}
   "dune"
+  "dune-configurator"
   "crlibm"
 ]
 synopsis: "An interval library for OCaml (crlibm version)"

--- a/packages/interval_crlibm/interval_crlibm.1.5/opam
+++ b/packages/interval_crlibm/interval_crlibm.1.5/opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "interval_base" {= version}
   "dune"
+  "dune-configurator"
   "crlibm"
 ]
 synopsis: "An interval library for OCaml (crlibm version)"

--- a/packages/io-page/io-page.2.1.0/opam
+++ b/packages/io-page/io-page.2.1.0/opam
@@ -9,6 +9,7 @@ doc: "https://mirage.github.io/io-page/"
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.0"}
+  "dune-configurator"
   "cstruct" {>= "2.0.0"}
 ]
 build: [

--- a/packages/io-page/io-page.2.2.0/opam
+++ b/packages/io-page/io-page.2.2.0/opam
@@ -9,6 +9,7 @@ doc: "https://mirage.github.io/io-page/"
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.0"}
+  "dune-configurator"
   "cstruct" {>= "2.0.0"}
   "bigarray-compat" {>= "1.0.0"}
 ]

--- a/packages/io-page/io-page.2.3.0/opam
+++ b/packages/io-page/io-page.2.3.0/opam
@@ -9,6 +9,7 @@ doc: "https://mirage.github.io/io-page/"
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune"
+  "dune-configurator"
   "cstruct" {>= "2.0.0"}
   "bigarray-compat"
 ]

--- a/packages/iter/iter.1.2.1/opam
+++ b/packages/iter/iter.1.2.1/opam
@@ -14,6 +14,7 @@ depends: [
   "base-bytes"
   "result"
   "dune"
+  "dune-configurator"
   "qcheck" {with-test}
   "qtest" {with-test}
   "mdx" {with-test}

--- a/packages/jst-config/jst-config.v0.12.0/opam
+++ b/packages/jst-config/jst-config.v0.12.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ppx_assert"        {>= "v0.12" & < "v0.13"}
   "stdio"             {>= "v0.12" & < "v0.13"}
   "dune"              {>= "1.5.1"}
+  "dune-configurator"
 ]
 depopts: [
   "base-native-int63"

--- a/packages/lablgtk3/lablgtk3.3.0.beta4/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta4/opam
@@ -14,6 +14,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk"
 depends: [
   "ocaml"     {         >= "4.05.0" }
   "dune"      { >= "1.4.0"  }
+  "dune-configurator"
   "conf-gtk3" { build & >= "18"     }
   "cairo2"    {         >= "0.6"    }
 ]

--- a/packages/lablgtk3/lablgtk3.3.0.beta5/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta5/opam
@@ -20,6 +20,7 @@ depends: [
   "dune"      {         >= "1.4.0"
                       & != "1.7.0"
                       & != "1.7.1"  } # Due to dune/dune#1833
+  "dune-configurator"
   "conf-gtk3" { build & >= "18"     }
   "cairo2"    {         >= "0.6"    }
 ]

--- a/packages/lablgtk3/lablgtk3.3.0.beta6/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta6/opam
@@ -20,6 +20,7 @@ depends: [
   "dune"      {         >= "1.4.0"
                       & != "1.7.0"
                       & != "1.7.1"  } # Due to dune/dune#1833
+  "dune-configurator"
   "conf-gtk3" { build & >= "18"     }
   "cairo2"    {         >= "0.6"    }
 ]

--- a/packages/lacaml/lacaml.11.0.2/opam
+++ b/packages/lacaml/lacaml.11.0.2/opam
@@ -29,6 +29,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4.0"}
+  "dune-configurator"
   "conf-blas" {build}
   "conf-lapack" {build}
   "base" {build & < "v0.13"}

--- a/packages/lacaml/lacaml.11.0.3/opam
+++ b/packages/lacaml/lacaml.11.0.3/opam
@@ -29,6 +29,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4.0"}
+  "dune-configurator"
   "conf-blas" {build}
   "conf-lapack" {build}
   "base" {build & < "v0.13"}

--- a/packages/lacaml/lacaml.11.0.4/opam
+++ b/packages/lacaml/lacaml.11.0.4/opam
@@ -29,6 +29,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4.0"}
+  "dune-configurator"
   "conf-blas" {build}
   "conf-lapack" {build}
   "base" {build}

--- a/packages/lbfgs/lbfgs.0.9.1/opam
+++ b/packages/lbfgs/lbfgs.0.9.1/opam
@@ -19,6 +19,7 @@ depends: [
   "base-bytes"
   "camlp4" {build}
   "dune"
+  "dune-configurator"
   "lacaml" {with-test}
 ]
 depexts: [

--- a/packages/lbfgs/lbfgs.0.9.2/opam
+++ b/packages/lbfgs/lbfgs.0.9.2/opam
@@ -19,6 +19,7 @@ depends: [
   "base-bytes"
   "camlp4" {build}
   "dune"
+  "dune-configurator"
   "conf-gfortran" {build}
   "lacaml" {with-test}
 ]

--- a/packages/lbfgs/lbfgs.0.9.3/opam
+++ b/packages/lbfgs/lbfgs.0.9.3/opam
@@ -18,6 +18,7 @@ depends: [
   "base-bigarray"
   "base-bytes"
   "dune" {>= "1.1"}
+  "dune-configurator"
   "cppo" {build}
   "conf-gfortran" {build}
   "lacaml" {with-test}

--- a/packages/links-postgresql/links-postgresql.0.9/opam
+++ b/packages/links-postgresql/links-postgresql.0.9/opam
@@ -17,6 +17,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.10"}
+  "dune-configurator"
   "postgresql"
   "links"
 ]

--- a/packages/links-sqlite3/links-sqlite3.0.9/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9/opam
@@ -16,6 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.10"}
+  "dune-configurator"
   "sqlite3"
   "links"
 ]

--- a/packages/links/links.0.9/opam
+++ b/packages/links/links.0.9/opam
@@ -19,6 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.10"}
+  "dune-configurator"
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}
   "base64"

--- a/packages/lwt/lwt.4.3.0/opam
+++ b/packages/lwt/lwt.4.3.0/opam
@@ -20,6 +20,7 @@ dev-repo: "git+https://github.com/ocsigen/lwt.git"
 depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.7.0"}
+  "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
   "ocaml" {>= "4.02.0"}
   "ocplib-endian"

--- a/packages/mesh-easymesh/mesh-easymesh.0.9.5/opam
+++ b/packages/mesh-easymesh/mesh-easymesh.0.9.5/opam
@@ -13,6 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
+  "dune-configurator"
   "base-bigarray"
   "base-bytes"
   "mesh" {= version}

--- a/packages/mesh/mesh.0.9.5/opam
+++ b/packages/mesh/mesh.0.9.5/opam
@@ -14,6 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
+  "dune-configurator"
   "base-bigarray"
   "base-bytes"
   "lacaml" {with-test}

--- a/packages/mindstorm-lwt/mindstorm-lwt.0.8/opam
+++ b/packages/mindstorm-lwt/mindstorm-lwt.0.8/opam
@@ -22,6 +22,7 @@ depends: [
   "base-threads"
   "lwt"
   "dune"
+  "dune-configurator"
   "cppo" {build}
   "base-bytes"
   "base-unix"

--- a/packages/mindstorm/mindstorm.0.8/opam
+++ b/packages/mindstorm/mindstorm.0.8/opam
@@ -19,6 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune"
+  "dune-configurator"
   "cppo" {build}
   "base-bytes"
   "base-unix"

--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.2.0.0/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.2.0.0/opam
@@ -16,6 +16,7 @@ MirageOS.
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune"
+  "dune-configurator"
   "mirage-clock" {>= "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "lwt"

--- a/packages/mirage-clock-lwt/mirage-clock-lwt.2.0.0/opam
+++ b/packages/mirage-clock-lwt/mirage-clock-lwt.2.0.0/opam
@@ -14,6 +14,7 @@ the `io` type to use the Lwt concurrency monad.
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune"
+  "dune-configurator"
   "mirage-clock" {>= "1.2.0"}
   "lwt"
 ]

--- a/packages/mirage-clock/mirage-clock.2.0.0/opam
+++ b/packages/mirage-clock/mirage-clock.2.0.0/opam
@@ -19,6 +19,7 @@ epoch.
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune"
+  "dune-configurator"
   "mirage-device" {>= "1.0.0"}
 ]
 build: [

--- a/packages/mssql/mssql.1.1/opam
+++ b/packages/mssql/mssql.1.1/opam
@@ -25,6 +25,7 @@ depends: [
 
   "bisect_ppx" {build & >= "1.3.1"}
   "dune" {>= "1.4"}
+  "dune-configurator"
 ]
 url {
   src: "https://github.com/arenadotio/ocaml-mssql/archive/1.1.tar.gz"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs6/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs6/opam
@@ -15,6 +15,7 @@ depends: [
   "base-unix"
   "camlidl"
   "dune"
+  "dune-configurator"
 ]
 depexts: [
   ["libfuse-dev"] {os-family = "debian"}

--- a/packages/odepack/odepack.0.6.9/opam
+++ b/packages/odepack/odepack.0.6.9/opam
@@ -19,6 +19,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "base-bigarray"
   "dune"
+  "dune-configurator"
   "base-bytes" {build}
   "conf-gfortran"
 ]

--- a/packages/odepack/odepack.0.7/opam
+++ b/packages/odepack/odepack.0.7/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "base-bigarray"
   "dune"
+  "dune-configurator"
   "base-bytes" {build}
   "conf-gfortran" {build}
 ]

--- a/packages/owl-base/owl-base.0.5.0/opam
+++ b/packages/owl-base/owl-base.0.5.0/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "base-bigarray"
   "dune"
+  "dune-configurator"
 ]
 url {
   src: "https://github.com/owlbarn/owl/releases/download/0.5.0/owl-0.5.0.tbz"

--- a/packages/owl-base/owl-base.0.6.0/opam
+++ b/packages/owl-base/owl-base.0.6.0/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "base-bigarray"
   "dune"
+  "dune-configurator"
 ]
 url {
   src: "https://github.com/owlbarn/owl/archive/0.6.0.tar.gz"

--- a/packages/owl/owl.0.5.0/opam
+++ b/packages/owl/owl.0.5.0/opam
@@ -29,6 +29,7 @@ depends: [
   "conf-openblas" {>= "0.2.0"}
   "ctypes"
   "dune" {>= "1.2.1"}
+  "dune-configurator"
   "eigen" {>= "0.1.0"}
   "owl-base" {>= "0.5.0" & < "0.6.0"}
   "stdio" {build}

--- a/packages/owl/owl.0.6.0/opam
+++ b/packages/owl/owl.0.6.0/opam
@@ -29,6 +29,7 @@ depends: [
   "conf-openblas" {>= "0.2.0"}
   "ctypes"
   "dune" {>= "1.2.1"}
+  "dune-configurator"
   "eigen" {>= "0.1.0"}
   "owl-base" {>= version}
   "stdio" {build}

--- a/packages/pcre/pcre.7.3.5/opam
+++ b/packages/pcre/pcre.7.3.5/opam
@@ -15,6 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "dune" {>= "1.4.0"}
+  "dune-configurator"
   "conf-libpcre" {build}
   "base" {build & < "v0.13"}
   "base-bytes"

--- a/packages/pcre/pcre.7.4.0/opam
+++ b/packages/pcre/pcre.7.4.0/opam
@@ -15,6 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "dune" {>= "1.4.0"}
+  "dune-configurator"
   "conf-libpcre" {build}
   "base" {build & < "v0.13"}
   "base-bytes"

--- a/packages/pcre/pcre.7.4.1/opam
+++ b/packages/pcre/pcre.7.4.1/opam
@@ -15,6 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "dune" {>= "1.4.0"}
+  "dune-configurator"
   "conf-libpcre" {build}
   "base" {build & < "v0.13"}
   "base-bytes"

--- a/packages/postgresql/postgresql.4.4.1/opam
+++ b/packages/postgresql/postgresql.4.4.1/opam
@@ -19,6 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4.0"}
+  "dune-configurator"
   "base" {build & < "v0.13"}
   "stdio" {build & < "v0.13"}
   "base-bytes"

--- a/packages/postgresql/postgresql.4.4.2/opam
+++ b/packages/postgresql/postgresql.4.4.2/opam
@@ -19,6 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4.0"}
+  "dune-configurator"
   "base" {build}
   "stdio" {build}
   "base-bytes"

--- a/packages/postgresql/postgresql.4.5.0/opam
+++ b/packages/postgresql/postgresql.4.5.0/opam
@@ -19,6 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4.0"}
+  "dune-configurator"
   "base" {build}
   "stdio" {build}
   "base-bytes"

--- a/packages/ppx_cstubs/ppx_cstubs.0.1.0/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.1.0/opam
@@ -20,6 +20,7 @@ depends: [
   "ocaml-migrate-parsetree"
   "ocamlfind" # not only a build dependency, it depends on findlib.top
   "dune" {>= "1.6"}
+  "dune-configurator"
   "ppx_tools_versioned" {>= "5.0.1"}
   "re" {>= "1.7.2"}
 ]

--- a/packages/ppx_cstubs/ppx_cstubs.0.2.0/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.2.0/opam
@@ -21,6 +21,7 @@ depends: [
   "ocaml-migrate-parsetree"
   "ocamlfind" # not only a build dependency, it depends on findlib.top
   "dune" {>= "1.6"}
+  "dune-configurator"
   "ppx_tools_versioned" {>= "5.0.1"}
   "re" {>= "1.7.2"}
 ]

--- a/packages/ppx_cstubs/ppx_cstubs.0.2.1/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.2.1/opam
@@ -21,6 +21,7 @@ depends: [
   "ocaml-migrate-parsetree"
   "ocamlfind" # not only a build dependency, it depends on findlib.top
   "dune" {>= "1.6"}
+  "dune-configurator"
   "ppx_tools_versioned" {>= "5.2.3"}
   "re" {>= "1.7.2"}
 ]

--- a/packages/qrencode/qrencode.0.2/opam
+++ b/packages/qrencode/qrencode.0.2/opam
@@ -7,6 +7,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 
 depends: [
   "dune" {>= "1.10"}
+  "dune-configurator"
   "ocaml"
 ]
 depexts: [

--- a/packages/sqlite3/sqlite3.4.4.1/opam
+++ b/packages/sqlite3/sqlite3.4.4.1/opam
@@ -19,6 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4.0"}
+  "dune-configurator"
   "base" {build & < "v0.13"}
   "stdio" {build & < "v0.13"}
   "conf-sqlite3" {build}

--- a/packages/ssl/ssl.0.5.6/opam
+++ b/packages/ssl/ssl.0.5.6/opam
@@ -11,6 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune"
+  "dune-configurator"
   "base-unix"
   "conf-openssl"
 ]

--- a/packages/ssl/ssl.0.5.7/opam
+++ b/packages/ssl/ssl.0.5.7/opam
@@ -10,6 +10,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2.1"}
+  "dune-configurator"
   "base-unix"
   "conf-openssl"
 ]

--- a/packages/ssl/ssl.0.5.8/opam
+++ b/packages/ssl/ssl.0.5.8/opam
@@ -10,6 +10,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2.1"}
+  "dune-configurator"
   "base-unix"
   "conf-openssl"
 ]

--- a/packages/ssl/ssl.0.5.9/opam
+++ b/packages/ssl/ssl.0.5.9/opam
@@ -10,6 +10,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2.1"}
+  "dune-configurator"
   "base-unix"
   "conf-openssl"
 ]

--- a/packages/tcpip/tcpip.3.7.6/opam
+++ b/packages/tcpip/tcpip.3.7.6/opam
@@ -21,6 +21,7 @@ build: [
 depopts: ["mirage-xen-ocaml"]
 depends: [
   "dune" {>= "1.0"}
+  "dune-configurator"
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.2.0"}

--- a/packages/tcpip/tcpip.3.7.7/opam
+++ b/packages/tcpip/tcpip.3.7.7/opam
@@ -21,6 +21,7 @@ build: [
 depopts: ["mirage-xen-ocaml"]
 depends: [
   "dune"     {>= "1.0"}
+  "dune-configurator"
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.2.0"}

--- a/packages/tcpip/tcpip.3.7.8/opam
+++ b/packages/tcpip/tcpip.3.7.8/opam
@@ -21,6 +21,7 @@ build: [
 depopts: ["mirage-xen-ocaml"]
 depends: [
   "dune" {>= "1.0"}
+  "dune-configurator"
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.2.0"}

--- a/packages/tensorflow/tensorflow.0.0.11/opam
+++ b/packages/tensorflow/tensorflow.0.0.11/opam
@@ -15,6 +15,7 @@ depends: [
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
+  "dune-configurator"
   "libtensorflow"
   "ocaml" {>= "4.06"}
   "ocamlfind" {build}

--- a/packages/torch/torch.0.1/opam
+++ b/packages/torch/torch.0.1/opam
@@ -12,6 +12,7 @@ depends: [
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
+  "dune-configurator"
   "imagelib"
   "libtorch" {< "1.1.0"}
   "npy"

--- a/packages/torch/torch.0.2/opam
+++ b/packages/torch/torch.0.2/opam
@@ -13,6 +13,7 @@ depends: [
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
+  "dune-configurator"
   "libtorch" {< "1.1.0"}
   "npy"
   "ocaml" {>= "4.06"}

--- a/packages/torch/torch.0.3/opam
+++ b/packages/torch/torch.0.3/opam
@@ -13,6 +13,7 @@ depends: [
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
+  "dune-configurator"
   "libtorch" {>= "1.0.1" & < "1.1.0"}
   "npy"
   "ocaml" {>= "4.06"}

--- a/packages/torch/torch.0.4/opam
+++ b/packages/torch/torch.0.4/opam
@@ -13,6 +13,7 @@ depends: [
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
+  "dune-configurator"
   "libtorch" {= "1.1.0"}
   "npy"
   "ocaml" {>= "4.06"}

--- a/packages/torch/torch.0.5/opam
+++ b/packages/torch/torch.0.5/opam
@@ -13,6 +13,7 @@ depends: [
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
+  "dune-configurator"
   "libtorch" {= "1.1.0"}
   "npy"
   "ocaml" {>= "4.06"}

--- a/packages/torch/torch.0.6/opam
+++ b/packages/torch/torch.0.6/opam
@@ -13,6 +13,7 @@ depends: [
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
+  "dune-configurator"
   "libtorch" {= "1.2.0"}
   "npy"
   "ocaml" {>= "4.07"}

--- a/packages/yaml/yaml.1.0.0/opam
+++ b/packages/yaml/yaml.1.0.0/opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>="1.3"}
+  "dune-configurator"
   "ctypes" {>= "0.12.0"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.13"}
   "sexplib" {< "v0.13"}

--- a/packages/yaml/yaml.2.0.0/opam
+++ b/packages/yaml/yaml.2.0.0/opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>="1.3"}
+  "dune-configurator"
   "ctypes" {>= "0.12.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"

--- a/packages/yaml/yaml.2.0.1/opam
+++ b/packages/yaml/yaml.2.0.1/opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>="1.3"}
+  "dune-configurator"
   "ctypes" {>= "0.12.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"


### PR DESCRIPTION
We are planning to split `dune.configurator` as a separate `dune-configurator` package in Dune 2.0.0. The `dune.configurator` name will still exist for backward compatibility reason, however packages that use it must declare an additional dependency on `dune-configurator` in order to be compatible with Dune >= 2.0.0.

In preparation of this, this PR adds an empty `dune-configurator.1.0.0` that depends on Dune < 2.0.0 and adds it as a dependency of all packages that use `dune.configurator`.