### PR TITLE
Restrict zmq-lwt and zmq-async to their respective zmq release

### DIFF
--- a/packages/zmq-async/zmq-async.5.0.0/opam
+++ b/packages/zmq-async/zmq-async.5.0.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "zmq" {>= "5.0.0"}
+  "zmq" {= version}
   "jbuilder" {build & >= "1.0+beta17"}
   "async_unix" {>= "v0.9.0" & < "v0.13"}
   "async_kernel" {>= "v0.9.0" & < "v0.13"}

--- a/packages/zmq-async/zmq-async.5.1.0/opam
+++ b/packages/zmq-async/zmq-async.5.1.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.1"}
-  "zmq" {>= "5.1.0"}
+  "zmq" {= version}
   "dune"
   "async_unix" {>= "v0.11.0" & < "v0.13"}
   "async_kernel" {>= "v0.11.0" & < "v0.13"}

--- a/packages/zmq-lwt/zmq-lwt.5.0.0/opam
+++ b/packages/zmq-lwt/zmq-lwt.5.0.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "zmq" {>= "5.0.0"}
+  "zmq" {= version}
   "ounit" {with-test & < "2.1.0"}
   "jbuilder" {build & >= "1.0+beta17"}
   "lwt"

--- a/packages/zmq-lwt/zmq-lwt.5.1.0/opam
+++ b/packages/zmq-lwt/zmq-lwt.5.1.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "zmq" {>= "5.1.0"}
+  "zmq" {= version}
   "ounit" {with-test & < "2.1.0"}
   "dune"
   "lwt"


### PR DESCRIPTION
In the last PR I was confused why the older `-lwt` and `-async` bindings were reverse-dependencies of the current `zmq` package and then it dawned on me that we didn't restrict an upper version in the older releases.

We started doing so in version `5.1.1` and this PR just extends this to older releases, so new releases of ZMQ won't be tested against old versions of the bindings. In *theory* that might work, but since these packages are all released from the same repo, tarball and at the same time and only tested against their respective versions I don't think it makes sense to have them as revdeps to new releases and having to bother with them whenever we send a PR.