### PR TITLE
travis: extend opam timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 install: bash -e .travis-ci-install.sh
-script: bash -e .travis-ci.sh
+script: travis_wait bash -e .travis-ci.sh
 cache: apt
 dist: xenial
 sudo: required


### PR DESCRIPTION
Let opam continue when running >10minutes without output, like it happens when a single package install runs that long.

This extends timeout to 20 minutes. `travis_wait $N` would give N minutes.
https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

This would help for instance with https://travis-ci.org/ocaml/opam-repository/jobs/596032476.