### PR TITLE
[new release] mirage-net-unix (2.7.0)

### DIFF
--- a/packages/mirage-net-unix/mirage-net-unix.2.7.0/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.2.7.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "David Scott" "Thomas Gazagnaire" "Hannes Mehnert"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/mirage-net-unix"
+doc: "https://mirage.github.io/mirage-net-unix/"
+bug-reports: "https://github.com/mirage/mirage-net-unix/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "1.7.1"}
+  "cstruct-lwt"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "tuntap" {>= "1.8.0"}
+  "alcotest" {with-test}
+  "logs"
+  "macaddr"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-net-unix.git"
+synopsis: "Unix implementation of the Mirage_net_lwt interface"
+description: """
+This interface exposes raw Ethernet frames using `ocaml-tuntap`,
+suitable for use with an OCaml network stack such as the one
+found at <https://github.com/mirage/mirage-tcpip>.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-unix/releases/download/v2.7.0/mirage-net-unix-v2.7.0.tbz"
+  checksum: [
+    "sha256=7487ddec3c597133b39b2070276999130ff9fc93742ffa6de670c2851f52b33a"
+    "sha512=e73afd9947fac68255586f6d3093ef5788391d58c14721fc06afc4175d4fb727e921e63ee9d12fcd65bd26e243ad7db3e63275a3b68821fe9b4c89efc2a11a79"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Adapt to mirage-net 3.0.0 changes (@hannesm)