### PR TITLE
Package 4cca7639d8df0ada759c9f8b3fd59e8c-1.1.2.5

### DIFF
--- a/packages/4cca7639d8df0ada759c9f8b3fd59e8c-1/4cca7639d8df0ada759c9f8b3fd59e8c-1.1.2.5/opam
+++ b/packages/4cca7639d8df0ada759c9f8b3fd59e8c-1/4cca7639d8df0ada759c9f8b3fd59e8c-1.1.2.5/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Protobuf compiler for OCaml"
+description: "Protobuf compiler for OCaml"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+authors: "Maxime Ransan <maxime.ransan@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "ocaml" {>= "4.02.1"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ppx_deriving_protobuf"
+]
+available: opam-version >= "1.2"
+build: [
+  [make "lib.byte"]
+  [make "lib.native"]
+  [make "bin.native"]
+]
+install: [
+  [make "lib.install"]
+  [make "bin.install" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
+]
+remove: [make "uninstall" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+url {
+  src: "https://github.com/mransan/ocaml-protoc/archive/1.2.5.tar.gz"
+  checksum: [
+    "md5=1658e542cf33a1e25cd82007220a4798"
+    "sha512=59cae066b687051204793a2a39f95bae596836ec14a9c2f737c74f0985eeae30bc6f41272dc6d1cb647bf26d26bdec62860dc943539a59db201b4ca980e311f0"
+  ]
+}


### PR DESCRIPTION
### `4cca7639d8df0ada759c9f8b3fd59e8c-1.1.2.5`
Protobuf compiler for OCaml
Protobuf compiler for OCaml



---
* Homepage: https://github.com/mransan/ocaml-protoc
* Source repo: git+https://github.com/mransan/ocaml-protoc.git
* Bug tracker: https://github.com/mransan/ocaml-protoc/issues

---
:camel: Pull-request generated by opam-publish v2.0.0