### PR TITLE
Package subtype-refinement.0.2

### DIFF
--- a/packages/subtype-refinement/subtype-refinement.0.2/opam
+++ b/packages/subtype-refinement/subtype-refinement.0.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Marco Aurélio <marcoonroad@gmail.com>"
+authors: "Marco Aurélio <marcoonroad@gmail.com>"
+bug-reports: "http://github.com/marcoonroad/subtype-refinement/issues"
+license: "MIT"
+homepage: "http://github.com/marcoonroad/subtype-refinement"
+dev-repo: "git+https://github.com/marcoonroad/subtype-refinement.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "build" "-p" name "-j" jobs "@install"]
+]
+depends: [
+  "ocaml" {>= "3.12"}
+  "dune" {>= "1.11"}
+  "ounit" {with-test}
+]
+synopsis: "Refinement types encoded with private types in OCaml"
+url {
+  src: "https://github.com/marcoonroad/subtype-refinement/archive/0.2.tar.gz"
+  checksum: [
+    "md5=d11855793d23bcd16d25bcc65128f687"
+    "sha512=56cfd4dda126460f23100485124d5565a138942e0f5ec919bc7217a0560e6079db9669b65cca24fea762b1121134b8bbdfdeaeb9bce867688806defd35ac89d0"
+  ]
+}


### PR DESCRIPTION
### `subtype-refinement.0.2`
Refinement types encoded with private types in OCaml



---
* Homepage: http://github.com/marcoonroad/subtype-refinement
* Source repo: git+https://github.com/marcoonroad/subtype-refinement.git
* Bug tracker: http://github.com/marcoonroad/subtype-refinement/issues

---
:camel: Pull-request generated by opam-publish v2.0.0