### PR TITLE
4 packages from c-cube/qcheck at 0.11

### DIFF
--- a/packages/qcheck-alcotest/qcheck-alcotest.0.11/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.11/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Alcotest backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: ["test" "quickcheck" "qcheck" "alcotest"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {= version}
+  "alcotest"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.11.tar.gz"
+  checksum: [
+    "md5=36f06108bb49df27b8a1b95aacfd4859"
+    "sha512=80d98632cc0a93ae9d0e2d1f393134171518d7fdc5f19d5583964254c31cf18c8f587f0d50e0b4b41e2ded1129715acde16b8de57b35ed6b69f2e7de5a50eee9"
+  ]
+}

--- a/packages/qcheck-core/qcheck-core.0.11/opam
+++ b/packages/qcheck-core/qcheck-core.0.11/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Core qcheck library"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.11.tar.gz"
+  checksum: [
+    "md5=36f06108bb49df27b8a1b95aacfd4859"
+    "sha512=80d98632cc0a93ae9d0e2d1f393134171518d7fdc5f19d5583964254c31cf18c8f587f0d50e0b4b41e2ded1129715acde16b8de57b35ed6b69f2e7de5a50eee9"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.11/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.11/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "OUnit backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: ["qcheck" "quickcheck" "ounit"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {= version}
+  "ounit" {>= "2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.11.tar.gz"
+  checksum: [
+    "md5=36f06108bb49df27b8a1b95aacfd4859"
+    "sha512=80d98632cc0a93ae9d0e2d1f393134171518d7fdc5f19d5583964254c31cf18c8f587f0d50e0b4b41e2ded1129715acde16b8de57b35ed6b69f2e7de5a50eee9"
+  ]
+}

--- a/packages/qcheck/qcheck.0.11/opam
+++ b/packages/qcheck/qcheck.0.11/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Compatibility package for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {= version}
+  "qcheck-ounit" {= version}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.11.tar.gz"
+  checksum: [
+    "md5=36f06108bb49df27b8a1b95aacfd4859"
+    "sha512=80d98632cc0a93ae9d0e2d1f393134171518d7fdc5f19d5583964254c31cf18c8f587f0d50e0b4b41e2ded1129715acde16b8de57b35ed6b69f2e7de5a50eee9"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`qcheck.0.11`: Compatibility package for qcheck
-`qcheck-alcotest.0.11`: Alcotest backend for qcheck
-`qcheck-core.0.11`: Core qcheck library
-`qcheck-ounit.0.11`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.0.0