### PR TITLE
[new release] ethernet (2.2.0)

### DIFF
--- a/packages/ethernet/ethernet.2.2.0/opam
+++ b/packages/ethernet/ethernet.2.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   "mirageos-devel@lists.xenproject.org"
+homepage:     "https://github.com/mirage/ethernet"
+dev-repo:     "git+https://github.com/mirage/ethernet.git"
+bug-reports:  "https://github.com/mirage/ethernet/issues"
+doc:          "https://mirage.github.io/ethernet/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.06.0"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {>= "3.0.2"}
+  "ppx_cstruct"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "logs" {>= "0.6.0"}
+]
+synopsis: "OCaml Ethernet (IEEE 802.3) layer, used in MirageOS"
+description: """
+`ethernet` provides an [Ethernet](https://en.wikipedia.org/wiki/Ethernet)
+(specified by IEEE 802.3) layer implementation for the
+[Mirage operating system](https://mirage.io).
+"""
+url {
+  src:
+    "https://github.com/mirage/ethernet/releases/download/v2.2.0/ethernet-v2.2.0.tbz"
+  checksum: [
+    "sha256=ffb858bdbd2533d48fced4e6944212e2f332ab20c682316046ed89be22d6f163"
+    "sha512=67bf2726962364eb8c72883c4ae41d907cbb0000d895909f2a9b6a3b241d2ed7e0025d01bbd4461ead6fa3e25cd961508da00ee9b3be37d802c11318802d4a8e"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Adapt to mirage-net 3.0.0 and mirage-protocols 4.0.0 changes (mirage/ethernet#6 @hannesm)