### PR TITLE
zmq-lwt 5.0.0 tests require ounit

### DIFF
--- a/packages/zmq-lwt/zmq-lwt.5.0.0/opam
+++ b/packages/zmq-lwt/zmq-lwt.5.0.0/opam
@@ -14,6 +14,7 @@ build: [
 depends: [
   "ocaml"
   "zmq" {>= "5.0.0"}
+  "ounit" {with-test}
   "jbuilder" {build & >= "1.0+beta17"}
   "lwt"
 ]


### PR DESCRIPTION
Tests for package zmq-lwt 5.0.0 [require](https://ci.ocaml.org/log/saved/docker-run-65d4af0716a46a5d48a6bfe2cdfc3dc2/69d151c5465c4df4d61797e7751913cc186765d2) OUnit. I based the fix on the dependencies in zmq-lwt 5.1.0. Since there is a newer package, I don't think anyone needs to be notified.