### PR TITLE
Package ocoi.~dev

### DIFF
--- a/packages/ocoi/ocoi.~dev/opam
+++ b/packages/ocoi/ocoi.~dev/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Backend web framework in the style of Ruby on Rails"
+maintainer: "Roddy MacSween <github@roddymacsween.co.uk>"
+authors: "Roddy MacSween <github@roddymacsween.co.uk>"
+license: "MIT"
+homepage: "https://github.com/roddyyaga/ocoi"
+bug-reports: "https://github.com/roddyyaga/ocoi/issues"
+depends: [
+  "dune"
+  "core"
+  "lwt"
+  "opium"
+  "ppx_deriving_yojson"
+  "caqti"
+  "caqti-lwt"
+  "caqti-driver-postgresql"
+  "lwt_ppx"
+  "fileutils"
+  "lwt_ppx"
+]
+build: [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+]
+dev-repo: "git+https://github.com/roddyyaga/ocoi.git"


### PR DESCRIPTION
### `ocoi.~dev`
Backend web framework in the style of Ruby on Rails



---
* Homepage: https://github.com/roddyyaga/ocoi
* Source repo: git+https://github.com/roddyyaga/ocoi.git
* Bug tracker: https://github.com/roddyyaga/ocoi/issues

---
:camel: Pull-request generated by opam-publish v2.0.0