### PR TITLE
[New release] ldap.2.4.1

### DIFF
--- a/packages/ldap/ldap.2.4.1/opam
+++ b/packages/ldap/ldap.2.4.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Implementation of the Light Weight Directory Access Protocol"
+license: "LGPL-2.1 with OCaml linking exception"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: [
+  "Kate <kit.ty.kate@disroot.org>"
+  "Eric Stokes <letaris@me.com>"
+]
+homepage: "https://github.com/kit-ty-kate/ocamldap"
+dev-repo: "git://github.com/kit-ty-kate/ocamldap.git"
+bug-reports: "https://github.com/kit-ty-kate/ocamldap/issues"
+build: [
+  "dune" "build" "-p" name "-j" jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.0"}
+  "ocamlnet" {>= "3.6.0"}
+  "pcre"
+  "ssl" {>= "0.5.3"}
+]
+tags: ["ldap"]
+url {
+  src: "https://github.com/kit-ty-kate/ocamldap/archive/2.4.1.tar.gz"
+  checksum: [
+    "md5=f05f823f95761ce2af7232b057995aa2"
+    "sha512=91baeaa31ac45fb53424008b9619b11ae85c02b1f8357d12141f85886ce2815798dd826aa19ec971f803232c9451e3dfafe59a674e7dbc08a94ae245a895d3f7"
+  ]
+}


### PR DESCRIPTION
### `ldap.2.4.1`
Implementation of the Light Weight Directory Access Protocol



---
* Homepage: https://github.com/kit-ty-kate/ocamldap
* Source repo: git://github.com/kit-ty-kate/ocamldap.git
* Bug tracker: https://github.com/kit-ty-kate/ocamldap/issues

---
:camel: Pull-request generated by opam-publish v2.0.0