### PR TITLE
anycache-lwt 0.7.4 requires anycache >= 0.7.0

### DIFF
--- a/packages/anycache-lwt/anycache-lwt.0.7.4/opam
+++ b/packages/anycache-lwt/anycache-lwt.0.7.4/opam
@@ -11,7 +11,7 @@ depends: [
   "topkg-jbuilder" {build}
   "alcotest" {with-test & >= "0.7.2"}
   "base-bytes"
-  "anycache"
+  "anycache" {>= "0.7.0"}
   "lwt"
 ]
 build: [


### PR DESCRIPTION
`anycache-lwt` 0.7.4 [expects](https://ci.ocaml.org/log/saved/docker-run-67163e3725c0cf22cf043e5f3088816b/5bd5fa1b8c13bf2bb9e5e2f1ac54ca1e81cdaf87) a module `Anycache.PendingLimit`, which first [appeared](https://gitlab.com/edwintorok/ocaml-anycache/blob/v0.7.0/lib/anycache.mli#L125) in `anycache` 0.7.0.

The source repo is archived, so we probably don't need to cc anyone.