### PR TITLE
Release stdcompat.11

### DIFF
--- a/packages/stdcompat/stdcompat.11/opam
+++ b/packages/stdcompat/stdcompat.11/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Compatibility module for OCaml standard library"
+description:
+  "Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml."
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+license: "BSD-3-Clause"
+homepage: "https://github.com/thierry-martinez/stdcompat"
+bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
+depends: [
+  "ocaml" {>= "3.07" & < "4.10.0"}
+]
+depopts: ["result" "seq" "uchar" "ocamlfind"]
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
+url {
+  src:
+    "https://github.com/thierry-martinez/stdcompat/releases/download/11/stdcompat-11.tar.gz"
+  checksum: [
+    "sha512=f467fc4de32933d6634b34ad23b245863f904080d2976d04c9f54841e98a8590d5f3d879ed97e24109403e0470eaf32faa42cc24eb5bf3e2c81a1280da81af02"
+  ]
+}

--- a/packages/stdcompat/stdcompat.11/opam
+++ b/packages/stdcompat/stdcompat.11/opam
@@ -21,6 +21,6 @@ url {
   src:
     "https://github.com/thierry-martinez/stdcompat/releases/download/11/stdcompat-11.tar.gz"
   checksum: [
-    "sha512=f467fc4de32933d6634b34ad23b245863f904080d2976d04c9f54841e98a8590d5f3d879ed97e24109403e0470eaf32faa42cc24eb5bf3e2c81a1280da81af02"
+    "sha512=bdb407ecbfbbb8fbca76987e5356d0b1219e32a5a90277d9293940fe67fdf616123e69aad5cd42dc80d1cc686b81638f4d8a929bc8c715f33d12d94fcb9b3356"
   ]
 }


### PR DESCRIPTION
- caml_alloc_initialized_string is now available for OCaml 4.05.0

- Added Printexc.to_string_default and Printexc.use_printers