### PR TITLE
[new release] mdx (1.5.0)

### DIFF
--- a/packages/mdx/mdx.1.5.0/opam
+++ b/packages/mdx/mdx.1.5.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org"]
+homepage:     "https://github.com/realworldocaml/mdx"
+license:      "ISC"
+dev-repo:     "git+https://github.com/realworldocaml/mdx.git"
+bug-reports:  "https://github.com/realworldocaml/mdx/issues"
+doc:          "https://realworldocaml.github.io/mdx/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune"
+  "ocamlfind"
+  "fmt"
+  "cppo" {build}
+  "astring"
+  "logs"
+  "cmdliner"
+  "re" {>= "1.7.2"}
+  "result"
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+  "ocaml-version" {>= "2.3.0"}
+  "lwt" {with-test}
+  "conf-pandoc" {with-test}
+]
+
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date.
+
+`ocaml-mdx` is released as two binaries called `ocaml-mdx` and `mdx` which are
+the same, mdx being the deprecated name, kept for now for compatibility.
+"""
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/1.5.0/mdx-1.5.0.tbz"
+  checksum: [
+    "sha256=96126e243d9119e27643ca265cc547aea1f0567937a7c92339b79a2ef61c262a"
+    "sha512=29d26f3f23e00d57b7e5cfbdaf1b0441efca6afb9adc9514c2b0f3460b4c08b76a67fb1bd4df983d31cdcda57b2fececb36b8f28f035f2a67bbdbd72d6576f68"
+  ]
+}

--- a/packages/mdx/mdx.1.5.0/opam
+++ b/packages/mdx/mdx.1.5.0/opam
@@ -10,7 +10,7 @@ doc:          "https://realworldocaml.github.io/mdx/"
 build: [
  ["dune" "subst"] {pinned}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "build" "@install" "@runtest"] {with-test}
 ]
 
 depends: [


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>
- Documentation: <a href="https://realworldocaml.github.io/mdx/">https://realworldocaml.github.io/mdx/</a>

##### CHANGES:

#### Added

- Add `--syntax` option to `rule` subcommand to allow generating rules for cram
  tests (realworldocaml/mdx#177, @craigfe)
- Add a `require-package` label to explicitly declare dune `package` dependencies of a code block
  (realworldocaml/mdx#149, @Julow)
- Add an `unset-` label to unset env variables in shell blocks (realworldocaml/mdx#132, @clecat)

#### Changed

- Run promotion of markdown files before `.ml` files in generated dune rules (realworldocaml/mdx#140, @clecat)

#### Fixed

- Remove trailing whitespaces at the end of toplevel or bash evaluation lines
  (realworldocaml/mdx#166, @clecat)
- Improve error reporting of ocaml-mdx test (realworldocaml/mdx#172, @Julow)
- Rule: Pass the --section option to `test` (realworldocaml/mdx#176, @Julow)
- Remove trailing whitespaces from shell outputs and toplevel evals (realworldocaml/mdx#166, @clecat)
- Remove inappropriate empty lines in generated dune rules (realworldocaml/mdx#163, @Julow)
- Fix ignored `skip` label in `ocaml-mdx pp` (realworldocaml/mdx#1561, @CraigFe)
- Fix synchronization of new parts from markdown to `.ml` (realworldocaml/mdx#156, @Julow)
- Fix ignored `[@@@parts ...]` markers within module definitions (realworldocaml/mdx#155, @Julow)
- Fix a bug in internal OCaml version comparison that lead to crashes in some cases (realworldocaml/mdx#145, @gpetiot)
- Promote to empty `.ml` file when using `to-ml` direction (realworldocaml/mdx#139, @clecat)
- Apply `--force-output` to `.ml` file as well (realworldocaml/mdx#137, @clecat)
- Fix a bug preventing `.corrected` files to be written in some cases (realworldocaml/mdx#136, @clecat)
- Add compatibility with `4.09.0` (realworldocaml/mdx#133, @xclerc)

#### Removed

- Remove the `infer-timestamp` direction (realworldocaml/mdx#171 @Julow)
