### PR TITLE
Package eliom.6.9.1

### DIFF
--- a/packages/eliom/eliom.6.9.1/opam
+++ b/packages/eliom/eliom.6.9.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: "Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppx_tools" {>= "0.99.3"}
+  "js_of_ocaml" {>= "3.3" & < "3.5"}
+  "js_of_ocaml-lwt" {>= "3.3" & < "3.5"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx" {>= "3.3" & < "3.5"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.3" & < "3.5"}
+  "js_of_ocaml-tyxml" {>= "3.3" & < "3.5"}
+  "lwt_log"
+  "lwt_ppx"
+  "tyxml" {>= "4.3.0"}
+  "ocsigenserver" {>= "2.10"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+]
+url {
+  src: "https://github.com/jrochel/eliom/archive/6.9.1.tar.gz"
+  checksum: [
+    "md5=330e932ac2fd1db1778df6a6363c2c20"
+    "sha512=b6d69ac433a3762f7fa6450cda8250eb828f544368d596aed8348c430f9104a60d47321c527d4ec0c56a72fa99d9e9b548726080e8737fe60c0bec88fb090fbd"
+  ]
+}

--- a/packages/eliom/eliom.6.9.1/opam
+++ b/packages/eliom/eliom.6.9.1/opam
@@ -29,7 +29,7 @@ depends: [
   "base-bytes"
 ]
 url {
-  src: "https://github.com/jrochel/eliom/archive/6.9.1.tar.gz"
+  src: "https://github.com/ocsigen/eliom/archive/6.9.1.tar.gz"
   checksum: [
     "md5=330e932ac2fd1db1778df6a6363c2c20"
     "sha512=b6d69ac433a3762f7fa6450cda8250eb828f544368d596aed8348c430f9104a60d47321c527d4ec0c56a72fa99d9e9b548726080e8737fe60c0bec88fb090fbd"


### PR DESCRIPTION
### `eliom.6.9.1`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0