### PR TITLE
[new release] mirage-console-xen-proto, mirage-console, mirage-console-unix, mirage-console-xen and mirage-console-xen-backend (3.0.0)

### DIFF
--- a/packages/mirage-console-unix/mirage-console-unix.3.0.0/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.3.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "4.4.0"}
+  "cstruct" {>= "4.0.0"}
+  "cstruct-lwt" {>= "4.0.0"}
+  "mirage-console" {=version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage consoles for Unix"
+description: """
+This implements a MirageOS console device for use with
+Unix-based targets.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v3.0.0/mirage-console-v3.0.0.tbz"
+  checksum: [
+    "sha256=0ff255114d3818a72eaa322f0683856f653ebee1f89b03a8dcd7e84d9b70d1f1"
+    "sha512=f8dd3a7d637fc7ca325e822dc8f0910b60373489f4987f82b2ff5e96830d14c902e19451e270c40ade8cc92bc11b385ea55cb4561a25fa420c0fdb607df4b257"
+  ]
+}

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.3.0.0/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.3.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-console" {=version}
+  "mirage-console-xen-proto" {=version}
+  "mirage-xen" {>= "4.0.0"}
+  "lwt"
+  "io-page-xen" {>= "2.0.0"}
+  "xenstore"
+  "xen-evtchn"
+  "shared-memory-ring-lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console backend for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v3.0.0/mirage-console-v3.0.0.tbz"
+  checksum: [
+    "sha256=0ff255114d3818a72eaa322f0683856f653ebee1f89b03a8dcd7e84d9b70d1f1"
+    "sha512=f8dd3a7d637fc7ca325e822dc8f0910b60373489f4987f82b2ff5e96830d14c902e19451e270c40ade8cc92bc11b385ea55cb4561a25fa420c0fdb607df4b257"
+  ]
+}

--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.3.0.0/opam
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.3.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-console" {= version}
+  "rresult"
+  "xenstore"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console protocol for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v3.0.0/mirage-console-v3.0.0.tbz"
+  checksum: [
+    "sha256=0ff255114d3818a72eaa322f0683856f653ebee1f89b03a8dcd7e84d9b70d1f1"
+    "sha512=f8dd3a7d637fc7ca325e822dc8f0910b60373489f4987f82b2ff5e96830d14c902e19451e270c40ade8cc92bc11b385ea55cb4561a25fa420c0fdb607df4b257"
+  ]
+}

--- a/packages/mirage-console-xen/mirage-console-xen.3.0.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.3.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-console" {=version}
+  "mirage-console-xen-proto" {=version}
+  "xen-evtchn"
+  "io-page-xen"
+  "mirage-xen" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v3.0.0/mirage-console-v3.0.0.tbz"
+  checksum: [
+    "sha256=0ff255114d3818a72eaa322f0683856f653ebee1f89b03a8dcd7e84d9b70d1f1"
+    "sha512=f8dd3a7d637fc7ca325e822dc8f0910b60373489f4987f82b2ff5e96830d14c902e19451e270c40ade8cc92bc11b385ea55cb4561a25fa420c0fdb607df4b257"
+  ]
+}

--- a/packages/mirage-console/mirage-console.3.0.0/opam
+++ b/packages/mirage-console/mirage-console.3.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "lwt" {>= "4.4.0"}
+  "cstruct" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementations of Mirage console devices"
+description: """
+This is a general implementation of a console device, intended
+for use in MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v3.0.0/mirage-console-v3.0.0.tbz"
+  checksum: [
+    "sha256=0ff255114d3818a72eaa322f0683856f653ebee1f89b03a8dcd7e84d9b70d1f1"
+    "sha512=f8dd3a7d637fc7ca325e822dc8f0910b60373489f4987f82b2ff5e96830d14c902e19451e270c40ade8cc92bc11b385ea55cb4561a25fa420c0fdb607df4b257"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Retire mirage-console-lwt (mirage/mirage-console#80 @hannesm)
* Specialise mirage-console to Lwt.t and Cstruct.t directly (mirage/mirage-console#80 @hannesm)
* Raise lower OCaml bound to 4.06.0 (mirage/mirage-console#80 @hannesm)