### PR TITLE
[new release] mirage-fs (3.0.0)

### DIFF
--- a/packages/mirage-fs/mirage-fs.3.0.0/opam
+++ b/packages/mirage-fs/mirage-fs.3.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+homepage:     "https://github.com/mirage/mirage-fs"
+doc:          "https://mirage.github.io/mirage-fs/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-fs.git"
+bug-reports:  "https://github.com/mirage/mirage-fs/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "fmt"
+  "mirage-device" {>= "2.0.0"}
+  "lwt" {>= "4.4.0"}
+  "cstruct" {>= "4.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+]
+synopsis: "MirageOS signatures for filesystem devices"
+description: """
+mirage-fs provides the `[Mirage_fs.S][fs]` signatures
+the MirageOS filesystem devices should implement.
+
+[fs]: http://mirage.github.io/mirage-fs/Mirage_fs.html
+"""
+post-messages: [
+  "This package will be retired in MirageOS 4.0. Please use mirage-kv instead."
+]
+url {
+  src:
+    "https://github.com/mirage/mirage-fs/releases/download/v3.0.0/mirage-fs-v3.0.0.tbz"
+  checksum: [
+    "sha256=01678dd223ccc4eec5b33203c9aaac750a04f054199366dec42e227013537649"
+    "sha512=88563f5fc3c6f0c7b20cd914e66c2c7a789922e1f6edb1ec6d077e64486bf8c3683902f628b9d9477486472ffa9d32a2fe0e4568d1f6bea3a14a3524ccec11cf"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Retire mirage-fs-lwt package (mirage/mirage-fs#25 @hannesm)
* Specialies io = LWt.t and page_aligned_buffer = Cstruct.t in mirage-fs (mirage/mirage-fs#25 @hannesm)
* Mark as deprecated, will be removed for MirageOS 4.0 (mirage/mirage-fs#25 @hannesm)
* Raise lower bound to OCaml 4.06.0 (mirage/mirage-fs#25 @hannesm)