### PR TITLE
Package ocoi.0.0.1

### DIFF
--- a/packages/ocoi/ocoi.0.0.1/opam
+++ b/packages/ocoi/ocoi.0.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Backend web framework in the style of Ruby on Rails"
+maintainer: "Roddy MacSween <github@roddymacsween.co.uk>"
+authors: "Roddy MacSween <github@roddymacsween.co.uk>"
+license: "MIT"
+homepage: "https://github.com/roddyyaga/ocoi"
+bug-reports: "https://github.com/roddyyaga/ocoi/issues"
+depends: [
+  "dune"
+  "core"
+  "lwt"
+  "opium"
+  "ppx_deriving_yojson"
+  "caqti"
+  "caqti-lwt"
+  "caqti-driver-postgresql"
+  "lwt_ppx"
+  "fileutils"
+  "lwt_ppx"
+]
+build: [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+]
+dev-repo: "git+https://github.com/roddyyaga/ocoi.git"
+url {
+  src: "https://github.com/roddyyaga/ocoi/archive/0.0.1.tar.gz"
+  checksum: [
+    "md5=054f85e1ba66acad061a9dcc3ec069bf"
+    "sha512=b257c2d7809412ebc2d4edd8b191de738858d42fddd16f259be03e1bd77c436067d8caf638e756df72e3098cb490751b2db4148595e6f85d9d29d79891a40fdc"
+  ]
+}


### PR DESCRIPTION
### `ocoi.0.0.1`
Backend web framework in the style of Ruby on Rails



---
* Homepage: https://github.com/roddyyaga/ocoi
* Source repo: git+https://github.com/roddyyaga/ocoi.git
* Bug tracker: https://github.com/roddyyaga/ocoi/issues

---
:camel: Pull-request generated by opam-publish v2.0.0