### PR TITLE
[new release] mirage-clock, mirage-clock-unix and mirage-clock-freestanding (3.0.0)

### DIFF
--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.3.0.0/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.3.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Paravirtual implementation of the MirageOS Clock interface"
+description: """
+This 'freestanding' implementation of the MirageOS CLOCK interface
+is designed to be linked against an embedded runtime that provides
+a concrete implementation of the clock source. Example implementations
+include the [Solo5](https://github.com/solo5/solo5) backend of
+MirageOS.
+"""
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "mirage-clock" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git://github.com/mirage/mirage-clock"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v3.0.0/mirage-clock-v3.0.0.tbz"
+  checksum: [
+    "sha256=aedd122018dc2dcb3bf486003455c3eee0dc9e65e22b3bfc693f601e447913f1"
+    "sha512=c14860767fe5886dc8590d68a804eabf41968687ef139eac5e681ed869255b8557818af0d18d9b97d20f1d0cc2b254c5d129e0ec8cc367f8d9b614a693965bbe"
+  ]
+}

--- a/packages/mirage-clock-unix/mirage-clock-unix.3.0.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.3.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Unix-based implementation for the MirageOS Clock interface"
+description: """
+The Unix implementation of the MirageOS Clock interface uses
+`gettimeofday` or `clock_gettime`, depending on
+which OS is in use (see [clock_stubs.c](https://github.com/mirage/mirage-clock/blob/master/unix/clock_stubs.c)).
+"""
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "mirage-clock" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v3.0.0/mirage-clock-v3.0.0.tbz"
+  checksum: [
+    "sha256=aedd122018dc2dcb3bf486003455c3eee0dc9e65e22b3bfc693f601e447913f1"
+    "sha512=c14860767fe5886dc8590d68a804eabf41968687ef139eac5e681ed869255b8557818af0d18d9b97d20f1d0cc2b254c5d129e0ec8cc367f8d9b614a693965bbe"
+  ]
+}

--- a/packages/mirage-clock/mirage-clock.3.0.0/opam
+++ b/packages/mirage-clock/mirage-clock.3.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Libraries and module types for portable clocks"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirage.io) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements an `MCLOCK` module that represents a monotonic timesource
+since an arbitrary point, and `PCLOCK` which counts time since the Unix
+epoch.
+"""
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v3.0.0/mirage-clock-v3.0.0.tbz"
+  checksum: [
+    "sha256=aedd122018dc2dcb3bf486003455c3eee0dc9e65e22b3bfc693f601e447913f1"
+    "sha512=c14860767fe5886dc8590d68a804eabf41968687ef139eac5e681ed869255b8557818af0d18d9b97d20f1d0cc2b254c5d129e0ec8cc367f8d9b614a693965bbe"
+  ]
+}

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.4.1/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.4.1/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-fs-lwt" {>= "1.0.0"}
   "lwt"
   "rresult" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "3.0.0"}
   "alcotest" {with-test & >= "0.7.1"}
   "ptime" {with-test}
 ]

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.5.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-fs-lwt" {>= "1.0.0"}
   "lwt"
   "rresult" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "3.0.0"}
   "alcotest" {with-test & >= "0.7.1"}
   "ptime" {with-test}
 ]

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.6.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.6.0/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-fs-lwt" {>= "1.0.0"}
   "lwt"
   "rresult" {with-test}
-  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-clock-unix" {with-test & >= "1.2.0" & < "3.0.0"}
   "alcotest" {with-test & >= "0.7.1"}
   "ptime" {with-test}
 ]

--- a/packages/mirage-kv-unix/mirage-kv-unix.2.0.0/opam
+++ b/packages/mirage-kv-unix/mirage-kv-unix.2.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "lwt"
   "ptime"
   "rresult" {with-test}
-  "mirage-clock-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "2.0.0" & < "3.0.0"}
   "alcotest" {with-test & >= "0.7.1"}
 ]
 synopsis: "Key-value store for MirageOS backed by Unix filesystem"

--- a/packages/mirage-kv-unix/mirage-kv-unix.2.0.0/opam
+++ b/packages/mirage-kv-unix/mirage-kv-unix.2.0.0/opam
@@ -10,7 +10,7 @@ tags:         [ "org:mirage" ]
 build: [
   ["dune" "subst" ] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
 ]
 
 depends: [


### PR DESCRIPTION
CHANGES:

* remove mirage-clock-lwt (mirage/mirage-clock#43 @hannesm)
* mirage-clock is no device anymore, drop lwt dependency (mirage/mirage-clock#43 @hannesm)
* raise lower OCaml bound to 4.06.0 (mirage/mirage-clock#43 @hannesm)