### PR TITLE
[new release] mirage, mirage-runtime, mirage-types-lwt and mirage-types (3.6.0)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.6.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria-runtime"  {>= "2.2.2"}
+  "fmt"
+  "logs"
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.6.0/mirage-v3.6.0.tbz"
+  checksum: [
+    "sha256=0ab6ee37fa44c05cc93ecf2456dabdbbe80935f11e82179d75ee64913cffc3d1"
+    "sha512=ecadf2266982b60b872b862c7c77c11c66b07e44110d98ed63a6e0e12570e3d6d0be06a519fd3a4edc8c184fe010055d7435d62491e22549a4776ac2d530bd41"
+  ]
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.6.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.6.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends:   [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.1.0"}
+  "lwt"
+  "cstruct" {>="3.2.1"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-types" {>= "3.5.0"}
+  "mirage-clock-lwt" {>= "2.0.0"}
+  "mirage-time-lwt" {>= "1.1.0"}
+  "mirage-random" {>= "1.2.0"}
+  "mirage-flow-lwt" {>= "1.5.0"}
+  "mirage-protocols-lwt" {>= "2.0.0"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-console-lwt" {>= "2.3.5"}
+  "mirage-block-lwt" {>= "1.1.0"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "mirage-fs-lwt" {>= "2.0.0"}
+  "mirage-kv-lwt" {>= "2.0.0"}
+  "mirage-channel-lwt" {>= "3.1.0"}
+]
+
+synopsis: "Lwt module type definitions for MirageOS applications"
+description: """
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.6.0/mirage-v3.6.0.tbz"
+  checksum: [
+    "sha256=0ab6ee37fa44c05cc93ecf2456dabdbbe80935f11e82179d75ee64913cffc3d1"
+    "sha512=ecadf2266982b60b872b862c7c77c11c66b07e44110d98ed63a6e0e12570e3d6d0be06a519fd3a4edc8c184fe010055d7435d62491e22549a4776ac2d530bd41"
+  ]
+}

--- a/packages/mirage-types/mirage-types.3.6.0/opam
+++ b/packages/mirage-types/mirage-types.3.6.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-device" {>= "1.1.0"}
+  "mirage-time" {>= "1.1.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-random" {>= "1.2.0"}
+  "mirage-flow" {>= "1.5.0"}
+  "mirage-console" {>= "2.3.5"}
+  "mirage-protocols" {>= "2.0.0"}
+  "mirage-stack" {>= "1.3.0"}
+  "mirage-block" {>= "1.1.0"}
+  "mirage-net" {>= "2.0.0"}
+  "mirage-fs" {>= "2.0.0"}
+  "mirage-kv" {>= "2.0.0"}
+  "mirage-channel" {>= "3.1.0"}
+]
+synopsis: "Module type definitions for MirageOS applications"
+description: """
+Module type definitions for MirageOS applications
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.6.0/mirage-v3.6.0.tbz"
+  checksum: [
+    "sha256=0ab6ee37fa44c05cc93ecf2456dabdbbe80935f11e82179d75ee64913cffc3d1"
+    "sha512=ecadf2266982b60b872b862c7c77c11c66b07e44110d98ed63a6e0e12570e3d6d0be06a519fd3a4edc8c184fe010055d7435d62491e22549a4776ac2d530bd41"
+  ]
+}

--- a/packages/mirage/mirage.3.6.0/opam
+++ b/packages/mirage/mirage.3.6.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria"          {>= "2.2.3"}
+  "bos"
+  "astring"
+  "logs"
+  "mirage-runtime"     {>= "3.5.0"}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.6.0/mirage-v3.6.0.tbz"
+  checksum: [
+    "sha256=0ab6ee37fa44c05cc93ecf2456dabdbbe80935f11e82179d75ee64913cffc3d1"
+    "sha512=ecadf2266982b60b872b862c7c77c11c66b07e44110d98ed63a6e0e12570e3d6d0be06a519fd3a4edc8c184fe010055d7435d62491e22549a4776ac2d530bd41"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* solo5 0.6 support for multiple devices (mirage/mirage#993, by @mato)
  please read https://github.com/Solo5/solo5/blob/v0.6.2/CHANGES.md for detailed changes
  observable mirage changes:
  - new target `-t spt` for sandboxed processed tender (seccomp on Linux)
  - new functions Mirage_key.is_solo5 and Mirage_key.is_xen, analogue to Mirage_key.is_unix
* respect verbosity when calling `ocamlbuild` -- verbose if log level is info or debug (mirage/mirage#999, by @mato)