### PR TITLE
[new release] mirage-protocols (4.0.0)

### DIFF
--- a/packages/mirage-protocols/mirage-protocols.4.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.4.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "fmt"
+  "duration"
+  "lwt" {>= "4.4.0"}
+  "ipaddr" {>= "4.0.0"}
+  "macaddr" {>= "4.0.0"}
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to
+be used as MirageOS network implementations should implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v4.0.0/mirage-protocols-v4.0.0.tbz"
+  checksum: [
+    "sha256=ea68e5f3281d5e23914df35f24558d3e1b817bdebfa2847d99e8d79da0b1e8cd"
+    "sha512=bbf092640b7f8af6ad4b99d442bcb951f5446d3ff0e779c709465ed6214b8d4f8a6a3be67fe022cffbfcabf9b7b77bf9c323f10aed159beeeeef30783f3821bb"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- remove mirage-protocols-lwt (mirage/mirage-protocols#23 @hannesm)
- specialise mirage-protocols to Lwt.t, Cstruct,t, Ipaddr.V4/V6.t, Macaddr.t (mirage/mirage-protocols#23 @hannesm)
- raise lower OCaml bound to 4.06.0 (mirage/mirage-protocols#23 @hannesm)