### PR TITLE
2 packages from sapristi/easy_logging at 0.7.1

### DIFF
--- a/packages/easy_logging/easy_logging.0.7.1/opam
+++ b/packages/easy_logging/easy_logging.0.7.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Module to log messages. Aimed at being both powerful and easy to use"
+description: """
+Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages printf style, or [string] or [string lazy_t]
+   * tree logging architecture for light configuration
+   * handlers associated to each logger will format, filter and treat the message independantly.
+   * use the infrastructure with your own handlers with the [MakeLogging] functor.
+   * use tags to add contextual information to log messages"""
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "GPL"
+homepage: "https://sapristi.github.io/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.8"}
+  "calendar" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "easy_logging/examples"] {with-test}
+]
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+url {
+  src: "https://github.com/sapristi/easy_logging/archive/v0.7.1.tar.gz"
+  checksum: [
+    "md5=ff59e729374d66cc927de16bd7b82dea"
+    "sha512=ca31fd39edab9a9592e9d5b2646dccc750037f823c4195de4b5ce4760e9463df1576806f850911ef96b359a45c35cc25f160860aa87b5519cf8b8feca8a68deb"
+  ]
+}

--- a/packages/easy_logging_yojson/easy_logging_yojson.0.7.1/opam
+++ b/packages/easy_logging_yojson/easy_logging_yojson.0.7.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Configuration loader for easy_logging with yojson backend"
+description: """
+Provides deserialisation of logging configuration 
+(loggers instantation and handlers parameters) from json,
+using ppx_deriving_yojson.
+
+-------
+
+     Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages printf style, or [string] or [string lazy_t]
+   * tree logging architecture for light configuration
+   * handlers associated to each logger will format, filter and treat the message independantly.
+   * use the infrastructure with your own handlers with the [MakeLogging] functor.
+   * use tags to add contextual information to log messages"""
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "GPL"
+homepage: "https://sapristi.github.io/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.8"}
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving_yojson"
+  "easy_logging" {= version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "conf_loader_modules/yojson"]
+    {with-test}
+]
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+url {
+  src: "https://github.com/sapristi/easy_logging/archive/v0.7.1.tar.gz"
+  checksum: [
+    "md5=ff59e729374d66cc927de16bd7b82dea"
+    "sha512=ca31fd39edab9a9592e9d5b2646dccc750037f823c4195de4b5ce4760e9463df1576806f850911ef96b359a45c35cc25f160860aa87b5519cf8b8feca8a68deb"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`easy_logging.0.7.1`: Module to log messages. Aimed at being both powerful and easy to use
-`easy_logging_yojson.0.7.1`: Configuration loader for easy_logging with yojson backend



---
* Homepage: https://sapristi.github.io/easy_logging/
* Source repo: git+https://github.com/sapristi/easy_logging.git
* Bug tracker: https://github.com/sapristi/easy_logging/issues

---
:camel: Pull-request generated by opam-publish v2.0.0