### PR TITLE
[new release] ounit-lwt and ounit (2.1.1)

### DIFF
--- a/packages/ounit-lwt/ounit-lwt.2.1.1/opam
+++ b/packages/ounit-lwt/ounit-lwt.2.1.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvaini+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ounit"
+dev-repo: "git+https://github.com/gildor478/ounit.git"
+bug-reports: "https://github.com/gildor478/ounit/issues"
+doc: "https://gildor478.github.io/ounit/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build & >= "1.11.0"}
+  "lwt"
+  "ounit" {= version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+synopsis: "OUnit testing framework (Lwt)"
+description:"""
+This library contains helper functions for building Lwt tests using OUnit.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ounit/releases/download/v2.1.1/ounit-v2.1.1.tbz"
+  checksum: [
+    "sha256=82f7d3ea299379bf7e96a0b9661e00f7b60db4cd8d66572bdfa9dacfb1f348ab"
+    "sha512=e8d5c6a85e13f5d75b4c26a778c8bcfe423c7b7773108a13408e3900f671616cbd1c19087cc6db3cd34f86c1c86adfd5057ab395fb5ebff94fc18c97a344a389"
+  ]
+}

--- a/packages/ounit/ounit.2.1.1/opam
+++ b/packages/ounit/ounit.2.1.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvaini+ocaml@le-gall.net>"
+authors: [ "Maas-Maarten Zeeman" "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ounit"
+dev-repo: "git+https://github.com/gildor478/ounit.git"
+bug-reports: "https://github.com/gildor478/ounit/issues"
+doc: "https://gildor478.github.io/ounit/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build & >= "1.11.0"}
+  "base-bytes"
+  "stdlib-shims"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+install: [
+  [ make "install-ounit" "version=%{version}%" ]
+]
+synopsis: "OUnit testing framework"
+description: """
+OUnit is a unit test framework for OCaml. It allows one to easily create
+unit-tests for OCaml code. It is loosely based on [HUnit], a unit testing
+framework for Haskell. It is similar to [JUnit], and other XUnit testing
+frameworks.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ounit/releases/download/v2.1.1/ounit-v2.1.1.tbz"
+  checksum: [
+    "sha256=82f7d3ea299379bf7e96a0b9661e00f7b60db4cd8d66572bdfa9dacfb1f348ab"
+    "sha512=e8d5c6a85e13f5d75b4c26a778c8bcfe423c7b7773108a13408e3900f671616cbd1c19087cc6db3cd34f86c1c86adfd5057ab395fb5ebff94fc18c97a344a389"
+  ]
+}


### PR DESCRIPTION
OUnit testing framework (Lwt)

- Project page: <a href="https://github.com/gildor478/ounit">https://github.com/gildor478/ounit</a>
- Documentation: <a href="https://gildor478.github.io/ounit/">https://gildor478.github.io/ounit/</a>

##### CHANGES:

### Changed
- install a backward compatible META to help the transition from oUnit to ounit
  library name. In order to depend on OUnit now, the name "ounit" should be
  used (rather than the old "oUnit"). This change allows to be consistent with
  the name of the opam package.
