### PR TITLE
Package resource-pooling.0.8

### DIFF
--- a/packages/resource-pooling/resource-pooling.0.8/opam
+++ b/packages/resource-pooling/resource-pooling.0.8/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jan Rochel <jan@besport.com>"
+authors: [ "Jan Rochel (BeSport)" ]
+synopsis: "Library for pooling resources like connections, threads, or similar"
+description: "This package is derived from the module Lwt_pool from the lwt package, which implements resource pooling. With Resource_pool this package provides a modified version with additional features. Also there is a module called Server_pool that manages resource clusters, specifically a cluster of servers each with its own connection pool."
+license: "MIT"
+homepage: "https://github.com/ocsigen/resource-pooling"
+dev-repo: "git+https://github.com/ocsigen/resource-pooling.git"
+bug-reports: "https://github.com/ocsigen/resource-pooling/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+depends: [
+  "ocaml" {>= "4.06"}
+  "lwt" {>= "2.4.7"}
+  "lwt_log"
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+url {
+  src: "https://github.com/ocsigen/resource-pooling/archive/0.8.tar.gz"
+  checksum: [
+    "md5=52afb6168141a06551a4c7721339be5c"
+    "sha512=027507959a454e498fed37f016174abbce8a803b19d203c39403d64e25f01204d116d9a43e8d2f0559da714db6c406a2a689dda634d0bd01fdd37097e94074f0"
+  ]
+}


### PR DESCRIPTION
### `resource-pooling.0.8`
Library for pooling resources like connections, threads, or similar
This package is derived from the module Lwt_pool from the lwt package, which implements resource pooling. With Resource_pool this package provides a modified version with additional features. Also there is a module called Server_pool that manages resource clusters, specifically a cluster of servers each with its own connection pool.



---
* Homepage: https://github.com/ocsigen/resource-pooling
* Source repo: git+https://github.com/ocsigen/resource-pooling.git
* Bug tracker: https://github.com/ocsigen/resource-pooling/issues

---
:camel: Pull-request generated by opam-publish v2.0.0