### PR TITLE
[new release] ssh-agent-unix and ssh-agent (0.2.0)

### DIFF
--- a/packages/ssh-agent-unix/ssh-agent-unix.0.2.0/opam
+++ b/packages/ssh-agent-unix/ssh-agent-unix.0.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Ssh-agent"
+description: """
+An ssh-agent protocol implementation in OCaml.
+
+For the Qubes OS unikernel using this library see [qubes-mirage-ssh-agent](https://github.com/reynir/qubes-mirage-ssh-agent)."""
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+authors: "Reynir Björnsson <reynir@reynir.dk>"
+license: "BSD-2-clause"
+homepage: "https://github.com/reynir/ocaml-ssh-agent/"
+bug-reports: "https://github.com/reynir/ocaml-ssh-agent/issues/"
+depends: [
+  "ocaml"
+  "dune" {>= "1.0"}
+  "ssh-agent" {= version}
+  "angstrom-unix"
+  "faraday"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/reynir/ocaml-ssh-agent.git"
+url {
+  src:
+    "https://github.com/reynir/ocaml-ssh-agent/releases/download/v0.2.0/ssh-agent-v0.2.0.tbz"
+  checksum: [
+    "sha256=7e83bbaea0c939c7b75d94e9df1296b07caf7082fa492d3867d84d242c603006"
+    "sha512=e01092f9ec7ca7a69db2cde86a56215676f90c418514a353bfa238c665876b25e20fd3acf1bbcdc52a60a765bbf9c16dca83383b2dda23de62ff90a3496e25f1"
+  ]
+}

--- a/packages/ssh-agent/ssh-agent.0.2.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Ssh-agent protocol parser and serialization implementation."
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+authors: "Reynir Björnsson <reynir@reynir.dk>"
+license: "BSD-2-clause"
+homepage: "https://github.com/reynir/ocaml-ssh-agent/"
+bug-reports: "https://github.com/reynir/ocaml-ssh-agent/issues/"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.0"}
+  "ppx_cstruct" {build}
+  "ppx_sexp_conv"
+  "angstrom" {>= "0.10" & < "0.13"}
+  "faraday" {>= "0.6" & < "0.8"}
+  "nocrypto"
+  "cstruct"
+  "alcotest" {with-test}
+  "sexplib" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/reynir/ocaml-ssh-agent.git"
+url {
+  src:
+    "https://github.com/reynir/ocaml-ssh-agent/releases/download/v0.2.0/ssh-agent-v0.2.0.tbz"
+  checksum: [
+    "sha256=7e83bbaea0c939c7b75d94e9df1296b07caf7082fa492d3867d84d242c603006"
+    "sha512=e01092f9ec7ca7a69db2cde86a56215676f90c418514a353bfa238c665876b25e20fd3acf1bbcdc52a60a765bbf9c16dca83383b2dda23de62ff90a3496e25f1"
+  ]
+}


### PR DESCRIPTION
Ssh-agent

- Project page: <a href="https://github.com/reynir/ocaml-ssh-agent/">https://github.com/reynir/ocaml-ssh-agent/</a>

##### CHANGES:

* Switch to dune

* Implement OpenSSH RSA certificates
