### PR TITLE
[new release] mirage-protocols and mirage-protocols-lwt (3.1.0)

### DIFF
--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.3.1.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.3.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "mirage-protocols" {>= "2.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "lwt"
+  "cstruct" {>= "1.9.0"}
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols-lwt provides a set of module types specialized to lwt which
+libraries intended to be used as MirageOS network implementations should
+implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v3.1.0/mirage-protocols-v3.1.0.tbz"
+  checksum: [
+    "sha256=d4087ca630321a723509c17253e4e88a506cd18fdf8792294a1a6e022c6ac029"
+    "sha512=39959f2f573970cc4ac9069fbb264837b412ea7bf7ef2784fcef9ae7ef97907cc1638289abeb6b1064af9a8e041faef12b1ae0757824904951b635b454a618f8"
+  ]
+}

--- a/packages/mirage-protocols/mirage-protocols.3.1.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.3.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
+  "mirage-net" {>= "2.0.0"}
+  "fmt"
+  "duration"
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to
+be used as MirageOS network implementations should implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v3.1.0/mirage-protocols-v3.1.0.tbz"
+  checksum: [
+    "sha256=d4087ca630321a723509c17253e4e88a506cd18fdf8792294a1a6e022c6ac029"
+    "sha512=39959f2f573970cc4ac9069fbb264837b412ea7bf7ef2784fcef9ae7ef97907cc1638289abeb6b1064af9a8e041faef12b1ae0757824904951b635b454a618f8"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- add polymorphic variant `Would_fragment to Ip.error (mirage/mirage-protocols#20 @hannesm)
- extend ICMP.write and UDP.write with optional ttl:int argument (mirage/mirage-protocols#21 @phaer)
- remove IP.set_ip (mirage/mirage-protocols#20 @hannesm)