### PR TITLE
[new release] gsl (1.24.1)

### DIFF
--- a/packages/gsl/gsl.1.24.1/opam
+++ b/packages/gsl/gsl.1.24.1/opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.05"}
-  "dune" {build & >= "1.7.0"}
+  "dune" {>= "1.7.0"}
   "conf-gsl" {build}
   "conf-pkg-config" {build}
   "base" {build}

--- a/packages/gsl/gsl.1.24.1/opam
+++ b/packages/gsl/gsl.1.24.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [
+  "Olivier Andrieu <oandrieu@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+]
+license: "GPL-3+"
+homepage: "https://mmottl.github.io/gsl-ocaml"
+doc: "https://mmottl.github.io/gsl-ocaml/api"
+dev-repo: "git+https://github.com/mmottl/gsl-ocaml.git"
+bug-reports: "https://github.com/mmottl/gsl-ocaml/issues"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {build & >= "1.7.0"}
+  "conf-gsl" {build}
+  "conf-pkg-config" {build}
+  "base" {build}
+  "stdio" {build}
+]
+
+synopsis: "GSL - Bindings to the GNU Scientific Library"
+
+description: """
+gsl-ocaml interfaces the GSL (GNU Scientific Library), providing many of the
+most frequently used functions for scientific computation including algorithms
+for optimization, differential equations, statistics, random number generation,
+linear algebra, etc."""
+url {
+  src:
+    "https://github.com/mmottl/gsl-ocaml/releases/download/1.24.1/gsl-1.24.1.tbz"
+  checksum: [
+    "sha256=f0a19763a9c899bf57b002a6132c403cb0a9d15e2bc146c4908581e702d9fd76"
+    "sha512=904760473855139490dbcba0cd1da4557bb0d5f07aeeb4d57f7db9acdd7260345b643f3ecf4d2520ecf6794f335051062b4da052ddb2987deffc35754b54e7a5"
+  ]
+}


### PR DESCRIPTION
GSL - Bindings to the GNU Scientific Library

- Project page: <a href="https://mmottl.github.io/gsl-ocaml">https://mmottl.github.io/gsl-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/gsl-ocaml/api">https://mmottl.github.io/gsl-ocaml/api</a>

##### CHANGES:

* Fixed warnings in C-stubs
