### PR TITLE
pgx_lwt: don't run tests, they call getlogin

### DIFF
--- a/packages/pgx_lwt/pgx_lwt.0.1/opam
+++ b/packages/pgx_lwt/pgx_lwt.0.1/opam
@@ -8,7 +8,6 @@ doc: "https://arenadotio.github.io/pgx/doc"
 
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.04.2"}

--- a/packages/pgx_lwt/pgx_lwt.0.1/opam
+++ b/packages/pgx_lwt/pgx_lwt.0.1/opam
@@ -14,8 +14,6 @@ depends: [
   "pgx"
   "ppx_jane" {< "v0.13"}
   "lwt"
-  "base64" {with-test & < "3.0.0"}
-  "ounit" {with-test}
 ]
 synopsis: "Pgx_lwt - Pgx using Lwt for IO"
 url {


### PR DESCRIPTION
Package `pgx_lwt`'s tests (transitively) run `getlogin`, which seems to fail in opam's containers. See [this log](https://ci.ocaml.org/log/saved/docker-run-cc33e62085841c5125f6a50112fa3c7c/8511d8abd1a6b269d3f6827e5b79ea1b8943f1d9). It seems best to simply not run them.

cc @brendanlong about removing that same line in the `pgx` repo, provided opam maintainers consider this change to be reasonable.