### PR TITLE
[new release] js_of_ocaml, js_of_ocaml-ocamlbuild, js_of_ocaml-ppx_deriving_json, js_of_ocaml-tyxml, js_of_ocaml-ppx, js_of_ocaml-lwt, js_of_ocaml-compiler and js_of_ocaml-toplevel (3.5.0)

### DIFF
--- a/packages/async_js/async_js.v0.12.0/opam
+++ b/packages/async_js/async_js.v0.12.0/opam
@@ -15,7 +15,7 @@ depends: [
   "async_rpc_kernel" {>= "v0.12" & < "v0.13"}
   "ppx_jane" {>= "v0.12" & < "v0.13"}
   "dune" {>= "1.5.1"}
-  "js_of_ocaml" {>= "3.2.1"}
+  "js_of_ocaml" {>= "3.2.1" & < "3.5.0"}
   "js_of_ocaml-ppx"
   "uri" {>= "2.0.0" & < "3.0.0"}
 ]

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.1.3/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.1.3/opam
@@ -27,9 +27,9 @@ depends: [
   "cohttp" {>= "1.0.0"}
   "cohttp-lwt" {>= "1.0.0"}
   "lwt" {>= "3.0.0"}
-  "js_of_ocaml" {>= "3.3.0"}
-  "js_of_ocaml-ppx" {>= "3.3.0"}
-  "js_of_ocaml-lwt" {>= "3.3.0"}
+  "js_of_ocaml" {>= "3.3.0" & < "3.5.0"}
+  "js_of_ocaml-ppx" {>= "3.3.0" & < "3.5.0"}
+  "js_of_ocaml-lwt" {>= "3.3.0" & < "3.5.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.2.0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.2.0/opam
@@ -27,9 +27,9 @@ depends: [
   "cohttp" {=version}
   "cohttp-lwt" {=version}
   "lwt" {>= "3.0.0"}
-  "js_of_ocaml" {>= "3.3.0"}
-  "js_of_ocaml-ppx" {>= "3.3.0"}
-  "js_of_ocaml-lwt" {>= "3.3.0"}
+  "js_of_ocaml" {>= "3.3.0" & < "3.5.0"}
+  "js_of_ocaml-ppx" {>= "3.3.0" & < "3.5.0"}
+  "js_of_ocaml-lwt" {>= "3.3.0" & < "3.5.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.3.0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.3.0/opam
@@ -27,9 +27,9 @@ depends: [
   "cohttp" {=version}
   "cohttp-lwt" {=version}
   "lwt" {>= "3.0.0"}
-  "js_of_ocaml" {>= "3.3.0"}
-  "js_of_ocaml-ppx" {>= "3.3.0"}
-  "js_of_ocaml-lwt" {>= "3.3.0"}
+  "js_of_ocaml" {>= "3.3.0" & < "3.5.0"}
+  "js_of_ocaml-ppx" {>= "3.3.0" & < "3.5.0"}
+  "js_of_ocaml-lwt" {>= "3.3.0" & < "3.5.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.4.0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.4.0/opam
@@ -27,9 +27,9 @@ depends: [
   "cohttp" {=version}
   "cohttp-lwt" {=version}
   "lwt" {>= "3.0.0"}
-  "js_of_ocaml" {>= "3.3.0"}
-  "js_of_ocaml-ppx" {>= "3.3.0"}
-  "js_of_ocaml-lwt" {>= "3.3.0"}
+  "js_of_ocaml" {>= "3.3.0" & < "3.5.0"}
+  "js_of_ocaml-ppx" {>= "3.3.0" & < "3.5.0"}
+  "js_of_ocaml-lwt" {>= "3.3.0" & < "3.5.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/dispatch-js/dispatch-js.0.4.1/opam
+++ b/packages/dispatch-js/dispatch-js.0.4.1/opam
@@ -8,7 +8,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.0"}
   "dispatch" {>="0.4.0"}
-  "js_of_ocaml-lwt" {>="3.3.0"}
+  "js_of_ocaml-lwt" {>="3.3.0" & < "3.5.0"}
   "result"
 ]
 build: [

--- a/packages/eliom/eliom.6.8.0/opam
+++ b/packages/eliom/eliom.6.8.0/opam
@@ -13,12 +13,12 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}
-  "js_of_ocaml" {>= "3.3"}
-  "js_of_ocaml-lwt" {>= "3.3"}
+  "js_of_ocaml" {>= "3.3" & < "3.5.0"}
+  "js_of_ocaml-lwt" {>= "3.3" & < "3.5.0"}
   "js_of_ocaml-ocamlbuild" {build}
-  "js_of_ocaml-ppx"
-  "js_of_ocaml-ppx_deriving_json" {>= "3.3"}
-  "js_of_ocaml-tyxml" {>= "3.3"}
+  "js_of_ocaml-ppx" {< "3.5.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.3" & < "3.5.0"}
+  "js_of_ocaml-tyxml" {>= "3.3" & < "3.5.0"}
   "lwt_log"
   "lwt_ppx"
   "tyxml" {>= "4.3.0"}

--- a/packages/github-jsoo/github-jsoo.4.1.0/opam
+++ b/packages/github-jsoo/github-jsoo.4.1.0/opam
@@ -26,7 +26,7 @@ depends: [
   "dune"
   "cohttp" {>= "0.99.0"}
   "cohttp-lwt-jsoo" {>= "0.99.0"}
-  "js_of_ocaml-lwt" {>="3.4.0"}
+  "js_of_ocaml-lwt" {>="3.4.0" & < "3.5.0"}
   "github"
 ]
 build: [

--- a/packages/github-jsoo/github-jsoo.4.2.0/opam
+++ b/packages/github-jsoo/github-jsoo.4.2.0/opam
@@ -32,7 +32,7 @@ depends: [
   "github" {= version}
   "cohttp" {>= "0.99.0"}
   "cohttp-lwt-jsoo" {>= "0.99.0"}
-  "js_of_ocaml-lwt" {>= "3.4.0"}
+  "js_of_ocaml-lwt" {>= "3.4.0" & < "3.5.0"}
 ]
 url {
   src:

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.11.1"}
+  "ppx_expect" {with-test & >= "0.12.0"}
+  "cmdliner"
+  "ocaml-migrate-parsetree"
+  "yojson" # It's optional, but we want users to be able to use source-map without pain.
+]
+
+depopts: [ "ocamlfind" ]
+
+conflicts: [
+  "ocamlfind"   {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.0/js_of_ocaml-3.5.0.tbz"
+  checksum: [
+    "sha256=c19903c11a7e7657a4bb92de9ad910e6daf5afc9da7222dcd8fe8da8867f05b7"
+    "sha512=3aa852552abe268504f7e26841bd1c43e95dba0a5827f70b97230e900909c3fa94f59715b45ce658f0c2e298a0e89c882a994d5fcc6bcf75250cf0b94733fa88"
+  ]
+}

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.0/opam
@@ -15,7 +15,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build & >= "1.11.1"}
+  "dune" {>= "1.11.1"}
   "ppx_expect" {with-test & >= "0.12.0"}
   "cmdliner"
   "ocaml-migrate-parsetree"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta17"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2"}
+  "js_of_ocaml" {>= "3.2" & < "3.5.0"}
   "js_of_ocaml-ppx"
 ]
 depopts: [ "graphics" "lwt_log" ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta17"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2"}
+  "js_of_ocaml" {>= "3.2" & < "3.5.0"}
   "js_of_ocaml-ppx"
 ]
 depopts: [ "graphics" "lwt_log" ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.3.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.3.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2"}
+  "js_of_ocaml" {>= "3.2" & < "3.5.0"}
   "js_of_ocaml-ppx"
 ]
 depopts: [ "graphics" "lwt_log" ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.4.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.4.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2"}
+  "js_of_ocaml" {>= "3.2" & < "3.5.0"}
   "js_of_ocaml-ppx"
 ]
 depopts: [ "graphics" "lwt_log" ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.0/opam
@@ -15,7 +15,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build & >= "1.11.1"}
+  "dune" {>= "1.11.1"}
   "lwt" {>= "2.4.4"}
   "js_of_ocaml" {>= "3.2"}
   "js_of_ocaml-ppx"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.11.1"}
+  "lwt" {>= "2.4.4"}
+  "js_of_ocaml" {>= "3.2"}
+  "js_of_ocaml-ppx"
+]
+depopts: [ "graphics" "lwt_log" ]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.0/js_of_ocaml-3.5.0.tbz"
+  checksum: [
+    "sha256=c19903c11a7e7657a4bb92de9ad910e6daf5afc9da7222dcd8fe8da8867f05b7"
+    "sha512=3aa852552abe268504f7e26841bd1c43e95dba0a5827f70b97230e900909c3fa94f59715b45ce658f0c2e298a0e89c882a994d5fcc6bcf75250cf0b94733fa88"
+  ]
+}

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.0/opam
@@ -14,6 +14,7 @@ environment like browsers and Node.js
 build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
+  "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11.1"}
   "ocamlbuild"
 ]

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.0/opam
@@ -14,7 +14,7 @@ environment like browsers and Node.js
 build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "dune" {build & >= "1.11.1"}
+  "dune" {>= "1.11.1"}
   "ocamlbuild"
 ]
 url {

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "dune" {build & >= "1.11.1"}
+  "ocamlbuild"
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.0/js_of_ocaml-3.5.0.tbz"
+  checksum: [
+    "sha256=c19903c11a7e7657a4bb92de9ad910e6daf5afc9da7222dcd8fe8da8867f05b7"
+    "sha512=3aa852552abe268504f7e26841bd1c43e95dba0a5827f70b97230e900909c3fa94f59715b45ce658f0c2e298a0e89c882a994d5fcc6bcf75250cf0b94733fa88"
+  ]
+}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.4.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.4.0/opam
@@ -14,7 +14,7 @@ environment like browsers and Node.js
 build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.09.0"}
   "dune" {>= "1.2"}
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.11.1"}
+  "ocaml-migrate-parsetree" {>= "1.4"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "js_of_ocaml" {>= "3.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.0/js_of_ocaml-3.5.0.tbz"
+  checksum: [
+    "sha256=c19903c11a7e7657a4bb92de9ad910e6daf5afc9da7222dcd8fe8da8867f05b7"
+    "sha512=3aa852552abe268504f7e26841bd1c43e95dba0a5827f70b97230e900909c3fa94f59715b45ce658f0c2e298a0e89c882a994d5fcc6bcf75250cf0b94733fa88"
+  ]
+}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.0/opam
@@ -15,7 +15,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build & >= "1.11.1"}
+  "dune" {>= "1.11.1"}
   "ocaml-migrate-parsetree" {>= "1.4"}
   "ppx_tools_versioned" {>= "5.2.3"}
   "js_of_ocaml" {>= "3.0"}

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.0/opam
@@ -15,7 +15,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
   "ocaml" {>= "4.04.1"}
