### PR TITLE
[new release] git-http, git, git-unix and git-mirage (2.1.1)

### DIFF
--- a/packages/git-http/git-http.2.0.0/opam
+++ b/packages/git-http/git-http.2.0.0/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml"        {>= "4.03.0"}
   "dune"
-  "git"          {>= "2.0.0" & < "2.1.0"}
+  "git"          {= version}
   "cohttp"       {>= "1.0.0"}
   "cohttp-lwt"   {>= "1.0.0"}
   "sexplib"

--- a/packages/git-http/git-http.2.1.1/opam
+++ b/packages/git-http/git-http.2.1.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "Client implementation of the \"Smart\" HTTP Git protocol in pure OCaml"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"        {>= "4.03.0"}
+  "dune"         {build}
+  "git"          {= version}
+  "cohttp"       {>= "1.0.0"}
+  "cohttp-lwt"   {>= "1.0.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.1/git-2.1.1.tbz"
+  checksum: [
+    "sha256=9d9db7028c58eb82ee44236afdd68feb42ebe9778aa23a3e59ba65aa2d40ce6d"
+    "sha512=ae73f03138455d2bbd3617c9740c2d950f6f6e848dc9f76fbc608cc17f57eab041e1fbdb338a82f94c5121e7dacb733618a40585959097e2dce9c8c87e9f10d0"
+  ]
+}

--- a/packages/git-mirage/git-mirage.2.1.1/opam
+++ b/packages/git-mirage/git-mirage.2.1.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "MirageOS backend for the Git protocol(s)"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"            {>= "4.03.0"}
+  "dune"             {build}
+  "cohttp-mirage"    {>= "1.0.0"}
+  "mirage-flow-lwt"
+  "mirage-channel-lwt"
+  "conduit-mirage"
+  "git-http"         {= version}
+  "git"              {= version}
+  "alcotest"         {with-test & >= "0.8.1"}
+  "mtime"            {with-test & >= "1.0.0"}
+  "nocrypto"         {with-test & >= "0.5.4"}
+  "tls"              {with-test}
+  "io-page"          {with-test & >= "1.6.1"}
+  "tcpip"            {with-test & >= "3.3.0"}
+  "io-page-unix"     {with-test}
+  "mirage-stack-lwt" {with-test & >= "1.3.0"}
+  "mirage-random-test" {with-test}
+  "mirage-time-unix"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.1/git-2.1.1.tbz"
+  checksum: [
+    "sha256=9d9db7028c58eb82ee44236afdd68feb42ebe9778aa23a3e59ba65aa2d40ce6d"
+    "sha512=ae73f03138455d2bbd3617c9740c2d950f6f6e848dc9f76fbc608cc17f57eab041e1fbdb338a82f94c5121e7dacb733618a40585959097e2dce9c8c87e9f10d0"
+  ]
+}

--- a/packages/git-mirage/git-mirage.2.1.1/opam
+++ b/packages/git-mirage/git-mirage.2.1.1/opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "ocaml"            {>= "4.03.0"}
-  "dune"             {build}
+  "dune"             {>= "1.1"}
   "cohttp-mirage"    {>= "1.0.0"}
   "mirage-flow-lwt"
   "mirage-channel-lwt"

--- a/packages/git-unix/git-unix.2.0.0/opam
+++ b/packages/git-unix/git-unix.2.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml"           {>= "4.03.0"}
   "dune"
   "cmdliner"
-  "git-http"        {>= "2.0.0"}
+  "git-http"        {= version}
   "cohttp"          {>= "1.0.0"}
   "cohttp-lwt-unix" {>= "1.0.0"}
   "mtime"           {>= "1.0.0"}

--- a/packages/git-unix/git-unix.2.1.1/opam
+++ b/packages/git-unix/git-unix.2.1.1/opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "ocaml"           {>= "4.03.0"}
-  "dune"            {build}
+  "dune"             {>= "1.1"}
   "mmap"            {>= "1.1.0"}
   "cmdliner"
   "git-http"        {= version}

