### PR TITLE
Update OCaml dev packages after 4.10 branching

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.10.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+trunk+afl/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "current trunk, with afl-fuzz instrumentation"
+synopsis: "latest 4.10.0 development, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -26,7 +26,7 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/4.10.tar.gz"
 }
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+trunk+flambda/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "current trunk, with flambda activated"
+synopsis: "latest 4.10.0 development, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -26,7 +26,7 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/4.10.tar.gz"
 }
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+trunk+afl/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-synopsis: "latest 4.10 development"
+synopsis: "current trunk, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 depends: [
-  "ocaml" {= "4.10.0" & post}
+  "ocaml" {= "4.11.0" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -12,20 +12,21 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%"]
+  ["./configure" "--prefix=%{prefix}%" "--with-afl" ]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
+    "--with-afl"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/4.10.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 }
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+trunk+flambda/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-synopsis: "latest 4.10 development"
+synopsis: "current trunk, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 depends: [
-  "ocaml" {= "4.10.0" & post}
+  "ocaml" {= "4.11.0" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -12,11 +12,12 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%"]
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
+    "--enable-flambda"
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
@@ -25,7 +26,7 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/4.10.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 }
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+trunk/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-synopsis: "latest 4.10 development"
+synopsis: "current trunk"
 maintainer: "platform@lists.ocaml.org"
 depends: [
-  "ocaml" {= "4.10.0" & post}
+  "ocaml" {= "4.11.0" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -25,7 +25,7 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/4.10.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 }
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism

--- a/packages/ocaml/ocaml.4.11.0/opam
+++ b/packages/ocaml/ocaml.4.11.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-config"
+  "ocaml-base-compiler" {= "4.11.0"} |
+  "ocaml-variants" {>= "4.11.0" & < "4.11.1~"} |
+  "ocaml-system" {>= "4.11.0" & < "4.11.1~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: CAML_LD_LIBRARY_PATH = ""
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]


### PR DESCRIPTION
This PR updates the 4.10.0+trunk* packages to point to the new 4.10 branch and adds new packages for the current OCaml trunk.