### PR TITLE
Pyml compatible with 4.09

### DIFF
--- a/packages/pyml/pyml.20190626/opam
+++ b/packages/pyml/pyml.20190626/opam
@@ -10,9 +10,9 @@ install: [make "install" "PREFIX=%{prefix}%"]
 synopsis: "OCaml bindings for Python"
 description: "OCaml bindings for Python 2 and Python 3"
 depends: [
-  "ocaml" {>= "3.12.1" & < "4.09.0"}
+  "ocaml" {>= "3.12.1" & < "4.10.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "9"}
+  "stdcompat" {>= "11"}
   "num"
 ]
 depopts: ["utop"]


### PR DESCRIPTION
Local testing seems to indicate that the latest `pyml`
is actually compatible with OCaml 4.09, at least with
`stdcompat >= 11`.

(This is done in preparation of the upcoming v0.13
release of Jane Street packages, as we will try to
have all our packages -and their dependencies-
compatible with 4.09.)

@thierry-martinez @LaurentMazare 