### PR TITLE
Package uecc.0.1

### DIFF
--- a/packages/uecc/uecc.0.1/opam
+++ b/packages/uecc/uecc.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Vincent Bernardoff <vb@luminar.eu.org>" "Nomadic Labs" ]
+license: "ISC"
+homepage: "https://gitlab.com/nomadic-labs/ocaml-uecc"
+synopsis: "Bindings for ECDH and ECDSA for 8-bit, 32-bit, and 64-bit processors"
+bug-reports: "https://gitlab.com/nomadic-labs/ocaml-uecc/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ocaml-uecc.git"
+build: [
+  ["dune" "build" "-j" jobs "-p" name "@install"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "1.7"}
+  "bigstring" {>= "0.1.1"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "cstruct" {with-test & >= "3.2.1"}
+  "hex" {with-test}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ocaml-uecc/-/archive/v0.1/ocaml-uecc-v0.1.tar.gz"
+  checksum: [
+    "md5=d375b766ef4243265ef67f2fd474574d"
+    "sha512=98d10e8d5ad21f971e2320c25003344d561929b17eb77fc6ac42fd08dec4da582b200d483964d05f3bc0352e37ee463c5d4c4dd11a663dfa463ad53f8293e881"
+  ]
+}


### PR DESCRIPTION
### `uecc.0.1`
Bindings for ECDH and ECDSA for 8-bit, 32-bit, and 64-bit processors



---
* Homepage: https://gitlab.com/nomadic-labs/ocaml-uecc
* Source repo: git+https://gitlab.com/nomadic-labs/ocaml-uecc.git
* Bug tracker: https://gitlab.com/nomadic-labs/ocaml-uecc/issues

---
:camel: Pull-request generated by opam-publish v2.0.0