### PR TITLE
mark insecure packages (MSA02 https://mirage.io/blog/MSA02) unavailable:

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.0.3.1/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.0.3.1/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-xen" {>= "0.9.9" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis: "Virtual package which installs the MirageOS block driver for xen"
 url {
   src: "https://github.com/mirage/mirage-block-xen/archive/0.3.1.tar.gz"

--- a/packages/mirage-block-xen/mirage-block-xen.0.4.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.0.4.0/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-xen" {>= "0.9.9" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis: "Virtual package which installs the MirageOS block driver for xen"
 url {
   src: "https://github.com/mirage/mirage-block-xen/archive/0.4.0.tar.gz"

--- a/packages/mirage-block-xen/mirage-block-xen.1.0.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.0.0/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-xen" {>= "0.9.9" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis:
   "MirageOS block driver for Xen that implements the blkfront/back protocol"
 url {

--- a/packages/mirage-block-xen/mirage-block-xen.1.1.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.1.0/opam
@@ -32,7 +32,7 @@ depends: [
   "mirage-xen" {>= "1.0.1" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis:
   "MirageOS block driver for Xen that implements the blkfront/back protocol"
 url {

--- a/packages/mirage-block-xen/mirage-block-xen.1.2.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.2.0/opam
@@ -32,7 +32,7 @@ depends: [
   "mirage-xen" {>= "1.0.1" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis:
   "MirageOS block driver for Xen that implements the blkfront/back protocol"
 description: """

--- a/packages/mirage-block-xen/mirage-block-xen.1.3.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.3.0/opam
@@ -32,7 +32,7 @@ depends: [
   "mirage-xen" {>= "1.0.1" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis:
   "MirageOS block driver for Xen that implements the blkfront/back protocol"
 description: """

--- a/packages/mirage-block-xen/mirage-block-xen.1.3.1/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.3.1/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-xen" {>= "1.0.1" & < "3.3.0"}
   "ocamlbuild" {build}
 ]
-available: os = "linux"
+available: false
 synopsis:
   "MirageOS block driver for Xen that implements the blkfront/back protocol"
 description: """

--- a/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.4.0/opam
@@ -30,7 +30,7 @@ depends: [
   "io-page" {>= "1.4.0"}
   "mirage-xen" {>= "1.0.1" & < "3.3.0"}
 ]
-available: os = "linux"
+available: false
 synopsis:
   "MirageOS block driver for Xen that implements the blkfront/back protocol"
 description: """

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.0/opam
@@ -32,7 +32,7 @@ depends: [
   "mirage-xen" {>= "1.0.1" & < "3.3.0"}
   "rresult"
 ]
-available: os = "linux"
+available: false
 synopsis:
   "MirageOS block driver for Xen that implements the blkfront/back protocol"
 description: """

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.2/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.2/opam
@@ -50,3 +50,4 @@ url {
     "https://github.com/mirage/mirage-block-xen/releases/download/1.5.2/mirage-block-xen-1.5.2.tbz"
   checksum: "md5=b630121cf6bd734ac01680fff24e6d04"
 }
+available: false

--- a/packages/mirage-block-xen/mirage-block-xen.1.5.3/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.5.3/opam
@@ -50,3 +50,4 @@ url {
     "https://github.com/mirage/mirage-block-xen/releases/download/1.5.3/mirage-block-xen-1.5.3.tbz"
   checksum: "md5=7a5bc94d4dc2d0584d25e191a35793a5"
 }
+available: false

--- a/packages/mirage-block-xen/mirage-block-xen.1.6.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.6.0/opam
@@ -47,3 +47,4 @@ url {
     "https://github.com/mirage/mirage-block-xen/releases/download/v1.6.0/mirage-block-xen-v1.6.0.tbz"
   checksum: "md5=6a07dd312289ba29efddb0e5ca98bf78"
 }
+available: false

--- a/packages/mirage-console-xen/mirage-console-xen.0.9.9/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.0.9.9/opam
@@ -19,3 +19,4 @@ url {
   src: "https://github.com/mirage/mirage-console/archive/v0.9.9.tar.gz"
   checksum: "md5=9628ac0871182f5bc3ade47190edcdab"
 }
+available: false

--- a/packages/mirage-console-xen/mirage-console-xen.1.0.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.1.0.0/opam
@@ -22,3 +22,4 @@ url {
   src: "https://github.com/mirage/mirage-console/archive/v1.0.0.tar.gz"
   checksum: "md5=50fe098cd7d56013f4f963a90e5320b5"
 }
+available: false

--- a/packages/mirage-console-xen/mirage-console-xen.1.0.1/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.1.0.1/opam
@@ -22,3 +22,4 @@ url {
   src: "https://github.com/mirage/mirage-console/archive/v1.0.1.tar.gz"
   checksum: "md5=568f5a590464ed598d71c33209e25b9c"
 }
+available: false

--- a/packages/mirage-console-xen/mirage-console-xen.1.0.2/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.1.0.2/opam
@@ -21,3 +21,4 @@ url {
   src: "https://github.com/mirage/mirage-console/archive/v1.0.2.tar.gz"
   checksum: "md5=5d4223f9c9d768d0543a634879826d0d"
 }
+available: false

--- a/packages/mirage-console-xen/mirage-console-xen.2.2.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.2.0/opam
@@ -27,3 +27,4 @@ url {
     "https://github.com/mirage/mirage-console/releases/download/2.2.0/mirage-console-xen-2.2.0.tbz"
   checksum: "md5=8a0fc5a0a0cce21770b4a20fb5fd61dc"
 }
+available: false

--- a/packages/mirage-console-xen/mirage-console-xen.2.3.2/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.3.2/opam
@@ -28,3 +28,4 @@ url {
     "https://github.com/mirage/mirage-console/releases/download/2.3.2/mirage-console-2.3.2.tbz"
   checksum: "md5=90bbc8993ad851a74b3a6d99c268d0e8"
 }
+available: false

--- a/packages/mirage-console-xen/mirage-console-xen.2.3.3/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.3.3/opam
@@ -67,3 +67,4 @@ url {
     "https://github.com/mirage/mirage-console/releases/download/v2.3.3/mirage-console-2.3.3.tbz"
   checksum: "md5=5333550e819614a59547a3ee98cf33ef"
 }
+available: false

--- a/packages/mirage-console-xen/mirage-console-xen.2.3.4/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.3.4/opam
@@ -67,3 +67,4 @@ url {
     "https://github.com/mirage/mirage-console/releases/download/v2.3.4/mirage-console-2.3.4.tbz"
   checksum: "md5=b81bd7033517c1e41527a2055ce0d22f"
 }
+available: false

--- a/packages/mirage-console-xen/mirage-console-xen.2.3.5/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.3.5/opam
@@ -67,3 +67,4 @@ url {
     "https://github.com/mirage/mirage-console/releases/download/v2.3.5/mirage-console-2.3.5.tbz"
   checksum: "md5=6d0d18cc25fc3e14f070fbb79a24f9ca"
 }
+available: false

--- a/packages/mirage-console-xen/mirage-console-xen.2.4.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.4.0/opam
@@ -27,3 +27,4 @@ url {
     "https://github.com/mirage/mirage-console/releases/download/v2.4.0/mirage-console-v2.4.0.tbz"
   checksum: "md5=d2ae5a712fe27c78d80b158ff99ac2e9"
 }
+available: false

--- a/packages/mirage-console-xen/mirage-console-xen.2.4.1/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.4.1/opam
@@ -27,3 +27,4 @@ url {
     "https://github.com/mirage/mirage-console/releases/download/v2.4.1/mirage-console-v2.4.1.tbz"
   checksum: "md5=50bcb141537d229f849f9503b7f54bc2"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.0.9.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.0.9.0/opam
@@ -24,3 +24,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v0.9.0.tar.gz"
   checksum: "md5=a6ed3e87c508f3a22b8bc12363f877f7"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.1.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.1.0/opam
@@ -24,3 +24,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.1.0.tar.gz"
   checksum: "md5=1706ed41e7c47a0754513c71469e53e0"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.1.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.1.1/opam
@@ -24,3 +24,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.1.1.tar.gz"
   checksum: "md5=65bf3e74a38be93ee4888157a2ed4cf8"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.1.2/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.1.2/opam
@@ -31,3 +31,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.1.2.tar.gz"
   checksum: "md5=84eb04c1f38e1bdc0d9c92fe8ad9f2a1"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.1.3/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.1.3/opam
@@ -31,3 +31,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.1.3.tar.gz"
   checksum: "md5=c0424606233ef006f5042aea350df152"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.10.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.10.1/opam
@@ -34,3 +34,4 @@ url {
     "https://github.com/mirage/mirage-net-xen/releases/download/v1.10.1/mirage-net-xen-v1.10.1.tbz"
   checksum: "md5=2a7e7da514d479a38a428f31d9b6ed02"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.2.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.2.0/opam
@@ -32,3 +32,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.2.0.tar.gz"
   checksum: "md5=219c2d66ef283b84f7906194b6d346ae"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.3.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.3.0/opam
@@ -32,3 +32,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.3.0.tar.gz"
   checksum: "md5=19153a5375f0322adebcb28e4efa88a5"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.4.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.4.0/opam
@@ -32,3 +32,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.4.0.tar.gz"
   checksum: "md5=981c7d09af7600ed74bae2f4d36c80d6"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.4.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.4.1/opam
@@ -32,3 +32,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.4.1.tar.gz"
   checksum: "md5=621be0dd240525931049770dc1668523"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.4.2/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.4.2/opam
@@ -33,3 +33,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.4.2.tar.gz"
   checksum: "md5=80531dea04e72d64bf1290c8d56df199"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.5.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.5.0/opam
@@ -37,3 +37,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.5.0.tar.gz"
   checksum: "md5=0134047dd2f130814b51eae5b3fe4d3d"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.0/opam
@@ -46,3 +46,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.6.0.tar.gz"
   checksum: "md5=f53888dfd5585fa3f98d4830169dcaa8"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.6.1/opam
@@ -46,3 +46,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.6.1.tar.gz"
   checksum: "md5=32bd4658383e831f57e68fa35669dbd8"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.7.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.7.0/opam
@@ -43,3 +43,4 @@ url {
   src: "https://github.com/mirage/mirage-net-xen/archive/v1.7.0.tar.gz"
   checksum: "md5=73b189d86dbe16f31ea3c6fc3203c80c"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.7.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.7.1/opam
@@ -36,3 +36,4 @@ url {
     "https://github.com/mirage/mirage-net-xen/releases/download/1.7.1/mirage-net-xen-1.7.1.tbz"
   checksum: "md5=ff89b0aa21dd3a3796aef7e537ff4ce7"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.8.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.8.1/opam
@@ -41,3 +41,4 @@ url {
 archive: "https://github.com/mirage/mirage-net-xen/releases/download/v1.8.1/mirage-net-xen-1.8.1.tbz"
 checksum: "ab5bf2613b8a37aa143d88d25e803c2d"
 }
+available: false

--- a/packages/mirage-net-xen/mirage-net-xen.1.9.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.9.0/opam
@@ -34,3 +34,4 @@ url {
     "https://github.com/mirage/mirage-net-xen/releases/download/v1.9.0/mirage-net-xen-v1.9.0.tbz"
   checksum: "md5=7116cf5cd1d3a4df593a7607237315b8"
 }
+available: false

--- a/packages/mirage-xen/mirage-xen.3.3.0/opam
+++ b/packages/mirage-xen/mirage-xen.3.3.0/opam
@@ -33,7 +33,7 @@ depends: [
 conflicts: [
   "dune" {> "1.9.0" & < "1.9.3"}
 ]
-available: [ os = "linux" ]
+available: false
 synopsis: "Xen core platform libraries for MirageOS"
 description: """
 This package provides the MirageOS `OS` library for

--- a/packages/netchannel/netchannel.1.10.1/opam
+++ b/packages/netchannel/netchannel.1.10.1/opam
@@ -42,3 +42,4 @@ url {
     "https://github.com/mirage/mirage-net-xen/releases/download/v1.10.1/mirage-net-xen-v1.10.1.tbz"
   checksum: "md5=2a7e7da514d479a38a428f31d9b6ed02"
 }
+available: false

--- a/packages/netchannel/netchannel.1.7.1/opam
+++ b/packages/netchannel/netchannel.1.7.1/opam
@@ -43,3 +43,4 @@ url {
     "https://github.com/mirage/mirage-net-xen/releases/download/1.7.1/mirage-net-xen-1.7.1.tbz"
   checksum: "md5=ff89b0aa21dd3a3796aef7e537ff4ce7"
 }
+available: false

--- a/packages/netchannel/netchannel.1.8.0/opam
+++ b/packages/netchannel/netchannel.1.8.0/opam
@@ -43,3 +43,4 @@ url {
     "https://github.com/mirage/mirage-net-xen/releases/download/v1.8.0/netchannel-1.8.0.tbz"
   checksum: "md5=afa3c1164fcbc6d96d2ebae95484ff17"
 }
+available: false

--- a/packages/netchannel/netchannel.1.8.1/opam
+++ b/packages/netchannel/netchannel.1.8.1/opam
@@ -48,3 +48,4 @@ url {
 archive: "https://github.com/mirage/mirage-net-xen/releases/download/v1.8.1/mirage-net-xen-1.8.1.tbz"
 checksum: "ab5bf2613b8a37aa143d88d25e803c2d"
 }
+available: false

--- a/packages/netchannel/netchannel.1.9.0/opam
+++ b/packages/netchannel/netchannel.1.9.0/opam
@@ -42,3 +42,4 @@ url {
     "https://github.com/mirage/mirage-net-xen/releases/download/v1.9.0/mirage-net-xen-v1.9.0.tbz"
   checksum: "md5=7116cf5cd1d3a4df593a7607237315b8"
 }
+available: false

--- a/packages/vchan/vchan.0.9.5/opam
+++ b/packages/vchan/vchan.0.9.5/opam
@@ -37,3 +37,4 @@ url {
   src: "https://github.com/mirage/ocaml-vchan/archive/v0.9.5.tar.gz"
   checksum: "md5=975a917d48037ebb928bf66eb62a0a21"
 }
+available: false

--- a/packages/vchan/vchan.0.9.6/opam
+++ b/packages/vchan/vchan.0.9.6/opam
@@ -40,3 +40,4 @@ url {
   src: "https://github.com/mirage/ocaml-vchan/archive/v0.9.6.tar.gz"
   checksum: "md5=58e798b7120f5bd910846dec17336b96"
 }
+available: false

--- a/packages/vchan/vchan.0.9.7/opam
+++ b/packages/vchan/vchan.0.9.7/opam
@@ -40,3 +40,4 @@ url {
   src: "https://github.com/mirage/ocaml-vchan/archive/v0.9.7.tar.gz"
   checksum: "md5=639be3c17c11337cc99bc87036d2d27c"
 }
+available: false

--- a/packages/vchan/vchan.1.0.0/opam
+++ b/packages/vchan/vchan.1.0.0/opam
@@ -40,3 +40,4 @@ url {
   src: "https://github.com/mirage/ocaml-vchan/archive/v1.0.0.tar.gz"
   checksum: "md5=41dbd9d245dc31603cbe02958fef2a71"
 }
+available: false

--- a/packages/vchan/vchan.2.0.0/opam
+++ b/packages/vchan/vchan.2.0.0/opam
@@ -45,3 +45,4 @@ url {
   src: "https://github.com/mirage/ocaml-vchan/archive/v2.0.0.tar.gz"
   checksum: "md5=49df9c44330e25f12e63c94527420933"
 }
+available: false

--- a/packages/vchan/vchan.2.0.1/opam
+++ b/packages/vchan/vchan.2.0.1/opam
@@ -45,3 +45,4 @@ url {
   src: "https://github.com/mirage/ocaml-vchan/archive/v2.0.1.tar.gz"
   checksum: "md5=02c801b4f6205725de83ebd406e0462c"
 }
+available: false

--- a/packages/vchan/vchan.2.0.2/opam
+++ b/packages/vchan/vchan.2.0.2/opam
@@ -45,3 +45,4 @@ url {
   src: "https://github.com/mirage/ocaml-vchan/archive/v2.0.2.tar.gz"
   checksum: "md5=3a52e32fd51c1c9887681c94f7b581ed"
 }
+available: false

--- a/packages/vchan/vchan.2.0.3/opam
+++ b/packages/vchan/vchan.2.0.3/opam
@@ -53,3 +53,4 @@ url {
   src: "https://github.com/mirage/ocaml-vchan/archive/v2.0.3.tar.gz"
   checksum: "md5=bd8760290707a8fd7fdc45dd4e7068c3"
 }
+available: false

--- a/packages/vchan/vchan.2.1.0/opam
+++ b/packages/vchan/vchan.2.1.0/opam
@@ -54,3 +54,4 @@ url {
   src: "https://github.com/mirage/ocaml-vchan/archive/v2.1.0.tar.gz"
   checksum: "md5=10fbee67b96dbc3b324a64d560f21438"
 }
+available: false

--- a/packages/vchan/vchan.2.2.0/opam
+++ b/packages/vchan/vchan.2.2.0/opam
@@ -59,3 +59,4 @@ url {
   src: "https://github.com/mirage/ocaml-vchan/archive/v2.2.0.tar.gz"
   checksum: "md5=63c9419ffdea9652f282042323d59599"
 }
+available: false

--- a/packages/vchan/vchan.2.3.0/opam
+++ b/packages/vchan/vchan.2.3.0/opam
@@ -71,3 +71,4 @@ url {
   src: "https://github.com/mirage/ocaml-vchan/archive/v2.3.0.tar.gz"
   checksum: "md5=7e1e41d119780ebc5dfc3171b2f2e8af"
 }
+available: false

--- a/packages/vchan/vchan.2.3.1/opam
+++ b/packages/vchan/vchan.2.3.1/opam
@@ -68,3 +68,4 @@ url {
   src: "https://github.com/mirage/ocaml-vchan/archive/v2.3.1.tar.gz"
   checksum: "md5=0e19dc2049706cb712f8972acf452940"
 }
+available: false

--- a/packages/vchan/vchan.3.0.0/opam
+++ b/packages/vchan/vchan.3.0.0/opam
@@ -45,3 +45,4 @@ url {
     "https://github.com/mirage/ocaml-vchan/releases/download/3.0.0/vchan-3.0.0.tbz"
   checksum: "md5=8be9a2d7df23fdf8983daecef3454b5d"
 }
+available: false

--- a/packages/vchan/vchan.4.0.0/opam
+++ b/packages/vchan/vchan.4.0.0/opam
@@ -39,3 +39,4 @@ url {
     "https://github.com/mirage/ocaml-vchan/releases/download/4.0.0/vchan-4.0.0.tbz"
   checksum: "md5=8b88d9f8d013469e99ecf5a91b9f78e3"
 }
+available: false

--- a/packages/vchan/vchan.4.0.1/opam
+++ b/packages/vchan/vchan.4.0.1/opam
@@ -39,3 +39,4 @@ url {
     "https://github.com/mirage/ocaml-vchan/releases/download/v4.0.1/vchan-v4.0.1.tbz"
   checksum: "md5=e6c8304aeffe57dee7aec37511251b23"
 }
+available: false


### PR DESCRIPTION
- mirage-xen < 3.4.0
- mirage-block-xen < 1.6.1
- mirage-net-xen < 1.10.2
- mirage-console < 2.4.2
- ocaml-vchan < 4.0.2