### PR TITLE
[new release] mirage-xen (5.0.0)

### DIFF
--- a/packages/mirage-xen/mirage-xen.5.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.5.0.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "subst" ] {pinned}
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "xen-evtchn" {>= "0.9.9"}
+  "conf-pkg-config"
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "mirage-xen-ocaml" {>= "3.3.1"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen-minios" {>= "0.7.0"}
+  "mirage-runtime" {>= "3.7.0"}
+  "logs"
+  "fmt"
+]
+conflicts: [
+  "dune" {= "1.9.1"}
+]
+available: [ os = "linux" ]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v5.0.0/mirage-xen-v5.0.0.tbz"
+  checksum: [
+    "sha256=ae8c9700d0cdbe49edaeec64cf2bb69f3da76f3d6cd5049b68d008448ab02e39"
+    "sha512=dda5a7818321d2177c3063c5d95c7b194d745ae19565372ffba05981d05f6a6ad302c10e719d7708106eb46d52b97d0deac8474881156f1f5717cb3a2e3f466c"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Revert the 4.0.0 change, Os_xen is now OS.Xen again (mirage/mirage-xen#20 @dinosaure)
* Adapt to mirage-runtime hooks (see mirage/mirage#1010) for at_enter_iter / at_exit_iter / at_exit (mirage/mirage-xen#21 @hannesm)
* Bump lower OCaml version to 4.06.0 (mirage/mirage-xen#21 @hannesm)