### PR TITLE
coqide8.10.0: use parallel build patch from coq8.10.0

### DIFF
--- a/packages/coqide/coqide.8.10.0/files/fix-parallel-make.patch
+++ b/packages/coqide/coqide.8.10.0/files/fix-parallel-make.patch
@@ -1,0 +1,72 @@
+commit d25990e2da7e5e84034b927cdab9ea4019c56a30
+Author: Enrico Tassi <Enrico.Tassi@inria.fr>
+Date:   Fri Oct 11 13:43:20 2019 +0200
+
+    [make] separate generated gramlib ml files from mli files (fix #10864)
+
+    (cherry picked from commit b0210638366d6584b709496b0f0eeeecb17c3fae)
+
+diff --git a/Makefile b/Makefile
+index 2b5d2cea16..74b23f97aa 100644
+--- a/Makefile
++++ b/Makefile
+@@ -101,15 +101,18 @@ EXISTINGMLI := $(call find, '*.mli')
+ 
+ ## Files that will be generated
+ 
+-GENMLGFILES:= $(MLGFILES:.mlg=.ml)
+ # GRAMFILES must be in linking order
+ GRAMFILES=$(addprefix gramlib/.pack/gramlib__,Ploc Plexing Gramext Grammar)
+-GRAMMLFILES := $(addsuffix .ml, $(GRAMFILES)) $(addsuffix .mli, $(GRAMFILES))
+-GENGRAMFILES := $(GRAMMLFILES) gramlib/.pack/gramlib.ml
+-GENMLFILES:=$(LEXFILES:.mll=.ml) $(YACCFILES:.mly=.ml) $(GENMLGFILES)  ide/coqide_os_specific.ml kernel/copcodes.ml kernel/uint63.ml
++GRAMMLFILES := $(addsuffix .ml, $(GRAMFILES))
++GRAMMLIFILES := $(addsuffix .mli, $(GRAMFILES))
++GENGRAMMLFILES := $(GRAMMLFILES) gramlib/.pack/gramlib.ml # why is gramlib.ml not in GRAMMLFILES?
++
++GENMLGFILES:= $(MLGFILES:.mlg=.ml)
++GENMLFILES:=$(LEXFILES:.mll=.ml) $(YACCFILES:.mly=.ml) $(GENMLGFILES) $(GENGRAMMLFILES) ide/coqide_os_specific.ml kernel/copcodes.ml kernel/uint63.ml
++GENMLIFILES:=$(GRAMMLIFILES)
+ GENHFILES:=kernel/byterun/coq_instruct.h kernel/byterun/coq_jumptbl.h
+ GENFILES:=$(GENMLFILES) $(GENMLIFILES) $(GENHFILES)
+-COQ_EXPORTED += GRAMFILES GRAMMLFILES GENGRAMFILES GENMLFILES GENHFILES GENFILES
++COQ_EXPORTED += GRAMFILES GRAMMLFILES GRAMMLIFILES GENMLFILES GENHFILES GENFILES
+ 
+ ## More complex file lists
+ 
+diff --git a/Makefile.build b/Makefile.build
+index 47f1b02c6e..4fbd4bfffd 100644
+--- a/Makefile.build
++++ b/Makefile.build
+@@ -779,9 +779,9 @@ OCAMLDEP = $(OCAMLFIND) ocamldep -slash -ml-synonym .mlpack
+ MAINMLFILES := $(filter-out gramlib/.pack/% checker/% plugins/%, $(MLFILES) $(MLIFILES))
+ MAINMLLIBFILES := $(filter-out gramlib/.pack/% checker/% plugins/%, $(MLLIBFILES) $(MLPACKFILES))
+ 
+-$(MLDFILE).d: $(D_DEPEND_BEFORE_SRC) $(MAINMLFILES) $(D_DEPEND_AFTER_SRC) $(GENFILES) $(GENGRAMFILES)
++$(MLDFILE).d: $(D_DEPEND_BEFORE_SRC) $(MAINMLFILES) $(D_DEPEND_AFTER_SRC) $(GENFILES)
+ 	$(SHOW)'OCAMLDEP  MLFILES MLIFILES'
+-	$(HIDE)$(OCAMLDEP) $(DEPFLAGS)  -passrest $(MAINMLFILES) -open Gramlib $(GRAMMLFILES) $(TOTARGET)
++	$(HIDE)$(OCAMLDEP) $(DEPFLAGS)  -passrest $(MAINMLFILES) -open Gramlib $(GRAMMLFILES) $(GRAMMLIFILES) $(TOTARGET)
+ #NB: -passrest is needed to avoid ocamlfind reordering the -open Gramlib
+ 
+ $(MLLIBDFILE).d: $(D_DEPEND_BEFORE_SRC) $(MAINMLLIBFILES) $(D_DEPEND_AFTER_SRC) $(OCAMLLIBDEP) $(GENFILES)
+diff --git a/Makefile.install b/Makefile.install
+index 5b5e548f9c..51017b7c3a 100644
+--- a/Makefile.install
++++ b/Makefile.install
+@@ -92,13 +92,13 @@ install-tools:
+ 
+ INSTALLCMI = $(sort \
+ 	$(filter-out checker/% ide/% tools/%, $(MLIFILES:.mli=.cmi)) \
+-	$(filter %.cmi, $(GRAMMLFILES:.mli=.cmi)) gramlib/.pack/gramlib.cmi \
++	$(GRAMMLIFILES:.mli=.cmi) gramlib/.pack/gramlib.cmi \
+ 	$(foreach lib,$(CORECMA), $(addsuffix .cmi,$($(lib:.cma=_MLLIB_DEPENDENCIES))))) \
+ 	$(PLUGINS:.cmo=.cmi)
+ 
+ INSTALLCMX = $(sort $(filter-out checker/% ide/% tools/% dev/% \
+ 	configure.cmx toplevel/coqtop_byte_bin.cmx plugins/extraction/big.cmx, \
+-	$(filter %.cmx, $(GRAMMLFILES:.ml=.cmx)) $(MLFILES:.ml=.cmx)))
++	$(GRAMMLFILES:.ml=.cmx) $(MLFILES:.ml=.cmx)))
+ 
+ install-devfiles:
+ 	$(MKDIR) $(FULLBINDIR)

