### PR TITLE
ocaml-manual: 4.08 and 4.09

### DIFF
--- a/packages/ocaml-manual/ocaml-manual.4.08.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.08.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Xavier Leroy"
+           "Damien Doligez"
+           "Alain Frisch"
+           "Jacques Garrigue"
+           "Didier Rémy"
+           "Jérôme Vouillon" ]
+homepage: "http://ocaml.org/"
+doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
+license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
+dev-repo: "git+https://github.com/ocaml/ocaml.git"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+install:
+[
+ [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
+ [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}
+]
+synopsis: "The OCaml system manual"
+depends: [
+  "ocaml" {>= "4.08.0" & < "4.09.0"}
+]
+url {
+  src:
+    "http://caml.inria.fr/distrib/ocaml-4.08/ocaml-4.08-refman-html.tar.gz"
+  checksum: "md5=20cbe4bd141f175d723f58cb9e89b215"
+}

--- a/packages/ocaml-manual/ocaml-manual.4.09.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.09.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Xavier Leroy"
+           "Damien Doligez"
+           "Alain Frisch"
+           "Jacques Garrigue"
+           "Didier Rémy"
+           "Jérôme Vouillon" ]
+homepage: "http://ocaml.org/"
+doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
+license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
+dev-repo: "git+https://github.com/ocaml/ocaml.git"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+install:
+[
+ [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
+ [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}
+]
+synopsis: "The OCaml system manual"
+depends: [
+  "ocaml" {>= "4.09.0" & < "4.10.0"}
+]
+url {
+  src:
+    "http://caml.inria.fr/distrib/ocaml-4.09/ocaml-4.09-refman-html.tar.gz"
+  checksum: "md5=ad177914c9c16806cea4020f303d1d55"
+}


### PR DESCRIPTION
Distributing the OCaml manual as an opam packages sounds like a nice idea. This PR adds the last two versions of the manual to the list of available manuals.

cc @dbuenzli 