### PR TITLE
ocp-browser.1.1.9: lambda-term upper constraint

### DIFF
--- a/packages/ocp-browser/ocp-browser.1.1.9/opam
+++ b/packages/ocp-browser/ocp-browser.1.1.9/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-index" {= version}
   "cmdliner"
-  "lambda-term" {< "2.0"}
+  "lambda-term" {< "3.0"}
 ]
 url {
   src: "https://github.com/OCamlPro/ocp-index/archive/1.1.9.tar.gz"


### PR DESCRIPTION
It works fine with lambda-term.2.0.2 when I tested it. The binary compiles and runs just fine for me.