### PR TITLE
fixes bug in conf-ida configuration

### DIFF
--- a/packages/conf-ida/conf-ida.0.2/files/find-ida.ml.in
+++ b/packages/conf-ida/conf-ida.0.2/files/find-ida.ml.in
@@ -7,7 +7,7 @@ type sys =
   | Linux
   | Other of string
 
-let os = match "linux" with
+let os = match "%{os}%" with
   | "macos" -> MacOs
   | "linux" -> Linux
   | s -> Other s


### PR DESCRIPTION
An awful bug was discovered in `conf-ida` configuration, thanks @hluwa for that.
The way we wrote OS kind inferring was absolutely wrong so that PR fixes it.