### PR TITLE
Fix dune 2.0's revdeps

### DIFF
--- a/packages/fluent-logger/fluent-logger.1.1.0/opam
+++ b/packages/fluent-logger/fluent-logger.1.1.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-    "dune"
+    "dune" {< "2.0"}
     "msgpack"
     "extlib"
     "ounit" {with-test}

--- a/packages/lz4_chans/lz4_chans.3.0.0/opam
+++ b/packages/lz4_chans/lz4_chans.3.0.0/opam
@@ -9,7 +9,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 # the tests don't pass on OCaml 4.03.0, because of a marshalling behavior
 # that was working before 4.03.0 and put back in place after 4.03.0
-  ["dune" "exec" "-p" name "src/test.exe"] {with-test & ocaml:version != "4.03.0"}
+  ["dune" "exec" "-p" name "src/test.exe"] {with-test & ocaml:version != "4.03.0" & dune:version < "2.0"}
 ]
 depends: [
   "ocaml"

--- a/packages/minicli/minicli.5.0.0/opam
+++ b/packages/minicli/minicli.5.0.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune"
+  "dune" {< "2.0"}
 ]
 synopsis: "Minimalist library for command line parsing"
 description: """

--- a/packages/minicli/minicli.5.0.1/opam
+++ b/packages/minicli/minicli.5.0.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune"
+  "dune" {< "2.0"}
 ]
 synopsis: "Minimalist library for command line parsing"
 description: """

--- a/packages/parany/parany.5.0.0/opam
+++ b/packages/parany/parany.5.0.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/UnixJunkie/parany/issues"
 dev-repo: "git+https://github.com/UnixJunkie/parany.git"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {< "2.0"}
   "base-unix"
   "ocamlnet"
 ]

--- a/packages/parany/parany.5.0.1/opam
+++ b/packages/parany/parany.5.0.1/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/UnixJunkie/parany/issues"
 dev-repo: "git+https://github.com/UnixJunkie/parany.git"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {< "2.0"}
   "base-unix"
   "ocamlnet"
 ]

--- a/packages/parany/parany.6.0.0/opam
+++ b/packages/parany/parany.6.0.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/UnixJunkie/parany/issues"
 dev-repo: "git+https://github.com/UnixJunkie/parany.git"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {< "2.0"}
   "base-unix"
   "ocamlnet"
 ]


### PR DESCRIPTION
Broken packages with dune 2.0 discovered in https://github.com/ocaml/opam-repository/pull/15261

cc @rgrinberg 

* cc @UnixJunkie for `minicli` and `lz4_chans`
* cc @komamitsu for `fluent-logger`

Reasons for each fixes are noted in the commit message. More details here: https://github.com/ocaml/opam-repository/pull/15261#issuecomment-553979070