### PR TITLE
upgraded dokeysto_camltc and dokeysto_lz4 to 3.0.2

### DIFF
--- a/packages/dokeysto_camltc/dokeysto_camltc.3.0.2/opam
+++ b/packages/dokeysto_camltc/dokeysto_camltc.3.0.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {>= "1.0"}
+  "dune" {>= "1.11"}
   "dokeysto"
   "camltc"
 ]

--- a/packages/dokeysto_camltc/dokeysto_camltc.3.0.2/opam
+++ b/packages/dokeysto_camltc/dokeysto_camltc.3.0.2/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/dokeysto"
+bug-reports: "https://github.com/UnixJunkie/dokeysto/issues"
+dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
+license: "LGPL-2.1"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  [make "test_camltc"] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.0"}
+  "dokeysto"
+  "camltc"
+]
+synopsis: "The dumb OCaml key-value store w/ tokyocabinet backend"
+description: "dokeysto with tokyocabinet backend (camltc package in opam)"
+url {
+  src: "https://github.com/UnixJunkie/dokeysto/archive/v3.0.2.tar.gz"
+  checksum: "md5=83d662dc40f4a8173942a89a9f2f232d"
+}

--- a/packages/dokeysto_camltc/dokeysto_camltc.3.0.2/opam
+++ b/packages/dokeysto_camltc/dokeysto_camltc.3.0.2/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
 license: "LGPL-2.1"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  [make "test_camltc"] {with-test}
+#  [make "test_camltc"] {with-test}
 ]
 depends: [
   "ocaml"

--- a/packages/dokeysto_camltc/dokeysto_camltc.3.0.2/opam
+++ b/packages/dokeysto_camltc/dokeysto_camltc.3.0.2/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
 license: "LGPL-2.1"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-#  [make "test_camltc"] {with-test}
+  ["dune" "exec" "-p" name "-j" jobs "src/test_camltc.exe"] {with-test}
 ]
 depends: [
   "ocaml"

--- a/packages/dokeysto_lz4/dokeysto_lz4.3.0.2/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.3.0.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
 license: "LGPL-2.1"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  [make "test_lz4"] {with-test}
+#  [make "test_lz4"] {with-test}
 ]
 depends: [
   "ocaml"

--- a/packages/dokeysto_lz4/dokeysto_lz4.3.0.2/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.3.0.2/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {>= "1.0" & < "2.0"}
+  "dune" {>= "1.11"}
   "dokeysto"
   "minicli" {>= "5.0.0"}
   "lz4"

--- a/packages/dokeysto_lz4/dokeysto_lz4.3.0.2/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.3.0.2/opam
@@ -16,7 +16,6 @@ depends: [
   "dokeysto"
   "minicli" {>= "5.0.0"}
   "lz4"
-  "dolog"
 ]
 synopsis: "The dumb OCaml key-value store w/ LZ4 compression"
 description:

--- a/packages/dokeysto_lz4/dokeysto_lz4.3.0.2/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.3.0.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
 license: "LGPL-2.1"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-#  [make "test_lz4"] {with-test}
+  ["dune" "exec" "-p" name "-j" jobs "src/test_lz4.exe"] {with-test}
 ]
 depends: [
   "ocaml"

--- a/packages/dokeysto_lz4/dokeysto_lz4.3.0.2/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.3.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "dokeysto_lz4"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/dokeysto"
+bug-reports: "https://github.com/UnixJunkie/dokeysto/issues"
+dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
+license: "LGPL-2.1"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  [make "test_lz4"] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.0" & < "2.0"}
+  "dokeysto"
+  "minicli" {>= "5.0.0"}
+  "lz4"
+  "dolog"
+]
+synopsis: "The dumb OCaml key-value store w/ LZ4 compression"
+description:
+  "dokeysto with on-the-fly compression/decompression of values via LZ4"
+url {
+  src: "https://github.com/UnixJunkie/dokeysto/archive/v3.0.2.tar.gz"
+  checksum: "md5=83d662dc40f4a8173942a89a9f2f232d"
+}

--- a/packages/lbvs_consent/lbvs_consent.2.0.1/opam
+++ b/packages/lbvs_consent/lbvs_consent.2.0.1/opam
@@ -22,6 +22,7 @@ depends: [
   "batteries"
   "bitv" {>= "1.2"}
   "parmap"
+  "minicli" {>= "5.0.0"}
   "dolog" {< "4.0.0"}
   "camlzip"
   "qcheck"


### PR DESCRIPTION
dokeysto, dokeysto_lz4 and dokeysto_camltc are sister packages
(they all come from the same source tree); hence they should
be version synchronized. dokeysto is already at 3.0.2 in the opam-repository.