### PR TITLE
Package ldap.2.4.1

### DIFF
--- a/packages/ldap/ldap.2.4.1/opam
+++ b/packages/ldap/ldap.2.4.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Implementation of the Light Weight Directory Access Protocol"
+license: "LGPL-2.1 with OCaml linking exception"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: [
+  "Kate <kit.ty.kate@disroot.org>"
+  "Eric Stokes <letaris@me.com>"
+]
+homepage: "https://github.com/kit-ty-kate/ocamldap"
+dev-repo: "git://github.com/kit-ty-kate/ocamldap.git"
+bug-reports: "https://github.com/kit-ty-kate/ocamldap/issues"
+build: [
+  "dune" "build" "-p" name "-j" jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.0"}
+  "ocamlnet" {>= "3.6.0"}
+  "pcre"
+  "ssl" {>= "0.5.3"}
+]
+conflicts: [
+  "ocamldap" {!= "transition"}
+]
+tags: ["ldap"]
+url {
+  src: "https://github.com/kit-ty-kate/ocamldap/archive/2.4.1.tar.gz"
+  checksum: [
+    "md5=4fe4b86fdd4d4448e642628c2f2c6762"
+    "sha512=ff1fd84013fb5dd592831a4b77f0b43d17ec70655912626399da804680426291e0cc34a32cc964d190ea0009926b8defc2670afd515ff66071e8f85127d2e390"
+  ]
+}


### PR DESCRIPTION
### `ldap.2.4.1`
Implementation of the Light Weight Directory Access Protocol



---
* Homepage: https://github.com/kit-ty-kate/ocamldap
* Source repo: git://github.com/kit-ty-kate/ocamldap.git
* Bug tracker: https://github.com/kit-ty-kate/ocamldap/issues

---
:camel: Pull-request generated by opam-publish v2.0.0