### PR TITLE
coq.8.10: backport fix to parallel build

### DIFF
--- a/packages/coq/coq.8.10.0/files/fix-parallel-make.patch
+++ b/packages/coq/coq.8.10.0/files/fix-parallel-make.patch
@@ -1,0 +1,72 @@
+commit d25990e2da7e5e84034b927cdab9ea4019c56a30
+Author: Enrico Tassi <Enrico.Tassi@inria.fr>
+Date:   Fri Oct 11 13:43:20 2019 +0200
+
+    [make] separate generated gramlib ml files from mli files (fix #10864)
+
+    (cherry picked from commit b0210638366d6584b709496b0f0eeeecb17c3fae)
+
+diff --git a/Makefile b/Makefile
+index 2b5d2cea16..74b23f97aa 100644
+--- a/Makefile
++++ b/Makefile
+@@ -101,15 +101,18 @@ EXISTINGMLI := $(call find, '*.mli')
+ 
+ ## Files that will be generated
+ 
+-GENMLGFILES:= $(MLGFILES:.mlg=.ml)
+ # GRAMFILES must be in linking order
+ GRAMFILES=$(addprefix gramlib/.pack/gramlib__,Ploc Plexing Gramext Grammar)
+-GRAMMLFILES := $(addsuffix .ml, $(GRAMFILES)) $(addsuffix .mli, $(GRAMFILES))
+-GENGRAMFILES := $(GRAMMLFILES) gramlib/.pack/gramlib.ml
+-GENMLFILES:=$(LEXFILES:.mll=.ml) $(YACCFILES:.mly=.ml) $(GENMLGFILES)  ide/coqide_os_specific.ml kernel/copcodes.ml kernel/uint63.ml
++GRAMMLFILES := $(addsuffix .ml, $(GRAMFILES))
++GRAMMLIFILES := $(addsuffix .mli, $(GRAMFILES))
++GENGRAMMLFILES := $(GRAMMLFILES) gramlib/.pack/gramlib.ml # why is gramlib.ml not in GRAMMLFILES?
++
++GENMLGFILES:= $(MLGFILES:.mlg=.ml)
++GENMLFILES:=$(LEXFILES:.mll=.ml) $(YACCFILES:.mly=.ml) $(GENMLGFILES) $(GENGRAMMLFILES) ide/coqide_os_specific.ml kernel/copcodes.ml kernel/uint63.ml
++GENMLIFILES:=$(GRAMMLIFILES)
+ GENHFILES:=kernel/byterun/coq_instruct.h kernel/byterun/coq_jumptbl.h
+ GENFILES:=$(GENMLFILES) $(GENMLIFILES) $(GENHFILES)
+-COQ_EXPORTED += GRAMFILES GRAMMLFILES GENGRAMFILES GENMLFILES GENHFILES GENFILES
++COQ_EXPORTED += GRAMFILES GRAMMLFILES GRAMMLIFILES GENMLFILES GENHFILES GENFILES
+ 
+ ## More complex file lists
+ 
+diff --git a/Makefile.build b/Makefile.build
+index 47f1b02c6e..4fbd4bfffd 100644
+--- a/Makefile.build
++++ b/Makefile.build
+@@ -779,9 +779,9 @@ OCAMLDEP = $(OCAMLFIND) ocamldep -slash -ml-synonym .mlpack
+ MAINMLFILES := $(filter-out gramlib/.pack/% checker/% plugins/%, $(MLFILES) $(MLIFILES))
+ MAINMLLIBFILES := $(filter-out gramlib/.pack/% checker/% plugins/%, $(MLLIBFILES) $(MLPACKFILES))
+ 
+-$(MLDFILE).d: $(D_DEPEND_BEFORE_SRC) $(MAINMLFILES) $(D_DEPEND_AFTER_SRC) $(GENFILES) $(GENGRAMFILES)
++$(MLDFILE).d: $(D_DEPEND_BEFORE_SRC) $(MAINMLFILES) $(D_DEPEND_AFTER_SRC) $(GENFILES)
+ 	$(SHOW)'OCAMLDEP  MLFILES MLIFILES'
+-	$(HIDE)$(OCAMLDEP) $(DEPFLAGS)  -passrest $(MAINMLFILES) -open Gramlib $(GRAMMLFILES) $(TOTARGET)
++	$(HIDE)$(OCAMLDEP) $(DEPFLAGS)  -passrest $(MAINMLFILES) -open Gramlib $(GRAMMLFILES) $(GRAMMLIFILES) $(TOTARGET)
+ #NB: -passrest is needed to avoid ocamlfind reordering the -open Gramlib
+ 
+ $(MLLIBDFILE).d: $(D_DEPEND_BEFORE_SRC) $(MAINMLLIBFILES) $(D_DEPEND_AFTER_SRC) $(OCAMLLIBDEP) $(GENFILES)
+diff --git a/Makefile.install b/Makefile.install
+index 5b5e548f9c..51017b7c3a 100644
+--- a/Makefile.install
++++ b/Makefile.install
+@@ -92,13 +92,13 @@ install-tools:
+ 
+ INSTALLCMI = $(sort \
+ 	$(filter-out checker/% ide/% tools/%, $(MLIFILES:.mli=.cmi)) \
+-	$(filter %.cmi, $(GRAMMLFILES:.mli=.cmi)) gramlib/.pack/gramlib.cmi \
++	$(GRAMMLIFILES:.mli=.cmi) gramlib/.pack/gramlib.cmi \
+ 	$(foreach lib,$(CORECMA), $(addsuffix .cmi,$($(lib:.cma=_MLLIB_DEPENDENCIES))))) \
+ 	$(PLUGINS:.cmo=.cmi)
+ 
+ INSTALLCMX = $(sort $(filter-out checker/% ide/% tools/% dev/% \
+ 	configure.cmx toplevel/coqtop_byte_bin.cmx plugins/extraction/big.cmx, \
+-	$(filter %.cmx, $(GRAMMLFILES:.ml=.cmx)) $(MLFILES:.ml=.cmx)))
++	$(GRAMMLFILES:.ml=.cmx) $(MLFILES:.ml=.cmx)))
+ 
+ install-devfiles:
+ 	$(MKDIR) $(FULLBINDIR)

