### PR TITLE
[new release] capnp-rpc-lwt, capnp-rpc-mirage, capnp-rpc and capnp-rpc-unix (0.4.0)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.2/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.2/opam
@@ -13,8 +13,8 @@ doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
   "conf-capnproto" {build}
-  "capnp" {>= "3.3.0"}
-  "capnp-rpc" {>= "0.3"}
+  "capnp" {>= "3.3.0" & < "3.4.0"}
+  "capnp-rpc" {>= "0.3" & < "0.4"}
   "lwt"
   "astring"
   "fmt"

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.3/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.3/opam
@@ -13,8 +13,8 @@ doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
   "conf-capnproto" {build}
-  "capnp" {>= "3.0.0"}
-  "capnp-rpc" {>= "0.3"}
+  "capnp" {>= "3.0.0" & < "3.4.0"}
+  "capnp-rpc" {>= "0.3" & < "0.4"}
   "lwt"
   "astring"
   "fmt"

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.4.0/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.4.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "lwt"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "mirage-flow-lwt"
+  "tls" {>= "0.8.0"}
+  "mirage-kv-lwt"
+  "mirage-clock"
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "0.7.0"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.4.0/capnp-rpc-v0.4.0.tbz"
+  checksum: [
+    "sha256=ce59c0644acb6834ab7d258ef59903d8d15dea0670648d5b09005f91189e3395"
+    "sha512=00d95ee27745319dc541026cd82f7002a20055f1fb64dc496312c6edc885c4c57fc627cd4e22c59b57d0bbd064c29d8a9a6b7b11b19199be667321b7f297d32f"
+  ]
+}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.2/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.2/opam
@@ -12,7 +12,7 @@ doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
   "capnp" {>= "3.1.0"}
-  "capnp-rpc-lwt" {>= "0.3.2"}
+  "capnp-rpc-lwt" {>= "0.3.2" & < "0.4.0"}
   "astring"
   "fmt"
   "logs"

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.3/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.3/opam
@@ -12,7 +12,7 @@ doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
   "capnp" {>= "3.1.0"}
-  "capnp-rpc-lwt" {>= "0.3"}
+  "capnp-rpc-lwt" {>= "0.3" & < "0.4.0"}
   "astring"
   "fmt"
   "logs"

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.4.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp" {>= "3.1.0"}
+  "capnp-rpc-lwt" {= version}
+  "astring"
+  "fmt"
+  "logs"
+  "arp-mirage"
+  "mirage-dns"
+  "mirage-stack-lwt"
+  "base64" {>= "3.0.0"}
+  "alcotest-lwt" {with-test}
+  "io-page-unix" {with-test}
+  "tcpip" {with-test}
+  "mirage-vnetif" {with-test}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.4.0/capnp-rpc-v0.4.0.tbz"
+  checksum: [
+    "sha256=ce59c0644acb6834ab7d258ef59903d8d15dea0670648d5b09005f91189e3395"
+    "sha512=00d95ee27745319dc541026cd82f7002a20055f1fb64dc496312c6edc885c4c57fc627cd4e22c59b57d0bbd064c29d8a9a6b7b11b19199be667321b7f297d32f"
+  ]
+}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.2/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.2/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "capnp-rpc-lwt" {>= "0.3.2"}
+  "capnp-rpc-lwt" {>= "0.3.2" & < "0.4.0"}
   "mirage-flow-unix"
   "cmdliner"
   "cstruct-lwt"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.3/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.3/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "capnp-rpc-lwt" {>= "0.3"}
+  "capnp-rpc-lwt" {>= "0.3" & < "0.4.0"}
   "mirage-flow-unix"
   "cmdliner"
   "cstruct-lwt"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.4.0/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp-rpc-lwt" {= version}
+  "mirage-flow-unix"
+  "cmdliner"
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.4"}
+  "logs"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "1.0"}
+  "alcotest-lwt" {with-test & >= "0.8.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.4.0/capnp-rpc-v0.4.0.tbz"
+  checksum: [
+    "sha256=ce59c0644acb6834ab7d258ef59903d8d15dea0670648d5b09005f91189e3395"
+    "sha512=00d95ee27745319dc541026cd82f7002a20055f1fb64dc496312c6edc885c4c57fc627cd4e22c59b57d0bbd064c29d8a9a6b7b11b19199be667321b7f297d32f"
+  ]
+}

--- a/packages/capnp-rpc/capnp-rpc.0.4.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "stdint"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "dune" {>= "1.0"}
+  "alcotest" {with-test}
+  "afl-persistent" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.4.0/capnp-rpc-v0.4.0.tbz"
+  checksum: [
+    "sha256=ce59c0644acb6834ab7d258ef59903d8d15dea0670648d5b09005f91189e3395"
+    "sha512=00d95ee27745319dc541026cd82f7002a20055f1fb64dc496312c6edc885c4c57fc627cd4e22c59b57d0bbd064c29d8a9a6b7b11b19199be667321b7f297d32f"
+  ]
+}


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

Breaking changes:

- Wrap errors with the `` `Capnp`` tag to make it easier to compose with other types of error (mirage/capnp-rpc#172, mirage/capnp-rpc#173).

- Prefix all command-line options with `capnp-` (mirage/capnp-rpc#163).
  e.g. `--listen-address` is now `--capnp-listen-address`.
  The old names were confusing for applications that supported other protocols too (e.g. a web server).

New features:

- Add `Capability.with_ref` convenience function (mirage/capnp-rpc#170).
  This automatically calls `dec_ref` when done.

- Add Unix `Cap_file` module to load and save `Sturdy_refs` (mirage/capnp-rpc#165).
  In particular, this ensures that saved cap files get a mode of `0o600`, since they contain secrets.

- Export cmdliner network address parsing (mirage/capnp-rpc#165).
  This is useful if you don't want to use the default option parsing.
  For example, if you want to make Cap'n Proto an optional feature of your program.

- Upgrade from `uint` (which is deprecated) to the newer `stdint` (mirage/capnp-rpc#166, mirage/capnp-rpc#168).
  The latest version of `uint` is just a wrapper around `stdint`,
  so this shouldn't break anything if you are using the latest version.

- Put cmdliner options in their own man-page section (mirage/capnp-rpc#163).
  Use `Capnp_rpc_unix.manpage_capnp_options` to control where in your man-page
  they appear.

- Enable `SO_KEEPALIVE` for TCP connections (mirage/capnp-rpc#167).
  For use with Docker's libnetwork, try something like this in your `stack.yml`:

  ```
  sysctls:
    - 'net.ipv4.tcp_keepalive_time=60'
  ```

Bug fixes:

- Close listening socket when shutting down a vat (mirage/capnp-rpc#171).

- Don't mark secret keys as executable (mirage/capnp-rpc#164).

- Update README example to use dune (mirage/capnp-rpc#162).

Build changes:

- Replace topkg with dune-release (mirage/capnp-rpc#169)

- Update opam email address and fix missing bound (mirage/capnp-rpc#161).

- Update the `dune` files to allow duniverse / vendored builds (mirage/capnp-rpc#165).

- Fix the crossed-calls unit test (mirage/capnp-rpc#171).

- Force all capnp-rpc subpackages to have the same version (mirage/capnp-rpc#173).
