### PR TITLE
Package fdkaac.0.3.1

### DIFF
--- a/packages/fdkaac/fdkaac.0.3.1/opam
+++ b/packages/fdkaac/fdkaac.0.3.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-fdkaac"
+bug-reports: "https://github.com/savonet/ocaml-fdkaac/issues"
+license: "GPL-2.0"
+dev-repo: "git+https://github.com/savonet/ocaml-fdkaac.git"
+build: [
+  ["./bootstrap"] {dev}
+  ["./configure" "--prefix=%{prefix}%"] {os != "macos"}
+  ["./configure" "OCAMLFLAGS=-cclib -L/usr/local/lib" "--prefix=%{prefix}%"]
+    {os = "macos"}
+  [make "clean"] {dev}
+  [make]
+]
+install: [make "install"]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+]
+conflicts: [
+  "liquidsoap" {< "1.4.0"}
+]
+depexts: [
+  ["fdk-aac-dev"] {os-distribution = "alpine"}
+  ["libfdk-aac"] {os-distribution = "arch"}
+  ["fdk-aac-devel"] {os-distribution = "centos"}
+  ["fdk-aac-devel"] {os-distribution = "fedora"}
+  ["fdk-aac-devel"] {os-family = "suse"}
+  ["libfdk-aac-dev"] {os-family = "debian"}
+  ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Fraunhofer FDK AAC Codec Library"
+description: """
+The FDK AAC Codec Library For Android contains an encoder implementation of the
+Advanced Audio Coding (AAC) audio codec.
+"""
+url {
+  src:
+    "https://github.com/savonet/ocaml-fdkaac/releases/download/0.3.1/ocaml-fdkaac-0.3.1.tar.gz"
+  checksum: [
+    "md5=8f97fbb8748732eb4a3b6e830cee61dc"
+    "sha512=e48442923b1136c9b5aa5581077c2f2e8d9ba20ac8daec88a749938d0594840e5097e5434b24fbab9ab14c2a80d0ab64a97d2101ec52146162b9daaabfdf827e"
+  ]
+}


### PR DESCRIPTION
### `fdkaac.0.3.1`
Fraunhofer FDK AAC Codec Library
The FDK AAC Codec Library For Android contains an encoder implementation of the
Advanced Audio Coding (AAC) audio codec.



---
* Homepage: https://github.com/savonet/ocaml-fdkaac
* Source repo: git+https://github.com/savonet/ocaml-fdkaac.git
* Bug tracker: https://github.com/savonet/ocaml-fdkaac/issues

---
:camel: Pull-request generated by opam-publish v2.0.0