### PR TITLE
[new release] icalendar (0.1.3)

### DIFF
--- a/packages/icalendar/icalendar.0.1.3/opam
+++ b/packages/icalendar/icalendar.0.1.3/opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune" {build}
+  "dune" {>= "1.3"}
   "alcotest" {with-test}
   "fmt"
   "angstrom"

--- a/packages/icalendar/icalendar.0.1.3/opam
+++ b/packages/icalendar/icalendar.0.1.3/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/roburio/icalendar"
+bug-reports: "https://github.com/roburio/icalendar/issues"
+dev-repo: "git+https://github.com/roburio/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://roburio.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom"
+  "re"
+  "uri"
+  "astring"
+  "rresult"
+  "ptime"
+  "ppx_deriving"
+  "stdlib-shims"
+  "gmap" {>= "0.3.0"}
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+url {
+  src:
+    "https://github.com/roburio/icalendar/releases/download/v0.1.3/icalendar-v0.1.3.tbz"
+  checksum: [
+    "sha256=c99e0560eeb534e5a8f567f127d42885cc557ef3c2d095b113276b0b88100697"
+    "sha512=ba2c1026753442c35943a86e18be826ac69894449717d61c2cc5d3380662e449d28617a1b5b937adbc7cb6a2556ff60448f700653db32a402d58c821162ab1a3"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Allow PRODID (and other calprops) to be after the components in a calendar
  CalDavZAP uses such ics - and now interoperability works roburio/icalendar#5