### PR TITLE
[new release] capnp (3.4.0)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.1/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.1/opam
@@ -10,7 +10,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}
   "conf-capnproto" {build}
-  "capnp" {>= "3.0.0"}
+  "capnp" {>= "3.0.0" & < "3.4.0"}
   "capnp-rpc" {< "0.2"}
   "lwt"
   "astring"

--- a/packages/capnp/capnp.3.4.0/opam
+++ b/packages/capnp/capnp.3.4.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/capnproto/capnp-ocaml"
 bug-reports: "https://github.com/capnproto/capnp-ocaml/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "result"
   "base" {>= "v0.11"}
   "stdio"

--- a/packages/capnp/capnp.3.4.0/opam
+++ b/packages/capnp/capnp.3.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "capnp"
+maintainer: "Paul Pelzl <pelzlpj@gmail.com>"
+authors: "Paul Pelzl <pelzlpj@gmail.com>"
+homepage: "https://github.com/capnproto/capnp-ocaml"
+bug-reports: "https://github.com/capnproto/capnp-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "result"
+  "base" {>= "v0.11"}
+  "stdio"
+  "base_quickcheck" {with-test}
+  "ocplib-endian" {>= "0.7"}
+  "res"
+  "stdint"
+  "ounit" {with-test}
+  "conf-capnproto" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest" "@src/benchmark/benchmarks"] {with-test}
+]
+dev-repo: "git+https://github.com/capnproto/capnp-ocaml.git"
+synopsis:
+  "OCaml code generation plugin for the Cap'n Proto serialization framework"
+description: """
+Cap'n Proto is a multi-language code generation framework designed for
+high performance through the use of lazy parsing and arena allocation.
+This package provides a plugin for the Cap'n Proto compiler which enables
+OCaml code generation, as well as corresponding runtime library support."""
+url {
+  src:
+    "https://github.com/capnproto/capnp-ocaml/releases/download/v3.4.0/capnp-v3.4.0.tbz"
+  checksum: [
+    "sha256=7a6b0e4dbbe6d246336f248c69f719fd372bb8d51805822ea123983c3181c17e"
+    "sha512=d8ecf1d6481edab02fd8cc7dc269ee0c357a1858f4434adacdd1f2af9d528c7304e3e467faa1273ebb8f6a452b80b5822cbddfcc4534229bd0edca24a70a5833"
+  ]
+}


### PR DESCRIPTION
OCaml code generation plugin for the Cap'n Proto serialization framework

- Project page: <a href="https://github.com/capnproto/capnp-ocaml">https://github.com/capnproto/capnp-ocaml</a>

##### CHANGES:

* Upgrade from uint to stdint (@talex5, capnproto/capnp-ocaml#64). From uint 2.0.1, these are
  compatible. Projects using the schema compiler should either upgrade to
  stdint themselves, or add a lower bound of `uint >= 2.0.1`. Otherwise,
  the build may fail because of a missing dependency on stdint.

* Require `base >= 0.11` for `Base.Queue` (@talex5, capnproto/capnp-ocaml#61).

* Fix compilation on OCaml 4.08 (@talex5, capnproto/capnp-ocaml#63).

* Fix generated files when one interface imports another (@talex5, capnproto/capnp-ocaml#65,
  reported by TealG).
