### PR TITLE
Jane Street packages: support for OCaml 4.09

### DIFF
--- a/packages/core/core.v0.12.4/opam
+++ b/packages/core/core.v0.12.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core"
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "git+https://github.com/janestreet/core.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"        {>= "4.07.0"}
+  "jst-config"   {>= "v0.12" & < "v0.13"}
+  "core_kernel"  {>= "v0.12" & < "v0.13"}
+  "ppx_jane"     {>= "v0.12" & < "v0.13"}
+  "sexplib"      {>= "v0.12" & < "v0.13"}
+  "base-threads"
+  "dune"         {>= "1.5.1"}
+  "spawn"        {>= "v0.12"}
+]
+synopsis: "Industrial strength alternative to OCaml's standard library"
+description: "
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+url {
+  src: "https://github.com/janestreet/core/archive/v0.12.4.tar.gz"
+  checksum: "md5=85f006b0666f4fe05c566be8fda64cb2"
+}

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.12.2/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.12.2/opam
@@ -10,7 +10,8 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"               {>= "4.07.0" & < "4.09.0"}
+  "ocaml"               {>= "4.07.0"}
+  "core"                {>= "v0.12.4" & < "v0.13"}
   "core_kernel"         {>= "v0.12" & < "v0.13"}
   "mlt_parser"          {>= "v0.12" & < "v0.13"}
   "ppx_expect"          {>= "v0.12" & < "v0.13"}
@@ -31,6 +32,6 @@ compilations errors as well as provide a nice alternative to using
 the toplevel in a terminal.
 "
 url {
-  src: "https://github.com/janestreet/toplevel_expect_test/archive/v0.12.1.tar.gz"
-  checksum: "md5=3447f1eccdde6d44cb13a89764ca0717"
+  src: "https://github.com/janestreet/toplevel_expect_test/archive/v0.12.2.tar.gz"
+  checksum: "md5=dddf9810458ae33a32df05c22e7b6a93"
 }


### PR DESCRIPTION
According to the latest report at http://check.ocamllabs.io,
only one package is not compatible with OCaml 4.09,
namely `toplevel_expect_test.v0.12.1`.

This pull request constrains this version to prior OCaml
versions, and releases a new version compatible with 4.09.

(This new version of `toplevel_expect_test` needs a new
version of `core`, also in this pull request.)