### PR TITLE
[new release] pcre (7.4.2)

### DIFF
--- a/packages/pcre/pcre.7.4.2/opam
+++ b/packages/pcre/pcre.7.4.2/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04"}
-  "dune" {build & >= "1.7.0"}
+  "dune" {>= "1.7.0"}
   "conf-libpcre" {build}
   "base" {build}
   "base-bytes"

--- a/packages/pcre/pcre.7.4.2/opam
+++ b/packages/pcre/pcre.7.4.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {build & >= "1.7.0"}
+  "conf-libpcre" {build}
+  "base" {build}
+  "base-bytes"
+]
+
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/7.4.2/pcre-7.4.2.tbz"
+  checksum: [
+    "sha256=d8963f19de4a2943a5761ed66ea97063232861416dc6b92b7f0c37cff71d003a"
+    "sha512=21058c311ec3469d77d29fadfa176d0f2acb323fb3cc0d3bc13960d8fe2c677ef1e25fd3a4f6f666ee2e9673299305637ab6353cdc01d021e36870665ecd463e"
+  ]
+}

--- a/packages/pcre/pcre.7.4.2/opam
+++ b/packages/pcre/pcre.7.4.2/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.08"}
   "dune" {>= "1.7.0"}
   "conf-libpcre" {build}
   "base" {build}


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

* Fixed warnings in C-stubs
