### PR TITLE
[new release] mirage-block-xen (1.7.0)

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.1.7.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.7.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott" "Thomas Leonard"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-block-xen"
+doc: "https://mirage.github.io/mirage-block-xen/"
+bug-reports: "https://github.com/mirage/mirage-block-xen/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "cmdliner"
+  "logs"
+  "stringext"
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_cstruct" {build & >= "3.6.0"}
+  "shared-memory-ring-lwt"
+  "mirage-block" {>= "2.0.0"}
+  "ipaddr"
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "5.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block-xen.git"
+synopsis: "MirageOS block driver for Xen that implements the blkfront/back protocol"
+description: """
+This library allows a Mirage OCaml application to
+
+  1. read and write blocks from any Xen "backend" (server)
+  2. service block requests from any Xen "frontend" (client)
+
+This library can be used in both kernelspace (on Xen)
+or in userspace (using libraries that come with Xen).
+
+This library depends on the
+[shared-memory-ring](https://github.com/mirage/shared-memory-ring)
+library which enables high-throughput, low-latency data
+transfers over shared memory on both x86 and ARM architectures,
+using the standard Xen RPC and event channel semantics.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-xen/releases/download/v1.7.0/mirage-block-xen-v1.7.0.tbz"
+  checksum: [
+    "sha256=034afbc7649df784ee4b59a2aa76f793fa53c13ff5e7fe5e9d3ccffe86968e0e"
+    "sha512=23fb77735c49453079434810d0249c6ed1e00ad0dbe5010bf0d80c81c5f5e8d77ac068741f837d3025b7dce266c3814ae00a1e890bd79969fb87386f113caa14"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Adapt to mirage-xen 5.0.0 API changes (mirage/mirage-block-xen#86 @hannesm)
* Adapt to mriage-block 2.0.0 API changs (mirage/mirage-block-xen#86 @hannesm)