### PR TITLE
Fix 4.09+musl switches

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+flambda/opam
@@ -30,7 +30,6 @@ build: [
     "CC=musl-gcc -Os"
     "ASPP=musl-gcc -c"
     "--enable-flambda"
-    "--disable-graph-lib"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
@@ -31,7 +31,6 @@ build: [
     "ASPP=musl-gcc -c"
     "--enable-flambda"
     "LIBS=-static"
-    "--disable-graph-lib"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]


### PR DESCRIPTION
Removes `--disable-graph-lib` on 4.09 switches since graph-lib has been removed from 4.09.