### PR TITLE
[new release] decompress and rfc1951 (1.0.0)

### DIFF
--- a/packages/decompress/decompress.1.0.0/opam
+++ b/packages/decompress/decompress.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name:         "decompress"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib in OCaml"
+description: """Decompress is an implementation of Zlib in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"
+  "base-bytes"
+  "bigarray-compat"
+  "optint"      {>= "0.0.3"}
+  "checkseum"   {>= "0.1.1"}
+  "bigstringaf" {with-test}
+  "alcotest"    {with-test}
+  "hxd"         {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.0.0/decompress-v1.0.0.tbz"
+  checksum: [
+    "sha256=34a04176a42955ce529a1b57e8b225e7cf63680e49dd8ad05b3fe463bc7863bd"
+    "sha512=cfc300cbf620563453ca166e5a53fde3317c8a24ce3010a5cdee080f51cca26c67f658e57bd8feee582c7dcb459a692010b90907ae2e9ba9fe494d5da5d88c13"
+  ]
+}

--- a/packages/rfc1951/rfc1951.1.0.0/opam
+++ b/packages/rfc1951/rfc1951.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name:         "rfc1951"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "decompress" {= version}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.0.0/decompress-v1.0.0.tbz"
+  checksum: [
+    "sha256=34a04176a42955ce529a1b57e8b225e7cf63680e49dd8ad05b3fe463bc7863bd"
+    "sha512=cfc300cbf620563453ca166e5a53fde3317c8a24ce3010a5cdee080f51cca26c67f658e57bd8feee582c7dcb459a692010b90907ae2e9ba9fe494d5da5d88c13"
+  ]
+}


### PR DESCRIPTION
Implementation of Zlib in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

** breaking changes **

`decompress.1.0.0` is 3 times faster about decompression than before. A huge
[amount of work was done](https://tarides.com/blog/2019-08-26-decompress-the-new-decompress-api.html) to improve performance and coverage.

The main reason to update the API is to fix a bad design decision regarding split
compression and encoding. User is able to implement a new compression algorithm
and use it.

Release comes with regressions:
- `decompress` only supports `Bigarray` now, not `Bytes`
- GZIP layer does not exist anymore
- state of RFC1951 encoder/decoder is not referentially transparent anymore

Of course, v1.0.0 comes with fixes and improvements:
- `decompress` is able to compress/uncompress [Calgary corpus](https://en.wikipedia.org/wiki/Calgary_corpus)
- tests are improved and they include all coverage tests from `zlib`
- compression algorithm has a fuzzer
- encoder has a fuzzer
- performance about decoder is 3 times better than `decompress.v0.9.0` and 3
  times slower than `zlib`

`decompress` is split into 2 main modules:
- `dd` which implements RFC1951
- `zz` which implements ZLIB

API of them are pretty-close to what `decompress.v0.9.0` does with some
advantages on `dd`:
- User can use their own compression algorithm instead of `Dd.L`
- encoder exposes more granular control over what it emits (which block, when, where)
- Huffman tree generation is out of `dd`

As a response to mirage/decompress#25, `dd` provides a _higher_ level API resembling `camlzip`.