--- a/packages/git-unix/git-unix.2.1.1/opam
+++ b/packages/git-unix/git-unix.2.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "Virtual package to install and configure ocaml-git's Unix backend"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+
+depends: [
+  "ocaml"           {>= "4.03.0"}
+  "dune"            {build}
+  "mmap"            {>= "1.1.0"}
+  "cmdliner"
+  "git-http"        {= version}
+  "cohttp"          {>= "1.0.0"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "mtime"           {>= "1.0.0"}
+  "base-unix"
+  "alcotest"        {with-test & >= "0.8.1"}
+  "nocrypto"        {with-test & >= "0.5.4"}
+  "tls"             {with-test}
+  "io-page"         {with-test & >= "1.6.1"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.1/git-2.1.1.tbz"
+  checksum: [
+    "sha256=9d9db7028c58eb82ee44236afdd68feb42ebe9778aa23a3e59ba65aa2d40ce6d"
+    "sha512=ae73f03138455d2bbd3617c9740c2d950f6f6e848dc9f76fbc608cc17f57eab041e1fbdb338a82f94c5121e7dacb733618a40585959097e2dce9c8c87e9f10d0"
+  ]
+}

--- a/packages/git/git.2.1.1/opam
+++ b/packages/git/git.2.1.1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "Git format and protocol in pure OCaml"
+description: """
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {build}
+  "uri"        {>= "1.9.0"}
+  "lwt"        {>= "2.4.7"}
+  "angstrom"   {>= "0.9.0"}
+  "fpath"      {>= "0.7.0"}
+  "digestif"   {>= "0.7.2"}
+  "lru"        {>= "0.3.0"}
+  "decompress" {>= "0.9.0" & < "1.0.0"}
+  "checkseum"  {>= "0.1.0"}
+  "stdlib-shims"
+  "ke"
+  "encore"
+  "duff"
+  "hex"
+  "ocplib-endian"
+  "rresult"
+  "logs"
+  "fmt"
+  "astring"
+  "cstruct"
+  "ocamlgraph"
+  "alcotest" {with-test & >= "0.8.1"}
+  "nocrypto" {with-test & >= "0.5.4"}
+  "tls"      {with-test}
+  "mtime"    {with-test & >= "1.0.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.1/git-2.1.1.tbz"
+  checksum: [
+    "sha256=9d9db7028c58eb82ee44236afdd68feb42ebe9778aa23a3e59ba65aa2d40ce6d"
+    "sha512=ae73f03138455d2bbd3617c9740c2d950f6f6e848dc9f76fbc608cc17f57eab041e1fbdb338a82f94c5121e7dacb733618a40585959097e2dce9c8c87e9f10d0"
+  ]
+}

--- a/packages/git/git.2.1.1/opam
+++ b/packages/git/git.2.1.1/opam
@@ -25,7 +25,7 @@ build: [
 
 depends: [
   "ocaml"      {>= "4.03.0"}
-  "dune"       {build}
+  "dune"             {>= "1.1"}
   "uri"        {>= "1.9.0"}
   "lwt"        {>= "2.4.7"}
   "angstrom"   {>= "0.9.0"}


### PR DESCRIPTION
Client implementation of the "Smart" HTTP Git protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Replace Pervasives by Stdlib and depends on `stdlib-shims` virtual package (@dinosaure, mirage/ocaml-git#372)
- Add `pp_fetch_one` and `pp_update_and_create` (@dinosaure, @pascutto, @samoht, mirage/ocaml-git#370)
- `git-mirage` depends on `conduit-mirage` instead `mirage-conduit` (@dinosaure, mirage/ocaml-git#371)
- Drop support of OCaml < 4.07.0
- Delete `mirage-fs-unix` useless dependency
- Constraint to use only `decompress.0.9.0`
