### PR TITLE
[new release] conduit-mirage, conduit-lwt, conduit, conduit-lwt-unix …

### DIFF
--- a/packages/conduit-async/conduit-async.2.0.2/opam
+++ b/packages/conduit-async/conduit-async.2.0.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "core"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "conduit" {=version}
+  "async" {>= "v0.10.0"}
+  "ipaddr" {>= "3.0.0"}
+]
+depopts: ["async_ssl"]
+conflicts: [
+  "async_ssl" {< "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Async"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.2/conduit-v2.0.2.tbz"
+  checksum: [
+    "sha256=2510372ed98c7e0446d788317a435f752d900d72df0fbe4c353f5e5bfb9d1dd2"
+    "sha512=3e25b754c84dd603acbb4d810b532c3cfb273808b9bf9a17890e40b79e65529d17cd66d613a447cb2a7f51f0522f17d46ab0ade5c79cb2a3c8565efd484238ae"
+  ]
+}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.2/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "conduit-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+depopts: ["tls" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls" {< "0.8.0"}
+  "ssl" {< "0.5.9"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.2/conduit-v2.0.2.tbz"
+  checksum: [
+    "sha256=2510372ed98c7e0446d788317a435f752d900d72df0fbe4c353f5e5bfb9d1dd2"
+    "sha512=3e25b754c84dd603acbb4d810b532c3cfb273808b9bf9a17890e40b79e65529d17cd66d613a447cb2a7f51f0522f17d46ab0ade5c79cb2a3c8565efd484238ae"
+  ]
+}

--- a/packages/conduit-lwt/conduit-lwt.2.0.2/opam
+++ b/packages/conduit-lwt/conduit-lwt.2.0.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "conduit" {=version}
+  "lwt" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.2/conduit-v2.0.2.tbz"
+  checksum: [
+    "sha256=2510372ed98c7e0446d788317a435f752d900d72df0fbe4c353f5e5bfb9d1dd2"
+    "sha512=3e25b754c84dd603acbb4d810b532c3cfb273808b9bf9a17890e40b79e65529d17cd66d613a447cb2a7f51f0522f17d46ab0ade5c79cb2a3c8565efd484238ae"
+  ]
+}

--- a/packages/conduit-mirage/conduit-mirage.2.0.2/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "cstruct" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "dns-client" {>= "4.1.0"}
+  "conduit-lwt"
+  "vchan" {>= "5.0.0"}
+  "xenstore"
+  "tls" {>= "0.8.0"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+
+  #these are required for tls.mirage, which conduit-mirage depends on
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "ptime"
+]
+conflicts: [
+  "mirage-conduit"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.2/conduit-v2.0.2.tbz"
+  checksum: [
+    "sha256=2510372ed98c7e0446d788317a435f752d900d72df0fbe4c353f5e5bfb9d1dd2"
+    "sha512=3e25b754c84dd603acbb4d810b532c3cfb273808b9bf9a17890e40b79e65529d17cd66d613a447cb2a7f51f0522f17d46ab0ade5c79cb2a3c8565efd484238ae"
+  ]
+}

--- a/packages/conduit/conduit.2.0.2/opam
+++ b/packages/conduit/conduit.2.0.2/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "astring"
+  "uri"
+  "logs" {>= "0.5.0"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for 
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.2/conduit-v2.0.2.tbz"
+  checksum: [
+    "sha256=2510372ed98c7e0446d788317a435f752d900d72df0fbe4c353f5e5bfb9d1dd2"
+    "sha512=3e25b754c84dd603acbb4d810b532c3cfb273808b9bf9a17890e40b79e65529d17cd66d613a447cb2a7f51f0522f17d46ab0ade5c79cb2a3c8565efd484238ae"
+  ]
+}


### PR DESCRIPTION
…and conduit-async (2.0.2)

CHANGES:

* mirage: do not raise exceptions in DNS lookup (mirage/ocaml-conduit#305 @hannesm)
* mirage: adapt to mirage-stack/mirage-time/mirage-flow/mirage-random 2.0.0 interfaces (mirage/ocaml-conduit#306 #hannesm)
* mirage: adapt to dns 4.1.0 changes (mirage/ocaml-conduit#306 @hannesm)
* mirage: adapt to vchan 5.0.0 changes (mirage/ocaml-conduit#306 @hannesm)