### PR TITLE
protocol-9p 0.10.0 assumes io-page < 2.0.0

### DIFF
--- a/packages/protocol-9p-unix/protocol-9p-unix.0.10.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.10.0/opam
@@ -37,6 +37,9 @@ depends: [
   "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
 ]
+conflicts: [
+  "io-page" {>= "2.0.0"}
+]
 synopsis: "Unix clients and servers for the 9P protocol"
 url {
   src: "https://github.com/mirage/ocaml-9p/archive/v0.10.0.tar.gz"

--- a/packages/protocol-9p/protocol-9p.0.10.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.10.0/opam
@@ -38,6 +38,9 @@ depends: [
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_cstruct"
 ]
+conflicts: [
+  "io-page" {>= "2.0.0"}
+]
 synopsis: "An implementation of the 9P protocol in pure OCaml"
 description: """
 [![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)

--- a/packages/protocol-9p/protocol-9p.0.11.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.0/opam
@@ -9,7 +9,6 @@ doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
@@ -36,7 +35,6 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "alcotest" {with-test & >= "0.4.0"}
 ]
 synopsis: "An implementation of the 9P protocol in pure OCaml"
 description: """

--- a/packages/protocol-9p/protocol-9p.0.11.1/opam
+++ b/packages/protocol-9p/protocol-9p.0.11.1/opam
@@ -9,7 +9,6 @@ doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
@@ -35,8 +34,6 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "alcotest" {with-test & >= "0.4.0"}
-  "prometheus" {with-test}
 ]
 synopsis: "An implementation of the 9P protocol in pure OCaml"
 description: """


### PR DESCRIPTION
Packages [protocol-9p 0.10.0](https://ci.ocaml.org/log/saved/docker-run-5430197842937898f6705692c5a97887/435d84467bd808f6229a90954758d52fcc3539ab) and [protocol-9p-unix 0.10.0](https://ci.ocaml.org/log/saved/docker-run-bda75b25b0c61c74d7fb179333694f1f/f62b991a5f20a2be2db1f4f8e3e30e5950e021b2) assume that io-page.unix is a real package, rather than an alias for io-page-unix, which they don't attempt to install. io-page.unix became an alias in io-page 2.0.0.

Newer versions of these packages build fine, so I don't think we need to notify anyone.

There are additional problems with some of the older protocol-9p packages. I will push in more commits after each build. I will mark this PR as ready for review once I think the problems are all addressed.