### PR TITLE
Restrict zmq-async minimal OCaml/JST version

### DIFF
--- a/packages/zmq-async/zmq-async.5.1.0/opam
+++ b/packages/zmq-async/zmq-async.5.1.0/opam
@@ -12,12 +12,12 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.04.1"}
   "zmq" {>= "5.1.0"}
   "dune"
-  "async_unix" {>= "v0.9.0" & < "v0.13"}
-  "async_kernel" {>= "v0.9.0" & < "v0.13"}
-  "base" {>= "v0.9.0" & < "v0.13"}
+  "async_unix" {>= "v0.11.0" & < "v0.13"}
+  "async_kernel" {>= "v0.11.0" & < "v0.13"}
+  "base" {>= "v0.11.0" & < "v0.13"}
   "ounit" {with-test}
 ]
 synopsis: "Async aware bindings to zmq"

--- a/packages/zmq-async/zmq-async.5.1.0/opam
+++ b/packages/zmq-async/zmq-async.5.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "async_unix" {>= "v0.11.0" & < "v0.13"}
   "async_kernel" {>= "v0.11.0" & < "v0.13"}
   "base" {>= "v0.11.0" & < "v0.13"}
-  "ounit" {with-test}
+  "ounit" {with-test & < "2.1.0"}
 ]
 synopsis: "Async aware bindings to zmq"
 url {


### PR DESCRIPTION
Due to an issue with where glibc puts `makedev` and where Core < v0.11 (a dependency of Async) expects `makedev` this package will always fail to build. It is fixed in Core v0.11 but that requires at least OCaml 4.04.1 so we're restricting the minimal version.

A similar change is planned upstream, the next release of ZMQ will probably drop 4.03 support altogether (also in the base library and Lwt bindings): https://github.com/issuu/ocaml-zmq/pull/93

This PR is a more conservative approach to limit the disruption to users of the release on OPAM.