### PR TITLE
Add Coq 8.10.1

### DIFF
--- a/packages/coq/coq.8.10.1/files/coq.install
+++ b/packages/coq/coq.8.10.1/files/coq.install
@@ -1,0 +1,12 @@
+bin: [
+  "bin/coqwc"
+  "bin/coqtop"
+  "bin/coqtop.byte"
+  "bin/coqdoc"
+  "bin/coqdep"
+  "bin/coqchk"
+  "bin/coqc"
+  "bin/coq_makefile"
+  "bin/coq-tex"
+  "bin/coqworkmgr"
+]

--- a/packages/coq/coq.8.10.1/opam
+++ b/packages/coq/coq.8.10.1/opam
@@ -6,6 +6,16 @@ bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 synopsis: "Formal proof management system"
+description: """
+The Coq proof assistant provides a formal language to write
+mathematical definitions, executable algorithms, and theorems, together
+with an environment for semi-interactive development of machine-checked
+proofs. Typical applications include the certification of properties of programming
+languages (e.g., the CompCert compiler certification project and the
+Bedrock verified low-level programming library), the formalization of
+mathematics (e.g., the full formalization of the Feit-Thompson theorem
+and homotopy type theory) and teaching.
+"""
 
 depends: [
   "ocaml" {>= "4.05.0"}

--- a/packages/coq/coq.8.10.1/opam
+++ b/packages/coq/coq.8.10.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, and contributors."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "git+https://github.com/coq/coq.git"
+license: "LGPL-2.1"
+synopsis: "Formal proof management system"
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "num"
+  "conf-findutils" {build}
+]
+build: [
+  [
+    "./configure"
+    "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
+    "-mandir" man
+    "-docdir" doc
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
+    "-coqide" "no"
+  ]
+  [make "-j%{jobs}%"]
+  [make "-j%{jobs}%" "byte"]
+]
+install: [
+  [make "install"]
+  [make "install-byte"]
+]
+
+extra-files: [
+   ["coq.install" "sha512=b501737b4dbd22adc1c0377d744448056fb1dc493caf72c05f57c8463cf23f758373605ab3a50b9f505e4c856c41039d0bd7f81f96ed62adc6a674179523e7d2"]
+]
+
+url {
+  src: "https://github.com/coq/coq/archive/V8.10.1.tar.gz"
+  checksum: "sha512=5c6a20e283c351a4b0ecdb393fb77cfc9b72b474453c99c95f52a70da47dd72fff7229c2ef92d61aadade8f2ed6e03c1a7740d0fa2fcc87ea72659f95eceb2dc"
+}


### PR DESCRIPTION
Via @Blaisorblade, here is a package definition for the recently-release Coq 8.10.1. This includes only Coq and not CoqIDE, since the latter usually causes CI trouble and is less prioritized. If/when this package gets merged, I will open a PR for CoqIDE 8.10.1.