### PR TITLE
[new release] stdlib-shims (0.2.0)

### DIFF
--- a/packages/stdlib-shims/stdlib-shims.0.2.0/opam
+++ b/packages/stdlib-shims/stdlib-shims.0.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "The stdlib-shims programmers"
+authors: "The stdlib-shims programmers"
+homepage: "https://github.com/ocaml/stdlib-shims"
+doc: "https://ocaml.github.io/stdlib-shims/"
+dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+tags: ["stdlib" "compatibility" "org:ocaml"]
+license: ["typeof OCaml system"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.3"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Backport some of the new stdlib features to older compiler"
+description: """
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code.
+"""
+url {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.2.0/stdlib-shims-0.2.0.tbz"
+  checksum: [
+    "sha256=2c59f0636edf415e550833def5e86150126e40ed9a5de1655014dfcf32756559"
+    "sha512=19e8d8e004583e94ce060d3598c886dae1c24dd79dfd177aab4bd2865846f668a83071f087d9371393f226c14c90042eb2ec76619654c655995aeff9d4765621"
+  ]
+}


### PR DESCRIPTION
Backport some of the new stdlib features to older compiler

- Project page: <a href="https://github.com/ocaml/stdlib-shims">https://github.com/ocaml/stdlib-shims</a>
- Documentation: <a href="https://ocaml.github.io/stdlib-shims/">https://ocaml.github.io/stdlib-shims/</a>

##### CHANGES:

- Fix compilation with OCaml >= 4.07 under msvc (@dra27, ocaml/stdlib-shims#12, fixes ocaml/stdlib-shims#11)
