### PR TITLE
[new release] tcpip (3.7.9)

### DIFF
--- a/packages/tcpip/tcpip.3.7.9/opam
+++ b/packages/tcpip/tcpip.3.7.9/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs]
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depopts: ["mirage-xen-ocaml"]
+depends: [
+  "dune"     {>= "1.0"}
+  "ocaml" {>= "4.03.0"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {>= "3.2.0"}
+  "cstruct-lwt"
+  "mirage-net-lwt" {>= "2.0.0"}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-protocols" {>= "3.1.0"}
+  "mirage-protocols-lwt" {>= "3.1.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv"
+  "ethernet" {>= "2.0.0"}
+  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-vnetif" {with-test & >= "0.4.0"}
+  "alcotest" {with-test & >="0.7.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-random-test" {with-test}
+  "arp-mirage" {with-test & >= "2.0.0"}
+  "lru" {>= "0.3.0"}
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v3.7.9/tcpip-v3.7.9.tbz"
+  checksum: [
+    "sha256=aded8f3c475054d761b892784774e9c5dd07a52505480b58707c225e37508459"
+    "sha512=fc807823f78c60adf4689563a677faebde032c87770c1f881a5ea7709fd5c7fbcf7cbc0a73666c60faafb474d132317f289ee27e890cde25d33f2a5a08f0659b"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Add ?ttl:int parameter to Udp and Icmp write (mirage/mirage-tcpip#416 @phaer)
* Ipv4.Fragments use a Lru.M.t instead of Lru.F.t (mirage/mirage-tcpip#418 @hannesm)
* Adapt to mirage-protocols 3.1.0 changes (mirage/mirage-tcpip#419 @hannesm)
  - removed IP.set_ip
  - added `Would_fragment to Ip.error