### PR TITLE
[new release] dune-build-info, dune, dune-configurator, dune-action-plugin, dune-private-libs and dune-glob (2.0.0+draft2)

### DIFF
--- a/packages/dune-action-plugin/dune-action-plugin.2.0.0+draft2/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.0.0+draft2/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.0"}
   "dune-glob"
-  "ppx_expect" {test}
+  "ppx_expect" {with-test}
   "dune-private-libs" {= version}
 ]
 build: [

--- a/packages/dune-action-plugin/dune-action-plugin.2.0.0+draft2/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.0.0+draft2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-glob"
+  "ppx_expect" {test}
+  "dune-private-libs" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/2.0.0+draft2/dune-2.0.0+draft2.tbz"
+  checksum: [
+    "sha256=a040fe9271d79a0e48832991533785c89199145c524aa1cc6d1952a85a6ef00e"
+    "sha512=bbfc41aed4c880354b47494beb1b134fb33ba817c39c09d8784082654ecf765ea646fa3603192fba62972bd42b1625d81a32dcd636a4a1ab40a6b0ec76fbfc99"
+  ]
+}

--- a/packages/dune-build-info/dune-build-info.2.0.0+draft2/opam
+++ b/packages/dune-build-info/dune-build-info.2.0.0+draft2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Embed build informations inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/2.0.0+draft2/dune-2.0.0+draft2.tbz"
+  checksum: [
+    "sha256=a040fe9271d79a0e48832991533785c89199145c524aa1cc6d1952a85a6ef00e"
+    "sha512=bbfc41aed4c880354b47494beb1b134fb33ba817c39c09d8784082654ecf765ea646fa3603192fba62972bd42b1625d81a32dcd636a4a1ab40a6b0ec76fbfc99"
+  ]
+}

--- a/packages/dune-configurator/dune-configurator.2.0.0+draft2/opam
+++ b/packages/dune-configurator/dune-configurator.2.0.0+draft2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-private-libs" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/2.0.0+draft2/dune-2.0.0+draft2.tbz"
+  checksum: [
+    "sha256=a040fe9271d79a0e48832991533785c89199145c524aa1cc6d1952a85a6ef00e"
+    "sha512=bbfc41aed4c880354b47494beb1b134fb33ba817c39c09d8784082654ecf765ea646fa3603192fba62972bd42b1625d81a32dcd636a4a1ab40a6b0ec76fbfc99"
+  ]
+}

--- a/packages/dune-glob/dune-glob.2.0.0+draft2/opam
+++ b/packages/dune-glob/dune-glob.2.0.0+draft2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-private-libs" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/2.0.0+draft2/dune-2.0.0+draft2.tbz"
+  checksum: [
+    "sha256=a040fe9271d79a0e48832991533785c89199145c524aa1cc6d1952a85a6ef00e"
+    "sha512=bbfc41aed4c880354b47494beb1b134fb33ba817c39c09d8784082654ecf765ea646fa3603192fba62972bd42b1625d81a32dcd636a4a1ab40a6b0ec76fbfc99"
+  ]
+}

--- a/packages/dune-private-libs/dune-private-libs.2.0.0+draft2/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.0.0+draft2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/2.0.0+draft2/dune-2.0.0+draft2.tbz"
+  checksum: [
+    "sha256=a040fe9271d79a0e48832991533785c89199145c524aa1cc6d1952a85a6ef00e"
+    "sha512=bbfc41aed4c880354b47494beb1b134fb33ba817c39c09d8784082654ecf765ea646fa3603192fba62972bd42b1625d81a32dcd636a4a1ab40a6b0ec76fbfc99"
+  ]
+}

