### PR TITLE
nocrypto: build mirage sublibrary if mirage-entropy is installed

### DIFF
--- a/packages/nocrypto/nocrypto.0.5.4-2/files/0001-add-missing-runtime-dependencies-in-_tags.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-2/files/0001-add-missing-runtime-dependencies-in-_tags.patch
@@ -1,0 +1,47 @@
+From 6f97531287a3e3ee749f2277248af28bdc85b8e4 Mon Sep 17 00:00:00 2001
+From: Gabriel Scherer <gabriel.scherer@gmail.com>
+Date: Mon, 26 Mar 2018 16:09:16 +0200
+Subject: [PATCH 1/4] add missing runtime dependencies in _tags
+
+Binaries in <bench/*>, <tests/*> depend on ppx_sexp_conv's runtime
+library within ppx_sexp_conv.
+
+The packed modules <src/nocrypto.cm{x,o}> also depend on the package
+ppx_sexp_conv: its presence at pack-creation time influences the
+generated .cmi interface, see
+
+  https://github.com/ocaml/opam-repository/pull/11628#issuecomment-375697444
+
+Note: the package ppx_sexp_conv.runtime-lib would suffice, but it is
+only available as such under recent ppx_sexp_conv versions, so its
+explicit use would make the build description (needlessly)
+incompatible with older ppx_sexp_conv versions.
+---
+ _tags | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/_tags b/_tags
+index 6d4e7de..c2a6610 100644
+--- a/_tags
++++ b/_tags
+@@ -7,6 +7,7 @@ true: package(bytes), package(cstruct)
+ <src/*.ml{,i}>: package(zarith), package(sexplib), package(ppx_sexp_conv)
+ <src/*.cm{x,o}> and not <src/nocrypto.cmx>: for-pack(Nocrypto)
+ <src/*.cm{,x}a>: link_stubs(src/libnocrypto_stubs)
++<src/nocrypto.cm{x,o}>: package(ppx_sexp_conv)
+ 
+ <unix>: include
+ <unix/*.ml{,i}>: package(unix), package(bytes)
+@@ -19,7 +20,7 @@ true: package(bytes), package(cstruct)
+ 
+ <**/*.c>: ccopt(--std=c99 -Wall -Wextra -O3)
+ 
+-<bench/*>: use_nocrypto, package(zarith), package(cstruct.unix)
+-<tests/*>: use_nocrypto, package(zarith), package(oUnit)
++<bench/*>: use_nocrypto, package(zarith), package(ppx_sexp_conv)
++<tests/*>: use_nocrypto, package(zarith), package(ppx_sexp_conv), package(oUnit)
+ 
+ <rondom>: -traverse
+-- 
+2.18.0
+

--- a/packages/nocrypto/nocrypto.0.5.4-2/files/0002-add-ppx_sexp_conv-as-a-runtime-dependency-in-the-pac.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-2/files/0002-add-ppx_sexp_conv-as-a-runtime-dependency-in-the-pac.patch
@@ -1,0 +1,39 @@
+From dc799fd2a66c41ca7729201a5d038cd403ca1de6 Mon Sep 17 00:00:00 2001
+From: Gabriel Scherer <gabriel.scherer@gmail.com>
+Date: Tue, 27 Mar 2018 12:00:23 +0200
+Subject: [PATCH 2/4] add ppx_sexp_conv as a runtime dependency in the
+ packaging metadata
+
+---
+ opam     | 2 +-
+ pkg/META | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/opam b/opam
+index ad1dbc7..c35570b 100644
+--- a/opam
++++ b/opam
+@@ -20,7 +20,7 @@ depends: [
+   "topkg" {build}
+   "cpuid" {build}
+   "ocb-stubblr" {build}
+-  "ppx_sexp_conv" {build}
++  "ppx_sexp_conv"
+   "oUnit" {test}
+   "cstruct"
+   "zarith"
+diff --git a/pkg/META b/pkg/META
+index 242b2bb..a7929c7 100644
+--- a/pkg/META
++++ b/pkg/META
+@@ -1,6 +1,6 @@
+ version = "0.5.4"
+ description = "Simple crypto for the modern age"
+-requires = "cstruct zarith sexplib"
++requires = "cstruct zarith sexplib ppx_sexp_conv"
+ archive(byte) = "nocrypto.cma"
+ archive(native) = "nocrypto.cmxa"
+ plugin(byte) = "nocrypto.cma"
+-- 
+2.18.0
+

--- a/packages/nocrypto/nocrypto.0.5.4-2/files/0003-Auto-detect-ppx_sexp_conv-runtime-library.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-2/files/0003-Auto-detect-ppx_sexp_conv-runtime-library.patch
@@ -1,0 +1,146 @@
+From ad9278021a65d423e30765e58110848adda4b13e Mon Sep 17 00:00:00 2001
+From: Jeremie Dimino <jeremie@dimino.org>
+Date: Fri, 11 May 2018 15:44:47 +0200
+Subject: [PATCH 3/4] Auto-detect ppx_sexp_conv runtime library
+
+---
+ myocamlbuild.ml | 25 ++++++++++++++++++++++---
+ pkg/META        | 43 -------------------------------------------
+ pkg/META.in     | 43 +++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 65 insertions(+), 46 deletions(-)
+ delete mode 100644 pkg/META
+ create mode 100644 pkg/META.in
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 2752315..7b29635 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -1,5 +1,24 @@
+ open Ocamlbuild_plugin
+ 
+-let () = dispatch Ocb_stubblr.(
+-  init & ccopt ~tags:["accelerate"] "-DACCELERATE -msse2 -maes"
+-)
++let runtime_deps_of_ppx ppx =
++  (Findlib.query "ppx_sexp_conv").dependencies
++  |> List.filter_opt (fun { Findlib.name; _ } ->
++      if name = ppx || name = "ppx_deriving" then
++        None
++      else
++        Some name)
++
++let () = dispatch (fun hook ->
++    Ocb_stubblr.(
++      init & ccopt ~tags:["accelerate"] "-DACCELERATE -msse2 -maes"
++    ) hook;
++    match hook with
++    | After_rules ->
++      let meta = "pkg/META" in
++      let meta_in = meta ^ ".in" in
++      rule meta ~dep:meta_in ~prod:meta (fun _ _ ->
++          let deps = String.concat " " (runtime_deps_of_ppx "ppx_sexp_conv") in
++          Echo([String.subst "PPX_SEXP_CONV_RUNTIME" deps
++                  (Pathname.read meta_in)],
++               meta))
++    | _ -> ())
+diff --git a/pkg/META b/pkg/META
+deleted file mode 100644
+index a7929c7..0000000
+--- a/pkg/META
++++ /dev/null
+@@ -1,43 +0,0 @@
+-version = "0.5.4"
+-description = "Simple crypto for the modern age"
+-requires = "cstruct zarith sexplib ppx_sexp_conv"
+-archive(byte) = "nocrypto.cma"
+-archive(native) = "nocrypto.cmxa"
+-plugin(byte) = "nocrypto.cma"
+-plugin(native) = "nocrypto.cmxs"
+-xen_linkopts = "-lnocrypto_stubs+mirage-xen"
+-freestanding_linkopts = "-lnocrypto_stubs+mirage-freestanding"
+-exists_if = "nocrypto.cma"
+-
+-package "unix" (
+- version = "0.5.4"
+- description = "Simple crypto for the modern age"
+- requires = "nocrypto unix bytes"
+- archive(byte) = "nocrypto_unix.cma"
+- archive(native) = "nocrypto_unix.cmxa"
+- plugin(byte) = "nocrypto_unix.cma"
+- plugin(native) = "nocrypto_unix.cmxs"
+- exists_if = "nocrypto_unix.cma"
+-)
+-
+-package "lwt" (
+- version = "0.5.4"
+- description = "Simple crypto for the modern age"
+- requires = "nocrypto nocrypto.unix lwt.unix cstruct.lwt"
+- archive(byte) = "nocrypto_lwt.cma"
+- archive(native) = "nocrypto_lwt.cmxa"
+- plugin(byte) = "nocrypto_lwt.cma"
+- plugin(native) = "nocrypto_lwt.cmxs"
+- exists_if = "nocrypto_lwt.cma"
+-)
+-
+-package "mirage" (
+- version = "0.5.4"
+- description = "Simple crypto for the modern age"
+- requires = "nocrypto lwt mirage-entropy"
+- archive(byte) = "nocrypto_mirage.cma"
+- archive(native) = "nocrypto_mirage.cmxa"
+- plugin(byte) = "nocrypto_mirage.cma"
+- plugin(native) = "nocrypto_mirage.cmxs"
+- exists_if = "nocrypto_mirage.cma"
+-)
+diff --git a/pkg/META.in b/pkg/META.in
+new file mode 100644
+index 0000000..0b263d7
+--- /dev/null
++++ b/pkg/META.in
+@@ -0,0 +1,43 @@
++version = "0.5.4"
++description = "Simple crypto for the modern age"
++requires = "cstruct zarith sexplib PPX_SEXP_CONV_RUNTIME"
++archive(byte) = "nocrypto.cma"
++archive(native) = "nocrypto.cmxa"
++plugin(byte) = "nocrypto.cma"
++plugin(native) = "nocrypto.cmxs"
++xen_linkopts = "-lnocrypto_stubs+mirage-xen"
++freestanding_linkopts = "-lnocrypto_stubs+mirage-freestanding"
++exists_if = "nocrypto.cma"
++
++package "unix" (
++ version = "0.5.4"
++ description = "Simple crypto for the modern age"
++ requires = "nocrypto unix bytes"
++ archive(byte) = "nocrypto_unix.cma"
++ archive(native) = "nocrypto_unix.cmxa"
++ plugin(byte) = "nocrypto_unix.cma"
++ plugin(native) = "nocrypto_unix.cmxs"
++ exists_if = "nocrypto_unix.cma"
++)
++
++package "lwt" (
++ version = "0.5.4"
++ description = "Simple crypto for the modern age"
++ requires = "nocrypto nocrypto.unix lwt.unix cstruct.lwt"
++ archive(byte) = "nocrypto_lwt.cma"
++ archive(native) = "nocrypto_lwt.cmxa"
++ plugin(byte) = "nocrypto_lwt.cma"
++ plugin(native) = "nocrypto_lwt.cmxs"
++ exists_if = "nocrypto_lwt.cma"
++)
++
++package "mirage" (
++ version = "0.5.4"
++ description = "Simple crypto for the modern age"
++ requires = "nocrypto lwt mirage-entropy"
++ archive(byte) = "nocrypto_mirage.cma"
++ archive(native) = "nocrypto_mirage.cmxa"
++ plugin(byte) = "nocrypto_mirage.cma"
++ plugin(native) = "nocrypto_mirage.cmxs"
++ exists_if = "nocrypto_mirage.cma"
++)
+-- 
+2.18.0
+

--- a/packages/nocrypto/nocrypto.0.5.4-2/files/0004-pack-package-workaround-ocamlbuild-272.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-2/files/0004-pack-package-workaround-ocamlbuild-272.patch
@@ -1,0 +1,38 @@
+From 063b3496340fe4c3544b532ec0d27797b7917bb4 Mon Sep 17 00:00:00 2001
+From: Gabriel Scherer <gabriel.scherer@gmail.com>
+Date: Mon, 26 Mar 2018 16:07:45 +0200
+Subject: [PATCH 4/4] pack+package: workaround ocamlbuild#272
+
+ocamlbuild should pass -package(...) flags to ocamlfind when building
+a -pack-ed file, see
+
+  https://github.com/ocaml/opam-repository/pull/11628#issuecomment-375697444
+---
+ myocamlbuild.ml | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 7b29635..7a5cdb6 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -8,9 +8,17 @@ let runtime_deps_of_ppx ppx =
+       else
+         Some name)
+ 
++let ocamlfind_and_pack = function
++  | After_rules ->
++     if !Options.use_ocamlfind then
++       pflag ["ocaml"; "pack"] "package"
++         (fun pkg -> S [A "-package"; A pkg]);
++  | _ -> ()
++
+ let () = dispatch (fun hook ->
+     Ocb_stubblr.(
+       init & ccopt ~tags:["accelerate"] "-DACCELERATE -msse2 -maes"
++      & ocamlfind_and_pack
+     ) hook;
+     match hook with
+     | After_rules ->
+-- 
+2.18.0
+

--- a/packages/nocrypto/nocrypto.0.5.4-2/files/0005-use-modern-cstruct-findlib.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-2/files/0005-use-modern-cstruct-findlib.patch
@@ -1,0 +1,32 @@
+From 063b3496340fe4c3544b532ec0d27797b7917bb4 Mon Sep 17 00:00:00 2001
+From: Anil Madhavapeddy <anil@recoil.org>
+Date: Tue, 12 Mar 2019 09:07:13 +0000
+Subject: [PATCH 5/5] use modern cstruct findlib
+
+see https://discuss.ocaml.org/t/psa-cstruct-3-4-0-removes-old-ocamlfind-subpackage-aliases/3275
+
+--- a/_tags.orig        2019-03-12 09:03:58.000000000 +0000
++++ b/_tags     2019-03-12 09:04:12.000000000 +0000
+@@ -13,7 +13,7 @@
+ <unix/*.ml{,i}>: package(unix), package(bytes)
+
+ <lwt>: include
+-<lwt/*.ml{,i}>: package(lwt.unix), package(cstruct.lwt)
++<lwt/*.ml{,i}>: package(lwt.unix), package(cstruct-lwt)
+
+ <mirage>: include
+ <mirage/*.ml{,i}>: package(lwt), package(mirage-entropy)
+--- a/pkg/META.in.orig  2019-03-12 09:03:19.000000000 +0000
++++ b/pkg/META.in       2019-03-12 09:03:33.000000000 +0000
+@@ -23,7 +23,7 @@
+ package "lwt" (
+  version = "0.5.4"
+  description = "Simple crypto for the modern age"
+- requires = "nocrypto nocrypto.unix lwt.unix cstruct.lwt"
++ requires = "nocrypto nocrypto.unix lwt.unix cstruct-lwt"
+  archive(byte) = "nocrypto_lwt.cma"
+  archive(native) = "nocrypto_lwt.cmxa"
+  plugin(byte) = "nocrypto_lwt.cma"
+-- 
+2.18.0
+

--- a/packages/nocrypto/nocrypto.0.5.4-2/files/0006-explicit-dependency-on-sexplib.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-2/files/0006-explicit-dependency-on-sexplib.patch
@@ -1,0 +1,24 @@
+From 063b3496340fe4c3544b532ec0d27797b7917bb4 Mon Sep 17 00:00:00 2001
+From: Anil Madhavapeddy <anil@recoil.org>
+Date: Tue, 26 Mar 2019 20:07:13 +0000
+Subject: [PATCH 6/6] explicitly depend on sexplib
+
+Need to explicitly depend on sexplib rather than hope
+it is a transitive dependency of cstruct. This lets
+cstruct.4.0.0 work which makes sexplib optional.
+
+--- a/_tags.orig	2019-03-26 20:33:33.000000000 +0000
++++ b/_tags	2019-03-26 20:33:42.000000000 +0000
+@@ -1,7 +1,7 @@
+ true: color(always)
+ true: bin_annot, safe_string
+ true: warn(A-4-29-33-40-41-42-43-34-44-48)
+-true: package(bytes), package(cstruct)
++true: package(bytes), package(sexplib), package(cstruct)
+
+ <src>: include
+ <src/*.ml{,i}>: package(zarith), package(sexplib), package(ppx_sexp_conv)
+
+-- 
+2.18.0
+

--- a/packages/nocrypto/nocrypto.0.5.4-2/files/0007-mirage-entropy.patch
+++ b/packages/nocrypto/nocrypto.0.5.4-2/files/0007-mirage-entropy.patch
@@ -1,0 +1,58 @@
+From: Hannes Mehnert <hannes@mehnert.org>
+Subject: [PATCH 1/1] compile mirage-entropy sublibrary if mirage-entropy is installed
+
+Previously the compilation depended on mirage-xen or ocaml-freestanding being
+present, but _tags show the dependency is actually mirage-entropy.
+
+--- a/opam	2019-11-02 13:38:17.202429000 +0100
++++ b/opam	2019-11-02 13:39:19.173535000 +0100
+@@ -12,6 +12,7 @@
+ 
+ build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+                 "--with-lwt" "%{lwt:installed}%"
++                "--with-mirage" "%{mirage-entropy:installed}%"
+                 "--xen" "%{mirage-xen:installed}%"
+                 "--freestanding" "%{ocaml-freestanding:installed}%"]
+ 
+@@ -26,11 +27,11 @@
+   "cstruct"
+   "zarith"
+   "sexplib"
+-  ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy" & "zarith-xen"))
+-  ("mirage-no-solo5" | ("mirage-solo5" & "mirage-entropy" & "zarith-freestanding"))
++  ("mirage-no-xen" | ("mirage-xen" & "zarith-xen"))
++  ("mirage-no-solo5" | ("mirage-solo5" & "zarith-freestanding"))
+ ]
+ 
+-depopts: [ "lwt" ]
++depopts: [ "lwt" "mirage-entropy" ]
+ conflicts: [
+   "topkg" {<"0.8.0"}
+   "ocb-stubblr" {<"0.1.0"}
+--- a/pkg/pkg.ml	2017-02-01 00:43:04.000000000 +0100
++++ b/pkg/pkg.ml	2019-11-02 13:37:30.295780000 +0100
+@@ -11,6 +11,7 @@
+ 
+ let unix = Conf.with_pkg ~default:true "unix"
+ let lwt  = Conf.with_pkg ~default:false "lwt"
++let mirage_entropy = Conf.with_pkg ~default:false "mirage"
+ let xen  = Conf.(key "xen" bool ~absent:false
+                  ~doc:"Build Mirage/Xen support.")
+ let fs   = Conf.(key "freestanding" bool ~absent:false
+@@ -39,12 +40,14 @@
+     let unix = Conf.value c unix in
+     let lwt  = Conf.value c lwt && unix
+     and xen  = Conf.value c xen
+-    and fs   = Conf.value c fs in
++    and fs   = Conf.value c fs
++    and mirage_entropy = Conf.value c mirage_entropy
++    in
+     Ok [ Pkg.clib "src/libnocrypto_stubs.clib";
+          Pkg.mllib "src/nocrypto.mllib";
+          Pkg.mllib ~cond:unix "unix/nocrypto_unix.mllib";
+          Pkg.mllib ~cond:lwt "lwt/nocrypto_lwt.mllib";
+-         Pkg.mllib ~cond:(xen||fs) "mirage/nocrypto_mirage.mllib";
++         Pkg.mllib ~cond:mirage_entropy "mirage/nocrypto_mirage.mllib";
+          Pkg.test "tests/testrunner";
+          Pkg.test ~run:false "bench/speed";
+          mirage ~xen ~fs "src/libnocrypto_stubs.clib"; ]

--- a/packages/nocrypto/nocrypto.0.5.4-2/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-2/opam
@@ -1,0 +1,95 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-nocrypto"
+dev-repo: "git+https://github.com/mirleft/ocaml-nocrypto.git"
+bug-reports:  "https://github.com/mirleft/ocaml-nocrypto/issues"
+doc:          "https://mirleft.github.io/ocaml-nocrypto/doc"
+authors:      ["David Kaloper <david@numm.org>"]
+maintainer:   "David Kaloper <david@numm.org>"
+license:      "ISC"
+tags:          [ "org:mirage" ]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+                "--jobs" "1"
+                "--with-lwt" "%{lwt:installed}%"
+                "--with-mirage" "%{mirage-entropy:installed}%"
+                "--xen" "%{mirage-xen:installed}%"
+                "--freestanding" "%{mirage-solo5:installed}%"]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "cpuid" {build}
+  "ocb-stubblr" {build}
+  "ppx_deriving"
+  "ppx_sexp_conv" {>= "113.33.01" & != "v0.11.0" & < "v0.13"}
+  "ounit" {with-test}
+  "cstruct" {>= "3.0.0"}
+  "cstruct-lwt"
+  "zarith"
+  "lwt"
+  "sexplib" {< "v0.13"}
+  "mirage-no-xen" | ("mirage-xen" & "zarith-xen")
+  "mirage-no-solo5" | ("mirage-solo5" & "zarith-freestanding")
+]
+depopts: [ "mirage-entropy" ]
+conflicts: [
+  "topkg" {<"0.9.1"}
+  "ocb-stubblr" {<"0.1.0"}
+  "mirage-xen" {<"2.2.0"}
+  "sexplib" {="v0.9.0"}
+  "ocaml" {= "4.08.0"}
+]
+
+patches: [
+    "0001-add-missing-runtime-dependencies-in-_tags.patch"
+    "0002-add-ppx_sexp_conv-as-a-runtime-dependency-in-the-pac.patch"
+    "0003-Auto-detect-ppx_sexp_conv-runtime-library.patch"
+    "0004-pack-package-workaround-ocamlbuild-272.patch"
+    "0005-use-modern-cstruct-findlib.patch"
+    "0006-explicit-dependency-on-sexplib.patch"
+    "0007-mirage-entropy.patch"
+]
+synopsis: "Simpler crypto"
+description: """
+nocrypto is a small cryptographic library that puts emphasis on the applicative
+style and ease of use. It includes basic ciphers (AES, 3DES, RC4), hashes (MD5,
+SHA1, SHA2), public-key primitives (RSA, DSA, DH) and a strong RNG (Fortuna).
+
+RSA timing attacks are countered by blinding. AES timing attacks are avoided by
+delegating to AES-NI."""
+extra-files: [
+  [
+    "0007-mirage-entropy.patch"
+    "md5=bb3368e3fd64857a6d05e1a3e61f08cf"
+  ]
+  [
+    "0006-explicit-dependency-on-sexplib.patch"
+    "md5=7f552e18ba304eb4e1e19d66d19b7888"
+  ]
+  [
+    "0005-use-modern-cstruct-findlib.patch"
+    "md5=4d4aab890f0ca9327d83548c32d64efc"
+  ]
+  [
+    "0004-pack-package-workaround-ocamlbuild-272.patch"
+    "md5=94615e4a8d5976e9e75c3b031d3484f1"
+  ]
+  [
+    "0003-Auto-detect-ppx_sexp_conv-runtime-library.patch"
+    "md5=871b3f904cf87527b7390993d5598884"
+  ]
+  [
+    "0002-add-ppx_sexp_conv-as-a-runtime-dependency-in-the-pac.patch"
+    "md5=06962f4f2f5b4c3f1e39293b3d3528f2"
+  ]
+  [
+    "0001-add-missing-runtime-dependencies-in-_tags.patch"
+    "md5=ae679a096e14c0a0ecb881bc7432cc2a"
+  ]
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-nocrypto/releases/download/v0.5.4/nocrypto-0.5.4.tbz"
+  checksum: "md5=c331a7a4d2a563d1d5ed581aeb849011"
+}


### PR DESCRIPTION
the `mirage` subdirectory / sublibrary depends on mirage-entropy (in sync with `_tags`) -- so if mirage-entropy is installed, install the mirage sublibrary (earlier, this was done if mirage-xen or mirage-solo5 was installed).