### PR TITLE
Add conf-gnome-icon-theme3

### DIFF
--- a/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
+++ b/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: ""
+homepage: "https://github.com/GNOME/adwaita-icon-theme"
+bug-reports: "https://gitlab.gnome.org/GNOME/adwaita-icon-theme/issues"
+authors: "GNU Project"
+license: ["LGPL-3.0-only" "CC-BY-SA-3.0"]
+build: []
+depexts: [
+  ["gnome-icon-theme"] {os-family = "debian"}
+  ["gnome-icon-theme"] {os-family = "fedora" | os-family = "rhel"}
+  ["gnome-icon-theme"] {os = "macos" & os-distribution = "homebrew"}
+  ["gnome-icon-theme"] {os-family = "suse"}
+  ["gnome-icon-theme"] {os-distribution = "arch"}
+  ["gnome-icon-theme"] {os-distribution = "alpine"}
+  ["gnome-icon-theme"] {os-distribution = "nixos"}
+  ["gnome-icon-theme"] {os-distribution = "ol"}
+]
+synopsis: "Virtual package relying on gnome-icon-theme"
+description:
+  "This package can only install if the gnome-icon-theme package is installed on the system."
+flags: conf


### PR DESCRIPTION
Prepare fixing coqide https://github.com/coq/opam-coq-archive/issues/945.
The list of supported distributions is taken from `conf-findutils`.
This first commit tests the package name is correct on all distributions.
Unfortunately, I don't have an automated reproduction.

The package name seems to work everywhere; I tested on Homebrew, and here are
links to various archives I consulted.

https://packages.debian.org/search?keywords=gnome-icon-theme
https://apps.fedoraproject.org/packages/gnome-icon-theme/
https://software.opensuse.org/search?utf8=✓&baseproject=ALL&q=gnome-icon-theme
https://www.archlinux.org/packages/extra/any/gnome-icon-theme/
https://pkgs.alpinelinux.org/packages?name=gnome-icon-theme&branch=edge
https://nixos.org/nixos/packages.html?channel=nixos-19.09&query=gnome-icon-theme
https://yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64/index.html