### PR TITLE
[new release] Add coq.8.10.0 and coqide.8.10.0

### DIFF
--- a/packages/conf-findutils/conf-findutils.1/opam
+++ b/packages/conf-findutils/conf-findutils.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: ""
+homepage: "https://www.gnu.org/software/findutils/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "GNU Project"
+license: "GPL-3.0-or-later"
+build: [["sh" "-exc" "find . -name ."]]
+depexts: [
+  ["findutils"] {os-family = "debian"}
+  ["findutils"] {os-distribution = "fedora"}
+  ["findutils"] {os-distribution = "rhel"}
+  ["findutils"] {os-distribution = "centos"}
+  ["findutils"] {os-distribution = "alpine"}
+  ["findutils"] {os-distribution = "nixos"}
+  ["findutils"] {os-family = "suse"}
+  ["findutils"] {os-distribution = "ol"}
+  ["findutils"] {os-distribution = "arch"}
+]
+synopsis: "Virtual package relying on findutils"
+description:
+  "This package can only install if the findutils binary is installed on the system."
+flags: conf

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+1/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: "The gtksourceview programmers"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://projects.gnome.org/gtksourceview/"
+license: "LGPL-2.1-or-later"
+build: [["pkg-config" "--short-errors" "--print-errors" "gtksourceview-3.0"]]
+depends: ["conf-pkg-config" {build}]
+depexts: [
+  ["gtksourceview-dev"] {os-distribution = "alpine"}
+  ["gtksourceview3"] {os-distribution = "arch"}
+  ["epel-release" "gtksourceview3-devel"] {os-distribution = "centos"}
+  ["libgtksourceview-3.0-dev"] {os-family = "debian"}
+  ["gtksourceview3-devel"] {os-distribution = "fedora"}
+  ["gtksourceview3"] {os = "freebsd"}
+  ["gtksourceview3"] {os = "openbsd"}
+  ["gtksourceview-devel"] {os-family = "suse"}
+  ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on a GtkSourceView-3 system installation"
+description:
+  "This package can only install if libgtksourceview-3.0-dev is installed on the system."
+flags: conf

--- a/packages/coq/coq.8.10.0/files/coq.install
+++ b/packages/coq/coq.8.10.0/files/coq.install
@@ -1,0 +1,12 @@
+bin: [
+  "bin/coqwc"
+  "bin/coqtop"
+  "bin/coqtop.byte"
+  "bin/coqdoc"
+  "bin/coqdep"
+  "bin/coqchk"
+  "bin/coqc"
+  "bin/coq_makefile"
+  "bin/coq-tex"
+  "bin/coqworkmgr"
+]

--- a/packages/coq/coq.8.10.0/opam
+++ b/packages/coq/coq.8.10.0/opam
@@ -11,6 +11,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
   "num"
+  "conf-findutils" {build}
 ]
 build: [
   [

--- a/packages/coq/coq.8.10.0/opam
+++ b/packages/coq/coq.8.10.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, and contributors."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "git+https://github.com/coq/coq.git"
+license: "LGPL-2.1"
+synopsis: "Formal proof management system"
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "num"
+]
+build: [
+  [
+    "./configure"
+    "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
+    "-mandir" man
+    "-docdir" doc
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
+    "-coqide" "no"
+  ]
+  [make "-j%{jobs}%"]
+  [make "-j%{jobs}%" "byte"]
+]
+install: [
+  [make "install"]
+  [make "install-byte"]
+]
+extra-files: ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"]
+
+url {
+  src: "https://github.com/coq/coq/archive/V8.10.0.tar.gz"
+  checksum: "sha512=f3da7f77f5ec760d6339233f5fcb3d743092d05baa33f3f0781e6729bcb996b14c2cfc45f5000a6fc4cee10b9e7532682bddda25c5dc2616d9e7ca70306b4724"
+}

--- a/packages/coq/coq.8.10.0/opam
+++ b/packages/coq/coq.8.10.0/opam
@@ -24,8 +24,8 @@ build: [
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
   ]
-  [make "-j%{jobs}%"]
-  [make "-j%{jobs}%" "byte"]
+  [make "-j1"]
+  [make "-j1" "byte"]
 ]
 install: [
   [make "install"]

--- a/packages/coqide/coqide.8.10.0/files/coqide.install
+++ b/packages/coqide/coqide.8.10.0/files/coqide.install
@@ -1,0 +1,9 @@
+bin: [
+  "bin/coqide"
+]
+share_root: [
+  "ide/coq.lang" {"coq/coq.lang"}
+  "ide/coq-ssreflect.lang" {"coq/coq-ssreflect.lang"}
+  "ide/coq.png" {"coq/coq.png"}
+  "ide/coq_style.xml" {"coq/coq_style.xml"}
+]

--- a/packages/coqide/coqide.8.10.0/opam
+++ b/packages/coqide/coqide.8.10.0/opam
@@ -10,6 +10,7 @@ synopsis: "IDE of the Coq formal proof management system"
 depends: [
   "coq" {= version}
   "lablgtk3-sourceview3"
+  "conf-findutils" {build}
 ]
 build: [
   [

--- a/packages/coqide/coqide.8.10.0/opam
+++ b/packages/coqide/coqide.8.10.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, and contributors."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "git+https://github.com/coq/coq.git"
+license: "LGPL-2.1"
+synopsis: "IDE of the Coq formal proof management system"
+
+depends: [
+  "coq" {= version}
+  "lablgtk3-sourceview3"
+]
+build: [
+  [
+    "./configure"
+    "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
+    "-mandir" man
+    "-docdir" doc
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
+  ]
+  [make "-j%{jobs}%" "coqide-files"]
+  [make "-j%{jobs}%" "coqide-opt"]
+]
+install: [
+  make
+  "install-ide-bin"
+  "install-ide-files"
+  "install-ide-info"
+  "install-ide-devfiles"
+]
+extra-files: ["coqide.install" "md5=d005cda8cb7888fbea94c5416dcb31bc"]
+
+url {
+  src: "https://github.com/coq/coq/archive/V8.10.0.tar.gz"
+  checksum: "sha512=f3da7f77f5ec760d6339233f5fcb3d743092d05baa33f3f0781e6729bcb996b14c2cfc45f5000a6fc4cee10b9e7532682bddda25c5dc2616d9e7ca70306b4724"
+}


### PR DESCRIPTION
Warning: I am not sure I know what I'm doing, but I took the contents of
https://coq.inria.fr/opam/core-dev/packages/coq/coq.8.10.dev/ and
https://coq.inria.fr/opam/core-dev/packages/coqide/coqide.8.10.dev/ (which
currently builds essentially the same version, successfully), and
updated URL and checksum following 8.9.1. I used sha512 for both checksums,
following *coqide.8.10+beta3/coq.8.10+beta3 (EDITED).

I already built coq locally, tho I was still using the md5 checksum — but IIUC PRs are checked by CI anyway? Or should I rebuild it locally from scratch?