### PR TITLE
Cryptokit version 1.14

### DIFF
--- a/packages/cryptokit/cryptokit.1.14/opam
+++ b/packages/cryptokit/cryptokit.1.14/opam
@@ -14,14 +14,12 @@ depends: [
 ]
 build: make
 install: [make "install"]
-remove: [["ocamlfind" "remove" "cryptokit"]]
 synopsis: "A library of cryptographic primitives."
 description: """
 Cryptokit includes block ciphers (AES, DES, 3DES), stream ciphers
 (ARCfour), public-key crypto (RSA, DH), hashes (SHA-1, SHA-256,
 SHA-3), MACs, compression, random number generation -- all presented
 with a compositional, extensible interface."""
-flags: light-uninstall
 url {
   src: "https://github.com/xavierleroy/cryptokit/archive/release114.tar.gz"
   checksum: "md5=9c7faf35494a5d0867b41c898e20751d"

--- a/packages/cryptokit/cryptokit.1.14/opam
+++ b/packages/cryptokit/cryptokit.1.14/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: ["Xavier Leroy"]
+bug-reports: "https://github.com/xavierleroy/cryptokit/issues"
+homepage: "https://github.com/xavierleroy/cryptokit"
+dev-repo: "git+https://github.com/xavierleroy/cryptokit.git"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "conf-zlib"
+  "conf-gmp-powm-sec"
+  "zarith" {>= "1.4"}
+]
+build: make
+install: [make "install"]
+remove: [["ocamlfind" "remove" "cryptokit"]]
+synopsis: "A library of cryptographic primitives."
+description: """
+Cryptokit includes block ciphers (AES, DES, 3DES), stream ciphers
+(ARCfour), public-key crypto (RSA, DH), hashes (SHA-1, SHA-256,
+SHA-3), MACs, compression, random number generation -- all presented
+with a compositional, extensible interface."""
+flags: light-uninstall
+url {
+  src: "https://github.com/xavierleroy/cryptokit/archive/release114.tar.gz"
+  checksum: "md5=9c7faf35494a5d0867b41c898e20751d"
+}


### PR DESCRIPTION
This matches the latest release of Cryptokit, a library of crypto primitives.  The release fixes some nasty bugs, such as:
* Zlib thinking that its data structures are corrupted just because the OCaml GC moved them;
* some AMD Ryzen 3000 processors having a broken RDRAND instruction that produces endless streams of ones as "random" data.

More info at https://github.com/xavierleroy/cryptokit/releases/tag/release114