--- a/packages/dune/dune.2.0.0+draft2/opam
+++ b/packages/dune/dune.2.0.0+draft2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "ocaml" {>= "4.06"}
+  "base-unix"
+  "base-threads"
+]
+conflicts: [
+  "odoc" {< "1.3.0"}
+  "dune-release" {< "1.3.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/2.0.0%2Bdraft2/dune-2.0.0.draft2.tbz"
+  checksum: [
+    "sha256=a040fe9271d79a0e48832991533785c89199145c524aa1cc6d1952a85a6ef00e"
+    "sha512=bbfc41aed4c880354b47494beb1b134fb33ba817c39c09d8784082654ecf765ea646fa3603192fba62972bd42b1625d81a32dcd636a4a1ab40a6b0ec76fbfc99"
+  ]
+}


### PR DESCRIPTION
Embed build informations inside executable

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- The `action` field in the `alias` stanza is not available starting `lang dune
  2.0`. The `alias` field in the `rule` stanza is a replacement. (ocaml/dune#2846, fixes
  2681, @rgrinberg)

- Introduce `alias` and `package` fields to the `rule` stanza. This is the
  preferred way of attaching rules to aliases. (ocaml/dune#2744, @rgrinberg)

- Add field `(optional)` for executable stanzas (ocaml/dune#2463, fixes ocaml/dune#2433, @bobot)

- Infer targets for rule stanzas expressed in long form (ocaml/dune#2494, fixes ocaml/dune#2469,
  @NathanReb)

- Indicate the progress of the initial file tree loading (ocaml/dune#2459, fixes ocaml/dune#2374,
  @bobot)

- Build `.cm[ox]` files for executables more eagerly. This speeds up builds at
  the cost of building unnecessary artifacts in some cases. Some of these extra
  artifacts can fail to built, so this is a breaking change. (ocaml/dune#2268, @rgrinberg)

- Do not put the `<package>.install` files in the source tree unless `-p` or
  `--promote-install-files` is passed on the command line (ocaml/dune#2329, @diml)

- Change `implicit_transive_deps` to be false. Implicit transitive deps now must
  be manually enabled (ocaml/dune#2306, @rgrinberg)

- Compilation units of user defined executables are now mangled by default. This
  is done to prevent the accidental collision with library dependencies of the
  executable. (ocaml/dune#2364, fixes ocaml/dune#2292, @rgrinberg)

- Enable `(explicit_js_mode)` by default. (ocaml/dune#1941, @nojb)

- Add an option to clear the console in-between builds with
 `--terminal-persistence=clear-on-rebuild`

- Stop symlinking object files to main directory for stanzas defined `jbuild`
  files (ocaml/dune#2440, @rgrinberg)

- Library names are now validated in a strict fashion. Previously, invalid names
  would be allowed for unwrapped libraries (ocaml/dune#2442, @rgrinberg)

- mli only modules must now be explicitly declared. This was previously a
  warning and is now an error. (ocaml/dune#2442, @rgrinberg)

- Modules filtered out from the module list via the Ordered Set Language must
  now be actual modules. (ocaml/dune#2442, @rgrinberg)

- Actions which introduce targets where new targets are forbidden (e.g.
  preprocessing) are now an error instead of a warning. (ocaml/dune#2442, @rgrinberg)

- No longer install a `jbuilder` binary. (ocaml/dune#2441, @diml)

- Stub names are no longer allowed relative paths. This was previously a warning
  and is now an error (ocaml/dune#2443, @rgrinberg).

- Define (paths ...) fields in (context ...) definitions in order to set or
  extend any PATH-like variable in the context environment. (ocaml/dune#2426, @nojb)

- The `diff` action will always normalize newlines before diffing. Perviousy, it
  would not do this normalization for rules defined in jbuild files. (ocaml/dune#2457,
  @rgrinberg)

- Modules may no longer belong to more than one stanza. This was previously
  allowed only in stanzas defined in `jbuild` files. (ocaml/dune#2458, @rgrinberg)

- Remove support for `jbuild-ignore` files. They have been replaced by the the
  `dirs` stanza in `dune` files. (ocaml/dune#2456, @rgrinberg)

- Add a new config option `sandboxing_preference`, the cli argument `--sandbox`,
  and the dep spec `sandbox` in dune language. These let the user control the level of
  sandboxing done by dune per rule and globally. The rule specification takes precedence.
  The global configuration merely specifies the default.
  (ocaml/dune#2213, @aalekseyev, @diml)

- Remove support for old style subsystems. Dune will now emit a warning to
  reinstall the library with the old style subsystem. (ocaml/dune#2480, @rgrinberg)

- Add action (with-stdin-from <file> <action>) to redirect input from <file>
  when performing <action>. (ocaml/dune#2487, @nojb)

- Change the automatically generated odoc index to only list public modules.
  This only affects unwrapped libraries (ocaml/dune#2479, @rgrinberg)

- Set up formatting rules by default. They can be configured through a new
  `(formatting)` stanza in `dune-project` (ocaml/dune#2347, fixes ocaml/dune#2315, @emillon)

- Change default target from `@install` to `@all`. (ocaml/dune#2449, fixes ocaml/dune#1220,
  @rgrinberg)

- Include building stubs in `@check` rules. (@rgrinberg, ocaml/dune#2530)

- Get rid of ad-hoc rules for guessing the version. Dune now only
  relies on the version written in the `dune-project` file and no
  longer read `VERSION` or similar files (ocaml/dune#2541, @diml)

- In `(diff? x y)` action, require `x` to exist and register a
  dependency on that file. (ocaml/dune#2486, @aalekseyev)

- On Windows, an .exe suffix is no longer added implicitly to binary names that
  already end in .exe. Second, when resolving binary names, .opt variants are no
  longer chosen automatically. (ocaml/dune#2543, @nojb)

- Make `(diff? x y)` move the correction file (`y`) away from the build
  directory to promotion staging area. This makes corrections work with
  sandboxing and in general reduces build directory pollution. (ocaml/dune#2486,
  @aalekseyev, fixes ocaml/dune#2482)

- `c_flags`, `c_names` and `cxx_names` are now supported in `executable`
  and `executables` stanzas. (ocaml/dune#2562, @nojb)
  Note: this feature has been subsequently extended into a separate
  `foreign_stubs` field. (ocaml/dune#2659, RFC ocaml/dune#2650, @snowleopard)

- Remove git integration from `$ dune upgrade` (ocaml/dune#2565, @rgrinberg)

- Add a `--disable-promotion` to disable all modification to the source
  directory. There's also a corresponding `DUNE_DISABLE_PROMOTION` environment
  variable. (ocaml/dune#2588, fix ocaml/dune#2568, @rgrinberg)

- Add a `forbidden_libraries` field to prevent some library from being
  linked in an executable. This help detecting who accidently pulls in
  `unix` for instance (ocaml/dune#2570, @diml)

- Fix incorrect error message when a variable is expanded in static context:
  `%{lib:lib:..}` when the library does not exist. (ocaml/dune#2597, fix ocaml/dune#1541,
  @rgrinberg)

- Add `--sections` option to `$ dune install` to install subsections of .install
  files. This is useful for installing only the binaries in a workspace for
  example. (ocaml/dune#2609, fixes ocaml/dune#2554, @rgrinberg)

- Drop support for `jbuild` and `jbuild-ignore` files (ocaml/dune#2607, @diml)

- Add a `dune-action-plugin` library for describing dependencies direcly in
  the executable source. Programs that use this feature can be run by a new
  action (dynamic-run <progn> ...). (ocaml/dune#2635, @staronj, @aalekseyev)

- Stop installing the `ocaml-syntax-shims` binary. In order to use
  `future_syntax`, one now need to depend on the `ocaml-syntax-shims`
  package (ocaml/dune#2654, @diml)

- Add support for dependencies that are re-exported. Such dependencies
  are marked with`re_export` and will automatically be provided to
  users of a library (ocaml/dune#2605, @rgrinberg)

- Add a `deprecated_library_name` stanza to redirect old names after a
  library has been renamed (ocaml/dune#2528, @diml)

- Error out when a `preprocessor_deps` field is present but not
  `preprocess` field is. It is a warning with Dune 1.x projects
  (ocaml/dune#2660, @Julow)

- Dune will use `-output-complete-exe` instead of `-custom` when compiling
  self-contained bytecode executables whenever this options is available
  (OCaml version >= 4.10) (ocaml/dune#2692, @nojb)

- Add action `(with-accepted-exit-codes <pred> <action>)` to specify the set of
  successful exit codes of `<action>`. `<pred>` is specified using the predicate
  language. (ocaml/dune#2699, @nojb)

- Do not setup rules for disabled libraries (ocaml/dune#2491, fixes ocaml/dune#2272, @bobot)

- Configurator: filter out empty flags from `pkg-config` (ocaml/dune#2716, @AltGr)

- `no_keep_locs` is a no-op for projects that use `lang dune` older than 2.0. In
  projects where the language is at least `2.0`, the field is now forbidden.
  (ocaml/dune#2752, fixes ocaml/dune#2747, @rgrinberg)

- Extend support for foreign sources and archives via the `(foreign_library ...)`
  stanza as well as the `(foreign_stubs ...)` and `(foreign_archives ...)` fields.
  (ocaml/dune#2659, RFC ocaml/dune#2650, @snowleopard)

- Add (deprecated_package_names) field to (package) declaration in
  dune-project. The names declared here can be used in the (old_public_name)
  field of (deprecated_library_name) stanza. These names are interpreted as
  library names (not prefixed by a package name) and appropiate redirections are
  setup in their META files. This feaure is meant to migrate old libraries which
  do not follow Dune's convention of prefixing libraries with the package
  name. (ocaml/dune#2696, @nojb)

- The fields `license`, `authors`, `maintainers`, `source`, `bug_reports`,
  `homepage`, and `documentation` of `dune-project` can now be overriden on a
  per-package basis. (ocaml/dune#2774, @nojb)

- Change the default `modes` field of executables to `(mode exe)`. If
  one wants to build a bytecode program, it now needs to be explicitly
  requested via `(modes byte exe)`. (ocaml/dune#2851, @diml)

- Allow `ccomp_type` as a variable for evaluating `enabled_if`. (ocaml/dune#2855, @dra27,
  @rgrinberg)

- Stricter validation of file names in `select`. The file names of conditional
  sources must match the prefix and the extension of the resultant filename.
  (ocaml/dune#2867, @rgrinberg)

- Add flag `disable_dynamically_linked_foreign_archives` to the workspace file.
  If the flag is set to `true` then: (i) when installing libraries, we do not
  install dynamic foreign archives `dll*.so`; (ii) when building executables in
  the `byte` mode, we statically link in foreign archives into the runtime
  system; (iii) we do not generate any `dll*.so` rules. (ocaml/dune#2864, @snowleopard)

- Reimplement the bootstrap procedure. The new procedure is faster and
  should no longer stack overflow (ocaml/dune#2854, @dra27, @diml)
