### PR TITLE
[new release] ocamlformat (0.12)

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.12/opam
+++ b/packages/ocamlformat/ocamlformat.0.12/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.12/ocamlformat-0.12.tbz"
+  checksum: [
+    "sha256=f2b64ff7f5cb9b4e19c6fc4e3f0fbd1747ef09d24848238540e2c27652e928fe"
+    "sha512=1785ec8e7fe5d7f9f4bdd056be612e8ee170dcf4886bea0dde6f58602fa1729579d352e3a15df3229d124dac467b91f32ef900ff30e19a53c42feb1904c8a352"
+  ]
+}
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.mlt" "src/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "base" {>= "v0.11.0"}
+  "base-unix"
+  "cmdliner"
+  "dune" {>= "1.11.1"}
+  "fpath"
+  "ocaml-migrate-parsetree" {>= "1.3.1"}
+  "odoc" {>= "1.4.2"}
+  "re"
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."

--- a/packages/ppx_mysql/ppx_mysql.1.0/opam
+++ b/packages/ppx_mysql/ppx_mysql.1.0/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "alcotest" {with-test & >= "0.8" & < "0.9"}
   "dune"
-  "ocamlformat" {with-test & >= "0.9"}
+  "ocamlformat" {with-test & >= "0.9" & <= "0.11.0"}
   "ocaml" {>= "4.06.0" }
   "ppxlib" {>= "0.2" & < "0.6"}
   "ppx_deriving" {with-test & >= "4.2" & < "5.0"}

--- a/packages/ppx_mysql/ppx_mysql.1.1/opam
+++ b/packages/ppx_mysql/ppx_mysql.1.1/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "alcotest" {with-test & >= "0.8" & < "0.9"}
   "dune"
-  "ocamlformat" {with-test & >= "0.9"}
+  "ocamlformat" {with-test & >= "0.9" & <= "0.11.0"}
   "ocaml" {>= "4.06.0" }
   "ppxlib" {>= "0.2" & < "0.9"}
   "ppx_deriving" {with-test & >= "4.2" & < "5.0"}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

CHANGES:

