### PR TITLE
exenum 0.86 is missing a dependency on lwt.unix

### DIFF
--- a/packages/exenum/exenum.0.86/opam
+++ b/packages/exenum/exenum.0.86/opam
@@ -15,6 +15,9 @@ depends: [
   "zarith"
 ]
 depopts: "lwt"
+conflicts: [
+  "lwt" {>= "4.0.0"}
+]
 synopsis:
   "Build efficient enumerations for datatypes. Inspired by Feat for Haskell."
 description: """


### PR DESCRIPTION
It was possible to link with `lwt.unix` while only specifying `lwt` until Lwt 4.0.0. The project repo has a fix, lebotlan/ocaml-exenum@eab63e63a26d0a014c254183e66f236abe1529ce, but it is not released to opam.