### PR TITLE
[new release] elpi (1.8.0)

### DIFF
--- a/packages/elpi/elpi.1.8.0/files/0001-Makefile-pass-DUNE_OPTS-to-dune.patch
+++ b/packages/elpi/elpi.1.8.0/files/0001-Makefile-pass-DUNE_OPTS-to-dune.patch
@@ -1,0 +1,64 @@
+From e65cca8392e7c2bf822cf052ff084833d733f2a3 Mon Sep 17 00:00:00 2001
+From: Enrico Tassi <Enrico.Tassi@Inria.fr>
+Date: Wed, 30 Oct 2019 10:01:17 +0100
+Subject: [PATCH 1/2] Makefile: pass DUNE_OPTS to dune
+
+---
+ Makefile | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 888c30e..25a3965 100644
+--- a/Makefile
++++ b/Makefile
+@@ -23,10 +23,11 @@ RUNNERS=\
+   $(shell if type tjsim >/dev/null 2>&1; then type -P tjsim; else echo; fi)
+ TIME=--time $(shell if type -P gtime >/dev/null 2>&1; then type -P gtime; else echo /usr/bin/time; fi)
+ STACK=32768
++DUNE_OPTS=
+ 
+ # this is to work around https://github.com/ocaml/dune/issues/1212
+ .merlin:
+-	@dune build .merlin
++	@dune build $(DUNE_OPTS) .merlin
+ 	@for ppx in `ls $$PWD/_build/default/.ppx/*/ppx.exe`; do\
+ 		if $$ppx --print-transformations | grep -q trace; then\
+ 	      echo PKG ppx_deriving.std ppx_deriving.runtime >> .merlin;\
+@@ -38,20 +39,20 @@ STACK=32768
+ 
+ build:
+ 	@$(MAKE) --no-print-directory .merlin
+-	dune build @install; RC=$?; $(MAKE) --no-print-directory .merlin; exit $$RC
++	dune build $(DUNE_OPTS) @install; RC=$?; $(MAKE) --no-print-directory .merlin; exit $$RC
+ 
+ install:
+-	dune install
++	dune install $(DUNE_OPTS) 
+ 
+ doc:
+-	dune build @doc
++	dune build $(DUNE_OPTS) @doc
+ 
+ clean:
+ 	rm -rf _build
+ 
+ tests:
+-	dune build $(INSTALL)/bin/elpi
+-	dune build $(BUILD)/tests/test.exe
++	dune build $(DUNE_OPTS) $(INSTALL)/bin/elpi
++	dune build $(DUNE_OPTS) $(BUILD)/tests/test.exe
+ 	ulimit -s $(STACK); \
+ 		$(BUILD)/tests/test.exe \
+ 		--seed $$RANDOM \
+@@ -68,7 +69,7 @@ git/%:
+ 	git clone -l . "elpi-$*"
+ 	cd "elpi-$*" && git checkout "$*"
+ 	cd "elpi-$*" && \
+-	  if [ -f dune ]; then dune build --root . @install; else make; fi
++	  if [ -f dune ]; then dune build --root . $(DUNE_OPTS) @install; else make; fi
+ 	cp "elpi-$*/elpi" "elpi.git.$*" || \
+ 		cp "elpi-$*/$(INSTALL)/bin/elpi" "elpi.git.$*"
+ 	rm -rf "$$PWD/elpi-$*"
+-- 
+2.17.1
+

--- a/packages/elpi/elpi.1.8.0/opam
+++ b/packages/elpi/elpi.1.8.0/opam
@@ -22,7 +22,7 @@ depends: [
   "re" {>= "1.7.2"}
   "ANSITerminal" {with-test}
   "cmdliner" {with-test}
-  "dune"
+  "dune" {>= "1.6"}
   "conf-time" {with-test}
 ]
 synopsis: "ELPI - Embeddable λProlog Interpreter"

--- a/packages/elpi/elpi.1.8.0/opam
+++ b/packages/elpi/elpi.1.8.0/opam
@@ -10,9 +10,10 @@ bug-reports: "https://github.com/LPCIC/elpi/issues"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  [make "tests"] {with-test & os != "macos"}
+  [make "tests" "DUNE_OPTS=-p %{name}%"] {with-test & os != "macos"}
 ]
