### PR TITLE
git.2.1.1: lower lower checkseum bound to support mirage 3

### DIFF
--- a/packages/git/git.2.1.1/opam
+++ b/packages/git/git.2.1.1/opam
@@ -33,7 +33,7 @@ depends: [
   "digestif"   {>= "0.7.2"}
   "lru"        {>= "0.3.0"}
   "decompress" {>= "0.9.0" & < "1.0.0"}
-  "checkseum"  {>= "0.1.0"}
+  "checkseum"  {>= "0.0.9"}
   "stdlib-shims"
   "ke"
   "encore"


### PR DESCRIPTION
//cc @dinosaure as done in https://github.com/mirage/ocaml-git/commit/62d581cb5fbe4109cbb19924d37aa808c2ab883a