### PR TITLE
4 packages from c-cube/calculon at 0.5

### DIFF
--- a/packages/calculon-redis-lib/calculon-redis-lib.0.5/opam
+++ b/packages/calculon-redis-lib/calculon-redis-lib.0.5/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "A library to interact with Calculon via Redis"
+authors: ["c-cube"]
+maintainer: "c-cube"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "redis" { >= "0.3" }
+  "calculon" { = version }
+  "redis-lwt"
+  "atdgen"
+  "yojson"
+]
+tags: [ "irc" "bot" "redis" ]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.5.tar.gz"
+  checksum: [
+    "md5=831b8d45ac76bfa1118e7e954bfd4474"
+    "sha512=b7e856d88a2c34f2f7bb2c5c8f416ef99e29ccd46a9016e5f7fefc838df6fcb5daffd45170b606562a2ba15e910421884071e6e19fa90b23f412f45d85cc7d5a"
+  ]
+}

--- a/packages/calculon-redis/calculon-redis.0.5/opam
+++ b/packages/calculon-redis/calculon-redis.0.5/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "A redis plugin for Calculon"
+authors: ["c-cube"]
+maintainer: "c-cube"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "calculon" { = version }
+  "calculon-redis-lib" { = version }
+  "redis" { >= "0.3" }
+  "redis-lwt"
+]
+tags: [ "irc" "bot" "redis" ]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.5.tar.gz"
+  checksum: [
+    "md5=831b8d45ac76bfa1118e7e954bfd4474"
+    "sha512=b7e856d88a2c34f2f7bb2c5c8f416ef99e29ccd46a9016e5f7fefc838df6fcb5daffd45170b606562a2ba15e910421884071e6e19fa90b23f412f45d85cc7d5a"
+  ]
+}

--- a/packages/calculon-web/calculon-web.0.5/opam
+++ b/packages/calculon-web/calculon-web.0.5/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "A collection of web plugins for Calculon"
+authors: ["Armael" "Enjolras" "c-cube"]
+maintainer: "c-cube"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  [ "dune" "build" "@doc" "-p" name ] {with-doc}
+  [ "dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "calculon" { = version }
+  "re" { >= "1.7.2" }
+  "uri"
+  "curly"
+  "atdgen"
+  "lambdasoup"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "irc" "bot" "factoids" ]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.5.tar.gz"
+  checksum: [
+    "md5=831b8d45ac76bfa1118e7e954bfd4474"
+    "sha512=b7e856d88a2c34f2f7bb2c5c8f416ef99e29ccd46a9016e5f7fefc838df6fcb5daffd45170b606562a2ba15e910421884071e6e19fa90b23f412f45d85cc7d5a"
+  ]
+}

--- a/packages/calculon/calculon.0.5/opam
+++ b/packages/calculon/calculon.0.5/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Library for writing IRC bots in OCaml and a collection of plugins"
+authors: ["Armael" "Enjolras" "c-cube"]
+maintainer: "c-cube"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  [ "dune" "build" "@doc" "-p" name] {with-doc}
+  [ "dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-bytes"
+  "base-unix"
+  "result"
+  "lwt"
+  "irc-client" { >= "0.6.0" }
+  "irc-client-lwt"
+  "irc-client-lwt-ssl"
+  "yojson"
+  "containers" { >= "1.0" }
+  "ISO8601"
+  "stringext"
+  "re" { >= "1.7.2" }
+  "iter"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "irc" "bot" "factoids" ]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.5.tar.gz"
+  checksum: [
+    "md5=831b8d45ac76bfa1118e7e954bfd4474"
+    "sha512=b7e856d88a2c34f2f7bb2c5c8f416ef99e29ccd46a9016e5f7fefc838df6fcb5daffd45170b606562a2ba15e910421884071e6e19fa90b23f412f45d85cc7d5a"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`calculon.0.5`: Library for writing IRC bots in OCaml and a collection of plugins
-`calculon-redis.0.5`: A redis plugin for Calculon
-`calculon-redis-lib.0.5`: A library to interact with Calculon via Redis
-`calculon-web.0.5`: A collection of web plugins for Calculon



---
* Homepage: https://github.com/c-cube/calculon
* Source repo: git+https://github.com/c-cube/calculon.git
* Bug tracker: https://github.com/c-cube/calculon/issues

---
:camel: Pull-request generated by opam-publish v2.0.0