### PR TITLE
Release clangml.4.0.1

### DIFF
--- a/packages/clangml/clangml.4.0.1/opam
+++ b/packages/clangml/clangml.4.0.1/opam
@@ -26,8 +26,8 @@ depends: [
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%"]
   ["dune" "build" "-p" name "-j" jobs]]
-run-test: [["dune" "build" "@runtest"]]
+run-test: [["dune" "runtest"  "-p" name "-j" jobs]]
 url {
   src: "https://gitlab.inria.fr/memcad/clangml/-/archive/v4.0.1/clangml-v4.0.1.tar.gz"
-  checksum: "sha512=ed2abfab7bb5750b9f4e2abb38b7b2907c9bc3c0f85e98e82513dab118d66428720ed9799f497f69e95de86a3d3ef0c8fb79131ae0809b7e9f0c24673c5e4a04"
+  checksum: "sha512=459c74fca36897fd9a4888fd06eb1140af148c983d30801fc094b3fb90480fa0662f1d9d2307eddddbbd8f10687118c293017a369293129d3a3465f4cfee4afc"
 }

--- a/packages/clangml/clangml.4.0.1/opam
+++ b/packages/clangml/clangml.4.0.1/opam
@@ -29,5 +29,5 @@ build: [
 run-test: [["dune" "runtest"  "-p" name "-j" jobs]]
 url {
   src: "https://gitlab.inria.fr/memcad/clangml/-/archive/v4.0.1/clangml-v4.0.1.tar.gz"
-  checksum: "sha512=459c74fca36897fd9a4888fd06eb1140af148c983d30801fc094b3fb90480fa0662f1d9d2307eddddbbd8f10687118c293017a369293129d3a3465f4cfee4afc"
+  checksum: "sha512=6585b26e26431942ea69b77b69f86d8582af0ef829a39244fc5d1b6ecd499e3ed6c4869d43d676b2222e3ad247c5caf370dd0f54ac850d5c1fb84e3fcd7d6cdc"
 }

--- a/packages/clangml/clangml.4.0.1/opam
+++ b/packages/clangml/clangml.4.0.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+bug-reports: "https://gitlab.inria.fr/memcad/clangml"
+homepage: "https://gitlab.inria.fr/memcad/clangml"
+doc: "https://gitlab.inria.fr/memcad/clangml"
+license: "BSD"
+dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
+synopsis: "OCaml bindings for Clang API"
+description: """
+clangml provides bindings to call the Clang API from OCaml.
+"""
+depends: [
+  "conf-libclang"
+  "conf-ncurses"
+  "conf-zlib"
+  "dune" {>= "1.10.0"}
+  "ppxlib" {>= "0.9.0"}
+  "stdcompat" {>= "10"}
+  "override" {>= "0.1.0"}
+  "ocaml" {>= "4.04.0"}
+  "ocamlfind" {build & >= "1.8.0"}
+  "ocamlcodoc" {with-test}
+  "pattern" {with-test}
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%"]
+  ["dune" "build" "-p" name "-j" jobs]]
+run-test: [["dune" "build" "@runtest"]]
+url {
+  src: "https://gitlab.inria.fr/memcad/clangml/-/archive/v4.0.1/clangml-v4.0.1.tar.gz"
+  checksum: "sha512=ed2abfab7bb5750b9f4e2abb38b7b2907c9bc3c0f85e98e82513dab118d66428720ed9799f497f69e95de86a3d3ef0c8fb79131ae0809b7e9f0c24673c5e4a04"
+}


### PR DESCRIPTION
- Support for Clang/LLVM 9.0

- Compatible with OCaml 4.09

- Better representation for input and outputs in assembler statements

- u'c' syntax is now correctly supported with Clang 3.6 and 3.7

- Support for C++ exception specification, function try block

- Better support for Gentoo

- Bug fixes