### PR TITLE
capnp.3.2.1: fix core dependency uses  (remove in v0.12).

### DIFF
--- a/packages/capnp/capnp.3.2.1/opam
+++ b/packages/capnp/capnp.3.2.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocplib-endian" {>= "0.7"}
   "res"
   "uint"
-  "core" {with-test & < "v0.13"}
+  "core" {with-test & < "v0.12"}
   "ounit" {with-test}
   "conf-capnproto" {with-test}
 ]


### PR DESCRIPTION
`capnp.3.2.1` uses `Core.Std`, but the module was removed in v0.12;
this pull request hence simply tighten the dependency on `core`.