### PR TITLE
Disable zmq.3.2-* as it is not installable. 

### DIFF
--- a/packages/zmq/zmq.3.2-0/opam
+++ b/packages/zmq/zmq.3.2-0/opam
@@ -25,3 +25,4 @@ url {
   src: "https://github.com/issuu/ocaml-zmq/archive/3.2-0.tar.gz"
   checksum: "md5=4728a8cc3475cf42bde10c0df503fe6f"
 }
+available: false

--- a/packages/zmq/zmq.3.2-1/opam
+++ b/packages/zmq/zmq.3.2-1/opam
@@ -26,3 +26,4 @@ url {
   src: "https://github.com/issuu/ocaml-zmq/archive/3.2-1.tar.gz"
   checksum: "md5=05f9d04dbb93b2c9ac07108aefb5f768"
 }
+available: false

--- a/packages/zmq/zmq.3.2-2/opam
+++ b/packages/zmq/zmq.3.2-2/opam
@@ -26,3 +26,4 @@ url {
   src: "https://github.com/issuu/ocaml-zmq/archive/3.2-2.tar.gz"
   checksum: "md5=e806e5507d41e3416be1a42b0a4a2098"
 }
+available: false


### PR DESCRIPTION
This PR disables zmq.3.2-* packages, as these are no longer installable:
* C types have changed
* Requires libzmq = 3.2, which is no longer available in popular distributions. 

See #14888.