### PR TITLE
[new release] ocaml-migrate-parsetree (1.4.0)

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.4.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.4.0/opam
@@ -4,7 +4,7 @@ authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
   "Jérémie Dimino <jeremie@dimino.org>"
 ]
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1 with OCaml linking exception"
 homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
 bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
@@ -16,7 +16,7 @@ build: [
 depends: [
   "result"
   "ppx_derivers"
-  "dune" {>= "1.9.0"}
+  "dune" {build & >= "1.9.0"}
   "ocaml" {>= "4.02.3"}
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
@@ -31,7 +31,7 @@ url {
   src:
     "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.4.0/ocaml-migrate-parsetree-v1.4.0.tbz"
   checksum: [
-    "sha256=231fbdc205187b3ee266b535d9cfe44b599067b2f6e97883c782ea7bb577d3b8"
-    "sha512=61ee91d2d146cc2d2ff2d5dc4ef5dea4dc4d3c8dbd8b4c9586d64b6ad7302327ab35547aa0a5b0103c3f07b66b13d416a1bee6d4d117293cd3cabe44113ec6d4"
+    "sha256=dcd77cd7090ce181a87df08a910ab2935da466f37db8e674e5a966d49743de64"
+    "sha512=659d6429a6817a867eab28a1fac03a47fdcd9cf8c0861046580013406dec98a8380405785312c3ebb4dc115250aba70c17ce275813083a213dd6577105ea0ba2"
   ]
 }


### PR DESCRIPTION
Convert OCaml parsetrees between different versions

- Project page: <a href="https://github.com/ocaml-ppx/ocaml-migrate-parsetree">https://github.com/ocaml-ppx/ocaml-migrate-parsetree</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ocaml-migrate-parsetree/">https://ocaml-ppx.github.io/ocaml-migrate-parsetree/</a>

##### CHANGES:

- Add support for 4.10 (ocaml-ppx/ocaml-migrate-parsetree#86, @diml)
