### PR TITLE
Release async_udp as a standalone package

### DIFF
--- a/packages/async_udp/async_udp.v0.12.0/opam
+++ b/packages/async_udp/async_udp.v0.12.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_udp"
+bug-reports: "https://github.com/janestreet/async_udp/issues"
+dev-repo: "git+https://github.com/janestreet/async_udp.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"            {>= "4.08.0"}
+  "async"            {>= "v0.12" & < "v0.13"}
+  "ppx_jane"         {>= "v0.12" & < "v0.13"}
+  "dune"             {>= "1.5.1"}
+]
+synopsis: "Monadic concurrency library"
+description: "
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+  src: "https://github.com/janestreet/async_udp/archive/v0.12.0.tar.gz"
+  checksum: "md5=4b3dc3eab6dde2d14788a9bb305585f9"
+}


### PR DESCRIPTION
`async_udp` was unfortunately not available among
Jane Street's v0.12 packages. This feature releases
it as a standalone package.

Relevant discussions:
- https://github.com/ocaml/opam-repository/pull/15107;
- https://github.com/janestreet/async_extra/issues/13.