### PR TITLE
opam admin add-constraint "mirage-xen<5.0.0"

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.1.6.2/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.6.2/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"
   "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "4.0.0"}
+  "mirage-xen" {>= "4.0.0" & < "5.0.0"}
   "rresult"
 ]
 build: [

--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.6.0/opam
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.6.0/opam
@@ -21,11 +21,11 @@ build: [
 
 depends: [
   "dune" {>= "1.0"}
-  "mirage-xen" { >= "4.0.0"}
-  "lwt" {>="2.4.3"}
+  "mirage-xen" {>= "4.0.0" & < "5.0.0"}
+  "lwt" {>= "2.4.3"}
   "astring"
   "parse-argv"
-  "ocaml" { >= "4.04.2" }
+  "ocaml" {>= "4.04.2"}
 ]
 url {
   src:

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.4.3/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.2.4.3/opam
@@ -9,9 +9,9 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-console-lwt" {=version}
-  "mirage-console-xen-proto" {=version}
-  "mirage-xen" {>= "4.0.0"}
+  "mirage-console-lwt" {= version}
+  "mirage-console-xen-proto" {= version}
+  "mirage-xen" {>= "4.0.0" & < "5.0.0"}
   "lwt"
   "io-page-xen" {>= "2.0.0"}
   "xenstore"

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.3.0.0/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.3.0.0/opam
@@ -9,9 +9,9 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
-  "mirage-console" {=version}
-  "mirage-console-xen-proto" {=version}
-  "mirage-xen" {>= "4.0.0"}
+  "mirage-console" {= version}
+  "mirage-console-xen-proto" {= version}
+  "mirage-xen" {>= "4.0.0" & < "5.0.0"}
   "lwt"
   "io-page-xen" {>= "2.0.0"}
   "xenstore"

--- a/packages/mirage-console-xen/mirage-console-xen.2.4.3/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.2.4.3/opam
@@ -9,11 +9,11 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-console-lwt" {=version}
-  "mirage-console-xen-proto" {=version}
+  "mirage-console-lwt" {= version}
+  "mirage-console-xen-proto" {= version}
   "xen-evtchn"
   "io-page-xen"
-  "mirage-xen" {>= "4.0.0"}
+  "mirage-xen" {>= "4.0.0" & < "5.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-console-xen/mirage-console-xen.3.0.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.3.0.0/opam
@@ -9,11 +9,11 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
-  "mirage-console" {=version}
-  "mirage-console-xen-proto" {=version}
+  "mirage-console" {= version}
+  "mirage-console-xen-proto" {= version}
   "xen-evtchn"
   "io-page-xen"
-  "mirage-xen" {>= "4.0.0"}
+  "mirage-xen" {>= "4.0.0" & < "5.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-http-xen/mirage-http-xen.1.0.0/opam
+++ b/packages/mirage-http-xen/mirage-http-xen.1.0.0/opam
@@ -5,7 +5,7 @@ remove: [[make "uninstall"]]
 depends: [
   "ocaml" {>= "4.00.0"}
   "mirage-types" {<= "1.0.0"}
-  "mirage-xen" {>= "1.0.0"}
+  "mirage-xen" {>= "1.0.0" & < "5.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "mirage-tcpip-xen" {>= "0.9.5"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.12.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.12.0/opam
@@ -12,18 +12,17 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"  {>= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "2.0.0"}
   "io-page" {>= "1.5.0"}
   "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "4.0.0"}
+  "mirage-xen" {>= "4.0.0" & < "5.0.0"}
   "netchannel" {>= "1.10.1"}
   "lwt-dllist"
   "logs" {>= "0.5.0"}
 ]
-
 tags: "org:mirage"
 synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
 description: """

--- a/packages/mirage-profile-xen/mirage-profile-xen.0.9.1/opam
+++ b/packages/mirage-profile-xen/mirage-profile-xen.0.9.1/opam
@@ -9,12 +9,12 @@ bug-reports: "https://github.com/mirage/mirage-profile/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.0"}
-  "mirage-profile" {=version}
+  "mirage-profile" {= version}
   "io-page-xen"
   "io-page"
   "mirage-xen-minios"
   "ocplib-endian"
-  "mirage-xen" {>= "4.0.0"}
+  "mirage-xen" {>= "4.0.0" & < "5.0.0"}
   "xenstore"
 ]
 build: [

--- a/packages/mirage-qubes/mirage-qubes.0.1/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "vchan" {>= "2.0.0" & < "3.0.0"}
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen"
+  "mirage-xen" {< "5.0.0"}
   "lwt"
   "mirage-types" {< "3.0.0"}
   "logs" {<= "0.4.2"}

--- a/packages/mirage-qubes/mirage-qubes.0.2/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.2/opam
@@ -16,14 +16,14 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "type_conv"
-  "cstruct" {<"2.0.0"}
+  "cstruct" {< "2.0.0"}
   "vchan" {>= "2.0.0" & < "3.0.0"}
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen"
-  "lwt" {<"4.0.0"}
+  "mirage-xen" {< "5.0.0"}
+  "lwt" {< "4.0.0"}
   "mirage-types" {< "3.0.0"}
-  "mirage-types-lwt" {<"3.0.0"}
+  "mirage-types-lwt" {< "3.0.0"}
   "logs" {>= "0.5.0"}
 ]
 synopsis: "Implementations of various QubesOS protocols:"

--- a/packages/mirage-qubes/mirage-qubes.0.4/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.4/opam
@@ -18,7 +18,7 @@ depends: [
   "vchan" {>= "2.3.0" & < "3.0.0"}
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen" {>= "3.0.0"}
+  "mirage-xen" {>= "3.0.0" & < "5.0.0"}
   "lwt"
   "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "logs" {>= "0.5.0"}

--- a/packages/mirage-qubes/mirage-qubes.0.5/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.5/opam
@@ -19,7 +19,7 @@ depends: [
   "vchan-xen"
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen" {>= "3.0.0"}
+  "mirage-xen" {>= "3.0.0" & < "5.0.0"}
   "lwt"
   "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "logs" {>= "0.5.0"}

--- a/packages/mirage-qubes/mirage-qubes.0.6/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.6/opam
@@ -20,7 +20,7 @@ depends: [
   "vchan-xen"
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen" {>= "3.0.0"}
+  "mirage-xen" {>= "3.0.0" & < "5.0.0"}
   "lwt"
   "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
   "logs" {>= "0.5.0"}

--- a/packages/mirage-qubes/mirage-qubes.0.7.0/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.7.0/opam
@@ -13,16 +13,16 @@ build: [
 ]
 
 depends: [
-  "dune"  {>= "1.0"}
-  "cstruct" { >= "1.9.0" }
+  "dune" {>= "1.0"}
+  "cstruct" {>= "1.9.0"}
   "ppx_cstruct"
   "vchan-xen"
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen" { >= "3.0.0" }
+  "mirage-xen" {>= "3.0.0" & < "5.0.0"}
   "lwt"
-  "logs" { >= "0.5.0" }
-  "ocaml" { >= "4.03.0" }
+  "logs" {>= "0.5.0"}
+  "ocaml" {>= "4.03.0"}
 ]
 synopsis: "Implementations of various Qubes protocols for MirageOS"
 url {

--- a/packages/netchannel/netchannel.1.12.0/opam
+++ b/packages/netchannel/netchannel.1.12.0/opam
@@ -12,7 +12,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"  {>= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {>= "3.0.0"}
   "ppx_sexp_conv" {< "v0.13"}
   "ppx_cstruct"
@@ -20,10 +20,10 @@ depends: [
   "mirage-net-lwt" {>= "2.0.0"}
   "io-page" {>= "1.5.0"}
   "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "4.0.0"}
+  "mirage-xen" {>= "4.0.0" & < "5.0.0"}
   "ipaddr" {>= "3.0.0"}
-  "mirage-profile" {>="0.3"}
-  "shared-memory-ring" {>="3.0.0"}
+  "mirage-profile" {>= "0.3"}
+  "shared-memory-ring" {>= "3.0.0"}
   "sexplib" {>= "113.01.00" & < "v0.13"}
   "logs" {>= "0.5.0"}
   "rresult"

--- a/packages/vchan-xen/vchan-xen.4.0.3/opam
+++ b/packages/vchan-xen/vchan-xen.4.0.3/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune"
-  "vchan" {=version}
+  "vchan" {= version}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
   "ppx_tools"
@@ -19,7 +19,7 @@ depends: [
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}
-  "mirage-xen" {>= "4.0.0"}
+  "mirage-xen" {>= "4.0.0" & < "5.0.0"}
   "xenstore_transport" {>= "1.0.0"}
   "sexplib" {< "v0.13"}
   "cmdliner"


### PR DESCRIPTION
in preparation for a new major mirage-xen release, breaking API