### PR TITLE
git-mirage.2.0 is not compatible with git.2.1.1

### DIFF
--- a/packages/git-mirage/git-mirage.2.0.0/opam
+++ b/packages/git-mirage/git-mirage.2.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-channel-lwt"
   "mirage-conduit"   {>= "3.0.0"}
   "git-http"         {>= "2.0.0"}
-  "git"              {>= "2.0.0"}
+  "git"              {>= "2.0.0" & < "2.1.1"}
   "alcotest"         {with-test & >= "0.8.1"}
   "mtime"            {with-test & >= "1.0.0"}
   "mirage-fs-unix"   {with-test & >= "1.3.0"}


### PR DESCRIPTION
See http://check.ocamllabs.io/log/1570453959-f412620d14e52a588975517bf940aea115523f44/4.04/bad/git-mirage.2.0.0