### PR TITLE
[new release] mirage-stack (2.0.0)

### DIFF
--- a/packages/mirage-stack/mirage-stack.2.0.0/opam
+++ b/packages/mirage-stack/mirage-stack.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-stack"
+doc: "https://mirage.github.io/mirage-stack/"
+bug-reports: "https://github.com/mirage/mirage-stack/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "fmt"
+  "lwt" {>= "4.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-stack.git"
+synopsis: "MirageOS signatures for network stacks"
+description: """
+mirage-stack provides a set of module types which libraries intended to be used
+as MirageOS network stacks should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-stack/releases/download/v2.0.0/mirage-stack-v2.0.0.tbz"
+  checksum: [
+    "sha256=5375e41e036b9d7b1a178054fd1465f7ccca227a59665ed3e91f885889dadd07"
+    "sha512=b060f8662a72e0f5b2387e2d1084f2c7101a66de7e8803ca219d8336f8593dd146803336e40a1c5fa46999bb1c3ca698ced0afa9226f71631b17050a6fe9dc88"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- remove mirage-stack-lwt package (mirage/mirage-stack#15 @hannesm)
- specialise on Lwt.t and Cstruct.t directly (mirage/mirage-stack#15 @hannesm)
- raise lower OCaml bound to 4.06.0 (mirage/mirage-stack#15 @hannesm)