### PR TITLE
zarith_stubs_js.v0.12.0

### DIFF
--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.12.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.12.0/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/zarith_stubs_js"
+bug-reports: "https://github.com/janestreet/zarith_stubs_js/issues"
+dev-repo: "git+https://github.com/janestreet/zarith_stubs_js.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.5.1"}
+]
+synopsis: "Javascripts stubs for the Zarith library"
+description: "
+This library contains no ocaml code, but instead implements
+all of the Zarith C stubs in Javascript for use in Js_of_ocaml
+"


### PR DESCRIPTION
This pull request simply releases `zarith_stubs_js.v0.12.0`.