### PR TITLE
[new release] certify (0.3.1)

### DIFF
--- a/packages/certify/certify.0.3.1/opam
+++ b/packages/certify/certify.0.3.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:  ["maintenance@identity-function.com"]
+homepage:     "https://github.com/yomimono/ocaml-certify"
+dev-repo:     "git+https://github.com/yomimono/ocaml-certify.git"
+bug-reports:  "https://github.com/yomimono/ocaml-certify/issues"
+doc:          "https://yomimono.github.io/ocaml-certify/doc"
+synopsis:     "CLI utilities for simple X509 certificate manipulation"
+authors: [
+  "Mindy Preston"
+]
+tags: ["org:mirage"]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "test/test.sh" ] {with-test}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "nocrypto" {>= "0.5.4"}
+  "x509" {>= "0.7.1"}
+  "cstruct" {>= "3.2.0"}
+  "ptime"
+  "ocaml" {>= "4.04.2"}
+  "cmdliner" {>= "1.0.0"}
+  "conf-openssl" {with-test}
+]
+description: """
+`certify` is a small selection of useful utilities for manipulating X509 certificates and public keys.  It uses the mirleft organization's x509, tls, and nocrypto libraries.
+
+Three subcommands to `certify` are provided:
+* `certify csr`: make a certificate signing request
+* `certify selfsign`: make a self-signed certificate
+* `certify sign`: sign a certificate
+"""
+url {
+  src:
+    "https://github.com/yomimono/ocaml-certify/releases/download/v0.3.1/certify-v0.3.1.tbz"
+  checksum: [
+    "sha256=35a9492d13d90f6e6c1720a38fb210af9c1d09f3d231bbb5518714fcbd9ca24e"
+    "sha512=dafbdfbafe8b6fa77599a03ce98d3139dbe39831b3a34466cbb5fb4a3a48004f19184b12d426908f4d28d5751b3c6e41aa45188bddc0f5d956d66b7ba3e49178"
+  ]
+}


### PR DESCRIPTION
CLI utilities for simple X509 certificate manipulation

- Project page: <a href="https://github.com/yomimono/ocaml-certify">https://github.com/yomimono/ocaml-certify</a>
- Documentation: <a href="https://yomimono.github.io/ocaml-certify/doc">https://yomimono.github.io/ocaml-certify/doc</a>

##### CHANGES:

* maintenance: use newer x509 (v0.7.1) (@hannesm)
