### PR TITLE
Mark dokeysto_lz4.3.0.1 as incompatible with dune 2.0

### DIFF
--- a/packages/dokeysto_lz4/dokeysto_lz4.3.0.1/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.3.0.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {>= "1.0"}
+  "dune" {>= "1.0" & < "2.0"}
   "dokeysto"
   "minicli" {>= "5.0.0"}
   "lz4"


### PR DESCRIPTION
cc @UnixJunkie (see https://github.com/ocaml/opam-repository/pull/15158#issuecomment-551103739 for more details)