### PR TITLE
[new release] pcre (7.4.3)

### DIFF
--- a/packages/pcre/pcre.7.4.3/opam
+++ b/packages/pcre/pcre.7.4.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "conf-libpcre" {build}
+  "base" {build}
+  "base-bytes"
+]
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/7.4.3/pcre-7.4.3.tbz"
+  checksum: [
+    "sha256=9068c5abcf6e2528e27250c9beca60645842c7a6ce2d36f64d1fe9104ef2121e"
+    "sha512=917e98aa86a75d2e17b0df9eb546c5dc568eacd0f2df0c5621467246142beff449e11544d88bc42eabf1cc288f7aa19aaebe90283ca8cf72dc023e52c6c21e02"
+  ]
+}


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

* Switched from `caml_alloc_custom` to `caml_alloc_custom_mem`.

    This should improve memory usage and GC performance.

  * Switched to OPAM file generation via `dune-project`
