### PR TITLE
mirage interfacs (not yet used): lower lwt lower bound to 4.0.0

### DIFF
--- a/packages/mirage-block-combinators/mirage-block-combinators.2.0.0/opam
+++ b/packages/mirage-block-combinators/mirage-block-combinators.2.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "cstruct" {>= "2.0.0"}
   "io-page"
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
   "logs"
   "mirage-block" {=version}
 ]

--- a/packages/mirage-block/mirage-block.2.0.0/opam
+++ b/packages/mirage-block/mirage-block.2.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "mirage-device" {>= "2.0.0"}
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
   "cstruct" {>= "4.0.0"}
 ]
 build: [

--- a/packages/mirage-channel/mirage-channel.4.0.0/opam
+++ b/packages/mirage-channel/mirage-channel.4.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "mirage-flow" {>= "2.0.0"}
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
   "cstruct" {>= "4.0.0"}
   "logs"
   "alcotest" {with-test}

--- a/packages/mirage-console-unix/mirage-console-unix.3.0.0/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.3.0.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
   "cstruct" {>= "4.0.0"}
   "cstruct-lwt" {>= "4.0.0"}
   "mirage-console" {=version}

--- a/packages/mirage-console/mirage-console.3.0.0/opam
+++ b/packages/mirage-console/mirage-console.3.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "mirage-device" {>= "2.0.0"}
   "mirage-flow" {>= "2.0.0"}
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
   "cstruct" {>= "4.0.0"}
 ]
 build: [

--- a/packages/mirage-device/mirage-device.2.0.0/opam
+++ b/packages/mirage-device/mirage-device.2.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "fmt"
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-flow-combinators/mirage-flow-combinators.2.0.0/opam
+++ b/packages/mirage-flow-combinators/mirage-flow-combinators.2.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "fmt"
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
   "logs"
   "cstruct" {>= "4.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/mirage-flow-unix/mirage-flow-unix.2.0.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.2.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "fmt"
   "logs"
   "mirage-flow" {= version}
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
   "cstruct" {>= "4.0.0"}
   "alcotest" {with-test}
   "mirage-flow-combinators" {with-test & = version}

--- a/packages/mirage-flow/mirage-flow.2.0.0/opam
+++ b/packages/mirage-flow/mirage-flow.2.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "cstruct" {>= "4.0.0"}
   "fmt"
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-fs/mirage-fs.3.0.0/opam
+++ b/packages/mirage-fs/mirage-fs.3.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"
   "fmt"
   "mirage-device" {>= "2.0.0"}
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
   "cstruct" {>= "4.0.0"}
   "mirage-kv" {>= "3.0.0"}
 ]

--- a/packages/mirage-kv/mirage-kv.3.0.0/opam
+++ b/packages/mirage-kv/mirage-kv.3.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"
   "mirage-device" {>= "2.0.0"}
   "fmt"
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
   "alcotest" {with-test}
 ]
 synopsis: "MirageOS signatures for key/value devices"

--- a/packages/mirage-protocols/mirage-protocols.4.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.4.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-flow" {>= "2.0.0"}
   "fmt"
   "duration"
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
   "ipaddr" {>= "4.0.0"}
   "macaddr" {>= "4.0.0"}
 ]

--- a/packages/mirage-stack/mirage-stack.2.0.0/opam
+++ b/packages/mirage-stack/mirage-stack.2.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "mirage-device" {>= "2.0.0"}
   "mirage-protocols" {>= "4.0.0"}
   "fmt"
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-time-unix/mirage-time-unix.2.0.0/opam
+++ b/packages/mirage-time-unix/mirage-time-unix.2.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "mirage-time" {=version}
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
   "duration"
 ]
 build: [

--- a/packages/mirage-time/mirage-time.2.0.0/opam
+++ b/packages/mirage-time/mirage-time.2.0.0/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/mirage/mirage-time/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
-  "lwt" {>= "4.4.0"}
+  "lwt" {>= "4.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
4.4.0 was a bit too eager.. i also upstreamed to the individual repositories these bounds!