### PR TITLE
[new release] mirage-random-stdlib (0.1.0)

### DIFF
--- a/packages/mirage-random-stdlib/mirage-random-stdlib.0.1.0/opam
+++ b/packages/mirage-random-stdlib/mirage-random-stdlib.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:    "hannes@mehnert.org"
+homepage:      "https://github.com/mirage/mirage-random-stdlib"
+bug-reports:   "https://github.com/mirage/mirage-random-stdlib/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-random-stdlib.git"
+doc:           "https://mirage.github.io/mirage-random-stdlib/"
+authors:       ["Thomas Gazagnaire" "Hannes Mehnert"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {>="1.1.0"}
+  "cstruct" {>= "1.9.0"}
+  "ocaml" {>= "4.06.0"}
+  "lwt"
+  "mirage-random" {>= "2.0.0"}
+  "mirage-entropy"
+]
+
+synopsis: "Random device implementation using the OCaml stdlib"
+description: """
+mirage-random-stdlib implements `Mirage_random.C` using the `Random` from
+the OCaml standard library (a lagged-Fibonacci PRNG). The entropy is seeded
+by mirage-entropy, depending on CPU features.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-random-stdlib/releases/download/v0.1.0/mirage-random-stdlib-v0.1.0.tbz"
+  checksum: [
+    "sha256=51783442c9b97711715ce62a15bcbefd3b01ae32c737f998eede395bc2dbfda3"
+    "sha512=979f4eabe61e97ceb84f6c0dddc03e2c46b404a8786fce3913feb2351369b8e755a1b737aa2d13db5abade72439186b04774ca892fe2b7f28b386fe6846d443a"
+  ]
+}

--- a/packages/mirage-random-stdlib/mirage-random-stdlib.0.1.0/opam
+++ b/packages/mirage-random-stdlib/mirage-random-stdlib.0.1.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {>="1.1.0"}
+  "dune" {>="1.3.0"}
   "cstruct" {>= "1.9.0"}
   "ocaml" {>= "4.06.0"}
   "lwt"


### PR DESCRIPTION
CHANGES:

* adapt to mirage-random 2.0.0 interface changes (mirage/mirage-random-stdlib#3 @hannesm)