### PR TITLE
[new release] mirage-console-solo5 (0.6.1)

### DIFF
--- a/packages/mirage-console-solo5/mirage-console-solo5.0.6.1/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.6.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-console-solo5"
+bug-reports:   "https://github.com/mirage/mirage-console-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-console-solo5.git"
+doc:           "https://mirage.github.io/mirage-console-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-console" {>= "3.0.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
+  "cstruct"
+  "lwt"
+]
+synopsis: "Solo5 implementation of MirageOS console interface"
+description:
+  "This library implements the MirageOS console interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-console-solo5/releases/download/v0.6.1/mirage-console-solo5-v0.6.1.tbz"
+  checksum: [
+    "sha256=097740d6bf4f8af0c4b331b183cf64f4f43c2b9b572d4f554b40faab0c938b39"
+    "sha512=81c6a98b778c0a663168f2d6517f0036d1d5508d5dac7228dbf9f5a555faa9e7f9e921f1b91df2377d304047bd88b8528a7863a76f69458b98127ba7f8891cc3"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Adapt to mirage-console 3.0.0 changes (mirage/mirage-console-solo5#19, @hannesm)
* Bump minimal OCaml version to 4.06.0 (mirage/mirage-console-solo5#19, @hannesm)