### PR TITLE
Release pattern.0.1.1

### DIFF
--- a/packages/pattern/pattern.0.1.1/opam
+++ b/packages/pattern/pattern.0.1.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+bug-reports: "https://gitlab.inria.fr/tmartine/pattern"
+homepage: "https://gitlab.inria.fr/tmartine/pattern"
+doc: "https://gitlab.inria.fr/tmartine/pattern"
+license: "BSD"
+dev-repo: "git+https://gitlab.inria.fr/tmartine/pattern"
+synopsis: "Run-time patterns that explain match failures"
+description: """
+pattern is a PPX extension that generates functions from patterns
+that explain match failures by returning the common context and
+the list of differences between a pattern and a value.
+"""
+depends: [
+  "dune" {>= "1.10.0"}
+  "ppxlib" {>= "0.9.0"}
+  "ppx_deriving" {>= "4.4"}
+  "stdcompat" {>= "10"}
+]
+url {
+  src: "https://gitlab.inria.fr/tmartine/pattern/-/archive/0.1.1/pattern-0.1.1.tar.gz"
+  checksum: "sha512sum=5fa5bfba1a4f2587a391ec622ab4281d4a2acceaac2fdc45a85990cbc98e5c2865b6634363374ae7b554435f500f5a80065c1abc2b33698175a72a38a66f8724"
+}


### PR DESCRIPTION
- compatible with OCaml 4.09.

- use ppxlib parsetree to be more independent from OCaml version.

- added Pattern_runtime.check function for a friendlier type inference
  in patterns