### PR TITLE
Shrink.filter is only provided since qcheck 0.8.

### DIFF
--- a/packages/qcstm/qcstm.0.1.1/opam
+++ b/packages/qcstm/qcstm.0.1.1/opam
@@ -26,7 +26,7 @@ url {
 }
 depends: [
   "ocaml"  {>= "4.05.0"}
-  "qcheck" {>= "0.6"}
+  "qcheck" {>= "0.8"}
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "ppx_deriving"   {with-test}

--- a/packages/qcstm/qcstm.0.1/opam
+++ b/packages/qcstm/qcstm.0.1/opam
@@ -18,7 +18,7 @@ url {
 }
 depends: [
   "ocaml" {>= "4.04.0"}
-  "qcheck" {>= "0.6"}
+  "qcheck" {>= "0.8"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Fix failure in #14890