### PR TITLE
Lwt 4.4.0, Lwt_ppx 1.2.4

### DIFF
--- a/packages/lwt/lwt.4.4.0/opam
+++ b/packages/lwt/lwt.4.4.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+
+version: "4.4.0"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.7.0"}
+  "dune-configurator"
+  "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0"}
+  "ocplib-endian"
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  "bisect_ppx" {dev & >= "1.3.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+post-messages: [
+  "Lwt 5.0.0 will make some breaking changes in November 2019. See
+  https://github.com/ocsigen/lwt/issues/584"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.4.0.tar.gz"
+  checksum: "md5=8bfc70c2944020fa08dd04877747f5f9"
+}

--- a/packages/lwt_ppx/lwt_ppx.1.2.4/opam
+++ b/packages/lwt_ppx/lwt_ppx.1.2.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "PPX syntax for Lwt, providing something similar to async/await from JavaScript"
+
+version: "1.2.4"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Ppx_lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Gabriel Radanne"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune"
+  "lwt"
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.4.0.tar.gz"
+  checksum: "md5=8bfc70c2944020fa08dd04877747f5f9"
+}


### PR DESCRIPTION
Additions

- `?suffix` argument for [`Lwt_io.with_temp_file`](http://ocsigen.org/lwt/dev/api/Lwt_io#VALwith_temp_file) and [`Lwt_io.open_temp_file`](http://ocsigen.org/lwt/dev/api/Lwt_io#VALopen_temp_file) (ocsigen/lwt#724, requested Volker Diels-Grabsch).
- [`Lwt_io.with_temp_dir`](http://ocsigen.org/lwt/dev/api/Lwt_io#VALwith_temp_dir) and [`Lwt_io.create_temp_dir`](http://ocsigen.org/lwt/dev/api/Lwt_io#VALcreate_temp_dir) (ocsigen/lwt#724, requested Volker Diels-Grabsch).

Changes

- [`Lwt_io.establish_server`](http://ocsigen.org/lwt/dev/api/Lwt_io#VALestablish_server_with_client_socket): increase default backlog from 5 to `SOMAXCONN` (ocsigen/lwt#731, suggested Konstantin Olkhovskiy).
- PPX: use OCaml 4.09 ASTs to support recent features (ocsigen/lwt@074f679).
- PPX: deprecate `let%lwt` structure items (ocsigen/lwt#733, prompted Didier Le Botlan).

Miscellaneous

- Tests now pass in more environments (ocsigen/lwt#721, ocsigen/lwt#722, ocsigen/lwt#725, ocsigen/lwt#729, reported Olaf Hering).