### PR TITLE
session <= 3.2: add upper bound on lwt

### DIFF
--- a/packages/session/session.0.1.0/opam
+++ b/packages/session/session.0.1.0/opam
@@ -32,14 +32,15 @@ depends: [
   "result"
 ]
 depopts: [
-  "async" {< "v0.13"}
+  "async"
   "base-threads"
   "cohttp"
-  "lwt" {< "4.0.0"}
+  "lwt"
   "postgresql"
   "webmachine"
 ]
 conflicts: [
+  "lwt" {>= "4.0.0"}
   "cohttp" {>= "0.99.0"}
 ]
 synopsis: "A session manager for your everyday needs"

--- a/packages/session/session.0.1.0/opam
+++ b/packages/session/session.0.1.0/opam
@@ -35,7 +35,7 @@ depopts: [
   "async" {< "v0.13"}
   "base-threads"
   "cohttp"
-  "lwt"
+  "lwt" {< "4.0.0"}
   "postgresql"
   "webmachine"
 ]

--- a/packages/session/session.0.2.0/opam
+++ b/packages/session/session.0.2.0/opam
@@ -49,7 +49,7 @@ depopts: [
   "async" {< "v0.13"}
   "base-threads"
   "cohttp"
-  "lwt"
+  "lwt" {< "4.0.0"}
   "postgresql"
   "webmachine"
 ]

--- a/packages/session/session.0.2.0/opam
+++ b/packages/session/session.0.2.0/opam
@@ -46,14 +46,15 @@ depends: [
   "result"
 ]
 depopts: [
-  "async" {< "v0.13"}
+  "async"
   "base-threads"
   "cohttp"
-  "lwt" {< "4.0.0"}
+  "lwt"
   "postgresql"
   "webmachine"
 ]
 conflicts: [
+  "lwt" {>= "4.0.0"}
   "cohttp" {>= "0.99.0"}
 ]
 synopsis: "A session manager for your everyday needs"

--- a/packages/session/session.0.3.0/opam
+++ b/packages/session/session.0.3.0/opam
@@ -49,16 +49,17 @@ depends: [
   "result"
 ]
 depopts: [
-  "async" {< "v0.13"}
+  "async"
   "base-threads"
   "cohttp"
-  "lwt" {< "4.0.0"}
+  "lwt"
   "postgresql"
   "redis"
   "webmachine"
 ]
 conflicts: [
-  "redis" {>="0.3.4"}
+  "lwt" {>= "4.0.0"}
+  "redis" {>= "0.3.4"}
   "cohttp" {>= "0.99.0"}
 ]
 synopsis: "A session manager for your everyday needs"

--- a/packages/session/session.0.3.0/opam
+++ b/packages/session/session.0.3.0/opam
@@ -52,7 +52,7 @@ depopts: [
   "async" {< "v0.13"}
   "base-threads"
   "cohttp"
-  "lwt"
+  "lwt" {< "4.0.0"}
   "postgresql"
   "redis"
   "webmachine"

--- a/packages/session/session.0.3.2/opam
+++ b/packages/session/session.0.3.2/opam
@@ -68,6 +68,7 @@ depopts: [
 ]
 conflicts: [
   "cohttp" {>= "0.99.0"}
+  "lwt" {>= "4.0.0"}
 ]
 synopsis: "A session manager for your everyday needs"
 description: """

--- a/packages/session/session.0.3.2/opam
+++ b/packages/session/session.0.3.2/opam
@@ -49,7 +49,7 @@ depends: [
   "result"
 ]
 depopts: [
-  "async" {< "v0.13"}
+  "async"
   "base-threads"
   "cohttp"
   "postgresql"


### PR DESCRIPTION
Should fix some of the failures in https://github.com/ocaml/opam-repository/pull/15043
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>