### PR TITLE
Disable tests of session 0.1.0

### DIFF
--- a/packages/session/session.0.1.0/opam
+++ b/packages/session/session.0.1.0/opam
@@ -19,19 +19,6 @@ build: [
     "--%{async:enable}%-async"
   ]
   ["ocaml" "setup.ml" "-build"]
-  [
-    "ocaml"
-    "setup.ml"
-    "-configure"
-    "--enable-tests"
-    "--%{webmachine:enable}%-webmachine"
-    "--%{postgresql:enable}%-postgresql"
-    "--%{lwt:enable}%-lwt"
-    "--%{cohttp:enable}%-cohttp"
-    "--%{async:enable}%-async"
-  ] {with-test}
-  ["ocaml" "setup.ml" "-build"] {with-test}
-  ["ocaml" "setup.ml" "-test"] {with-test}
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]
 install: ["ocaml" "setup.ml" "-install"]
@@ -42,7 +29,6 @@ depends: [
   "ocaml"
   "nocrypto"
   "ocamlfind" {build}
-  "ounit" {with-test & >= "1.0.2"}
   "result"
 ]
 depopts: [


### PR DESCRIPTION
They [fail](https://ci.ocaml.org/log/saved/docker-run-663068e986527ca1811abad70d6b2399/0f16353d96c8538dc439a4ccb52575e7b447eb06) while trying to find package `postgresql`, which is not installed. This was fixed in the upstream repo the day after the 0.1.0 release in https://github.com/inhabitedtype/ocaml-session/commit/254b88e62f406632609ccbf82ee94309700c5810, which is included in every subsequent release, so we don't need to notify anyone.