### PR TITLE
md2mld: use dune instead of jbuilder

### DIFF
--- a/packages/md2mld/md2mld.0.2.0/opam
+++ b/packages/md2mld/md2mld.0.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "base-bytes"
   "omd"
 ]
-build: ["jbuilder" "build" "-p" name "-j" jobs]
+build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/mseri/md2mld.git"
 url {
   src:

--- a/packages/md2mld/md2mld.0.3.0/opam
+++ b/packages/md2mld/md2mld.0.3.0/opam
@@ -29,7 +29,7 @@ depends: [
   "base-bytes"
   "omd"
 ]
-build: ["jbuilder" "build" "-p" name "-j" jobs]
+build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/mseri/md2mld.git"
 url {
   src:


### PR DESCRIPTION
Spotted by @kit-ty-kate https://github.com/ocaml/opam-repository/pull/15206

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>