### PR TITLE
Package ocaml-protoc.2.0.1

### DIFF
--- a/packages/ocaml-protoc/ocaml-protoc.2.0.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Protobuf compiler for OCaml"
+description: "Protobuf compiler for OCaml"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+authors:[
+  "Maxime Ransan <maxime.ransan@gmail.com>"
+]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
+dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="4.02.1"}
+  "dune"  {build}
+  "stdlib-shims"
+  "ocamlbuild" {build}
+]
+url {
+  src: "https://github.com/mransan/ocaml-protoc/archive/2.0.1.tar.gz"
+  checksum: [
+    "md5=40c8142a8ad00228dadeb8162d25bb64"
+    "sha512=5d23004b506e26672379518f8df964a3b4121d2b178dfd7b73268efe5c2114a8cef7249136fb66ac2a26a9f701c81e2a2c361ae1eb1596309144cf5432e08170"
+  ]
+}

--- a/packages/ocaml-protoc/ocaml-protoc.2.0.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.0.1/opam
@@ -17,7 +17,6 @@ depends: [
   "ocaml" {>="4.02.1"}
   "dune"  {>= "1.11"}
   "stdlib-shims"
-  "ocamlbuild" {build}
 ]
 url {
   src: "https://github.com/mransan/ocaml-protoc/archive/2.0.1.tar.gz"

--- a/packages/ocaml-protoc/ocaml-protoc.2.0.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.0.1/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>="4.02.1"}
-  "dune"  {build}
+  "dune"  {>= "1.11"}
   "stdlib-shims"
   "ocamlbuild" {build}
 ]

--- a/packages/ocamlbuild-protoc/ocamlbuild-protoc.0.1/opam
+++ b/packages/ocamlbuild-protoc/ocamlbuild-protoc.0.1/opam
@@ -11,6 +11,7 @@ remove: ["ocamlfind" "remove" "ocamlbuild_protoc"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
+  "ocamlbuild"
   "ocaml-protoc"
 ]
 synopsis: "ocaml-protoc plugin for Ocamlbuild"


### PR DESCRIPTION
### `ocaml-protoc.2.0.1`
Protobuf compiler for OCaml
Protobuf compiler for OCaml



---
* Homepage: https://github.com/mransan/ocaml-protoc
* Source repo: git+https://github.com/mransan/ocaml-protoc.git
* Bug tracker: https://github.com/mransan/ocaml-protoc/issues

---
:camel: Pull-request generated by opam-publish v2.0.0