### PR TITLE
Some older versions of ocurl assume unsafe strings

### DIFF
--- a/packages/ocurl/ocurl.0.7.6/opam
+++ b/packages/ocurl/ocurl.0.7.6/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ygrek/ocurl/issues"
 build: [
   ["./configure"]
   [make]
-  [make "test"] {with-test}
+  [make "test"] {with-test & ocaml:version < "4.06"}
   [make "doc"] {with-doc}
 ]
 install: [

--- a/packages/ocurl/ocurl.0.7.7/opam
+++ b/packages/ocurl/ocurl.0.7.7/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ygrek/ocurl/issues"
 build: [
   ["./configure"]
   [make]
-  [make "test"] {with-test}
+  [make "test"] {with-test & ocaml:version < "4.06"}
   [make "doc"] {with-doc}
 ]
 install: [

--- a/packages/ocurl/ocurl.0.7.8/opam
+++ b/packages/ocurl/ocurl.0.7.8/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ygrek/ocurl/issues"
 build: [
   ["./configure"]
   [make]
-  [make "test"] {with-test}
+  [make "test"] {with-test & ocaml:version < "4.06"}
   [make "doc"] {with-doc}
 ]
 install: [

--- a/packages/ocurl/ocurl.0.7.9/opam
+++ b/packages/ocurl/ocurl.0.7.9/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ygrek/ocurl/issues"
 build: [
   ["./configure"]
   [make]
-  [make "test"] {with-test}
+  [make "test"] {with-test & ocaml:version < "4.06"}
   [make "doc"] {with-doc}
 ]
 install: [


### PR DESCRIPTION
See logs for [0.7.6](https://ci.ocaml.org/log/saved/docker-run-2edf718cf0f7f2a984876c2af0c890cc/6b909724d662e86ef4e837f71d881fd5fd5ce594), [0.7.7](https://ci.ocaml.org/log/saved/docker-run-31c62807864c453449cb85385bd82041/b989be8ad0d7ffe55f721ec01464b13b7b1e8793), [0.7.8](https://ci.ocaml.org/log/saved/docker-run-18d2e949d02fab3c1965a6571476a7a4/30bec6de002e6ab904005f68368ea1df3761413c), and [0.7.9](https://ci.ocaml.org/log/saved/docker-run-ae5110e0d3d81bf879b4f4caf04e18c9/6f7e27ca78d464d2904700c6ace1877c04b0fb68). Newer versions don't have the problem, so I don't think we need to notify anyone.