### PR TITLE
Package unidecode.0.2.0

### DIFF
--- a/packages/unidecode/unidecode.0.2.0/opam
+++ b/packages/unidecode/unidecode.0.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+
+synopsis: "Convert unicode strings into its ASCII representation"
+
+authors: [ "Daniel de Rauglaudre" ]
+
+maintainer: "Julien Sagot <julien.sagot@geneanet.org>"
+
+license: "GNU GPL"
+
+homepage: "https://github.com/geneweb/unidecode"
+
+bug-reports: "https://github.com/geneweb/unidecode/issues"
+
+dev-repo: "git+https://github.com/geneweb/unidecode.git"
+
+depends: [
+  "dune" { "1.10" }
+  "ocaml" { >= "4.05" }
+  ]
+
+build: [ [ "dune" "build" "-p" name "-j" jobs] ]
+url {
+  src: "https://github.com/geneweb/unidecode/archive/v0.2.0.tar.gz"
+  checksum: [
+    "md5=2c4129b017e08aa07c7a2f6cc1e6e9ff"
+    "sha512=8ff3c6b06f2ecaaf99b04a6810b0a3a4ab8bfc4fd7b6fcb130d0a8294d7de9f37049da719dcd73a794718626f8c84a52030315cd964e8f860f607d8f6185918f"
+  ]
+}

--- a/packages/unidecode/unidecode.0.2.0/opam
+++ b/packages/unidecode/unidecode.0.2.0/opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/geneweb/unidecode/issues"
 dev-repo: "git+https://github.com/geneweb/unidecode.git"
 
 depends: [
-  "dune" { "1.10" }
+  "dune" { >= "1.10" }
   "ocaml" { >= "4.05" }
   ]
 


### PR DESCRIPTION
### `unidecode.0.2.0`
Convert unicode strings into its ASCII representation



---
* Homepage: https://github.com/geneweb/unidecode
* Source repo: git+https://github.com/geneweb/unidecode.git
* Bug tracker: https://github.com/geneweb/unidecode/issues

---
:camel: Pull-request generated by opam-publish v2.0.0