### PR TITLE
prepare for next mirage-types release

### DIFF
--- a/packages/arp-mirage/arp-mirage.1.0.0/opam
+++ b/packages/arp-mirage/arp-mirage.1.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-vnetif" {with-test}
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}
-  "mirage-random" {with-test}
+  "mirage-random" {with-test & < "2.0.0"}
   "mirage-random-test" {with-test}
   "mirage-unix" {with-test}
 ]

--- a/packages/arp-mirage/arp-mirage.2.0.0/opam
+++ b/packages/arp-mirage/arp-mirage.2.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-vnetif" {with-test}
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}
-  "mirage-random" {with-test}
+  "mirage-random" {with-test & < "2.0.0"}
   "mirage-random-test" {with-test}
   "mirage-unix" {with-test}
 ]

--- a/packages/arp-mirage/arp-mirage.2.1.0/opam
+++ b/packages/arp-mirage/arp-mirage.2.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-vnetif" {with-test}
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}
-  "mirage-random" {with-test}
+  "mirage-random" {with-test & < "2.0.0"}
   "mirage-random-test" {with-test}
   "mirage-unix" {with-test}
 ]

--- a/packages/arp/arp.1.0.0/opam
+++ b/packages/arp/arp.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ipaddr" {>= "3.0.0" & < "4.0.0"}
   "macaddr" {< "4.0.0"}
   "logs"
-  "mirage-random" {with-test}
+  "mirage-random" {with-test & < "2.0.0"}
   "mirage-random-test" {with-test}
   "bisect_ppx" {with-test}
   "alcotest" {with-test}

--- a/packages/arp/arp.2.0.0/opam
+++ b/packages/arp/arp.2.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ipaddr" {>= "3.0.0" & < "4.0.0"}
   "macaddr" {< "4.0.0"}
   "logs"
-  "mirage-random" {with-test}
+  "mirage-random" {with-test & < "2.0.0"}
   "mirage-random-test" {with-test}
   "bisect_ppx" {with-test}
   "alcotest" {with-test}

--- a/packages/arp/arp.2.1.0/opam
+++ b/packages/arp/arp.2.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ipaddr" {>= "4.0.0"}
   "macaddr" {>= "4.0.0"}
   "logs"
-  "mirage-random" {with-test}
+  "mirage-random" {with-test & < "2.0.0"}
   "mirage-random-test" {with-test}
   "bisect_ppx" {with-test}
   "alcotest" {with-test}

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.2/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.2/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-flow-lwt"
   "tls" {>= "0.8.0" & < "0.9.0"}
   "mirage-kv-lwt" {< "2.0.0"}
-  "mirage-clock"
+  "mirage-clock" {< "3.0.0"}
   "base64" {< "3.0.0"}
   "uri" {>= "1.6.0"}
   "jbuilder" {build & >= "1.0+beta10"}

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.1/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.1/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-flow-lwt"
   "tls" {>= "0.8.0"}
   "mirage-kv-lwt" {< "2.0.0"}
-  "mirage-clock"
+  "mirage-clock" {< "3.0.0"}
   "base64" {< "3.0.0"}
   "uri" {>= "1.6.0"}
   "ptime"

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.2/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.2/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-flow-lwt"
   "tls" {>= "0.8.0"}
   "mirage-kv-lwt"
-  "mirage-clock"
+  "mirage-clock" {< "3.0.0"}
   "base64" {>= "3.0.0"}
   "uri" {>= "1.6.0"}
   "ptime"

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.3/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.3/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-flow-lwt"
   "tls" {>= "0.8.0"}
   "mirage-kv-lwt"
-  "mirage-clock"
+  "mirage-clock" {< "3.0.0"}
   "base64" {>= "3.0.0"}
   "uri" {>= "1.6.0"}
   "ptime"

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-flow-lwt"
   "tls" {>= "0.8.0" & < "0.9.0"}
   "mirage-kv-lwt" {< "2.0.0"}
-  "mirage-clock"
+  "mirage-clock" {< "3.0.0"}
   "base64" {< "3.0.0"}
   "uri" {>= "1.6.0"}
   "jbuilder" {build & >= "1.0+beta10"}

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.4.0/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.4.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-flow-lwt"
   "tls" {>= "0.8.0"}
   "mirage-kv-lwt"
-  "mirage-clock"
+  "mirage-clock" {< "3.0.0"}
   "base64" {>= "3.0.0"}
   "uri" {>= "1.6.0"}
   "ptime"

--- a/packages/charrua-client-lwt/charrua-client-lwt.0.10/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.10/opam
@@ -30,7 +30,7 @@ depends: [
   "tcpip" {>= "3.2.0" & < "3.6.0"}
   "fmt"
   "lwt"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
 ]
 synopsis: "DHCP - a DHCP client, server and wire frame encoder and decoder"
 description: """

--- a/packages/charrua-client-lwt/charrua-client-lwt.0.11.0/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.11.0/opam
@@ -16,21 +16,21 @@ build: [
 depends: [
   "jbuilder" {build & >= "1.0+beta9"}
   "ocaml" {>= "4.04.2"}
-  "alcotest"     {with-test}
+  "alcotest" {with-test}
   "cstruct-unix" {with-test}
   "charrua-core" {>= "0.11.0" & < "0.12.0"}
   "charrua-client" {>= "0.11.0" & < "0.12.0"}
-  "cstruct" {>="3.0.2"}
+  "cstruct" {>= "3.0.2"}
   "ipaddr" {< "3.0.0"}
   "rresult"
-  "mirage-random" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "duration"
   "mirage-time-lwt"
   "logs"
   "tcpip" {>= "3.2.0" & < "3.6.0"}
   "fmt"
   "lwt"
-  "mirage-types-lwt" {>="3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
 ]
 synopsis: "A DHCP client using lwt as effectful layer"
 description: """

