### PR TITLE
Release mirage protocols 4.0.1

### DIFF
--- a/packages/mirage-protocols/mirage-protocols.4.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.4.0.0/opam
@@ -39,3 +39,4 @@ url {
     "sha512=bbf092640b7f8af6ad4b99d442bcb951f5446d3ff0e779c709465ed6214b8d4f8a6a3be67fe022cffbfcabf9b7b77bf9c323f10aed159beeeeef30783f3821bb"
   ]
 }
+available: false

--- a/packages/mirage-protocols/mirage-protocols.4.0.1/opam
+++ b/packages/mirage-protocols/mirage-protocols.4.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "fmt"
+  "duration"
+  "lwt" {>= "4.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "macaddr" {>= "4.0.0"}
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to
+be used as MirageOS network implementations should implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v4.0.1/mirage-protocols-v4.0.1.tbz"
+  checksum: [
+    "sha256=b10e3a8f530d48e424ba089fe9e404c2e3b6f0420ea99b39a52bf0d64d4715a1"
+    "sha512=bcb2ed457fd143d4c8d13d37fd19e80764e224c0bd7c9c724ed2cd6fb535ba2dee49e39dc00f0dca22a4d55f43aa33e3a02af0451dc4f5042796f764f60e7f1c"
+  ]
+}


### PR DESCRIPTION
this provides a smooth transition from mirage 3.6 to 3.7 -- at the same time, remove the mirage-protocols 4.0.0 which does not provide a smooth transition.