### PR TITLE
Release mirage net 3.0.1

### DIFF
--- a/packages/mirage-net/mirage-net.3.0.0/opam
+++ b/packages/mirage-net/mirage-net.3.0.0/opam
@@ -35,3 +35,4 @@ url {
     "sha512=08fc5fc0a299b5678ca7202943acec354ef290b0cdb67c9d71dc80092bffaab6c4e872a4aa503020b10ac0a614da40d30d31bd51992dec0196ca3bbd416f40fc"
   ]
 }
+available: false

--- a/packages/mirage-net/mirage-net.3.0.1/opam
+++ b/packages/mirage-net/mirage-net.3.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-net"
+bug-reports:   "https://github.com/mirage/mirage-net/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net.git"
+doc:           "https://mirage.github.io/mirage-net/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "fmt"
+  "macaddr" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "lwt" {>= "4.0.0"}
+]
+synopsis: "Network signatures for MirageOS"
+description: """
+mirage-net defines `Mirage_net.S`, the signature for network operations for MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net/releases/download/v3.0.1/mirage-net-v3.0.1.tbz"
+  checksum: [
+    "sha256=e3b553a254de725bab23e287350f14aa84a18e5259dd394f2cbe1ffd1ca0db79"
+    "sha512=b2f27787bd5756729e1e8797e9fda041d0176ba305fb7b2e72f6f374d263c1d547a98ef0771510302ed80026bf47fb79d737efda9c769c9e604c44aa2ba51967"
+  ]
+}


### PR DESCRIPTION
this provides a smooth transition from mirage 3.6 to 3.7 -- at the same time, remove the mirage-net 3.0.0 which does _not_ provide a smooth transition.