### PR TITLE
[new release] mirage, mirage-runtime, mirage-types-lwt and mirage-types (3.7.1)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.7.1/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.7.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria-runtime"  {>= "3.0.2"}
+  "fmt"
+  "logs"
+  "lwt" {>= "4.0.0"}
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.7.1/mirage-v3.7.1.tbz"
+  checksum: [
+    "sha256=3a074c085eb687f6fc533db2c63dbc235b5f8f1ae706fbffdef602d66ddc4e93"
+    "sha512=1e27148dc015e83af0a9dedc15aaf732db3d337cfc833c79c3aaee2ac5ff9026b7b6b3d628adf1649d1dd099ad951112e50597695f32c1b96aa0e042cc17c926"
+  ]
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.7.1/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.7.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends:   [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-types" {= version}
+]
+
+synopsis: "Lwt module type definitions for MirageOS applications"
+description: """
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`
+"""
+post-messages: [
+ "This package will be retired in MirageOS 4.0. Please use individual signatures (mirage-net / mirage-clock / etc.) instead."
+]
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.7.1/mirage-v3.7.1.tbz"
+  checksum: [
+    "sha256=3a074c085eb687f6fc533db2c63dbc235b5f8f1ae706fbffdef602d66ddc4e93"
+    "sha512=1e27148dc015e83af0a9dedc15aaf732db3d337cfc833c79c3aaee2ac5ff9026b7b6b3d628adf1649d1dd099ad951112e50597695f32c1b96aa0e042cc17c926"
+  ]
+}

--- a/packages/mirage-types/mirage-types.3.7.1/opam
+++ b/packages/mirage-types/mirage-types.3.7.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-console" {>= "3.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "mirage-fs" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+]
+synopsis: "Module type definitions for MirageOS applications"
+description: """
+Module type definitions for MirageOS applications
+"""
+post-messages: [
+  "This package will be retired in MirageOS 4.0. Please use individual signatures (mirage-net / mirage-clock / etc.) instead."
+]
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.7.1/mirage-v3.7.1.tbz"
+  checksum: [
+    "sha256=3a074c085eb687f6fc533db2c63dbc235b5f8f1ae706fbffdef602d66ddc4e93"
+    "sha512=1e27148dc015e83af0a9dedc15aaf732db3d337cfc833c79c3aaee2ac5ff9026b7b6b3d628adf1649d1dd099ad951112e50597695f32c1b96aa0e042cc17c926"
+  ]
+}

--- a/packages/mirage/mirage.3.7.1/opam
+++ b/packages/mirage/mirage.3.7.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria"          {>= "3.0.2"}
+  "bos"
+  "astring"
+  "logs"
+  "stdlib-shims"
+  "mirage-runtime"     {= version}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.7.1/mirage-v3.7.1.tbz"
+  checksum: [
+    "sha256=3a074c085eb687f6fc533db2c63dbc235b5f8f1ae706fbffdef602d66ddc4e93"
+    "sha512=1e27148dc015e83af0a9dedc15aaf732db3d337cfc833c79c3aaee2ac5ff9026b7b6b3d628adf1649d1dd099ad951112e50597695f32c1b96aa0e042cc17c926"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* clean opam files when `mirage configure` is executed (mirage/mirage#1013 @dinosaure)
* deprecate mirage-types and mirage-types-lwt (mirage/mirage#1006 @hannes)
* remove abstraction over 'type 'a io' and 'buffer', remove mirage-*-lwt packages (mirage/mirage#1006 @hannesm)
* unify targets in respect to hooks (Mirage_runtime provides the hooks and registration)
* unify targets in respect to error handling (no toplevel try .. with installed anymore, mirage-unix does no longer ignore all errors)