### PR TITLE
crunch 3.1.0 conflicts with earlier mirage-kv releases

### DIFF
--- a/packages/crunch/crunch.3.1.0/opam
+++ b/packages/crunch/crunch.3.1.0/opam
@@ -17,6 +17,9 @@ depends: [
   "mirage-kv" {with-test & >= "3.0.0"}
   "mirage-kv-mem" {with-test & >= "3.0.0"}
 ]
+conflicts: [
+  "mirage-kv" {< "3.0.0"}
+]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
 (leads to travis failures in mirage-skeleton without the conflict) -- https://travis-ci.org/mirage/mirage-skeleton/jobs/606111424?utm_medium=notification&utm_source=github_status