### PR TITLE
stdcompat: bump base ocaml version constraint

### DIFF
--- a/packages/stdcompat/stdcompat.10/opam
+++ b/packages/stdcompat/stdcompat.10/opam
@@ -8,7 +8,7 @@ license: "BSD-3-Clause"
 homepage: "https://github.com/thierry-martinez/stdcompat"
 bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
-  "ocaml" {>= "3.07" & < "4.09.0"}
+  "ocaml" {>= "3.07" & < "4.10.0"}
 ]
 depopts: ["result" "seq" "uchar" "ocamlfind"]
 build: [


### PR DESCRIPTION
Last version of stdcompat works as is with ocaml 4.09, so this is just a change in the declared constraint.