### PR TITLE
Add new package mlfenv

### DIFF
--- a/packages/mlfenv/mlfenv.1.0.0/opam
+++ b/packages/mlfenv/mlfenv.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name:         "mlfenv"
+version:      "1.0.0"
+maintainer:   "Laurent Thévenoux <lrnt@thvnx.com>"
+authors:      "Laurent Thévenoux <lrnt@thvnx.com>"
+homepage:     "https://github.com/thvnx/mlfenv"
+bug-reports:  "https://github.com/thvnx/mlfenv/issues"
+license:      "LGPL-3.0"
+dev-repo:     "git+https://github.com/thvnx/mlfenv.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.11.0"}
+]
+synopsis: "OCaml C bindings for fenv(3)"
+url {
+  src: "https://github.com/thvnx/mlfenv/archive/mlfenv.1.0.0.tar.gz"
+  checksum: "md5=ce6c1145fb0f91cee9b41685611de3d1"
+}
+description: """
+The package provides bindings for fenv(3).
+
+The Fenv module aims to bind fenv(3) functions for floating-point
+rounding and exception handling. At this point, only bindings for
+fegetround and fesetround are implemented. Please, create an issue if
+you need more support to fenv functions."""


### PR DESCRIPTION
The Fenv module aims to bind fenv(3) functions for floating-point
rounding and exception handling. At this point, only bindings for
fegetround and fesetround are implemented.