### PR TITLE
irmin-chunk 1.3.0 tests require irmin < 1.4.0

### DIFF
--- a/packages/irmin-chunk/irmin-chunk.1.3.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.1.3.0/opam
@@ -15,6 +15,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "irmin" {>= "1.3.0" & < "2.0.0"}
   "lwt"
+  "irmin" {with-test & < "1.4.0"}
   "irmin-mem" {with-test & >= "1.3.0" & < "2.0.0"}
   "alcotest" {with-test & >= "0.4.1"}
   "mtime" {with-test}


### PR DESCRIPTION
`irmin-chunk` 1.3.0 tests [fail](https://ci.ocaml.org/log/saved/docker-run-fcf048877ad106be6aff09499684765e/131b422dfedfb562ce493ebd574d34928c4abb2b) with

```
File "test/common/test_store.ml", line 90, characters 24-27:
90 |     S.Tree.of_hash repo kn2 >>= function
                             ^^^
Error: This expression has type Graph.node = S.Tree.Hash.t
       but an expression was expected of type S.Tree.hash
```

when built against `irmin` 1.4.0. The type `S.Tree.hash` was [introduced](https://github.com/mirage/irmin/commit/6cf5287452ed84362c94c7e0d3a9da842afd844d#diff-1be34172140401295ad7258b1add6782R2372) in Irmin 1.4.0, so I added a `with-test` constraint (it seems the type was later removed in `master`, too, but I think we can restrict `irmin-chunk` 1.3.0 to testing against `irmin` 1.3.x).