### PR TITLE
[new release] vchan, vchan-unix and vchan-xen (5.0.0)

### DIFF
--- a/packages/vchan-unix/vchan-unix.5.0.0/opam
+++ b/packages/vchan-unix/vchan-unix.5.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "vchan" {= version}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "io-page-unix"
+  "mirage-flow" {>= "2.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "xen-evtchn-unix"
+  "xen-gnt-unix"
+  "sexplib"
+  "cmdliner"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v5.0.0/vchan-v5.0.0.tbz"
+  checksum: [
+    "sha256=c3fca6c6db1890cec35a74c2d6fe5644a69285c460976f2a6c8bd0e6012fa52f"
+    "sha512=0e11e90197dcc1552424f99208927bf4a3ade41578320ee89e582b8ad510e206ddcb78c49c5c6c3706bb398bbf778f9713d65c255254b34e5faee850ce0ff34c"
+  ]
+}

--- a/packages/vchan-xen/vchan-xen.5.0.0/opam
+++ b/packages/vchan-xen/vchan-xen.5.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "vchan" {=version}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "mirage-flow" {>= "2.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "mirage-xen" {>= "5.0.0"}
+  "xenstore_transport" {>= "1.0.0"}
+  "sexplib"
+  "cmdliner"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v5.0.0/vchan-v5.0.0.tbz"
+  checksum: [
+    "sha256=c3fca6c6db1890cec35a74c2d6fe5644a69285c460976f2a6c8bd0e6012fa52f"
+    "sha512=0e11e90197dcc1552424f99208927bf4a3ade41578320ee89e582b8ad510e206ddcb78c49c5c6c3706bb398bbf778f9713d65c255254b34e5faee850ce0ff34c"
+  ]
+}

--- a/packages/vchan/vchan.5.0.0/opam
+++ b/packages/vchan/vchan.5.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+description: """
+This is an implementation of the Xen "libvchan" or "vchan" communication
+protocol in OCaml. It allows fast inter-domain communication using shared
+memory.
+"""
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "mirage-flow" {>= "2.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "sexplib"
+  "cmdliner"
+  "ounit" {with-test}
+  "io-page-unix" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v5.0.0/vchan-v5.0.0.tbz"
+  checksum: [
+    "sha256=c3fca6c6db1890cec35a74c2d6fe5644a69285c460976f2a6c8bd0e6012fa52f"
+    "sha512=0e11e90197dcc1552424f99208927bf4a3ade41578320ee89e582b8ad510e206ddcb78c49c5c6c3706bb398bbf778f9713d65c255254b34e5faee850ce0ff34c"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Adapt to mrage-xen 5.0.0 changes (mirage/ocaml-vchan#134 @hannesm)
* Adapt to mirage-flow 2.0.0 changes (mirage/ocaml-vchan#134 @hannesm)
* API change: ``val port_of_string: string -> (port, [> `Msg of string ]) result`` instead of custom result type with polyvars