### PR TITLE
[new release] mirage-random-test (0.1.0)

### DIFF
--- a/packages/mirage-random-test/mirage-random-test.0.1.0/opam
+++ b/packages/mirage-random-test/mirage-random-test.0.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:    "hannes@mehnert.org"
+homepage:      "https://github.com/mirage/mirage-random-test"
+bug-reports:   "https://github.com/mirage/mirage-random-test/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-random-test.git"
+doc:           "https://mirage.github.io/mirage-random-test/"
+authors:       ["Hannes Mehnert"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {>="1.1.0"}
+  "cstruct" {>= "1.9.0"}
+  "ocaml" {>= "4.06.0"}
+  "mirage-random" {>= "2.0.0"}
+]
+
+synopsis: "Stub random device implementation for testing"
+description: """
+mirage-random-test implements `Mirage_random.C` as stub for testing.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-random-test/releases/download/v0.1.0/mirage-random-test-v0.1.0.tbz"
+  checksum: [
+    "sha256=86ec89265f5685729bf046e5e5e1981de50ff54ff9f2f67a07f46ca2d2f2b2ca"
+    "sha512=8c155111d0a9b9f5b557597b250ea4a53b84eb6e9f3f50e9a47092c8844c7de08857ddfd078b5237f7e7d097da4f3a4bc8d704fa577bacd1c9150550503e5dd2"
+  ]
+}

--- a/packages/mirage-random-test/mirage-random-test.0.1.0/opam
+++ b/packages/mirage-random-test/mirage-random-test.0.1.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {>="1.1.0"}
+  "dune" {>= "1.3.0"}
   "cstruct" {>= "1.9.0"}
   "ocaml" {>= "4.06.0"}
   "mirage-random" {>= "2.0.0"}


### PR DESCRIPTION
CHANGES:

* adapt to mirage-random 2.0.0 interface (mirage/mirage-random-test#2 @hannesm)