### PR TITLE
[new release] tcpip (4.0.0)

### DIFF
--- a/packages/tcpip/tcpip.4.0.0/opam
+++ b/packages/tcpip/tcpip.4.0.0/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs]
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depopts: ["mirage-xen-ocaml"]
+depends: [
+  "dune"     {>= "1.0"}
+  "ocaml" {>= "4.06.0"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {>= "3.2.0"}
+  "cstruct-lwt"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv"
+  "ethernet" {>= "2.0.0"}
+  "mirage-flow" {with-test & >= "2.0.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "alcotest" {with-test & >="0.7.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "arp-mirage" {with-test & >= "2.0.0"}
+  "lru" {>= "0.3.0"}
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v4.0.0/tcpip-v4.0.0.tbz"
+  checksum: [
+    "sha256=0d4df94e1563d9f4a3f4715be93e03d32dabfdf0dde827fe4d2127e9a82c1d24"
+    "sha512=9dfcc9b5205d39fbe4ed4b1a045e3c3c1650a5711b02f4d06ac997dbaebe3cae1db99e18f4b7f36c8661d354ed8a628dd034124f92bfe321c604421a5e7aec4a"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Adapt to mirage-protocols 4.0.0, mirage-net 3.0.0, mirage-time 2.0.0,
  mirage-clock 3.0.0, mirage-stack 2.0.0 interface changes (mirage/mirage-tcpip#420 @hannesm)
* Revise Static_ipv4.connect signature (for more safety):
  val connect : ip:(Ipaddr.V4.Prefix.t * Ipaddr.V4.t) -> ?gateway:Ipaddr.V4.t ->
                ?fragment_cache_size:int -> E.t -> A.t -> t Lwt.t
  it used to be:
  val connect : ?ip:Ipaddr.V4.t -> ?network:Ipaddr.V4.Prefix.t ->
                ?gateway:Ipaddr.V4.t option -> C.t -> E.t -> A.t -> t Lwt.t
  The clock `C.t` is gone (due to mirage-clock 3.0.0), `~ip` and `~network` are
  now required and passed as pair `~ip`. The optional argument `?gateway` is
  of type Ipaddr.V4.t. The new optional labeled argument `~fragment_cache_size`
  specifies the byte size of the IPv4 fragment cache (mirage/mirage-tcpip#420 @hannesm)