### PR TITLE
Travis: Fix failures when a package is unavailable using opam depext but not opam install

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -70,9 +70,6 @@ function build_one {
       fi
   else
     echo "... package available."
-    echo
-    echo "====== External dependency handling ======"
-    opam install 'depext>=1.1.3'
     depext=$(opam depext --with-test -ls $pkg)
     opam depext --with-test $pkg
     echo
@@ -103,6 +100,9 @@ ocaml -version
 echo OPAM versions
 opam --version
 opam --git-version
+
+echo "====== External dependency handling ======"
+opam install 'opam-depext>=1.1.3'
 
 for i in `cat tobuild.txt`; do
     name=$(echo $i | cut -f1 -d".")

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -58,7 +58,7 @@ function build_one {
   echo "build one: $pkg"
   # test for installability
   echo "Checking for availability..."
-  if ! opam install -t $pkg --dry-run; then
+  if ! opam depext --with-test -ls $pkg; then
       echo "Package unavailable."
       if opam show $pkg; then
           echo "Package is unavailable on this configuration, skipping:"


### PR DESCRIPTION
See https://github.com/ocaml/opam-depext/issues/121
This will only be resolved in opam 2.1. In the meantime we can avoid the failures by simply using `opam depext` for the availability check.