### PR TITLE
Patch JS packages for upcoming dune 2

### DIFF
--- a/packages/patdiff/patdiff.v0.12.1/opam
+++ b/packages/patdiff/patdiff.v0.12.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/patdiff"
+bug-reports: "https://github.com/janestreet/patdiff/issues"
+dev-repo: "git+https://github.com/janestreet/patdiff.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/patdiff/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"               {>= "4.07.0"}
+  "core"                {>= "v0.12" & < "v0.13"}
+  "core_extended"       {>= "v0.12" & < "v0.13"}
+  "expect_test_helpers" {>= "v0.12" & < "v0.13"}
+  "patience_diff"       {>= "v0.12" & < "v0.13"}
+  "ppx_jane"            {>= "v0.12" & < "v0.13"}
+  "sexplib"             {>= "v0.12" & < "v0.13"}
+  "shell"               {>= "v0.12" & < "v0.13"}
+  "dune"                {>= "1.5.1"}
+  "pcre"
+  "re"                  {>= "1.8.0"}
+]
+synopsis: "File Diff using the Patience Diff algorithm"
+description: "
+"
+url {
+  src: "https://github.com/janestreet/patdiff/archive/v0.12.1.tar.gz"
+  checksum: "md5=ff1f479dc9f19da583318e6fbaa3786f"
+}

--- a/packages/re2/re2.v0.12.1/opam
+++ b/packages/re2/re2.v0.12.1/opam
@@ -14,6 +14,7 @@ depends: [
   "core_kernel" {>= "v0.12" & < "v0.13"}
   "ppx_jane"    {>= "v0.12" & < "v0.13"}
   "dune"        {>= "1.5.1"}
+  "conf-g++" {build}
 ]
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
 description: "

--- a/packages/re2/re2.v0.12.1/opam
+++ b/packages/re2/re2.v0.12.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/re2"
+bug-reports: "https://github.com/janestreet/re2/issues"
+dev-repo: "git+https://github.com/janestreet/re2.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/re2/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
+  "ppx_jane"    {>= "v0.12" & < "v0.13"}
+  "dune"        {>= "1.5.1"}
+]
+synopsis: "OCaml bindings for RE2, Google's regular expression library"
+description: "
+"
+depexts: [
+ ["gcc-c++"] {os-distribution = "fedora"}
+ ["gcc-c++"] {os-distribution = "ol"}
+]
+url {
+  src: "https://github.com/janestreet/re2/archive/v0.12.1.tar.gz"
+  checksum: "md5=6fcc8aa488f7888d358c773c359e7345"
+}

--- a/packages/re2/re2.v0.12.1/opam
+++ b/packages/re2/re2.v0.12.1/opam
@@ -17,12 +17,6 @@ depends: [
   "conf-g++" {build}
 ]
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
-description: "
-"
-depexts: [
- ["gcc-c++"] {os-distribution = "fedora"}
- ["gcc-c++"] {os-distribution = "ol"}
-]
 url {
   src: "https://github.com/janestreet/re2/archive/v0.12.1.tar.gz"
   checksum: "md5=6fcc8aa488f7888d358c773c359e7345"

--- a/packages/zstandard/zstandard.v0.12.1/opam
+++ b/packages/zstandard/zstandard.v0.12.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/zstandard"
+bug-reports: "https://github.com/janestreet/zstandard/issues"
+dev-repo: "git+https://github.com/janestreet/zstandard.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/zstandard/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
+  "ppx_jane"    {>= "v0.12" & < "v0.13"}
+  "conf-zstd"   {= "1.3.8"}
+  "ctypes"
+  "dune"        {>= "1.5.1"}
+]
+synopsis: "OCaml bindings to Zstandard"
+description: "
+Zstandard is a real-time compression algorithm which provides high compression ratios.
+"
+url {
+  src: "https://github.com/janestreet/zstandard/archive/v0.12.1.tar.gz"
+  checksum: "md5=3fa14dbe928320e26b05df31e7ed0e8a"
+}


### PR DESCRIPTION
The upcoming dune 2 will feature a few breaking changes,
that will affect Jane Street packages. This pull request updates:

- `patdiff` by adding a `(modules_without_implementation ...)` stanza;
- `re2` and `zstandard` by adding a `(mode fallback)` stanza.