### PR TITLE
[new release] mirage-device (2.0.0)

### DIFF
--- a/packages/mirage-device/mirage-device.2.0.0/opam
+++ b/packages/mirage-device/mirage-device.2.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-device"
+doc: "https://mirage.github.io/mirage-device/"
+bug-reports: "https://github.com/mirage/mirage-device/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "fmt"
+  "lwt" {>= "4.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-device.git"
+synopsis: "Abstract devices for MirageOS"
+description: """
+mirage-device defines [Mirage_device.S][1], the signature for
+basic abstract devices for MirageOS and a pretty-printing function
+for device errors.
+
+[1]: https://mirage.github.io/mirage-device/Mirage_device.S.html
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-device/releases/download/v2.0.0/mirage-device-v2.0.0.tbz"
+  checksum: [
+    "sha256=04286c6728f280cf6ec53dc54e67d552b1375d5b544a45c9dab8536ea2ef54a1"
+    "sha512=f6718647230930927b8f870ff1dd9d55554473f555641154db83a2123a3bda002431616cf012fcb7a07ab1e5cde622a6b52b0cc804b73a77db55db5e1276c6da"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- specialise io to Lwt.t (@hannesm mirage/mirage-device#5)
- remove type io (@hannesm mirage/mirage-device#5)
- lower OCaml bound 4.06.0, test up to 4.09.0 (@hannesm mirage/mirage-device#5)