### PR TITLE
Package resource-pooling.1.1

### DIFF
--- a/packages/resource-pooling/resource-pooling.1.1/opam
+++ b/packages/resource-pooling/resource-pooling.1.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "Jan Rochel <jan@besport.com>"
+authors: [ "Jan Rochel (BeSport)" ]
+synopsis: "Library for pooling resources like connections, threads, or similar"
+description: "This package is derived from the module Lwt_pool from the lwt package, which implements resource pooling. With Resource_pool this package provides a modified version with additional features. Also there is a module called Server_pool that manages resource clusters, specifically a cluster of servers each with its own connection pool."
+license: "MIT"
+homepage: "https://github.com/ocsigen/resource-pooling"
+dev-repo: "git+https://github.com/ocsigen/resource-pooling.git"
+bug-reports: "https://github.com/ocsigen/resource-pooling/issues"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.11"}
+  "lwt" {>= "2.4.7"}
+  "lwt_log"
+]
+url {
+  src: "https://github.com/ocsigen/resource-pooling/archive/1.1.tar.gz"
+  checksum: [
+    "md5=157de5cafe031c39eaade341d1054e7f"
+    "sha512=c5c4f0cdd84521fc17f8e371cfb5c99499eceb407644f423d9990a6be5ed7010adf8674d771e35a7113a4774a84a0a01437e9282977509d3ee725d6e2d4995fb"
+  ]
+}


### PR DESCRIPTION
### `resource-pooling.1.1`
Library for pooling resources like connections, threads, or similar
This package is derived from the module Lwt_pool from the lwt package, which implements resource pooling. With Resource_pool this package provides a modified version with additional features. Also there is a module called Server_pool that manages resource clusters, specifically a cluster of servers each with its own connection pool.



---
* Homepage: https://github.com/ocsigen/resource-pooling
* Source repo: git+https://github.com/ocsigen/resource-pooling.git
* Bug tracker: https://github.com/ocsigen/resource-pooling/issues

---
:camel: Pull-request generated by opam-publish v2.0.0