### PR TITLE
[new release] mirage-net-solo5 (0.6.1)

### DIFF
--- a/packages/mirage-net-solo5/mirage-net-solo5.0.6.1/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.6.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-net-solo5"
+bug-reports:   "https://github.com/mirage/mirage-net-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-solo5.git"
+doc:           "https://mirage.github.io/mirage-net-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "macaddr" { >= "4.0.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
+  "logs" {>= "0.6.0"}
+  "fmt"
+]
+synopsis: "Solo5 implementation of MirageOS network interface"
+description:
+  "This library implements the MirageOS network interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-net-solo5/releases/download/v0.6.1/mirage-net-solo5-v0.6.1.tbz"
+  checksum: [
+    "sha256=b6a1cfe620b65001d071d28072bf26e61ae52ca01937eca31922742ed58b0a1f"
+    "sha512=ac541f0639f743f61256b21e89a744764c93d14407ae334c1b096dbc6b856049234f9a0d24af2ff79dfc9d1afc3375adc91dd1af8024c652a2f5d05b28a8d792"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Adapt to mirage-net 3.0.0 changes (@hannesm, mirage/mirage-net-solo5#35)
* Raise OCaml lower bound to 4.06.0 (@hannesm, mirage/mirage-net-solo5#35)
* cleanup: use Mirage_net.Stats helper functions (@hannesm, mirage/mirage-net-solo5#35)