### PR TITLE
[new release] logs-syslog (0.2.2)

### DIFF
--- a/packages/logs-syslog/logs-syslog.0.2.2/opam
+++ b/packages/logs-syslog/logs-syslog.0.2.2/opam
@@ -9,7 +9,7 @@ license: "ISC"
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {>= "1.1.0" & build}
+  "dune" {>= "1.1.0"}
   "logs"
   "ptime"
   "syslog-message" {>= "1.0.0"}

--- a/packages/logs-syslog/logs-syslog.0.2.2/opam
+++ b/packages/logs-syslog/logs-syslog.0.2.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/hannesm/logs-syslog"
+doc: "https://hannesm.github.io/logs-syslog/doc"
+dev-repo: "git+https://github.com/hannesm/logs-syslog.git"
+bug-reports: "https://github.com/hannesm/logs-syslog/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1.0" & build}
+  "logs"
+  "ptime"
+  "syslog-message" {>= "1.0.0"}
+]
+
+depopts: [
+  "lwt"
+  "x509" "tls" "cstruct"
+  "mirage-kv"
+  "mirage-console" "mirage-clock" "mirage-stack" "ipaddr"
+]
+
+conflicts: [
+  "mirage-kv" {< "3.0.0"}
+  "mirage-console" {< "3.0.0"}
+  "mirage-clock" {< "3.0.0"}
+  "mirage-stack" {< "2.0.0"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+
+synopsis: "Logs reporter to syslog (UDP/TCP/TLS)"
+description: """
+This library provides log reporters using syslog over various transports (UDP,
+TCP, TLS) with various effectful layers: Unix, Lwt, MirageOS.  It integrates the
+[Logs](http://erratique.ch/software/logs) library, which provides logging
+infrastructure for OCaml, with the
+[syslog-message](http://verbosemo.de/syslog-message/) library, which provides
+encoding and decoding of syslog messages ([RFC
+3164](https://tools.ietf.org/html/rfc3164)).
+"""
+url {
+  src:
+    "https://github.com/hannesm/logs-syslog/releases/download/v0.2.2/logs-syslog-v0.2.2.tbz"
+  checksum: [
+    "sha256=2d96b764f0e6e904f5dd068fc128f1c7a41b0ad3cef4b661fd6233a348aa67e1"
+    "sha512=6180ce970921ba2027a91412b4952f17f96d46ff684cb10d4f87f1bd55aec251d078bd23c18ddaa0ffff876ad5b61886691c25ecedf3daf9875b021446ea8ade"
+  ]
+}


### PR DESCRIPTION
Logs reporter to syslog (UDP/TCP/TLS)

- Project page: <a href="https://github.com/hannesm/logs-syslog">https://github.com/hannesm/logs-syslog</a>
- Documentation: <a href="https://hannesm.github.io/logs-syslog/doc">https://hannesm.github.io/logs-syslog/doc</a>

##### CHANGES:

- adapt to mirage interfaces (mirage-kv, mirage-clock, mirage-console 3.0.0)
