### PR TITLE
Fixes for package brotli

### DIFF
--- a/packages/brotli/brotli.1.0/opam
+++ b/packages/brotli/brotli.1.0/opam
@@ -20,7 +20,7 @@ remove: ["ocamlfind" "remove" "brotli"]
 depends: [
   "ocaml" {>= "4.02.3"}
   "oasis"
-  "lwt" {>= "2.4.6"}
+  "lwt" {>= "2.4.6" & < "4.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/brotli/brotli.1.0/opam
+++ b/packages/brotli/brotli.1.0/opam
@@ -29,7 +29,7 @@ description: """
 High level and easy to use OCaml bindings to brotli, a compression
 algorithm from Google.
 
-Brotli source: https://github.com/google/brotli/ 
+Brotli source: https://github.com/google/brotli/
 
 RFC: http://www.ietf.org/id/draft-alakuijala-brotli"""
 flags: light-uninstall
@@ -39,5 +39,5 @@ extra-files: [
 ]
 url {
   src: "https://github.com/fxfactorial/ocaml-brotli/archive/v1.0.tar.gz"
-  checksum: "md5=6ea3059245bc03746e05f022573cd05d"
+  checksum: "md5=9f42857216a6f5915e71bb9ecc565585"
 }

--- a/packages/brotli/brotli.1.1/opam
+++ b/packages/brotli/brotli.1.1/opam
@@ -20,7 +20,7 @@ remove: ["ocamlfind" "remove" "brotli"]
 depends: [
   "ocaml" {>= "4.02.3"}
   "oasis"
-  "lwt" {>= "2.4.6"}
+  "lwt" {>= "2.4.6" & < "4.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/brotli/brotli.1.1/opam
+++ b/packages/brotli/brotli.1.1/opam
@@ -30,7 +30,7 @@ High level and easy to use OCaml bindings to brotli, a compression
 algorithm from Google. Uses Bigarrays for memory efficiency and
 ready for Lwt concurrency.
 
-Brotli source: https://github.com/google/brotli/ 
+Brotli source: https://github.com/google/brotli/
 
 RFC: http://www.ietf.org/id/draft-alakuijala-brotli"""
 flags: light-uninstall
@@ -40,5 +40,5 @@ extra-files: [
 ]
 url {
   src: "https://github.com/fxfactorial/ocaml-brotli/archive/v1.1.tar.gz"
-  checksum: "md5=f87ae9b9f4c3e616f7ee03631025075d"
+  checksum: "md5=3ffbce4180455d5d08908a613b008368"
 }

--- a/packages/brotli/brotli.2.0.2/opam
+++ b/packages/brotli/brotli.2.0.2/opam
@@ -23,6 +23,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "conf-brotli"
+  "base-unsafe-string"
 ]
 post-messages: [
   "Be sure to have libbrotli installed on your machine" {failure}

--- a/packages/brotli/brotli.2.0.2/opam
+++ b/packages/brotli/brotli.2.0.2/opam
@@ -35,5 +35,5 @@ http://www.ietf.org/id/draft-alakuijala-brotli"""
 flags: light-uninstall
 url {
   src: "https://github.com/fxfactorial/ocaml-brotli/archive/v2.0.2.tar.gz"
-  checksum: "md5=458754056a9e1a6668582340a80276c6"
+  checksum: "md5=1ac69ff0f512de104cfa6f533c882b0f"
 }


### PR DESCRIPTION
Fix checksums for brotli [1.0](https://ci.ocaml.org/log/saved/docker-run-933c30df330efb810f8fc7c069e4b09d/d5a8e7dcef7b0fa9dbe5d8063d6cbc1134ebfaae), [1.1](https://ci.ocaml.org/log/saved/docker-run-ef3daf14977c1c65528d9ea63c169a86/ac3c4d121d8ef77e1024ab429160e4f4fe4ac68a), [2.0.2](https://ci.ocaml.org/log/saved/docker-run-904babafd71b5144aa59bdfc6d91ecab/902d2b4b5f3b7d43a50f10f97a82f65c73668908). Other versions are probably also affected. Are the original archives available in a cache somewhere, so we can link them instead of changing the checksums?

cc @fxfactorial

@avsm, I'm beginning to suspect that the checksum change is related to renaming the repo. Perhaps that is when GitHub repacks releases?

Lambda Soup used to be `lambda-soup`, and now it is `lambdasoup`, while brotli used to be `ocaml-brotli`, but is now `reason-brotli`.