### PR TITLE
[new release] dotenv (0.0.1)

### DIFF
--- a/packages/dotenv/dotenv.0.0.1/opam
+++ b/packages/dotenv/dotenv.0.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base"
   "stdio"
   "uutf"
-  "dune"
+  "dune" {>= "1.1"}
 ]
 synopsis: "Javascript's dotenv port to ocaml"
 description: """

--- a/packages/dotenv/dotenv.0.0.1/opam
+++ b/packages/dotenv/dotenv.0.0.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jose Nogueira <ze@thatportugueseguy.com>"
+authors: [ "Jose Nogueira <ze@thatportugueseguy.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/thatportugueseguy/ocaml-dotenv"
+dev-repo: "git+https://github.com/thatportugueseguy/ocaml-dotenv.git"
+bug-reports: "https://github.com/thatportugueseguy/ocaml-dotenv/issues"
+doc: "https://thatportugueseguy.github.io/ocaml-dotenv"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05"}
+  "base"
+  "stdio"
+  "uutf"
+  "dune"
+]
+synopsis: "Javascript's dotenv port to ocaml"
+description: """
+This tool allows for the user to keep a file (default `.env`, hence the name) which contains environment variables to be exported when running locally. When deployed, the file will not be available and the variables will be read from the environment, as always.
+
+This is a port of JavaScript's Dotenv (https://github.com/motdotla/dotenv).
+"""
+url {
+  src:
+    "https://github.com/thatportugueseguy/ocaml-dotenv/releases/download/v0.0.1/dotenv-v0.0.1.tbz"
+  checksum: [
+    "sha256=7d7cb7dd9b428ac3db8f2950add30ff7864eb2bbe0b218d33fec75f00160ab2e"
+    "sha512=3effccc7feec286354d1f942bfbdf8c854ba76bb1bb1ac5e6f060c4a127d0fc87c0f998e389a729c380b11ab969c19256f0fe2ac418077bec6170f05b0eeff6c"
+  ]
+}


### PR DESCRIPTION
Javascript's dotenv port to ocaml

- Project page: <a href="https://github.com/thatportugueseguy/ocaml-dotenv">https://github.com/thatportugueseguy/ocaml-dotenv</a>
- Documentation: <a href="https://thatportugueseguy.github.io/ocaml-dotenv">https://thatportugueseguy.github.io/ocaml-dotenv</a>

##### CHANGES:

- Initial public release
