### PR TITLE
[new release] mirage-net-xen and netchannel (1.13.0)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.1.13.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.13.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "5.0.0"}
+  "netchannel" {= version}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v1.13.0/mirage-net-xen-v1.13.0.tbz"
+  checksum: [
+    "sha256=3f22614131d8c405f3259fb1ce2b5dd0b1b4f721f0aafed133c23b41c95c2079"
+    "sha512=35d6f515ce554ab2b0da4b3b8c3fd969cb6e7d75d0bc0ae291128695f6961faa5f30209a1e320f425af8cdd81ee3e4f9e0a957b4d94e28a555fa972f3be1019e"
+  ]
+}

--- a/packages/netchannel/netchannel.1.13.0/opam
+++ b/packages/netchannel/netchannel.1.13.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "5.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-profile" {>="0.3"}
+  "shared-memory-ring" {>="3.0.0"}
+  "sexplib" {>= "113.01.00"}
+  "logs" {>= "0.5.0"}
+  "rresult"
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+
+Note: the `Netif` module is the public API.
+The `Netchannel` API is still under development.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v1.13.0/mirage-net-xen-v1.13.0.tbz"
+  checksum: [
+    "sha256=3f22614131d8c405f3259fb1ce2b5dd0b1b4f721f0aafed133c23b41c95c2079"
+    "sha512=35d6f515ce554ab2b0da4b3b8c3fd969cb6e7d75d0bc0ae291128695f6961faa5f30209a1e320f425af8cdd81ee3e4f9e0a957b4d94e28a555fa972f3be1019e"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Adapt to mirage-xen 5.0.0 API changes (@hannesm, mirage/mirage-net-xen#95)
* Adapt to mirage-net 3.0.0 API changes (@hannesm, mirage/mirage-net-xen#95)