### PR TITLE
[new release] mirage-random (2.0.0)

### DIFF
--- a/packages/mirage-random/mirage-random.2.0.0/opam
+++ b/packages/mirage-random/mirage-random.2.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-random"
+bug-reports:   "https://github.com/mirage/mirage-random/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-random.git"
+doc:           "https://mirage.github.io/mirage-random/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {>="1.1.0"}
+  "cstruct" {>= "4.0.0"}
+  "ocaml" {>= "4.06.0"}
+]
+
+synopsis: "Random-related devices for MirageOS"
+description: """
+mirage-random defines `Mirage_random.S` the signature for random-related devices for MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-random/releases/download/v2.0.0/mirage-random-v2.0.0.tbz"
+  checksum: [
+    "sha256=61db16e7c217f8093391c3e5513667a29124215ce17cabb95c73ceaa4b0b4462"
+    "sha512=9e8a8ba415c175225225e021429f219546cde2798c95bacb906368e68bec3eb9bbd849f8c4dabae8115f399fae7a23192665c2eb9314676120010090bcc07713"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Specialise buffer to Cstruct.t directly in Mirage_random.S (mirage/mirage-random#12 @hannesm)
* Deprecate Mirage_random.C (mirage/mirage-random#12 @hannesm)
* Raise lower bound of OCaml to 4.06.0 (mirage/mirage-random#12 @hannesm)