### PR TITLE
Remove constraint on digestif.0.7.4 with mirage.3.*

### DIFF
--- a/packages/digestif/digestif.0.7.4/opam
+++ b/packages/digestif/digestif.0.7.4/opam
@@ -47,7 +47,7 @@ depopts: [
 conflicts: [
   "mirage-xen-posix" {< "3.1.0"}
   "ocaml-freestanding" {< "0.4.1"}
-  "mirage-runtime"{< "4.0.0"}
+  "mirage-runtime" {>= "4.0.0"}
 ]
 url {
   src:


### PR DESCRIPTION
digestif.0.7.4 is a special version to keep a compatibility package with MirageOS 3. Only digestif.0.7.3 and digestif.0.8.0 have a conflict with MirageOS 3.