### PR TITLE
Release ocamlcodoc 1.0.1

### DIFF
--- a/packages/ocamlcodoc/ocamlcodoc.1.0.1/opam
+++ b/packages/ocamlcodoc/ocamlcodoc.1.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+bug-reports: "https://gitlab.inria.fr/tmartine/ocamlcodoc"
+homepage: "https://gitlab.inria.fr/tmartine/ocamlcodoc"
+doc: "https://gitlab.inria.fr/tmartine/ocamlcodoc"
+license: "BSD"
+dev-repo: "git+https://gitlab.inria.fr/tmartine/ocamlcodoc"
+synopsis: "Extract test code from doc-comments"
+description: """
+ocamlcodoc extracts the preformatted source code in OCaml
+documentation comments, i.e. the code delimited by {[ ... ]} in
+comments delimited by (** ... *). A typical usage is to write examples
+in documentation comments that can be extracted and tested.
+"""
+depends: [
+  "dune" {>= "1.10.0"}
+  "cmdliner"
+  "redirect"
+  "stdcompat" {>= "10"}
+]
+url {
+  src: "https://gitlab.inria.fr/tmartine/ocamlcodoc/-/archive/v1.0.1/ocamlcodoc-v1.0.1.tar.gz"
+  checksum: "sha512=c95ed76a2f654913c0cc8a128cdaea15923e0fb7ec82db96c5aa35cbdcd88ad316999a853c5bb247fc2d785918bb904193fd0b7e33b895ddddfeb140400608e5"
+}


### PR DESCRIPTION
- Support for {| ... |} strings without identifiers

- Update for changes in dependencies API