-  "dune" {build & >= "1.11.1"}
+  "dune" {>= "1.11.1"}
   "js_of_ocaml"
   "ocaml-migrate-parsetree"
   "ppxlib" {< "0.9.0"}

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {build & >= "1.11.1"}
+  "js_of_ocaml"
+  "ocaml-migrate-parsetree"
+  "ppxlib" {< "0.9.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.0/js_of_ocaml-3.5.0.tbz"
+  checksum: [
+    "sha256=c19903c11a7e7657a4bb92de9ad910e6daf5afc9da7222dcd8fe8da8867f05b7"
+    "sha512=3aa852552abe268504f7e26841bd1c43e95dba0a5827f70b97230e900909c3fa94f59715b45ce658f0c2e298a0e89c882a994d5fcc6bcf75250cf0b94733fa88"
+  ]
+}

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.4.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.4.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2"}
   "ocamlfind" {>= "1.5.1"}
-  "js_of_ocaml-compiler" {>= "3.4.0"}
+  "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-ppx"
   "js_of_ocaml" {>= "3.0"}
 ]

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.4.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.4.0/opam
@@ -14,7 +14,7 @@ environment like browsers and Node.js
 build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.09.0"}
   "dune" {>= "1.2"}
   "ocamlfind" {>= "1.5.1"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.0/opam
@@ -15,7 +15,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build & >= "1.11.1"}
+  "dune" {>= "1.11.1"}
   "ocamlfind" {>= "1.5.1"}
   "js_of_ocaml-compiler"
   "js_of_ocaml-ppx"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.11.1"}
