### PR TITLE
[new release] postgresql (4.5.2)

### DIFF
--- a/packages/postgresql/postgresql.4.5.2/opam
+++ b/packages/postgresql/postgresql.4.5.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "base" {build}
+  "stdio" {build}
+  "conf-postgresql" {build}
+  "base-bytes"
+]
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/4.5.2/postgresql-4.5.2.tbz"
+  checksum: [
+    "sha256=da25c8ba2700d8599ff4899b366f70aaf7f752b4201f6f8a076290932cc798f4"
+    "sha512=df5df0bd4eb4cfbdf9cd2f9ac98fdcc12faf8ce8bdb50e1596afced62eced1bf8ea773c811ecfb62d17d870a74fbbcfff297b44794e491dbd1bfb49930515366"
+  ]
+}


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

* Switched from `caml_alloc_custom` to `caml_alloc_custom_mem`.

    This should improve memory usage and GC performance.

  * Switched to OPAM file generation via `dune-project`
