### PR TITLE
Package seq.0.2

### DIFF
--- a/packages/seq/seq.0.2/opam
+++ b/packages/seq/seq.0.2/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis:
+  "Compatibility package for OCaml's standard iterator type starting from 4.07"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+license: "LGPL2.1"
+tags: ["iterator" "seq" "pure" "list" "compatibility" "cascade"]
+homepage: "https://github.com/c-cube/seq/"
+bug-reports: "https://github.com/c-cube/seq/issues"
+depends: [
+  "dune" {>= "1.1.0"}
+  "ocaml" {< "4.07.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/c-cube/seq.git"
+url {
+  src: "https://github.com/c-cube/seq/archive/0.2.tar.gz"
+  checksum: [
+    "md5=1d5a9d0aba27b22433f518cdc495d0fd"
+    "sha512=b2571225a18e624b79dad5e1aab91b22e2fda17702f2e23c438b75d2a71e24c55ee8672005f5cc4b17ae79e3b277b1918b71b5d0d674b8b12ea19b3fb2d747cb"
+  ]
+}


### PR DESCRIPTION
### `seq.0.2`
Compatibility package for OCaml's standard iterator type starting from 4.07



---
* Homepage: https://github.com/c-cube/seq/
* Source repo: git+https://github.com/c-cube/seq.git
* Bug tracker: https://github.com/c-cube/seq/issues

---
:camel: Pull-request generated by opam-publish v2.0.0