### PR TITLE
[new release] mirage-runtime (3.7.0)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.7.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.7.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria-runtime"  {>= "2.2.2"}
+  "fmt"
+  "logs"
+  "lwt" {>= "4.0.0"}
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.7.0/mirage-v3.7.0.tbz"
+  checksum: [
+    "sha256=96d4a819ada475f2706bba457d62b2341c515ec7ac1d5cc4cc28cee9895bd9a5"
+    "sha512=19b6d51e5f0b79156282eda079ac4d168c23482677e4581022e54ad6ffeb532ed7ed7f650b85f63d8f3a87268bd151afa64aef554acceeb1eee6ea95eb0b0b54"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* mirage-runtime: provide at_enter_iter/at_exit_iter/at_exit hooks for the event loop (mirage/mirage#1010, @samoht @dinosaure @hannesm)
* call `exit 0` after the Lwt event loop returned (to run at_exit handlers in freestanding environments) (mirage/mirage#1011, @hannesm)
* NOTE: this release only contains the mirage-runtime opam package to unblock other releases, there'll be a 3.7.1 soon