### PR TITLE
Disable tests of zmq-lwt 5.0.0

### DIFF
--- a/packages/zmq-lwt/zmq-lwt.5.0.0/opam
+++ b/packages/zmq-lwt/zmq-lwt.5.0.0/opam
@@ -9,12 +9,10 @@ bug-reports: "https://github.com/issuu/ocaml-zmq/issues"
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml"
   "zmq" {= version}
-  "ounit" {with-test & < "2.1.0"}
   "jbuilder" {build & >= "1.0+beta17"}
   "lwt"
   "base" {>= "v0.9.0" & < "v0.13"}


### PR DESCRIPTION
`zmq-lwt` 5.0.0 tests fail with [an error](https://ci.ocaml.org/log/saved/docker-run-6b01f06e84cd18f5cc979bbd20653a12/1eed241baf1730c6e7c19bea05ce64cc2064349d) that we likely can't fix with a constraint, so this PR disables them. There are newer releases of `zmq-lwt`, and their tests pass.