### PR TITLE
Lwt 4.3.1

### DIFF
--- a/packages/lwt/lwt.4.3.1/opam
+++ b/packages/lwt/lwt.4.3.1/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+
+version: "4.3.1"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.7.0"}
+  "dune-configurator"
+  "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0"}
+  "ocplib-endian"
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  "bisect_ppx" {dev & >= "1.3.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+post-messages: [
+  "Lwt 5.0.0 will make some breaking changes in November 2019. See
+  https://github.com/ocsigen/lwt/issues/584"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.3.1.tar.gz"
+  checksum: "md5=926936860087c5819d6ca04241bc894a"
+}


### PR DESCRIPTION
Bugs fixed

- Lwt clobbered backtraces (ocsigen/lwt#714, ocsigen/lwt@6e855b8, ocsigen/lwt@4694853, reported Volker Diels-Grabsch).
- [`Lwt_unix.fork`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALfork) was broken on glibc 2.28 (ocsigen/lwt#704, @ygrek).
- Fix build with musl-gcc (ocsigen/lwt#718, ocsigen/lwt#719, reported Fabian Hemmer).
- Support more [`Lwt_unix.madvise`](http://ocsigen.org/lwt/dev/api/Lwt_bytes#TYPEadvice) options (ocsigen/lwt#716, Anton Kochkov).

Miscellaneous

- Silence configure script (ocsigen/lwt#717, requested Anil Madhavapeddy).
- Greatly sped up CI and tests.