### PR TITLE
Fix conf-libX11 always recompiling

### DIFF
--- a/packages/conf-libX11/conf-libX11.1/opam
+++ b/packages/conf-libX11/conf-libX11.1/opam
@@ -8,9 +8,7 @@ build: [
   ["pkg-config" "x11"] {os != "macos"}
   [
     "sh" "-exc"
-    """
-    PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig" pkg-config --libs x11
-    """
+    """PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig" pkg-config --libs x11"""
   ] {os = "macos"}
 ]
 depends: ["conf-pkg-config" {build}]


### PR DESCRIPTION
Reported in https://github.com/ocaml/opam/issues/3995, this issue started with #13747. There's a bug in opam which is causing an extra newline to be added to the opam file which is installed to
`.opam-switch/packages/conf-libX11/opam` which is causing opam to think
the file has changed on every update.

The workaround is to use the triple quotes without a line-break, which I suggest is the best course of action here.