### PR TITLE
[new release] debian-formats (0.1.2)

### DIFF
--- a/packages/debian-formats/debian-formats.0.1.2/opam
+++ b/packages/debian-formats/debian-formats.0.1.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-debian-formats"
+dev-repo: "git+https://github.com/gildor478/ocaml-debian-formats.git"
+bug-reports: "https://github.com/gildor478/ocaml-debian-formats/issues"
+doc: "https://gildor478.github.io/ocaml-debian-formats/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs
+   "@install"
+   "@doc" {with-doc}
+   "@runtest" {with-test} ]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.11.0"}
+  "re" {>= "1.8.0"}
+  "extlib"
+  "ounit2" {with-test & > "2.0.8"}
+]
+synopsis: "Parse debian files"
+description:"""
+This library allows to parse various files used in Debian packaging:
+* changelog files
+* source and binary control files
+* watch files
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-debian-formats/releases/download/v0.1.2/debian-formats-v0.1.2.tbz"
+  checksum: [
+    "sha256=927713b273e76d15950e805713444c987fe246683a1e44c074dd496b72d49d04"
+    "sha512=1125cd369b3b619b01145e4453ff7fa5ec836be21545e1dabc376e5f0b0ec0ae802a116e48cca18e17ea8c527f52ba42c06355cb85fbe262e74ac5c5d9c64eca"
+  ]
+}


### PR DESCRIPTION
Parse debian files

- Project page: <a href="https://github.com/gildor478/ocaml-debian-formats">https://github.com/gildor478/ocaml-debian-formats</a>
- Documentation: <a href="https://gildor478.github.io/ocaml-debian-formats/">https://gildor478.github.io/ocaml-debian-formats/</a>

##### CHANGES:

### Changed
- Migrate to dune (Closes: gildor478/ocaml-debian-formats#2)
