### PR TITLE
ocaml-system, ocaml-config: quote ocamlc path on Win32

### DIFF
--- a/packages/alcotest/alcotest.1.1.0/opam
+++ b/packages/alcotest/alcotest.1.1.0/opam
@@ -26,6 +26,7 @@ depends: [
   "uuidm"
   "re"
   "stdlib-shims"
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/lmdb/lmdb.1.0/opam
+++ b/packages/lmdb/lmdb.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "bigstringaf"
   "dune" {>= "1.2"}
-  "dune-configurator"
+  "dune-configurator" {build}
   "alcotest" {with-test}
   "benchmark" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
This is necessary because of Windows' very special quoting rules in [system](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/system-wsystem?view=vs-2019#remarks) and [cmd](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmd#remarks).
Could someone with access to a Windows machine test this on Cygwin, please?