### PR TITLE
Fix missing os-family="debian" in a bunch of packages

### DIFF
--- a/packages/bjack/bjack.0.1.4/opam
+++ b/packages/bjack/bjack.0.1.4/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "bjack"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
-  ["libjack-dev" "libsamplerate0-dev"] {os-distribution = "debian"}
-  ["libjack-dev" "libsamplerate0-dev"] {os-distribution = "ubuntu"}
+  ["libjack-dev" "libsamplerate0-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/bjack/bjack.0.1.5/opam
+++ b/packages/bjack/bjack.0.1.5/opam
@@ -13,8 +13,7 @@ remove: ["ocamlfind" "remove" "bjack"]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["jack-dev"] {os-distribution = "alpine"}
-  ["libjack-dev" "libsamplerate0-dev"] {os-distribution = "debian"}
-  ["libjack-dev" "libsamplerate0-dev"] {os-distribution = "ubuntu"}
+  ["libjack-dev" "libsamplerate0-dev"] {os-family = "debian"}
   ["jack" "drfill/liquidsoap/ocaml-bjack"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/brotli/brotli.1.2.0/opam
+++ b/packages/brotli/brotli.1.2.0/opam
@@ -24,8 +24,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["clang" "libc++-dev"] {os-distribution = "debian"}
-  ["clang" "libc++-dev"] {os-distribution = "ubuntu"}
+  ["clang" "libc++-dev"] {os-family = "debian"}
 ]
 messages: [
  "Note, you'll need to have libbrotli installed: https://github.com/bagder/libbrotli"

--- a/packages/bwrap/bwrap.0.1/opam
+++ b/packages/bwrap/bwrap.0.1/opam
@@ -25,7 +25,7 @@ depends: [
 ]
 available: [os = "linux"]
 depexts: [
-  ["bubblewrap"] {os-distribution = "debian"}
+  ["bubblewrap"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["bubblewrap"] {os-distribution = "ubuntu" & os-version >= "17.0"}
   ["bubblewrap"] {os-distribution = "alpine"}
   ["bubblewrap"] {os-distribution = "fedora"}

--- a/packages/clangml/clangml.0.5.1/opam
+++ b/packages/clangml/clangml.0.5.1/opam
@@ -32,14 +32,7 @@ depexts: [
     "clang-3.4"
     "libclang-3.4-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.4-dev"
-    "clang-3.4"
-    "libclang-3.4-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   [
     "dev-libs/boost"
     "sys-devel/llvm-3.4.1-r2"

--- a/packages/clangml/clangml.0.5.2/opam
+++ b/packages/clangml/clangml.0.5.2/opam
@@ -30,14 +30,7 @@ depexts: [
     "clang-3.4"
     "libclang-3.4-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.4-dev"
-    "clang-3.4"
-    "libclang-3.4-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   [
     "dev-libs/boost"
     "sys-devel/llvm-3.4.1-r2"

--- a/packages/clangml/clangml.3.5.0.1/opam
+++ b/packages/clangml/clangml.3.5.0.1/opam
@@ -31,14 +31,7 @@ depexts: [
     "clang-3.5"
     "libclang-3.5-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.5-dev"
-    "clang-3.5"
-    "libclang-3.5-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
   ["boost" "binutils"] {os-distribution = "arch"}

--- a/packages/clangml/clangml.3.5.0.2/opam
+++ b/packages/clangml/clangml.3.5.0.2/opam
@@ -26,16 +26,9 @@ depexts: [
     "libboost-dev"
     "libclang-3.5-dev"
     "llvm-3.5-dev"
-  ] {os-distribution = "debian"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
-  [
-    "binutils-dev"
-    "clang-3.5"
-    "libboost-dev"
-    "libclang-3.5-dev"
-    "llvm-3.5-dev"
-  ] {os-distribution = "ubuntu"}
   ["boost" "homebrew/versions/llvm35"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/clangml/clangml.3.5.0/opam
+++ b/packages/clangml/clangml.3.5.0/opam
@@ -30,14 +30,7 @@ depexts: [
     "clang-3.5"
     "libclang-3.5-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.5-dev"
-    "clang-3.5"
-    "libclang-3.5-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils"] {os-distribution = "gentoo"}
   ["boost" "binutils"] {os-distribution = "arch"}
 ]

--- a/packages/clangml/clangml.3.6.0.1/opam
+++ b/packages/clangml/clangml.3.6.0.1/opam
@@ -30,14 +30,7 @@ depexts: [
     "clang-3.6"
     "libclang-3.6-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.6-dev"
-    "clang-3.6"
-    "libclang-3.6-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils"] {os-distribution = "gentoo"}
   ["boost" "binutils"] {os-distribution = "arch"}
 ]

--- a/packages/clangml/clangml.3.6.0.2/opam
+++ b/packages/clangml/clangml.3.6.0.2/opam
@@ -31,14 +31,7 @@ depexts: [
     "clang-3.6"
     "libclang-3.6-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.6-dev"
-    "clang-3.6"
-    "libclang-3.6-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils"] {os-distribution = "gentoo"}
   ["boost" "binutils"] {os-distribution = "arch"}
 ]

--- a/packages/clangml/clangml.3.6.0.4/opam
+++ b/packages/clangml/clangml.3.6.0.4/opam
@@ -31,14 +31,7 @@ depexts: [
     "clang-3.6"
     "libclang-3.6-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.6-dev"
-    "clang-3.6"
-    "libclang-3.6-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
   ["boost" "binutils"] {os-distribution = "arch"}

--- a/packages/clangml/clangml.3.6.0.5/opam
+++ b/packages/clangml/clangml.3.6.0.5/opam
@@ -31,14 +31,7 @@ depexts: [
     "clang-3.6"
     "libclang-3.6-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.6-dev"
-    "clang-3.6"
-    "libclang-3.6-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
   ["boost" "binutils"] {os-distribution = "arch"}

--- a/packages/clangml/clangml.3.6.0.6/opam
+++ b/packages/clangml/clangml.3.6.0.6/opam
@@ -26,16 +26,9 @@ depexts: [
     "libboost-dev"
     "libclang-3.6-dev"
     "llvm-3.6-dev"
-  ] {os-distribution = "debian"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
-  [
-    "binutils-dev"
-    "clang-3.6"
-    "libboost-dev"
-    "libclang-3.6-dev"
-    "llvm-3.6-dev"
-  ] {os-distribution = "ubuntu"}
   ["boost160" "homebrew/versions/llvm36"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/clangml/clangml.3.6.0/opam
+++ b/packages/clangml/clangml.3.6.0/opam
@@ -30,14 +30,7 @@ depexts: [
     "clang-3.6"
     "libclang-3.6-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.6-dev"
-    "clang-3.6"
-    "libclang-3.6-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils"] {os-distribution = "gentoo"}
   ["boost" "binutils"] {os-distribution = "arch"}
 ]

--- a/packages/clangml/clangml.3.7.0.1/opam
+++ b/packages/clangml/clangml.3.7.0.1/opam
@@ -31,14 +31,7 @@ depexts: [
     "clang-3.7"
     "libclang-3.7-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.7-dev"
-    "clang-3.7"
-    "libclang-3.7-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
   ["boost" "binutils"] {os-distribution = "arch"}

--- a/packages/clangml/clangml.3.7.0.2/opam
+++ b/packages/clangml/clangml.3.7.0.2/opam
@@ -26,16 +26,9 @@ depexts: [
     "libboost-dev"
     "libclang-3.7-dev"
     "llvm-3.7-dev"
-  ] {os-distribution = "debian"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
-  [
-    "binutils-dev"
-    "clang-3.7"
-    "libboost-dev"
-    "libclang-3.7-dev"
-    "llvm-3.7-dev"
-  ] {os-distribution = "ubuntu"}
   ["boost160" "homebrew/versions/llvm37"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/clangml/clangml.3.7.0/opam
+++ b/packages/clangml/clangml.3.7.0/opam
@@ -31,14 +31,7 @@ depexts: [
     "clang-3.7"
     "libclang-3.7-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.7-dev"
-    "clang-3.7"
-    "libclang-3.7-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
   ["boost" "binutils"] {os-distribution = "arch"}

--- a/packages/clangml/clangml.3.8.0.1/opam
+++ b/packages/clangml/clangml.3.8.0.1/opam
@@ -31,14 +31,7 @@ depexts: [
     "clang-3.8"
     "libclang-3.8-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.8-dev"
-    "clang-3.8"
-    "libclang-3.8-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
   ["boost" "binutils"] {os-distribution = "arch"}

--- a/packages/clangml/clangml.3.8.0/opam
+++ b/packages/clangml/clangml.3.8.0/opam
@@ -31,14 +31,7 @@ depexts: [
     "clang-3.8"
     "libclang-3.8-dev"
     "binutils-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libboost-dev"
-    "llvm-3.8-dev"
-    "clang-3.8"
-    "libclang-3.8-dev"
-    "binutils-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   ["dev-libs/boost" "sys-devel/binutils" "sys-devel/binutils-libs"]
     {os-distribution = "gentoo"}
   ["boost" "binutils"] {os-distribution = "arch"}

--- a/packages/clangml/clangml.3.9.1.2/opam
+++ b/packages/clangml/clangml.3.9.1.2/opam
@@ -33,12 +33,15 @@ depends: [
 ]
 depexts: [
   ["boost"] {os-distribution = "arch"}
-  ["binutils-dev" "clang-3.9" "libboost-dev" "libclang-3.9-dev" "llvm-3.9-dev"
-   "libncurses-dev"]
-    {os-distribution = "debian"}
+  [
+    "binutils-dev"
+    "clang-3.9"
+    "libboost-dev"
+    "libclang-3.9-dev"
+    "llvm-3.9-dev"
+    "libncurses-dev"
+  ] {os-family = "debian"}
   ["dev-libs/boost"] {os-distribution = "gentoo"}
-  ["binutils-dev" "clang-3.9" "libboost-dev" "libclang-3.9-dev" "llvm-3.9-dev"
-   "libncurses-dev"] {os-distribution = "ubuntu"}
   ["boost160"] {os = "macos" & os-distribution = "homebrew"}
 ]
 available: os != "alpine" & os != "centos"

--- a/packages/clangml/clangml.3.9.1/opam
+++ b/packages/clangml/clangml.3.9.1/opam
@@ -37,15 +37,7 @@ depexts: [
     "libclang-3.9-dev"
     "llvm-3.9-dev"
     "libncurses-dev"
-  ] {os-distribution = "debian"}
-  [
-    "binutils-dev"
-    "clang-3.9"
-    "libboost-dev"
-    "libclang-3.9-dev"
-    "llvm-3.9-dev"
-    "libncurses-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
   ["boost160"] {os = "macos" & os-distribution = "homebrew"}
 ]
 post-messages: [

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.1/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.1/opam
@@ -16,7 +16,7 @@ depends: [
 depexts: [
 
   # debian
-  ["llvm-4.0-dev"] {os-distribution = "debian"}
+  ["llvm-4.0-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
 
   # ubuntu
   ["llvm-3.8-dev"] {os-distribution = "ubuntu" & os-version = "14.04"} #trusty

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.2/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.2/opam
@@ -16,7 +16,7 @@ depends: [
 depexts: [
 
   # debian
-  ["llvm-4.0-dev"] {os-distribution = "debian"}
+  ["llvm-4.0-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
 
   # ubuntu
   ["llvm-3.8-dev"] {os-distribution = "ubuntu" & os-version = "14.04"} #trusty

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.3/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.3/opam
@@ -16,7 +16,7 @@ depends: [
 depexts: [
 
   # debian
-  ["llvm-4.0-dev"] {os-distribution = "debian"}
+  ["llvm-4.0-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
 
   # ubuntu
   ["llvm-3.8-dev"] {os-distribution = "ubuntu" & os-version = "14.04"} #trusty

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.4/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.4/opam
@@ -16,7 +16,7 @@ depends: [
 depexts: [
 
   # debian
-  ["llvm-4.0-dev"] {os-distribution = "debian"}
+  ["llvm-4.0-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
 
   # ubuntu
   ["llvm-3.8-dev"] {os-distribution = "ubuntu" & os-version = "14.04"} #trusty

--- a/packages/conf-capnproto/conf-capnproto.0/opam
+++ b/packages/conf-capnproto/conf-capnproto.0/opam
@@ -16,13 +16,12 @@ depexts: [
   ["capnproto-dev@testing"] {os-distribution = "alpine"}
   ["capnproto"] {os-distribution = "arch"}
   ["capnproto"] {os-distribution = "centos"}
-  ["capnproto" "libcapnp-dev"] {os-distribution = "debian"}
+  ["capnproto" "libcapnp-dev"] {os-family = "debian"}
   ["capnproto"] {os-distribution = "fedora"}
   ["capnproto"] {os-distribution = "gentoo"}
   ["capnp"] {os-distribution = "homebrew" & os = "macos"}
   ["capnproto"] {os-distribution = "macports" & os = "macos"}
   ["capnproto"] {os-family = "suse"}
-  ["capnproto" "libcapnp-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on captnproto installation"
 flags: conf

--- a/packages/conf-csdp/conf-csdp.1/opam
+++ b/packages/conf-csdp/conf-csdp.1/opam
@@ -4,7 +4,7 @@ authors: "CSDP"
 homepage: "https://github.com/coin-or/Csdp/wiki"
 build: ["sh" "-exc" "command -v csdp"]
 depexts: [
-  ["coinor-csdp"] {os-distribution = "debian" | os-distribution = "ubuntu"}
+  ["coinor-csdp"] {os-family = "debian"}
   ["csdp"] {os-distribution = "centos"}
 ]
 synopsis: "Virtual package relying on a CSDP binary system installation"

--- a/packages/conf-efl/conf-efl.1.8/opam
+++ b/packages/conf-efl/conf-efl.1.8/opam
@@ -7,7 +7,7 @@ build: [["pkg-config" "elementary" "--atleast-version=1.8"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["efl"] {os-distribution = "arch" & os = "linux"}
-  ["libelementary-dev"] {os-distribution = "debian" & os = "linux"}
+  ["libelementary-dev"] {os-family = "debian" & os-distribution != "ubuntu" & os = "linux"}
   ["elementary-devel"] {os-distribution = "fedora" & os = "linux"}
   ["efl"] {os = "freebsd"}
   ["efl"] {os-distribution = "gentoo"}

--- a/packages/conf-emacs/conf-emacs.1/opam
+++ b/packages/conf-emacs/conf-emacs.1/opam
@@ -5,7 +5,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
 build: ["emacs" "--version"]
 depexts: [
-  ["emacs-nox"] {os-distribution = "debian"}
+  ["emacs-nox"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["emacs"] {os-distribution = "ubuntu"}
   ["emacs-nox"] {os-distribution = "centos"}
   ["emacs-nox"] {os-distribution = "rhel"}

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -5,8 +5,7 @@ authors: ["Nikos Mavrogiannopoulos" "Simon Josefsson"]
 build: [["pkg-config" "gnutls" "nettle"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libgnutls28-dev" "nettle-dev"] {os-distribution = "debian"}
-  ["libgnutls28-dev" "nettle-dev"] {os-distribution = "ubuntu"}
+  ["libgnutls28-dev" "nettle-dev"] {os-family = "debian"}
   ["gnutls-dev"] {os-distribution = "alpine"}
   ["gnutls-devel" "nettle-devel"] {os-distribution = "fedora"}
   ["gnutls"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -6,8 +6,7 @@ bug-reports: "https://github.com/garrigue/lablgtk/issues"
 build: [["pkg-config" "--short-errors" "--print-errors" "--atleast-version" "3.18" "gtk+-3.0"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libgtk-3-dev" "libexpat1-dev"] {os-distribution = "debian"}
-  ["libgtk-3-dev" "libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libgtk-3-dev" "libexpat1-dev"] {os-family = "debian"}
   ["gtk" "expat"] {os-distribution = "homebrew" & os = "macos"}
   ["gtk3-devel"] {os-distribution = "centos"}
   ["gtk3-devel"] {os-distribution = "fedora"}

--- a/packages/conf-libX11/conf-libX11.1/opam
+++ b/packages/conf-libX11/conf-libX11.1/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libx11-dev"] {os-distribution = "debian" | os-distribution = "ubuntu"}
+  ["libx11-dev"] {os-family = "debian"}
   ["libX11-devel"] {os-distribution = "centos" | os-distribution = "oraclelinux" | os-distribution = "fedora" | os-distribution = "opensuse"}
   ["libx11-dev"] {os-distribution = "alpine"}
   ["libx11`"] {os-distribution = "archlinux"}

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -10,8 +10,7 @@ build: [
 depexts: [
   ["llvm"] {os-distribution = "homebrew" & os = "macos"}
   ["llvm"] {os-distribution = "macports" & os = "macos"}
-  ["libclang-dev" "llvm-dev"] {os-distribution = "debian"}
-  ["libclang-dev" "llvm-dev"] {os-distribution = "ubuntu"}
+  ["libclang-dev" "llvm-dev"] {os-family = "debian"}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-static" "zlib-devel"] {os-distribution = "centos"}
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]

--- a/packages/conf-libmaxminddb/conf-libmaxminddb.1/opam
+++ b/packages/conf-libmaxminddb/conf-libmaxminddb.1/opam
@@ -11,7 +11,7 @@ license: "Apache-2.0"
 build: [["pkg-config" "libmaxminddb"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libmaxminddb-dev"] {os-distribution = "debian" | os-distribution = "ubuntu"}
+  ["libmaxminddb-dev"] {os-family = "debian"}
   ["net/libmaxminddb"] {os = "freebsd"}
   ["libmaxminddb"] {os-distribution = "homebrew" & os = "macos"}
   ["libmaxminddb-dev"] {os-distribution = "alpine"}

--- a/packages/conf-libpng/conf-libpng.1/opam
+++ b/packages/conf-libpng/conf-libpng.1/opam
@@ -10,7 +10,7 @@ homepage: "http://www.libpng.org/pub/png/libpng.html"
 license: "Zlib"
 build: [["pkg-config" "libpng"]]
 depexts: [
-  ["libpng-dev"] {os-distribution = "debian"}
+  ["libpng-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["libpng-devel"] {os-distribution = "mageia"}
   ["libpng12-dev"] {os-distribution = "ubuntu"}
 ]

--- a/packages/conf-libseccomp/conf-libseccomp.1/opam
+++ b/packages/conf-libseccomp/conf-libseccomp.1/opam
@@ -7,12 +7,11 @@ build: ["pkg-config" "libseccomp"]
 depends: ["conf-pkg-config"]
 depexts: [
   ["libseccomp-dev"] {os-distribution = "alpine"}
-  ["libseccomp-dev"] {os-distribution = "debian"}
+  ["libseccomp-dev"] {os-family = "debian"}
   ["libseccomp-devel"] {os-distribution = "fedora"}
   ["libseccomp-devel"] {os-distribution = "rhel"}
   ["libseccomp-devel"] {os-distribution = "centos"}
   ["libseccomp-devel"] {os-family = "suse"}
-  ["libseccomp-dev"] {os-distribution = "ubuntu"}
   ["libseccomp"] {os-distribution = "arch"}
   ["libseccomp"] {os-distribution = "nixos"}
 ]

--- a/packages/conf-mecab/conf-mecab.0.996/opam
+++ b/packages/conf-mecab/conf-mecab.0.996/opam
@@ -8,8 +8,7 @@ build: [
   ["cc" "test.c" "-I/usr/local/include" "-L/usr/local/lib" "-lmecab"]
 ]
 depexts: [
-  ["mecab" "libmecab-dev"] {os-distribution = "debian"}
-  ["mecab" "libmecab-dev"] {os-distribution = "ubuntu"}
+  ["mecab" "libmecab-dev"] {os-family = "debian"}
   ["mecab" "mecab-devel"] {os-distribution = "fedora"}
   ["mecab"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-neko/conf-neko.1/opam
+++ b/packages/conf-neko/conf-neko.1/opam
@@ -7,8 +7,7 @@ license: ["MIT"]
 build: [["neko" "-version"]]
 depexts: [
   ["neko-dev"] {os-distribution = "alpine"}
-  ["neko" "neko-dev"] {os-distribution = "debian"}
-  ["neko" "neko-dev"] {os-distribution = "ubuntu"}
+  ["neko" "neko-dev"] {os-family = "debian"}
   ["nekovm-devel"] {os-distribution = "fedora"}
   ["neko"] {os-distribution = "nixos"}
   ["neko"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/conf-openblas/conf-openblas.0.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.1/opam
@@ -21,8 +21,7 @@ build: [
 depexts: [
   ["openblas-devel"] {os-distribution = "fedora"}
   ["libc-dev" "openblas-dev"] {os-distribution = "alpine"}
-  ["libopenblas-dev" "liblapacke-dev"] {os-distribution = "ubuntu"}
-  ["libopenblas-dev" "liblapacke-dev"] {os-distribution = "debian"}
+  ["libopenblas-dev" "liblapacke-dev"] {os-family = "debian"}
   ["homebrew/science/openblas"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package to install OpenBLAS and LAPACKE"

--- a/packages/conf-openblas/conf-openblas.0.2.0/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.0/opam
@@ -20,8 +20,7 @@ build: [
 depexts: [
   ["libc-dev" "openblas-dev"] {os-distribution = "alpine"}
   ["epel-release" "openblas-devel"] {os-distribution = "centos"}
-  ["libopenblas-dev" "liblapacke-dev"] {os-distribution = "debian"}
-  ["libopenblas-dev" "liblapacke-dev"] {os-distribution = "ubuntu"}
+  ["libopenblas-dev" "liblapacke-dev"] {os-family = "debian"}
   ["openblas-devel"] {os-distribution = "fedora"}
   ["openblas-devel"] {os-family = "suse"}
   ["openblas" "lapacke" "cblas"] {os-distribution = "arch"}

--- a/packages/conf-protoc/conf-protoc.0.9/opam
+++ b/packages/conf-protoc/conf-protoc.0.9/opam
@@ -8,9 +8,8 @@ dev-repo: "git+https://github.com/protocolbuffers/protobuf.git"
 build: [ "protoc" "--version" ]
 
 depexts: [
-  ["protobuf-compiler"] {os-distribution = "debian"}
+  ["protobuf-compiler"] {os-family = "debian"}
   ["protobuf-compiler"] {os-distribution = "mageia"}
-  ["protobuf-compiler"] {os-distribution = "ubuntu"}
   ["protobuf-compiler"] {os-distribution = "centos"}
   ["protobuf-compiler"] {os-distribution = "fedora"}
   ["protobuf-compiler"] {os-distribution = "rhel"}

--- a/packages/conf-protoc/conf-protoc.1.0.0/opam
+++ b/packages/conf-protoc/conf-protoc.1.0.0/opam
@@ -8,9 +8,8 @@ dev-repo: "git+https://github.com/protocolbuffers/protobuf.git"
 build: [ "protoc" "--version" ]
 
 depexts: [
-  ["libprotobuf-dev" "protobuf-compiler"]   {os-distribution = "debian"}
+  ["libprotobuf-dev" "protobuf-compiler"]   {os-family = "debian"}
   ["libprotobuf-devel" "protobuf-compiler"] {os-distribution = "mageia"}
-  ["libprotobuf-dev" "protobuf-compiler"]   {os-distribution = "ubuntu"}
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "centos"}
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "fedora"}
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "rhel"}

--- a/packages/conf-qt/conf-qt.5.2.1/opam
+++ b/packages/conf-qt/conf-qt.5.2.1/opam
@@ -29,16 +29,13 @@ post-messages:
 depexts: [
   ["qt5"] {os = "macos" & os-distribution = "homebrew"}
   ["qt5-default" "qtdeclarative5-dev" "qt5-qmake"]
-    {os-distribution = "ubuntu"}
-  ["qt5-default" "qtdeclarative5-dev" "qt5-qmake"]
-    {os-distribution = "debian"}
+    {os-family = "debian"}
 
   # to set right paths for qt5 automatically we should 
   #   1) add `@edge http://nl.alpinelinux.org/alpine/edge/testing` to `/etc/apk/repositories`
   #   2) perform installation via `apk add qtchooser@edge`
   # but this repo is not shipped by default on CI
   ["qt5-qtbase-dev" "qt5-qtdeclarative-dev"] {os-distribution = "alpine"}
-
   ["qt-devel" "qt5-qtbase-devel" "qt5-qtdeclarative-devel"] {os-distribution = "centos"}
   ["qtchooser" "qt5-qtbase-devel" "qt5-qtdeclarative-devel"] {os-distribution = "fedora"}
   ["libqt5-qtbase-common-devel" "libqt5-qtbase-devel" "libqt5-qtdeclarative-devel" ] {os-family = "suse" }

--- a/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
+++ b/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
@@ -7,11 +7,10 @@ license: "MIT"
 dev-repo: "git+https://github.com/dakk/conf-secp256k1"
 
 depexts: [
-  ["libsecp256k1-0" "libsecp256k1-dev"] {os-distribution = "debian"}
+  ["libsecp256k1-0" "libsecp256k1-dev"] {os-family = "debian"}
   ["dev-libs/libsecp256k1"] {os-distribution = "gentoo"}
   ["secp256k1"] {os-distribution = "homebrew" & os = "macos"}
   ["libsecp256k1-git"] {os-distribution = "arch"}
-  ["libsecp256k1-0" "libsecp256k1-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Virtual package relying on a secp256k1 lib system installation"
 description:

--- a/packages/conf-wxwidgets/conf-wxwidgets.3.0/opam
+++ b/packages/conf-wxwidgets/conf-wxwidgets.3.0/opam
@@ -10,7 +10,7 @@ depexts: [
     "wx3.0-headers"
     "libwxgtk-webview3.0-dev"
     "libwxgtk-media3.0-dev"
-  ] {os-distribution = "debian"}
+  ] {os-family = "debian" & os-distribution != "ubuntu"}
   ["libwxgtk3.0-dev" "libwxgtk-webview3.0-dev" "libwxgtk-media3.0-dev"]
     {os-distribution = "ubuntu"}
 ]

--- a/packages/dssi/dssi.0.1.1/opam
+++ b/packages/dssi/dssi.0.1.1/opam
@@ -10,8 +10,7 @@ build: [
 remove: [["ocamlfind" "remove" "dssi"]]
 depends: ["ocaml" "ocamlfind" "ladspa"]
 depexts: [
-  ["dssi-dev" "ladspa-sdk"] {os-distribution = "debian"}
-  ["dssi-dev" "ladspa-sdk"] {os-distribution = "ubuntu"}
+  ["dssi-dev" "ladspa-sdk"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Bindings for the DSSI API which provides audio synthesizers"

--- a/packages/ffmpeg/ffmpeg.0.1.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.0/opam
@@ -11,8 +11,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libavutil-dev" "libswscale-dev"] {os-distribution = "debian"}
-  ["libavutil-dev" "libswscale-dev"] {os-distribution = "ubuntu"}
+  ["libavutil-dev" "libswscale-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/ffmpeg/ffmpeg.0.1.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.1/opam
@@ -16,8 +16,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libavutil-dev" "libswscale-dev"] {os-distribution = "debian"}
-  ["libavutil-dev" "libswscale-dev"] {os-distribution = "ubuntu"}
+  ["libavutil-dev" "libswscale-dev"] {os-family = "debian"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}

--- a/packages/ffmpeg/ffmpeg.0.1.2/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.2/opam
@@ -16,8 +16,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libavutil-dev" "libswscale-dev"] {os-distribution = "debian"}
-  ["libavutil-dev" "libswscale-dev"] {os-distribution = "ubuntu"}
+  ["libavutil-dev" "libswscale-dev"] {os-family = "debian"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}

--- a/packages/ffmpeg/ffmpeg.0.2.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.0/opam
@@ -17,10 +17,7 @@ depends: [
   "base-bigarray"
 ]
 depexts: [
-  ["libavutil-dev" "libswscale-dev" "libavformat-dev"]
-    {os-distribution = "debian"}
-  ["libavutil-dev" "libswscale-dev" "libavformat-dev"]
-    {os-distribution = "ubuntu"}
+  ["libavutil-dev" "libswscale-dev" "libavformat-dev"] {os-family = "debian"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}

--- a/packages/ffmpeg/ffmpeg.0.2.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.1/opam
@@ -17,10 +17,14 @@ depends: [
   "base-bigarray"
 ]
 depexts: [
-  ["libavutil-dev" "libswscale-dev" "libavformat-dev" "libavcodec-dev" "libavdevice-dev" "libswresample-dev"]
-    {os-distribution = "debian"}
-  ["libavutil-dev" "libswscale-dev" "libavformat-dev" "libavcodec-dev" "libavdevice-dev" "libswresample-dev"]
-    {os-distribution = "ubuntu"}
+  [
+    "libavutil-dev"
+    "libswscale-dev"
+    "libavformat-dev"
+    "libavcodec-dev"
+    "libavdevice-dev"
+    "libswresample-dev"
+  ] {os-family = "debian"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}

--- a/packages/ffmpeg/ffmpeg.0.3.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.3.0/opam
@@ -21,10 +21,14 @@ build: [
 ]
 install: [make "install"]
 depexts: [
-  ["libavutil-dev" "libswscale-dev" "libavformat-dev" "libavcodec-dev" "libavdevice-dev" "libswresample-dev"]
-    {os-distribution = "debian"}
-  ["libavutil-dev" "libswscale-dev" "libavformat-dev" "libavcodec-dev" "libavdevice-dev" "libswresample-dev"]
-    {os-distribution = "ubuntu"}
+  [
+    "libavutil-dev"
+    "libswscale-dev"
+    "libavformat-dev"
+    "libavcodec-dev"
+    "libavdevice-dev"
+    "libswresample-dev"
+  ] {os-family = "debian"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}

--- a/packages/ffmpeg/ffmpeg.0.4.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.0/opam
@@ -21,10 +21,14 @@ build: [
 ]
 install: [make "install"]
 depexts: [
-  ["libavutil-dev" "libswscale-dev" "libavformat-dev" "libavcodec-dev" "libavdevice-dev" "libswresample-dev"]
-    {os-distribution = "debian"}
-  ["libavutil-dev" "libswscale-dev" "libavformat-dev" "libavcodec-dev" "libavdevice-dev" "libswresample-dev"]
-    {os-distribution = "ubuntu"}
+  [
+    "libavutil-dev"
+    "libswscale-dev"
+    "libavformat-dev"
+    "libavcodec-dev"
+    "libavdevice-dev"
+    "libswresample-dev"
+  ] {os-family = "debian"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}

--- a/packages/ffmpeg/ffmpeg.0.4.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.1/opam
@@ -21,10 +21,14 @@ build: [
 ]
 install: [make "install"]
 depexts: [
-  ["libavutil-dev" "libswscale-dev" "libavformat-dev" "libavcodec-dev" "libavdevice-dev" "libswresample-dev"]
-    {os-distribution = "debian"}
-  ["libavutil-dev" "libswscale-dev" "libavformat-dev" "libavcodec-dev" "libavdevice-dev" "libswresample-dev"]
-    {os-distribution = "ubuntu"}
+  [
+    "libavutil-dev"
+    "libswscale-dev"
+    "libavformat-dev"
+    "libavcodec-dev"
+    "libavdevice-dev"
+    "libswresample-dev"
+  ] {os-family = "debian"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}

--- a/packages/freetds/freetds.0.4.1/opam
+++ b/packages/freetds/freetds.0.4.1/opam
@@ -32,9 +32,8 @@ depends: ["ocaml" "ocamlfind"]
 install: [make "install"]
 depexts: [
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "centos"}
-  ["autoconf" "automake" "freetds-dev"] {os-distribution = "debian"}
+  ["autoconf" "automake" "freetds-dev"] {os-family = "debian"}
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "fedora"}
-  ["autoconf" "automake" "freetds-dev"] {os-distribution = "ubuntu"}
   ["autoconf" "automake" "freetds"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/freetds/freetds.0.4.2/opam
+++ b/packages/freetds/freetds.0.4.2/opam
@@ -32,9 +32,8 @@ depends: ["ocaml" "ocamlfind"]
 install: [make "install"]
 depexts: [
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "centos"}
-  ["autoconf" "automake" "freetds-dev"] {os-distribution = "debian"}
+  ["autoconf" "automake" "freetds-dev"] {os-family = "debian"}
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "fedora"}
-  ["autoconf" "automake" "freetds-dev"] {os-distribution = "ubuntu"}
   ["autoconf" "automake" "freetds"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/freetds/freetds.0.4/opam
+++ b/packages/freetds/freetds.0.4/opam
@@ -28,9 +28,8 @@ depends: ["ocaml" "ocamlfind"]
 install: [make "install"]
 depexts: [
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "centos"}
-  ["autoconf" "automake" "freetds-dev"] {os-distribution = "debian"}
+  ["autoconf" "automake" "freetds-dev"] {os-family = "debian"}
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "fedora"}
-  ["autoconf" "automake" "freetds-dev"] {os-distribution = "ubuntu"}
   ["autoconf" "automake" "freetds"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/freetds/freetds.0.5.1/opam
+++ b/packages/freetds/freetds.0.5.1/opam
@@ -30,9 +30,8 @@ remove: [["ocamlfind" "remove" "freetds"]]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "centos"}
-  ["autoconf" "automake" "freetds-dev"] {os-distribution = "debian"}
+  ["autoconf" "automake" "freetds-dev"] {os-family = "debian"}
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "fedora"}
-  ["autoconf" "automake" "freetds-dev"] {os-distribution = "ubuntu"}
   ["autoconf" "automake" "freetds"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/freetds/freetds.0.5/opam
+++ b/packages/freetds/freetds.0.5/opam
@@ -32,9 +32,8 @@ depends: ["ocaml" "ocamlfind"]
 install: [make "install"]
 depexts: [
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "centos"}
-  ["autoconf" "automake" "freetds-dev"] {os-distribution = "debian"}
+  ["autoconf" "automake" "freetds-dev"] {os-family = "debian"}
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "fedora"}
-  ["autoconf" "automake" "freetds-dev"] {os-distribution = "ubuntu"}
   ["autoconf" "automake" "freetds"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/freetennis/freetennis.0.4.8/opam
+++ b/packages/freetennis/freetennis.0.4.8/opam
@@ -23,15 +23,7 @@ depexts: [
     "libsdl-ttf2.0-dev"
     "freeglut3-dev"
     "libgtk2.0-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libsdl-gfx1.2-dev"
-    "libsdl-mixer1.2-dev"
-    "libsdl-image1.2-dev"
-    "libsdl-ttf2.0-dev"
-    "freeglut3-dev"
-    "libgtk2.0-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
 ]
 synopsis: "Free Tennis, a free tennis simulation."
 extra-files: [

--- a/packages/grib/grib.0.11.0/opam
+++ b/packages/grib/grib.0.11.0/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depexts: [
   ["libjpeg-dev" "libopenjpeg-dev" "libgrib-api-dev" "libpng-dev"]
-    {os-distribution = "debian"}
+    {os-family = "debian" & os-distribution != "ubuntu"}
   [
     "libjpeg-dev"
     "libjasper-dev"

--- a/packages/grib/grib.0.9.7/opam
+++ b/packages/grib/grib.0.9.7/opam
@@ -26,14 +26,7 @@ depexts: [
     "libopenjpeg-dev"
     "libgrib-api-dev"
     "libpng-dev"
-  ] {os-distribution = "debian"}
-  [
-    "libjpeg-dev"
-    "libjasper-dev"
-    "libopenjpeg-dev"
-    "libgrib-api-dev"
-    "libpng-dev"
-  ] {os-distribution = "ubuntu"}
+  ] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-grib"
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/gstreamer/gstreamer.0.2.1/opam
+++ b/packages/gstreamer/gstreamer.0.2.1/opam
@@ -13,9 +13,7 @@ remove: ["ocamlfind" "remove" "gstreamer"]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]
-    {os-distribution = "debian"}
-  ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]
-    {os-distribution = "ubuntu"}
+    {os-family = "debian"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-gstreamer/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-gstreamer.git"

--- a/packages/gstreamer/gstreamer.0.2.2/opam
+++ b/packages/gstreamer/gstreamer.0.2.2/opam
@@ -16,9 +16,7 @@ depends: [
 ]
 depexts: [
   ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]
-    {os-distribution = "debian"}
-  ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]
-    {os-distribution = "ubuntu"}
+    {os-family = "debian"}
   ["gstreamer" "gst-plugins-base"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/gstreamer/gstreamer.0.2.3/opam
+++ b/packages/gstreamer/gstreamer.0.2.3/opam
@@ -16,16 +16,13 @@ depends: [
 ]
 depexts: [
   ["gstreamer1-dev" "gst-plugins-base1-dev"] {os-distribution = "alpine"}
-  ["gstreamer-devel" "gstreamer-plugins-base-devel"]
-    {os-family = "suse"}
+  ["gstreamer-devel" "gstreamer-plugins-base-devel"] {os-family = "suse"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
     {os-distribution = "fedora"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
     {os-distribution = "centos"}
   ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]
-    {os-distribution = "debian"}
-  ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]
-    {os-distribution = "ubuntu"}
+    {os-family = "debian"}
   ["gstreamer1"] {os = "freebsd"}
   ["gstreamer" "gst-plugins-base"]
     {os = "macos" & os-distribution = "homebrew"}

--- a/packages/gstreamer/gstreamer.0.3.0/opam
+++ b/packages/gstreamer/gstreamer.0.3.0/opam
@@ -16,16 +16,13 @@ depends: [
 ]
 depexts: [
   ["gstreamer-dev" "gst-plugins-base-dev"] {os-distribution = "alpine"}
-  ["gstreamer-devel" "gstreamer-plugins-base-devel"]
-    {os-family = "suse"}
+  ["gstreamer-devel" "gstreamer-plugins-base-devel"] {os-family = "suse"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
     {os-distribution = "fedora"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
     {os-distribution = "centos"}
   ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]
-    {os-distribution = "debian"}
-  ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]
-    {os-distribution = "ubuntu"}
+    {os-family = "debian"}
   ["gstreamer1"] {os = "freebsd"}
   ["gstreamer" "gst-plugins-base"]
     {os = "macos" & os-distribution = "homebrew"}

--- a/packages/hdf/hdf.0.9.1/opam
+++ b/packages/hdf/hdf.0.9.1/opam
@@ -18,8 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libhdf4-dev" "hdf4-tools"] {os-distribution = "debian"}
-  ["libhdf4-dev" "hdf4-tools"] {os-distribution = "ubuntu"}
+  ["libhdf4-dev" "hdf4-tools"] {os-family = "debian"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Bindings for the HDF4 library"

--- a/packages/imagemagick/imagemagick.0.33.1/opam
+++ b/packages/imagemagick/imagemagick.0.33.1/opam
@@ -7,7 +7,7 @@ remove: [[make "uninstall"]]
 depends: ["ocaml" "ocamlfind" "base-unsafe-string"]
 available: os != "macos"
 depexts: [
-  ["libgraphicsmagick1-dev" "libmagickcore-dev"] {os-distribution = "debian"}
+  ["libgraphicsmagick1-dev" "libmagickcore-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["libmagickcore-dev"] {os-distribution = "ubuntu"}
 ]
 install: [make "install"]

--- a/packages/imagemagick/imagemagick.0.33.2/opam
+++ b/packages/imagemagick/imagemagick.0.33.2/opam
@@ -7,7 +7,7 @@ remove: [[make "uninstall"]]
 depends: ["ocaml" "ocamlfind" "base-unsafe-string"]
 available: os != "macos"
 depexts: [
-  ["libgraphicsmagick1-dev" "libmagickcore-dev"] {os-distribution = "debian"}
+  ["libgraphicsmagick1-dev" "libmagickcore-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["libmagickcore-dev"] {os-distribution = "ubuntu"}
 ]
 install: [make "install"]

--- a/packages/imagemagick/imagemagick.0.33/opam
+++ b/packages/imagemagick/imagemagick.0.33/opam
@@ -7,7 +7,7 @@ remove: [[make "uninstall"]]
 depends: ["ocaml" "ocamlfind" "base-unsafe-string"]
 available: os != "macos"
 depexts: [
-  ["libgraphicsmagick1-dev" "libmagickcore-dev"] {os-distribution = "debian"}
+  ["libgraphicsmagick1-dev" "libmagickcore-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["libmagickcore-dev"] {os-distribution = "ubuntu"}
 ]
 install: [make "install"]

--- a/packages/imagemagick/imagemagick.0.34-1/opam
+++ b/packages/imagemagick/imagemagick.0.34-1/opam
@@ -9,7 +9,7 @@ remove: [["ocamlfind" "remove" "magick"]]
 depends: ["ocaml" "ocamlfind" "base-unsafe-string"]
 available: os != "macos"
 depexts: [
-  ["libgraphicsmagick1-dev" "libmagickcore-dev"] {os-distribution = "debian"}
+  ["libgraphicsmagick1-dev" "libmagickcore-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["libmagickcore-dev"] {os-distribution = "ubuntu"}
   ["imagemagick"] {os-distribution = "homebrew" & os = "macos"}
 ]

--- a/packages/imagemagick/imagemagick.0.34/opam
+++ b/packages/imagemagick/imagemagick.0.34/opam
@@ -7,7 +7,7 @@ remove: [["ocamlfind" "remove" "magick"]]
 depends: ["ocaml" "ocamlfind" "base-unsafe-string"]
 available: os != "macos"
 depexts: [
-  ["libgraphicsmagick1-dev" "libmagickcore-dev"] {os-distribution = "debian"}
+  ["libgraphicsmagick1-dev" "libmagickcore-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["libmagickcore-dev"] {os-distribution = "ubuntu"}
 ]
 install: [make "find_install"]

--- a/packages/javascriptcore/javascriptcore.0.0.1/opam
+++ b/packages/javascriptcore/javascriptcore.0.0.1/opam
@@ -21,8 +21,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libc++-dev" "libjavascriptcoregtk-3.0-dev"] {os-distribution = "debian"}
-  ["libc++-dev" "libjavascriptcoregtk-3.0-dev"] {os-distribution = "ubuntu"}
+  ["libc++-dev" "libjavascriptcoregtk-3.0-dev"] {os-family = "debian"}
 ]
 messages: [
   "Installation might fail on Linux, follow depext instructions and try again."

--- a/packages/jitsu/jitsu.0.2/opam
+++ b/packages/jitsu/jitsu.0.2/opam
@@ -38,8 +38,7 @@ depends: [
   "alcotest"
 ]
 depexts: [
-  ["libvirt-bin" "libvirt-dev" "libxen-dev"] {os-distribution = "debian"}
-  ["libvirt-bin" "libvirt-dev" "libxen-dev"] {os-distribution = "ubuntu"}
+  ["libvirt-bin" "libvirt-dev" "libxen-dev"] {os-family = "debian"}
   ["libvirt"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis:

--- a/packages/kafka/kafka.0.3/opam
+++ b/packages/kafka/kafka.0.3/opam
@@ -16,10 +16,9 @@ depends: [
 depexts: [
   ["zlib-dev" "librdkafka-dev"] {os-distribution = "alpine"}
   ["zlib-devel" "librdkafka-devel"] {os-distribution = "centos"}
-  ["zlib1g-dev" "librdkafka-dev"] {os-distribution = "debian"}
+  ["zlib1g-dev" "librdkafka-dev"] {os-family = "debian"}
   ["zlib-devel" "librdkafka-devel"] {os-distribution = "fedora"}
   ["zlib" "librdkafka"] {os-distribution = "homebrew" & os = "macos"}
-  ["zlib1g-dev" "librdkafka-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "OCaml bindings for Kafka"
 description: "Kafka is a high-throughput distributed messaging system."

--- a/packages/kafka/kafka.0.4/opam
+++ b/packages/kafka/kafka.0.4/opam
@@ -16,10 +16,9 @@ depends: [
 depexts: [
   ["librdkafka-dev" "zlib-dev"] {os-distribution = "alpine"}
   ["librdkafka-devel" "zlib-devel"] {os-distribution = "centos"}
-  ["librdkafka-dev" "zlib1g-dev"] {os-distribution = "debian"}
+  ["librdkafka-dev" "zlib1g-dev"] {os-family = "debian"}
   ["librdkafka-devel" "zlib-devel"] {os-distribution = "fedora"}
   ["librdkafka" "zlib"] {os-distribution = "homebrew" & os = "macos"}
-  ["librdkafka-dev" "zlib1g-dev"] {os-distribution = "ubuntu"}
 ]
 synopsis: "OCaml bindings for Kafka"
 description: "Kafka is a high-throughput distributed messaging system."

--- a/packages/lablgl/lablgl.1.04.20120306/opam
+++ b/packages/lablgl/lablgl.1.04.20120306/opam
@@ -10,9 +10,7 @@ build: [
 depends: ["ocaml" "camlp4"]
 depexts: [
   ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
-    {os-distribution = "debian"}
-  ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
-    {os-distribution = "ubuntu"}
+    {os-family = "debian"}
 ]
 install: [
   [

--- a/packages/lablgl/lablgl.1.05/opam
+++ b/packages/lablgl/lablgl.1.05/opam
@@ -23,9 +23,7 @@ remove: [
 depends: ["ocaml" "camlp4"]
 depexts: [
   ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
-    {os-distribution = "debian"}
-  ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
-    {os-distribution = "ubuntu"}
+    {os-family = "debian"}
 ]
 synopsis: "Interface to OpenGL"
 description: """

--- a/packages/lablgl/lablgl.1.06/opam
+++ b/packages/lablgl/lablgl.1.06/opam
@@ -23,13 +23,11 @@ remove: [
 depends: ["ocaml" {>= "4.03"}]
 depexts: [
   ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
-    {os-distribution = "debian"}
-  ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
-    {os-distribution = "ubuntu"}
-  ["freeglut-dev"]   {os-distribution = "alpine"}
+    {os-family = "debian"}
+  ["freeglut-dev"] {os-distribution = "alpine"}
   ["freeglut-devel"] {os-distribution = "centos"}
   ["freeglut-devel"] {os-distribution = "fedora"}
-  ["freeglut-devel"] {os-family = "suse"}    
+  ["freeglut-devel"] {os-family = "suse"}
 ]
 synopsis: "Interface to OpenGL"
 description: """

--- a/packages/lablgtk/lablgtk.2.16.0/opam
+++ b/packages/lablgtk/lablgtk.2.16.0/opam
@@ -18,8 +18,7 @@ depopts: [
   "lablgl"
 ]
 depexts: [
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "debian"}
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libgtk2.0-dev" "libexpat1-dev"] {os-family = "debian"}
   ["gtk" "expat"] {os-distribution = "homebrew" & os = "macos"}
   ["gtk2-devel"] {os-distribution = "centos"}
   ["gtk2-devel"] {os-distribution = "fedora"}

--- a/packages/lablgtk/lablgtk.2.18.2/opam
+++ b/packages/lablgtk/lablgtk.2.18.2/opam
@@ -18,8 +18,7 @@ depopts: [
   "lablgl"
 ]
 depexts: [
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "debian"}
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libgtk2.0-dev" "libexpat1-dev"] {os-family = "debian"}
   ["gtk" "expat"] {os-distribution = "homebrew" & os = "macos"}
   ["gtk2-devel"] {os-distribution = "centos"}
   ["gtk2-devel"] {os-distribution = "fedora"}

--- a/packages/lablgtk/lablgtk.2.18.3/opam
+++ b/packages/lablgtk/lablgtk.2.18.3/opam
@@ -18,8 +18,7 @@ depopts: [
   "lablgl"
 ]
 depexts: [
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "debian"}
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libgtk2.0-dev" "libexpat1-dev"] {os-family = "debian"}
   ["gtk" "expat"] {os-distribution = "homebrew" & os = "macos"}
   ["gtk2-devel"] {os-distribution = "centos"}
   ["gtk2-devel"] {os-distribution = "fedora"}

--- a/packages/lablgtk/lablgtk.2.18.4/opam
+++ b/packages/lablgtk/lablgtk.2.18.4/opam
@@ -24,8 +24,7 @@ depopts: [
   "lablgl"
 ]
 depexts: [
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "debian"}
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libgtk2.0-dev" "libexpat1-dev"] {os-family = "debian"}
   ["gtk" "expat"] {os-distribution = "homebrew" & os = "macos"}
   ["gtk2-devel"] {os-distribution = "centos"}
   ["gtk2-devel"] {os-distribution = "fedora"}

--- a/packages/lablgtk/lablgtk.2.18.5/opam
+++ b/packages/lablgtk/lablgtk.2.18.5/opam
@@ -24,8 +24,7 @@ depopts: [
   "lablgl"
 ]
 depexts: [
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "debian"}
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libgtk2.0-dev" "libexpat1-dev"] {os-family = "debian"}
   ["gtk" "expat"] {os-distribution = "homebrew" & os = "macos"}
   ["gtk2-devel"] {os-distribution = "centos"}
   ["gtk2-devel"] {os-distribution = "fedora"}

--- a/packages/lablgtk/lablgtk.2.18.6/opam
+++ b/packages/lablgtk/lablgtk.2.18.6/opam
@@ -24,8 +24,7 @@ depopts: [
   "lablgl"
 ]
 depexts: [
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "debian"}
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libgtk2.0-dev" "libexpat1-dev"] {os-family = "debian"}
   ["gtk" "expat"] {os-distribution = "homebrew" & os = "macos"}
   ["gtk2-devel"] {os-distribution = "centos"}
   ["gtk2-devel"] {os-distribution = "fedora"}

--- a/packages/lablgtk/lablgtk.2.18.7/opam
+++ b/packages/lablgtk/lablgtk.2.18.7/opam
@@ -24,8 +24,7 @@ depopts: [
   "lablgl"
 ]
 depexts: [
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "debian"}
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libgtk2.0-dev" "libexpat1-dev"] {os-family = "debian"}
   ["gtk" "expat"] {os-distribution = "homebrew" & os = "macos"}
   ["gtk2-devel"] {os-distribution = "centos"}
   ["gtk2-devel"] {os-distribution = "fedora"}

--- a/packages/lablgtk/lablgtk.2.18.8/opam
+++ b/packages/lablgtk/lablgtk.2.18.8/opam
@@ -24,8 +24,7 @@ depopts: [
   "lablgl"
 ]
 depexts: [
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "debian"}
-  ["libgtk2.0-dev" "libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libgtk2.0-dev" "libexpat1-dev"] {os-family = "debian"}
   ["gtk" "expat"] {os-distribution = "homebrew" & os = "macos"}
   ["gtk2-devel"] {os-distribution = "centos"}
   ["gtk2-devel"] {os-distribution = "fedora"}

--- a/packages/lacaml/lacaml.7.2.1/opam
+++ b/packages/lacaml/lacaml.7.2.1/opam
@@ -33,8 +33,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "debian"}
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "ubuntu"}
+  ["libblas-dev" "liblapack-dev"] {os-family = "debian"}
   ["blas-devel" "lapack-devel"] {os-distribution = "centos"}
 ]
 synopsis: "OCaml-bindings to BLAS and LAPACK"

--- a/packages/lacaml/lacaml.7.2.2/opam
+++ b/packages/lacaml/lacaml.7.2.2/opam
@@ -33,8 +33,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "debian"}
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "ubuntu"}
+  ["libblas-dev" "liblapack-dev"] {os-family = "debian"}
   ["blas-devel" "lapack-devel"] {os-distribution = "centos"}
 ]
 synopsis: "OCaml-bindings to BLAS and LAPACK"

--- a/packages/lacaml/lacaml.7.2.6/opam
+++ b/packages/lacaml/lacaml.7.2.6/opam
@@ -34,8 +34,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "debian"}
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "ubuntu"}
+  ["libblas-dev" "liblapack-dev"] {os-family = "debian"}
   ["blas-devel" "lapack-devel"] {os-distribution = "centos"}
 ]
 synopsis: "OCaml-bindings to BLAS and LAPACK"

--- a/packages/lacaml/lacaml.8.0.4/opam
+++ b/packages/lacaml/lacaml.8.0.4/opam
@@ -34,8 +34,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "debian"}
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "ubuntu"}
+  ["libblas-dev" "liblapack-dev"] {os-family = "debian"}
   ["blas-devel" "lapack-devel"] {os-distribution = "centos"}
 ]
 synopsis: "OCaml-bindings to BLAS and LAPACK"

--- a/packages/lacaml/lacaml.8.0.5/opam
+++ b/packages/lacaml/lacaml.8.0.5/opam
@@ -34,8 +34,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "debian"}
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "ubuntu"}
+  ["libblas-dev" "liblapack-dev"] {os-family = "debian"}
   ["blas-devel" "lapack-devel"] {os-distribution = "centos"}
 ]
 synopsis: "OCaml-bindings to BLAS and LAPACK"

--- a/packages/lacaml/lacaml.8.0.6/opam
+++ b/packages/lacaml/lacaml.8.0.6/opam
@@ -34,8 +34,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "debian"}
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "ubuntu"}
+  ["libblas-dev" "liblapack-dev"] {os-family = "debian"}
   ["blas-devel" "lapack-devel"] {os-distribution = "centos"}
 ]
 synopsis: "OCaml-bindings to BLAS and LAPACK"

--- a/packages/lacaml/lacaml.8.0.7/opam
+++ b/packages/lacaml/lacaml.8.0.7/opam
@@ -34,8 +34,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "debian"}
-  ["libblas-dev" "liblapack-dev"] {os-distribution = "ubuntu"}
+  ["libblas-dev" "liblapack-dev"] {os-family = "debian"}
   ["blas-devel" "lapack-devel"] {os-distribution = "centos"}
 ]
 synopsis: "OCaml-bindings to BLAS and LAPACK"

--- a/packages/libsvm/libsvm.0.9.4/opam
+++ b/packages/libsvm/libsvm.0.9.4/opam
@@ -20,7 +20,7 @@ depends: [
   "lacaml"
   "jbuilder" {build & >= "1.0+beta2"}
 ]
-depexts: ["g++"] {os-distribution = "debian"}
+depexts: ["g++"] {os-family = "debian" & os-distribution != "ubuntu"}
 synopsis: "LIBSVM bindings for OCaml"
 description: """
 LIBSVM-OCaml is an OCaml library with bindings to the LIBSVM library,

--- a/packages/libsvm/libsvm.0.9.4/opam
+++ b/packages/libsvm/libsvm.0.9.4/opam
@@ -19,8 +19,8 @@ depends: [
   "stdio" {< "v0.13"}
   "lacaml"
   "jbuilder" {build & >= "1.0+beta2"}
+  "conf-g++"
 ]
-depexts: ["g++"] {os-family = "debian" & os-distribution != "ubuntu"}
 synopsis: "LIBSVM bindings for OCaml"
 description: """
 LIBSVM-OCaml is an OCaml library with bindings to the LIBSVM library,

--- a/packages/libvhd/libvhd.0.9.0/opam
+++ b/packages/libvhd/libvhd.0.9.0/opam
@@ -18,8 +18,7 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["blktap-dev" "uuid-dev"] {os-distribution = "ubuntu"}
-  ["blktap-dev" "uuid-dev"] {os-distribution = "debian"}
+  ["blktap-dev" "uuid-dev"] {os-family = "debian"}
   ["blktap-devel" "libuuid-devel"] {os-distribution = "centos"}
 ]
 dev-repo: "git://github.com/xen-org/libvhd"

--- a/packages/llvm/llvm.3.4/opam
+++ b/packages/llvm/llvm.3.4/opam
@@ -15,7 +15,7 @@ remove: [
   ["sh" "./compile.sh" "uninstall" "3.4" make prefix lib]
 ]
 depexts: [
-  ["llvm-3.4-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
+  ["llvm-3.4-dev"] {os-family = "debian"}
   ["homebrew/versions/llvm34"] {os = "macos" & os-distribution = "homebrew"}
 ]
 depends: [

--- a/packages/llvm/llvm.3.4/opam
+++ b/packages/llvm/llvm.3.4/opam
@@ -15,7 +15,7 @@ remove: [
   ["sh" "./compile.sh" "uninstall" "3.4" make prefix lib]
 ]
 depexts: [
-  ["llvm-3.4-dev"] {os-distribution = "debian"}
+  ["llvm-3.4-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["homebrew/versions/llvm34"] {os = "macos" & os-distribution = "homebrew"}
 ]
 depends: [

--- a/packages/llvm/llvm.3.5/opam
+++ b/packages/llvm/llvm.3.5/opam
@@ -15,7 +15,7 @@ remove: [
   ["sh" "./compile.sh" "uninstall" "3.5" make prefix lib]
 ]
 depexts: [
-  ["llvm-3.5-dev"] {os-distribution = "debian"}
+  ["llvm-3.5-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["homebrew/versions/llvm35"] {os = "macos" & os-distribution = "homebrew"}
 ]
 depends: [

--- a/packages/llvm/llvm.3.5/opam
+++ b/packages/llvm/llvm.3.5/opam
@@ -15,7 +15,7 @@ remove: [
   ["sh" "./compile.sh" "uninstall" "3.5" make prefix lib]
 ]
 depexts: [
-  ["llvm-3.5-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
+  ["llvm-3.5-dev"] {os-family = "debian"}
   ["homebrew/versions/llvm35"] {os = "macos" & os-distribution = "homebrew"}
 ]
 depends: [

--- a/packages/llvm/llvm.3.6/opam
+++ b/packages/llvm/llvm.3.6/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["llvm-3.6-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
+  ["llvm-3.6-dev"] {os-family = "debian"}
   ["homebrew/versions/llvm36"] {os = "macos" & os-distribution = "homebrew"}
 ]
 available: opam-version >= "1.2"

--- a/packages/llvm/llvm.3.6/opam
+++ b/packages/llvm/llvm.3.6/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["llvm-3.6-dev"] {os-distribution = "debian"}
+  ["llvm-3.6-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["homebrew/versions/llvm36"] {os = "macos" & os-distribution = "homebrew"}
 ]
 available: opam-version >= "1.2"

--- a/packages/llvm/llvm.3.7/opam
+++ b/packages/llvm/llvm.3.7/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["llvm-3.7-dev"] {os-distribution = "debian"}
+  ["llvm-3.7-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["homebrew/versions/llvm37"] {os = "macos" & os-distribution = "homebrew"}
 ]
 available: opam-version >= "1.2"

--- a/packages/llvm/llvm.3.7/opam
+++ b/packages/llvm/llvm.3.7/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["llvm-3.7-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
+  ["llvm-3.7-dev"] {os-family = "debian"}
   ["homebrew/versions/llvm37"] {os = "macos" & os-distribution = "homebrew"}
 ]
 available: opam-version >= "1.2"

--- a/packages/lutin/lutin.2.56/opam
+++ b/packages/lutin/lutin.2.56/opam
@@ -44,8 +44,7 @@ depends: [
 depexts: [
   ["perl" "gmp-dev" "mpfr-dev" "m4"] {os-distribution = "alpine"}
   ["perl" "gmp-devel" "mpfr-devel" "m4"] {os-distribution = "centos"}
-  ["perl" "libgmp-dev" "libmpfr-dev" "m4"] {os-distribution = "debian"}
-  ["perl" "libgmp-dev" "libmpfr-dev" "m4"] {os-distribution = "ubuntu"}
+  ["perl" "libgmp-dev" "libmpfr-dev" "m4"] {os-family = "debian"}
 ]
 post-messages: ["The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/ "]
 synopsis: "Lutin: modeling stochastic reactive systems"

--- a/packages/lutin/lutin.2.70.4/opam
+++ b/packages/lutin/lutin.2.70.4/opam
@@ -46,8 +46,7 @@ post-messages:
 depexts: [
   ["perl" "gmp-dev" "mpfr-dev" "m4"] {os-distribution = "alpine"}
   ["perl" "gmp-devel" "mpfr-devel" "m4"] {os-distribution = "centos"}
-  ["perl" "libgmp-dev" "libmpfr-dev" "m4"] {os-distribution = "debian"}
-  ["perl" "libgmp-dev" "libmpfr-dev" "m4"] {os-distribution = "ubuntu"}
+  ["perl" "libgmp-dev" "libmpfr-dev" "m4"] {os-family = "debian"}
 ]
 dev-repo:
   "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutin.git"

--- a/packages/mariadb/mariadb.1.1.4/opam
+++ b/packages/mariadb/mariadb.1.1.4/opam
@@ -21,8 +21,7 @@ depends: [
   "ctypes-foreign" {>= "0.4.0"}
 ]
 depexts: [
-  ["libmariadb-dev"] {os-distribution = "debian"}
-  ["libmariadb-dev"] {os-distribution = "ubuntu"}
+  ["libmariadb-dev"] {os-family = "debian"}
 ]
 url {
   src: "https://github.com/andrenth/ocaml-mariadb/archive/1.1.4.tar.gz"

--- a/packages/netlink/netlink.0.1.0/opam
+++ b/packages/netlink/netlink.0.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ctypes" {< "0.2.3"} | ("ctypes" {< "0.4.0"} "obuild" {< "0.1.2"})
 ]
 depexts: [
-  ["libnl-3"] {os-distribution = "debian"}
+  ["libnl-3"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["libnl-3-200"] {os-distribution = "ubuntu"}
 ]
 dev-repo: "git://github.com/xapi-project/ocaml-netlink"

--- a/packages/netlink/netlink.0.2.1/opam
+++ b/packages/netlink/netlink.0.2.1/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 available: [ os="linux" ]
 depexts: [
-  ["libnl-3-dev"] {os-distribution = "debian"}
+  ["libnl-3-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["libnl-3-200"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Bindings to the Netlink Protocol Library Suite (libnl)"

--- a/packages/nlopt-ocaml/nlopt-ocaml.0.5.1/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.5.1/opam
@@ -18,8 +18,7 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["libnlopt0" "libnlopt-dev"] {os-distribution = "debian"}
-  ["libnlopt0" "libnlopt-dev"] {os-distribution = "ubuntu"}
+  ["libnlopt0" "libnlopt-dev"] {os-family = "debian"}
   ["nlopt"] {os = "macos" & os-distribution = "homebrew"}
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/ocsfml/ocsfml.2.0/opam
+++ b/packages/ocsfml/ocsfml.2.0/opam
@@ -7,8 +7,7 @@ build: [
 remove: [[make "uninstall"]]
 depends: ["ocaml" "ocamlfind" "ocamlbuild"]
 depexts: [
-  ["cmake" "libboost-dev" "libsfml-dev"] {os-distribution = "debian"}
-  ["cmake" "libboost-dev" "libsfml-dev"] {os-distribution = "ubuntu"}
+  ["cmake" "libboost-dev" "libsfml-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis: "Binding to the C++ SFML gaming library."

--- a/packages/ocsigen-start/ocsigen-start.2.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.0.0/opam
@@ -24,14 +24,10 @@ depends: [
   "conf-npm" {>= "1"}
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
+  ["postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {

--- a/packages/ocsigen-start/ocsigen-start.2.0.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.0.1/opam
@@ -24,14 +24,10 @@ depends: [
   "conf-npm" {>= "1"}
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
+  ["postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {

--- a/packages/ocsigen-start/ocsigen-start.2.2.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.2.2/opam
@@ -26,14 +26,10 @@ depends: [
   "ocamlnet"
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
+  ["postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {

--- a/packages/ocsigen-start/ocsigen-start.2.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.3.0/opam
@@ -27,14 +27,10 @@ depends: [
   "lwt_camlp4"
 ]
 depexts: [
-  ["imagemagick"] {os-distribution = "debian"}
-  ["ruby-sass"] {os-distribution = "debian"}
-  ["postgresql"] {os-distribution = "debian"}
-  ["postgresql-common"] {os-distribution = "debian"}
-  ["imagemagick"] {os-distribution = "ubuntu"}
-  ["ruby-sass"] {os-distribution = "ubuntu"}
-  ["postgresql"] {os-distribution = "ubuntu"}
-  ["postgresql-common"] {os-distribution = "ubuntu"}
+  ["imagemagick"] {os-family = "debian"}
+  ["ruby-sass"] {os-family = "debian"}
+  ["postgresql"] {os-family = "debian"}
+  ["postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {

--- a/packages/opus/opus.0.1.0/opam
+++ b/packages/opus/opus.0.1.0/opam
@@ -11,8 +11,7 @@ depends: [
   "ogg" {< "0.5.0"}
 ]
 depexts: [
-  ["libavutil-dev" "libopus-dev"] {os-distribution = "debian"}
-  ["libavutil-dev" "libopus-dev"] {os-distribution = "ubuntu"}
+  ["libavutil-dev" "libopus-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/opus/opus.0.1.1/opam
+++ b/packages/opus/opus.0.1.1/opam
@@ -20,8 +20,7 @@ install: [
 remove: ["ocamlfind" "remove" "opus"]
 depends: ["ocaml" "ocamlfind" "ogg"]
 depexts: [
-  ["libavutil-dev" "libopus-dev"] {os-distribution = "debian"}
-  ["libavutil-dev" "libopus-dev"] {os-distribution = "ubuntu"}
+  ["libavutil-dev" "libopus-dev"] {os-family = "debian"}
   ["opus"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-opus/issues"

--- a/packages/oqamldebug/oqamldebug.0.9.5/opam
+++ b/packages/oqamldebug/oqamldebug.0.9.5/opam
@@ -11,8 +11,7 @@ build: [
   [ "strip" "oqamldebug" ]
 ]
 depexts: [
-  ["qt4-qmake" "libqt4-dev"] {os-distribution = "debian"}
-  ["qt4-qmake" "libqt4-dev"] {os-distribution = "ubuntu"}
+  ["qt4-qmake" "libqt4-dev"] {os-family = "debian"}
 ]
 synopsis: "Graphical front-end to ocamldebug"
 description: """

--- a/packages/ordma/ordma.0.0.3/opam
+++ b/packages/ordma/ordma.0.0.3/opam
@@ -17,8 +17,7 @@ depends: [
   "lwt_log"
 ]
 depexts: [
-  ["libibverbs-dev" "librdmacm-dev"] {os-distribution = "ubuntu"}
-  ["libibverbs-dev" "librdmacm-dev"] {os-distribution = "debian"}
+  ["libibverbs-dev" "librdmacm-dev"] {os-family = "debian"}
   ["libibverbs-devel" "librdmacm-devel"] {os-distribution = "centos"}
 ]
 available: os = "linux"

--- a/packages/ordma/ordma.0.0.4/opam
+++ b/packages/ordma/ordma.0.0.4/opam
@@ -17,8 +17,7 @@ depends: [
   "lwt_log"
 ]
 depexts: [
-  ["libibverbs-dev" "librdmacm-dev"] {os-distribution = "ubuntu"}
-  ["libibverbs-dev" "librdmacm-dev"] {os-distribution = "debian"}
+  ["libibverbs-dev" "librdmacm-dev"] {os-family = "debian"}
   ["libibverbs-devel" "librdmacm-devel"] {os-distribution = "centos"}
 ]
 available: os = "linux"

--- a/packages/ordma/ordma.0.0.5/opam
+++ b/packages/ordma/ordma.0.0.5/opam
@@ -20,8 +20,7 @@ depends: [
   "cmdliner" {with-test}
 ]
 depexts: [
-  ["libibverbs-dev" "librdmacm-dev"] {os-distribution = "ubuntu"}
-  ["libibverbs-dev" "librdmacm-dev"] {os-distribution = "debian"}
+  ["libibverbs-dev" "librdmacm-dev"] {os-family = "debian"}
   ["libibverbs-devel" "librdmacm-devel"] {os-distribution = "centos"}
 ]
 patches: [

--- a/packages/pci/pci.1.0.0/opam
+++ b/packages/pci/pci.1.0.0/opam
@@ -24,8 +24,7 @@ depends: [
 ]
 available: os = "linux"
 depexts: [
-  ["hwdata" "libpci-dev"] {os-distribution = "debian"}
-  ["hwdata" "libpci-dev"] {os-distribution = "ubuntu"}
+  ["hwdata" "libpci-dev"] {os-family = "debian"}
   ["hwdata" "pciutils-devel"] {os-distribution = "centos"}
 ]
 post-messages: [

--- a/packages/pci/pci.1.0.1/opam
+++ b/packages/pci/pci.1.0.1/opam
@@ -24,8 +24,7 @@ depends: [
 ]
 available: os = "linux"
 depexts: [
-  ["hwdata" "libpci-dev"] {os-distribution = "debian"}
-  ["hwdata" "libpci-dev"] {os-distribution = "ubuntu"}
+  ["hwdata" "libpci-dev"] {os-family = "debian"}
   ["hwdata" "pciutils-devel"] {os-distribution = "centos"}
   ["hwdata" "pciutils-dev"] {os-distribution = "alpine"}
   ["hwdata" "pciutil-devel"] {os-distribution = "fedora"}

--- a/packages/planets/planets.0.1.13/opam
+++ b/packages/planets/planets.0.1.13/opam
@@ -5,8 +5,7 @@ build: [
   [make]
 ]
 depexts: [
-  ["tcl8.5-dev" "tk8.5-dev"] {os-distribution = "debian"}
-  ["tcl8.5-dev" "tk8.5-dev"] {os-distribution = "ubuntu"}
+  ["tcl8.5-dev" "tk8.5-dev"] {os-family = "debian"}
 ]
 install: [make "install" "PREFIX=%{prefix}%"]
 synopsis:

--- a/packages/planets/planets.0.1.14/opam
+++ b/packages/planets/planets.0.1.14/opam
@@ -12,8 +12,7 @@ depends: [
   "labltk"
 ]
 depexts: [
-  ["tcl8.5-dev" "tk8.5-dev"] {os-distribution = "debian"}
-  ["tcl8.5-dev" "tk8.5-dev"] {os-distribution = "ubuntu"}
+  ["tcl8.5-dev" "tk8.5-dev"] {os-family = "debian"}
 ]
 synopsis:
   "A simple interactive program for playing with simulations of planetary systems"

--- a/packages/plist/plist.1.0.0/opam
+++ b/packages/plist/plist.1.0.0/opam
@@ -27,9 +27,7 @@ depends: [
 ]
 depexts: [
   ["gnustep" "gnustep-devel" "gobjc" "gobjc++" "libgnustep-base-dev"]
-    {os-distribution = "debian"}
-  ["gnustep" "gnustep-devel" "gobjc" "gobjc++" "libgnustep-base-dev"]
-    {os-distribution = "ubuntu"}
+    {os-family = "debian"}
 ]
 post-messages: [
   "You need to have gnustep installed, opam depexts can install it for you."

--- a/packages/plplot/plplot.5.11.0/opam
+++ b/packages/plplot/plplot.5.11.0/opam
@@ -24,8 +24,7 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  ["libplplot-dev" "libshp-dev"] {os-distribution = "debian"}
-  ["libplplot-dev" "libshp-dev"] {os-distribution = "ubuntu"}
+  ["libplplot-dev" "libshp-dev"] {os-family = "debian"}
   ["plplot"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Bindings for the PLplot library"

--- a/packages/portaudio/portaudio.0.2.0/opam
+++ b/packages/portaudio/portaudio.0.2.0/opam
@@ -10,8 +10,7 @@ depends: [
   "ocamlfind"
 ]
 depexts: [
-  ["portaudio19-dev" "pkg-config"] {os-distribution = "debian"}
-  ["portaudio19-dev" "pkg-config"] {os-distribution = "ubuntu"}
+  ["portaudio19-dev" "pkg-config"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/protocell/protocell.1.0.0/opam
+++ b/packages/protocell/protocell.1.0.0/opam
@@ -8,9 +8,8 @@ maintainer: "Martin Slota <martin.slota@keemail.me>"
 build: [["dune" "build" "-p" name "-j" jobs]]
 run-test: [["dune" "runtest" "-p" name "-j" jobs]]
 depexts: [
-  ["libprotoc-dev" "protobuf-compiler"] {os-distribution = "debian"}
+  ["libprotoc-dev" "protobuf-compiler"] {os-family = "debian"}
   ["libprotoc-devel" "protobuf-compiler"] {os-distribution = "mageia"}
-  ["libprotoc-dev" "protobuf-compiler"] {os-distribution = "ubuntu"}
   ["protobuf-devel" "protobuf-compiler"] {os-distribution = "centos"}
   ["protobuf-devel" "protobuf-compiler"] {os-distribution = "fedora"}
   ["protobuf-devel" "protobuf-compiler"] {os-distribution = "rhel"}

--- a/packages/qrencode/qrencode.0.1/opam
+++ b/packages/qrencode/qrencode.0.1/opam
@@ -16,8 +16,7 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["libqrencode-dev" "libpng-dev"] {os-distribution = "ubuntu"}
-  ["libqrencode-dev" "libpng-dev"] {os-distribution = "debian"}
+  ["libqrencode-dev" "libpng-dev"] {os-family = "debian"}
 ]
 dev-repo: "git://github.com/vbmithr/qrencode-ocaml"
 install: [make "install"]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.2/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.2/opam
@@ -21,10 +21,9 @@ remove: [
 depends: "conf-pkg-config"
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: [
   "solo5-bindings-spt"

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.3/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.3/opam
@@ -24,10 +24,9 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: [
   "solo5-bindings-spt"

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.2/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.2/opam
@@ -21,16 +21,14 @@ remove: [
 depends: "conf-pkg-config"
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
   ["libseccomp-dev"] {os-distribution = "alpine"}
-  ["libseccomp-dev"] {os-distribution = "debian"}
+  ["libseccomp-dev"] {os-family = "debian"}
   ["libseccomp-devel"] {os-distribution = "fedora"}
   ["libseccomp-devel"] {os-distribution = "rhel"}
   ["libseccomp-devel"] {os-distribution = "suse"}
-  ["libseccomp-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: [
   "solo5-bindings-hvt"

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.3/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.3/opam
@@ -24,10 +24,9 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["linux-libc-dev"] {os-family = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: [
   "solo5-bindings-hvt"

--- a/packages/udunits/udunits.0.1.1/opam
+++ b/packages/udunits/udunits.0.1.1/opam
@@ -19,8 +19,7 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["libudunits2-dev" "libexpat1-dev"] {os-distribution = "debian"}
-  ["libudunits2-dev" "libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libudunits2-dev" "libexpat1-dev"] {os-family = "debian"}
   ["udunits" "expat"] {os = "macos" & os-distribution = "homebrew"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-udunits"

--- a/packages/udunits/udunits.0.2.0/opam
+++ b/packages/udunits/udunits.0.2.0/opam
@@ -19,8 +19,7 @@ depends: [
   "oasis" {build}
 ]
 depexts: [
-  ["libudunits2-dev" "libexpat1-dev"] {os-distribution = "debian"}
-  ["libudunits2-dev" "libexpat1-dev"] {os-distribution = "ubuntu"}
+  ["libudunits2-dev" "libexpat1-dev"] {os-family = "debian"}
   ["udunits" "expat"] {os = "macos" & os-distribution = "homebrew"}
 ]
 dev-repo: "git://github.com/hcarty/ocaml-udunits"

--- a/packages/vchan/vchan.2.0.3/opam
+++ b/packages/vchan/vchan.2.0.3/opam
@@ -41,8 +41,7 @@ conflicts: [
   "mirage-xen" {>= "4.0.0"}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
 ]
 synopsis: "Xen Vchan implementation"
 description: """

--- a/packages/vchan/vchan.2.1.0/opam
+++ b/packages/vchan/vchan.2.1.0/opam
@@ -42,8 +42,7 @@ conflicts: [
   "mirage-xen" {>= "4.0.0"}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
 ]
 synopsis: "Xen Vchan implementation"
 description: """

--- a/packages/vchan/vchan.2.2.0/opam
+++ b/packages/vchan/vchan.2.2.0/opam
@@ -47,8 +47,7 @@ conflicts: [
   "mirage-xen" {>= "4.0.0"}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
 ]
 synopsis: "Xen Vchan implementation"
 description: """

--- a/packages/vchan/vchan.2.3.0/opam
+++ b/packages/vchan/vchan.2.3.0/opam
@@ -58,8 +58,7 @@ conflicts: [
 ]
 
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
 ]
 tags: "org:mirage"
 synopsis: "Xen Vchan implementation"

--- a/packages/vchan/vchan.2.3.1/opam
+++ b/packages/vchan/vchan.2.3.1/opam
@@ -54,8 +54,7 @@ conflicts: [
   "mirage-xen" {>="4.0.0"}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
   ["xenstore"] {os-distribution = "arch"}
 ]
 tags: "org:mirage"

--- a/packages/vhdlib/vhdlib.0.9.1/opam
+++ b/packages/vhdlib/vhdlib.0.9.1/opam
@@ -12,8 +12,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["blktap-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["blktap-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["blktap-dev" "uuid-dev"] {os-family = "debian"}
   ["blktap-devel" "libuuid-devel"] {os-distribution = "centos"}
 ]
 dev-repo: "git://github.com/xapi-project/libvhd"

--- a/packages/voaacenc/voaacenc.0.1.0/opam
+++ b/packages/voaacenc/voaacenc.0.1.0/opam
@@ -7,8 +7,7 @@ build: [
 remove: [["ocamlfind" "remove" "voaacenc"]]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config"]
 depexts: [
-  ["camlidl" "libvo-aacenc-dev"] {os-distribution = "debian"}
-  ["camlidl" "libvo-aacenc-dev"] {os-distribution = "ubuntu"}
+  ["camlidl" "libvo-aacenc-dev"] {os-family = "debian"}
 ]
 install: [make "install"]
 synopsis:

--- a/packages/vorbis/vorbis.0.7.1/opam
+++ b/packages/vorbis/vorbis.0.7.1/opam
@@ -20,8 +20,7 @@ depexts: [
   ["libvorbis-devel"] {os-distribution = "centos"}
   ["libvorbis-devel"] {os-distribution = "fedora"}
   ["libvorbis-devel"] {os-family = "suse"}
-  ["pkg-config" "libvorbis-dev"] {os-distribution = "debian"}
-  ["pkg-config" "libvorbis-dev"] {os-distribution = "ubuntu"}
+  ["pkg-config" "libvorbis-dev"] {os-family = "debian"}
   ["libvorbis"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-vorbis/issues"

--- a/packages/xenctrl/xenctrl.0.10.0/opam
+++ b/packages/xenctrl/xenctrl.0.10.0/opam
@@ -40,8 +40,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
   ["xen-devel" "libuuid-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xen-devel"] {os-distribution = "rhel"}

--- a/packages/xenctrl/xenctrl.0.9.26/opam
+++ b/packages/xenctrl/xenctrl.0.9.26/opam
@@ -21,8 +21,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
 ]

--- a/packages/xenctrl/xenctrl.0.9.29/opam
+++ b/packages/xenctrl/xenctrl.0.9.29/opam
@@ -40,8 +40,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
 ]

--- a/packages/xenctrl/xenctrl.0.9.30/opam
+++ b/packages/xenctrl/xenctrl.0.9.30/opam
@@ -40,8 +40,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
 ]

--- a/packages/xenctrl/xenctrl.0.9.31/opam
+++ b/packages/xenctrl/xenctrl.0.9.31/opam
@@ -40,8 +40,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
 ]

--- a/packages/xenctrl/xenctrl.0.9.32/opam
+++ b/packages/xenctrl/xenctrl.0.9.32/opam
@@ -40,8 +40,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
 ]

--- a/packages/xenstore/xenstore.1.3.0/opam
+++ b/packages/xenstore/xenstore.1.3.0/opam
@@ -26,8 +26,7 @@ depends: [
   "ounit" {build}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
 ]

--- a/packages/xentropyd/xentropyd.0.9.1/opam
+++ b/packages/xentropyd/xentropyd.0.9.1/opam
@@ -28,8 +28,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
 ]

--- a/packages/xentropyd/xentropyd.0.9.3/opam
+++ b/packages/xentropyd/xentropyd.0.9.3/opam
@@ -31,8 +31,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["libxen-dev" "uuid-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
 ]


### PR DESCRIPTION
As discussed in #14906, this fixes the missing `os-family` problem that plagues raspbian-users.

The first commit was automatically generated by a script I made modifying the one by @toots [here](https://github.com/ocaml/opam-repository/pull/14440#issuecomment-508762509) ([my version](https://github.com/ocaml/opam-repository/files/3730078/odeb.txt) with a txt extension because github wanted me to).

The two big differences with toots's code: handling the case where several packages are required and modifying a lot of files inplace.

The second commit is a bunch of calls to `sed`:

```
s/os-distribution = "debian"/os-family = "debian" \& os-distribution != "ubuntu"/
s/ & os-distribution != "ubuntu" | os-distribution = "ubuntu"//

```

Some notes on where I'm not totally sure if this is a bug so I just leave it here just in case:
 * In `conf-efl.1.8`, the constraint on `debian` adds a constraint on `linux`. This might not work on `debian/kfreebsd` and maybe we should discourage that kind of pattern. (ping @axiles)
 * In `frama-c.10.0`, a conflict is noted on `debian`, there is no mention of `ubuntu` (and I excluded it to maintain behavior). (ping @bobot)
 * In several packages (take for example `bwrap.0.1`), there are constraints for some version(s) of `ubuntu` but no failure if on `ubuntu` but the version constraint fails. This is probably a bug.

Needless to say, testing that kind of constraints will be added to opam-lint shortly (ahem @AltGr).

@kit-ty-kate any thoughts?