### PR TITLE
Release override 0.2.2

### DIFF
--- a/packages/override/override.0.2.2/opam
+++ b/packages/override/override.0.2.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+bug-reports: "https://gitlab.inria.fr/tmartine/override"
+homepage: "https://gitlab.inria.fr/tmartine/override"
+doc: "https://gitlab.inria.fr/tmartine/override"
+license: "BSD"
+dev-repo: "git+https://gitlab.inria.fr/tmartine/override"
+synopsis: "PPX extension for overriding modules"
+description: """
+PPX extensions [%%override], [%%import], [%%include] and [%%rewrite] to import
+and change module interfaces.
+"""
+depends: [
+  "dune" {>= "1.10.0"}
+  "ppxlib" {>= "0.9.0"}
+  "stdcompat" {>= "9"}
+  "ppx_deriving" {>= "4.4"}
+  "cppo" {>= "1.6.4"}
+]
+url {
+  src: "https://gitlab.inria.fr/tmartine/override/-/archive/0.2.2/override-0.2.2.tar.gz"
+  checksum: "sha512=d068135191f4f0c051c293ccb3cf2077673ed0a537b95ba134523d94ae0801640bb5b07a74039813c0042223579a7533c6d36467ebe9a9b2e1c52ee927a4f1d7"
+}

--- a/packages/override/override.0.2.2/opam
+++ b/packages/override/override.0.2.2/opam
@@ -26,5 +26,5 @@ depends: [
 ]
 url {
   src: "https://gitlab.inria.fr/tmartine/override/-/archive/0.2.2/override-0.2.2.tar.gz"
-  checksum: "sha512=d068135191f4f0c051c293ccb3cf2077673ed0a537b95ba134523d94ae0801640bb5b07a74039813c0042223579a7533c6d36467ebe9a9b2e1c52ee927a4f1d7"
+  checksum: "sha512=2a22d74285570ad9f2a73327f52d4bef4aeb523f1b385f229775cc2a3bce4c389f2939da320c917707713ffc852cbcb3a1b515f9d7203da5751018589766ce01"
 }


### PR DESCRIPTION
- support for OCaml 4.09

- compatible with the last versions of `ppxlib` and `ppx_deriving`