#### Changes

  + Set "conventional" as the default profile (ocaml-ppx/ocamlformat#1060) (Guillaume Petiot)
    This new profile is made to better match the most used style and is encouraged.
    To continue using the previous default, use `profile = ocamlformat` in your `.ocamlformat`.
  + CLI: Allow both values of boolean options (ocaml-ppx/ocamlformat#1062) (Jules Aguillon)
    Now, both `--opt` and --no-opt` are available on the CLI for any boolean option "opt".
    Previously, only one of them were available depending on the default value.
  + Auto mode for `break-string-literals` (ocaml-ppx/ocamlformat#1057) (Guillaume Petiot)
    `wrap`, `newlines` and `newlines-and-wrap` values of `break-string-literals` are removed.
    `auto` replaces them, it is equivalent to `newlines-and-wrap`.
  + Dock collection brackets (ocaml-ppx/ocamlformat#1014) (Guillaume Petiot)
    `after-and-docked` value of `break-separators` is removed and is replaced by a new `dock-collection-brackets` option.
  + Preserve `begin` and `end` keywords in if-then-else (ocaml-ppx/ocamlformat#978) (Jules Aguillon)
    Previously, `begin`/`end` keywords around if-then-else branches were turned into parentheses.

#### New features

  + Give a hint when warning 50 is raised (ocaml-ppx/ocamlformat#1111) (Guillaume Petiot)
  + Add a message when a config value is removed (ocaml-ppx/ocamlformat#1089) (Etienne Millon)
    Explain what replaces removed options and avoid printing a parsing error.
  + Implement `sequence-blank-line=preserve-one` for let bindings (ocaml-ppx/ocamlformat#1077) (Jules Aguillon)
    Preserve a blank line after `let .. in` when `sequence-blank-line` set to `preserve-one`.
    Previously, only blank lines after `;` could be preserved.
  + Parse toplevel directives (ocaml-ppx/ocamlformat#1020) (Jules Aguillon)
    Allow `#directives` in `.ml` files.
    Previously, files containing a directive needed to be parsed as "use file".
    The "use file" mode is removed and `--use-file` is now the same as `--impl`.
  + Don't require `--name`, require kind, forbid `--inplace`, allow `--check`, make `--enable-outside-detected-project` implicit when reading from stdin (ocaml-ppx/ocamlformat#1018) (Guillaume Petiot)
  + Parse code in docstrings (ocaml-ppx/ocamlformat#941) (Guillaume Petiot)
    Format OCaml code in cinaps-style comments `(*$ code *)` and code blocks in documentation comments `(** {[ code ]} *)`.
  + Parse documentation comments with Odoc (ocaml-ppx/ocamlformat#721) (Jules Aguillon)
    Formatting of documentation comments is more robust and support newer Odoc syntaxes.
    Internally, Odoc replaces Octavius as the documentation parser.

#### Bug fixes

  + Fix unstabilizing comments on assignments (ocaml-ppx/ocamlformat#1093) (Guillaume Petiot)
  + Fix the default value documentation for `max-indent` (ocaml-ppx/ocamlformat#1105) (Guillaume Petiot)
  + Fix closing parenthesis exceeding the margin in function application (ocaml-ppx/ocamlformat#1098) (Jules Aguillon)
  + Missing break before attributes of `Pmty_with` (ocaml-ppx/ocamlformat#1103) (Josh Berdine)
  + Fix closing quote exceeding the margin (ocaml-ppx/ocamlformat#1096) (Jules Aguillon)
  + Fix break before the closing bracket of collections (exceeding the margin) (ocaml-ppx/ocamlformat#1073) (Guillaume Petiot)
  + Fix precedence of Dot wrt Hash (ocaml-ppx/ocamlformat#1058) (Guillaume Petiot)
  + Fix break in variant type definition to not exceed the margin (ocaml-ppx/ocamlformat#1064) (Guillaume Petiot)
  + Fix newlines and indentation in toplevel extension points (ocaml-ppx/ocamlformat#1054) (Guillaume Petiot)
  + Fix placement of doc comments around extensions (ocaml-ppx/ocamlformat#1052) (Jules Aguillon)
  + Inline extensions that do not break (ocaml-ppx/ocamlformat#1050) (Guillaume Petiot)
  + Add missing cut before attributes in type declarations (ocaml-ppx/ocamlformat#1051) (Guillaume Petiot)
  + Fix alignment of cases (ocaml-ppx/ocamlformat#1046) (Guillaume Petiot)
  + Fix blank line after comments at the end of lists (ocaml-ppx/ocamlformat#1045) (Guillaume Petiot)
  + Fix indexing operators precedence (ocaml-ppx/ocamlformat#1039) (Jules Aguillon)
  + Fix dropped comment after infix op (ocaml-ppx/ocamlformat#1030) (Guillaume Petiot)
  + No newline if the input is empty (ocaml-ppx/ocamlformat#1031) (Guillaume Petiot)
  + Fix unstable comments around attributes (ocaml-ppx/ocamlformat#1029) (Guillaume Petiot)
  + Fix extra blank line in sequence (ocaml-ppx/ocamlformat#1021) (Jules Aguillon)
  + Check functor arguments when computing placement of doc comments (ocaml-ppx/ocamlformat#1013) (Jules Aguillon)
  + Fix indentation of labelled args (ocaml-ppx/ocamlformat#1006) (Guillaume Petiot)
  + Fix linebreak between or-cases with comments when `break-cases=all` (ocaml-ppx/ocamlformat#1002) (Guillaume Petiot)
  + Fix unstable unattached doc comment in records (ocaml-ppx/ocamlformat#998) (Jules Aguillon)
  + Fix string literal changed (ocaml-ppx/ocamlformat#995) (Jules Aguillon)
  + Fix type variable (ocaml-ppx/ocamlformat#996) (Jules Aguillon)
  + Fix crash on extension sequence (ocaml-ppx/ocamlformat#992) (Guillaume Petiot)
  + Fix position of expressions regarding of comments in infix-op expressions (ocaml-ppx/ocamlformat#986) (Guillaume Petiot)
  + Escape special characters in external declaration (ocaml-ppx/ocamlformat#988) (Jules Aguillon)
  + Fix parens around constrained expr with attrs (ocaml-ppx/ocamlformat#987) (Guillaume Petiot)
  + Fix the margin, and correctly breaks comments (ocaml-ppx/ocamlformat#957) (Guillaume Petiot)
  + Fix formatting of custom indexing operators (ocaml-ppx/ocamlformat#975) (Guillaume Petiot)
  + Fix position of comments of labelled arrow types (ocaml-ppx/ocamlformat#976) (Guillaume Petiot)
  + No box around inline odoc styles (ocaml-ppx/ocamlformat#971) (Guillaume Petiot)
  + Fix boxing of collection expressions/patterns (ocaml-ppx/ocamlformat#960) (Guillaume Petiot)
  + Fix crash on record expr with pack fields (ocaml-ppx/ocamlformat#963) (Jules Aguillon)
  + Fix letop in subexpr (ocaml-ppx/ocamlformat#956) (hhugo)

#### Internal

  + Take file kind from --name when formatting stdin (ocaml-ppx/ocamlformat#1119) (Jules Aguillon)
  + Make Fmt.t abstract (ocaml-ppx/ocamlformat#1109) (Jules Aguillon)
  + Future-proof Fmt API in case Fmt.t goes abstract (ocaml-ppx/ocamlformat#1106) (Etienne Millon)
  + Future-proof `Fmt` API in case `Fmt.t` goes abstract (ocaml-ppx/ocamlformat#1106) (Etienne Millon)
  + Optional names for formatting boxes in debug output (ocaml-ppx/ocamlformat#1083) (Guillaume Petiot)
  + Check ocamlformat error codes in the testsuite (ocaml-ppx/ocamlformat#1084) (Etienne Millon)
  + Clean `Translation_unit` (ocaml-ppx/ocamlformat#1078) (Guillaume Petiot)
  + Use dune file generation in test/passing/dune (ocaml-ppx/ocamlformat#1082) (Etienne Millon)
  + CI: factorize tests and check reason build (ocaml-ppx/ocamlformat#1079) (Guillaume Petiot)
  + Use short form for action in src/dune (ocaml-ppx/ocamlformat#1076) (Etienne Millon)
  + Cleanup `sequence_blank_line` (ocaml-ppx/ocamlformat#1075) (Jules Aguillon)
  + CI: use a script travis-ci.sh to simplify .travis.yml (ocaml-ppx/ocamlformat#1063) (Guillaume Petiot)
  + Remove utility functions from `Fmt_ast` (ocaml-ppx/ocamlformat#1059) (Guillaume Petiot)
  + CI: use opam-2.0.5 in Travis (ocaml-ppx/ocamlformat#1044) (Anton Kochkov)
  + CI: check the build with OCaml 4.07.1 and 4.08.0 (ocaml-ppx/ocamlformat#1036) (Jules Aguillon)
  + Use the same sets of options for both branches by default in `test_branch.sh` (ocaml-ppx/ocamlformat#1033) (Guillaume Petiot)
  + Fix `test_branch.sh` and CI checking of CHANGES.md (ocaml-ppx/ocamlformat#1032, ocaml-ppx/ocamlformat#1034) (Jules Aguillon)
  + Fix flag of git-worktree in `test_branch.sh` and `bisect.sh` (ocaml-ppx/ocamlformat#1027) (Guillaume Petiot)
  + Remove the `bisect_ppx` dependency and clean the `Makefile` (ocaml-ppx/ocamlformat#1005) (Jules Aguillon)
  + Use a `CHANGES.md` log file again (ocaml-ppx/ocamlformat#1023) (Guillaume Petiot)
  + Support OCaml 4.09.0 (add the odoc.1.4.2 dependency) (ocaml-ppx/ocamlformat#1024) (Guillaume Petiot)
  + Update labels of issue templates (ocaml-ppx/ocamlformat#1017) (Guillaume Petiot)
  + Update labels in `CONTRIBUTING.md` (ocaml-ppx/ocamlformat#1007) (Guillaume Petiot)
  + Allow to ignore invalid options (ocaml-ppx/ocamlformat#984) (hhugo)
    The `--ignore-invalid-option` flag is added to ignore invalid options in `.ocamlformat` files.
  + Improve the documentation of `--doc-comments` (ocaml-ppx/ocamlformat#982) (Jules Aguillon)
  + Remove symbolic links and change naming convention of tests (ocaml-ppx/ocamlformat#980) (Guillaume Petiot)
  + Change the type of `fmt_code` (ocaml-ppx/ocamlformat#974) (Guillaume Petiot)
  + Simplify `Makefile` (ocaml-ppx/ocamlformat#973) (hhugo)
  + Dune should not be flagged as a build dep anymore (ocaml-ppx/ocamlformat#954) (Guillaume Petiot)