### PR TITLE
[new release] mirage-flow-unix, mirage-flow and mirage-flow-combinators (2.0.0)

### DIFF
--- a/packages/mirage-flow-combinators/mirage-flow-combinators.2.0.0/opam
+++ b/packages/mirage-flow-combinators/mirage-flow-combinators.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "fmt"
+  "lwt" {>= "4.4.0"}
+  "logs"
+  "cstruct" {>= "4.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS specialized to lwt"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v2.0.0/mirage-flow-v2.0.0.tbz"
+  checksum: [
+    "sha256=61f3b736541ce7b6780def542b2fe99a27acab19f430b52fe7f22ee898faf0ea"
+    "sha512=8d95a195c4d37220fa58dfc55acb632bd9874649926a36c1074234b728ad93b6bbc1a8ddb3d90eb74a41279c8228cab4faa05c93610cd06809fce0b7fc3319a8"
+  ]
+}

--- a/packages/mirage-flow-unix/mirage-flow-unix.2.0.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "fmt"
+  "logs"
+  "mirage-flow" {= version}
+  "lwt" {>= "4.4.0"}
+  "cstruct" {>= "4.0.0"}
+  "alcotest" {with-test}
+  "mirage-flow-combinators" {with-test & = version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS on Unix"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v2.0.0/mirage-flow-v2.0.0.tbz"
+  checksum: [
+    "sha256=61f3b736541ce7b6780def542b2fe99a27acab19f430b52fe7f22ee898faf0ea"
+    "sha512=8d95a195c4d37220fa58dfc55acb632bd9874649926a36c1074234b728ad93b6bbc1a8ddb3d90eb74a41279c8228cab4faa05c93610cd06809fce0b7fc3319a8"
+  ]
+}

--- a/packages/mirage-flow/mirage-flow.2.0.0/opam
+++ b/packages/mirage-flow/mirage-flow.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt"
+  "lwt" {>= "4.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v2.0.0/mirage-flow-v2.0.0.tbz"
+  checksum: [
+    "sha256=61f3b736541ce7b6780def542b2fe99a27acab19f430b52fe7f22ee898faf0ea"
+    "sha512=8d95a195c4d37220fa58dfc55acb632bd9874649926a36c1074234b728ad93b6bbc1a8ddb3d90eb74a41279c8228cab4faa05c93610cd06809fce0b7fc3319a8"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* mirage-flow uses Lwt.t and Cstruct.t directly (mirage/mirage-flow#43 @hannesm)
* mirage-flow-lwt was removed, combinators are now in mirage-flow-combinators (mirage/mirage-flow#43 @hannesm)
* raise lower OCaml bound to 4.06.0 (mirage/mirage-flow#43 @hannesm)