### PR TITLE
Fix invalid {doc} tags

### DIFF
--- a/packages/mpris-clients/mpris-clients.0.2.0/opam
+++ b/packages/mpris-clients/mpris-clients.0.2.0/opam
@@ -9,7 +9,7 @@ depends: [
   "dune"
   "mpris"
   "obus"
-  "odoc" {doc}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "build" "@install" "-p" name]

--- a/packages/mpris/mpris.0.2.0/opam
+++ b/packages/mpris/mpris.0.2.0/opam
@@ -9,7 +9,7 @@ depends: [
   "dune"
   "lwt_ppx" {build}
   "obus"
-  "odoc" {doc}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "build" "@install" "-p" name]

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
@@ -12,7 +12,7 @@ depends: [
   "base-unix"
   "qcheck-core" {>= "0.9"}
   "alcotest" {>= "0.8.0"}
-  "odoc" {doc}
+  "odoc" {with-doc}
 ]
 build:[
     ["dune" "build" "-p" name "-j" jobs]

--- a/packages/qcheck-core/qcheck-core.0.9/opam
+++ b/packages/qcheck-core/qcheck-core.0.9/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "base-bytes"
   "base-unix"
-  "odoc" {doc}
+  "odoc" {with-doc}
 ]
 conflicts: [
   "ounit" {< "2.0"}

--- a/packages/qcheck-ounit/qcheck-ounit.0.9/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.9/opam
@@ -12,7 +12,7 @@ depends: [
   "base-unix"
   "qcheck-core" {>= "0.9"}
   "ounit" {>= "2.0"}
-  "odoc" {doc}
+  "odoc" {with-doc}
 ]
 build: [
     ["dune" "build" "-p" name "-j" jobs]

--- a/packages/qcheck/qcheck.0.9/opam
+++ b/packages/qcheck/qcheck.0.9/opam
@@ -12,7 +12,7 @@ depends: [
   "base-unix"
   "qcheck-core" {>= "0.9"}
   "qcheck-ounit" {>= "0.9"}
-  "odoc" {doc}
+  "odoc" {with-doc}
 ]
 conflicts: [
   "ounit" {< "2.0"}

--- a/packages/tip-parser/tip-parser.0.5/opam
+++ b/packages/tip-parser/tip-parser.0.5/opam
@@ -9,7 +9,7 @@ depends: [
   "base-bytes"
   "result"
   "menhir" {build}
-  "odoc" {doc}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "build" "-p" name]


### PR DESCRIPTION
Replace `{doc}` tags after odoc dependencies with the proper `{with-doc}`.