### PR TITLE
asn-combinators 0.2.0-1: leverage the cstruct constraint by using bigarray-compat

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.2.0-1/files/0001-bigarray-compat.patch
+++ b/packages/asn1-combinators/asn1-combinators.0.2.0-1/files/0001-bigarray-compat.patch
@@ -1,0 +1,31 @@
+--- a/_tags	2019-11-03 16:34:40.691766000 +0100
++++ b/_tags	2019-11-03 16:34:41.850239000 +0100
+@@ -1,7 +1,7 @@
+ true: color(always)
+ true: bin_annot, safe_string, strict_sequence
+ true: warn(A-4-41-42-44-48-58)
+-true: package(bytes), package(result), package(cstruct), package(zarith), package(ptime)
++true: package(bytes), package(result), package(cstruct), package(zarith), package(ptime), package(bigarray-compat)
+ 
+ <src>: include
+ 
+--- a/pkg/META	2019-11-03 16:34:20.947072000 +0100
++++ b/pkg/META	2019-11-03 16:34:22.050043000 +0100
+@@ -1,6 +1,6 @@
+ description = "Embed typed ASN.1 grammars in OCaml"
+ version = "0.2.0"
+-requires = "cstruct zarith ptime"
++requires = "cstruct zarith ptime bigarray-compat"
+ archive(byte) = "asn1-combinators.cma"
+ archive(native) = "asn1-combinators.cmxa"
+ plugin(byte) = "asn1-combinators.cma"
+--- a/src/asn_prim.ml.orig	2019-11-03 16:34:00.685635000 +0100
++++ b/src/asn_prim.ml	2019-11-03 16:34:01.930523000 +0100
+@@ -4,6 +4,7 @@
+ open Asn_core
+ 
+ module Writer = Asn_writer
++module Bigarray = Bigarray_compat
+ 
+ module type Prim = sig
+   type t

--- a/packages/asn1-combinators/asn1-combinators.0.2.0-1/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.0-1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
+doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+tags: [ "org:mirage" ]
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"]
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+    {with-test}
+  ["ocaml" "pkg/pkg.ml" "test"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result"
+  "cstruct" {>= "4.0.0"}
+  "zarith"
+  "ptime"
+  "ounit" {with-test}
+  "bigarray-compat"
+]
+conflicts: [ "cstruct" {< "1.6.0"} ]
+patches: [ "0001-bigarray-compat.patch" ]
+synopsis: "Embed typed ASN.1 grammars in OCaml"
+description: """
+asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
+part of ASN.1, and embed the abstract syntax directly in the language. These
+abstract syntax representations can be used for parsing, serialization, or
+random testing.
+
+The only ASN.1 encodings currently supported are BER and DER.
+
+asn1-combinators is distributed under the ISC license."""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.2.0/asn1-combinators-0.2.0.tbz"
+  checksum: "md5=f695aec35f8934d20d966032adbf3520"
+}
+extra-files: [
+  [ "0001-bigarray-compat.patch" "md5=cca9c049641c510b9425fa75b7b669da" ]
+]


### PR DESCRIPTION
see mirleft/ocaml-asn1-combinators#27 for the origin of the patch (here applied to the most recent release). asn1-combinators is the only package that requires cstruct downgrade in various mirageos unikernels / universes. it is preferable to be compatible with 5.0.0 which introduced capabilities.