### PR TITLE
tls < 0.7.1: Add missing constraint on lwt (use lwt.syntax)

### DIFF
--- a/packages/tls/tls.0.1.0/opam
+++ b/packages/tls/tls.0.1.0/opam
@@ -31,6 +31,7 @@ depopts: [
   "mirage-types-lwt"
 ]
 conflicts: [
+  "lwt" {>= "4.0.0"}
   "mirage-types-lwt" {< "1.2.0"}
   "mirage-types-lwt" {> "2.0.0"}
 ]

--- a/packages/tls/tls.0.2.0/opam
+++ b/packages/tls/tls.0.2.0/opam
@@ -33,6 +33,7 @@ depopts: [
   "mirage-types-lwt"
 ]
 conflicts: [
+  "lwt" {>= "4.0.0"}
   "mirage-types-lwt" {< "2.0.0"}
   "mirage-types-lwt" {>= "2.2.0"}
 ]

--- a/packages/tls/tls.0.3.0/opam
+++ b/packages/tls/tls.0.3.0/opam
@@ -33,6 +33,7 @@ depopts: [
   "mirage-types-lwt"
 ]
 conflicts: [
+  "lwt" {>= "4.0.0"}
   "mirage-types-lwt" {< "2.2.0"}
   "mirage-types-lwt" {>= "2.3.0"}
   "io-page" {>= "1.3.0"}

--- a/packages/tls/tls.0.4.0/opam
+++ b/packages/tls/tls.0.4.0/opam
@@ -34,6 +34,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {< "2.4.8"}
+  "lwt" {>= "4.0.0"}
   "mirage-types-lwt" {< "2.3.0"}
   "mirage-types-lwt" {>= "2.5.0"}
   "mirage-net-xen" {< "1.3.0"}

--- a/packages/tls/tls.0.5.0/opam
+++ b/packages/tls/tls.0.5.0/opam
@@ -32,6 +32,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {<"2.4.8"}
+  "lwt" {>= "4.0.0"}
   "mirage-types-lwt" {<"2.3.0"}
   "mirage-types-lwt" {>="3.0.0"}
   "mirage-net-xen" {<"1.3.0"}

--- a/packages/tls/tls.0.6.0/opam
+++ b/packages/tls/tls.0.6.0/opam
@@ -40,6 +40,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {<"2.4.8"}
+  "lwt" {>= "4.0.0"}
   "mirage-types-lwt" {<"2.3.0"}
   "mirage-types-lwt" {>="3.0.0"}
   "mirage-net-xen" {<"1.3.0"}


### PR DESCRIPTION
Follow-up of #14896
Detected in https://github.com/ocaml/opam-repository/pull/14883