### PR TITLE
[new release] h2, h2-lwt, h2-lwt-unix and h2-mirage (0.4.0)

### DIFF
--- a/packages/h2-lwt-unix/h2-lwt-unix.0.4.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.4.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.04"}
   "faraday-lwt-unix"
   "h2-lwt" {= version}
-  "dune"
+  "dune" {>= "1.5"}
   "lwt"
 ]
 depopts: ["tls" "lwt_ssl"]

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.4.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "faraday-lwt-unix"
+  "h2-lwt" {= version}
+  "dune"
+  "lwt"
+]
+depopts: ["tls" "lwt_ssl"]
+synopsis: "Lwt + UNIX support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-lwt-unix provides an Lwt runtime implementation for h2 that targets UNIX
+binaries.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.4.0/h2-0.4.0.tbz"
+  checksum: [
+    "sha256=dc90b1245cbe7ba32075481d6a1ba08ea512d85d6fb8a3ff2b07f22094a0fad1"
+    "sha512=cebf90799bbb8281afa7d459b4576a35b68c69c1310867a74b620e6eb055940c8df2d1245966fac1a1461aa55e81f6f269cfa514d3879252740ae6cec1e5f281"
+  ]
+}

--- a/packages/h2-lwt/h2-lwt.0.4.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.4.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "h2" {= version}
+  "dune"
+  "lwt"
+]
+synopsis: "Lwt support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-lwt
+provides an Lwt runtime implementation for h2.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.4.0/h2-0.4.0.tbz"
+  checksum: [
+    "sha256=dc90b1245cbe7ba32075481d6a1ba08ea512d85d6fb8a3ff2b07f22094a0fad1"
+    "sha512=cebf90799bbb8281afa7d459b4576a35b68c69c1310867a74b620e6eb055940c8df2d1245966fac1a1461aa55e81f6f269cfa514d3879252740ae6cec1e5f281"
+  ]
+}

--- a/packages/h2-lwt/h2-lwt.0.4.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.4.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "h2" {= version}
-  "dune"
+  "dune" {>= "1.5"}
   "lwt"
 ]
 synopsis: "Lwt support for h2"

--- a/packages/h2-mirage/h2-mirage.0.4.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.4.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.04"}
   "faraday-lwt"
   "h2-lwt" {= version}
-  "dune"
+  "dune" {>= "1.5"}
   "lwt"
   "conduit-mirage" {>= "2.0.2"}
   "mirage-flow" {>= "2.0.0"}

--- a/packages/h2-mirage/h2-mirage.0.4.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "faraday-lwt"
+  "h2-lwt" {= version}
+  "dune"
+  "lwt"
+  "conduit-mirage" {>= "2.0.2"}
+  "mirage-flow" {>= "2.0.0"}
+  "cstruct"
+]
+synopsis: "Mirage support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-mirage provides an Lwt runtime implementation for h2 that targets MirageOS
+unikernels.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.4.0/h2-0.4.0.tbz"
+  checksum: [
+    "sha256=dc90b1245cbe7ba32075481d6a1ba08ea512d85d6fb8a3ff2b07f22094a0fad1"
+    "sha512=cebf90799bbb8281afa7d459b4576a35b68c69c1310867a74b620e6eb055940c8df2d1245966fac1a1461aa55e81f6f269cfa514d3879252740ae6cec1e5f281"
+  ]
+}

--- a/packages/h2/h2.0.4.0/opam
+++ b/packages/h2/h2.0.4.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04"}
-  "dune"
+  "dune" {>= "1.5"}
   "alcotest" {with-test}
   "yojson" {with-test}
   "hex" {with-test}

--- a/packages/h2/h2.0.4.0/opam
+++ b/packages/h2/h2.0.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune"
+  "alcotest" {with-test}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "bigstringaf" {>= "0.5.0"}
+  "angstrom" {>= "0.11.2"}
+  "faraday" {>= "0.5.0"}
+  "psq"
+  "hpack"
+  "httpaf"
+]
+synopsis:
+  "A high-performance, memory-efficient, and scalable HTTP/2 library for for OCaml"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. It
+is based on the concepts in http/af, and therefore uses the Angstrom and
+Faraday libraries to implement the parsing and serialization layers of the
+HTTP/2 standard as a state machine that is agnostic to the underlying I/O
+specifics. It also preserves the same API as http/af wherever possible.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.4.0/h2-0.4.0.tbz"
+  checksum: [
+    "sha256=dc90b1245cbe7ba32075481d6a1ba08ea512d85d6fb8a3ff2b07f22094a0fad1"
+    "sha512=cebf90799bbb8281afa7d459b4576a35b68c69c1310867a74b620e6eb055940c8df2d1245966fac1a1461aa55e81f6f269cfa514d3879252740ae6cec1e5f281"
+  ]
+}


### PR DESCRIPTION
A high-performance, memory-efficient, and scalable HTTP/2 library for for OCaml

- Project page: <a href="https://github.com/anmonteiro/ocaml-h2">https://github.com/anmonteiro/ocaml-h2</a>
- Documentation: <a href="https://anmonteiro.github.io/ocaml-h2/">https://anmonteiro.github.io/ocaml-h2/</a>

##### CHANGES:

- h2-mirage: depend on `mirage-conduit` instead of `conduit-mirage`,
  effectively placing a lower bound of OCaml 4.07 on the next release of
  h2-mirage ([#67](https://github.com/anmonteiro/ocaml-h2/pull/67))
- h2-lwt-unix: replace the `dune` file (previously written in OCaml) with a
  `(select)` form to avoid depending on `ocamlfind`
  ([#68](https://github.com/anmonteiro/ocaml-h2/pull/68))
- h2-lwt, h2-lwt-unix, h2-mirage: Refactor interface code through common
  `H2_lwt_intf` and expose less (internal) types
  ([#65](https://github.com/anmonteiro/ocaml-h2/pull/65))
- h2-lwt, h2-lwt-unix, h2-mirage: Expose `Client.is_closed`
  ([#65](https://github.com/anmonteiro/ocaml-h2/pull/65))
- h2: Don't count peer max concurrent streams based on what the endpoint
  receives; the endpoint is responsible for selecting it
  ([#71](https://github.com/anmonteiro/ocaml-h2/pull/71))
- h2: Fix bug in `Headers.remove` that prevented removing the last header pair
  ([#73](https://github.com/anmonteiro/ocaml-h2/pull/73))
- h2: Fix bug in `Headers.replace` that prevented replacing the last header
  pair ([#76](https://github.com/anmonteiro/ocaml-h2/pull/76))
- h2-mirage: Adapt to Mirage 3.7 interfaces. `h2_mirage` now requires
  `conduit-mirage` >= 2.0.2 and `mirage-flow` >= 2.0.0
  ([#77](https://github.com/anmonteiro/ocaml-h2/pull/77))