-
+patches: [ "0001-Makefile-pass-DUNE_OPTS-to-dune.patch" ]
+extra-files: [ ["0001-Makefile-pass-DUNE_OPTS-to-dune.patch" "810836aa85bdb52d6a02947e93353ced"] ]
 depends: [
   "ocaml" {>= "4.04.0"}
   "camlp5"

--- a/packages/elpi/elpi.1.8.0/opam
+++ b/packages/elpi/elpi.1.8.0/opam
@@ -1,0 +1,84 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Claudio Sacerdoti Coen" "Enrico Tassi" ]
+license: "LGPL 2.1+"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  [make "tests"] {with-test & os != "macos"}
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "camlp5"
+  "ppx_tools_versioned"
+  "ppx_deriving"
+  "ocaml-migrate-parsetree"
+  "re" {>= "1.7.2"}
+  "ANSITerminal" {with-test}
+  "cmdliner" {with-test}
+  "dune"
+  "conf-time" {with-test}
+]
+synopsis: "ELPI - Embeddable λProlog Interpreter"
+description: """
+ELPI implements a variant of λProlog enriched with Constraint Handling Rules,
+a programming language well suited to manipulate syntax trees with binders.
+
+ELPI is designed to be embedded into larger applications written in OCaml as
+an extension language. It comes with an API to drive the interpreter and 
+with an FFI for defining built-in predicates and data types, as well as
+quotations and similar goodies that are handy to adapt the language to the host
+application.
+
+This package provides both a command line interpreter (elpi) and a library to
+be linked in other applications (eg by passing -package elpi to ocamlfind).
+
+The ELPI programming language has the following features:
+
+- Native support for variable binding and substitution, via an Higher Order
+  Abstract Syntax (HOAS) embedding of the object language. The programmer needs
+  not to care about De Bruijn indexes.
+
+- Native support for hypothetical context. When moving under a binder one can
+  attach to the bound variable extra information that is collected when the
+  variable gets out of scope. For example when writing a type-checker the
+  programmer needs not to care about managing the typing context.
+
+- Native support for higher order unification variables, again via HOAS.
+  Unification variables of the meta-language (λProlog) can be reused to
+  represent the unification variables of the object language. The programmer
+  does not need to care about the unification-variable assignment map and
+  cannot assign to a unification variable a term containing variables out of
+  scope, or build a circular assignment.
+
+- Native support for syntactic constraints and their meta-level handling rules.
+  The generative semantics of Prolog can be disabled by turning a goal into a
+  syntactic constraint (suspended goal). A syntactic constraint is resumed as
+  soon as relevant variables gets assigned. Syntactic constraints can be
+  manipulated by constraint handling rules (CHR).
+
+- Native support for backtracking. To ease implementation of search.
+
+- The constraint store is extensible.  The host application can declare
+  non-syntactic constraints and use custom constraint solvers to check their
+  consistency.
+
+- Clauses are graftable. The user is free to extend an existing program by
+  inserting/removing clauses, both at runtime (using implication) and at
+  "compilation" time by accumulating files.
+
+ELPI is free software released under the terms of LGPL 2.1 or above."""
+url {
+  src:
+    "https://github.com/LPCIC/elpi/releases/download/v1.8.0/elpi-v1.8.0.tbz"
+  checksum: [
+    "sha256=757a4f8fddd6a809a420a07f4eb20d11a283ab2f05ac50443010508b22eb1bc1"
+    "sha512=12f275f907a578f37deb53cd3524ad96ce358bb953dbfe6189d0e47f6ef6914bc7a4e559d55767431f5de84555f03cbf1b8d5a47d54ee10775b8fd8e1cda6d2b"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- Bugfix:
  - `shorten foo.{ bar }.` when `foo.bar` is a builtin used to be miscompiled.
  - `elpi-typechecker.elpi` now correclty stops printing warnings after it
    printed 10 (used to stop after he processed 10, that may not be the same
    thing, since some warnings are suppressed).

- Parser:
  - Interpret `-2` (with no space) as the negative `2` not as the constant `-2`.
    This way `X is 3 - 2` and `Y is 3 + -2` are both valid.

- FFI:
  - `OpaqueData` now requires a ternary comparison, not just equality.

- Stdlib:
  - new data type `cmp` for ternary comparison.
  - `std.set` and `std.map` now based on ternary comparison.

- Builtin:
  - `cmp_term` giving an order on ground terms.
  - `ground_term` to check if a term is ground.