### PR TITLE
2 packages from sapristi/easy_logging at 0.6.2

### DIFF
--- a/packages/easy_logging/easy_logging.0.6.2/opam
+++ b/packages/easy_logging/easy_logging.0.6.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Module to log messages. Aimed at being both powerful and easy to use"
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "GPL"
+homepage: "https://sapristi.github.io/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.8"}
+  "calendar" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "easy_logging/examples"] {with-test}
+]
+
+description: """Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages printf style, or [string] or [string lazy_t]
+   * tree logging architecture for light configuration
+   * handlers associated to each logger will format, filter and treat the message independantly.
+   * use the infrastructure with your own handlers with the [MakeLogging] functor.
+   * use tags to add contextual information to log messages
+"""
+url {
+  src: "https://github.com/sapristi/easy_logging/archive/v0.6.2.tar.gz"
+  checksum: [
+    "md5=2c805f25050b6917a4c99edbd3bb73fb"
+    "sha512=a20aa4cbcbfa4b8241daf4775f86e91ed3b91dcec51ad628edff5d6857354e63d93c312c023a5c0e59f2924f051d618636701563933e89762af63679f981f18b"
+  ]
+}

--- a/packages/easy_logging_yojson/easy_logging_yojson.0.6.2/opam
+++ b/packages/easy_logging_yojson/easy_logging_yojson.0.6.2/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "1.8"}
   "ppx_deriving"{>= "4.0" & < "5.0"}
   "ppx_deriving_yojson"
-  "easy_logging" {= "0.6.2"}
+  "easy_logging" {= version}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/easy_logging_yojson/easy_logging_yojson.0.6.2/opam
+++ b/packages/easy_logging_yojson/easy_logging_yojson.0.6.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Configuration loader for easy_logging with yojson backend"
+
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "GPL"
+homepage: "https://sapristi.github.io/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.8"}
+  "ppx_deriving"{>= "4.0" & < "5.0"}
+  "ppx_deriving_yojson"
+  "easy_logging" {= "0.6.2"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "conf_loader_modules/yojson"] {with-test}
+]
+
+description: """Provides deserialisation of logging configuration 
+(loggers instantation and handlers parameters) from json,
+using ppx_deriving_yojson.
+
+-------
+
+     Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages printf style, or [string] or [string lazy_t]
+   * tree logging architecture for light configuration
+   * handlers associated to each logger will format, filter and treat the message independantly.
+   * use the infrastructure with your own handlers with the [MakeLogging] functor.
+   * use tags to add contextual information to log messages
+"""
+url {
+  src: "https://github.com/sapristi/easy_logging/archive/v0.6.2.tar.gz"
+  checksum: [
+    "md5=2c805f25050b6917a4c99edbd3bb73fb"
+    "sha512=a20aa4cbcbfa4b8241daf4775f86e91ed3b91dcec51ad628edff5d6857354e63d93c312c023a5c0e59f2924f051d618636701563933e89762af63679f981f18b"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`easy_logging.0.6.2`: Module to log messages. Aimed at being both powerful and easy to use
-`easy_logging_yojson.0.6.2`: Configuration loader for easy_logging with yojson backend



---
* Homepage: https://sapristi.github.io/easy_logging/
* Source repo: git+https://github.com/sapristi/easy_logging.git
* Bug tracker: https://github.com/sapristi/easy_logging/issues

---
:camel: Pull-request generated by opam-publish v2.0.0