### PR TITLE
Package opus.0.1.3

### DIFF
--- a/packages/opus/opus.0.1.3/opam
+++ b/packages/opus/opus.0.1.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-opus"
+build: [
+  ["./bootstrap"] {dev}
+  ["./configure" "--prefix" prefix]
+  [make "clean"] {dev}
+  [make]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+  "ogg"
+]
+depexts: [
+  ["opus-dev"] {os-distribution = "alpine"}
+  ["opus"] {os-distribution = "arch"}
+  ["libopus-dev"] {os-family = "debian"}
+  ["opus-devel"] {os-distribution = "centos"}
+  ["opus-devel"] {os-distribution = "fedora"}
+  ["opus-devel"] {os-family = "suse"}
+  ["libopus"] {os-distribution = "nixos"}
+  ["opus"] {os = "macos" & os-distribution = "homebrew"}
+]
+bug-reports: "https://github.com/savonet/ocaml-opus/issues"
+dev-repo: "git+https://github.com/savonet/ocaml-opus.git"
+synopsis:
+  "Bindings for the opus library to decode audio files in opus format"
+url {
+  src:
+    "https://github.com/savonet/ocaml-opus/releases/download/0.1.3/ocaml-opus-0.1.3.tar.gz"
+  checksum: [
+    "md5=b92bbb8130da99d1a57d52682754c385"
+    "sha512=6f3ce5de1366e8f23e5d43f77806eb6dec9689d3c7e0a4c55776027c10695e7e792147c2ac44a2618d6f058af1660f3e85493ef99369bcfadf1a716426d37138"
+  ]
+}

--- a/packages/opus/opus.0.1.3/opam
+++ b/packages/opus/opus.0.1.3/opam
@@ -22,7 +22,7 @@ depexts: [
   ["libopus-dev"] {os-family = "debian"}
   ["opus-devel"] {os-distribution = "centos"}
   ["opus-devel"] {os-distribution = "fedora"}
-  ["opus-devel"] {os-family = "suse"}
+  ["libopus-devel"] {os-family = "suse"}
   ["libopus"] {os-distribution = "nixos"}
   ["opus"] {os = "macos" & os-distribution = "homebrew"}
 ]


### PR DESCRIPTION
### `opus.0.1.3`
Bindings for the opus library to decode audio files in opus format



---
* Homepage: https://github.com/savonet/ocaml-opus
* Source repo: git+https://github.com/savonet/ocaml-opus.git
* Bug tracker: https://github.com/savonet/ocaml-opus/issues

---
:camel: Pull-request generated by opam-publish v2.0.0