### PR TITLE
mccs requires a C++ compiler

### DIFF
--- a/packages/conf-g++/conf-g++.1.0/opam
+++ b/packages/conf-g++/conf-g++.1.0/opam
@@ -4,8 +4,7 @@ authors: "Francois Berenger"
 homepage: "https://github.com/ocaml/opam-repository"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-2.0-or-later"
-build: [["which" "g++"]]
-depends: ["conf-which" {build}]
+build: ["g++" "--version"]
 depexts: [
   ["gcc-c++"] {os-distribution = "centos"}
   ["gcc-c++"] {os-distribution = "fedora"}

--- a/packages/mccs/mccs.1.1+10/opam
+++ b/packages/mccs/mccs.1.1+10/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml"
   "dune" {>= "1.0"}
   "cudf" {>= "0.7"}
+  "conf-g++" {build}
 ]
 synopsis: "MCCS (which stands for Multi Criteria CUDF Solver) is a CUDF problem solver
 developed at UNS during the European MANCOOSI project"

--- a/packages/mccs/mccs.1.1+2/opam
+++ b/packages/mccs/mccs.1.1+2/opam
@@ -14,6 +14,7 @@ depends: [
   "jbuilder" {build}
   "conf-glpk"
   "cudf" {>= "0.7"}
+  "conf-g++" {build}
 ]
 synopsis: "Multi Criteria CUDF Solver with OCaml bindings"
 description: """

--- a/packages/mccs/mccs.1.1+3/opam
+++ b/packages/mccs/mccs.1.1+3/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta14"}
   "cudf" {>= "0.7"}
+  "conf-g++" {build}
 ]
 synopsis: "Multi Criteria CUDF Solver with OCaml bindings"
 description: """

--- a/packages/mccs/mccs.1.1+4/opam
+++ b/packages/mccs/mccs.1.1+4/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta14"}
   "cudf" {>= "0.7"}
+  "conf-g++" {build}
 ]
 synopsis: "Multi Criteria CUDF Solver with OCaml bindings"
 description: """

--- a/packages/mccs/mccs.1.1+5/opam
+++ b/packages/mccs/mccs.1.1+5/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml"
   "dune" {(< "1.6.0" | > "1.6.1")}
   "cudf" {>= "0.7"}
+  "conf-g++" {build}
 ]
 synopsis: "Multi Criteria CUDF Solver with OCaml bindings"
 description: """

--- a/packages/mccs/mccs.1.1+6/opam
+++ b/packages/mccs/mccs.1.1+6/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml"
   "dune" {(< "1.6.0" | > "1.6.1")}
   "cudf" {>= "0.7"}
+  "conf-g++" {build}
 ]
 synopsis: "Multi Criteria CUDF Solver with OCaml bindings"
 description: """

--- a/packages/mccs/mccs.1.1+8/opam
+++ b/packages/mccs/mccs.1.1+8/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml"
   "dune" {(< "1.6.0" | > "1.6.1")}
   "cudf" {>= "0.7"}
+  "conf-g++" {build}
 ]
 synopsis: "Multi Criteria CUDF Solver with OCaml bindings"
 description: """

--- a/packages/mccs/mccs.1.1+9/opam
+++ b/packages/mccs/mccs.1.1+9/opam
@@ -11,6 +11,7 @@ depends: [
   "ocaml"
   "dune" {(< "1.6.0" | > "1.6.1")}
   "cudf" {>= "0.7"}
+  "conf-g++" {build}
 ]
 build: [
   ["dune" "build" "-p" name]


### PR DESCRIPTION
This PR also gets ride of the dependency on `which` to check whether g++ (or other C++ compilers linked as g++ are present) and use `--version` instead (this should be supported by most C++ compilers)