### PR TITLE
[new release] mirage-bootvar-xen (0.7.0)

### DIFF
--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.7.0/opam
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.7.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Handle boot-time arguments for Xen platform"
+description: """
+Simple library for reading MirageOS unikernel boot parameters from Xen.
+
+To send boot parameters to the unikernel you can either add them as options in the "extra=" field in the .xl-file.
+"""
+
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-bootvar-xen"
+bug-reports: "https://github.com/mirage/mirage-bootvar-xen/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-bootvar-xen.git"
+doc: "https://mirage.github.io/mirage-bootvar-xen/"
+license: "ISC"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {>= "1.0"}
+  "mirage-xen" {>= "5.0.0"}
+  "lwt" {>="2.4.3"}
+  "astring"
+  "parse-argv"
+  "ocaml" { >= "4.06.0" }
+]
+url {
+  src:
+    "https://github.com/mirage/mirage-bootvar-xen/releases/download/v0.7.0/mirage-bootvar-xen-v0.7.0.tbz"
+  checksum: [
+    "sha256=21289b726fab61c6ef9ee3d217ba1dae65a065e33cc218abc40b9fe951041dd2"
+    "sha512=753a062746357da894244d4819a6c67a6e4c247b059dcd5b2026eb8424b6943869f5946fbc397657e1d6fdf54b694da4c050bc59d92c1eff93e06616f78a4ba1"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Adapt to mirage-xen 5.0.0 changes (mirage/mirage-bootvar-xen#42 @dinosaure)
* Require OCaml 4.06.0 now (mirage/mirage-bootvar-xen#43 @hannesm)