### PR TITLE
[new release] capnp-rpc-net, capnp-rpc-lwt, capnp-rpc-mirage, capnp-rpc and capnp-rpc-unix (0.5.0)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.1/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3.1/opam
@@ -12,8 +12,9 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "conf-capnproto" {build}
-  "capnp" {>= "3.0.0"}
-  "capnp-rpc" {>= "0.3"}
+  "capnp" {>= "3.0.0" & < "3.4"}
+  "uint" {< "2.0.0"}
+  "capnp-rpc" {>= "0.3" & < "0.4"}
   "lwt"
   "astring"
   "fmt"

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3/opam
@@ -12,8 +12,9 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "conf-capnproto" {build}
-  "capnp" {>= "3.0.0"}
-  "capnp-rpc" {>= "0.3"}
+  "capnp" {>= "3.0.0" & < "3.4"}
+  "uint" {< "2.0.0"}
+  "capnp-rpc" {>= "0.3" & < "0.4"}
   "lwt"
   "astring"
   "fmt"

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.3/opam
@@ -7,7 +7,6 @@ bug-reports:  "https://github.com/mirage/capnp-rpc/issues"
 dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.5.0/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "lwt"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.5.0/capnp-rpc-v0.5.0.tbz"
+  checksum: [
+    "sha256=79d40451c6eac583a3bd5ea7fcdb5defdca99ace64b0b4c895de2be5d3ea9d3e"
+    "sha512=212d682e1cfbe85bfe343b8c011ce1c62a8467105424e769bf0cff790290ebdf414f1e1aa63cf5afb95a74b3cfbdc81b732e3cc8d5988963dbc291b2259a8d38"
+  ]
+}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "capnp" {>= "3.3.0"}
-  "capnp-rpc-lwt" {>= "0.3"}
+  "capnp-rpc-lwt" {>= "0.3" & < "0.5"}
   "astring"
   "fmt"
   "logs"

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "capnp" {>= "3.3.0"}
-  "capnp-rpc-lwt" {>= "0.3"}
+  "capnp-rpc-lwt" {>= "0.3" & < "0.5"}
   "astring"
   "fmt"
   "logs"

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.5.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp" {>= "3.1.0"}
+  "capnp-rpc-net" {= version}
+  "astring"
+  "fmt"
+  "logs"
+  "arp-mirage"
+  "mirage-dns"
+  "mirage-stack-lwt"
+  "base64" {>= "3.0.0"}
+  "alcotest-lwt" {with-test}
+  "io-page-unix" {with-test}
+  "tcpip" {with-test}
+  "mirage-vnetif" {with-test}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.5.0/capnp-rpc-v0.5.0.tbz"
+  checksum: [
+    "sha256=79d40451c6eac583a3bd5ea7fcdb5defdca99ace64b0b4c895de2be5d3ea9d3e"
+    "sha512=212d682e1cfbe85bfe343b8c011ce1c62a8467105424e769bf0cff790290ebdf414f1e1aa63cf5afb95a74b3cfbdc81b732e3cc8d5988963dbc291b2259a8d38"
+  ]
+}

--- a/packages/capnp-rpc-net/capnp-rpc-net.0.5.0/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.0.5.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "capnp-rpc-lwt" {= version}
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "mirage-flow-lwt"
+  "tls" {>= "0.8.0"}
+  "mirage-kv-lwt"
+  "mirage-clock"
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "0.8.0"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.5.0/capnp-rpc-v0.5.0.tbz"
+  checksum: [
+    "sha256=79d40451c6eac583a3bd5ea7fcdb5defdca99ace64b0b4c895de2be5d3ea9d3e"
+    "sha512=212d682e1cfbe85bfe343b8c011ce1c62a8467105424e769bf0cff790290ebdf414f1e1aa63cf5afb95a74b3cfbdc81b732e3cc8d5988963dbc291b2259a8d38"
+  ]
+}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.1/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "capnp-rpc-lwt" {>= "0.3"}
+  "capnp-rpc-lwt" {>= "0.3" & < "0.5"}
   "mirage-flow-unix"
   "cmdliner"
   "cstruct-lwt"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
-  "capnp-rpc-lwt" {>= "0.3"}
+  "capnp-rpc-lwt" {>= "0.3" & < "0.5"}
   "mirage-flow-unix"
   "cmdliner"
   "cstruct-lwt"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.5.0/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.5.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp-rpc-net" {= version}
+  "cmdliner"
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.4"}
+  "logs"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "1.0"}
+  "alcotest-lwt" {with-test & >= "0.8.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.5.0/capnp-rpc-v0.5.0.tbz"
+  checksum: [
+    "sha256=79d40451c6eac583a3bd5ea7fcdb5defdca99ace64b0b4c895de2be5d3ea9d3e"
+    "sha512=212d682e1cfbe85bfe343b8c011ce1c62a8467105424e769bf0cff790290ebdf414f1e1aa63cf5afb95a74b3cfbdc81b732e3cc8d5988963dbc291b2259a8d38"
+  ]
+}

--- a/packages/capnp-rpc/capnp-rpc.0.5.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.5.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "stdint"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "dune" {>= "1.0"}
+  "alcotest" {with-test}
+  "afl-persistent" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.5.0/capnp-rpc-v0.5.0.tbz"
+  checksum: [
+    "sha256=79d40451c6eac583a3bd5ea7fcdb5defdca99ace64b0b4c895de2be5d3ea9d3e"
+    "sha512=212d682e1cfbe85bfe343b8c011ce1c62a8467105424e769bf0cff790290ebdf414f1e1aa63cf5afb95a74b3cfbdc81b732e3cc8d5988963dbc291b2259a8d38"
+  ]
+}


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

Breaking changes:

- The networking parts of `capnp-rpc-lwt` have been split off into a new
  `capnp-rpc-net` package (@talex5, mirage/capnp-rpc#182). This means that libraries that
  provide or consume capnp-rpc services can just depend on `capnp-rpc-lwt`,
  without pulling in a full TLS stack. Only applications should need to
  depend on `capnp-rpc-net` (which will probably happen automatically via
  `capnp-rpc-unix` or `capnp-rpc-mirage`). If you get compile errors in
  your code due to this change, you probably just need to
  `open Capnp_rpc_net`.

Other changes:

- Add Prometheus metrics for connections (@talex5, mirage/capnp-rpc#183). 
  `capnp-rpc-net` now reports the current number of active connections,
  the total number of messages received, and
  the total number of messages enqueued, sent and dropped
  (from which you can work out the current number of queued messages).

- Adapt to x509 0.8.x API changes (@hannesm, mirage/capnp-rpc#176).

- In the tutorial, say where to put the `Callback` module (@talex5, mirage/capnp-rpc#177).

- "No client certificate found" should not be fatal (@talex5, mirage/capnp-rpc#178).

- Remove unused dependency on `mirage-flow-unix` from opam file (@talex5,
  mirage/capnp-rpc#179).
