### PR TITLE
Package smtlib-utils.0.1

### DIFF
--- a/packages/smtlib-utils/smtlib-utils.0.1/opam
+++ b/packages/smtlib-utils/smtlib-utils.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Parser for SMTLIB2"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-bytes"
+  "result"
+  "menhir" {build}
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "SMTLIB" "smt2" "parse" "logic" ]
+homepage: "https://github.com/c-cube/smtlib-utils/"
+bug-reports: "https://github.com/c-cube/smtlib-utils/issues"
+dev-repo: "git+https://github.com/c-cube/smtlib-utils.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/smtlib-utils/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=902d731ee51fde809adb39c37a837702"
+    "sha512=ad083b2b761ad57d21bdfabad5e833e4973c9f23c91a2ed957fac4e9c3f144f8af7a304d16eee2197c2ff1232dc9d3b34e89b99c578f07b09e6c92287da85e2b"
+  ]
+}


### PR DESCRIPTION
### `smtlib-utils.0.1`
Parser for SMTLIB2



---
* Homepage: https://github.com/c-cube/smtlib-utils/
* Source repo: git+https://github.com/c-cube/smtlib-utils.git
* Bug tracker: https://github.com/c-cube/smtlib-utils/issues

---
:camel: Pull-request generated by opam-publish v2.0.0