### PR TITLE
libzmq seems to only be in EPEL on CentOS

### DIFF
--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["libzmq3-dev"] {os-family = "debian"}
   ["zeromq"] {os = "macos" & os-distribution = "homebrew"}
   ["zeromq-dev"] {os-distribution = "alpine"}
-  ["zeromq-devel"] {os-distribution = "centos"}
+  ["epel-release" "zeromq-devel"] {os-distribution = "centos"}
   ["zeromq"] {os-distribution = "arch"}
   ["zeromq-devel"] {os-distribution = "fedora"}
 ]


### PR DESCRIPTION
Adding `epel-release` is what `conf-openblas` is doing so presumably this is the correct thing to do.

This should solve the openSUSE build issue in #14916.