### PR TITLE
[new release] gettext-stub, gettext-camomile and gettext (0.4.1)

### DIFF
--- a/packages/gettext-camomile/gettext-camomile.0.4.1/opam
+++ b/packages/gettext-camomile/gettext-camomile.0.4.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-gettext"
+dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
+bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
+doc: "https://gildor478.github.io/ocaml-gettext/"
+build: [
+  ["ocaml" "configure.ml"
+    "--with-defaultlocaledir" "%{lib}%/gettext/share/locale"
+    "--version" version]
+  ["dune" "build" "-p" name "-j" jobs
+   "@install"
+   "@doc" {with-doc}
+   "@runtest" {with-test} ]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.11.0"}
+  "camomile"
+  "base-bytes"
+  "gettext" {= version}
+  "ounit" {with-test & > "2.0.8"}
+  "fileutils" {with-test}
+]
+synopsis: "Internationalization library using camomile (i18n)"
+description:"""
+See gettext package description.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-gettext/releases/download/v0.4.1/gettext-v0.4.1.tbz"
+  checksum: [
+    "sha256=a80408ff891ed22b5be7e8a5331f4b31e7b50dea482bff56abe73457aa379e5f"
+    "sha512=574530a0c0822b7e1d5772f1c58db92bb52c742432666deb1cc2291fbe603250fa61263df033eb88769c8d7e8bcbbd728c91379d0a5377cfe6026d83a9222fb8"
+  ]
+}

--- a/packages/gettext-stub/gettext-stub.0.4.1/opam
+++ b/packages/gettext-stub/gettext-stub.0.4.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-gettext"
+dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
+bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
+doc: "https://gildor478.github.io/ocaml-gettext/"
+build: [
+  ["ocaml" "configure.ml"
+    "--with-defaultlocaledir" "%{lib}%/gettext/share/locale"
+    "--version" version]
+  ["dune" "build" "-p" name "-j" jobs
+   "@install"
+   "@doc" {with-doc}
+   "@runtest" {with-test} ]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.11.0"}
+  "base-bytes"
+  "gettext" {= version}
+  "ounit" {with-test & > "2.0.8"}
+  "fileutils" {with-test}
+]
+depexts: [
+  ["gettext"] {os = "macos" & os-distribution = "homebrew"}
+  ["gettext"] {os = "macos" & os-distribution = "macports"}
+  ["gettext"] {os = "win32" & os-distribution = "cygwinports"}
+  ["gettext-dev"] {os-distribution = "alpine"}
+  ["libc6-dev"] {os-family = "debian"}
+]
+synopsis: "Internationalization using C gettext library (i18n)"
+description:"""
+See gettext package description.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-gettext/releases/download/v0.4.1/gettext-v0.4.1.tbz"
+  checksum: [
+    "sha256=a80408ff891ed22b5be7e8a5331f4b31e7b50dea482bff56abe73457aa379e5f"
+    "sha512=574530a0c0822b7e1d5772f1c58db92bb52c742432666deb1cc2291fbe603250fa61263df033eb88769c8d7e8bcbbd728c91379d0a5377cfe6026d83a9222fb8"
+  ]
+}

--- a/packages/gettext/gettext.0.4.1/opam
+++ b/packages/gettext/gettext.0.4.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-gettext"
+dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
+bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
+doc: "https://gildor478.github.io/ocaml-gettext/"
+build: [
+  ["ocaml" "configure.ml"
+    "--with-defaultlocaledir" "%{lib}%/gettext/share/locale"
+    "--version" version]
+  ["dune" "build" "-p" name "-j" jobs
+   "@install"
+   "@doc" {with-doc}
+   "@runtest" {with-test} ]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.11.0"}
+  "fileutils"
+  "base-bytes"
+  "ounit" {with-test & > "2.0.8"}
+]
+synopsis: "Internationalization library (i18n)"
+description:"""
+This library enables string translation in OCaml. The API is based on GNU
+gettext. It comes with a tool to extract strings which need to be translated
+from OCaml source files.
+
+This enables OCaml program to output string in the native language of
+the user, if a corresponding translation file of the English strings is
+provided.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-gettext/releases/download/v0.4.1/gettext-v0.4.1.tbz"
+  checksum: [
+    "sha256=a80408ff891ed22b5be7e8a5331f4b31e7b50dea482bff56abe73457aa379e5f"
+    "sha512=574530a0c0822b7e1d5772f1c58db92bb52c742432666deb1cc2291fbe603250fa61263df033eb88769c8d7e8bcbbd728c91379d0a5377cfe6026d83a9222fb8"
+  ]
+}


### PR DESCRIPTION
Internationalization using C gettext library (i18n)

- Project page: <a href="https://github.com/gildor478/ocaml-gettext">https://github.com/gildor478/ocaml-gettext</a>
- Documentation: <a href="https://gildor478.github.io/ocaml-gettext/">https://gildor478.github.io/ocaml-gettext/</a>

##### CHANGES:

### Fixed
- Improve documentation layout.
- Set minimum version of OCaml to 4.03.
- Add depext for Alpine Linux.
