### PR TITLE
Package ocaml-protoc.2.0.2

### DIFF
--- a/packages/ocaml-protoc/ocaml-protoc.2.0.2/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Protobuf compiler for OCaml"
+description: "Protobuf compiler for OCaml"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+authors:[
+  "Maxime Ransan <maxime.ransan@gmail.com>"
+]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
+dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="4.02.1"}
+  "dune"  {>="1.11"}
+  "stdlib-shims"
+]
+url {
+  src: "https://github.com/mransan/ocaml-protoc/archive/2.0.2.tar.gz"
+  checksum: [
+    "md5=abbed1e3cb56dfe6dbf2fe9370838e57"
+    "sha512=9803eb3d0f7649c2c63ee3c3750d591e59b8383ffa00244fe46fbb2f536a05c6cec201870ab5c87e14774199c221c8e2da14db232cbc82fdb46b1f0ec7a76a64"
+  ]
+}


### PR DESCRIPTION
### `ocaml-protoc.2.0.2`
Protobuf compiler for OCaml
Protobuf compiler for OCaml



---
* Homepage: https://github.com/mransan/ocaml-protoc
* Source repo: git+https://github.com/mransan/ocaml-protoc.git
* Bug tracker: https://github.com/mransan/ocaml-protoc/issues

---
:camel: Pull-request generated by opam-publish v2.0.0