### PR TITLE
Constrain some package in anticipation of dune 2.0

### DIFF
--- a/packages/0install/0install.2.14.1/opam
+++ b/packages/0install/0install.2.14.1/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_react"
   "ocurl" {>= "0.7.9"}
   "sha" {>= "1.9"}
-  "dune"
+  "dune" {< "2.0"}
   "cppo" {build}
 ]
 depopts: ["obus" "lablgtk" "lwt_glib"]

--- a/packages/0install/0install.2.14/opam
+++ b/packages/0install/0install.2.14/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_react"
   "ocurl" {>= "0.7.9"}
   "sha" {>= "1.9"}
-  "dune"
+  "dune" {< "2.0"}
   "cppo" {build}
 ]
 depopts: ["obus" "lablgtk" "lwt_glib"]

--- a/packages/herdtools7/herdtools7.7.54/opam
+++ b/packages/herdtools7/herdtools7.7.54/opam
@@ -16,7 +16,7 @@ install: ["sh" "./dune-install.sh" "%{prefix}%"]
 # @todo Add "build-test" field
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune"
+  "dune" {< "2.0"}
 ]
 url {
   src: "https://github.com/herd/herdtools7/archive/7.54.tar.gz"

--- a/packages/irmin-watcher/irmin-watcher.0.4.0/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.4.0/opam
@@ -16,7 +16,7 @@ run-test: ["dune" "runtest" "-p" name]
 
 depends: [
   "ocaml"    {>= "4.02.0"}
-  "dune"
+  "dune"     {< "2.0"}
   "alcotest" {with-test}
   "mtime"    {with-test & >= "1.0.0"}
   "lwt"

--- a/packages/irmin-watcher/irmin-watcher.0.4.1/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.4.1/opam
@@ -16,7 +16,7 @@ run-test: ["dune" "runtest" "-p" name]
 
 depends: [
   "ocaml"    {>= "4.02.0"}
-  "dune"
+  "dune"     {< "2.0"}
   "alcotest" {with-test}
   "mtime"    {with-test & >= "1.0.0"}
   "lwt"

--- a/packages/links-postgresql/links-postgresql.0.8/opam
+++ b/packages/links-postgresql/links-postgresql.0.8/opam
@@ -13,7 +13,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune"
+  "dune" {< "2.0"}
   "postgresql"
   "links"
 ]

--- a/packages/links/links.0.8/opam
+++ b/packages/links/links.0.8/opam
@@ -51,7 +51,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.06.0" & < "4.08.0"}
-  "dune"
+  "dune" {< "2.0"}
   "ppx_deriving"
   "ppx_deriving_yojson"
   "base64" {< "3.0.0"}

--- a/packages/lwt-pipeline/lwt-pipeline.0.1/opam
+++ b/packages/lwt-pipeline/lwt-pipeline.0.1/opam
@@ -12,7 +12,7 @@ bug-reports: "https://gitlab.com/nomadic-labs/lwt_pipeline/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/lwt_pipeline.git"
 depends: [
 	"ocaml" { >= "4.03" }
-	"dune" { >= "1.7" }
+	"dune" { >= "1.7" & < "2.0" }
 	"lwt"
 	]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/minisat/minisat.0.2/opam
+++ b/packages/minisat/minisat.0.2/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune"
+  "dune" {< "2.0"}
   "odoc" {with-doc}
 ]
 synopsis: "Bindings to Minisat-C-1.14.1, with the solver included"

--- a/packages/npy/npy.0.0.8/opam
+++ b/packages/npy/npy.0.0.8/opam
@@ -8,7 +8,7 @@ authors:      [ "Laurent Mazare" ]
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "camlzip"
-  "dune"
+  "dune" {< "2.0"}
   "ocaml" {>= "4.06"}
 ]
 synopsis: "Numpy npy file format reading/writing."


### PR DESCRIPTION
Follow up to https://github.com/ocaml/opam-repository/pull/15206

* cc @talex5 for `0install`
* cc @maranget for `herdtools7`
* cc @samoht  for `irmin-watcher`
* cc @raphael-proust for `lwt-pipeline`
* cc @c-cube for `minisat`
* cc @LaurentMazare for `npy`

The reason for each breakage is stated in each individual commit messages and further information is available in #15158 