+  "ocamlfind" {>= "1.5.1"}
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml" {>= "3.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.0/js_of_ocaml-3.5.0.tbz"
+  checksum: [
+    "sha256=c19903c11a7e7657a4bb92de9ad910e6daf5afc9da7222dcd8fe8da8867f05b7"
+    "sha512=3aa852552abe268504f7e26841bd1c43e95dba0a5827f70b97230e900909c3fa94f59715b45ce658f0c2e298a0e89c882a994d5fcc6bcf75250cf0b94733fa88"
+  ]
+}

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.0/opam
@@ -21,9 +21,6 @@ depends: [
   "js_of_ocaml" {>= "3.0"}
   "js_of_ocaml-ppx"
 ]
-conflicts: [
-  "js_of_ocaml"             {<"3.0"}
-]
 url {
   src:
     "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.0/js_of_ocaml-3.5.0.tbz"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.11.1"}
+  "tyxml" {>= "4.3"}
+  "reactiveData" {>= "0.2"}
+  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml-ppx"
+]
+conflicts: [
+  "js_of_ocaml"             {<"3.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.0/js_of_ocaml-3.5.0.tbz"
+  checksum: [
+    "sha256=c19903c11a7e7657a4bb92de9ad910e6daf5afc9da7222dcd8fe8da8867f05b7"
+    "sha512=3aa852552abe268504f7e26841bd1c43e95dba0a5827f70b97230e900909c3fa94f59715b45ce658f0c2e298a0e89c882a994d5fcc6bcf75250cf0b94733fa88"
+  ]
+}

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.0/opam
@@ -15,7 +15,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build & >= "1.11.1"}
+  "dune" {>= "1.11.1"}
   "tyxml" {>= "4.3"}
   "reactiveData" {>= "0.2"}
   "js_of_ocaml" {>= "3.0"}

