### PR TITLE
Fix other packages affected by triple-quoting opam bug

### DIFF
--- a/packages/clangml/clangml.3.9.1.2/opam
+++ b/packages/clangml/clangml.3.9.1.2/opam
@@ -9,12 +9,7 @@ build: [
   [
     "sh"
     "-c"
-    """
-test -d ${HOME}/usr/clang39 \\
-    || ( wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz \\
-      && tar -xf clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz \\
-      && mkdir -p ${HOME}/usr/clang39 \\
-      && mv clang+llvm-3.9.0-x86_64-apple-darwin/* ${HOME}/usr/clang39 )"""
+    "test -d ${HOME}/usr/clang39 || ( wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz && tar -xf clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz && mkdir -p ${HOME}/usr/clang39 && mv clang+llvm-3.9.0-x86_64-apple-darwin/* ${HOME}/usr/clang39 )"
   ] {os = "macos"}
   [make]
 ]

--- a/packages/clangml/clangml.3.9.1/opam
+++ b/packages/clangml/clangml.3.9.1/opam
@@ -8,11 +8,7 @@ build: [
   [
     "sh"
     "-c"
-    """
-test -d ${HOME}/usr/clang39 ||
-              ( wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz &&
-                tar -xf clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz &&
-                mkdir -p ${HOME}/usr/clang39 && mv clang+llvm-3.9.0-x86_64-apple-darwin/* ${HOME}/usr/clang39 )"""
+    "test -d ${HOME}/usr/clang39 || ( wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz && tar -xf clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz && mkdir -p ${HOME}/usr/clang39 && mv clang+llvm-3.9.0-x86_64-apple-darwin/* ${HOME}/usr/clang39 )"
   ] {os = "macos"}
   [make]
 ]

