### PR TITLE
[new release] mirage-net-macosx (1.8.0)

### DIFF
--- a/packages/mirage-net-macosx/mirage-net-macosx.1.8.0/opam
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.8.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:  "Anil Madhavapeddy <anil@recoil.org>"
+authors:     "Anil Madhavapeddy <anil@recoil.org>"
+homepage:    "https://github.com/mirage/mirage-net-macosx"
+bug-reports: "https://github.com/mirage/mirage-net-macosx/issues"
+dev-repo:    "git+https://github.com/mirage/mirage-net-macosx.git"
+doc:         "https://mirage.github.io/mirage-net-macosx/"
+
+license: "ISC"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "1.4.0"}
+  "macaddr"
+  "sexplib"
+  "logs"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "vmnet" {>= "1.5.1"}
+]
+tags: "org:mirage"
+
+synopsis: "MacOS implementation of the Mirage_net_lwt interface"
+description: """
+This interface exposes raw Ethernet frames using the
+[Vmnet](https://github.com/mirage/ocaml-vmnet) framework that
+is available on MacOS X Yosemite onwards.  It is suitable for
+use with an OCaml network stack such as the one found at
+<https://github.com/mirage/mirage-tcpip>.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-macosx/releases/download/v1.8.0/mirage-net-macosx-v1.8.0.tbz"
+  checksum: [
+    "sha256=e55ef37a217cd3b64ed2517d8701f7e04bea6011489d8d2be288f4ca6f279d40"
+    "sha512=736cf0dd557dbc086cd0f2a18e835c05b3d180700205ab201258dcf8c877be8e2a1da2d60a0cc6bec367306d8f5ad23726d987c47851add9dbf1b7bd6de786a8"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- Adapt to mirage-net 3.0.0 API changes (@hannesm)