### PR TITLE
3 packages from sneeuwballen/zipperposition at 1.5.1

### DIFF
--- a/packages/libzipperposition/libzipperposition.1.5.1/opam
+++ b/packages/libzipperposition/libzipperposition.1.5.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/sneeuwballen/zipperposition"
+synopsis: "Library for Zipperposition"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "base-bytes"
+  "base-unix"
+  "zarith"
+  "logtk" { = version }
+  "containers" { >= "1.0" }
+  "iter" { >= "1.2" }
+  "dune" { >= "1.1" }
+  "msat" { >= "0.8" < "0.9" }
+  "menhir" {build}
+  "logtk"
+  "ocaml" {>= "4.03"}
+]
+tags: [ "logic" "unification" "term" "superposition" "prover" ]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/1.5.1.tar.gz"
+  checksum: [
+    "md5=cc320f66f10555c54822da624419e003"
+    "sha512=f8d5f7a5ae790bf0388d74261673803cf375f91f92f7b413b70db1ce5841ef55343a208f98727c8551d66f1840ab892f1c0c943a34861d14d79ce469b235a2f2"
+  ]
+}

--- a/packages/logtk/logtk.1.5.1/opam
+++ b/packages/logtk/logtk.1.5.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/sneeuwballen/zipperposition"
+synopsis: "Core types and algorithms for logic"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "base-bytes"
+  "base-unix"
+  "zarith"
+  "containers" { >= "1.0" }
+  "iter" { >= "1.2" }
+  "menhir" {build}
+  "dune" { >= "1.1" }
+  "alcotest" {with-test}
+  "qcheck-core" {with-test & >= "0.9"}
+  "qcheck-alcotest" {with-test & >= "0.9"}
+  "ocaml" {>= "4.03"}
+]
+depopts: [
+  "msat"
+]
+conflicts: [
+  "msat" { < "0.8" }
+  "msat" { >= "0.9" }
+]
+tags: [ "logic" "unification" "term" ]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/1.5.1.tar.gz"
+  checksum: [
+    "md5=cc320f66f10555c54822da624419e003"
+    "sha512=f8d5f7a5ae790bf0388d74261673803cf375f91f92f7b413b70db1ce5841ef55343a208f98727c8551d66f1840ab892f1c0c943a34861d14d79ce469b235a2f2"
+  ]
+}

--- a/packages/zipperposition/zipperposition.1.5.1/opam
+++ b/packages/zipperposition/zipperposition.1.5.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/sneeuwballen/zipperposition"
+synopsis: "A fully automatic theorem prover for typed first-order and beyond"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "base-unix"
+  "zarith"
+  "logtk" { = version }
+  "libzipperposition" { = version }
+  "containers" { >= "1.0" }
+  "iter" { >= "1.2" }
+  "dune" { >= "1.1" }
+  "msat" { >= "0.8" < "0.9" }
+  "menhir" {build}
+  "ocaml" {>= "4.03"}
+]
+tags: [ "logic" "unification" "term" "superposition" "prover" ]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/1.5.1.tar.gz"
+  checksum: [
+    "md5=cc320f66f10555c54822da624419e003"
+    "sha512=f8d5f7a5ae790bf0388d74261673803cf375f91f92f7b413b70db1ce5841ef55343a208f98727c8551d66f1840ab892f1c0c943a34861d14d79ce469b235a2f2"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`libzipperposition.1.5.1`: Library for Zipperposition
-`logtk.1.5.1`: Core types and algorithms for logic
-`zipperposition.1.5.1`: A fully automatic theorem prover for typed first-order and beyond



---
* Homepage: https://github.com/sneeuwballen/zipperposition
* Source repo: git+https://github.com/sneeuwballen/zipperposition.git
* Bug tracker: https://github.com/sneeuwballen/zipperposition/issues

---
:camel: Pull-request generated by opam-publish v2.0.0