### PR TITLE
Package unidecode.0.4.0

### DIFF
--- a/packages/unidecode/unidecode.0.4.0/opam
+++ b/packages/unidecode/unidecode.0.4.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+
+synopsis: "Convert unicode strings into its ASCII representation"
+
+authors: [ "Daniel de Rauglaudre" ]
+
+maintainer: "Julien Sagot <julien.sagot@geneanet.org>"
+
+license: "GNU GPL"
+
+homepage: "https://github.com/geneweb/unidecode"
+
+bug-reports: "https://github.com/geneweb/unidecode/issues"
+
+dev-repo: "git+https://github.com/geneweb/unidecode.git"
+
+depends: [
+  "dune" { >= "1.10" }
+  "ocaml" { >= "4.05" }
+  ]
+
+build: [ [ "dune" "build" "-p" name "-j" jobs] ]
+url {
+  src: "https://github.com/geneweb/unidecode/archive/v0.4.0.tar.gz"
+  checksum: [
+    "md5=88090f06c51464a0d829081640be3f3d"
+    "sha512=a411685ddb1d52585251eff3e2cd56fc9b4e91dcfceff424d7cfd5f721be73561d7a8e9223ecaeeda6178b02e5f6df74d50a49d4ce61d72a7d3fa1e8aefe5cf3"
+  ]
+}


### PR DESCRIPTION
### `unidecode.0.4.0`
Convert unicode strings into its ASCII representation



---
* Homepage: https://github.com/geneweb/unidecode
* Source repo: git+https://github.com/geneweb/unidecode.git
* Bug tracker: https://github.com/geneweb/unidecode/issues

---
:camel: Pull-request generated by opam-publish v2.0.0