### PR TITLE
Package ocaml-protoc.1.2.6

### DIFF
--- a/packages/ocaml-protoc/ocaml-protoc.1.2.6/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.1.2.6/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Protobuf compiler for OCaml"
+description: "Protobuf compiler for OCaml"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+authors:[
+  "Maxime Ransan <maxime.ransan@gmail.com>"
+]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
+dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
+license: "MIT"
+build: [
+  [make "lib.byte"]   
+  [make "lib.native"]
+  [make "bin.native"]
+]
+install: [
+  [make "lib.install" ]
+  [make "bin.install" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
+]
+depends: [
+  "ocaml" {>="4.02.1"}
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "ppx_deriving_protobuf"
+]
+url {
+  src: "https://github.com/mransan/ocaml-protoc/archive/1.2.6.tar.gz"
+  checksum: [
+    "md5=e9ad80abc334a296cffe7fd98b36fb52"
+    "sha512=414357d7c5e708b985048aedf7f9141e2894fac044c255dda2dd29fdd239a0a63d5ec8999e70998fe12ea5a41a7618c01ccda86ee4dfd396de54b8282c473d6b"
+  ]
+}


### PR DESCRIPTION
### `ocaml-protoc.1.2.6`
Protobuf compiler for OCaml
Protobuf compiler for OCaml



---
* Homepage: https://github.com/mransan/ocaml-protoc
* Source repo: git+https://github.com/mransan/ocaml-protoc.git
* Bug tracker: https://github.com/mransan/ocaml-protoc/issues

---
:camel: Pull-request generated by opam-publish v2.0.0