### PR TITLE
[new release] mirage-time and mirage-time-unix (2.0.0)

### DIFF
--- a/packages/mirage-time-unix/mirage-time-unix.2.0.0/opam
+++ b/packages/mirage-time-unix/mirage-time-unix.2.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-time"
+doc: "https://mirage.github.io/mirage-time/"
+bug-reports: "https://github.com/mirage/mirage-time/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-time" {=version}
+  "lwt" {>= "4.4.0"}
+  "duration"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-time.git"
+synopsis: "Time operations for MirageOS on Unix"
+description: """
+mirage-time-unix defines `Time`, an implementation of the `Mirage_time.S` signature for the Unix backend.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-time/releases/download/v2.0.0/mirage-time-v2.0.0.tbz"
+  checksum: [
+    "sha256=3088c37afbbcee102eb90dbc23e5d88df6fd9183c343a1a1012f7344d25f7eec"
+    "sha512=0fb3e9ae5debb113a60a16e0623ea2e6590b66d5553355dd9b667495f43c0115efaee698b31b2dd2bd0053d9f0e6dcaaead914d142af4fc6f36e1e9221220580"
+  ]
+}

--- a/packages/mirage-time/mirage-time.2.0.0/opam
+++ b/packages/mirage-time/mirage-time.2.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-time"
+doc: "https://mirage.github.io/mirage-time/"
+bug-reports: "https://github.com/mirage/mirage-time/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "4.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-time.git"
+synopsis: "Time operations for MirageOS"
+description: """
+mirage-time defines `Mirage_time.S`, the signature for time-related operations for MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-time/releases/download/v2.0.0/mirage-time-v2.0.0.tbz"
+  checksum: [
+    "sha256=3088c37afbbcee102eb90dbc23e5d88df6fd9183c343a1a1012f7344d25f7eec"
+    "sha512=0fb3e9ae5debb113a60a16e0623ea2e6590b66d5553355dd9b667495f43c0115efaee698b31b2dd2bd0053d9f0e6dcaaead914d142af4fc6f36e1e9221220580"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* remove mirage-time-lwt (mirage/mirage-time#10 @hannesm)
* specialise mirage-time to io being Lwt.t directly (mirage/mirage-time#10 @hannesm)
* raise OCaml lower bound to 4.06.0 (mirage/mirage-time#10 @hannesm)