### PR TITLE
release mirage-entropy 0.5.0

### DIFF
--- a/packages/mirage-entropy/mirage-entropy.0.5.0/opam
+++ b/packages/mirage-entropy/mirage-entropy.0.5.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+name:         "mirage-entropy"
+homepage:     "https://github.com/mirage/mirage-entropy"
+dev-repo:     "git+https://github.com/mirage/mirage-entropy.git"
+bug-reports:  "https://github.com/mirage/mirage-entropy/issues"
+doc:          "https://mirage.github.io/mirage-entropy/doc"
+author:       ["Hannes Mehnert" "David Kaloper" "Anil Madhavapeddy" "Dave Scott"]
+maintainer:   "david@numm.org"
+license:      "BSD2"
+
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+          "--with-mirage-xen" "%{mirage-xen:installed}%"
+          "--with-mirage-solo5" "%{mirage-solo5:installed}%"
+          "--with-ocaml-freestanding" "%{ocaml-freestanding:installed}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build & >= "0.1.1-1"}
+  "ocaml" {>= "4.04.2"}
+  "cstruct" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.7.0"}
+  "lwt" {>= "4.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+]
+depopts: [
+  "mirage-solo5"
+  "ocaml-freestanding"
+  "mirage-xen"
+]
+conflicts: [
+  "mirage-xen" {<"2.2.0"}
+]
+tags: [ "org:mirage"]
+available: [
+  arch = "arm" | arch = "x86_32" | arch = "x86_64" | arch = "arm64"
+]
+synopsis: "Entropy source for MirageOS unikernels"
+description: """
+mirage-entropy implements various entropy sources for MirageOS unikernels:
+- timer based ones (see [whirlwind RNG paper](https://www.ieee-security.org/TC/SP2014/papers/Not-So-RandomNumbersinVirtualizedLinuxandtheWhirlwindRNG.pdf))
+- rdseed and rdrand (x86/x86-64 only)
+"""
+
+url {
+archive: "https://github.com/mirage/mirage-entropy/releases/download/v0.5.0/mirage-entropy-0.5.0.tbz"
+checksum: "395ea04f5d149422d90383fbeccb10a2"
+}


### PR DESCRIPTION
uses mirage-runtime provided hooks instead of mirage-os-shim dependency