### PR TITLE
[new release] mirage-net (3.0.0)

### DIFF
--- a/packages/mirage-net/mirage-net.3.0.0/opam
+++ b/packages/mirage-net/mirage-net.3.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-net"
+bug-reports:   "https://github.com/mirage/mirage-net/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net.git"
+doc:           "https://mirage.github.io/mirage-net/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "fmt"
+  "macaddr" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0"}
+]
+synopsis: "Network signatures for MirageOS"
+description: """
+mirage-net defines `Mirage_net.S`, the signature for network operations for MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net/releases/download/v3.0.0/mirage-net-v3.0.0.tbz"
+  checksum: [
+    "sha256=0740da3343a0b69dfef82763881f1e21f78658115ff62400232e7b34663a1b72"
+    "sha512=08fc5fc0a299b5678ca7202943acec354ef290b0cdb67c9d71dc80092bffaab6c4e872a4aa503020b10ac0a614da40d30d31bd51992dec0196ca3bbd416f40fc"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- remove mirage-net-lwt (mirage/mirage-net#21 @hannesm)
- specialise to Lwt.t, Cstruct.t, Macaddr.t (mirage/mirage-net#21 @hannesm)
- raise lower OCaml bound to 4.06.0 (mirage/mirage-net#21 @hannesm)