--- a/packages/js_of_ocaml/js_of_ocaml.3.5.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.5.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+name: "js_of_ocaml"
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build & >= "1.11.1"}
+  "ocaml-migrate-parsetree" {>= "1.4"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "uchar"
+  "js_of_ocaml-compiler"
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.0/js_of_ocaml-3.5.0.tbz"
+  checksum: [
+    "sha256=c19903c11a7e7657a4bb92de9ad910e6daf5afc9da7222dcd8fe8da8867f05b7"
+    "sha512=3aa852552abe268504f7e26841bd1c43e95dba0a5827f70b97230e900909c3fa94f59715b45ce658f0c2e298a0e89c882a994d5fcc6bcf75250cf0b94733fa88"
+  ]
+}

--- a/packages/js_of_ocaml/js_of_ocaml.3.5.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.5.0/opam
@@ -17,7 +17,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build & >= "1.11.1"}
+  "dune" {>= "1.11.1"}
   "ocaml-migrate-parsetree" {>= "1.4"}
   "ppx_tools_versioned" {>= "5.2.3"}
   "uchar"


### PR DESCRIPTION
Compiler from OCaml bytecode to Javascript

- Project page: <a href="http://ocsigen.github.io/js_of_ocaml">http://ocsigen.github.io/js_of_ocaml</a>

