### PR TITLE
mirage-solo5 0.6.0

### DIFF
--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.3.0/opam
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "mirage-solo5" {>= "0.3.0"}
+  "mirage-solo5" {>= "0.3.0" & < "0.6.0"}
   "lwt"
   "parse-argv"
 ]

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.3.0/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "mirage-console-lwt" {>= "2.2.0"}
-  "mirage-solo5" {>= "0.3.0"}
+  "mirage-solo5" {>= "0.3.0" & < "0.6.0"}
   "cstruct"
   "lwt"
 ]

--- a/packages/mirage-solo5/mirage-solo5.0.6.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.6.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%" ]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "bheap"
+  "ocb-stubblr" {build}
+  "ocaml" {>= "4.05.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "lwt-dllist"
+  "ocaml-freestanding" {>= "0.4.5"}
+  "metrics"
+  "logs"
+  ("solo5-bindings-hvt" {>= "0.6.0"} | "solo5-bindings-spt" {>= "0.6.0"} | "solo5-bindings-virtio" {>= "0.6.0"} | "solo5-bindings-muen" {>= "0.6.0"} | "solo5-bindings-genode" {>= "0.6.0"})
+]
+conflicts: [
+  "io-page" {< "2.0.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+url {
+  src: "https://github.com/mirage/mirage-solo5/releases/download/v0.6.0/mirage-solo5-0.6.0.tbz"
+  checksum: "sha512=60342bca01e106a1af48fc96fabb4f88608440ec24eea2403e468f7cd428405542c6c0f368db17bd72693826094ebe35a5521b88c658ef9a7c2ace9b016634ff"
+}


### PR DESCRIPTION
This is an API breaking release, this PR also adds additional upper bounds to device driver packages.

Part of mirage/mirage#992.