### PR TITLE
[new release] certify (0.3.2)

### DIFF
--- a/packages/certify/certify.0.3.2/opam
+++ b/packages/certify/certify.0.3.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:  ["maintenance@identity-function.com"]
+homepage:     "https://github.com/yomimono/ocaml-certify"
+dev-repo:     "git+https://github.com/yomimono/ocaml-certify.git"
+bug-reports:  "https://github.com/yomimono/ocaml-certify/issues"
+doc:          "https://yomimono.github.io/ocaml-certify/doc"
+synopsis:     "CLI utilities for simple X509 certificate manipulation"
+authors: [
+  "Mindy Preston"
+]
+tags: ["org:mirage"]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "test/test.sh" ] {with-test}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "nocrypto" {>= "0.5.4"}
+  "x509" {>= "0.8.0"}
+  "cstruct" {>= "3.2.0"}
+  "ptime"
+  "ocaml" {>= "4.04.2"}
+  "cmdliner" {>= "1.0.0"}
+  "conf-openssl" {with-test}
+]
+description: """
+`certify` is a small selection of useful utilities for manipulating X509 certificates and public keys.  It uses the mirleft organization's x509, tls, and nocrypto libraries.
+
+Three subcommands to `certify` are provided:
+* `certify csr`: make a certificate signing request
+* `certify selfsign`: make a self-signed certificate
+* `certify sign`: sign a certificate
+"""
+url {
+  src:
+    "https://github.com/yomimono/ocaml-certify/releases/download/v0.3.2/certify-v0.3.2.tbz"
+  checksum: [
+    "sha256=5460485110d0e3ce99bcab80514111a717e6264394bef80d1285352bbfa4b0b1"
+    "sha512=86e5199666e669088cb924ccd2c58f914cceb5c7bf0c2c7bf4742aa4eca785a2b7507a8c9308d401a553a298aba67b39e15072b64b600aef059f469fc9e43d87"
+  ]
+}


### PR DESCRIPTION
CLI utilities for simple X509 certificate manipulation

- Project page: <a href="https://github.com/yomimono/ocaml-certify">https://github.com/yomimono/ocaml-certify</a>
- Documentation: <a href="https://yomimono.github.io/ocaml-certify/doc">https://yomimono.github.io/ocaml-certify/doc</a>

##### CHANGES:

* maintenance: use newer yet x509 (v0.8.0) (@hannesm)
