### PR TITLE
[new release] mirage-time and mirage-time-unix (2.0.1)

### DIFF
--- a/packages/mirage-time-unix/mirage-time-unix.2.0.1/opam
+++ b/packages/mirage-time-unix/mirage-time-unix.2.0.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-time"
+doc: "https://mirage.github.io/mirage-time/"
+bug-reports: "https://github.com/mirage/mirage-time/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-time" {=version}
+  "lwt" {>= "4.0.0"}
+  "duration"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-time.git"
+synopsis: "Time operations for MirageOS on Unix"
+description: """
+mirage-time-unix defines `Time`, an implementation of the `Mirage_time.S` signature for the Unix backend.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-time/releases/download/v2.0.1/mirage-time-v2.0.1.tbz"
+  checksum: [
+    "sha256=002e06d2d2cf22bcb15e497f8c09d0618665b54b1a686681662930771ea9d5f0"
+    "sha512=0c195c00f4fd33453a12f3677bdaa89ce7055b39aa067b9ea0b4062aec51cfd8a591f2e9b291ad421e11ca57eebaf9b388d104322b9e1d34def7906a8c1b2963"
+  ]
+}

--- a/packages/mirage-time/mirage-time.2.0.0/opam
+++ b/packages/mirage-time/mirage-time.2.0.0/opam
@@ -39,3 +39,4 @@ url {
     "sha512=0fb3e9ae5debb113a60a16e0623ea2e6590b66d5553355dd9b667495f43c0115efaee698b31b2dd2bd0053d9f0e6dcaaead914d142af4fc6f36e1e9221220580"
   ]
 }
+available: false

--- a/packages/mirage-time/mirage-time.2.0.1/opam
+++ b/packages/mirage-time/mirage-time.2.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-time"
+doc: "https://mirage.github.io/mirage-time/"
+bug-reports: "https://github.com/mirage/mirage-time/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-time.git"
+synopsis: "Time operations for MirageOS"
+description: """
+mirage-time defines `Mirage_time.S`, the signature for time-related operations for MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-time/releases/download/v2.0.1/mirage-time-v2.0.1.tbz"
+  checksum: [
+    "sha256=002e06d2d2cf22bcb15e497f8c09d0618665b54b1a686681662930771ea9d5f0"
+    "sha512=0c195c00f4fd33453a12f3677bdaa89ce7055b39aa067b9ea0b4062aec51cfd8a591f2e9b291ad421e11ca57eebaf9b388d104322b9e1d34def7906a8c1b2963"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* provide deprecated Mirage_time_lwt for smooth transition (mirage/mirage-time#12 @hannesm)

this provides a smooth transition from mirage 3.6 to 3.7 -- at the same time, remove the mirage-time{-unix} 2.0.0 which does _not_ provide a smooth transition.