### PR TITLE
Mirage solo5 0.6.0 components

### DIFF
--- a/packages/mirage-block-solo5/mirage-block-solo5.0.6.0/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.6.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-block-solo5"
+dev-repo:     "git+https://github.com/mirage/mirage-block-solo5.git"
+bug-reports:  "https://github.com/mirage/mirage-block-solo5/issues"
+authors:      ["Dan Williams" "Martin Lucina"]
+tags: [
+  "org:mirage"
+]
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"  {build & >= "1.0"}
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.0.1"}
+  "mirage-block-lwt" {>= "1.0.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
+  "fmt"
+]
+synopsis: "Solo5 implementation of MirageOS block interface"
+description:
+  "This library implements the MirageOS block interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-block-solo5/releases/download/v0.6.0/mirage-block-solo5-v0.6.0.tbz"
+  checksum: [
+    "sha256=d3079a6cd8e9f5d4571f4ed950b4c4323e95cb76ed068ead0e38658523c7f8c1"
+    "sha512=0839fc584a2bcd064cf932bda0131135f812931f348226637bfc5736ed9d9a3c0802da8e1603e7757b3164aee30fe398d86e90da9158a43df75008383160fddc"
+  ]
+}

--- a/packages/mirage-block-solo5/mirage-block-solo5.0.6.0/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.6.0/opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune"  {build & >= "1.0"}
+  "dune"  {>= "1.0"}
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "mirage-block-lwt" {>= "1.0.0"}

--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.6.0/opam
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.6.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name:         "mirage-bootvar-solo5"
+maintainer:   "Martin Lucina <martin@lucina.net>"
+homepage:     "https://github.com/mirage/mirage-bootvar-solo5"
+bug-reports:  "https://github.com/mirage/mirage-bootvar-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-bootvar-solo5.git"
+license:      "ISC"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
+  "lwt"
+  "parse-argv"
+]
+synopsis: "Solo5 implementation of MirageOS Bootvar interface"
+url {
+  src:
+    "https://github.com/mirage/mirage-bootvar-solo5/releases/download/v0.6.0/mirage-bootvar-solo5-v0.6.0.tbz"
+  checksum: [
+    "sha256=113ea304f8c418d3045aa9611492d200ec8ce3b06c40a91b0aa3ca190d691737"
+    "sha512=4966c100f8ee87537e586a1a305d8c706baa36ce5c208dce2ae89cc101d4faa458fa3b10e7b79b42b412137d81c7f56676d89e6fde1d955ec1d609538e9b04e0"
+  ]
+}

--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.6.0/opam
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.6.0/opam
@@ -20,7 +20,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
   "lwt"
   "parse-argv"

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.6.0/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.6.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-console-solo5"
+bug-reports:   "https://github.com/mirage/mirage-console-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-console-solo5.git"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
+  "mirage-console-lwt" {>= "2.2.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
+  "cstruct"
+  "lwt"
+]
+synopsis: "Solo5 implementation of MirageOS console interface"
+url {
+  src:
+    "https://github.com/mirage/mirage-console-solo5/releases/download/v0.6.0/mirage-console-solo5-v0.6.0.tbz"
+  checksum: [
+    "sha256=5642cffbb109aaaf58dc7c2129b880336105ed3a0908e4657f925af95097ff1a"
+    "sha512=6122f1ca87cdc2d63200a839755b41e026fd23c662e52f0fd5c4dd7c18bf6a41c28806df19b918b75a6265f95843bc1a7168b31b69bb391cfd8f7dbd6dc30051"
+  ]
+}

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.6.0/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.6.0/opam
@@ -19,7 +19,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-console-lwt" {>= "2.2.0"}
   "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
   "cstruct"

--- a/packages/mirage-net-solo5/mirage-net-solo5.0.6.0/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.6.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-net-solo5"
+bug-reports:   "https://github.com/mirage/mirage-net-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-solo5.git"
+doc:           "https://mirage.github.io/mirage-net-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune"
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "macaddr" { >= "4.0.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
+  "logs" {>= "0.6.0"}
+  "fmt"
+]
+synopsis: "Solo5 implementation of MirageOS network interface"
+description:
+  "This library implements the MirageOS network interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-net-solo5/releases/download/v0.6.0/mirage-net-solo5-v0.6.0.tbz"
+  checksum: [
+    "sha256=5a8126ddefe9a71034e6a85c38774911e98982c0021a1ce02c4ba2ca9214513b"
+    "sha512=9a828fdb49e628823ae7f88c4c63b1c8717eb924556bb5712ad6b90aa3a86e02aff10de335dc4ecb773c2aa7818b6c443d012e43612b63100269269ab1679460"
+  ]
+}

--- a/packages/mirage-solo5/mirage-solo5.0.6.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.6.0/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml-freestanding" {>= "0.4.5"}
   "metrics"
   "logs"
-  ("solo5-bindings-hvt" {>= "0.6.0"} | "solo5-bindings-spt" {>= "0.6.0"} | "solo5-bindings-virtio" {>= "0.6.0"} | "solo5-bindings-muen" {>= "0.6.0"} | "solo5-bindings-genode" {>= "0.6.0"})
+  ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"})
 ]
 conflicts: [
   "io-page" {< "2.0.0"}

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.2/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.2/opam
@@ -29,6 +29,7 @@ depexts: [
   ["libseccomp-dev"] {os-distribution = "debian"}
   ["libseccomp-devel"] {os-distribution = "fedora"}
   ["libseccomp-devel"] {os-distribution = "rhel"}
+  ["libseccomp-devel"] {os-distribution = "suse"}
   ["libseccomp-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: [


### PR DESCRIPTION
This is an "omnibus" PR with the component packages for Mirage/Solo5 0.6.0.

Additionally, I have added some upper bounds on the existing mirage-solo5.0.6.0 to make later breaking releases easier.

Part of mirage/mirage#992.