### PR TITLE
Update for conf-libclang

### DIFF
--- a/packages/conf-libclang/conf-libclang.1.0.0/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.1.0.0/files/configure.sh
@@ -4,14 +4,16 @@ find_llvm_config () {
     # Locate llvm-config (taken from conf-llvm's configure.sh file)
 
     shopt -s nullglob
-    for version in 7 6 5 4 3; do
+    for version in 9 8 7 6 5 4 3; do
         if hash brew 2>/dev/null; then
            brew_llvm_config="$(brew --cellar)"/llvm*/${version}*/bin/llvm-config
         fi
         for llvm_config in \
-            llvm-config-$version llvm-config-${version}.0 \
+            llvm-config-${version} llvm-config-${version}.0 \
             llvm-config${version}0 llvm-config-mp-$version \
             llvm-config-mp-${version}.0 $brew_llvm_config \
+            /usr/lib64/llvm/${version}/bin/llvm-config \
+            /usr/lib/llvm/${version}/bin/llvm-config \
             llvm-config; do
             llvm_version="`$llvm_config --version`" || continue
             return
@@ -71,3 +73,6 @@ CC=cc
 "$tempdir/test_libclang" || \
     ( clean_tempdir; echo "Error: cannot execute libclang test."; exit 1 )
 clean_tempdir
+
+echo "config: \"$llvm_config\"" >> conf-libclang.config
+echo "version: \"$llvm_version\"" >> conf-libclang.config

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -18,6 +18,7 @@ depexts: [
     {os-distribution = "fedora"}
   ["llvm-clang-devel"] {os-family = "suse"}
   ["devel/clang" "devel/llvm"] {os = "freebsd"}
+  ["sys-devel/clang"] {os-distribution = "gentoo"}
 ]
 extra-files: [[
   "configure.sh" "md5=2980f60a8c38e9a85352e4afb6a11fd3"

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -21,7 +21,7 @@ depexts: [
   ["sys-devel/clang"] {os-distribution = "gentoo"}
 ]
 extra-files: [[
-  "configure.sh" "md5=2980f60a8c38e9a85352e4afb6a11fd3"
+  "configure.sh" "sha512=7bff64d4185ddd97597d096d26d255a59b1a68fb96776823cc4fe161ccaf24ff50d30c39f7880fdff2f10b7a9c75c967280085bda5e2aba27433159c6b33ceeb"
 ]]
 synopsis: "Virtual package relying on the installation of llvm and clang libraries (any version)"
 flags: conf

--- a/packages/override/override.0.2.0/opam
+++ b/packages/override/override.0.2.0/opam
@@ -24,6 +24,7 @@ depends: [
   "ppx_show" {>= "0.1.0"}
   "ppx_compare" {>= "v0.12.0"}
   "cppo" {>= "1.6.4"}
+  "ocaml" {< "4.09.0"}
 ]
 url {
   src: "https://gitlab.inria.fr/tmartine/override/-/archive/0.2.0/override-0.2.0.tar.gz"

--- a/packages/override/override.0.2.1/opam
+++ b/packages/override/override.0.2.1/opam
@@ -24,6 +24,7 @@ depends: [
   "ppx_show" {>= "0.1.0"}
   "ppx_compare" {>= "v0.12.0"}
   "cppo" {>= "1.6.4"}
+  "ocaml" {< "4.09.0"}
 ]
 url {
   src: "https://gitlab.inria.fr/tmartine/override/-/archive/0.2.1/override-0.2.1.tar.gz"


### PR DESCRIPTION
- support LLVM versions 8 and 9.

- add config variables `config` and `version` that can be used by packages depending on this one to get the path to `llvm-config` and the detected version number.