### PR TITLE
[new release] gettext-stub, gettext-camomile and gettext (0.4.0)

### DIFF
--- a/packages/gettext-camomile/gettext-camomile.0.4.0/opam
+++ b/packages/gettext-camomile/gettext-camomile.0.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-gettext"
+dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
+bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
+doc: "https://gildor478.github.io/ocaml-gettext/"
+build: [
+  ["ocaml" "configure.ml"
+    "--with-defaultlocaledir" "%{lib}%/gettext/share/locale"
+    "--version" version]
+  ["dune" "build" "-p" name "-j" jobs
+   "@install"
+   "@doc" {with-doc}
+   "@runtest" {with-test} ]
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11.0"}
+  "camomile"
+  "base-bytes"
+  "gettext" {= version}
+  "ounit" {with-test & > "2.0.8"}
+  "fileutils" {with-test}
+]
+synopsis: "Internationalization library using camomile (i18n)"
+description:"""
+See gettext package description.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-gettext/releases/download/v0.4.0/gettext-v0.4.0.tbz"
+  checksum: [
+    "sha256=3a248783c09204d5575f3257ddd27144c25a5f7353f849c150cdb1b8fbc73c09"
+    "sha512=72390e58529aa2273c8026c990581bc209bc194d7d437eaf665a58105030400fb9f26aba8940cf0c8906589a9298bf6bbc6ce37d2a94d025cfc1d1e95a9ff815"
+  ]
+}

--- a/packages/gettext-stub/gettext-stub.0.4.0/opam
+++ b/packages/gettext-stub/gettext-stub.0.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-gettext"
+dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
+bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
+doc: "https://gildor478.github.io/ocaml-gettext/"
+build: [
+  ["ocaml" "configure.ml"
+    "--with-defaultlocaledir" "%{lib}%/gettext/share/locale"
+    "--version" version]
+  ["dune" "build" "-p" name "-j" jobs
+   "@install"
+   "@doc" {with-doc}
+   "@runtest" {with-test} ]
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11.0"}
+  "base-bytes"
+  "gettext" {= version}
+  "ounit" {with-test & > "2.0.8"}
+  "fileutils" {with-test}
+]
+depexts: [
+  ["gettext"] {os = "macos" & os-distribution = "homebrew"}
+  ["gettext"] {os = "macos" & os-distribution = "macports"}
+  ["gettext"] {os = "win32" & os-distribution = "cygwinports"}
+]
+synopsis: "Internationalization using C gettext library (i18n)"
+description:"""
+See gettext package description.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-gettext/releases/download/v0.4.0/gettext-v0.4.0.tbz"
+  checksum: [
+    "sha256=3a248783c09204d5575f3257ddd27144c25a5f7353f849c150cdb1b8fbc73c09"
+    "sha512=72390e58529aa2273c8026c990581bc209bc194d7d437eaf665a58105030400fb9f26aba8940cf0c8906589a9298bf6bbc6ce37d2a94d025cfc1d1e95a9ff815"
+  ]
+}

--- a/packages/gettext/gettext.0.4.0/opam
+++ b/packages/gettext/gettext.0.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-gettext"
+dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
+bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
+doc: "https://gildor478.github.io/ocaml-gettext/"
+build: [
+  ["ocaml" "configure.ml"
+    "--with-defaultlocaledir" "%{lib}%/gettext/share/locale"
+    "--version" version]
+  ["dune" "build" "-p" name "-j" jobs
+   "@install"
+   "@doc" {with-doc}
+   "@runtest" {with-test} ]
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11.0"}
+  "fileutils"
+  "base-bytes"
+  "ounit" {with-test & > "2.0.8"}
+]
+synopsis: "Internationalization library (i18n)"
+description:"""
+This library enables string translation in OCaml. The API is based on GNU
+gettext. It comes with a tool to extract strings which need to be translated
+from OCaml source files.
+
+This enables OCaml program to output string in the native language of
+the user, if a corresponding translation file of the English strings is
+provided.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-gettext/releases/download/v0.4.0/gettext-v0.4.0.tbz"
+  checksum: [
+    "sha256=3a248783c09204d5575f3257ddd27144c25a5f7353f849c150cdb1b8fbc73c09"
+    "sha512=72390e58529aa2273c8026c990581bc209bc194d7d437eaf665a58105030400fb9f26aba8940cf0c8906589a9298bf6bbc6ce37d2a94d025cfc1d1e95a9ff815"
+  ]
+}


### PR DESCRIPTION
Internationalization using C gettext library (i18n)

- Project page: <a href="https://github.com/gildor478/ocaml-gettext">https://github.com/gildor478/ocaml-gettext</a>
- Documentation: <a href="https://gildor478.github.io/ocaml-gettext/">https://gildor478.github.io/ocaml-gettext/</a>

##### CHANGES:

### Changed
- Migrate build system to dune and opam.
- Make the package available on Linux, MacOSX and Windows.
- Reformat the documentation to use GitHub compatible Markdown.

### Fixed
- Move ocaml-xgettext from Camlp4 to ppx (thanks to Richard W.M. Jones).