##### CHANGES:

## Features/Changes
* Compiler: Improve testing of the compiler (Ty Overby)
* Compiler: Add several macros for making the runtime easier to maintain (ocsigen/js_of_ocaml#771) (Ty Overby)
* Compiler: Allow to emit one javascript per compilation unit (ocsigen/js_of_ocaml#783)
* Compiler: refactoring (ocsigen/js_of_ocaml#781, ocsigen/js_of_ocaml#782, ocsigen/js_of_ocaml#787, ocsigen/js_of_ocaml#795, ocsigen/js_of_ocaml#802)
* Compiler: more source map location for the javascript runtime (ocsigen/js_of_ocaml#795)
* Compiler: tune variable naming (ocsigen/js_of_ocaml#838)
* Compiler: Work around num lib incompatibility
* Compiler: escape '</' in strings (ocsigen/js_of_ocaml#899)
* Compiler: speedup toplevel creation
* Runtime: support sharing when marshaling (ocsigen/js_of_ocaml#814)
* Runtime: add caml_obj_with_tag
* Runtime: support marshaling custom block
* Runtime: complete rewrite of bigarray
* Runtime: complete num implementation
* Runtime: add caml_ba_hash
* Runtime: rewrite polymorphic compare
* Ppx: switch ppx rewriter to the OCaml 4.08 ast
* Misc: Improve CI speed
* Misc: remove ppx_deriving dependency
* Misc: remove cppo dependency
* Misc: remove ppx_tools_versioned dependency in ppx_deriving_json
* Misc: support for ocaml 4.09
* Misc: switch to ocamlformat.0.12
* Misc: many more tests
* Misc: new jsoo_fs tool to embed files in a jsoo pseudo fs.
* Lib: Use expect tests
* Lib: Add support for 'addEventListener' with options (ocsigen/js_of_ocaml#807)
* Lib: Change api of [Lwt_js_events.async] (ocsigen/js_of_ocaml#862)
* Lib: Change api of responseText in xmlhttprequest (ocsigen/js_of_ocaml#863)
* Lib: add resizeObserver bindings
* Lib: Added support for custom events (ocsigen/js_of_ocaml#877)
* Lib: Added support for focus events (ocsigen/js_of_ocaml#885)
* Lib: Added `passive` option support for `Lwt_js_events` module
* Lib: Added bindings for pointer events (ocsigen/js_of_ocaml#894)

## Bug fixes
* Compiler: don't generate source if no-source-map passed (ocsigen/js_of_ocaml#780)
* Compiler: Fix compilation of [Array.set] to return [unit]/0 (ocsigen/js_of_ocaml#792)
* Compiler: Fix assertion failure (ocsigen/js_of_ocaml#828)
* Compiler: Fix compilation of exception handlers (ocsigen/js_of_ocaml#830)
* Compiler: Fix static evaluation of caml_equal (ocsigen/js_of_ocaml#906)
* Misc: Fix install on windows (ocsigen/js_of_ocaml#794)
* Lib: Fix Dom_svg.createForeignObject (ocsigen/js_of_ocaml#756)
* Runtime: Fix caml_obj_tag, causing miscompilation with lazy value (ocsigen/js_of_ocaml#772)
* Runtime: Fix caml_ml_seek_out, caml_ml_pos_out (ocsigen/js_of_ocaml#779) (Shachar Itzhaky)
* Runtime: caml_parse_sign_and_base to support unsigned syntax (ocsigen/js_of_ocaml#792) (Shachar Itzhaky)
* Runtime: fix encoding when printing to stdout (ocsigen/js_of_ocaml#800)
* Runtime: Handle browserfs in fs_node detection logic (ocsigen/js_of_ocaml#831)
* Runtime: fix Obj.tag (ocsigen/js_of_ocaml#832)
* Runtime: fix marshalling of custom blocks (ocsigen/js_of_ocaml#861)
* Runtime: fix frexp
* Runtime: fix float printing with "%f" and large floats
