### PR TITLE
conf-libev: try to build without any flags first

### DIFF
--- a/packages/conf-libev/conf-libev.4-11/files/discover.ml
+++ b/packages/conf-libev/conf-libev.4-11/files/discover.ml
@@ -118,7 +118,7 @@ let c_args =
     | None -> ""
     | Some path -> flags path
 
-let compile args stub_file =
+let compile c_args args stub_file =
   let cmd = sprintf "%s -custom %s %s %s %s > %s 2>&1"
     !ocamlc
     c_args
@@ -144,7 +144,7 @@ let test_code args stub_code =
     output_string oc stub_code;
     flush oc;
     close_out oc;
-    let result = compile args stub_file in
+    let result = compile "" args stub_file || compile c_args args stub_file in
     cleanup ();
     result
   with exn ->

--- a/packages/conf-libev/conf-libev.4-11/opam
+++ b/packages/conf-libev/conf-libev.4-11/opam
@@ -22,7 +22,7 @@ Libev is modelled (very loosely) after libevent and the Event perl
 module, but is faster, scales better and is more correct, and also more
 featureful. And also smaller. Yay."""
 extra-files: [
-  ["discover.ml" "md5=45c6a7a77eac449e1214235a3407a344"]
+  ["discover.ml" "md5=da9804a7324ae1afe65f48a7f7f6b70c"]
   ["build.sh" "md5=f37b5eb73ebeb177dff1cd8bb2f38c4e"]
 ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"


### PR DESCRIPTION
Before adding -I and -L flags, try to build using just $CC test.c -lev.
This will succeed if libev is installed already in the compiler's
default search path. This improves libev detection with musl-gcc, as the
musl libev is typically installed in musl-gcc's search path. With
musl-gcc, immediately searching for ev.h and adding -I and -L is likely
to find a glibc (system) libev, rather than the one compiled for use
with musl-gcc.

See

  https://github.com/ocsigen/lwt/issues/718#issuecomment-535053644