### PR TITLE
Update package conf-glfw3

### DIFF
--- a/packages/conf-glfw3/conf-glfw3.2/opam
+++ b/packages/conf-glfw3/conf-glfw3.2/opam
@@ -13,10 +13,10 @@ depexts: [
   ["libglfw3-dev"] {os-family = "debian"}
   ["glfw-devel" "epel-release" "mesa-libGL-devel"]
     {os-distribution = "centos"}
-  ["glfw-devel"] {os-distribution = "rhel"}
-  ["glfw-devel"] {os-distribution = "fedora"}
+  ["glfw-devel" "mesa-libGL-devel"] {os-distribution = "rhel"}
+  ["glfw-devel" "mesa-libGL-devel"] {os-distribution = "fedora"}
   ["glfw-dev"] {os-distribution = "alpine"}
-  ["libglfw-devel"] {os-family = "suse"}
-  ["libglfw-devel"] {os-distribution = "mageia"}
+  ["libglfw-devel" "Mesa-libGL-devel"] {os-family = "suse"}
+  ["libglfw-devel" "mesagl-devel"] {os-distribution = "mageia"}
   ["glfw"] {os = "macos" & os-distribution = "homebrew"}
 ]


### PR DESCRIPTION
CHANGES:

* Add explicit dependency on mesa-libGL-dev on distributions where the GLFW package does not depend on a package that provides GL/gl.h .