### PR TITLE
mirage-block-ramdisk 0.3 expects real package io-page.unix

### DIFF
--- a/packages/mirage-block-ramdisk/mirage-block-ramdisk.0.3/opam
+++ b/packages/mirage-block-ramdisk/mirage-block-ramdisk.0.3/opam
@@ -22,7 +22,7 @@ depends: [
   "alcotest" {with-test}
   "base-bytes"
   "cstruct"
-  "io-page"
+  "io-page" {< "2.0.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "lwt"
 ]


### PR DESCRIPTION
See [log](https://ci.ocaml.org/log/saved/docker-run-04ce8ffd4887f755f65018bf021b4ba7/0591e1832eb6c89a9b1d42b11fbe905cca54ed9f). `io-page.unix` was a true package in the io-page repo until io-page 2.0.0, when it became an alias for io-page-unix, which has to be installed separately. mirage-block-ramdisk 0.3 expects `io-page.unix` not to be an alias.

This is not the latest release of mirage-block-ramdisk, so I don't think we have to ping anyone.