### PR TITLE
Adds CamlPDF v2.3

### DIFF
--- a/packages/camlpdf/camlpdf.2.3/opam
+++ b/packages/camlpdf/camlpdf.2.3/opam
@@ -6,10 +6,11 @@ bug-reports: "http://github.com/johnwhitington/camlpdf/issues"
 dev-repo: "git://github.com/johnwhitington/camlpdf"
 build: [[make]]
 install: [[make "install"]]
-remove: [["ocamlfind" "remove" "camlpdf"]]
-depends: ["ocaml" "ocamlfind"]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+]
 synopsis: "Read, write and modify PDF files"
-flags: light-uninstall
 url {
   src: "https://github.com/johnwhitington/camlpdf/archive/v2.3.zip"
   checksum: "md5=61631634e5e91017281676253ff690e5"

--- a/packages/camlpdf/camlpdf.2.3/opam
+++ b/packages/camlpdf/camlpdf.2.3/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+maintainer: "contact@coherentgraphics.co.uk"
+authors: ["John Whitington"]
+homepage: "http://github.com/johnwhitington/camlpdf"
+bug-reports: "http://github.com/johnwhitington/camlpdf/issues"
+dev-repo: "git://github.com/johnwhitington/camlpdf"
+build: [[make]]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "camlpdf"]]
+depends: ["ocaml" "ocamlfind"]
+synopsis: "Read, write and modify PDF files"
+flags: light-uninstall
+url {
+  src: "https://github.com/johnwhitington/camlpdf/archive/v2.3.zip"
+  checksum: "md5=61631634e5e91017281676253ff690e5"
+}


### PR DESCRIPTION
I tried the new mechanism for automatic submission, but didn't get past step one (`opam pin .` failed, saying it could not locate a patch file). So here it is manually...

This release uses safe strings. Cpdf v2.3 to follow once we know CamlPDF is up and working.
