### PR TITLE
release mirage-qubes 0.8.0

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "4.0.0" }
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-protocols" { >= "4.0.0" }
+  "cstruct" { >= "1.9.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.8.0/mirage-qubes-v0.8.0.tbz"
+  checksum: [
+    "sha256=969703ec5159c68b5e1573bdeccd71efe7067e4cce31f9f0af5539c5a0fe3f3b"
+    "sha512=48c7b302af40861a9c9a14239c6999737a9cc4797c423d5b387242d9c1f6e996bf7b601aded329f57f53161fe6d48fe667fa7c33c24a4336458ad16f70d83a6e"
+  ]
+}

--- a/packages/mirage-qubes/mirage-qubes.0.8.0/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.8.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "2.2.0" }
+  "ppx_cstruct"
+  "vchan-xen" { >= "5.0.0" }
+  "xen-evtchn"
+  "xen-gnt"
+  "mirage-xen" { >= "5.0.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.8.0/mirage-qubes-v0.8.0.tbz"
+  checksum: [
+    "sha256=969703ec5159c68b5e1573bdeccd71efe7067e4cce31f9f0af5539c5a0fe3f3b"
+    "sha512=48c7b302af40861a9c9a14239c6999737a9cc4797c423d5b387242d9c1f6e996bf7b601aded329f57f53161fe6d48fe667fa7c33c24a4336458ad16f70d83a6e"
+  ]
+}


### PR DESCRIPTION
CHANGES
- adapt to mirage-protocols tcpip 4.0.0; mirage-xen vchan-xen 5.0.0 (mirage/mirage-qubes#46 @hannesm)
- support initiating qrexec calls (mirage/mirage-qubes#39 @reynir @yomimono @linse, review by @cfcs, discussion in mirage/mirage-qubes#35 mirage/mirage-qubes#36)
- add trigger_service_params and service_refused format string_of_type for messages (mirage/mirage-qubes#43 @yomimono @linse)
- GUI window support (mirage/mirage-qubes#32 mirage/mirage-qubes#33 mirage/mirage-qubes#37 mirage/mirage-qubes#41 @cfcs @reynir @yomimono)
