### PR TITLE
Package bogue.20190920

### DIFF
--- a/packages/bogue/bogue.20190920/opam
+++ b/packages/bogue/bogue.20190920/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Vu Ngoc San <san.vu-ngoc@laposte.net>"]
+authors: ["Vu Ngoc San <san.vu-ngoc@laposte.net>"]
+bug-reports: "https://github.com/sanette/bogue/issues"
+homepage: "https://github.com/sanette/bogue"
+doc: "http://sanette.github.io/bogue/Bogue.html"
+license: "GPL2"
+dev-repo: "git+https://github.com/sanette/bogue.git"
+synopsis: "GUI library for ocaml, with animations, based on SDL2"
+description: """
+bogue is a GUI library for ocaml, with animations, based on SDL2.
+
+This library can be used for games or for adding GUI elements to any
+ocaml program.
+
+It uses the SDL2 renderer library, which makes it quite fast.
+
+It is themable, and does not try to look like your desktop. Instead,
+it will look the same on every platform.
+
+Graphics output is scalable, and hence easily adapts to Hi-DPI
+displays.
+
+Programming with bogue is easy if you're used to GUIs with widgets,
+layouts, callbacks, and of course it has a functional flavor. It uses
+Threads when non-blocking reactions are needed."""
+depends: [
+  "tsdl-image" {>= "0.2"}
+  "tsdl-ttf" {>= "0.2"}
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "tsdl" {>= "0.9.0" & < "0.9.7"}
+]
+url {
+  src: "https://github.com/sanette/bogue/archive/20190920.tar.gz"
+  checksum: [
+    "md5=b97973e802f8b81826637998e8246b2d"
+    "sha512=7f05127da4d82a01f9c9eeb9e157faf8e15a952ee31bd9042a0a34531ae7463eed7b6aeb75be6623e4883d83de7df67651d57bd5dbc6507f69144a94112e1bea"
+  ]
+}


### PR DESCRIPTION
### `bogue.20190920`
GUI library for ocaml, with animations, based on SDL2
bogue is a GUI library for ocaml, with animations, based on SDL2.

This library can be used for games or for adding GUI elements to any
ocaml program.

It uses the SDL2 renderer library, which makes it quite fast.

It is themable, and does not try to look like your desktop. Instead,
it will look the same on every platform.

Graphics output is scalable, and hence easily adapts to Hi-DPI
displays.

Programming with bogue is easy if you're used to GUIs with widgets,
layouts, callbacks, and of course it has a functional flavor. It uses
Threads when non-blocking reactions are needed.



---
* Homepage: https://github.com/sanette/bogue
* Source repo: git+https://github.com/sanette/bogue.git
* Bug tracker: https://github.com/sanette/bogue/issues

---
:camel: Pull-request generated by opam-publish v2.0.0