### PR TITLE
[new release] mirage-block-solo5 (0.6.1)

### DIFF
--- a/packages/mirage-block-solo5/mirage-block-solo5.0.6.1/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.6.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-block-solo5"
+dev-repo:     "git+https://github.com/mirage/mirage-block-solo5.git"
+bug-reports:  "https://github.com/mirage/mirage-block-solo5/issues"
+doc:           "https://mirage.github.io/mirage-block-solo5/"
+license:       "ISC"
+authors:      ["Dan Williams" "Martin Lucina"]
+tags: [
+  "org:mirage"
+]
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"  {>= "1.0"}
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.0.1"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
+  "fmt"
+]
+synopsis: "Solo5 implementation of MirageOS block interface"
+description:
+  "This library implements the MirageOS block interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-block-solo5/releases/download/v0.6.1/mirage-block-solo5-v0.6.1.tbz"
+  checksum: [
+    "sha256=5ee782291ca4a5770259c1724cd1f55c8b604ff8ebf79a447d4c3d8da516173f"
+    "sha512=5c9c80b86714005ab9dcc730aa8910828cd2fb79971f65a9667619dc88f84dc309e727f17ec8efd9a45701652114d5a8586243db8814a3416f9341430e39e9aa"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Adapt to mirage-block 2.0.0 changes (@hannesm, mirage/mirage-block-solo5#19)
* Raise lower bound to OCaml 4.06.0 (@hannesm, mirage/mirage-block-solo5#19)