### PR TITLE
New version of ACGtk

### DIFF
--- a/packages/acgtk/acgtk.1.5.1/opam
+++ b/packages/acgtk/acgtk.1.5.1/opam
@@ -12,7 +12,7 @@ build: [
 install: ["dune" "install"]
 
 depends: [
-  "ocaml" { >= "4.03.0"}
+  "ocaml" { >= "4.05.0"}
   "dune" {build}
   "menhir"
   "ANSITerminal"
@@ -38,5 +38,5 @@ description: "This toolkit provides a compiler and an interpreter for Abstract C
 
 url {
      src: "http://acg.loria.fr/software/acg-1.5.1-20191113.tar.gz"
-     checksum: "2ca67ad457bdfd036e942caf6d85164c"
+     checksum: "6d770c390d2b7870c4261dc2d1772696"
 }

--- a/packages/acgtk/acgtk.1.5.1/opam
+++ b/packages/acgtk/acgtk.1.5.1/opam
@@ -13,7 +13,7 @@ install: ["dune" "install"]
 
 depends: [
   "ocaml" { >= "4.05.0"}
-  "dune" {build}
+  "dune" {>= "1.1"}
   "menhir"
   "ANSITerminal"
   "fmt"

--- a/packages/acgtk/acgtk.1.5.1/opam
+++ b/packages/acgtk/acgtk.1.5.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "sylvain.pogodalla@inria.fr"
+
+build: [
+  ["dune" "subst"] {pinned}
+# remove the -p to also build the local libraries: conflict with the
+# fact that some libraries are also part of the acgtkLib package
+#  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-j" jobs]
+]
+
+install: ["dune" "install"]
+
+depends: [
+  "ocaml" { >= "4.03.0"}
+  "dune" {build}
+  "menhir"
+  "ANSITerminal"
+  "fmt"
+  "logs"
+  "mtime"
+  "cmdliner"
+  "cairo2"
+  "yojson"
+  "easy-format"
+]
+
+dev-repo: "git+https://gitlab.inria.fr/ACG/dev/ACGtk.git"
+
+homepage: "http://acg.loria.fr/"
+license: "CeCILL-1.0+"
+authors: ["Sylvain Pogodalla"]
+bug-reports: "sylvain.pogodalla@inria.fr"
+
+synopsis: "Abstract Categorial Grammar development toolkit"
+
+description: "This toolkit provides a compiler and an interpreter for Abstract Categorial Grammars (ACGs). Grammars can be compiled and then used by the interpreter to parse (if the grammar is at most second-order) or to generate terms. See http://acg.loria.fr for more details and bibliographic references."
+
+url {
+     src: "http://acg.loria.fr/software/acg-1.5.1-20191113.tar.gz"
+     checksum: "2ca67ad457bdfd036e942caf6d85164c"
+}

--- a/packages/acgtk/acgtk.1.5.1/opam
+++ b/packages/acgtk/acgtk.1.5.1/opam
@@ -38,5 +38,5 @@ description: "This toolkit provides a compiler and an interpreter for Abstract C
 
 url {
      src: "http://acg.loria.fr/software/acg-1.5.1-20191113.tar.gz"
-     checksum: "f813f0ba2d4403667da4ac302af52990"
+     checksum: "md5=f813f0ba2d4403667da4ac302af52990"
 }

--- a/packages/acgtk/acgtk.1.5.1/opam
+++ b/packages/acgtk/acgtk.1.5.1/opam
@@ -38,5 +38,5 @@ description: "This toolkit provides a compiler and an interpreter for Abstract C
 
 url {
      src: "http://acg.loria.fr/software/acg-1.5.1-20191113.tar.gz"
-     checksum: "6d770c390d2b7870c4261dc2d1772696"
+     checksum: "f813f0ba2d4403667da4ac302af52990"
 }


### PR DESCRIPTION
This new version removes dependency to ocf (which currently does not compile with 4.08). Also introduces using cmdliner to handle command line arguments.