### PR TITLE
2 packages from issuu/ocaml-protoc-plugin at 0.9

### DIFF
--- a/packages/conf-protoc/conf-protoc.0.9/opam
+++ b/packages/conf-protoc/conf-protoc.0.9/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Issuu"
+authors: "Google"
+license: "https://github.com/protocolbuffers/protobuf/blob/master/LICENSE"
+homepage: "https://developers.google.com/protocol-buffers/"
+bug-reports: "https://github.com/protocolbuffers/protobuf/issues"
+dev-repo: "git+https://github.com/protocolbuffers/protobuf.git"
+build: [ "protoc" "--version" ]
+
+depexts: [
+  ["protobuf-compiler"] {os-distribution = "debian"}
+  ["protobuf-compiler"] {os-distribution = "mageia"}
+  ["protobuf-compiler"] {os-distribution = "ubuntu"}
+  ["protobuf-compiler"] {os-distribution = "centos"}
+  ["protobuf-compiler"] {os-distribution = "fedora"}
+  ["protobuf-compiler"] {os-distribution = "rhel"}
+  ["protobuf"]          {os-distribution = "alpine"}
+  ["protobuf"]          {os-distribution = "arch"}
+  ["protobuf-devel"]    {os-family = "suse"}
+  ["protobuf"]          {os = "freebsd"}
+  ["protobuf"]          {os = "macos" & os-distribution = "homebrew"}
+]
+
+available: os-distribution != "ubuntu" | os-version >= "18.04"
+synopsis: "Virtual package to install protoc compiler"
+description:
+  "This package will install the protoc compiler if invoked via `opam depext`"
+url {
+  src: "https://github.com/issuu/ocaml-protoc-plugin/archive/0.9.tar.gz"
+  checksum: [
+    "md5=ba564a123f4db98745eb7ed250bf24bf"
+    "sha512=cdf115d133c638965ad12d7f0e0167dfb8437c5334c56e1000418f08be966c9edeebd95802e2c470e6cbc5085a52fa682222c2fe3478a18ee66ae087c79daebb"
+  ]
+}

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.0.9/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.0.9/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Issuu"
+authors: "Anders Fugmann <af@issuu.com>"
+license: "APACHE 2.0"
+homepage: "https://github.com/issuu/ocaml-protoc-plugin"
+dev-repo: "git+https://github.com/issuu/ocaml-protoc-plugin"
+bug-reports: "https://github.com/issuu/ocaml-protoc-plugin/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "base"
+  "conf-protoc"
+  "dune" {>= "1.10" & build}
+  "ocaml" {>= "4.07.0"}
+  "ocaml-protoc" {build}
+  "ocplib-endian"
+  "ppx_let"
+  "ppx_deriving"
+  "ppx_expect"
+  "ppx_inline_test"
+]
+
+synopsis: "Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file"
+
+description: """ The plugin generates ocaml type definitions,
+serialization and deserialization functions from a protobuf file.
+The types generated aims to create ocaml idiomatic types;
+- messages are mapped into modules
+- oneof constructs are mapped to polymorphic variants
+- enums are mapped to adt's
+- map types are mapped to assoc lists
+- all integer types are mapped to int
+- all floating point types are mapped to float.
+- packages are mapped to nested modules
+"""
+url {
+  src: "https://github.com/issuu/ocaml-protoc-plugin/archive/0.9.tar.gz"
+  checksum: [
+    "md5=ba564a123f4db98745eb7ed250bf24bf"
+    "sha512=cdf115d133c638965ad12d7f0e0167dfb8437c5334c56e1000418f08be966c9edeebd95802e2c470e6cbc5085a52fa682222c2fe3478a18ee66ae087c79daebb"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`conf-protoc.0.9`: Virtual package to install protoc compiler
-`ocaml-protoc-plugin.0.9`: Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file



---

---
:camel: Pull-request generated by opam-publish v2.0.0