### PR TITLE
Package ezsqlite.0.4.2

### DIFF
--- a/packages/ezsqlite/ezsqlite.0.4.2/opam
+++ b/packages/ezsqlite/ezsqlite.0.4.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Simplified SQLite3 bindings for OCaml"
+description: """
+Ezsqlite provides custom SQLite3 bindings and a familiar API for interacting with SQL datatypes in OCaml.
+
+Additionally, SQLite3 is compiled into Ezsqlite with many extensions enabled. For more information see https://github.com/zshipko/ocaml-ezsqlite"""
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: "Zach Shipko"
+license: "ISC"
+homepage: "https://github.com/zshipko/ocaml-ezsqlite"
+doc: "https://zshipko.github.io/ocaml-ezsqlite/doc"
+bug-reports: "https://github.com/zshipko/ocaml-ezsqlite/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1"}
+  "hex"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/zshipko/ocaml-ezsqlite.git"
+url {
+  src: "https://github.com/zshipko/ocaml-ezsqlite/archive/0.4.2.tar.gz"
+  checksum: [
+    "md5=021dde03920799e924dda065e3b5e9c3"
+    "sha512=472b5d998e5ad359d001b17886755520b4c13e8677ddf36fec31e1de8476fad5aa4e3b7d09b524e3c00a0a0619f61dd67ea0ade3211c764129bbb54abe796487"
+  ]
+}


### PR DESCRIPTION
### `ezsqlite.0.4.2`
Simplified SQLite3 bindings for OCaml
Ezsqlite provides custom SQLite3 bindings and a familiar API for interacting with SQL datatypes in OCaml.

Additionally, SQLite3 is compiled into Ezsqlite with many extensions enabled. For more information see https://github.com/zshipko/ocaml-ezsqlite



---
* Homepage: https://github.com/zshipko/ocaml-ezsqlite
* Source repo: git://github.com/zshipko/ocaml-ezsqlite.git
* Bug tracker: https://github.com/zshipko/ocaml-ezsqlite/issues

---
:camel: Pull-request generated by opam-publish v2.0.0