### PR TITLE
Fix checksum for brotli 2.0.1

### DIFF
--- a/packages/brotli/brotli.2.0.1/opam
+++ b/packages/brotli/brotli.2.0.1/opam
@@ -35,5 +35,5 @@ http://www.ietf.org/id/draft-alakuijala-brotli"""
 flags: light-uninstall
 url {
   src: "https://github.com/fxfactorial/ocaml-brotli/archive/v2.0.1.tar.gz"
-  checksum: "md5=bcbaa5c5684cdd5864bb9b194842b66a"
+  checksum: "md5=5e9dbf18f33e7e42bfb05038bb0b31e3"
 }

--- a/packages/brotli/brotli.2.0.1/opam
+++ b/packages/brotli/brotli.2.0.1/opam
@@ -23,6 +23,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "conf-brotli"
+  "base-unsafe-string"
 ]
 post-messages: [
   "Be sure to have libbrotli installed on your machine" {failure}


### PR DESCRIPTION
The source repo was renamed from `ocaml-brotli` to `reasonml-brotli`. GitHub repacked the release archive, and the checksum changed, resulting in [this failure](https://ci.ocaml.org/log/saved/docker-run-d728705fa816843c17dd1b4bfb4cc956/241fd65e58fd63150dd8e755c97c1a36bd250fe7).