### PR TITLE
Add depext package name for ZMQ on openSUSE

### DIFF
--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["zeromq-devel"] {os-distribution = "centos"}
   ["zeromq"] {os-distribution = "arch"}
   ["zeromq-devel"] {os-distribution = "fedora"}
-  ["zeromq-devel"] {os-distribution = "opensuse"}
+  ["zeromq-devel"] {os-family = "suse"}
 ]
 synopsis: "Virtual package relying on zmq library installation"
 description: """

--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["zeromq-devel"] {os-distribution = "centos"}
   ["zeromq"] {os-distribution = "arch"}
   ["zeromq-devel"] {os-distribution = "fedora"}
+  ["zeromq-devel"] {os-distribution = "opensuse"}
 ]
 synopsis: "Virtual package relying on zmq library installation"
 description: """


### PR DESCRIPTION
openSUSE can't install `zmq` because the `conf-zmq` does not specify a package name to install. This PR specifies the name to a name that the internet claims might be correct and matches the RPM tradition at least.

This should solve the openSUSE build issue in #14916.