### PR TITLE
Switch mlmpfr package to dune

### DIFF
--- a/packages/mlmpfr/mlmpfr.4.0.2+dune/files/mlmpfr_compatibility_test.c
+++ b/packages/mlmpfr/mlmpfr.4.0.2+dune/files/mlmpfr_compatibility_test.c
@@ -1,0 +1,24 @@
+#include <string.h>
+#include <stdio.h>
+#include <mpfr.h>
+
+int main(int argc, char **argv)
+{
+  const char *version = mpfr_get_version();
+  char subversion[6];
+  memcpy(subversion, version, 5);
+  subversion[5] = '\0';
+
+  // mlmpfr.4.0.2 is fully compatible with MPFR-4.0.0
+  if(strcmp(subversion, "4.0.0") == 0)
+    return 0;
+
+  // mlmpfr.4.0.2 is fully compatible with MPFR-4.0.1
+  if(strcmp(subversion, "4.0.1") == 0)
+    return 0;
+
+  if(strcmp(subversion, "4.0.2") == 0)
+    return 0;
+
+  return 1;
+}

--- a/packages/mlmpfr/mlmpfr.4.0.2+dune/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.2+dune/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name:         "mlmpfr"
+version:      "4.0.2+dune"
+maintainer:   "Laurent Thévenoux <lrnt@thvnx.com>"
+authors:      "Laurent Thévenoux <lrnt@thvnx.com>"
+homepage:     "https://github.com/thvnx/mlmpfr"
+bug-reports:  "https://github.com/thvnx/mlmpfr/issues"
+license:      "LGPL-3.0"
+dev-repo:     "git+https://github.com/thvnx/mlmpfr.git"
+build: [
+  ["cc" "mlmpfr_compatibility_test.c" "-lmpfr" "-o" "mlmpfr_compatibility_test"]
+  ["./mlmpfr_compatibility_test"]
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {>= "1.11.0"}
+]
+depexts: [
+  ["libmpfr-dev"] {os-family = "debian"}
+]
+post-messages: [
+  "Make sure you had MPFR version 4.0.2 installed on your system." {failure}
+]
+synopsis: "OCaml C bindings for MPFR-4.0.2"
+url {
+  src: "https://github.com/thvnx/mlmpfr/archive/mlmpfr.4.0.2-dune.tar.gz"
+  checksum: "md5=4bcddf894de457abdfd299fb81a50c78"
+}
+description: """
+The package provides bindings for MPFR-4.0.2.
+
+You'll need to have MPFR-4.0.2 installed on your system.
+See opam info mlmpfr for all available versions."""
+extra-files: ["mlmpfr_compatibility_test.c"
+              "md5=56e82ee5c1ca319b0c5ad514fb306f97"]


### PR DESCRIPTION
Hi, I switched the package to dune.

CI should fail if mpfr C library <= 4.0.0 is installed on test machine.