### PR TITLE
[new release] Solo5 0.6.3

### DIFF
--- a/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.3/opam
+++ b/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "ehmry@posteo.net"
+authors: [
+  "Emery Hemingway <ehmry@posteo.net>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN="]
+]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "install-opam-genode" "PREFIX=%{prefix}%"]
+remove: [
+  ["touch" "./Makeconf"]
+  [make "V=1" "uninstall-opam-genode" "PREFIX=%{prefix}%"]
+]
+depends: "conf-pkg-config"
+conflicts: [
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+]
+available: [
+  arch = "x86_64" &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment (genode target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels on the "genode" target. The resulting
+unikernels can then be deployed directly on a host running the
+Genode Operating System Framework.
+
+Building the "genode" target is supported on 64-bit Linux, FreeBSD
+and OpenBSD systems."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.3/solo5-v0.6.3.tar.gz"
+  checksum: "sha512=c3a9d9891ab538ebf9eaf4c98bb228ee91a58bae9ee1ef0071f3dca8dfdf921ea34375d603323bda0652de47dfbe59585c21f100dc2ed4e41ebd7e3437eb13fd"
+}

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.3/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.3/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE="]
+]
+install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-hvt" "PREFIX=%{prefix}%"]
+remove: [
+  ["touch" "./Makeconf"]
+  [make "V=1" "uninstall-opam-hvt" "PREFIX=%{prefix}%"]
+]
+depends: "conf-pkg-config"
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+]
+conflicts: [
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment (hvt target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the "hvt" target, including the
+"solo5-hvt" tender source code, and "solo5-hvt-configure" script
+used to specialize the tender at MirageOS unikernel build time.
+
+The "hvt" target is supported on 64-bit Linux, FreeBSD and
+OpenBSD systems with hardware virtualization."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.3/solo5-v0.6.3.tar.gz"
+  checksum: "sha512=c3a9d9891ab538ebf9eaf4c98bb228ee91a58bae9ee1ef0071f3dca8dfdf921ea34375d603323bda0652de47dfbe59585c21f100dc2ed4e41ebd7e3437eb13fd"
+}

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.3/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.3/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE="]
+]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE=" "install-opam-muen" "PREFIX=%{prefix}%"]
+remove: [
+  ["touch" "./Makeconf"]
+  [make "V=1" "uninstall-opam-muen" "PREFIX=%{prefix}%"]
+]
+depends: "conf-pkg-config"
+conflicts: [
+  "solo5-bindings-genode"
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+]
+available: [
+  arch = "x86_64" &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment (muen target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels on the "muen" target. The resulting
+unikernels can then be deployed directly on a host running the
+Muen Separation Kernel.
+
+Building the "muen" target is supported on 64-bit Linux, FreeBSD
+and OpenBSD systems."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.3/solo5-v0.6.3.tar.gz"
+  checksum: "sha512=c3a9d9891ab538ebf9eaf4c98bb228ee91a58bae9ee1ef0071f3dca8dfdf921ea34375d603323bda0652de47dfbe59585c21f100dc2ed4e41ebd7e3437eb13fd"
+}

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.3/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.3/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE="]
+]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-spt" "PREFIX=%{prefix}%"]
+remove: [
+  ["touch" "./Makeconf"]
+  [make "V=1" "uninstall-opam-spt" "PREFIX=%{prefix}%"]
+]
+depends: "conf-pkg-config"
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+  ["libseccomp-dev"] {os-distribution = "alpine"}
+  ["libseccomp-dev"] {os-distribution = "debian"}
+  ["libseccomp-devel"] {os-distribution = "fedora"}
+  ["libseccomp-devel"] {os-distribution = "rhel"}
+  ["libseccomp-dev"] {os-distribution = "ubuntu"}
+]
+conflicts: [
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64") & os = "linux"
+]
+synopsis: "Solo5 sandboxed execution environment (spt target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels on the "spt" target and the "solo5-spt" tender
+binary used to run such unikernels.
+
+The "spt" target is supported on 64-bit Linux systems only."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.3/solo5-v0.6.3.tar.gz"
+  checksum: "sha512=c3a9d9891ab538ebf9eaf4c98bb228ee91a58bae9ee1ef0071f3dca8dfdf921ea34375d603323bda0652de47dfbe59585c21f100dc2ed4e41ebd7e3437eb13fd"
+}

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.3/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.3/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE="]
+]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-virtio" "PREFIX=%{prefix}%"]
+remove: [
+  ["touch" "./Makeconf"]
+  [make "V=1" "uninstall-opam-virtio" "PREFIX=%{prefix}%"]
+]
+depends: "conf-pkg-config"
+conflicts: [
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+]
+available: [
+  arch = "x86_64" &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment (virtio target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels using the "virtio" target.
+
+The "virtio" target is supported on 64-bit Linux and FreeBSD
+systems with hardware virtualization, and produces unikernels
+suitable for running on any virtio-compliant hypervisor (e.g.
+QEMU/KVM).
+
+Note that the "virtio" target provides limited support for
+current and future Solo5 features and abstractions. We recommend
+that you use the "hvt" target instead."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.3/solo5-v0.6.3.tar.gz"
+  checksum: "sha512=c3a9d9891ab538ebf9eaf4c98bb228ee91a58bae9ee1ef0071f3dca8dfdf921ea34375d603323bda0652de47dfbe59585c21f100dc2ed4e41ebd7e3437eb13fd"
+}


### PR DESCRIPTION
This should fix the build problems seen on OpenSUSE CI, by using pkg-config to find libseccomp.

/cc @avsm 