### PR TITLE
[new release] ounit2-lwt, ounit2, ounit-lwt and ounit (2.2.0)

### DIFF
--- a/packages/ounit-lwt/ounit-lwt.2.2.0/opam
+++ b/packages/ounit-lwt/ounit-lwt.2.2.0/opam
@@ -9,11 +9,6 @@ depends: [
   "ocamlfind"
   "ounit2-lwt" {= version}
 ]
-build: [
-  [make "null"]
-  [make "null"] {with-test}
-  [make "null"] {with-doc}
-]
 install: [
   [make "install-ounit-lwt" "version=%{version}%"]
 ]

--- a/packages/ounit-lwt/ounit-lwt.2.2.0/opam
+++ b/packages/ounit-lwt/ounit-lwt.2.2.0/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/gildor478/ounit.git"
 bug-reports: "https://github.com/gildor478/ounit/issues"
 doc: "https://gildor478.github.io/ounit/"
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ounit2-lwt" {= version}
 ]
 install: [

--- a/packages/ounit-lwt/ounit-lwt.2.2.0/opam
+++ b/packages/ounit-lwt/ounit-lwt.2.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvaini+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ounit"
+dev-repo: "git+https://github.com/gildor478/ounit.git"
+bug-reports: "https://github.com/gildor478/ounit/issues"
+doc: "https://gildor478.github.io/ounit/"
+depends: [
+  "ocamlfind"
+  "ounit2-lwt" {= version}
+]
+build: [
+  [make "null"]
+  [make "null"] {with-test}
+  [make "null"] {with-doc}
+]
+install: [
+  [make "install-ounit-lwt" "version=%{version}%"]
+]
+synopsis: "This is a transition package, ounit-lwt is now ounit2-lwt"
+description:"""
+More details for the transition:
+https://github.com/gildor478/ounit#transition-to-ounit2
+"""
+url {
+  src:
+    "https://github.com/gildor478/ounit/releases/download/v2.2.0/ounit-v2.2.0.tbz"
+  checksum: [
+    "sha256=b6783612c3dbe0cd244cc93d56d9de9d2d43590d79fe6d1b8e6545b0ce2b5a08"
+    "sha512=0f51313b85f834172591c8151d94e13c5249365efa506f710f02b34c951182c58bf27244f845ac20f63dedaadbc3574d152549496856aeebdd29447df03b36bf"
+  ]
+}

--- a/packages/ounit/ounit.2.2.0/opam
+++ b/packages/ounit/ounit.2.2.0/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/gildor478/ounit.git"
 bug-reports: "https://github.com/gildor478/ounit/issues"
 doc: "https://gildor478.github.io/ounit/"
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "ounit2" {= version}
 ]
 install: [

--- a/packages/ounit/ounit.2.2.0/opam
+++ b/packages/ounit/ounit.2.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvaini+ocaml@le-gall.net>"
+authors: [ "Maas-Maarten Zeeman" "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ounit"
+dev-repo: "git+https://github.com/gildor478/ounit.git"
+bug-reports: "https://github.com/gildor478/ounit/issues"
+doc: "https://gildor478.github.io/ounit/"
+depends: [
+  "ocamlfind"
+  "ounit2" {= version}
+]
+build: [
+  [make "null"]
+  [make "null"] {with-test}
+  [make "null"] {with-doc}
+]
+install: [
+  [make "install-ounit" "version=%{version}%"]
+]
+synopsis: "This is a transition package, ounit is now ounit2"
+description:"""
+More details for the transition:
+https://github.com/gildor478/ounit#transition-to-ounit2
+"""
+url {
+  src:
+    "https://github.com/gildor478/ounit/releases/download/v2.2.0/ounit-v2.2.0.tbz"
+  checksum: [
+    "sha256=b6783612c3dbe0cd244cc93d56d9de9d2d43590d79fe6d1b8e6545b0ce2b5a08"
+    "sha512=0f51313b85f834172591c8151d94e13c5249365efa506f710f02b34c951182c58bf27244f845ac20f63dedaadbc3574d152549496856aeebdd29447df03b36bf"
+  ]
+}

--- a/packages/ounit/ounit.2.2.0/opam
+++ b/packages/ounit/ounit.2.2.0/opam
@@ -9,11 +9,6 @@ depends: [
   "ocamlfind"
   "ounit2" {= version}
 ]
-build: [
-  [make "null"]
-  [make "null"] {with-test}
-  [make "null"] {with-doc}
-]
 install: [
   [make "install-ounit" "version=%{version}%"]
 ]

--- a/packages/ounit2-lwt/ounit2-lwt.2.2.0/opam
+++ b/packages/ounit2-lwt/ounit2-lwt.2.2.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.11.0"}
   "lwt"
-  "ounit" {= version}
+  "ounit2" {= version}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ounit2-lwt/ounit2-lwt.2.2.0/opam
+++ b/packages/ounit2-lwt/ounit2-lwt.2.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvaini+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ounit"
+dev-repo: "git+https://github.com/gildor478/ounit.git"
+bug-reports: "https://github.com/gildor478/ounit/issues"
+doc: "https://gildor478.github.io/ounit/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.11.0"}
+  "lwt"
+  "ounit" {= version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+synopsis: "OUnit testing framework (Lwt)"
+description:"""
+This library contains helper functions for building Lwt tests using OUnit.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ounit/releases/download/v2.2.0/ounit-v2.2.0.tbz"
+  checksum: [
+    "sha256=b6783612c3dbe0cd244cc93d56d9de9d2d43590d79fe6d1b8e6545b0ce2b5a08"
+    "sha512=0f51313b85f834172591c8151d94e13c5249365efa506f710f02b34c951182c58bf27244f845ac20f63dedaadbc3574d152549496856aeebdd29447df03b36bf"
+  ]
+}

--- a/packages/ounit2/ounit2.2.2.0/opam
+++ b/packages/ounit2/ounit2.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvaini+ocaml@le-gall.net>"
+authors: [ "Maas-Maarten Zeeman" "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ounit"
+dev-repo: "git+https://github.com/gildor478/ounit.git"
+bug-reports: "https://github.com/gildor478/ounit/issues"
+doc: "https://gildor478.github.io/ounit/"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.11.0"}
+  "base-bytes"
+  "base-unix"
+  "stdlib-shims"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+synopsis: "OUnit testing framework"
+description: """
+OUnit is a unit test framework for OCaml. It allows one to easily create
+unit-tests for OCaml code. It is loosely based on [HUnit], a unit testing
+framework for Haskell. It is similar to [JUnit], and other XUnit testing
+frameworks.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ounit/releases/download/v2.2.0/ounit-v2.2.0.tbz"
+  checksum: [
+    "sha256=b6783612c3dbe0cd244cc93d56d9de9d2d43590d79fe6d1b8e6545b0ce2b5a08"
+    "sha512=0f51313b85f834172591c8151d94e13c5249365efa506f710f02b34c951182c58bf27244f845ac20f63dedaadbc3574d152549496856aeebdd29447df03b36bf"
+  ]
+}


### PR DESCRIPTION
OUnit testing framework (Lwt)

- Project page: <a href="https://github.com/gildor478/ounit">https://github.com/gildor478/ounit</a>
- Documentation: <a href="https://gildor478.github.io/ounit/">https://gildor478.github.io/ounit/</a>

##### CHANGES:

### Changed
- Rename ounit/ounit-lwt OPAM and library to ounit2/ounit2-lwt. The META file
  to rename oUnit to ounit was not working on Windows and MacOSX because their
  filesystems are case insensitive and the install directories were the same.
  The new ounit2/ounit2-lwt packages avoid name clash on Windows/MacOSX and
  we still have ounit/ounit-lwt to allow the transition to the new package
  name. (Closes: gildor478/ounit#8)
