### PR TITLE
[new release] lacaml (11.0.5)

### DIFF
--- a/packages/lacaml/lacaml.11.0.5/opam
+++ b/packages/lacaml/lacaml.11.0.5/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+authors: [
+  "Egbert Ammicht <eammicht@lucent.com>"
+  "Patrick Cousot <Patrick.Cousot@ens.fr>"
+  "Sam Ehrlichman <sehrlichman@janestreet.com>"
+  "Florent Hoareau <h.florent@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Liam Stewart <liam@cs.toronto.edu>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Oleg Trott <ot14@columbia.edu>"
+  "Martin Willensdorfer <ma.wi@gmx.at>"
+]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "http://mmottl.github.io/lacaml"
+doc: "https://mmottl.github.io/lacaml/api"
+dev-repo: "git+https://github.com/mmottl/lacaml.git"
+bug-reports: "https://github.com/mmottl/lacaml/issues"
+tags: [ "clib:lapack" "clib:blas" ]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {build & >= "1.7.0"}
+  "conf-blas" {build}
+  "conf-lapack" {build}
+  "base" {build}
+  "stdio" {build}
+  "base-bytes"
+  "base-bigarray"
+]
+
+synopsis: "Lacaml - OCaml-bindings to BLAS and LAPACK"
+
+description: """
+Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
+LAPACK-library (Linear Algebra routines).  It also contains many additional
+convenience functions for vectors and matrices."""
+url {
+  src:
+    "https://github.com/mmottl/lacaml/releases/download/11.0.5/lacaml-11.0.5.tbz"
+  checksum: [
+    "sha256=2c34d2fb65f6cb99dc40a527d2e314a2375114639159a1114d69b9b1a600bc35"
+    "sha512=20ca8569d6eaf808fe2bc80eaa134c6673283729e564e4f5913f7edacf26e14c213297ad5c33594bc4e801260696716faa9c4870425d73e6df9b62ae80bb8618"
+  ]
+}


### PR DESCRIPTION
Lacaml - OCaml-bindings to BLAS and LAPACK

- Project page: <a href="http://mmottl.github.io/lacaml">http://mmottl.github.io/lacaml</a>
- Documentation: <a href="https://mmottl.github.io/lacaml/api">https://mmottl.github.io/lacaml/api</a>

##### CHANGES:

* Fixed warnings in C-stubs
