### PR TITLE
Package ocaml-protoc.2.0.0

### DIFF
--- a/packages/ocaml-protoc/ocaml-protoc.2.0.0/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Protobuf compiler for OCaml"
+description: "Protobuf compiler for OCaml"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+authors:[
+  "Maxime Ransan <maxime.ransan@gmail.com>"
+]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
+dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="4.02.1"}
+  "dune"  {build}
+  "stdlib-shims"
+]
+url {
+  src: "https://github.com/mransan/ocaml-protoc/archive/2.0.0.tar.gz"
+  checksum: [
+    "md5=b54063f3fdef247c0f7502ee43246578"
+    "sha512=43037761856211153bb25b9e5c3e96390b9b11da03fc0f57f682e753b9b3f45d364ef4d448cf1cb7765ddcbfc367d80b4f0f75bd38e4cd5182b02df898670a73"
+  ]
+}


### PR DESCRIPTION
### `ocaml-protoc.2.0.0`
Protobuf compiler for OCaml
Protobuf compiler for OCaml



---
* Homepage: https://github.com/mransan/ocaml-protoc
* Source repo: git+https://github.com/mransan/ocaml-protoc.git
* Bug tracker: https://github.com/mransan/ocaml-protoc/issues

---
:camel: Pull-request generated by opam-publish v2.0.0