### PR TITLE
[new release] mirage-kv (3.0.0)

### DIFF
--- a/packages/mirage-kv/mirage-kv.3.0.0/opam
+++ b/packages/mirage-kv/mirage-kv.3.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "mirage-device" {>= "2.0.0"}
+  "fmt"
+  "lwt" {>= "4.4.0"}
+  "alcotest" {with-test}
+]
+synopsis: "MirageOS signatures for key/value devices"
+description: """
+mirage-kv provides the `Mirage_kv.RO` and `Mirage_kv.RW`
+signatures the MirageOS key/value devices should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv/releases/download/v3.0.0/mirage-kv-v3.0.0.tbz"
+  checksum: [
+    "sha256=31d06b53bd0780ec3bdfac5c8d3d058bbccaa6132524a91c89ebc6c5ff37431b"
+    "sha512=18b882c096b0b49dc66fdc443f6f97f351fb6509884a3956b718e876629c50efe663187503a60e959b82d921381ed32cbf4fa20f6f1cf4e36e2609d0086af987"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* remove mirage-kv-lwt (mirage/mirage-kv#19 @hannesm)
* specialise mirage-kv on Lwt.t and value being string (mirage/mirage-kv#19 @hannesm)
* raise lower OCaml bound to 4.06.0 (mirage/mirage-kv#19 @hannesm)