### PR TITLE
[new release] decoders, decoders-bencode, decoders-cbor, decoders-ezjsonm, decoders-sexplib and decoders-yojson (0.3.0)

### DIFF
--- a/packages/decoders-bencode/decoders-bencode.0.3.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Matt Bray <mattjbray@gmail.com>"
+authors: ["Simon Cruanes"]
+synopsis: "Bencode interface for decoders"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders-bencode"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {build}
+  "ounit" {with-test}
+  "containers" {with-test}
+  "decoders"
+  "bencode"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz"
+  checksum: [
+    "sha256=a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
+    "sha512=2f596f444ec815759234b50a53e3a67e7413f871d5fce1ae950e145dd5e81c4507acf784334ca86c935344b59ea619baa96ac07a0207cfb70681986dd81e2079"
+  ]
+}

--- a/packages/decoders-bencode/decoders-bencode.0.3.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.3.0/opam
@@ -26,7 +26,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "dune" {build}
+  "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
   "decoders"

--- a/packages/decoders-cbor/decoders-cbor.0.3.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.0.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Matt Bray <mattjbray@gmail.com>"
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+synopsis: "CBOR interface for decoders"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders-cbor"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {build}
+  "ounit" {with-test}
+  "containers" {with-test}
+  "decoders"
+  "cbor"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz"
+  checksum: [
+    "sha256=a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
+    "sha512=2f596f444ec815759234b50a53e3a67e7413f871d5fce1ae950e145dd5e81c4507acf784334ca86c935344b59ea619baa96ac07a0207cfb70681986dd81e2079"
+  ]
+}

--- a/packages/decoders-cbor/decoders-cbor.0.3.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.0.3.0/opam
@@ -26,7 +26,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "dune" {build}
+  "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
   "decoders"

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.3.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.3.0/opam
@@ -26,7 +26,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "dune" {build}
+  "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
   "decoders"

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.3.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Matt Bray <matt@aestheticintegration.com>"
+authors: ["Matt Bray <matt@aestheticintegration.com>"]
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+synopsis: "Interface to ezjsonm for decoders"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders-ezjsonm"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {build}
+  "ounit" {with-test}
+  "containers" {with-test}
+  "decoders"
+  "ezjsonm" {>= "0.4.0"}
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz"
+  checksum: [
+    "sha256=a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
+    "sha512=2f596f444ec815759234b50a53e3a67e7413f871d5fce1ae950e145dd5e81c4507acf784334ca86c935344b59ea619baa96ac07a0207cfb70681986dd81e2079"
+  ]
+}

--- a/packages/decoders-sexplib/decoders-sexplib.0.3.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.0.3.0/opam
@@ -26,7 +26,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "dune" {build}
+  "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
   "decoders"

--- a/packages/decoders-sexplib/decoders-sexplib.0.3.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.0.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Matt Bray <mattjbray@gmail.com>"
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+synopsis: "Sexplib interface for decoders"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders-sexplib"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {build}
+  "ounit" {with-test}
+  "containers" {with-test}
+  "decoders"
+  "sexplib0"
+  "sexplib"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz"
+  checksum: [
+    "sha256=a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
+    "sha512=2f596f444ec815759234b50a53e3a67e7413f871d5fce1ae950e145dd5e81c4507acf784334ca86c935344b59ea619baa96ac07a0207cfb70681986dd81e2079"
+  ]
+}

--- a/packages/decoders-yojson/decoders-yojson.0.3.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.3.0/opam
@@ -26,7 +26,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "dune" {build}
+  "dune" {>= "1.0"}
   "ounit" {with-test}
   "decoders"
   "yojson"

--- a/packages/decoders-yojson/decoders-yojson.0.3.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Matt Bray <matt@aestheticintegration.com>"
+authors: ["Matt Bray <matt@aestheticintegration.com>"]
+synopsis: "Interface to yojson for decoders"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders-yojson"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {build}
+  "ounit" {with-test}
+  "decoders"
+  "yojson"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz"
+  checksum: [
+    "sha256=a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
+    "sha512=2f596f444ec815759234b50a53e3a67e7413f871d5fce1ae950e145dd5e81c4507acf784334ca86c935344b59ea619baa96ac07a0207cfb70681986dd81e2079"
+  ]
+}

--- a/packages/decoders/decoders.0.3.0/opam
+++ b/packages/decoders/decoders.0.3.0/opam
@@ -26,7 +26,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "dune" {build}
+  "dune" {>= "1.0"}
   "containers" {with-test}
   "ocaml" { >= "4.03.0" }
 ]

--- a/packages/decoders/decoders.0.3.0/opam
+++ b/packages/decoders/decoders.0.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Elm-inspired decoders for Ocaml"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+maintainer: "Matt Bray <matt@aestheticintegration.com>"
+authors: ["Matt Bray <matt@aestheticintegration.com>"]
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {build}
+  "containers" {with-test}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.3.0/decoders-v0.3.0.tbz"
+  checksum: [
+    "sha256=a50e613cfd18a584e765d8368ad0afe920482bf1e6745caf13f2b6a7d3634d9d"
+    "sha512=2f596f444ec815759234b50a53e3a67e7413f871d5fce1ae950e145dd5e81c4507acf784334ca86c935344b59ea619baa96ac07a0207cfb70681986dd81e2079"
+  ]
+}


### PR DESCRIPTION
Elm-inspired decoders for Ocaml

- Project page: <a href="https://github.com/mattjbray/ocaml-decoders">https://github.com/mattjbray/ocaml-decoders</a>
- Documentation: <a href="https://mattjbray.github.io/ocaml-decoders/decoders">https://mattjbray.github.io/ocaml-decoders/decoders</a>

##### CHANGES:

* Add `uncons` primitive (mattjbray/ocaml-decoders#7, @mattjbray)
* Add `Decoders_sexplib` (mattjbray/ocaml-decoders#7, @mattjbray)
* Add `Decoders_cbor` (mattjbray/ocaml-decoders#9, @mattjbray)
* Add `Decoders_bencode` (mattjbray/ocaml-decoders#14, @c-cube)
* Remove `containers` dependency (mattjbray/ocaml-decoders#16, @c-cube)