--- a/packages/coq/coq.8.10.0/opam
+++ b/packages/coq/coq.8.10.0/opam
@@ -31,8 +31,11 @@ install: [
   [make "install"]
   [make "install-byte"]
 ]
+patches: ["fix-parallel-make.patch"]
+
 extra-files: [
    ["coq.install" "sha512=b501737b4dbd22adc1c0377d744448056fb1dc493caf72c05f57c8463cf23f758373605ab3a50b9f505e4c856c41039d0bd7f81f96ed62adc6a674179523e7d2"]
+   ["fix-parallel-make.patch" "sha512=3801156db1d95bf35948599f366775afff72bbeef958e73321b1f9627220ef7ca61b402c478374f31a23db0f4394bafca5fa56c0708dfad589cad85bfa20d526"]
 ]
 
 url {

--- a/packages/coq/coq.8.10.0/opam
+++ b/packages/coq/coq.8.10.0/opam
@@ -31,7 +31,9 @@ install: [
   [make "install"]
   [make "install-byte"]
 ]
-extra-files: ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"]
+extra-files: [
+   ["coq.install" "sha512=b501737b4dbd22adc1c0377d744448056fb1dc493caf72c05f57c8463cf23f758373605ab3a50b9f505e4c856c41039d0bd7f81f96ed62adc6a674179523e7d2"]
+]
 
 url {
   src: "https://github.com/coq/coq/archive/V8.10.0.tar.gz"

--- a/packages/coq/coq.8.10.0/opam
+++ b/packages/coq/coq.8.10.0/opam
@@ -24,8 +24,8 @@ build: [
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
   ]
-  [make "-j1"]
-  [make "-j1" "byte"]
+  [make "-j%{jobs}%"]
+  [make "-j%{jobs}%" "byte"]
 ]
 install: [
   [make "install"]


### PR DESCRIPTION
Followup to #15017.
The backported patch matches https://github.com/vbgl/coq/commit/d25990e2da7e5e84034b927cdab9ea4019c56a30 from coq/coq#9963, backporting coq/coq#10881; I checked it makes sense also for 8.10 and I tested this locally as far as possible. But CI here is much better at finding issues with parallel builds.

/cc @kit-ty-kate.