### PR TITLE
inotify 2.1 and 2.2 with-test requires OUnit

### DIFF
--- a/packages/inotify/inotify.2.1/opam
+++ b/packages/inotify/inotify.2.1/opam
@@ -34,6 +34,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "fileutils" {with-test}
+  "ounit" {with-test & >= "2.0.0"}
 ]
 depopts: ["lwt"]
 available: os = "linux" | os = "macos"

--- a/packages/inotify/inotify.2.2/opam
+++ b/packages/inotify/inotify.2.2/opam
@@ -34,6 +34,7 @@ depends: [
   "ocamlfind" {build}
   "fileutils" {with-test}
   "ocamlbuild" {build}
+  "ounit" {with-test & >= "2.0.0"}
 ]
 depopts: ["lwt"]
 available: [os = "linux"]


### PR DESCRIPTION
See the builds logs for [2.1](https://ci.ocaml.org/log/saved/docker-run-f0214beb3618a0cc43be979fe654a978/b812ca31c5c04e43356df591fc0c28008eed0996) and [2.2](https://ci.ocaml.org/log/saved/docker-run-993b87ea8f3f46992097fd5c77ed7490/3efb551b4cc10149c75651e72938f01b7e786147). inotify 2.3 doesn't have `with-test` build commands, so I don't think we need to notify anyone.