### PR TITLE
[new release] mirage-vnetif (0.5.0)

### DIFF
--- a/packages/mirage-vnetif/mirage-vnetif.0.5.0/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.5.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+name: "mirage-vnetif"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-vnetif"
+bug-reports: "https://github.com/mirage/mirage-vnetif/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-vnetif.git"
+doc: "https://mirage.github.io/mirage-vnetif/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"  {>= "1.0"}
+  "lwt"
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "cstruct" {>="2.4.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "mirage-profile"
+  "duration"
+  "logs"
+]
+tags: ["org:mirage"]
+synopsis: "Virtual network interface and software switch for Mirage"
+description: """
+Provides the module `Vnetif` which can be used as a replacement for the regular
+`Netif` implementation in Xen and Unix. Stacks built using `Vnetif` are
+connected to a software switch that allows the stacks to communicate as if they
+were connected to the same LAN.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-vnetif/releases/download/v0.5.0/mirage-vnetif-v0.5.0.tbz"
+  checksum: [
+    "sha256=b85460222a780c9b99151b40a00cf57c29bd865baa63d702f997891d8ae3f832"
+    "sha512=7889d12b35647868bea34ecd8fd1976411f2e74bc0b97b49e9b0eafca67ca2c37f2fd360afc3362d447f9b93445e888d52f4da484bece86ecb4075bb6e225491"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- adapt to mirage-net 3.0.0 interface changes (mirage/mirage-vnetif#28 @hannesm)