--- a/packages/libtensorflow/libtensorflow.0.1/opam
+++ b/packages/libtensorflow/libtensorflow.0.1/opam
@@ -9,26 +9,12 @@ install: [
   [
     "sh"
     "-c"
-    """
-test -d %{lib}%/tensorflow/libtensorflow.so ||
-  ( tar xzf libtensorflow-linux.tar.gz &&
-    mkdir -p %{lib}%/tensorflow &&
-    cp lib/libtensorflow.so %{lib}%/tensorflow/ &&
-    cp lib/libtensorflow_framework.so %{lib}%/tensorflow/
-  )
-    """
+    "test -d %{lib}%/tensorflow/libtensorflow.so || ( tar xzf libtensorflow-linux.tar.gz && mkdir -p %{lib}%/tensorflow && cp lib/libtensorflow.so %{lib}%/tensorflow/ && cp lib/libtensorflow_framework.so %{lib}%/tensorflow/ )"
   ] { os = "linux" }
   [
     "sh"
     "-c"
-    """
-test -d %{lib}%/tensorflow/libtensorflow.so ||
-  ( tar xzf libtensorflow-darwin.tar.gz &&
-    mkdir -p %{lib}%/tensorflow &&
-    cp lib/libtensorflow.so %{lib}%/tensorflow/ &&
-    cp lib/libtensorflow_framework.so %{lib}%/tensorflow/
-  )
-    """
+    "test -d %{lib}%/tensorflow/libtensorflow.so || ( tar xzf libtensorflow-darwin.tar.gz && mkdir -p %{lib}%/tensorflow && cp lib/libtensorflow.so %{lib}%/tensorflow/ && cp lib/libtensorflow_framework.so %{lib}%/tensorflow/ )"
   ] { os = "macos" }
 ]
 remove: [

--- a/packages/libtorch/libtorch.1.0.0/opam
+++ b/packages/libtorch/libtorch.1.0.0/opam
@@ -9,22 +9,12 @@ install: [
   [
     "sh"
     "-c"
-    """
-test -d %{lib}%/libtorch/lib/libtorch.so ||
-  ( unzip libtorch-linux.zip &&
-    mv -f libtorch %{lib}%/
-  )
-    """
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-linux.zip && mv -f libtorch %{lib}%/ )"
   ] { os = "linux" }
   [
     "sh"
     "-c"
-    """
-test -d %{lib}%/libtorch/lib/libtorch.so ||
-  ( unzip libtorch-macos.zip &&
-    mv -f libtorch %{lib}%/
-  )
-    """
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-macos.zip && mv -f libtorch %{lib}%/ )"
   ] { os = "macos" }
 ]
 remove: [

--- a/packages/libtorch/libtorch.1.0.1/opam
+++ b/packages/libtorch/libtorch.1.0.1/opam
@@ -9,25 +9,12 @@ install: [
   [
     "sh"
     "-c"
-    """
-test -d %{lib}%/libtorch/lib/libtorch.so ||
-  ( unzip libtorch-linux.zip &&
-    mv -f libtorch %{lib}%/
-  )
-    """
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-linux.zip && mv -f libtorch %{lib}%/ )"
   ] { os = "linux" }
   [
     "sh"
     "-c"
-    """
-test -d %{lib}%/libtorch/lib/libtorch.so ||
-  ( unzip libtorch-macos.zip &&
-    mv -f libtorch %{lib}%/ &&
-    tar xzf mklml-macos.tgz &&
-    mv -f mklml_mac_2019.0.1.20181227/lib/libmklml.dylib %{lib}%/libtorch/lib/ &&
-    mv -f mklml_mac_2019.0.1.20181227/lib/libiomp5.dylib %{lib}%/libtorch/lib/
-  )
-    """
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-macos.zip && mv -f libtorch %{lib}%/ && tar xzf mklml-macos.tgz && mv -f mklml_mac_2019.0.1.20181227/lib/libmklml.dylib %{lib}%/libtorch/lib/ && mv -f mklml_mac_2019.0.1.20181227/lib/libiomp5.dylib %{lib}%/libtorch/lib/ )"
   ] { os = "macos" }
 ]
 remove: [

--- a/packages/libtorch/libtorch.1.1.0/opam
+++ b/packages/libtorch/libtorch.1.1.0/opam
@@ -9,25 +9,12 @@ install: [
   [
     "sh"
     "-c"
-    """
-test -d %{lib}%/libtorch/lib/libtorch.so ||
-  ( unzip libtorch-linux.zip &&
-    mv -f libtorch %{lib}%/
-  )
-    """
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-linux.zip && mv -f libtorch %{lib}%/ )"
   ] { os = "linux" }
   [
     "sh"
     "-c"
-    """
-test -d %{lib}%/libtorch/lib/libtorch.so ||
-  ( unzip libtorch-macos.zip &&
-    mv -f libtorch %{lib}%/ &&
-    tar xzf mklml-macos.tgz &&
-    mv -f mklml_mac_2019.0.1.20181227/lib/libmklml.dylib %{lib}%/libtorch/lib/ &&
-    mv -f mklml_mac_2019.0.1.20181227/lib/libiomp5.dylib %{lib}%/libtorch/lib/
-  )
-    """
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-macos.zip && mv -f libtorch %{lib}%/ && tar xzf mklml-macos.tgz && mv -f mklml_mac_2019.0.1.20181227/lib/libmklml.dylib %{lib}%/libtorch/lib/ && mv -f mklml_mac_2019.0.1.20181227/lib/libiomp5.dylib %{lib}%/libtorch/lib/ )"
   ] { os = "macos" }
 ]
 remove: [

--- a/packages/libtorch/libtorch.1.2.0/opam
+++ b/packages/libtorch/libtorch.1.2.0/opam
@@ -9,25 +9,12 @@ install: [
   [
     "sh"
     "-c"
-    """
-test -d %{lib}%/libtorch/lib/libtorch.so ||
-  ( unzip libtorch-linux.zip &&
-    mv -f libtorch %{lib}%/
-  )
-    """
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-linux.zip && mv -f libtorch %{lib}%/ )"
   ] { os = "linux" }
   [
     "sh"
     "-c"
-    """
-test -d %{lib}%/libtorch/lib/libtorch.so ||
-  ( unzip libtorch-macos.zip &&
-    mv -f libtorch %{lib}%/ &&
-    tar xzf mklml-macos.tgz &&
-    mv -f mklml_mac_2019.0.1.20181227/lib/libmklml.dylib %{lib}%/libtorch/lib/ &&
-    mv -f mklml_mac_2019.0.1.20181227/lib/libiomp5.dylib %{lib}%/libtorch/lib/
-  )
-    """
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-macos.zip && mv -f libtorch %{lib}%/ && tar xzf mklml-macos.tgz && mv -f mklml_mac_2019.0.1.20181227/lib/libmklml.dylib %{lib}%/libtorch/lib/ && mv -f mklml_mac_2019.0.1.20181227/lib/libiomp5.dylib %{lib}%/libtorch/lib/ )"
   ] { os = "macos" }
 ]
 depexts: [


### PR DESCRIPTION
Following on from #14910, I checked for other packages.

The fix is to ensure the strings contain no newlines, which creates some hideously long lines (in some cases, these might better be moved to scripts?)

For now, `"""` should only be used in meta-data (so `messages`, `post-messages`, `synopsis` and `description` are OK, but commands are not)