### PR TITLE
[new release] mirage-unix (4.0.0)

### DIFF
--- a/packages/arp-mirage/arp-mirage.1.0.0/opam
+++ b/packages/arp-mirage/arp-mirage.1.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-clock-unix" {with-test}
   "mirage-random" {with-test & < "2.0.0"}
   "mirage-random-test" {with-test}
-  "mirage-unix" {with-test}
+  "mirage-unix" {with-test & < "4.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/arp-mirage/arp-mirage.2.0.0/opam
+++ b/packages/arp-mirage/arp-mirage.2.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "mirage-clock-unix" {with-test}
   "mirage-random" {with-test & < "2.0.0"}
   "mirage-random-test" {with-test}
-  "mirage-unix" {with-test}
+  "mirage-unix" {with-test & < "4.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/arp-mirage/arp-mirage.2.1.0/opam
+++ b/packages/arp-mirage/arp-mirage.2.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "mirage-clock-unix" {with-test}
   "mirage-random" {with-test & < "2.0.0"}
   "mirage-random-test" {with-test}
-  "mirage-unix" {with-test}
+  "mirage-unix" {with-test & < "4.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-os-shim/mirage-os-shim.3.1.0/opam
+++ b/packages/mirage-os-shim/mirage-os-shim.3.1.0/opam
@@ -27,8 +27,11 @@ depopts: [
 ]
 conflicts: [
   "mirage-unix" {< "3.1.0"}
+  "mirage-unix" {>= "4.0.0"}
   "mirage-xen" {< "3.1.0"}
+  "mirage-xen" {>= "5.0.0"}
   "mirage-solo5" {< "0.5.0"}
+  "mirage-solo5" {>= "0.6.1"}
 ]
 synopsis: "Portable shim for MirageOS OS API"
 description: """

--- a/packages/mirage-unix/mirage-unix.4.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.4.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-unix"
+bug-reports:  "https://github.com/mirage/mirage-unix/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-unix.git"
+doc:          "https://mirage.github.io/mirage-unix/doc"
+license:      "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "lwt" {>= "2.4.3"}
+  "duration"
+  "mirage-runtime" {>= "3.7.0"}
+  "io-page-unix" {>= "2.0.0"}
+]
+tags: "org:mirage"
+synopsis: "Unix core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Unix targets, which handles the main loop and timers.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-unix/releases/download/v4.0.0/mirage-unix-v4.0.0.tbz"
+  checksum: [
+    "sha256=129e4eaddbceb3ebe2c6dd7e7474dd28f72206518357b2041a16ca3bd740cd4f"
+    "sha512=fb92036c2b7487ec97f70531425202f6adfdcbdb8c8f475596bc173f7d8d4fda216d50bf42162414e1e2d70b7137b92c33e85d391f23649ac34d75208185f360"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Use mirage-runtime hooks (at_enter_iter/at_exit_iter/at_exit), see mirage/mirage#1010 for details (mirage/mirage-unix#14 mirage/mirage-unix#15 by @samoht @dinosaure)
* Adapt to uniform exit handling, see mirage/mirage#1011 (mirage/mirage-unix#15 by @hannesm)
* Require OCaml 4.06.0 (mirage/mirage-unix#15 by @hannesm)