### PR TITLE
[new release] markdown (0.2.1)

### DIFF
--- a/packages/markdown/markdown.0.2.1/opam
+++ b/packages/markdown/markdown.0.2.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" "Mauricio Fernandez" ]
+license: "MIT"
+homepage: "https://github.com/gildor478/ocaml-markdown"
+dev-repo: "git+https://github.com/gildor478/ocaml-markdown.git"
+bug-reports: "https://github.com/gildor478/ocaml-markdown/issues"
+doc: "https://gildor478.github.io/ocaml-markdown/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs
+   "@install"
+   "@doc" {with-doc}
+   "@runtest" {with-test}]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.11.0"}
+  "ounit2" {with-test & > "2.0.8"}
+  "batteries" {>= "2.10.0"}
+  "tyxml" {>= "4.3.0"}
+]
+conflicts: [
+  "ocaml-markdown"
+]
+synopsis: "Markdown processor for Ocsigen"
+description:"""
+This is a pure OCaml parser for Markdown files. It was originally written for
+Ocsigen but may be useful in other contexts too.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-markdown/releases/download/v0.2.1/markdown-v0.2.1.tbz"
+  checksum: [
+    "sha256=9c575b74ad14229ab089819a348a1a8f453023bfcf1c20ebc5fc47343623de5e"
+    "sha512=98e42acfb09026670adad6cf4efb531f06854a9b2035cbac2c4a824037a0b08d4fe4fe3b661759983bb202882d3acd73bac0c6631ed34ac35f588f0a4817341e"
+  ]
+}

--- a/packages/markdown/markdown.0.2.1/opam
+++ b/packages/markdown/markdown.0.2.1/opam
@@ -20,7 +20,7 @@ depends: [
   "tyxml" {>= "4.3.0"}
 ]
 conflicts: [
-  "ocaml-markdown"
+  "ocaml-markdown" {!= "transition"}
 ]
 synopsis: "Markdown processor for Ocsigen"
 description:"""

--- a/packages/ocaml-markdown/ocaml-markdown.transition/opam
+++ b/packages/ocaml-markdown/ocaml-markdown.transition/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" "Mauricio Fernandez" ]
+license: "MIT"
+homepage: "https://github.com/gildor478/ocaml-markdown"
+dev-repo: "git+https://github.com/gildor478/ocaml-markdown.git"
+bug-reports: "https://github.com/gildor478/ocaml-markdown/issues"
+depends: [ "ocaml" "markdown" ]
+synopsis: "This is a transition package, ocaml-markdown is now named markdown."
+Description:"""
+Use package markdown instead.
+"""


### PR DESCRIPTION
Markdown processor for Ocsigen

This was the package "ocaml-markdown" that has migrated to markdown, to be consistent with the findlib package name.

- Project page: <a href="https://github.com/gildor478/ocaml-markdown">https://github.com/gildor478/ocaml-markdown</a>
- Documentation: <a href="https://gildor478.github.io/ocaml-markdown/">https://gildor478.github.io/ocaml-markdown/</a>

##### CHANGES:

### Fixed
- URL for homepage.