--- a/packages/charrua-client-lwt/charrua-client-lwt.0.11.1/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.11.1/opam
@@ -23,7 +23,7 @@ depends: [
   "cstruct" {>= "3.0.2"}
   "ipaddr" {>= "3.0.0"}
   "rresult"
-  "mirage-random" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "duration"
   "mirage-time-lwt"
   "mirage-net-lwt" {< "2.0.0"}

--- a/packages/charrua-client-lwt/charrua-client-lwt.0.11.2/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.11.2/opam
@@ -23,7 +23,7 @@ depends: [
   "cstruct" {>= "3.0.2"}
   "ipaddr" {>= "3.0.0"}
   "rresult"
-  "mirage-random" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "duration"
   "mirage-time-lwt"
   "mirage-net-lwt" {< "2.0.0"}

--- a/packages/charrua-client-lwt/charrua-client-lwt.0.12.0/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.12.0/opam
@@ -16,13 +16,13 @@ build: [
 depends: [
   "dune" {>= "1.0"}
   "ocaml" {>= "4.04.2"}
-  "alcotest"     {with-test}
+  "alcotest" {with-test}
   "cstruct-unix" {with-test}
   "charrua-core" {>= "0.12.0"}
   "charrua-client" {>= "0.12.0"}
-  "cstruct" {>="3.0.2"}
-  "ipaddr" {>="3.0.0"}
-  "mirage-random" {>= "1.0.0"}
+  "cstruct" {>= "3.0.2"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "duration"
   "mirage-time-lwt"
   "mirage-net-lwt" {>= "2.0.0"}

--- a/packages/charrua-client-lwt/charrua-client-lwt.0.9/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.9/opam
@@ -31,7 +31,7 @@ depends: [
   "tcpip" {>= "3.2.0" & < "3.6.0"}
   "fmt"
   "lwt"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
 ]
 synopsis: "DHCP - a DHCP client, server and wire frame encoder and decoder"
 description: """

--- a/packages/charrua-client-lwt/charrua-client-lwt.1.0.0/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.1.0.0/opam
@@ -16,13 +16,13 @@ build: [
 depends: [
   "dune" {>= "1.0"}
   "ocaml" {>= "4.04.2"}
-  "alcotest"     {with-test}
+  "alcotest" {with-test}
   "cstruct-unix" {with-test}
-  "charrua" {>= "1.0.0" & <"1.1.0"}
+  "charrua" {>= "1.0.0" & < "1.1.0"}
   "charrua-client" {>= "1.0.0" & < "1.1.0"}
-  "cstruct" {>="3.0.2"}
-  "ipaddr" {>="3.0.0"}
-  "mirage-random" {>= "1.0.0"}
+  "cstruct" {>= "3.0.2"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "duration"
   "mirage-time-lwt"
   "mirage-net-lwt" {>= "2.0.0"}

--- a/packages/charrua-client-lwt/charrua-client-lwt.1.1.0/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.1.1.0/opam
@@ -16,13 +16,13 @@ build: [
 depends: [
   "dune" {>= "1.2"}
   "ocaml" {>= "4.04.2"}
-  "alcotest"     {with-test}
+  "alcotest" {with-test}
   "cstruct-unix" {with-test}
   "charrua" {= version}
   "charrua-client" {= version}
-  "cstruct" {>="3.0.2"}
-  "ipaddr" {>="3.0.0"}
-  "mirage-random" {>= "1.0.0"}
+  "cstruct" {>= "3.0.2"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "duration"
   "mirage-time-lwt"
   "mirage-net-lwt" {>= "2.0.0"}

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.10/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.10/opam
@@ -24,13 +24,13 @@ depends: [
   "ipaddr"
   "rresult"
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
-  "mirage-clock"
+  "mirage-clock" {< "3.0.0"}
   "duration"
   "logs"
   "tcpip" {>= "3.5.0" & < "3.6.0"}
   "fmt"
   "lwt"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
 ]
 synopsis: "DHCP - a DHCP client, server and wire frame encoder and decoder"
 description: """

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.11.0/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.11.0/opam
@@ -18,17 +18,17 @@ depends: [
   "charrua-core" {>= "0.11.0" & < "0.12.0"}
   "charrua-client-lwt" {>= "0.11.0" & < "0.12.0"}
   "charrua-client" {>= "0.11.0" & < "0.12.0"}
-  "cstruct" {>="3.0.2"}
+  "cstruct" {>= "3.0.2"}
   "ipaddr"
   "rresult"
-  "mirage-random" {>= "1.0.0"}
-  "mirage-clock"
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-clock" {< "3.0.0"}
   "duration"
   "logs"
   "tcpip" {>= "3.5.0" & < "3.6.0"}
   "fmt"
   "lwt"
-  "mirage-types-lwt" {>="3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
 ]
 synopsis: "A DHCP client for MirageOS"
 description: """

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.11.1/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.11.1/opam
@@ -21,8 +21,8 @@ depends: [
   "cstruct" {>= "3.0.2"}
   "ipaddr" {>= "3.0.0"}
   "rresult"
-  "mirage-random" {>= "1.0.0"}
-  "mirage-clock"
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-clock" {< "3.0.0"}
   "mirage-time-lwt"
   "mirage-net-lwt" {< "2.0.0"}
   "mirage-protocols-lwt" {< "2.0.0"}

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.11.2/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.11.2/opam
@@ -21,8 +21,8 @@ depends: [
   "cstruct" {>= "3.0.2"}
   "ipaddr" {>= "3.0.0"}
   "rresult"
-  "mirage-random" {>= "1.0.0"}
-  "mirage-clock"
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-clock" {< "3.0.0"}
   "mirage-time-lwt"
   "mirage-net-lwt" {< "2.0.0"}
   "mirage-protocols-lwt" {< "2.0.0"}

--- a/packages/charrua-client-mirage/charrua-client-mirage.0.12.0/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.0.12.0/opam
@@ -17,8 +17,8 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "charrua-client-lwt" {>= "0.12.0"}
   "ipaddr" {>= "3.0.0"}
-  "mirage-random" {>= "1.0.0"}
-  "mirage-clock"
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-clock" {< "3.0.0"}
   "mirage-time-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
   "mirage-protocols-lwt" {>= "2.0.0"}

--- a/packages/charrua-client-mirage/charrua-client-mirage.1.0.0/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.1.0.0/opam
@@ -17,8 +17,8 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "charrua-client-lwt" {>= "1.0.0" & < "1.1.0"}
   "ipaddr" {>= "3.0.0"}
-  "mirage-random" {>= "1.0.0"}
-  "mirage-clock"
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-clock" {< "3.0.0"}
   "mirage-time-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
   "mirage-protocols-lwt" {>= "2.0.0"}

--- a/packages/charrua-client-mirage/charrua-client-mirage.1.1.0/opam
+++ b/packages/charrua-client-mirage/charrua-client-mirage.1.1.0/opam
@@ -17,8 +17,8 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "charrua-client-lwt" {= version}
   "ipaddr" {>= "3.0.0"}
-  "mirage-random" {>= "1.0.0"}
-  "mirage-clock"
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-clock" {< "3.0.0"}
   "mirage-time-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
   "mirage-protocols-lwt" {>= "2.0.0"}

--- a/packages/conduit-mirage/conduit-mirage.2.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.0/opam
@@ -8,13 +8,13 @@ bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
-  "ppx_sexp_conv" {>="v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
   "cstruct" {>= "3.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-time-lwt" {>= "1.1.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-random" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
   "dns-client" {>= "4.0.0"}
   "conduit-lwt"
   "vchan" {>= "3.0.0"}
@@ -22,10 +22,8 @@ depends: [
   "tls" {>= "0.8.0"}
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
-
-  #these are required for tls.mirage, which conduit-mirage depends on
   "mirage-kv-lwt" {>= "2.0.0"}
-  "mirage-clock" {>= "2.0.0"}
+  "mirage-clock" {>= "2.0.0" & < "3.0.0"}
   "ptime"
 ]
 conflicts: [

--- a/packages/conduit-mirage/conduit-mirage.2.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.0/opam
@@ -22,6 +22,8 @@ depends: [
   "tls" {>= "0.8.0"}
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
+
+  #these are required for tls.mirage, which conduit-mirage depends on
   "mirage-kv-lwt" {>= "2.0.0"}
   "mirage-clock" {>= "2.0.0" & < "3.0.0"}
   "ptime"

--- a/packages/conduit-mirage/conduit-mirage.2.0.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.1/opam
@@ -8,13 +8,13 @@ bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
-  "ppx_sexp_conv" {>="v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
   "cstruct" {>= "3.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-time-lwt" {>= "1.1.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-random" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
   "dns-client" {>= "4.0.0"}
   "conduit-lwt"
   "vchan" {>= "3.0.0"}
@@ -22,10 +22,8 @@ depends: [
   "tls" {>= "0.8.0"}
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
-
-  #these are required for tls.mirage, which conduit-mirage depends on
   "mirage-kv-lwt" {>= "2.0.0"}
-  "mirage-clock" {>= "2.0.0"}
+  "mirage-clock" {>= "2.0.0" & < "3.0.0"}
   "ptime"
 ]
 conflicts: [

--- a/packages/conduit-mirage/conduit-mirage.2.0.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.1/opam
@@ -22,6 +22,8 @@ depends: [
   "tls" {>= "0.8.0"}
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
+
+  #these are required for tls.mirage, which conduit-mirage depends on
   "mirage-kv-lwt" {>= "2.0.0"}
   "mirage-clock" {>= "2.0.0" & < "3.0.0"}
   "ptime"

--- a/packages/datakit-client-git/datakit-client-git.0.11.0/opam
+++ b/packages/datakit-client-git/datakit-client-git.0.11.0/opam
@@ -21,7 +21,7 @@ depends: [
   "alcotest" {with-test & < "0.8.0"}
   "irmin-mem" {with-test & < "2.0.0"}
   "irmin-git" {with-test & < "2.0.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "Orchestrate applications using a Git-like dataflow"
 description: """

--- a/packages/datakit-client-git/datakit-client-git.0.12.0/opam
+++ b/packages/datakit-client-git/datakit-client-git.0.12.0/opam
@@ -21,7 +21,7 @@ depends: [
   "irmin-watcher"
   "git-unix" {< "2.0"}
   "alcotest" {with-test & >= "0.8.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "irmin-mem" {with-test & < "2.0.0"}
   "irmin-git" {with-test & < "2.0.0"}
   "io-page-unix" {with-test}

--- a/packages/datakit-client-git/datakit-client-git.0.12.2/opam
+++ b/packages/datakit-client-git/datakit-client-git.0.12.2/opam
@@ -14,12 +14,12 @@ depends: [
   "irmin-git" {>= "1.2.0" & < "2.0.0"}
   "irmin-watcher"
   "git-unix"
-  "io-page" {>="1.0.0"}
-  "io-page" {<"2.0.0" & with-test}
+  "io-page" {>= "1.0.0"}
+  "io-page" {< "2.0.0" & with-test}
   "alcotest" {with-test}
   "irmin-mem" {with-test & < "2.0.0"}
   "irmin-git" {with-test & < "2.0.0"}
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/datakit-client-git/datakit-client-git.0.12.3/opam
+++ b/packages/datakit-client-git/datakit-client-git.0.12.3/opam
@@ -14,12 +14,12 @@ depends: [
   "irmin-git" {>= "1.2.0" & < "2.0.0"}
   "irmin-watcher"
   "git-unix"
-  "io-page" {>="1.0.0"}
-  "io-page" {<"2.0.0" & with-test}
+  "io-page" {>= "1.0.0"}
+  "io-page" {< "2.0.0" & with-test}
   "alcotest" {with-test}
   "irmin-mem" {with-test & < "2.0.0"}
   "irmin-git" {with-test & < "2.0.0"}
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/datakit/datakit.0.10.0/opam
+++ b/packages/datakit/datakit.0.10.0/opam
@@ -29,7 +29,7 @@ depends: [
   "result"
   "lwt" {>= "2.7.1"}
   "conduit" {< "0.99"}
-  "mirage-flow"
+  "mirage-flow" {< "2.0.0"}
   "named-pipe" {>= "0.4.0"}
   "hvsock" {>= "0.8.1"}
   "logs" {>= "0.5.0"}

--- a/packages/datakit/datakit.0.10.1/opam
+++ b/packages/datakit/datakit.0.10.1/opam
@@ -29,7 +29,7 @@ depends: [
   "result"
   "lwt" {>= "3.0.0"}
   "conduit" {< "0.99"}
-  "mirage-flow"
+  "mirage-flow" {< "2.0.0"}
   "named-pipe" {>= "0.4.0"}
   "hvsock" {>= "0.8.1"}
   "logs" {>= "0.5.0"}

--- a/packages/datakit/datakit.0.11.0/opam
+++ b/packages/datakit/datakit.0.11.0/opam
@@ -30,7 +30,7 @@ depends: [
   "result"
   "lwt" {>= "3.0.0"}
   "conduit" {< "0.99"}
-  "mirage-flow"
+  "mirage-flow" {< "2.0.0"}
   "named-pipe" {>= "0.4.0"}
   "hvsock" {>= "0.8.1"}
   "logs" {>= "0.5.0"}

--- a/packages/datakit/datakit.0.12.0/opam
+++ b/packages/datakit/datakit.0.12.0/opam
@@ -30,7 +30,7 @@ depends: [
   "result"
   "lwt" {>= "3.0.0"}
   "conduit-lwt-unix" {>= "1.0.0"}
-  "mirage-flow"
+  "mirage-flow" {< "2.0.0"}
   "named-pipe" {>= "0.4.0"}
   "hvsock" {>= "0.8.1"}
   "logs" {>= "0.5.0"}

--- a/packages/datakit/datakit.0.12.2/opam
+++ b/packages/datakit/datakit.0.12.2/opam
@@ -16,15 +16,15 @@ depends: [
   "fmt"
   "asetmap"
   "git" {>= "1.11.5"}
-  "uri" {>="2.0.0"}
-  "irmin" {>="1.4.0" & < "2.0.0"}
+  "uri" {>= "2.0.0"}
+  "irmin" {>= "1.4.0" & < "2.0.0"}
   "irmin-mem" {>= "1.2.0" & < "2.0.0"}
   "irmin-git" {>= "1.2.0" & < "2.0.0"}
   "cstruct" {>= "2.2"}
   "result"
   "lwt" {>= "3.0.0"}
   "conduit-lwt-unix" {>= "1.0.0"}
-  "mirage-flow"
+  "mirage-flow" {< "2.0.0"}
   "named-pipe" {>= "0.4.0"}
   "hvsock" {>= "0.8.1"}
   "logs" {>= "0.5.0"}

--- a/packages/datakit/datakit.0.12.3/opam
+++ b/packages/datakit/datakit.0.12.3/opam
@@ -16,15 +16,15 @@ depends: [
   "fmt"
   "asetmap"
   "git" {>= "1.11.5"}
-  "uri" {>="2.0.0"}
-  "irmin" {>="1.4.0" & < "2.0.0"}
+  "uri" {>= "2.0.0"}
+  "irmin" {>= "1.4.0" & < "2.0.0"}
   "irmin-mem" {>= "1.2.0" & < "2.0.0"}
   "irmin-git" {>= "1.2.0" & < "2.0.0"}
   "cstruct" {>= "2.2"}
   "result"
   "lwt" {>= "3.0.0"}
   "conduit-lwt-unix" {>= "1.0.0"}
-  "mirage-flow"
+  "mirage-flow" {< "2.0.0"}
   "named-pipe" {>= "0.4.0"}
   "hvsock" {>= "0.8.1"}
   "logs" {>= "0.5.0"}

--- a/packages/datakit/datakit.0.8.0/opam
+++ b/packages/datakit/datakit.0.8.0/opam
@@ -29,7 +29,7 @@ depends: [
   "result"
   "lwt"
   "conduit"
-  "mirage-flow"
+  "mirage-flow" {< "2.0.0"}
   "cohttp"
   "named-pipe" {>= "0.4.0"}
   "hvsock" {>= "0.11.1" & < "0.14.0"}

--- a/packages/datakit/datakit.0.9.0/opam
+++ b/packages/datakit/datakit.0.9.0/opam
@@ -34,7 +34,7 @@ depends: [
   "result"
   "lwt" {>= "2.7.0"}
   "conduit" {< "0.99"}
-  "mirage-flow"
+  "mirage-flow" {< "2.0.0"}
   "cohttp"
   "named-pipe" {>= "0.4.0"}
   "hvsock" {>= "0.8.1" & < "0.14.0"}

--- a/packages/datakit/datakit.1.0.0/opam
+++ b/packages/datakit/datakit.1.0.0/opam
@@ -16,15 +16,15 @@ depends: [
   "fmt"
   "asetmap"
   "git" {>= "1.11.5"}
-  "uri" {>="2.0.0"}
-  "irmin" {>="1.4.0" & < "2.0.0"}
+  "uri" {>= "2.0.0"}
+  "irmin" {>= "1.4.0" & < "2.0.0"}
   "irmin-mem" {>= "1.2.0" & < "2.0.0"}
   "irmin-git" {>= "1.2.0" & < "2.0.0"}
   "cstruct" {>= "2.2"}
   "result"
   "lwt" {>= "3.0.0"}
   "conduit-lwt-unix" {>= "1.0.0"}
-  "mirage-flow"
+  "mirage-flow" {< "2.0.0"}
   "named-pipe" {>= "0.4.0"}
   "hvsock" {>= "0.8.1"}
   "logs" {>= "0.5.0"}

--- a/packages/dns-certify/dns-certify.4.0.0/opam
+++ b/packages/dns-certify/dns-certify.4.0.0/opam
@@ -18,12 +18,11 @@ depends: [
   "x509" {>= "0.7.1" & < "0.8.0"}
   "lwt" {>= "4.2.1"}
   "tls" {>= "0.10.3"}
-  "mirage-random" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
   "mirage-time-lwt" {>= "1.3.0"}
   "mirage-clock-lwt" {>= "2.0.0"}
   "mirage-stack-lwt" {>= "1.4.0"}
 ]
-
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/dns-client/dns-client.4.0.0/opam
+++ b/packages/dns-client/dns-client.4.0.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 
 depends: [
-  "dune" {>="1.5.1"}
+  "dune" {>= "1.5.1"}
   "ocaml" {>= "4.07.0"}
   "cstruct" {>= "4.0.0"}
   "fmt" {>= "0.8.8"}
@@ -24,7 +24,7 @@ depends: [
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}
   "mirage-stack-lwt" {>= "1.4.0"}
-  "mirage-random" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "Pure DNS resolver API"
 description: """

--- a/packages/dns-resolver/dns-resolver.4.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.0.0/opam
@@ -19,11 +19,10 @@ depends: [
   "lwt" {>= "4.2.1"}
   "mirage-time-lwt" {>= "1.3.0"}
   "mirage-clock-lwt" {>= "2.0.0"}
-  "mirage-random" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
   "mirage-stack-lwt" {>= "1.4.0"}
   "alcotest" {with-test}
 ]
-
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/fat-filesystem/fat-filesystem.0.12.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.12.0/opam
@@ -22,7 +22,7 @@ depends: [
   "result"
   "rresult"
   "lwt" {>= "2.4.3"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-block-unix" {>= "2.5.0"}

--- a/packages/fat-filesystem/fat-filesystem.0.12.1/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.12.1/opam
@@ -19,7 +19,7 @@ depends: [
   "result"
   "rresult"
   "lwt" {>= "2.4.3"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-block-unix" {>= "2.5.0"}

--- a/packages/fat-filesystem/fat-filesystem.0.12.2/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.12.2/opam
@@ -19,7 +19,7 @@ depends: [
   "result"
   "rresult"
   "lwt" {>= "2.4.3"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-block-unix" {>= "2.5.0"}

--- a/packages/fat-filesystem/fat-filesystem.0.12.3/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.12.3/opam
@@ -13,13 +13,13 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta7"}
-  "cstruct" {>= "3.0.0" & <"3.7.0"}
+  "cstruct" {>= "3.0.0" & < "3.7.0"}
   "ppx_tools"
   "ppx_cstruct"
   "result"
   "rresult"
   "lwt" {>= "2.4.3"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-block-unix" {>= "2.5.0"}

--- a/packages/fat-filesystem/fat-filesystem.0.13.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.13.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ppx_cstruct"
   "rresult"
   "lwt" {>= "2.4.3"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-block-unix" {>= "2.5.0"}

--- a/packages/git/git.1.4.10/opam
+++ b/packages/git/git.1.4.10/opam
@@ -32,7 +32,7 @@ depends: [
   "alcotest" {with-test}
   "ounit" {with-test}
   "mirage-fs-unix" {with-test}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
   "cohttp" {with-test}
   "conduit" {with-test}
   "cmdliner"

--- a/packages/git/git.1.5.0/opam
+++ b/packages/git/git.1.5.0/opam
@@ -29,7 +29,7 @@ depends: [
   "cstruct" {< "3.2.0"}
   "alcotest" {with-test}
   "mirage-fs-unix" {with-test & = "1.1.4"}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
   "cohttp" {with-test}
   "conduit" {with-test}
   "ocamlbuild" {build}

--- a/packages/git/git.1.5.1/opam
+++ b/packages/git/git.1.5.1/opam
@@ -33,7 +33,7 @@ depends: [
   "cstruct" {< "3.2.0"}
   "alcotest" {with-test & <= "0.3.3"}
   "mirage-fs-unix" {with-test & = "1.1.4"}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
   "cohttp" {with-test}
   "conduit" {with-test}
   "ocamlbuild" {build}

--- a/packages/git/git.1.5.2/opam
+++ b/packages/git/git.1.5.2/opam
@@ -33,8 +33,8 @@ depends: [
   "hex"
   "cstruct" {< "3.2.0"}
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
+  "mirage-flow" {with-test & < "2.0.0"}
   "mirage-http" {with-test}
   "mirage-fs-unix" {with-test & = "1.1.4"}
   "cohttp" {with-test}

--- a/packages/git/git.1.5.3/opam
+++ b/packages/git/git.1.5.3/opam
@@ -33,8 +33,8 @@ depends: [
   "cstruct" {< "3.2.0"}
   "hex"
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
+  "mirage-flow" {with-test & < "2.0.0"}
   "mirage-http" {with-test}
   "mirage-fs-unix" {with-test & = "1.1.4"}
   "cohttp" {with-test}

--- a/packages/git/git.1.6.0/opam
+++ b/packages/git/git.1.6.0/opam
@@ -34,8 +34,8 @@ depends: [
   "ocplib-endian"
   "stringext"
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
+  "mirage-flow" {with-test & < "2.0.0"}
   "mirage-http" {with-test}
   "mirage-fs-unix" {with-test & = "1.1.4"}
   "cohttp" {with-test}

--- a/packages/git/git.1.6.1/opam
+++ b/packages/git/git.1.6.1/opam
@@ -34,8 +34,8 @@ depends: [
   "stringext"
   "ocplib-endian"
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
+  "mirage-flow" {with-test & < "2.0.0"}
   "mirage-http" {with-test}
   "mirage-fs-unix" {with-test & = "1.1.4"}
   "cohttp" {with-test}

--- a/packages/git/git.1.6.2/opam
+++ b/packages/git/git.1.6.2/opam
@@ -34,8 +34,8 @@ depends: [
   "stringext"
   "ocplib-endian"
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
+  "mirage-flow" {with-test & < "2.0.0"}
   "mirage-http" {with-test}
   "mirage-fs-unix" {with-test & = "1.1.4"}
   "cohttp" {with-test}

--- a/packages/git/git.1.7.0/opam
+++ b/packages/git/git.1.7.0/opam
@@ -33,9 +33,9 @@ depends: [
   "crc" {<= "1.0.0"}
   "ocplib-endian"
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
   "mirage-http" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
   "channel" {with-test}
   "mirage-fs-unix" {with-test & >= "1.1.4"}
   "cohttp" {with-test}

--- a/packages/git/git.1.7.1/opam
+++ b/packages/git/git.1.7.1/opam
@@ -33,9 +33,9 @@ depends: [
   "crc" {<= "1.0.0"}
   "ocplib-endian"
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
   "mirage-http" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
   "channel" {with-test}
   "mirage-fs-unix" {with-test & >= "1.1.4"}
   "cohttp" {with-test}

--- a/packages/git/git.1.7.2/opam
+++ b/packages/git/git.1.7.2/opam
@@ -33,9 +33,9 @@ depends: [
   "crc" {<= "1.0.0"}
   "ocplib-endian"
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
   "mirage-http" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
   "channel" {with-test}
   "mirage-fs-unix" {with-test & >= "1.1.4"}
   "cohttp" {with-test}

--- a/packages/git/git.1.8.0/opam
+++ b/packages/git/git.1.8.0/opam
@@ -35,9 +35,9 @@ depends: [
   "crc" {<= "1.0.0"}
   "ocplib-endian"
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
   "mirage-http" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
   "channel" {with-test}
   "mirage-fs-unix" {with-test & >= "1.1.4"}
   "cohttp" {with-test}

--- a/packages/git/git.1.9.0/opam
+++ b/packages/git/git.1.9.0/opam
@@ -51,9 +51,9 @@ depends: [
   "crc" {<= "1.0.0"}
   "ocplib-endian" {>= "0.6"}
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
   "mirage-http" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
   "channel" {with-test}
   "mirage-fs-unix" {with-test & >= "1.1.4"}
   "cohttp" {with-test}

--- a/packages/git/git.1.9.1/opam
+++ b/packages/git/git.1.9.1/opam
@@ -51,9 +51,9 @@ depends: [
   "crc" {<= "1.0.0"}
   "ocplib-endian" {>= "0.6"}
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
   "mirage-http" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
   "channel" {with-test}
   "mirage-fs-unix" {with-test & >= "1.1.4"}
   "cohttp" {with-test}

--- a/packages/git/git.1.9.2/opam
+++ b/packages/git/git.1.9.2/opam
@@ -50,9 +50,9 @@ depends: [
   "astring"
   "ocplib-endian" {>= "0.6"}
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
   "mirage-http" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
   "channel" {with-test}
   "mirage-fs-unix" {with-test & >= "1.1.4"}
   "cohttp" {with-test}

--- a/packages/git/git.1.9.3/opam
+++ b/packages/git/git.1.9.3/opam
@@ -50,9 +50,9 @@ depends: [
   "astring"
   "ocplib-endian" {>= "0.6"}
   "alcotest" {with-test}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
   "mirage-http" {with-test}
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
   "channel" {with-test}
   "mirage-fs-unix" {with-test & >= "1.1.4"}
   "cohttp" {with-test}

--- a/packages/irmin-mirage/irmin-mirage.1.0.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "git-mirage" {>= "1.10.0"}
   "ptime"
   "mirage-kv-lwt" {< "2.0.0"}
-  "mirage-clock"
+  "mirage-clock" {< "3.0.0"}
   "result"
 ]
 synopsis: "MirageOS-compatible Irmin stores"

--- a/packages/irmin-mirage/irmin-mirage.1.2.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "git-mirage" {>= "1.11.0"}
   "ptime"
   "mirage-kv-lwt" {< "2.0.0"}
-  "mirage-clock"
+  "mirage-clock" {< "3.0.0"}
   "result"
 ]
 synopsis: "MirageOS-compatible Irmin stores"

--- a/packages/irmin-mirage/irmin-mirage.1.3.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "git-mirage" {>= "1.11.0"}
   "ptime"
   "mirage-kv-lwt" {< "2.0.0"}
-  "mirage-clock"
+  "mirage-clock" {< "3.0.0"}
   "result"
 ]
 synopsis: "MirageOS-compatible Irmin stores"

--- a/packages/jitsu/jitsu.0.2/opam
+++ b/packages/jitsu/jitsu.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "camlp4" {build}
   "lwt"
   "dns" {>= "0.15.3" & < "1.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-stack-lwt"
   "mirage-kv-lwt" {< "2.0.0"}
   "duration"

--- a/packages/jitsu/jitsu.0.3.0/opam
+++ b/packages/jitsu/jitsu.0.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "camlp4" {build}
   "lwt"
   "dns" {>= "0.15.3" & < "1.0.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-stack-lwt"
   "mirage-kv-lwt" {< "2.0.0"}
   "duration"

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.1.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.1.0/opam
@@ -21,7 +21,7 @@ depends: [
   "io-page"
   "lwt"
   "logs"
-  "mirage-block" {>= "1.0.0"}
+  "mirage-block" {>= "1.0.0" & < "2.0.0"}
   "result"
 ]
 tags: "org:mirage"

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.2.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "io-page"
   "lwt"
   "logs"
-  "mirage-block" {>= "1.0.0"}
+  "mirage-block" {>= "1.0.0" & < "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-block/mirage-block.1.0.0/opam
+++ b/packages/mirage-block/mirage-block.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
   "result"
 ]
 tags: "org:mirage"

--- a/packages/mirage-block/mirage-block.1.1.0/opam
+++ b/packages/mirage-block/mirage-block.1.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
   "result"
 ]
 tags: "org:mirage"

--- a/packages/mirage-block/mirage-block.1.2.0/opam
+++ b/packages/mirage-block/mirage-block.1.2.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-block/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-channel-lwt/mirage-channel-lwt.3.1.0/opam
+++ b/packages/mirage-channel-lwt/mirage-channel-lwt.3.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build & >= "1.0+beta10"}
   "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-channel" {>= "3.1.0"}
+  "mirage-channel" {>= "3.1.0" & < "4.0.0"}
   "io-page"
   "result"
   "lwt" {>= "2.4.7"}

--- a/packages/mirage-channel-lwt/mirage-channel-lwt.3.2.0/opam
+++ b/packages/mirage-channel-lwt/mirage-channel-lwt.3.2.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-channel" {>= "3.0.0"}
+  "mirage-channel" {>= "3.0.0" & < "4.0.0"}
   "io-page"
   "lwt" {>= "2.4.7"}
   "cstruct"

--- a/packages/mirage-channel/mirage-channel.3.0.0/opam
+++ b/packages/mirage-channel/mirage-channel.3.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "result"
 ]
 conflicts: [

--- a/packages/mirage-channel/mirage-channel.3.1.0/opam
+++ b/packages/mirage-channel/mirage-channel.3.1.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "result"
 ]
 conflicts: [

--- a/packages/mirage-channel/mirage-channel.3.2.0/opam
+++ b/packages/mirage-channel/mirage-channel.3.2.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-channel/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 conflicts: [
   "tcpip" {< "3.0.0"}

--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.1.2.0/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.1.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "lwt"
 ]

--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.1.3.0/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.1.3.0/opam
@@ -9,7 +9,7 @@ tags: ["org:mirage"]
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "lwt"
 ]

--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.2.0.0/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.2.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune"
   "dune-configurator"
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "lwt"
 ]

--- a/packages/mirage-clock-lwt/mirage-clock-lwt.1.3.0/opam
+++ b/packages/mirage-clock-lwt/mirage-clock-lwt.1.3.0/opam
@@ -11,7 +11,7 @@ tags: ["org:mirage"]
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "lwt"
 ]
 build: [

--- a/packages/mirage-clock-lwt/mirage-clock-lwt.2.0.0/opam
+++ b/packages/mirage-clock-lwt/mirage-clock-lwt.2.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune"
   "dune-configurator"
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "lwt"
 ]
 build: [

--- a/packages/mirage-clock-unix/mirage-clock-unix.2.0.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.2.0.0/opam
@@ -15,7 +15,7 @@ which OS is in use (see [clock_stubs.c](https://github.com/mirage/mirage-clock/b
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune"
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "lwt"
 ]

--- a/packages/mirage-clock/mirage-clock.1.2.0/opam
+++ b/packages/mirage-clock/mirage-clock.1.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
 ]
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" ]
 synopsis: "Libraries and module types for two kinds of clocks:"

--- a/packages/mirage-clock/mirage-clock.1.3.0/opam
+++ b/packages/mirage-clock/mirage-clock.1.3.0/opam
@@ -10,7 +10,7 @@ tags: ["org:mirage"]
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
 ]
 build: [
   [ "jbuilder" "subst" "-p" name ] {pinned}

--- a/packages/mirage-clock/mirage-clock.2.0.0/opam
+++ b/packages/mirage-clock/mirage-clock.2.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune"
   "dune-configurator"
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-conduit/mirage-conduit.1.0.3/opam
+++ b/packages/mirage-conduit/mirage-conduit.1.0.3/opam
@@ -15,10 +15,10 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "ipaddr" {<"3.0.0"}
+  "ipaddr" {< "3.0.0"}
   "ppx_sexp_conv" {< "v0.13"}
   "cstruct" {>= "3.0.0"}
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-dns" {>= "3.0.0" & < "4.0.0"}
   "conduit-lwt"

--- a/packages/mirage-conduit/mirage-conduit.2.3.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.2.3.0/opam
@@ -10,7 +10,7 @@ license:      "ISC"
 build:   ["ocamlfind" "query" "conduit.mirage"]
 depends: [
   "ocaml" {>= "4.01.0"}
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-dns" {>= "2.0.0" & < "3.0.0"}
   "conduit" {>= "0.15.0" & < "0.16.0"}

--- a/packages/mirage-conduit/mirage-conduit.2.3.1/opam
+++ b/packages/mirage-conduit/mirage-conduit.2.3.1/opam
@@ -11,7 +11,7 @@ build:   ["ocamlfind" "query" "conduit.mirage"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "cstruct" {>= "1.0.1"}
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-dns" {>= "2.6.0" & < "3.0.0"}
   "conduit" {>= "0.15.0" & < "0.16.0"}

--- a/packages/mirage-conduit/mirage-conduit.3.0.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.0.0/opam
@@ -17,11 +17,11 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "ppx_sexp_conv" {< "v0.13"}
   "cstruct" {>= "3.0.0"}
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-dns" {>= "3.0.0" & < "4.0.0"}
   "conduit-lwt"
-  "ipaddr" {<"3.0.0"}
+  "ipaddr" {< "3.0.0"}
   "vchan" {>= "3.0.0"}
   "tls" {>= "0.8.0"}
 ]

--- a/packages/mirage-conduit/mirage-conduit.3.0.1/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.0.1/opam
@@ -17,11 +17,11 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "ppx_sexp_conv" {< "v0.13"}
   "cstruct" {>= "3.0.0"}
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-dns" {>= "3.0.0" & < "4.0.0"}
   "conduit-lwt"
-  "ipaddr" {<"3.0.0"}
+  "ipaddr" {< "3.0.0"}
   "vchan" {>= "3.0.0"}
   "tls" {>= "0.8.0"}
 ]

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.3.2/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.3.2/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-console" {>= "2.3.0"}
+  "mirage-console" {>= "2.3.0" & < "3.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.3.3/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.3.3/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.3.4/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.3.4/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.3.5/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.3.5/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-console" {>= "2.3.5"}
+  "mirage-console" {>= "2.3.5" & < "3.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.4.0/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.4.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.4.1/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.4.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.4.2/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.4.2/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]

--- a/packages/mirage-console-lwt/mirage-console-lwt.2.4.3/opam
+++ b/packages/mirage-console-lwt/mirage-console-lwt.2.4.3/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-console" {=version}
+  "mirage-console" {= version & < "3.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]

--- a/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.2.0/opam
+++ b/packages/mirage-console-xen-cli/mirage-console-xen-cli.2.2.0/opam
@@ -13,7 +13,7 @@ build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "mirage-console-lwt" {>= "2.2.0"}
   "lwt"
   "cstruct" {< "3.0.0"}

--- a/packages/mirage-console/mirage-console.2.0.0/opam
+++ b/packages/mirage-console/mirage-console.2.0.0/opam
@@ -8,7 +8,7 @@ remove: [
 depends: [
   "ocaml"
   "ocamlfind"
-  "mirage-types-lwt" {< "2.3.0" & >= "2.0.0"}
+  "mirage-types-lwt" {>= "2.0.0" & < "2.3.0"}
   "mirage-unix" {>= "1.1.0"}
   "cstruct-lwt"
   "ocamlbuild" {build}

--- a/packages/mirage-console/mirage-console.2.2.0/opam
+++ b/packages/mirage-console/mirage-console.2.2.0/opam
@@ -15,8 +15,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "A Mirage-compatible Console library for Xen and Unix"
 url {

--- a/packages/mirage-console/mirage-console.2.3.2/opam
+++ b/packages/mirage-console/mirage-console.2.3.2/opam
@@ -16,8 +16,8 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "A Mirage-compatible Console library for Xen and Unix"
 url {

--- a/packages/mirage-console/mirage-console.2.3.3/opam
+++ b/packages/mirage-console/mirage-console.2.3.3/opam
@@ -16,8 +16,8 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "Implementations of Mirage consoles, for Unix and Xen"
 description: """

--- a/packages/mirage-console/mirage-console.2.3.4/opam
+++ b/packages/mirage-console/mirage-console.2.3.4/opam
@@ -16,8 +16,8 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "Implementations of Mirage consoles, for Unix and Xen"
 description: """

--- a/packages/mirage-console/mirage-console.2.3.5/opam
+++ b/packages/mirage-console/mirage-console.2.3.5/opam
@@ -16,8 +16,8 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "Implementations of Mirage consoles, for Unix and Xen"
 description: """

--- a/packages/mirage-console/mirage-console.2.4.0/opam
+++ b/packages/mirage-console/mirage-console.2.4.0/opam
@@ -9,8 +9,8 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-console/mirage-console.2.4.1/opam
+++ b/packages/mirage-console/mirage-console.2.4.1/opam
@@ -9,8 +9,8 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-console/mirage-console.2.4.2/opam
+++ b/packages/mirage-console/mirage-console.2.4.2/opam
@@ -9,8 +9,8 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-console/mirage-console.2.4.3/opam
+++ b/packages/mirage-console/mirage-console.2.4.3/opam
@@ -9,8 +9,8 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.3.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.3.0/opam
@@ -19,8 +19,8 @@ depends: [
   "fmt"
   "lwt"
   "cstruct" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-flow" {>= "1.3.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-flow" {>= "1.3.0" & < "2.0.0"}
 ]
 synopsis: "Flow implementations and combinators for MirageOS"
 description: """

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.4.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.4.0/opam
@@ -20,8 +20,8 @@ depends: [
   "lwt"
   "logs"
   "cstruct" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "Flow implementations and combinators for MirageOS using Lwt"
 url {

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.5.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.5.0/opam
@@ -20,8 +20,8 @@ depends: [
   "lwt"
   "logs"
   "cstruct" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "Flow implementations and combinators for MirageOS"
 description: """

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.6.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.6.0/opam
@@ -13,8 +13,8 @@ depends: [
   "lwt"
   "logs"
   "cstruct" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.2.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.2.0/opam
@@ -40,7 +40,7 @@ depends: [
   "topkg" {build & >= "0.9.0"}
   "alcotest" {with-test}
   "fmt"
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "lwt"
   "cstruct" {>= "2.3.0"}

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.3.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta7"}
   "fmt"
-  "mirage-flow" {>= "1.3.0"}
+  "mirage-flow" {>= "1.3.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.3.0"}
   "lwt"
   "cstruct" {>= "2.3.0"}

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.4.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta7"}
   "fmt"
   "logs"
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "lwt"
   "cstruct" {>= "2.3.0"}

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.5.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.5.0/opam
@@ -18,7 +18,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta7"}
   "fmt"
   "logs"
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "lwt"
   "cstruct" {>= "3.2.0"}

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.6.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.6.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "fmt"
   "logs"
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "lwt"
   "cstruct" {>= "3.2.0"}

--- a/packages/mirage-fs-lwt/mirage-fs-lwt.1.1.1/opam
+++ b/packages/mirage-fs-lwt/mirage-fs-lwt.1.1.1/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-kv-lwt" {< "2.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}

--- a/packages/mirage-fs-lwt/mirage-fs-lwt.1.2.0/opam
+++ b/packages/mirage-fs-lwt/mirage-fs-lwt.1.2.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune"
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-kv-lwt" {< "2.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}

--- a/packages/mirage-fs-lwt/mirage-fs-lwt.2.0.0/opam
+++ b/packages/mirage-fs-lwt/mirage-fs-lwt.2.0.0/opam
@@ -16,13 +16,12 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune"
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-kv-lwt" {>= "2.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"
 ]
-
 synopsis: "MirageOS signatures for filesystem devices using Lwt"
 description: """
 mirage-fs-lwt provides the `[Mirage_fs.S][fs]` and `[Mirage_fs_lwt.S]` signatures

--- a/packages/mirage-fs/mirage-fs.1.0.0/opam
+++ b/packages/mirage-fs/mirage-fs.1.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "topkg" {build}
   "fmt"
   "result"
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
 ]
 synopsis: "MirageOS filesystem utilities"
 url {

--- a/packages/mirage-fs/mirage-fs.1.1.1/opam
+++ b/packages/mirage-fs/mirage-fs.1.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
   "fmt"
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
 ]
 synopsis: "MirageOS signatures for filesystem devices"
 description: """

--- a/packages/mirage-fs/mirage-fs.1.2.0/opam
+++ b/packages/mirage-fs/mirage-fs.1.2.0/opam
@@ -17,9 +17,8 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune"
   "fmt"
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
 ]
-
 synopsis: "MirageOS signatures for filesystem devices"
 description: """
 mirage-fs provides the `[Mirage_fs.S][fs]` and `[Mirage_fs_lwt.S]` signatures

--- a/packages/mirage-fs/mirage-fs.2.0.0/opam
+++ b/packages/mirage-fs/mirage-fs.2.0.0/opam
@@ -17,9 +17,8 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune"
   "fmt"
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
 ]
-
 synopsis: "MirageOS signatures for filesystem devices"
 description: """
 mirage-fs provides the `[Mirage_fs.S][fs]` and `[Mirage_fs_lwt.S]` signatures

--- a/packages/mirage-kv-lwt/mirage-kv-lwt.2.0.0/opam
+++ b/packages/mirage-kv-lwt/mirage-kv-lwt.2.0.0/opam
@@ -14,13 +14,12 @@ build: [
 ]
 
 depends: [
-  "ocaml"     {>= "4.05.0"}
+  "ocaml" {>= "4.05.0"}
   "dune"
-  "mirage-kv" {>= "2.0.0"}
+  "mirage-kv" {>= "2.0.0" & < "3.0.0"}
   "lwt"
   "cstruct"
 ]
-
 synopsis: "MirageOS signatures for key/value devices"
 description: """
 mirage-kv-lwt provides the `Mirage_kv_lwt.RO` and `Mirage_kv_lwt.RW` signatures,

--- a/packages/mirage-kv-mem/mirage-kv-mem.2.0.0/opam
+++ b/packages/mirage-kv-mem/mirage-kv-mem.2.0.0/opam
@@ -25,14 +25,13 @@ depends: [
   "dune"
   "alcotest" {with-test}
   "ppx_deriving" {with-test}
-  "mirage-clock" {>= "2.0.0"}
+  "mirage-clock" {>= "2.0.0" & < "3.0.0"}
   "mirage-kv-lwt" {>= "2.0.0"}
   "rresult"
   "fmt"
   "ptime"
   "mirage-clock-unix" {>= "2.0.0"}
 ]
-
 synopsis: "In-memory key value store for MirageOS"
 description: """
 Implements the mirage-kv interface, but does not provide a persistent data storage.

--- a/packages/mirage-kv/mirage-kv.1.0.0/opam
+++ b/packages/mirage-kv/mirage-kv.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
   "fmt"
   "result"
 ]

--- a/packages/mirage-kv/mirage-kv.1.1.1/opam
+++ b/packages/mirage-kv/mirage-kv.1.1.1/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
   "fmt"
 ]
 synopsis: "MirageOS signatures for key/value devices"

--- a/packages/mirage-kv/mirage-kv.2.0.0/opam
+++ b/packages/mirage-kv/mirage-kv.2.0.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune"
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
   "fmt" {>= "0.8.4"}
   "alcotest" {with-test}
 ]

--- a/packages/mirage-logs/mirage-logs.0.3.0/opam
+++ b/packages/mirage-logs/mirage-logs.0.3.0/opam
@@ -13,7 +13,7 @@ depends: [
   "topkg" {build}
   "logs" {>= "0.5.0"}
   "ptime" {>= "0.8.1"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-profile"
   "lwt"
   "alcotest" {with-test}

--- a/packages/mirage-logs/mirage-logs.1.0.0/opam
+++ b/packages/mirage-logs/mirage-logs.1.0.0/opam
@@ -8,11 +8,11 @@ bug-reports: "https://github.com/mirage/mirage-logs/issues"
 doc: "https://mirage.github.io/mirage-logs/"
 tags: ["org:mirage"]
 depends: [
-  "ocaml" { >= "4.01.0"}
+  "ocaml" {>= "4.01.0"}
   "dune" {>= "1.0"}
-  "logs" { >= "0.5.0" }
-  "ptime" { >= "0.8.1" }
-  "mirage-clock" { >= "1.2.0"}
+  "logs" {>= "0.5.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-profile"
   "lwt"
   "alcotest" {with-test}

--- a/packages/mirage-logs/mirage-logs.1.1.0/opam
+++ b/packages/mirage-logs/mirage-logs.1.1.0/opam
@@ -8,11 +8,11 @@ bug-reports: "https://github.com/mirage/mirage-logs/issues"
 doc: "https://mirage.github.io/mirage-logs/"
 tags: ["org:mirage"]
 depends: [
-  "ocaml" { >= "4.01.0"}
+  "ocaml" {>= "4.01.0"}
   "dune" {>= "1.0"}
-  "logs" { >= "0.5.0" }
-  "ptime" { >= "0.8.1" }
-  "mirage-clock" { >= "1.2.0"}
+  "logs" {>= "0.5.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-profile"
   "lwt"
   "alcotest" {with-test}

--- a/packages/mirage-net-lwt/mirage-net-lwt.2.0.0/opam
+++ b/packages/mirage-net-lwt/mirage-net-lwt.2.0.0/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-net" {>= "2.0.0"}
+  "mirage-net" {>= "2.0.0" & < "3.0.0"}
   "lwt"
   "macaddr"
   "cstruct"

--- a/packages/mirage-net/mirage-net.1.0.0/opam
+++ b/packages/mirage-net/mirage-net.1.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
   "result"
 ]
 synopsis: "MirageOS TCP/IP networking library"

--- a/packages/mirage-net/mirage-net.1.1.1/opam
+++ b/packages/mirage-net/mirage-net.1.1.1/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {> "4.02.3"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
   "fmt"
 ]
 synopsis: "Network signatures for MirageOS"

--- a/packages/mirage-net/mirage-net.1.2.0/opam
+++ b/packages/mirage-net/mirage-net.1.2.0/opam
@@ -17,8 +17,8 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.2"}
-  "jbuilder" {build & >="1.0+beta10"}
-  "mirage-device" {>= "1.0.0"}
+  "jbuilder" {build & >= "1.0+beta10"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
   "fmt"
 ]
 synopsis: "Network signatures for MirageOS"

--- a/packages/mirage-net/mirage-net.2.0.0/opam
+++ b/packages/mirage-net/mirage-net.2.0.0/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
   "fmt"
 ]
 synopsis: "Network signatures for MirageOS"

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.3.0.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.3.0.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-protocols" {>= "2.0.0"}
+  "mirage-protocols" {>= "2.0.0" & < "4.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"
   "lwt"

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.3.1.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.3.1.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-protocols" {>= "2.0.0"}
+  "mirage-protocols" {>= "2.0.0" & < "4.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"
   "lwt"

--- a/packages/mirage-protocols/mirage-protocols.1.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.0.0/opam
@@ -15,8 +15,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "fmt" {>= "0.8.2"}
 ]
 synopsis: "Module type definitions for network protocols."

--- a/packages/mirage-protocols/mirage-protocols.1.1.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.1.0/opam
@@ -15,8 +15,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "fmt" {>= "0.8.2"}
 ]
 synopsis: "Module type definitions for network protocols."

--- a/packages/mirage-protocols/mirage-protocols.1.2.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.2.0/opam
@@ -16,8 +16,8 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "fmt"
 ]
 synopsis: "MirageOS signatures for network protocols"

--- a/packages/mirage-protocols/mirage-protocols.1.3.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.3.0/opam
@@ -16,8 +16,8 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "fmt"
   "duration"
 ]

--- a/packages/mirage-protocols/mirage-protocols.1.4.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.4.0/opam
@@ -16,8 +16,8 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "fmt"
   "duration"
 ]

--- a/packages/mirage-protocols/mirage-protocols.1.4.1/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.4.1/opam
@@ -15,9 +15,9 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.2"}
-  "jbuilder" {build & >="1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "jbuilder" {build & >= "1.0+beta9"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "fmt"
   "duration"
 ]

--- a/packages/mirage-protocols/mirage-protocols.2.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.2.0.0/opam
@@ -16,9 +16,9 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
-  "mirage-net" {>= "2.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
+  "mirage-net" {>= "2.0.0" & < "3.0.0"}
   "fmt"
   "duration"
 ]

--- a/packages/mirage-protocols/mirage-protocols.3.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.3.0.0/opam
@@ -16,9 +16,9 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
-  "mirage-net" {>= "2.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
+  "mirage-net" {>= "2.0.0" & < "3.0.0"}
   "fmt"
   "duration"
 ]

--- a/packages/mirage-protocols/mirage-protocols.3.1.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.3.1.0/opam
@@ -16,9 +16,9 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
-  "mirage-net" {>= "2.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
+  "mirage-net" {>= "2.0.0" & < "3.0.0"}
   "fmt"
   "duration"
 ]

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.5/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.5/opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-protocols-lwt" {< "1.4.0"}
   "cstruct" {>= "1.9.0"}
   "lwt"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "logs" {>= "0.5.0"}
 ]
 synopsis: "Implementations of various QubesOS protocols:"

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6.1/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6.1/opam
@@ -17,12 +17,12 @@ depends: [
   "mirage-qubes" {>= "0.6" & < "0.7.0"}
   "tcpip" {>= "3.5.0"}
   "ipaddr" {>= "3.0.0"}
-  "mirage-random"
-  "mirage-clock"
+  "mirage-random" {< "2.0.0"}
+  "mirage-clock" {< "3.0.0"}
   "mirage-protocols-lwt" {< "2.0.0"}
   "cstruct" {>= "1.9.0"}
   "lwt"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "logs" {>= "0.5.0"}
   "ocaml" {>= "4.03.0"}
 ]

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6/opam
@@ -19,12 +19,12 @@ depends: [
   "mirage-qubes" {>= "0.6" & < "0.7.0"}
   "tcpip" {>= "3.5.0"}
   "ipaddr" {< "3.0.0"}
-  "mirage-random"
-  "mirage-clock"
+  "mirage-random" {< "2.0.0"}
+  "mirage-clock" {< "3.0.0"}
   "mirage-protocols-lwt" {< "2.0.0"}
   "cstruct" {>= "1.9.0"}
   "lwt"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "logs" {>= "0.5.0"}
 ]
 synopsis: "Implementations of various Qubes protocols"

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.7.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.7.0/opam
@@ -13,17 +13,17 @@ build: [
 ]
 
 depends: [
-  "dune"  {>= "1.0"}
-  "mirage-qubes" { >= "0.7.0" }
-  "tcpip" { >= "3.5.0" }
-  "ipaddr" { >= "3.0.0" }
-  "mirage-random"
-  "mirage-clock"
-  "mirage-protocols-lwt" { >= "2.0.0" }
-  "cstruct" { >= "1.9.0" }
+  "dune" {>= "1.0"}
+  "mirage-qubes" {>= "0.7.0"}
+  "tcpip" {>= "3.5.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-random" {< "2.0.0"}
+  "mirage-clock" {< "3.0.0"}
+  "mirage-protocols-lwt" {>= "2.0.0"}
+  "cstruct" {>= "1.9.0"}
   "lwt"
-  "logs" { >= "0.5.0" }
-  "ocaml" { >= "4.03.0" }
+  "logs" {>= "0.5.0"}
+  "ocaml" {>= "4.03.0"}
 ]
 synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
 url {

--- a/packages/mirage-qubes/mirage-qubes.0.4/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.4/opam
@@ -20,7 +20,7 @@ depends: [
   "xen-gnt"
   "mirage-xen" {>= "3.0.0"}
   "lwt"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "logs" {>= "0.5.0"}
 ]
 depopts: [

--- a/packages/mirage-qubes/mirage-qubes.0.5/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.5/opam
@@ -21,7 +21,7 @@ depends: [
   "xen-gnt"
   "mirage-xen" {>= "3.0.0"}
   "lwt"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "logs" {>= "0.5.0"}
 ]
 synopsis: "Implementations of various QubesOS protocols:"

--- a/packages/mirage-qubes/mirage-qubes.0.6/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.6/opam
@@ -16,13 +16,13 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
   "jbuilder" {build & >= "1.0+beta9"}
-  "cstruct" {>= "1.9.0" & <"3.4.0"}
+  "cstruct" {>= "1.9.0" & < "3.4.0"}
   "vchan-xen"
   "xen-evtchn"
   "xen-gnt"
   "mirage-xen" {>= "3.0.0"}
   "lwt"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "logs" {>= "0.5.0"}
 ]
 synopsis: "Implementations of various Qubes protocols"

--- a/packages/mirage-random-stdlib/mirage-random-stdlib.0.0.1/opam
+++ b/packages/mirage-random-stdlib/mirage-random-stdlib.0.0.1/opam
@@ -14,13 +14,12 @@ build: [
 ]
 
 depends: [
-  "dune" {>="1.1.0"}
+  "dune" {>= "1.1.0"}
   "cstruct" {>= "1.9.0"}
   "ocaml" {>= "4.04.2"}
-  "mirage-random"
+  "mirage-random" {< "2.0.0"}
   "mirage-entropy"
 ]
-
 synopsis: "Random device implementation using the OCaml stdlib"
 description: """
 mirage-random-stdlib implements `Mirage_random.C` using the `Random` from

--- a/packages/mirage-random-test/mirage-random-test.0.0.1/opam
+++ b/packages/mirage-random-test/mirage-random-test.0.0.1/opam
@@ -14,12 +14,11 @@ build: [
 ]
 
 depends: [
-  "dune" {>="1.1.0"}
+  "dune" {>= "1.1.0"}
   "cstruct" {>= "1.9.0"}
   "ocaml" {>= "4.04.2"}
-  "mirage-random"
+  "mirage-random" {< "2.0.0"}
 ]
-
 synopsis: "Stub random device implementation for testing"
 description: """
 mirage-random-test implements `Mirage_random.C` as stub for testing.

--- a/packages/mirage-stack-lwt/mirage-stack-lwt.1.3.0/opam
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.1.3.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-stack" {>= "1.3.0"}
+  "mirage-stack" {>= "1.3.0" & < "2.0.0"}
   "ipaddr"
   "lwt"
   "cstruct" {>= "2.4.0"}

--- a/packages/mirage-stack-lwt/mirage-stack-lwt.1.4.0/opam
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.1.4.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-stack/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-stack" {>= "1.3.0"}
+  "mirage-stack" {>= "1.3.0" & < "2.0.0"}
   "ipaddr"
   "lwt"
   "cstruct" {>= "2.4.0"}

--- a/packages/mirage-stack/mirage-stack.1.0.0/opam
+++ b/packages/mirage-stack/mirage-stack.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
   "mirage-protocols" {>= "1.0.0" & < "1.3.0"}
   "fmt"
 ]

--- a/packages/mirage-stack/mirage-stack.1.1.0/opam
+++ b/packages/mirage-stack/mirage-stack.1.1.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
   "mirage-protocols" {>= "1.0.0" & < "1.3.0"}
   "fmt"
 ]

--- a/packages/mirage-stack/mirage-stack.1.2.0/opam
+++ b/packages/mirage-stack/mirage-stack.1.2.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
   "mirage-protocols" {>= "1.3.0" & < "1.4.0"}
   "fmt"
 ]

--- a/packages/mirage-stack/mirage-stack.1.3.0/opam
+++ b/packages/mirage-stack/mirage-stack.1.3.0/opam
@@ -16,8 +16,8 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-protocols" {>= "1.4.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-protocols" {>= "1.4.0" & < "4.0.0"}
   "fmt"
 ]
 synopsis: "MirageOS signatures for network stacks"

--- a/packages/mirage-stack/mirage-stack.1.4.0/opam
+++ b/packages/mirage-stack/mirage-stack.1.4.0/opam
@@ -9,8 +9,8 @@ bug-reports: "https://github.com/mirage/mirage-stack/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-protocols" {>= "1.4.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-protocols" {>= "1.4.0" & < "4.0.0"}
   "fmt"
 ]
 build: [

--- a/packages/mirage-time-lwt/mirage-time-lwt.1.1.0/opam
+++ b/packages/mirage-time-lwt/mirage-time-lwt.1.1.0/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-time" {>= "1.0.0"}
+  "mirage-time" {>= "1.0.0" & < "2.0.0"}
   "lwt"
 ]
 synopsis: "Time operations for MirageOS"

--- a/packages/mirage-time-lwt/mirage-time-lwt.1.3.0/opam
+++ b/packages/mirage-time-lwt/mirage-time-lwt.1.3.0/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/mirage/mirage-time/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-time" {>= "1.0.0"}
+  "mirage-time" {>= "1.0.0" & < "2.0.0"}
   "lwt"
 ]
 build: [

--- a/packages/mirage-time/mirage-time.1.0.0/opam
+++ b/packages/mirage-time/mirage-time.1.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
 ]
 synopsis: "Module type definitions for dealing with time."
 description:

--- a/packages/mirage-time/mirage-time.1.1.0/opam
+++ b/packages/mirage-time/mirage-time.1.1.0/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta9"}
-  "mirage-device"
+  "mirage-device" {< "2.0.0"}
 ]
 synopsis: "Time operations for MirageOS"
 description: """

--- a/packages/mirage-time/mirage-time.1.3.0/opam
+++ b/packages/mirage-time/mirage-time.1.3.0/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/mirage/mirage-time/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-device"
+  "mirage-device" {< "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.0.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.0.0/opam
@@ -16,10 +16,10 @@ depends: [
   "cstruct" {>= "1.4.0"}
   "io-page" {>= "1.4.0"}
   "ipaddr"
-  "mirage-types" {>= "3.0.0"}
+  "mirage-types" {>= "3.0.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-time-lwt" {>= "1.0.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-protocols-lwt" {>= "1.0.0" & < "1.4.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.3.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.0.5/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.0.5/opam
@@ -19,10 +19,10 @@ depends: [
   "cstruct" {>= "1.4.0"}
   "io-page" {>= "1.4.0"}
   "ipaddr"
-  "mirage-types" {>= "3.0.0"}
+  "mirage-types" {>= "3.0.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-time-lwt" {>= "1.0.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-protocols-lwt" {>= "1.0.0" & < "1.4.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.3.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.0.7/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.0.7/opam
@@ -19,10 +19,10 @@ depends: [
   "cstruct" {>= "1.4.0"}
   "io-page" {>= "1.4.0"}
   "ipaddr"
-  "mirage-types" {>= "3.0.0"}
+  "mirage-types" {>= "3.0.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-time-lwt" {>= "1.0.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-protocols-lwt" {>= "1.0.0" & < "1.4.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.3.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.1.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.1.0/opam
@@ -19,10 +19,10 @@ depends: [
   "cstruct" {>= "1.4.0"}
   "io-page" {>= "1.4.0"}
   "ipaddr"
-  "mirage-types" {>= "3.0.0"}
+  "mirage-types" {>= "3.0.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-time-lwt" {>= "1.0.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-protocols-lwt" {>= "1.0.0" & < "1.4.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.3.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.1.1/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.1.1/opam
@@ -19,10 +19,10 @@ depends: [
   "cstruct" {>= "1.4.0"}
   "io-page" {>= "1.4.0"}
   "ipaddr"
-  "mirage-types" {>= "3.0.0"}
+  "mirage-types" {>= "3.0.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-time-lwt" {>= "1.0.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-protocols-lwt" {>= "1.0.0" & < "1.4.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.3.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.2.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.2.0/opam
@@ -11,10 +11,10 @@ depends: [
   "cstruct" {>= "1.4.0"}
   "io-page" {>= "1.4.0"}
   "ipaddr"
-  "mirage-types" {>= "3.2.0"}
+  "mirage-types" {>= "3.2.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-time-lwt" {>= "1.0.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-protocols-lwt" {>= "1.4.0" & < "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.3.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.3.0/opam
@@ -21,10 +21,10 @@ depends: [
   "cstruct" {>= "1.4.0"}
   "io-page" {>= "1.4.0"}
   "ipaddr"
-  "mirage-types" {>= "3.3.0"}
+  "mirage-types" {>= "3.3.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-time-lwt" {>= "1.0.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-protocols-lwt" {>= "1.4.0" & < "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.4.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.4.0/opam
@@ -21,10 +21,10 @@ depends: [
   "cstruct" {>= "3.2.1"}
   "io-page" {>= "2.0.1"}
   "ipaddr" {>= "3.0.0"}
-  "mirage-types" {>= "3.4.0"}
+  "mirage-types" {>= "3.4.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "2.0.0"}
   "mirage-time-lwt" {>= "1.1.0"}
-  "mirage-random" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.5.0"}
   "mirage-protocols-lwt" {>= "1.4.1" & < "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.4.1/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.4.1/opam
@@ -21,10 +21,10 @@ depends: [
   "cstruct" {>= "3.2.1"}
   "io-page" {>= "2.0.1"}
   "ipaddr" {>= "3.0.0"}
-  "mirage-types" {>= "3.4.0"}
+  "mirage-types" {>= "3.4.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "2.0.0"}
   "mirage-time-lwt" {>= "1.1.0"}
-  "mirage-random" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.5.0"}
   "mirage-protocols-lwt" {>= "1.4.1" & < "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.5.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.5.0/opam
@@ -14,16 +14,16 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
-depends:   [
+depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
   "lwt"
-  "cstruct" {>="3.2.1"}
+  "cstruct" {>= "3.2.1"}
   "ipaddr" {>= "3.0.0"}
-  "mirage-types" {>= "3.5.0"}
+  "mirage-types" {>= "3.5.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "2.0.0"}
   "mirage-time-lwt" {>= "1.1.0"}
-  "mirage-random" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.5.0"}
   "mirage-protocols-lwt" {>= "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
@@ -34,7 +34,6 @@ depends:   [
   "mirage-kv-lwt" {>= "2.0.0"}
   "mirage-channel-lwt" {>= "3.1.0"}
 ]
-
 synopsis: "Lwt module type definitions for MirageOS applications"
 description: """
 The purpose of this library is to provide concrete types

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.5.1/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.5.1/opam
@@ -14,16 +14,16 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
-depends:   [
+depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
   "lwt"
-  "cstruct" {>="3.2.1"}
+  "cstruct" {>= "3.2.1"}
   "ipaddr" {>= "3.0.0"}
-  "mirage-types" {>= "3.5.0"}
+  "mirage-types" {>= "3.5.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "2.0.0"}
   "mirage-time-lwt" {>= "1.1.0"}
-  "mirage-random" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.5.0"}
   "mirage-protocols-lwt" {>= "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
@@ -34,7 +34,6 @@ depends:   [
   "mirage-kv-lwt" {>= "2.0.0"}
   "mirage-channel-lwt" {>= "3.1.0"}
 ]
-
 synopsis: "Lwt module type definitions for MirageOS applications"
 description: """
 The purpose of this library is to provide concrete types

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.5.2/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.5.2/opam
@@ -14,16 +14,16 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
-depends:   [
+depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
   "lwt"
-  "cstruct" {>="3.2.1"}
+  "cstruct" {>= "3.2.1"}
   "ipaddr" {>= "3.0.0"}
-  "mirage-types" {>= "3.5.0"}
+  "mirage-types" {>= "3.5.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "2.0.0"}
   "mirage-time-lwt" {>= "1.1.0"}
-  "mirage-random" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.5.0"}
   "mirage-protocols-lwt" {>= "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
@@ -34,7 +34,6 @@ depends:   [
   "mirage-kv-lwt" {>= "2.0.0"}
   "mirage-channel-lwt" {>= "3.1.0"}
 ]
-
 synopsis: "Lwt module type definitions for MirageOS applications"
 description: """
 The purpose of this library is to provide concrete types

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.6.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.6.0/opam
@@ -14,16 +14,16 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
-depends:   [
+depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
   "lwt"
-  "cstruct" {>="3.2.1"}
+  "cstruct" {>= "3.2.1"}
   "ipaddr" {>= "3.0.0"}
-  "mirage-types" {>= "3.5.0"}
+  "mirage-types" {>= "3.5.0" & < "3.7.0"}
   "mirage-clock-lwt" {>= "2.0.0"}
   "mirage-time-lwt" {>= "1.1.0"}
-  "mirage-random" {>= "1.2.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.5.0"}
   "mirage-protocols-lwt" {>= "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
@@ -34,7 +34,6 @@ depends:   [
   "mirage-kv-lwt" {>= "2.0.0"}
   "mirage-channel-lwt" {>= "3.1.0"}
 ]
-
 synopsis: "Lwt module type definitions for MirageOS applications"
 description: """
 The purpose of this library is to provide concrete types

--- a/packages/mirage-types/mirage-types.3.0.0/opam
+++ b/packages/mirage-types/mirage-types.3.0.0/opam
@@ -13,19 +13,19 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-time" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-time" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock" {>= "1.2.0" & < "2.0.0"}
-  "mirage-random" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "mirage-protocols" {>= "1.0.0" & < "1.4.0"}
   "mirage-stack" {>= "1.0.0" & < "1.3.0"}
-  "mirage-block" {>= "1.0.0"}
+  "mirage-block" {>= "1.0.0" & < "2.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-kv" {>= "1.0.0" & < "2.0.0"}
-  "mirage-channel" {>= "3.0.0"}
+  "mirage-channel" {>= "3.0.0" & < "4.0.0"}
 ]
 synopsis: "Module type definitions for Mirage-compatible applications"
 url {

--- a/packages/mirage-types/mirage-types.3.0.5/opam
+++ b/packages/mirage-types/mirage-types.3.0.5/opam
@@ -17,19 +17,19 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {build & >= "1.0+beta10"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-time" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-time" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock" {>= "1.2.0" & < "2.0.0"}
-  "mirage-random" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "mirage-protocols" {>= "1.0.0" & < "1.4.0"}
   "mirage-stack" {>= "1.0.0" & < "1.3.0"}
-  "mirage-block" {>= "1.0.0"}
+  "mirage-block" {>= "1.0.0" & < "2.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-kv" {>= "1.0.0" & < "2.0.0"}
-  "mirage-channel" {>= "3.0.0"}
+  "mirage-channel" {>= "3.0.0" & < "4.0.0"}
 ]
 synopsis: "Module type definitions for Mirage-compatible applications"
 url {

--- a/packages/mirage-types/mirage-types.3.0.7/opam
+++ b/packages/mirage-types/mirage-types.3.0.7/opam
@@ -17,19 +17,19 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-time" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-time" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock" {>= "1.2.0" & < "2.0.0"}
-  "mirage-random" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "mirage-protocols" {>= "1.0.0" & < "1.4.0"}
   "mirage-stack" {>= "1.0.0" & < "1.3.0"}
-  "mirage-block" {>= "1.0.0"}
+  "mirage-block" {>= "1.0.0" & < "2.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-kv" {>= "1.0.0" & < "2.0.0"}
-  "mirage-channel" {>= "3.0.0"}
+  "mirage-channel" {>= "3.0.0" & < "4.0.0"}
 ]
 synopsis: "Module type definitions for Mirage-compatible applications"
 url {

--- a/packages/mirage-types/mirage-types.3.1.0/opam
+++ b/packages/mirage-types/mirage-types.3.1.0/opam
@@ -17,19 +17,19 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-time" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-time" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock" {>= "1.2.0" & < "2.0.0"}
-  "mirage-random" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "mirage-protocols" {>= "1.0.0" & < "1.4.0"}
   "mirage-stack" {>= "1.0.0" & < "1.3.0"}
-  "mirage-block" {>= "1.0.0"}
+  "mirage-block" {>= "1.0.0" & < "2.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-kv" {>= "1.0.0" & < "2.0.0"}
-  "mirage-channel" {>= "3.0.0"}
+  "mirage-channel" {>= "3.0.0" & < "4.0.0"}
 ]
 synopsis: "Module type definitions for Mirage-compatible applications"
 url {

--- a/packages/mirage-types/mirage-types.3.1.1/opam
+++ b/packages/mirage-types/mirage-types.3.1.1/opam
@@ -17,19 +17,19 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-time" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-time" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock" {>= "1.2.0" & < "2.0.0"}
-  "mirage-random" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "mirage-protocols" {>= "1.0.0" & < "1.4.0"}
   "mirage-stack" {>= "1.0.0" & < "1.3.0"}
-  "mirage-block" {>= "1.0.0"}
+  "mirage-block" {>= "1.0.0" & < "2.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-kv" {>= "1.0.0" & < "2.0.0"}
-  "mirage-channel" {>= "3.0.0"}
+  "mirage-channel" {>= "3.0.0" & < "4.0.0"}
 ]
 synopsis: "Module type definitions for Mirage-compatible applications"
 url {

--- a/packages/mirage-types/mirage-types.3.2.0/opam
+++ b/packages/mirage-types/mirage-types.3.2.0/opam
@@ -18,19 +18,19 @@ bug-reports: "https://github.com/mirage/mirage/issues/"
 depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-time" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-time" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock" {>= "1.2.0" & < "2.0.0"}
-  "mirage-random" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
-  "mirage-stack" {>= "1.3.0"}
-  "mirage-block" {>= "1.0.0"}
+  "mirage-stack" {>= "1.3.0" & < "2.0.0"}
+  "mirage-block" {>= "1.0.0" & < "2.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-kv" {>= "1.0.0" & < "2.0.0"}
-  "mirage-channel" {>= "3.0.0"}
+  "mirage-channel" {>= "3.0.0" & < "4.0.0"}
 ]
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}

--- a/packages/mirage-types/mirage-types.3.3.0/opam
+++ b/packages/mirage-types/mirage-types.3.3.0/opam
@@ -19,19 +19,19 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
-  "mirage-device" {>= "1.0.0"}
-  "mirage-time" {>= "1.0.0"}
+  "mirage-device" {>= "1.0.0" & < "2.0.0"}
+  "mirage-time" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock" {>= "1.2.0" & < "2.0.0"}
-  "mirage-random" {>= "1.0.0"}
-  "mirage-flow" {>= "1.2.0"}
-  "mirage-console" {>= "2.2.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.2.0" & < "2.0.0"}
+  "mirage-console" {>= "2.2.0" & < "3.0.0"}
   "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
-  "mirage-stack" {>= "1.3.0"}
-  "mirage-block" {>= "1.0.0"}
+  "mirage-stack" {>= "1.3.0" & < "2.0.0"}
+  "mirage-block" {>= "1.0.0" & < "2.0.0"}
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
-  "mirage-fs" {>= "1.0.0"}
+  "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-kv" {>= "1.0.0" & < "2.0.0"}
-  "mirage-channel" {>= "3.0.0"}
+  "mirage-channel" {>= "3.0.0" & < "4.0.0"}
 ]
 synopsis: "Module type definitions for MirageOS applications"
 description: """

--- a/packages/mirage-types/mirage-types.3.4.0/opam
+++ b/packages/mirage-types/mirage-types.3.4.0/opam
@@ -19,19 +19,19 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
-  "mirage-device" {>= "1.1.0"}
-  "mirage-time" {>= "1.1.0"}
-  "mirage-clock" {>= "2.0.0"}
-  "mirage-random" {>= "1.2.0"}
-  "mirage-flow" {>= "1.5.0"}
-  "mirage-console" {>= "2.3.5"}
+  "mirage-device" {>= "1.1.0" & < "2.0.0"}
+  "mirage-time" {>= "1.1.0" & < "2.0.0"}
+  "mirage-clock" {>= "2.0.0" & < "3.0.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.5.0" & < "2.0.0"}
+  "mirage-console" {>= "2.3.5" & < "3.0.0"}
   "mirage-protocols" {>= "1.4.1" & < "2.0.0"}
-  "mirage-stack" {>= "1.3.0"}
-  "mirage-block" {>= "1.1.0"}
+  "mirage-stack" {>= "1.3.0" & < "2.0.0"}
+  "mirage-block" {>= "1.1.0" & < "2.0.0"}
   "mirage-net" {>= "1.2.0" & < "2.0.0"}
-  "mirage-fs" {>= "1.1.1"}
+  "mirage-fs" {>= "1.1.1" & < "3.0.0"}
   "mirage-kv" {>= "1.1.1" & < "2.0.0"}
-  "mirage-channel" {>= "3.1.0"}
+  "mirage-channel" {>= "3.1.0" & < "4.0.0"}
 ]
 synopsis: "Module type definitions for MirageOS applications"
 description: """

--- a/packages/mirage-types/mirage-types.3.4.1/opam
+++ b/packages/mirage-types/mirage-types.3.4.1/opam
@@ -19,19 +19,19 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
-  "mirage-device" {>= "1.1.0"}
-  "mirage-time" {>= "1.1.0"}
-  "mirage-clock" {>= "2.0.0"}
-  "mirage-random" {>= "1.2.0"}
-  "mirage-flow" {>= "1.5.0"}
-  "mirage-console" {>= "2.3.5"}
+  "mirage-device" {>= "1.1.0" & < "2.0.0"}
+  "mirage-time" {>= "1.1.0" & < "2.0.0"}
+  "mirage-clock" {>= "2.0.0" & < "3.0.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.5.0" & < "2.0.0"}
+  "mirage-console" {>= "2.3.5" & < "3.0.0"}
   "mirage-protocols" {>= "1.4.1" & < "2.0.0"}
-  "mirage-stack" {>= "1.3.0"}
-  "mirage-block" {>= "1.1.0"}
+  "mirage-stack" {>= "1.3.0" & < "2.0.0"}
+  "mirage-block" {>= "1.1.0" & < "2.0.0"}
   "mirage-net" {>= "1.2.0" & < "2.0.0"}
-  "mirage-fs" {>= "1.1.1"}
+  "mirage-fs" {>= "1.1.1" & < "3.0.0"}
   "mirage-kv" {>= "1.1.1" & < "2.0.0"}
-  "mirage-channel" {>= "3.1.0"}
+  "mirage-channel" {>= "3.1.0" & < "4.0.0"}
 ]
 synopsis: "Module type definitions for MirageOS applications"
 description: """

--- a/packages/mirage-types/mirage-types.3.5.0/opam
+++ b/packages/mirage-types/mirage-types.3.5.0/opam
@@ -19,19 +19,19 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
-  "mirage-device" {>= "1.1.0"}
-  "mirage-time" {>= "1.1.0"}
-  "mirage-clock" {>= "2.0.0"}
-  "mirage-random" {>= "1.2.0"}
-  "mirage-flow" {>= "1.5.0"}
-  "mirage-console" {>= "2.3.5"}
-  "mirage-protocols" {>= "2.0.0"}
-  "mirage-stack" {>= "1.3.0"}
-  "mirage-block" {>= "1.1.0"}
-  "mirage-net" {>= "2.0.0"}
-  "mirage-fs" {>= "2.0.0"}
-  "mirage-kv" {>= "2.0.0"}
-  "mirage-channel" {>= "3.1.0"}
+  "mirage-device" {>= "1.1.0" & < "2.0.0"}
+  "mirage-time" {>= "1.1.0" & < "2.0.0"}
+  "mirage-clock" {>= "2.0.0" & < "3.0.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.5.0" & < "2.0.0"}
+  "mirage-console" {>= "2.3.5" & < "3.0.0"}
+  "mirage-protocols" {>= "2.0.0" & < "4.0.0"}
+  "mirage-stack" {>= "1.3.0" & < "2.0.0"}
+  "mirage-block" {>= "1.1.0" & < "2.0.0"}
+  "mirage-net" {>= "2.0.0" & < "3.0.0"}
+  "mirage-fs" {>= "2.0.0" & < "3.0.0"}
+  "mirage-kv" {>= "2.0.0" & < "3.0.0"}
+  "mirage-channel" {>= "3.1.0" & < "4.0.0"}
 ]
 synopsis: "Module type definitions for MirageOS applications"
 description: """

--- a/packages/mirage-types/mirage-types.3.5.1/opam
+++ b/packages/mirage-types/mirage-types.3.5.1/opam
@@ -19,19 +19,19 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
-  "mirage-device" {>= "1.1.0"}
-  "mirage-time" {>= "1.1.0"}
-  "mirage-clock" {>= "2.0.0"}
-  "mirage-random" {>= "1.2.0"}
-  "mirage-flow" {>= "1.5.0"}
-  "mirage-console" {>= "2.3.5"}
-  "mirage-protocols" {>= "2.0.0"}
-  "mirage-stack" {>= "1.3.0"}
-  "mirage-block" {>= "1.1.0"}
-  "mirage-net" {>= "2.0.0"}
-  "mirage-fs" {>= "2.0.0"}
-  "mirage-kv" {>= "2.0.0"}
-  "mirage-channel" {>= "3.1.0"}
+  "mirage-device" {>= "1.1.0" & < "2.0.0"}
+  "mirage-time" {>= "1.1.0" & < "2.0.0"}
+  "mirage-clock" {>= "2.0.0" & < "3.0.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.5.0" & < "2.0.0"}
+  "mirage-console" {>= "2.3.5" & < "3.0.0"}
+  "mirage-protocols" {>= "2.0.0" & < "4.0.0"}
+  "mirage-stack" {>= "1.3.0" & < "2.0.0"}
+  "mirage-block" {>= "1.1.0" & < "2.0.0"}
+  "mirage-net" {>= "2.0.0" & < "3.0.0"}
+  "mirage-fs" {>= "2.0.0" & < "3.0.0"}
+  "mirage-kv" {>= "2.0.0" & < "3.0.0"}
+  "mirage-channel" {>= "3.1.0" & < "4.0.0"}
 ]
 synopsis: "Module type definitions for MirageOS applications"
 description: """

--- a/packages/mirage-types/mirage-types.3.5.2/opam
+++ b/packages/mirage-types/mirage-types.3.5.2/opam
@@ -19,19 +19,19 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
-  "mirage-device" {>= "1.1.0"}
-  "mirage-time" {>= "1.1.0"}
-  "mirage-clock" {>= "2.0.0"}
-  "mirage-random" {>= "1.2.0"}
-  "mirage-flow" {>= "1.5.0"}
-  "mirage-console" {>= "2.3.5"}
-  "mirage-protocols" {>= "2.0.0"}
-  "mirage-stack" {>= "1.3.0"}
-  "mirage-block" {>= "1.1.0"}
-  "mirage-net" {>= "2.0.0"}
-  "mirage-fs" {>= "2.0.0"}
-  "mirage-kv" {>= "2.0.0"}
-  "mirage-channel" {>= "3.1.0"}
+  "mirage-device" {>= "1.1.0" & < "2.0.0"}
+  "mirage-time" {>= "1.1.0" & < "2.0.0"}
+  "mirage-clock" {>= "2.0.0" & < "3.0.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.5.0" & < "2.0.0"}
+  "mirage-console" {>= "2.3.5" & < "3.0.0"}
+  "mirage-protocols" {>= "2.0.0" & < "4.0.0"}
+  "mirage-stack" {>= "1.3.0" & < "2.0.0"}
+  "mirage-block" {>= "1.1.0" & < "2.0.0"}
+  "mirage-net" {>= "2.0.0" & < "3.0.0"}
+  "mirage-fs" {>= "2.0.0" & < "3.0.0"}
+  "mirage-kv" {>= "2.0.0" & < "3.0.0"}
+  "mirage-channel" {>= "3.1.0" & < "4.0.0"}
 ]
 synopsis: "Module type definitions for MirageOS applications"
 description: """

--- a/packages/mirage-types/mirage-types.3.6.0/opam
+++ b/packages/mirage-types/mirage-types.3.6.0/opam
@@ -19,19 +19,19 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
-  "mirage-device" {>= "1.1.0"}
-  "mirage-time" {>= "1.1.0"}
-  "mirage-clock" {>= "2.0.0"}
-  "mirage-random" {>= "1.2.0"}
-  "mirage-flow" {>= "1.5.0"}
-  "mirage-console" {>= "2.3.5"}
-  "mirage-protocols" {>= "2.0.0"}
-  "mirage-stack" {>= "1.3.0"}
-  "mirage-block" {>= "1.1.0"}
-  "mirage-net" {>= "2.0.0"}
-  "mirage-fs" {>= "2.0.0"}
-  "mirage-kv" {>= "2.0.0"}
-  "mirage-channel" {>= "3.1.0"}
+  "mirage-device" {>= "1.1.0" & < "2.0.0"}
+  "mirage-time" {>= "1.1.0" & < "2.0.0"}
+  "mirage-clock" {>= "2.0.0" & < "3.0.0"}
+  "mirage-random" {>= "1.2.0" & < "2.0.0"}
+  "mirage-flow" {>= "1.5.0" & < "2.0.0"}
+  "mirage-console" {>= "2.3.5" & < "3.0.0"}
+  "mirage-protocols" {>= "2.0.0" & < "4.0.0"}
+  "mirage-stack" {>= "1.3.0" & < "2.0.0"}
+  "mirage-block" {>= "1.1.0" & < "2.0.0"}
+  "mirage-net" {>= "2.0.0" & < "3.0.0"}
+  "mirage-fs" {>= "2.0.0" & < "3.0.0"}
+  "mirage-kv" {>= "2.0.0" & < "3.0.0"}
+  "mirage-channel" {>= "3.1.0" & < "4.0.0"}
 ]
 synopsis: "Module type definitions for MirageOS applications"
 description: """

--- a/packages/nbd/nbd.3.0.0/opam
+++ b/packages/nbd/nbd.3.0.0/opam
@@ -30,10 +30,10 @@ depends: [
   "result"
   "rresult"
   "cstruct" {>= "1.9.0" & < "3.4.0"}
-  "ppx_cstruct" {<"3.4.0"}
+  "ppx_cstruct" {< "3.4.0"}
   "cmdliner"
   "sexplib" {< "v0.13"}
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "mirage-block-unix"
   "mirage-block-lwt"
   "io-page-unix"

--- a/packages/protocol-9p/protocol-9p.0.8.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.8.0/opam
@@ -35,7 +35,7 @@ depends: [
   "cstruct-lwt"
   "sexplib" {> "113.00.00" & < "v0.13"}
   "result"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.7.0"}
   "channel" {>= "1.1.0"}
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "base-unix"

--- a/packages/qcow-tool/qcow-tool.0.10.0/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.0/opam
@@ -16,12 +16,12 @@ depends: [
   "cstruct"
   "result"
   "unix-type-representations"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.1.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "sha" {= "1.9"}
   "sexplib" {< "v0.13"}

--- a/packages/qcow-tool/qcow-tool.0.10.2/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.2/opam
@@ -21,12 +21,12 @@ depends: [
   "cstruct"
   "result"
   "unix-type-representations"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.1.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "sha" {= "1.9"}
   "sexplib" {< "v0.13"}

--- a/packages/qcow-tool/qcow-tool.0.10.3/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.3/opam
@@ -21,12 +21,12 @@ depends: [
   "cstruct"
   "result"
   "unix-type-representations"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.1.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "sha" {= "1.9"}
   "sexplib" {< "v0.13"}

--- a/packages/qcow-tool/qcow-tool.0.10.4/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.4/opam
@@ -21,12 +21,12 @@ depends: [
   "cstruct"
   "result"
   "unix-type-representations"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.1.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "sha" {>= "1.10"}
   "sexplib" {< "v0.13"}

--- a/packages/qcow-tool/qcow-tool.0.10.5/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.5/opam
@@ -21,12 +21,12 @@ depends: [
   "cstruct"
   "result"
   "unix-type-representations"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.9.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "sha" {>= "1.10"}
   "sexplib" {< "v0.13"}

--- a/packages/qcow/qcow.0.10.0/opam
+++ b/packages/qcow/qcow.0.10.0/opam
@@ -15,12 +15,12 @@ depends: [
   "cstruct" {< "4.0.0"}
   "result"
   "prometheus"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.1.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "cmdliner"
   "sexplib" {< "v0.13"}

--- a/packages/qcow/qcow.0.10.2/opam
+++ b/packages/qcow/qcow.0.10.2/opam
@@ -20,12 +20,12 @@ depends: [
   "cstruct" {< "4.0.0"}
   "result"
   "prometheus"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.3.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "sexplib" {< "v0.13"}
   "logs"

--- a/packages/qcow/qcow.0.10.3/opam
+++ b/packages/qcow/qcow.0.10.3/opam
@@ -20,12 +20,12 @@ depends: [
   "cstruct" {< "4.0.0"}
   "result"
   "prometheus"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.3.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "sexplib" {< "v0.13"}
   "logs"

--- a/packages/qcow/qcow.0.10.4/opam
+++ b/packages/qcow/qcow.0.10.4/opam
@@ -20,12 +20,12 @@ depends: [
   "cstruct" {< "4.0.0"}
   "result"
   "prometheus"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.3.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "sexplib" {< "v0.13"}
   "logs"

--- a/packages/qcow/qcow.0.8.1/opam
+++ b/packages/qcow/qcow.0.8.1/opam
@@ -15,12 +15,12 @@ depends: [
   "cmdliner"
   "cstruct" {< "4.0.0"}
   "result"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.3.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "sexplib" {< "v0.13"}
   "logs"

--- a/packages/qcow/qcow.0.9.0/opam
+++ b/packages/qcow/qcow.0.9.0/opam
@@ -15,12 +15,12 @@ depends: [
   "cmdliner"
   "cstruct" {< "4.0.0"}
   "result"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.3.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "cmdliner"
   "sha" {= "1.9"}

--- a/packages/qcow/qcow.0.9.4/opam
+++ b/packages/qcow/qcow.0.9.4/opam
@@ -15,12 +15,12 @@ depends: [
   "cmdliner"
   "cstruct" {< "4.0.0"}
   "result"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.3.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "sha" {= "1.9"}
   "sexplib" {< "v0.13"}

--- a/packages/qcow/qcow.0.9.5/opam
+++ b/packages/qcow/qcow.0.9.5/opam
@@ -15,12 +15,12 @@ depends: [
   "cmdliner"
   "cstruct" {< "4.0.0"}
   "result"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
-  "mirage-block" {>= "0.2"}
+  "mirage-block" {>= "0.2" & < "2.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix" {>= "2.1.0"}
-  "mirage-time"
+  "mirage-time" {< "2.0.0"}
   "mirage-time-lwt"
   "cmdliner"
   "sha" {= "1.9"}

--- a/packages/shared-block-ring/shared-block-ring.2.3.0/opam
+++ b/packages/shared-block-ring/shared-block-ring.2.3.0/opam
@@ -24,7 +24,7 @@ depends: [
   "lwt" {< "4.0.0"}
   "ocamlfind"
   "ounit"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {< "3.7.0"}
   "mirage-block-unix" {<= "2.4.0"}
   "mirage-clock-unix" {= "1.0.0"}
   "sexplib" {< "v0.13"}

--- a/packages/shared-block-ring/shared-block-ring.2.4.0/opam
+++ b/packages/shared-block-ring/shared-block-ring.2.4.0/opam
@@ -24,7 +24,7 @@ depends: [
   "lwt" {< "4.0.0"}
   "ocamlfind"
   "ounit"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "mirage-block-unix"
   "mirage-clock-unix" {>= "1.0.0"}
   "sexplib" {< "v0.13"}

--- a/packages/tar-format/tar-format.0.4.1/opam
+++ b/packages/tar-format/tar-format.0.4.1/opam
@@ -40,7 +40,7 @@ depends: [
   "ounit" {with-test}
   "mirage-block-unix" {with-test}
   "lwt" {with-test}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
   "ocamlbuild" {build}
 ]
 depopts: ["lwt" "mirage-types-lwt"]

--- a/packages/tar-format/tar-format.0.4.2/opam
+++ b/packages/tar-format/tar-format.0.4.2/opam
@@ -38,7 +38,7 @@ depends: [
   "ounit" {with-test}
   "mirage-block-unix" {with-test}
   "lwt" {with-test}
-  "mirage-types-lwt" {with-test}
+  "mirage-types-lwt" {with-test & < "3.7.0"}
 ]
 depopts: ["lwt" "mirage-types-lwt"]
 synopsis: "A pure OCaml library to read and write tar files"

--- a/packages/tar-format/tar-format.0.7.1/opam
+++ b/packages/tar-format/tar-format.0.7.1/opam
@@ -45,7 +45,7 @@ depends: [
   "re"
   "result"
   "mirage-block-unix" {with-test & >= "2.5.0"}
-  "mirage-types-lwt" {with-test & >= "3.0.0"}
+  "mirage-types-lwt" {with-test & >= "3.0.0" & < "3.7.0"}
   "ounit" {with-test}
   "lwt" {with-test}
 ]

--- a/packages/tar-mirage/tar-mirage.0.8.0/opam
+++ b/packages/tar-mirage/tar-mirage.0.8.0/opam
@@ -20,7 +20,7 @@ depends: [
   "re"
   "result"
   "mirage-block-unix" {with-test & >= "2.5.0"}
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
   "ounit" {with-test}
 ]

--- a/packages/tar-mirage/tar-mirage.0.9.0/opam
+++ b/packages/tar-mirage/tar-mirage.0.9.0/opam
@@ -20,7 +20,7 @@ depends: [
   "re"
   "result"
   "mirage-block-unix" {with-test & >= "2.5.0"}
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
   "io-page"
   "io-page-unix" {with-test}

--- a/packages/tar-mirage/tar-mirage.1.0.0/opam
+++ b/packages/tar-mirage/tar-mirage.1.0.0/opam
@@ -10,10 +10,10 @@ depends: [
   "dune" {>= "1.0"}
   "tar" {>= "1.0.0"}
   "cstruct" {>= "1.9.0"}
-  "re" {>="1.7.2"}
+  "re" {>= "1.7.2"}
   "result"
   "mirage-block-unix" {with-test & >= "2.5.0"}
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
   "io-page"
   "mirage-block-unix" {with-test}

--- a/packages/tar-mirage/tar-mirage.1.0.1/opam
+++ b/packages/tar-mirage/tar-mirage.1.0.1/opam
@@ -10,10 +10,10 @@ depends: [
   "dune" {>= "1.0"}
   "tar" {>= "1.0.0"}
   "cstruct" {>= "1.9.0"}
-  "re" {>="1.7.2"}
+  "re" {>= "1.7.2"}
   "result"
   "mirage-block-unix" {with-test & >= "2.5.0"}
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "lwt"
   "io-page"
   "mirage-block-unix" {with-test}

--- a/packages/tar-mirage/tar-mirage.1.1.0/opam
+++ b/packages/tar-mirage/tar-mirage.1.1.0/opam
@@ -10,10 +10,10 @@ depends: [
   "dune" {>= "1.0"}
   "tar"
   "cstruct" {>= "1.9.0"}
-  "re" {>="1.7.2"}
-  "mirage-block"
+  "re" {>= "1.7.2"}
+  "mirage-block" {< "2.0.0"}
   "mirage-block-lwt"
-  "mirage-kv" {>= "2.0.0"}
+  "mirage-kv" {>= "2.0.0" & < "3.0.0"}
   "mirage-kv-lwt" {>= "2.0.0"}
   "lwt"
   "io-page"

--- a/packages/tcpip/tcpip.2.4.2/opam
+++ b/packages/tcpip/tcpip.2.4.2/opam
@@ -37,7 +37,7 @@ depends: [
   "mirage-net-unix" {>= "1.1.0" & < "2.3.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {< "0.8.0"}
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
   "alcotest" {with-test}
   "ocamlbuild" {build}
 ]

--- a/packages/tcpip/tcpip.2.6.1/opam
+++ b/packages/tcpip/tcpip.2.6.1/opam
@@ -39,7 +39,7 @@ depends: [
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5" & < "0.8.0"}
   "lwt" {>= "2.4.7" & < "3.0.0"}
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
   "mirage-vnetif" {with-test & < "0.3.0"}
   "alcotest" {with-test}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.2.8.0/opam
+++ b/packages/tcpip/tcpip.2.8.0/opam
@@ -56,7 +56,7 @@ depends: [
   "mirage-profile" {>= "0.5" & < "0.8.0"}
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "cstruct-lwt"
-  "mirage-flow" {with-test}
+  "mirage-flow" {with-test & < "2.0.0"}
   "mirage-vnetif" {with-test & < "0.3.0"}
   "alcotest" {with-test}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.0.0/opam
+++ b/packages/tcpip/tcpip.3.0.0/opam
@@ -45,7 +45,7 @@ depends: [
   "ppx_tools"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.2.0"}
@@ -54,7 +54,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5" & < "0.8.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.3.1"}
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}

--- a/packages/tcpip/tcpip.3.1.0/opam
+++ b/packages/tcpip/tcpip.3.1.0/opam
@@ -45,7 +45,7 @@ depends: [
   "ppx_tools"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.2.0"}
@@ -54,7 +54,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5" & < "0.8.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.3.1"}
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}

--- a/packages/tcpip/tcpip.3.1.1/opam
+++ b/packages/tcpip/tcpip.3.1.1/opam
@@ -45,7 +45,7 @@ depends: [
   "ppx_tools"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.2.0"}
@@ -54,7 +54,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5" & < "0.8.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.3.1"}
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}

--- a/packages/tcpip/tcpip.3.1.2/opam
+++ b/packages/tcpip/tcpip.3.1.2/opam
@@ -45,7 +45,7 @@ depends: [
   "ppx_tools"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.2.0"}
@@ -54,7 +54,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5" & < "0.8.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.3.1"}
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}

--- a/packages/tcpip/tcpip.3.1.3/opam
+++ b/packages/tcpip/tcpip.3.1.3/opam
@@ -45,7 +45,7 @@ depends: [
   "ppx_tools"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.2.0"}
@@ -54,7 +54,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5" & < "0.8.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}

--- a/packages/tcpip/tcpip.3.1.4/opam
+++ b/packages/tcpip/tcpip.3.1.4/opam
@@ -46,7 +46,7 @@ depends: [
   "ppx_tools"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.2.0"}
@@ -55,7 +55,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}

--- a/packages/tcpip/tcpip.3.2.0/opam
+++ b/packages/tcpip/tcpip.3.2.0/opam
@@ -29,7 +29,7 @@ depends: [
   "cstruct-lwt"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.3.0"}
@@ -38,7 +38,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "ounit" {with-test}

--- a/packages/tcpip/tcpip.3.3.0/opam
+++ b/packages/tcpip/tcpip.3.3.0/opam
@@ -29,7 +29,7 @@ depends: [
   "cstruct-lwt"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.2.0"}
@@ -44,7 +44,7 @@ depends: [
   "duration"
   "io-page-unix"
   "randomconv"
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.3.1/opam
+++ b/packages/tcpip/tcpip.3.3.1/opam
@@ -29,7 +29,7 @@ depends: [
   "cstruct-lwt"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.0.0" & < "1.2.0"}
@@ -44,7 +44,7 @@ depends: [
   "duration"
   "io-page-unix"
   "randomconv"
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.4.0/opam
+++ b/packages/tcpip/tcpip.3.4.0/opam
@@ -29,7 +29,7 @@ depends: [
   "cstruct-lwt"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.2.0" & < "1.3.0"}
@@ -44,7 +44,7 @@ depends: [
   "duration"
   "io-page-unix"
   "randomconv"
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.4.1/opam
+++ b/packages/tcpip/tcpip.3.4.1/opam
@@ -29,7 +29,7 @@ depends: [
   "cstruct-lwt"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.2.0" & < "1.3.0"}
@@ -44,7 +44,7 @@ depends: [
   "duration"
   "io-page-unix"
   "randomconv"
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.4.2/opam
+++ b/packages/tcpip/tcpip.3.4.2/opam
@@ -28,7 +28,7 @@ depends: [
   "cstruct-lwt"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.2.0" & < "1.3.0"}
@@ -43,7 +43,7 @@ depends: [
   "duration"
   "io-page-unix"
   "randomconv"
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.5.0/opam
+++ b/packages/tcpip/tcpip.3.5.0/opam
@@ -29,7 +29,7 @@ depends: [
   "cstruct-lwt"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
@@ -44,7 +44,7 @@ depends: [
   "duration"
   "io-page-unix"
   "randomconv"
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.5.1/opam
+++ b/packages/tcpip/tcpip.3.5.1/opam
@@ -29,8 +29,8 @@ depends: [
   "cstruct-lwt"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
@@ -44,7 +44,7 @@ depends: [
   "duration"
   "io-page-unix"
   "randomconv"
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.6.0/opam
+++ b/packages/tcpip/tcpip.3.6.0/opam
@@ -29,8 +29,8 @@ depends: [
   "cstruct-lwt"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
@@ -45,7 +45,7 @@ depends: [
   "duration"
   "io-page-unix"
   "randomconv"
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.7.0/opam
+++ b/packages/tcpip/tcpip.3.7.0/opam
@@ -29,8 +29,8 @@ depends: [
   "cstruct-lwt"
   "mirage-net" {>= "1.0.0" & < "2.0.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-protocols" {>= "1.4.0" & < "2.0.0"}
@@ -47,7 +47,7 @@ depends: [
   "io-page-unix"
   "randomconv"
   "ethernet" {< "2.0.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.7.1/opam
+++ b/packages/tcpip/tcpip.3.7.1/opam
@@ -28,8 +28,8 @@ depends: [
   "cstruct" {>= "3.2.0"}
   "cstruct-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-protocols" {>= "2.0.0" & < "3.0.0"}
@@ -45,7 +45,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.7.2/opam
+++ b/packages/tcpip/tcpip.3.7.2/opam
@@ -28,8 +28,8 @@ depends: [
   "cstruct" {>= "3.2.0"}
   "cstruct-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-protocols" {>= "2.0.0" & < "3.0.0"}
@@ -45,7 +45,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.7.3/opam
+++ b/packages/tcpip/tcpip.3.7.3/opam
@@ -28,8 +28,8 @@ depends: [
   "cstruct" {>= "3.2.0"}
   "cstruct-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-protocols" {>= "2.0.0" & < "3.0.0"}
@@ -45,7 +45,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.7.4/opam
+++ b/packages/tcpip/tcpip.3.7.4/opam
@@ -28,8 +28,8 @@ depends: [
   "cstruct" {>= "3.2.0"}
   "cstruct-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-protocols" {>= "2.0.0" & < "3.0.0"}
@@ -45,7 +45,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.7.5/opam
+++ b/packages/tcpip/tcpip.3.7.5/opam
@@ -27,8 +27,8 @@ depends: [
   "cstruct" {>= "3.2.0"}
   "cstruct-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-protocols" {>= "2.0.0" & < "3.0.0"}
@@ -44,7 +44,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.7.6/opam
+++ b/packages/tcpip/tcpip.3.7.6/opam
@@ -27,8 +27,8 @@ depends: [
   "cstruct" {>= "3.2.0"}
   "cstruct-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-protocols" {>= "3.0.0" & < "3.1.0"}
@@ -44,7 +44,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.3.7.7/opam
+++ b/packages/tcpip/tcpip.3.7.7/opam
@@ -20,22 +20,22 @@ build: [
 
 depopts: ["mirage-xen-ocaml"]
 depends: [
-  "dune"     {>= "1.0"}
+  "dune" {>= "1.0"}
   "dune-configurator"
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.2.0"}
   "cstruct-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-protocols" {>= "3.0.0" & < "3.1.0"}
   "mirage-protocols-lwt" {>= "3.0.0" & < "3.1.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "4.0.0"}
-  "macaddr" {>="4.0.0"}
+  "macaddr" {>= "4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
   "fmt"
@@ -45,9 +45,9 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >="0.7.0"}
+  "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.8/opam
+++ b/packages/tcpip/tcpip.3.7.8/opam
@@ -27,15 +27,15 @@ depends: [
   "cstruct" {>= "3.2.0"}
   "cstruct-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-protocols" {>= "3.0.0" & < "3.1.0"}
   "mirage-protocols-lwt" {>= "3.0.0" & < "3.1.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "4.0.0"}
-  "macaddr" {>="4.0.0"}
+  "macaddr" {>= "4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
   "fmt"
@@ -45,9 +45,9 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >="0.7.0"}
+  "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.9/opam
+++ b/packages/tcpip/tcpip.3.7.9/opam
@@ -20,21 +20,21 @@ build: [
 
 depopts: ["mirage-xen-ocaml"]
 depends: [
-  "dune"     {>= "1.0"}
+  "dune" {>= "1.0"}
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.2.0"}
   "cstruct-lwt"
   "mirage-net-lwt" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-random" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" & < "3.0.0"}
+  "mirage-random" {>= "1.0.0" & < "2.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
-  "mirage-protocols" {>= "3.1.0"}
+  "mirage-protocols" {>= "3.1.0" & < "4.0.0"}
   "mirage-protocols-lwt" {>= "3.1.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "4.0.0"}
-  "macaddr" {>="4.0.0"}
+  "macaddr" {>= "4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
   "fmt"
@@ -44,9 +44,9 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >="0.7.0"}
+  "alcotest" {with-test & >= "0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tftp/tftp.0.1.4/opam
+++ b/packages/tftp/tftp.0.1.4/opam
@@ -25,7 +25,7 @@ depends: [
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "mirage" {>= "2.5.0" & < "3.0.0"}
   "io-page"
-  "mirage-console"
+  "mirage-console" {< "3.0.0"}
   "mirage-fs-unix"
   "tcpip"
   "ocamlbuild" {build}

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.12.0/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.12.0/opam
@@ -9,8 +9,8 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "cstruct"
   "lwt" {>= "3.2.0"}
-  "mirage-block"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-block" {< "2.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "ounit"
   "vhd-format"
   "io-page-unix" {with-test}

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.9.1/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.9.1/opam
@@ -17,8 +17,8 @@ depends: [
   "jbuilder" {build}
   "cstruct"
   "lwt" {>= "2.4.3" & <= "3.1.0"}
-  "mirage-block"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-block" {< "2.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "ounit"
   "vhd-format" {= "0.9.1"}
   "io-page-unix" {with-test}

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.9.2/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.9.2/opam
@@ -17,8 +17,8 @@ depends: [
   "jbuilder" {build}
   "cstruct"
   "lwt" {>= "2.4.3" & <= "3.1.0"}
-  "mirage-block"
-  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-block" {< "2.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "ounit"
   "vhd-format" {>= "0.9.1" & < "0.10.0"}
   "io-page-unix" {with-test}

--- a/packages/vpnkit/vpnkit.0.0.0/opam
+++ b/packages/vpnkit/vpnkit.0.0.0/opam
@@ -51,7 +51,7 @@ depends: [
   "logs"
   "fmt"
   "astring"
-  "mirage-flow" {>= "1.1.0"}
+  "mirage-flow" {>= "1.1.0" & < "2.0.0"}
   "mirage-types-lwt" {< "3.0.0"}
 ]
 synopsis:

--- a/packages/vpnkit/vpnkit.0.1.1/opam
+++ b/packages/vpnkit/vpnkit.0.1.1/opam
@@ -56,7 +56,7 @@ depends: [
   "mirage-time-lwt" {>= "1.1.0"}
   "mirage-time-unix"
   "mirage-protocols" {>= "1.1.0" & < "1.3.0"}
-  "mirage-channel" {>= "3.0.1"}
+  "mirage-channel" {>= "3.0.1" & < "4.0.0"}
   "mirage-console-unix"
   "mirage-clock-unix"
   "cohttp-lwt" {>= "0.99.0"}

--- a/packages/vpnkit/vpnkit.0.2.0/opam
+++ b/packages/vpnkit/vpnkit.0.2.0/opam
@@ -54,7 +54,7 @@ depends: [
   "mirage-flow-lwt" {>= "1.4.0"}
   "mirage-time-lwt" {>= "1.1.0"}
   "mirage-protocols" {>= "1.1.0" & < "1.3.0"}
-  "mirage-channel" {>= "3.0.1"}
+  "mirage-channel" {>= "3.0.1" & < "4.0.0"}
   "cohttp-lwt" {>= "0.99.0"}
   "mirage-dns" {< "4.0.0"}
   "protocol-9p" {>= "0.11.3"}

--- a/packages/xe-unikernel-upload/xe-unikernel-upload.0.4/opam
+++ b/packages/xe-unikernel-upload/xe-unikernel-upload.0.4/opam
@@ -14,7 +14,7 @@ depends: [
   "mbr-format" {>= "0.3"}
   "fat-filesystem"
   "io-page"
-  "mirage-types" {< "2.3.0" & > "2.1.0"}
+  "mirage-types" {> "2.1.0" & < "2.3.0"}
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/djs55/xe-unikernel-upload"


### PR DESCRIPTION
prepare for upcoming and breaking mirage-types release (see mirage/mirage#1004):
    opam admin add-constraint "mirage-device<2.0.0"
    opam admin add-constraint "mirage-random<2.0.0"
    opam admin add-constraint "mirage-time<2.0.0"
    opam admin add-constraint "mirage-clock<3.0.0"
    opam admin add-constraint "mirage-flow<2.0.0"
    opam admin add-constraint "mirage-fs<3.0.0"
    opam admin add-constraint "mirage-console<3.0.0"
    opam admin add-constraint "mirage-protocols<4.0.0"
    opam admin add-constraint "mirage-stack<2.0.0"
    opam admin add-constraint "mirage-block<2.0.0"
    opam admin add-constraint "mirage-net<3.0.0"
    opam admin add-constraint "mirage-kv<3.0.0"
    opam admin add-constraint "mirage-channel<4.0.0"
    opam admin add-constraint "mirage-types<3.7.0"
    opam admin add-constraint "mirage-types-lwt<3.7.0"