### PR TITLE
[new release] mirage-block-combinators and mirage-block (2.0.0)

### DIFF
--- a/packages/mirage-block-combinators/mirage-block-combinators.2.0.0/opam
+++ b/packages/mirage-block-combinators/mirage-block-combinators.2.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: "David Scott"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block"
+doc: "https://mirage.github.io/mirage-block/"
+bug-reports: "https://github.com/mirage/mirage-block/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "2.0.0"}
+  "io-page"
+  "lwt" {>= "4.4.0"}
+  "logs"
+  "mirage-block" {=version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block.git"
+synopsis: "Block signatures and implementations for MirageOS using Lwt"
+description: """
+This repo contains generic operations over Mirage `BLOCK` devices.
+This package is specialised to the Lwt concurrency library for IO.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block/releases/download/v2.0.0/mirage-block-v2.0.0.tbz"
+  checksum: [
+    "sha256=50c87e7d8085c3ac1b8238e344498df56dac9e242350e8d429564c5b3c531b17"
+    "sha512=999032a535860603bc4c5e35592bff5518856edb00d4eea996e95c5c1f94425981cd50e5c570778b9d887d2e942bfe14e4b1e68e73bcf7fd26545a8e23b8c10f"
+  ]
+}

--- a/packages/mirage-block/mirage-block.2.0.0/opam
+++ b/packages/mirage-block/mirage-block.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block"
+doc: "https://mirage.github.io/mirage-block/"
+bug-reports: "https://github.com/mirage/mirage-block/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "lwt" {>= "4.4.0"}
+  "cstruct" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block.git"
+synopsis: "Block signatures and implementations for MirageOS"
+description: """
+This repo contains generic operations over Mirage `BLOCK` devices.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block/releases/download/v2.0.0/mirage-block-v2.0.0.tbz"
+  checksum: [
+    "sha256=50c87e7d8085c3ac1b8238e344498df56dac9e242350e8d429564c5b3c531b17"
+    "sha512=999032a535860603bc4c5e35592bff5518856edb00d4eea996e95c5c1f94425981cd50e5c570778b9d887d2e942bfe14e4b1e68e73bcf7fd26545a8e23b8c10f"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- remove mirage-block-lwt, specialise mirage-block to Lwt.t and Cstruct.t (mirage/mirage-block#46 @hannesm)
- move combinators to mirage-block-combinators (mirage/mirage-block#46 @hannesm)
- raise lower OCaml bound to 4.06.0 (mirage/mirage-block#46 @hannesm)