### PR TITLE
Package lwt-watcher.0.1

### DIFF
--- a/packages/lwt-watcher/lwt-watcher.0.1/opam
+++ b/packages/lwt-watcher/lwt-watcher.0.1/opam
@@ -6,6 +6,8 @@ bug-reports: "https://gitlab.com/nomadic-labs/lwt-watcher/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/lwt-watcher.git"
 license: "MIT"
 depends: [
+  "ocaml"
+  "dune"
   "lwt"
 ]
 build: [

--- a/packages/lwt-watcher/lwt-watcher.0.1/opam
+++ b/packages/lwt-watcher/lwt-watcher.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://gitlab.com/nomadic-labs/lwt-watcher"
+bug-reports: "https://gitlab.com/nomadic-labs/lwt-watcher/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/lwt-watcher.git"
+license: "MIT"
+depends: [
+  "lwt"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "One-to-many broadcast in Lwt"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/lwt-watcher/-/archive/v0.1/lwt-watcher-v0.1.tar.gz"
+  checksum: [
+    "md5=85fa938c25895aad8f47872ed5225a4e"
+    "sha512=7a93368ab6133e17fdf8512c28380fdba5bd0eb397deac9c7018278138b4fa4e4d65b5f32af624a0c725087640ae105be890d93d9019ca90352c36fb43183b14"
+  ]
+}


### PR DESCRIPTION
### `lwt-watcher.0.1`
One-to-many broadcast in Lwt



---
* Homepage: https://gitlab.com/nomadic-labs/lwt-watcher
* Source repo: git+https://gitlab.com/nomadic-labs/lwt-watcher.git
* Bug tracker: https://gitlab.com/nomadic-labs/lwt-watcher/issues

---
:camel: Pull-request generated by opam-publish v2.0.0