--- a/packages/coqide/coqide.8.10.0/opam
+++ b/packages/coqide/coqide.8.10.0/opam
@@ -33,8 +33,11 @@ install: [
   "install-ide-info"
   "install-ide-devfiles"
 ]
+patches: ["fix-parallel-make.patch"]
+
 extra-files: [
   ["coqide.install" "sha512=0c59f0c3cf3453e92c02b29aceb31090020410d2b0dd2856172cd19b1b2b58b2a1d46047fb08a9c1d4767d87934c73ae6adfcb4204b1ea6a55a85ba75b2b812d"]
+  ["fix-parallel-make.patch" "sha512=3801156db1d95bf35948599f366775afff72bbeef958e73321b1f9627220ef7ca61b402c478374f31a23db0f4394bafca5fa56c0708dfad589cad85bfa20d526"]
 ]
 
 url {

--- a/packages/coqide/coqide.8.10.0/opam
+++ b/packages/coqide/coqide.8.10.0/opam
@@ -33,7 +33,9 @@ install: [
   "install-ide-info"
   "install-ide-devfiles"
 ]
-extra-files: ["coqide.install" "md5=d005cda8cb7888fbea94c5416dcb31bc"]
+extra-files: [
+  ["coqide.install" "sha512=0c59f0c3cf3453e92c02b29aceb31090020410d2b0dd2856172cd19b1b2b58b2a1d46047fb08a9c1d4767d87934c73ae6adfcb4204b1ea6a55a85ba75b2b812d"]
+]
 
 url {
   src: "https://github.com/coq/coq/archive/V8.10.0.tar.gz"


### PR DESCRIPTION
Fix #15070.
Apparently, building coqide builds enough of coq that this patch is needed;
this is confirmed by the verbose build log.