### PR TITLE
Package shared-secret.0.4

### DIFF
--- a/packages/shared-secret/shared-secret.0.4/opam
+++ b/packages/shared-secret/shared-secret.0.4/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Marco Aurélio da Silva <marcoonroad@gmail.com>"
+authors: "Marco Aurélio da Silva <marcoonroad@gmail.com>"
+bug-reports: "https://github.com/marcoonroad/shared-secret/issues"
+license: "MIT"
+homepage: "https://github.com/marcoonroad/shared-secret"
+dev-repo: "git+https://github.com/marcoonroad/shared-secret.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs
+    "@install"
+    "@doc" {with-doc}
+    "@runtest" {with-test}]
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "1.11"}
+  "ounit" {with-test}
+]
+synopsis: "Exceptions are shared secrets"
+description: """
+Abstract (encapsulated) messages or hidden (semi-deterministic) exceptions using OCaml's module system.
+"""
+url {
+  src: "https://github.com/marcoonroad/shared-secret/archive/0.4.tar.gz"
+  checksum: [
+    "md5=cbdacb2c2ae8d888af027e8464f1b234"
+    "sha512=cdc11da593f35c82312754a793067728adbd6fac068717dea7baa530c0fb6c466dd5c0e092d4f70e1ff0bf04d7e0d66f44c8ef22606e4060483ee5a453acfc2a"
+  ]
+}


### PR DESCRIPTION
### `shared-secret.0.4`
Exceptions are shared secrets
Abstract (encapsulated) messages or hidden (semi-deterministic) exceptions using OCaml's module system.



---
* Homepage: https://github.com/marcoonroad/shared-secret
* Source repo: git+https://github.com/marcoonroad/shared-secret.git
* Bug tracker: https://github.com/marcoonroad/shared-secret/issues

---
:camel: Pull-request generated by opam-publish v2.0.0