### PR TITLE
Dune >= 1.10.0 fails on caqti-lwt 0.11.0

### DIFF
--- a/packages/caqti-lwt/caqti-lwt.0.11.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.0.11.0/opam
@@ -19,6 +19,9 @@ depends: [
   "logs"
   "lwt" {>= "3.2.0"}
 ]
+conflicts: [
+  "dune" {>= "1.10.0"}
+]
 synopsis: "Lwt support for Caqti"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
 url {


### PR DESCRIPTION
See [this log](https://ci.ocaml.org/log/saved/docker-run-ddf86665accb49c4cdcb25d64aa5816c/c276c00a549bf533cad9606cf32a832ead77631c). I reported the issue to Dune: https://github.com/ocaml/dune/issues/2674.

This doesn't affect the latest `caqti-lwt`, so I don't think we need to notify anyone else.