### PR TITLE
Disable tests of qcow 0.10.0

### DIFF
--- a/packages/qcow/qcow.0.10.0/opam
+++ b/packages/qcow/qcow.0.10.0/opam
@@ -32,14 +32,9 @@ depends: [
   "ppx_tools"
   "ppx_sexp_conv" {< "v0.13"}
   "ppx_type_conv" {build}
-  "ounit" {with-test}
-  "mirage-block-ramdisk" {with-test}
-  "ezjsonm" {with-test}
-  "nbd" {with-test & >= "2.0.1"}
 ]
 build: [
   ["jbuilder" "build" "--only-packages=qcow"]
-  [make "test"] {with-test}
 ]
 synopsis: "Support for Qcow2 images"
 description: """


### PR DESCRIPTION
These tests are [failing](https://ci.ocaml.org/log/saved/docker-run-ce590c58a5d05af2dcabe12abcd10711/ea0a30c6c8ef81cb212828c8ad264c8cefc6d7e1). There are newer versions of qcow, so I don't think there is anything to report or do about these tests; they can only be disabled.

Interestingly, the newer versions, not affected by this PR, had their tests disabled in one of the commits in https://github.com/ocaml/opam-repository/pull/14621.