### PR TITLE
4 packages from c-cube/qcheck at 0.12

### DIFF
--- a/packages/qcheck-alcotest/qcheck-alcotest.0.12/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.12/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+synopsis: "Alcotest backend for qcheck"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "quickcheck"
+  "qcheck"
+  "alcotest"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "alcotest"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.12.tar.gz"
+  checksum: [
+    "md5=799ef7e77d77c640db29cb6be546de8e"
+    "sha512=a8b844d66b65fdc8cd1cb2ff1a84801815501559dccac5e4188593f5b294ca318f7de971987ce810b6f7840a292999a98ea8beb1e2c989ee3abd78314fca3ad3"
+  ]
+}

--- a/packages/qcheck-core/qcheck-core.0.12/opam
+++ b/packages/qcheck-core/qcheck-core.0.12/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+synopsis: "Core qcheck library"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.12.tar.gz"
+  checksum: [
+    "md5=799ef7e77d77c640db29cb6be546de8e"
+    "sha512=a8b844d66b65fdc8cd1cb2ff1a84801815501559dccac5e4188593f5b294ca318f7de971987ce810b6f7840a292999a98ea8beb1e2c989ee3abd78314fca3ad3"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.12/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.12/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://c-cube.github.io/qcheck/"]
+synopsis: "OUnit backend for qcheck"
+tags: [
+  "qcheck"
+  "quickcheck"
+  "ounit"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "ounit" {>= "2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.12.tar.gz"
+  checksum: [
+    "md5=799ef7e77d77c640db29cb6be546de8e"
+    "sha512=a8b844d66b65fdc8cd1cb2ff1a84801815501559dccac5e4188593f5b294ca318f7de971987ce810b6f7840a292999a98ea8beb1e2c989ee3abd78314fca3ad3"
+  ]
+}

--- a/packages/qcheck/qcheck.0.12/opam
+++ b/packages/qcheck/qcheck.0.12/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Compatibility package for qcheck"
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "qcheck-ounit" { = version }
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.12.tar.gz"
+  checksum: [
+    "md5=799ef7e77d77c640db29cb6be546de8e"
+    "sha512=a8b844d66b65fdc8cd1cb2ff1a84801815501559dccac5e4188593f5b294ca318f7de971987ce810b6f7840a292999a98ea8beb1e2c989ee3abd78314fca3ad3"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`qcheck.0.12`: Compatibility package for qcheck
-`qcheck-alcotest.0.12`: Alcotest backend for qcheck
-`qcheck-core.0.12`: Core qcheck library
-`qcheck-ounit.0.12`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.0.0