### PR TITLE
Package choice.0.4

### DIFF
--- a/packages/choice/choice.0.4/opam
+++ b/packages/choice/choice.0.4/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Choice monad, for easy backtracking"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+homepage: "https://github.com/c-cube/choice/"
+bug-reports: "https://github.com/c-cube/choice/issues"
+depends: [
+  "dune" {>= "1.1"}
+  "ocaml" {>= "4.03.0"}
+  "seq"
+  "ounit" {with-test}
+  "gen" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/choice.git"
+url {
+  src: "https://github.com/c-cube/choice/archive/v0.4.tar.gz"
+  checksum: [
+    "md5=90f12307c085deba053997bded3a4b84"
+    "sha512=9078b75ba63ae5afcbea80e7b9838c721b69e95190f787f399e18dfbd39735abdf0c8b22cfae34c6801475f542d530bee5f0665284c4df9a4b14c4fb638a3188"
+  ]
+}


### PR DESCRIPTION
### `choice.0.4`
Choice monad, for easy backtracking



---
* Homepage: https://github.com/c-cube/choice/
* Source repo: git+https://github.com/c-cube/choice.git
* Bug tracker: https://github.com/c-cube/choice/issues

---
:camel: Pull-request generated by opam-publish v2.0.0