### PR TITLE
BAP 2.0.0 release

### DIFF
--- a/packages/bap-abi/bap-abi.2.0.0/opam
+++ b/packages/bap-abi/bap-abi.2.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "bap-abi"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-abi"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-abi"]
+         ["ocamlfind" "remove" "bap-abi"]
+         ["bapbundle" "remove" "abi.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+]
+synopsis: "BAP ABI integration subsystem"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-api/bap-api.2.0.0/opam
+++ b/packages/bap-api/bap-api.2.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "bap-api"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-api"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-api"]
+         ["ocamlfind" "remove" "bap-api"]
+         ["bapbundle" "remove" "api.plugin"]
+         ["rm" "-rf" "%{prefix}%/share/bap-api/c"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+]
+synopsis: "A pass that adds parameters to subroutines based on known API"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-arm/bap-arm.2.0.0/opam
+++ b/packages/bap-arm/bap-arm.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-arm"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-arm"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-arm"]
+        ["ocamlfind" "remove" "bap-plugin-arm"]
+        ["bapbundle"   "remove" "arm.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-llvm"
+  "bap-abi"
+  "bap-c"
+]
+synopsis: "BAP ARM lifter and disassembler"
+description: """
+Provides semantics for ARM instructions, disassembler, and partial
+support for the gnueabi ABI"""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-beagle/bap-beagle.2.0.0/opam
+++ b/packages/bap-beagle/bap-beagle.2.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name: "bap-beagle"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-beagle"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-beagle"]
+         ["ocamlfind" "remove" "bap-beagle-prey"]
+         ["ocamlfind" "remove" "bap-plugin-strings"]
+         ["bapbundle" "remove" "beagle.plugin"]
+         ["bapbundle" "remove" "strings.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+  "bap-microx"
+  "bap-primus" {= "2.0.0"}
+]
+synopsis: "BAP obfuscated string solver"
+description: """
+Like strings on steroids - finds strings encoded in binaries,
+even if they are not truly static."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-bil/bap-bil.2.0.0/opam
+++ b/packages/bap-bil/bap-bil.2.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "bap-std" {= "2.0.0"}
   "cmdliner"
 ]
-synopsis: "Controls the BIL transformation pipeline"
+synopsis: "Denotes semantics of programs in terms of BIL"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
   checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"

--- a/packages/bap-bil/bap-bil.2.0.0/opam
+++ b/packages/bap-bil/bap-bil.2.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "bap-bil"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bil"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-bil"]
+         ["bapbundle" "remove" "bil.plugin"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+]
+synopsis: "Controls the BIL transformation pipeline"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-build/bap-build.2.0.0/opam
+++ b/packages/bap-build/bap-build.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-build"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-build"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap-build"]
+  ["rm" "-f" "%{bin}%/bapbuild"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "ocamlbuild"
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ppx_jane"
+]
+
+synopsis: "BAP build automation tools"
+
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-bundle/bap-bundle.2.0.0/opam
+++ b/packages/bap-bundle/bap-bundle.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "bap-bundle"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bundle"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-bundle"]
+         ["rm" "-f" "%{bin}%/bapbundle"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "uri"
+  "camlzip"
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ppx_jane"
+  "fileutils"
+]
+synopsis: "BAP bundler"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.2.0.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-byteweight-frontend"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-byteweight-frontend"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-byteweight"
+  "cmdliner"
+  "ocurl"
+  "fileutils"
+  "re"
+]
+synopsis: "BAP Toolkit for training and controlling Byteweight algorithm"
+description: """
+A command line interface to the byteweight system that can train,
+test, download, and upload binary signatures."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-byteweight/bap-byteweight.2.0.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-byteweight"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-byteweight"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-byteweight"]
+        ["ocamlfind" "remove" "bap-plugin-byteweight"]
+        [ "bapbundle" "remove" "byteweight.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-signatures"
+]
+synopsis: "BAP facility for indentifying code entry points"
+description: """
+Provides a library and a plugin that uses the Byteweigh algorithm for
+finding entry points (function strats) in stripped code."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-c/bap-c.2.0.0/opam
+++ b/packages/bap-c/bap-c.2.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "bap-c"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-c"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-c"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-api"
+]
+synopsis: "A C language support library for BAP"
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-cache/bap-cache.2.0.0/opam
+++ b/packages/bap-cache/bap-cache.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-cache"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-cache"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-cache"]
+        [ "bapbundle" "remove" "cache.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+]
+synopsis: "BAP caching service"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-callsites/bap-callsites.2.0.0/opam
+++ b/packages/bap-callsites/bap-callsites.2.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "bap-callsites"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-callsites"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-callsites"]
+        [ "bapbundle" "remove" "callsites.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+]
+synopsis: "Inject data definition terms at callsites"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-constant-tracker/bap-constant-tracker.2.0.0/opam
+++ b/packages/bap-constant-tracker/bap-constant-tracker.2.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "bap-constant-tracker"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-constant-tracker"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-costant_tracker"]
+         ["bapbundle" "remove" "constant_tracker.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-primus" {= "2.0.0"}
+]
+synopsis: "Constant Tracking Analysis based on Primus"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-core-theory/bap-core-theory.2.0.0/opam
+++ b/packages/bap-core-theory/bap-core-theory.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-core-theory"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-core-theory"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-core-theory"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-knowledge" {= "2.0.0"}
+  "bitvec" {= "2.0.0"}
+  "bitvec-binprot" {= "2.0.0"}
+  "bitvec-order" {= "2.0.0"}
+  "bitvec-sexp" {= "2.0.0"}
+]
+synopsis: "BAP Semantics Representation"
+description: """
+The Core Theory is an intermediate language that is designed to
+express the semantics of computer programs. It focuses on programs
+that are represented in binary machine code and is capable of an
+accurate representation of the architectural and micro-architectural
+details of the program behavior.
+"""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-cxxfilt/bap-cxxfilt.2.0.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-cxxfilt"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-cxxfilt"
+                 "--cxxfilt-targets=%{conf-binutils:targets}%"
+                 "--cxxfilt-path=%{conf-binutils:cxxfilt}%"
+                 ]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-cxxfilt"]
+        ["bapbundle" "remove" "cxxfilt.plugin"]
+]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-demangle"
+  "conf-binutils" {>= "0.2"}
+]
+synopsis: "A demangler that relies on a c++filt utility"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-demangle/bap-demangle.2.0.0/opam
+++ b/packages/bap-demangle/bap-demangle.2.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "bap-demangle"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-demangle"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-demangle"]
+        ["ocamlfind" "remove" "bap-plugin-demangle"]
+        ["bapbundle"   "remove" "demangle.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+]
+synopsis: "Library for name demangling"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-disassemble/bap-disassemble.2.0.0/opam
+++ b/packages/bap-disassemble/bap-disassemble.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "bap-disassemble"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-disassemble"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-disassemble"]
+         ["bapbundle" "remove" "disassemble.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+]
+synopsis: "Implements the BAP disassemble command"
+description: """
+Disassembles and analyzes the input file. This is the default
+command of the BAP frontend which is assumed when no other command
+was specified.
+"""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-dump-symbols/bap-dump-symbols.2.0.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "bap-dump-symbols"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-dump-symbols"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-dump_symbols"]
+        ["bapbundle" "remove" "dump_symbols.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+]
+synopsis: "BAP plugin that dumps symbols information from a binary"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-dwarf/bap-dwarf.2.0.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.2.0.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+name: "bap-dwarf"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-dwarf"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-dwarf"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+]
+synopsis: "BAP DWARF parsing library"
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-elementary/bap-elementary.2.0.0/opam
+++ b/packages/bap-elementary/bap-elementary.2.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "bap-elementary"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-elementary"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-elementary"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-core-theory" {= "2.0.0"}
+]
+synopsis: "BAP floating point approximations of elementary functions"
+description:
+"""
+Library provides few primitives for approximations of floating
+point operations via table methods.
+"""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-elf/bap-elf.2.0.0/opam
+++ b/packages/bap-elf/bap-elf.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-elf"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-elf"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-elf"]
+        ["ocamlfind" "remove" "bap-plugin-elf_loader"]
+        ["bapbundle" "remove" "elf_loader.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-dwarf"
+  "bitstring" {>= "3.0.0"}
+]
+synopsis: "BAP ELF parser and loader written in native OCaml"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-frontc/bap-frontc.2.0.0/opam
+++ b/packages/bap-frontc/bap-frontc.2.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+name: "bap-frontc"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-frontc-parser"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
+        ["bapbundle" "remove" "frontc_parser.plugin"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-c"
+  "FrontC"
+]
+synopsis: "A C language frontend for based on FrontC library"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-frontend/bap-frontend.2.0.0/opam
+++ b/packages/bap-frontend/bap-frontend.2.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name: "bap-frontend"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-frontend"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["rm" "-f" "%{bin}%/bap"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+  "parsexp" {>= "v0.11" & < "v0.12"}
+]
+synopsis: "BAP frontend"
+description: "The command-line interface to the Binary Analysis Platform."
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-future/bap-future.2.0.0/opam
+++ b/packages/bap-future/bap-future.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-future"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-future"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-future"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+  "monads"
+]
+synopsis: "A library for asynchronous values"
+description: """
+A library for reasoning about state based dynamic systems. This can
+be seen as a common denominator between Lwt and Async libraries."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-ida-plugin/bap-ida-plugin.2.0.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.2.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "bap-ida-plugin"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-ida-plugin"]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-emit_ida_script"]
+        [ "bapbundle" "remove" "emit_ida_script.plugin"]
+
+]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap"
+  "cmdliner"
+]
+synopsis: "Plugins for IDA and BAP integration"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-ida-python/bap-ida-python.2.0.0/files/bap.cfg.in
+++ b/packages/bap-ida-python/bap-ida-python.2.0.0/files/bap.cfg.in
@@ -1,0 +1,2 @@
+.default
+bap_executable_path    %{bap:bin}%/bap

--- a/packages/bap-ida-python/bap-ida-python.2.0.0/opam
+++ b/packages/bap-ida-python/bap-ida-python.2.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+name: "bap-ida-python"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-ida-python/"
+license: "MIT"
+substs: [
+    "bap.cfg"
+]
+install: [
+    ["mkdir" "-p" "%{prefix}%/share/%{name}%/"]
+    ["cp" "-v"  "plugins/plugin_loader_bap.py" "%{prefix}%/share/%{name}%/"]
+    ["cp" "-rv" "plugins/bap" "%{prefix}%/share/%{name}%/"]
+    ["cp" "-v"  "bap.cfg" "%{prefix}%/share/%{name}%/"]
+]
+remove: [
+    ["rm" "-rf" "%{prefix}%/share/%{name}%/"]
+]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap" {= "2.0.0"}
+  "conf-ida"
+]
+synopsis: "A BAP - IDA Pro integration library"
+flags: light-uninstall
+extra-files: ["bap.cfg.in" "md5=aec3a830555380469b523da74daef069"]
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/archive/v2.0.0.tar.gz"
+  checksum: "md5=9eaa4c1ecbb0c112816dd8083e388fd8"
+}
+
+post-messages: [
+  "In order to install bap-ida-python plugin:
+
+   rm -rf %{conf-ida:path}%/plugins/bap/
+   cp %{prefix}%/share/%{name}%/plugin_loader_bap.py %{conf-ida:path}%/plugins/
+   cp -r %{prefix}%/share/%{name}%/bap %{conf-ida:path}%/plugins/
+   cp %{prefix}%/share/%{name}%/bap.cfg %{conf-ida:path}%/cfg/
+ "
+]

--- a/packages/bap-ida/bap-ida.2.0.0/opam
+++ b/packages/bap-ida/bap-ida.2.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name: "bap-ida"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+     "--prefix=%{prefix}%"
+     "--enable-ida"
+     "--ida-path=%{conf-ida:path}%"
+     "--ida-headless=%{conf-ida:headless}%"
+]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-ida"]
+        ["ocamlfind" "remove" "bap-plugin-ida"]
+        ["bapbundle" "remove" "ida.plugin"]
+]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "conf-ida"
+  "bap-ida-python" {>= "1.5.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+  "fileutils"
+  "re"
+  "bap-ida-plugin"
+]
+synopsis: "An IDA Pro integration library"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-knowledge/bap-knowledge.2.0.0/opam
+++ b/packages/bap-knowledge/bap-knowledge.2.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name: "bap-knowledge"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-knowledge"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "knowledge"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "monads"
+]
+synopsis: "Knowledge Representation Library"
+description: """
+The library provides facilities for storing, accumulating, and
+computing knowledge. The knowledge could be represented indirectly,
+in the Knowledge Base, or directly as knowledge values. The
+library focuses on representing knowledge that is partial and
+provides mechanisms for knowledge accumulation and
+refinement. The knowledge representation library leverages the
+powerful type system of the OCaml language to facilitate
+development of complex knowledge representation and reasoning systems.
+"""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-llvm/bap-llvm.2.0.0/files/detect.travis
+++ b/packages/bap-llvm/bap-llvm.2.0.0/files/detect.travis
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cat > bap-llvm.config <<EOF
+ travis : ${TRAVIS:-false}
+EOF

--- a/packages/bap-llvm/bap-llvm.2.0.0/opam
+++ b/packages/bap-llvm/bap-llvm.2.0.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+name: "bap-llvm"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+  "--prefix=%{prefix}%"
+  "--with-cxx=`which clang++`"
+  "--with-llvm-version=%{conf-bap-llvm:package-version}%"
+  "--with-llvm-config=%{conf-bap-llvm:config}%"
+  "--enable-llvm"]
+  [make]
+  ]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap-plugin-llvm"]
+  ["ocamlfind" "remove" "bap-llvm"]
+  ["bapbundle" "remove" "llvm.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+  "conf-env-travis"
+  "conf-bap-llvm" {>= "1.1"}
+  "ogre"
+  "monads"
+]
+depexts: [
+  ["clang"] {os-distribution = "ubuntu"}
+  ["clang"] {os-distribution = "debian"}
+  ["clang"] {os-distribution = "alpine"}
+]
+synopsis: "BAP LLVM backend"
+description:
+  "Provides a loader and a disassembler, based on LLVM-MC library."
+extra-files: ["detect.travis" "md5=00e7b28719062d550dcd7813becf7396"]
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-main/bap-main.2.0.0/opam
+++ b/packages/bap-main/bap-main.2.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "bap-plugins" {= "2.0.0"}
   "bap-recipe"  {= "2.0.0"}
 ]
-synopsis: "Build BAP Main Framework Configuration Library"
+synopsis: "The BAP entry point"
 description:
 """
 This library is an entry point to BAP and serves the two goals:

--- a/packages/bap-main/bap-main.2.0.0/opam
+++ b/packages/bap-main/bap-main.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-main"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-main"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-main"] ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "base"
+  "stdio"
+  "cmdliner"
+  "bap-build"   {= "2.0.0"}
+  "bap-future"  {= "2.0.0"}
+  "bap-plugins" {= "2.0.0"}
+  "bap-recipe"  {= "2.0.0"}
+]
+synopsis: "Build BAP Main Framework Configuration Library"
+description:
+"""
+This library is an entry point to BAP and serves the two goals:
+- embedding BAP in other applications;
+- extending BAP with the user code.
+"""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-mc/bap-mc.2.0.0/opam
+++ b/packages/bap-mc/bap-mc.2.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+name: "bap-mc"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-mc"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap-plugin-mc"]
+  ["bapbundle" "remove" "mc.plugin"]
+  ["rm" "-f" "%{bin}%/bap-mc"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "bap-std" {= "2.0.0"}
+  "bap-main" {= "2.0.0"}
+]
+synopsis: "BAP machine instruction playground"
+description: "A BAP version of llvm-mc tool."
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-microx/bap-microx.2.0.0/opam
+++ b/packages/bap-microx/bap-microx.2.0.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+name: "bap-microx"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-microx"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-microx"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+]
+synopsis: "A micro execution framework"
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-mips/bap-mips.2.0.0/opam
+++ b/packages/bap-mips/bap-mips.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "bap-mips"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-mips"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-mips"]
+         ["bapbundle" "remove" "mips.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-abi"
+  "bap-c"
+]
+synopsis: "BAP MIPS lifter"
+description: "Provides lifter for MIPS and MIPS32 architectures"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-objdump/bap-objdump.2.0.0/opam
+++ b/packages/bap-objdump/bap-objdump.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-objdump"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-objdump"
+                 "--objdump-targets=%{conf-binutils:targets}%"
+                 "--objdump-path=%{conf-binutils:objdump}%"
+                 ]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
+	 ["bapbundle" "remove" "objdump.plugin"]
+]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "re"
+  "cmdliner"
+  "conf-binutils"
+]
+synopsis: "Extract symbols from binary, using binutils objdump"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-optimization/bap-optimization.2.0.0/opam
+++ b/packages/bap-optimization/bap-optimization.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-optimization"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-optimization"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-optimization"]
+         ["bapbundle" "remove" "optimization.plugin"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+]
+synopsis: "A BAP plugin that removes dead IR code"
+description: """
+A pass that conservatively removes dead code in the generated IR. The
+removed dead code is usually produced by a lifter, though it might be
+possible that a binary indeed contains a dead code. The algorithm
+doesn't remove variables that are stored in memory, only registers are
+considered."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-phoenix/bap-phoenix.2.0.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.2.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+name: "bap-phoenix"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-phoenix"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-phoenix"]
+        ["bapbundle" "remove" "phoenix.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+  "text-tags"
+  "ocamlgraph"
+  "ezjsonm"
+]
+synopsis: "BAP plugin that dumps information in a phoenix decompiler format"
+description: "Useful for visualization and project exploration"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-piqi/bap-piqi.2.0.0/opam
+++ b/packages/bap-piqi/bap-piqi.2.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+name: "bap-piqi"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-piqi"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-piqi_printers"]
+        [ "ocamlfind" "remove" "bap-piqi"]
+        [ "bapbundle" "remove" "piqi_printers.plugin"]
+        [ "rm" "-f" "%{prefix}%/share/bap/exp.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap/ir.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap/stmt.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap/type.piqi"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+  "piqi" {>= "0.7.4"}
+]
+synopsis: "BAP plugin for serialization based on piqi library"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-plugins/bap-plugins.2.0.0/opam
+++ b/packages/bap-plugins/bap-plugins.2.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "bap-bundle" {= "2.0.0"}
   "bap-future" {= "2.0.0"}
 ]
-synopsis: "BAP plugins support library"
+synopsis: "Dynamically loads plugins (shared libraries)"
 url {
   src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
   checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"

--- a/packages/bap-plugins/bap-plugins.2.0.0/opam
+++ b/packages/bap-plugins/bap-plugins.2.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "bap-plugins"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-plugins"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugins"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "cmdliner"
+  "fileutils"
+  "bap-bundle" {= "2.0.0"}
+  "bap-future" {= "2.0.0"}
+]
+synopsis: "BAP plugins support library"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-powerpc/bap-powerpc.2.0.0/opam
+++ b/packages/bap-powerpc/bap-powerpc.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-powerpc"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-powerpc"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-powerpc"]
+         ["bapbundle" "remove" "powerpc.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-abi"
+  "bap-c"
+  "bap-primus" {= "2.0.0"}
+  "zarith"
+]
+synopsis: "BAP PowerPC lifter"
+description: "Provides support for PPC and PPC64 architectures."
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-primus-dictionary/bap-primus-dictionary.2.0.0/opam
+++ b/packages/bap-primus-dictionary/bap-primus-dictionary.2.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name: "bap-primus-dictionary"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-dictionary"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_dictionary"]
+        ["bapbundle" "remove" "primus_dictionary.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-primus" {= "2.0.0"}
+]
+synopsis: "BAP Primus Lisp library that provides dictionaries"
+description: """
+Provides a key-value storage for Primus Lisp programs.  Dictionaries
+are represented with symbols and it is a responsibility of user to
+prevent name clashing between different dictionaries."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-primus-lisp/bap-primus-lisp.2.0.0/opam
+++ b/packages/bap-primus-lisp/bap-primus-lisp.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-primus-lisp"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-lisp"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_lisp"]
+        ["bapbundle" "remove" "primus_lisp.plugin"]
+        ["rm" "-rf" "%{prefix}%/share/primus/site-lisp"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-primus" {= "2.0.0"}
+]
+synopsis: "BAP Primus Lisp Runtime"
+description: """
+The default (and the only one so far) Primus Lisp runtime. The plugin
+provides Lisp primitives for manipulation program state, loads user
+specified libraries, and integrates Primus Lisp with BAP universe."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-primus-powerpc/bap-primus-powerpc.2.0.0/opam
+++ b/packages/bap-primus-powerpc/bap-primus-powerpc.2.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "bap-primus-powerpc"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-powerpc"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-primus_powerpc"]
+         ["bapbundle" "remove" "primus_powerpc.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "bap-std" {= "2.0.0"}
+  "bap-primus" {= "2.0.0"}
+]
+synopsis: "Performs the PowerPC target specific setup"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-primus-region/bap-primus-region.2.0.0/opam
+++ b/packages/bap-primus-region/bap-primus-region.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-primus-region"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-region"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_region"]
+        ["bapbundle" "remove" "primus_region.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-primus" {= "2.0.0"}
+]
+synopsis:
+  "Provides a set of operations to store and manipulate interval trees"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-primus-support/bap-primus-support.2.0.0/opam
+++ b/packages/bap-primus-support/bap-primus-support.2.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+name: "bap-primus-support"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-support"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_exploring"]
+        ["ocamlfind" "remove" "bap-plugin-primus_greedy"]
+        ["ocamlfind" "remove" "bap-plugin-primus_limit"]
+        ["ocamlfind" "remove" "bap-plugin-primus_loader"]
+        ["ocamlfind" "remove" "bap-plugin-primus_mark_visited"]
+        ["ocamlfind" "remove" "bap-plugin-primus_print"]
+        ["ocamlfind" "remove" "bap-plugin-primus_promiscuous"]
+        ["ocamlfind" "remove" "bap-plugin-primus_round_robin"]
+        ["ocamlfind" "remove" "bap-plugin-primus_wandering"]
+        ["bapbundle" "remove" "primus_exploring.plugin"]
+        ["bapbundle" "remove" "primus_greedy.plugin"]
+        ["bapbundle" "remove" "primus_limit.plugin"]
+        ["bapbundle" "remove" "primus_loader.plugin"]
+        ["bapbundle" "remove" "primus_mark_visited.plugin"]
+        ["bapbundle" "remove" "primus_print.plugin"]
+        ["bapbundle" "remove" "primus_promiscuous.plugin"]
+        ["bapbundle" "remove" "primus_round_robin.plugin"]
+        ["bapbundle" "remove" "primus_wandering.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-primus" {= "2.0.0"}
+  "bare"
+]
+synopsis: "Provides supporting components for Primus"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-primus-test/bap-primus-test.2.0.0/opam
+++ b/packages/bap-primus-test/bap-primus-test.2.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+name: "bap-primus-test"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-test"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_test"]
+        ["bapbundle" "remove" "primus_test.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-primus" {= "2.0.0"}
+]
+synopsis: "BAP Primus Testing and Program Verification module"
+description: """
+With Primus Test Framework program analysis could be implemented as a
+set of simple tests written in Primus Lisp language. The framework
+provides an unified incident reporting facility for generalized
+problem reporting. The framework comes with a couple of analysis on
+board as a showcase.
+
+Memcheck - a memory checker that detects vioalations of memory
+management discipline, such as use-after-free, double free, and
+corrupted free.
+
+Check Returned Value - verifies that a program is addressing all
+possible outcomes of certain API calls, e.g., checks return values,
+error codes, etc."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-primus-x86/bap-primus-x86.2.0.0/opam
+++ b/packages/bap-primus-x86/bap-primus-x86.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-primus-x86"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-x86"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_x86"]
+        ["bapbundle" "remove" "primus_x86.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-primus" {= "2.0.0"}
+  "bap-x86"
+]
+synopsis: "The x86 CPU support package for BAP Primus CPU emulator"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-primus/bap-primus.2.0.0/opam
+++ b/packages/bap-primus/bap-primus.2.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+name: "bap-primus"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-primus"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-abi"
+  "bap-c"
+  "bap-future"
+  "bap-strings"
+  "monads"
+  "uuidm"
+  "graphlib" {= "2.0.0"}
+  "parsexp" {>= "v0.11" & < "v0.12"}
+]
+synopsis: "The BAP Microexecution Framework"
+description: """
+BAP Primus is a Microexecutuin Framework. The Microexecution technique
+was pioneered by Patrice Godefroid from Microsoft Research. The idea
+is to execute a binary from any point, using random inputs for
+undefined values.
+
+The idea of Primus is very similiar. A program is lifted into the
+Intermediate Representation, that is interpreted using the Primus
+interpreter. The Framework allows users to customize the interpreter
+by implementing different machine components."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-print/bap-print.2.0.0/opam
+++ b/packages/bap-print/bap-print.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-print"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-print"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-print"]
+        ["bapbundle" "remove" "print.plugin"]
+
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-demangle"
+  "text-tags"
+]
+synopsis: "Print plugin - print project in various formats"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-raw/bap-raw.2.0.0/opam
+++ b/packages/bap-raw/bap-raw.2.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "bap-raw"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-raw"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-raw"]
+         ["bapbundle" "remove" "raw.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ppx_jane"
+  "bap-std" {= "2.0.0"}
+  "bap-main" {= "2.0.0"}
+]
+synopsis: "Provides a BAP loader for raw binaries"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-recipe-command/bap-recipe-command.2.0.0/opam
+++ b/packages/bap-recipe-command/bap-recipe-command.2.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "bap-recipe-command"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-recipe-command"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-recipe_command"]
+          ["bapbundle" "remove" "recipe_command.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "base"
+  "stdio"
+  "parsexp"
+  "fileutils"
+  "camlzip"
+  "uuidm"
+  "bap-std" {= "2.0.0"}
+  "bap-recipe" {= "2.0.0"}
+  "bap-main" {= "2.0.0"}
+]
+synopsis: "Provides commands to manipulate the recipe subsystem"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-recipe/bap-recipe.2.0.0/opam
+++ b/packages/bap-recipe/bap-recipe.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-recipe"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-recipe"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-recipe"]
+         ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "base"
+  "stdio"
+  "parsexp"
+  "fileutils"
+  "camlzip"
+  "uuidm"
+  "stdlib-shims"
+]
+synopsis: "Stores command line parameters and resources in a single file"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-relocatable/bap-relocatable.2.0.0/opam
+++ b/packages/bap-relocatable/bap-relocatable.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-relocatable"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-relocatable"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-relocatable"]
+        ["bapbundle" "remove" "relocatable.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "ogre"
+]
+synopsis:
+  "Provides a brancher service for BAP that handles certain relocations"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-report/bap-report.2.0.0/opam
+++ b/packages/bap-report/bap-report.2.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "bap-report"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-report"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-report"]
+         ["bapbundle" "remove" "report.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+]
+synopsis: "A BAP plugin that reports program status"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-run/bap-run.2.0.0/opam
+++ b/packages/bap-run/bap-run.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-run"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-run"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-run"]
+        ["bapbundle" "remove" "run.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-primus" {= "2.0.0"}
+]
+synopsis: "A BAP plugin that executes a binary"
+description: "Uses the Primus Microexecution Framework to execute a binary."
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-signatures/bap-signatures.2.0.0/opam
+++ b/packages/bap-signatures/bap-signatures.2.0.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+name: "bap-signatures"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+install: [
+  ["mkdir" "-p" "%{share}%/bap/"]
+  ["cp" "sigs.zip" "%{share}%/bap/sigs.zip"]
+]
+
+remove: [["rm" "%{share}%/bap/sigs.zip"]]
+synopsis: "A data package with binary signatures for bap"
+description: "A package contains signatures for Byteweight algorithm."
+depends: ["ocaml"]
+flags: light-uninstall
+url {
+  src:
+    "https://github.com/BinaryAnalysisPlatform/bap/releases/download/v2.0.0/sigs.tar.gz"
+  checksum: "md5=1099975bb3473f001f6d7b0dbda8b14a"
+}

--- a/packages/bap-ssa/bap-ssa.2.0.0/opam
+++ b/packages/bap-ssa/bap-ssa.2.0.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+name: "bap-ssa"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-ssa"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-ssa"]
+         ["bapbundle" "remove" "ssa.plugin"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+]
+synopsis: "A BAP plugin, that translates a program into the SSA form"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-std/bap-std.2.0.0/opam
+++ b/packages/bap-std/bap-std.2.0.0/opam
@@ -1,0 +1,75 @@
+opam-version: "2.0"
+name: "bap-std"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--with-cxx=`which clang++`"
+                 "--mandir=%{man}%"
+                 "--enable-bap-std"]
+  [make]
+]
+
+install: [
+  [make "reinstall"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap"]
+  ["rm" "-f" "%{bin}%/baptop"]
+  ["rm" "-f" "%{bin}%/ppx-bap"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "base-unix"
+  "bap-future" {= "2.0.0"}
+  "bap-knowledge" {= "2.0.0"}
+  "bitvec" {= "2.0.0"}
+  "bap-core-theory"  {= "2.0.0"}
+  "bap-bundle" {= "2.0.0"}
+  "bap-main" {= "2.0.0"}
+  "bap-plugins" {= "2.0.0"}
+  "camlzip" {>= "1.07"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "bin_prot" {>= "v0.11" & < "v0.12"}
+  "fileutils"
+  "graphlib" {= "2.0.0"}
+  "oasis" {build & >= "0.4.7"}
+  "ocamlfind" {>= "1.5.6" & < "2.0"}
+  "ppx_jane" {>= "v0.11" & < "v0.12"}
+  "regular"
+  "uri"
+  "utop" {build & >= "2.0.0"}
+  "uuidm"
+  "zarith"
+  "cmdliner" {>= "0.9.8"}
+  "ogre"
+  "monads"
+]
+depexts: [
+  ["libgmp-dev" "libzip-dev" "clang"] {os-distribution = "ubuntu"}
+  ["gmp" "libzip"] {os = "macos" & os-distribution = "macports"}
+  ["clang"] {os-distribution = "debian"}
+  ["binutils" "gmp-dev" "libzip-dev" "m4" "perl" "zlib-dev"] {os-distribution = "alpine"}
+
+
+]
+conflicts: [
+  "fileutils" {= "0.5.0"}
+  "jbuilder" {= "1.0+beta18"}
+]
+synopsis: "The Binary Analysis Platform Standard Library"
+description: "Provides the main BAP library."
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-strings/bap-strings.2.0.0/opam
+++ b/packages/bap-strings/bap-strings.2.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+name: "bap-strings"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-strings"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-strings"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+]
+synopsis: "Text utilities useful in Binary Analysis and Reverse Engineering"
+description: """
+The library provides several algorithms:
+
+- Detector - that uses a maximum aposteriori likelihood estimator
+  (MAP) to detect code that operates with textual data (aka Bayesian
+  inference).
+
+- Unscrambler - that is capable of finding all possible words, that
+  can be built from a bag of letters in O(1).
+
+- Scanner - a generic algorithm for finding strings of characters (a
+  library variant of strings tool)"""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-symbol-reader/bap-symbol-reader.2.0.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-symbol-reader"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-symbol-reader"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-read_symbols"]
+        [ "bapbundle" "remove" "read_symbols.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+]
+synopsis: "BAP plugin that reads symbol information from files"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-taint-propagator/bap-taint-propagator.2.0.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.2.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+name: "bap-taint-propagator"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-propagate-taint"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
+         ["bapbundle" "remove" "propagate_taint.plugin"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+  "bap-microx"
+]
+synopsis: "BAP Taint propagation engine using based on microexecution"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-taint/bap-taint.2.0.0/opam
+++ b/packages/bap-taint/bap-taint.2.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "bap-taint"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-taint"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-taint"]
+  ["ocamlfind" "remove" "bap-plugin-taint"]
+  ["ocamlfind" "remove" "bap-plugin-primus_propagate_taint"]
+  ["ocamlfind" "remove" "bap-plugin-primus_taint"]
+  ["bapbundle" "remove" "taint.plugin"]
+  ["bapbundle" "remove" "primus_propagate_taint.plugin"]
+  ["bapbundle" "remove" "primus_taint.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-primus" {= "2.0.0"}
+]
+synopsis: "BAP Taint Analysis Framework"
+description: """
+Provides a generic library for handling program taints, and plugins
+that integrate existing and new taint analysis tools with the new
+framework."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-term-mapper/bap-term-mapper.2.0.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.2.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "bap-term-mapper"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-map-terms"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
+         [ "ocamlfind" "remove" "bap-bml"]
+         [ "bapbundle" "remove" "map_terms.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+]
+synopsis: "A BAP DSL for mapping program terms"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-trace/bap-trace.2.0.0/opam
+++ b/packages/bap-trace/bap-trace.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-trace"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-trace"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-trace"]
+        ["bapbundle" "remove" "trace.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.0.0"}
+  "bap-traces"
+  "cmdliner"
+]
+synopsis: "A plugin to load and run program execution traces"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-traces/bap-traces.2.0.0/opam
+++ b/packages/bap-traces/bap-traces.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-traces"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-traces"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-traces"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.0.0"}
+  "uri" {>= "1.9.0"}
+  "uuidm"
+]
+synopsis: "BAP Library for loading and parsing execution traces"
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-trivial-condition-form/bap-trivial-condition-form.2.0.0/opam
+++ b/packages/bap-trivial-condition-form/bap-trivial-condition-form.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-trivial-condition-form"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-trivial-condition-form"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-trivial_condition_form"]
+         ["bapbundle" "remove" "trivial_condition_form.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+]
+synopsis: "Eliminates complex conditionals in branches"
+description: """
+Ensures that all branching conditions are either a variable
+or a constant. We call such representation a Trivial Condition Form
+(TCF). During the translation all complex condition expressions are
+hoisted into the assignemnt section of a block."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-veri/bap-veri.0.2.4/opam
+++ b/packages/bap-veri/bap-veri.0.2.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+name: "bap-veri"
+version: "0.2.4"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-veri/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-veri/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-veri/"
+license: "MIT"
+
+build: [
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+  ["ocamlfind" "remove" "bap-veri"]
+  ["bapbundle" "remove" "veri_bil.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {>= "2.0.0"}
+  "bap-traces"
+  "cmdliner"
+  "oasis" {build}
+  "ounit"
+  "pcre"
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "textutils"   {>= "v0.11" & < "v0.12"}
+  "uri"
+]
+synopsis: "BAP Instruction Semantics Verification Tool"
+description: """
+Verifies that our understaning of instruction semantics is correct, or
+at least the same as in QEMU by checking if our execution bisimulates
+the QEMU."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap-veri/archive/v0.2.4.tar.gz"
+  checksum: "md5=35ca8475c4616ffa4752a6d971aa2182"
+}

--- a/packages/bap-warn-unused/bap-warn-unused.2.0.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-warn-unused"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-warn-unused"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
+        ["bapbundle" "remove" "warn_unused.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.0.0"}
+  "cmdliner"
+]
+synopsis:
+  "Emit a warning if an unused result may cause a bug or security issue"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap-x86/bap-x86.2.0.0/opam
+++ b/packages/bap-x86/bap-x86.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-x86"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-x86"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-x86-cpu"]
+        ["ocamlfind" "remove" "bap-plugin-x86"]
+        ["bapbundle" "remove" "x86.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-abi"
+  "bap-c"
+  "bap-llvm"
+  "cmdliner"
+]
+synopsis: "BAP x86 lifter"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap/bap.2.0.0/opam
+++ b/packages/bap/bap.2.0.0/opam
@@ -1,0 +1,91 @@
+opam-version: "2.0"
+name: "bap"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "bap-abi" {= "2.0.0"}
+  "bap-api" {= "2.0.0"}
+  "bap-arm" {= "2.0.0"}
+  "bap-beagle" {= "2.0.0"}
+  "bap-bil" {= "2.0.0"}
+  "bap-build" {= "2.0.0"}
+  "bap-bundle" {= "2.0.0"}
+  "bap-byteweight" {= "2.0.0"}
+  "bap-c" {= "2.0.0"}
+  "bap-cache" {= "2.0.0"}
+  "bap-cxxfilt" {= "2.0.0"}
+  "bap-callsites" {= "2.0.0"}
+  "bap-constant-tracker" {= "2.0.0"}
+  "bap-demangle" {= "2.0.0"}
+  "bap-disassemble" {= "2.0.0"}
+  "bap-dump-symbols" {= "2.0.0"}
+  "bap-elementary" {= "2.0.0"}
+  "bap-elf" {= "2.0.0"}
+  "bap-frontend" {= "2.0.0"}
+  "bap-frontc" {= "2.0.0"}
+  "bap-llvm" {= "2.0.0"}
+  "bap-main" {= "2.0.0"}
+  "bap-mc" {= "2.0.0"}
+  "bap-microx" {= "2.0.0"}
+  "bap-mips" {= "2.0.0"}
+  "bap-objdump" {= "2.0.0"}
+  "bap-optimization" {= "2.0.0"}
+  "bap-plugins" {= "2.0.0"}
+  "bap-powerpc" {= "2.0.0"}
+  "bap-primus" {= "2.0.0"}
+  "bap-primus-dictionary" {= "2.0.0"}
+  "bap-primus-lisp" {= "2.0.0"}
+  "bap-primus-powerpc" {= "2.0.0"}
+  "bap-primus-region" {= "2.0.0"}
+  "bap-primus-support" {= "2.0.0"}
+  "bap-primus-test" {= "2.0.0"}
+  "bap-primus-x86" {= "2.0.0"}
+  "bap-print" {= "2.0.0"}
+  "bap-raw" {= "2.0.0"}
+  "bap-recipe" {= "2.0.0"}
+  "bap-recipe-command" {= "2.0.0"}
+  "bap-relocatable" {= "2.0.0"}
+  "bap-report" {= "2.0.0"}
+  "bap-run" {= "2.0.0"}
+  "bap-ssa" {= "2.0.0"}
+  "bap-std" {= "2.0.0"}
+  "bap-strings" {= "2.0.0"}
+  "bap-symbol-reader" {= "2.0.0"}
+  "bap-taint" {= "2.0.0"}
+  "bap-taint-propagator" {= "2.0.0"}
+  "bap-term-mapper" {= "2.0.0"}
+  "bap-trace" {= "2.0.0"}
+  "bap-traces" {= "2.0.0"}
+  "bap-trivial-condition-form" {= "2.0.0"}
+  "bap-warn-unused" {= "2.0.0"}
+  "bap-x86" {= "2.0.0"}
+  "bap-emacs-goodies"
+]
+synopsis: "Binary Analysis Platform"
+description: """
+The Carnegie Mellon University Binary Analysis Platform (CMU BAP) is a
+reverse engineering and program analysis platform that works with
+binary code and doesn't require the source code. BAP supports multiple
+architectures: ARM, x86, x86-64, PowerPC, and MIPS. BAP disassembles
+and lifts binary code into the RISC-like BAP Instruction Language
+(BIL). Program analysis is performed using the BIL representation and
+is architecture independent in a sense that it will work equally well
+for all supported architectures. The main purpose of BAP is to provide
+a toolkit for implementing automated program analysis. BAP is written
+in OCaml and it is the preferred language to write analysis, but we
+have bindings to C, Python and Rust. The Primus Framework also provide
+a Lisp-like DSL for writing program analysis tools.
+
+This is a meta package that installs essential parts of BAP."""
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bap/bap.2.0.0/opam
+++ b/packages/bap/bap.2.0.0/opam
@@ -23,6 +23,7 @@ depends: [
   "bap-cxxfilt" {= "2.0.0"}
   "bap-callsites" {= "2.0.0"}
   "bap-constant-tracker" {= "2.0.0"}
+  "bap-core-theory" {= "2.0.0"}
   "bap-demangle" {= "2.0.0"}
   "bap-disassemble" {= "2.0.0"}
   "bap-dump-symbols" {= "2.0.0"}
@@ -30,6 +31,7 @@ depends: [
   "bap-elf" {= "2.0.0"}
   "bap-frontend" {= "2.0.0"}
   "bap-frontc" {= "2.0.0"}
+  "bap-knowledge" {= "2.0.0"}
   "bap-llvm" {= "2.0.0"}
   "bap-main" {= "2.0.0"}
   "bap-mc" {= "2.0.0"}

--- a/packages/bare/bare.2.0.0/opam
+++ b/packages/bare/bare.2.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "bare"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bare"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bare"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build}
+  "parsexp" {>= "v0.11" & < "v0.12"}
+]
+synopsis: "BAP Rule Engine Library"
+description: """
+BARE is a library that provides non-linear pattern matching on streams
+of facts that are represented as s-expressions. We use BARE, in particular,
+to process Primus observations. Since Primus components use observations to
+convey their knowledge downstream it is very convenient to be able to query
+and join observations through the stream. In a sense, BARE could be seen as
+SQL select/join for streams."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bitvec-binprot/bitvec-binprot.2.0.0/opam
+++ b/packages/bitvec-binprot/bitvec-binprot.2.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+name: "bitvec-binprot"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bitvec-binprot"]
+  [make]
+]
+install: [[make "install"]]
+remove: [ ["ocamlfind" "remove" "bitvec-binprot"] ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bitvec"
+  "bin_prot"
+  "ppx_jane"
+]
+synopsis: "Janestreet's Binprot serialization for Bitvec"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bitvec-order/bitvec-order.2.0.0/opam
+++ b/packages/bitvec-order/bitvec-order.2.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+name: "bitvec-order"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bitvec-order"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bitvec-order"]]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "base"
+  "bitvec"
+  "bitvec-sexp"
+]
+synopsis: "Base style comparators and orders for Bitvec"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bitvec-sexp/bitvec-sexp.2.0.0/opam
+++ b/packages/bitvec-sexp/bitvec-sexp.2.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+name: "bitvec-sexp"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bitvec-sexp"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bitvec-sexp"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bitvec"
+  "sexplib0"
+]
+synopsis: "Sexp serializers for Bitvec"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/bitvec/bitvec.2.0.0/opam
+++ b/packages/bitvec/bitvec.2.0.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+name: "bitvec"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bitvec"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bitvec"] ]
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "oasis" {build & >= "0.4.7"}
+  "zarith"
+]
+synopsis: "Fixed-size bitvectors and modular arithmetic, based on Zarith"
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.5/files/find-llvm.ml.in
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.5/files/find-llvm.ml.in
@@ -1,0 +1,146 @@
+#load "unix.cma"
+
+open Printf
+
+let read_all ch =
+  let buf = Buffer.create 16 in
+  let rec loop () =
+    match input_char ch with
+    | ch -> Buffer.add_char buf ch; loop ()
+    | exception End_of_file -> String.trim (Buffer.contents buf) in
+  loop ()
+
+exception Command_failed of Unix.process_status
+
+let process_status_to_string s =
+  let open Unix in
+  match s with
+  | WEXITED i -> sprintf "exit status %d" 1
+  | WSTOPPED i -> sprintf "proccess was stopped by signal %d" i
+  | WSIGNALED i -> sprintf "proccess was killed by signal %d" i
+
+let exn_to_string = function
+  | Command_failed s -> sprintf "%s" (process_status_to_string s)
+  | e -> Printexc.to_string e
+
+let cmd fmt =
+  let run c =
+    try
+      let inp = Unix.open_process_in c in
+      let res = read_all inp in
+      match Unix.close_process_in inp with
+      | Unix.WEXITED 0 -> Some res
+      | s -> raise (Command_failed s)
+    with e -> None in
+  ksprintf run fmt
+
+let of_opam_config () =
+  let cfg = "%{llvm-config}%" in
+  if cfg = "" then None
+  else Some cfg
+
+let of_env () =
+  try Some (Sys.getenv "LLVM_CONFIG")
+  with Not_found -> None
+
+let write path version =
+  let digest = Digest.to_hex (Digest.file path) in
+  let oc = open_out "%{_:name}%.config" in
+  fprintf oc {|
+opam-version: "2.0"
+file-depends: [ [ %S %S ] ]
+variables {
+  config: %S
+  package-version: "%s"
+}
+|} path digest path version;
+  close_out oc
+
+let (/) = Filename.concat
+
+let normalize ver =
+  let ver =
+    if String.length ver >= 3 then
+      String.sub ver 0 3
+    else ver in
+  if ver > "3.8" then String.sub ver 0 1
+  else ver
+
+let brew_config ver =
+  match cmd "brew --cellar" with
+  | None -> None
+  | Some cellar ->
+    match cmd "ls %s | grep %s" cellar (normalize ver) with
+    | None -> None
+    | Some p ->
+      cmd "find %s/%s -name \"llvm-config\"" cellar p
+
+let macports_config ver = sprintf "llvm-config-mp-%s" ver
+
+let index_opt str c =
+  try Some (String.index str '.')
+  with Not_found -> None
+
+let configs ver =
+  let ver' = match index_opt ver '.' with
+    | None -> ver
+    | Some i -> String.sub ver 0 i ^ String.sub ver (i + 1) 1 in
+  let configs = [
+    sprintf "llvm-config-%s" ver;
+    sprintf "llvm-config-%s" ver';
+    "llvm-config";
+  ] in
+  match "%{os}%" with
+  | "macos" ->
+    let configs = match brew_config ver with
+      | None -> configs
+      | Some b -> b :: configs in
+    macports_config ver :: configs
+  | _ -> configs
+
+let find_opt ~f xs =
+  try Some (List.find f xs)
+  with Not_found -> None
+
+let versions_equal v v' =
+  String.equal (normalize v) (normalize v')
+
+let locate () =
+  let versions = ["9.0"; "8.0"; "7.0"; "6.0"; "5.0"; "4.0"; "3.8"; "3.4"] in
+  List.fold_left (fun cfg ver ->
+      match cfg with
+      | Some _ -> cfg
+      | None ->
+        let configs = configs ver in
+        find_opt (fun cfg ->
+            match cmd "which %s" cfg with
+            | None -> false
+            | Some cfg ->
+              match cmd "%s --version" cfg with
+              | None -> false
+              | Some ver' ->
+                List.exists (versions_equal ver') versions) configs)
+    None versions
+
+let rec find_map fs =
+  match fs with
+  | [] -> None
+  | f :: fs ->
+    match f () with
+    | None -> find_map fs
+    | x -> x
+
+let () =
+  try
+    let path = match find_map [of_opam_config; of_env; locate] with
+      | Some cfg -> cmd "which %s" cfg
+      | None -> None in
+    match path with
+    | None -> eprintf "LLVM not found"; exit 1
+    | Some path ->
+      match cmd "%s --version" path with
+      | None -> eprintf "'%s --version' failed\n" path; exit 1
+      | Some version -> write path version
+  with e ->
+    eprintf "build failed: %s\n" (Printexc.to_string e);
+    exit 1

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.5/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.5/opam
@@ -16,7 +16,7 @@ depends: [
 depexts: [
 
   # debian
-  ["llvm-4.0-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
+  ["llvm-6.0-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
 
   # ubuntu
   ["llvm-3.8-dev"] {os-distribution = "ubuntu" & os-version = "14.04"} #trusty
@@ -32,6 +32,12 @@ depexts: [
   ["llvm@6"]   {os = "macos" & os-distribution = "homebrew"}
 
   ["llvm-dev" "llvm-static"] {os-distribution = "alpine"}
+
+  ["llvm-devel"] {os-distribution = "opensuse-leap"}
+
+  ["llvm-devel" "llvm-static"] {os-distribution = "centos"}
+
+
 ]
 
 substs: [ "find-llvm.ml" ]

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.5/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.5/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+version: "1.5"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+homepage: "http://llvm.org"
+authors: "The LLVM Team"
+bug-reports: "https://llvm.org/bugs/"
+license: "BSD"
+build: [
+  ["ocaml" "find-llvm.ml"]
+]
+depends: [
+  "ocaml"
+  "base-unix"
+  "conf-which" {build}
+]
+depexts: [
+
+  # debian
+  ["llvm-4.0-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
+
+  # ubuntu
+  ["llvm-3.8-dev"] {os-distribution = "ubuntu" & os-version = "14.04"} #trusty
+  ["llvm-6.0-dev"] {os-distribution = "ubuntu" & os-version = "16.04"} #xenial
+  ["llvm-6.0-dev"] {os-distribution = "ubuntu" & os-version = "18.04"} #bionic
+  ["llvm-6.0-dev"] {os-distribution = "ubuntu" & os-version = "18.10"}
+
+  # fedora
+  ["llvm-devel" "llvm-static"] {os-distribution = "fedora"}
+
+  # macos
+  ["llvm-6.0"] {os = "macos" & os-distribution = "macports"}
+  ["llvm@6"]   {os = "macos" & os-distribution = "homebrew"}
+
+  ["llvm-dev" "llvm-static"] {os-distribution = "alpine"}
+]
+
+substs: [ "find-llvm.ml" ]
+flags: [ conf ]
+
+synopsis: "Checks that supported version of LLVM is installed"
+description: """
+Supported LLVM versions are: 3.4 3.8 4.0 5.0 6.0 7.0 8.0 9.0
+
+A preferred llvm-config can be choosen by setting opam config variable:
+$: opam config set llvm-config your-llvm-config
+OR by setting LLVM_CONFIG environment variable.
+"""

--- a/packages/conf-ida/conf-ida.0.2/files/find-ida.ml.in
+++ b/packages/conf-ida/conf-ida.0.2/files/find-ida.ml.in
@@ -143,7 +143,7 @@ let write path =
       Filename.dirname path,
       sprintf "file-depends: [ [ %S %S ] ]\n"
         path (Digest.to_hex (Digest.file path)) in
-  let oc = open_out "conf-ida.config" in
+  let oc = open_out "%{_:name}%.config" in
   fprintf oc {|
 opam-version: "2.0"
 %s
@@ -155,7 +155,7 @@ variables {
   close_out oc
 
 let of_config () =
-  let path = "" in
+  let path = "%{ida-path}%" in
   if path = "" then None
   else Some path
 

--- a/packages/graphlib/graphlib.2.0.0/opam
+++ b/packages/graphlib/graphlib.2.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+name: "graphlib"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-graphlib"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "graphlib"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+  "ppx_jane" {>= "v0.11" & < "v0.12"}
+  "ocamlgraph"
+  "regular"
+]
+synopsis: "Generic Graph library"
+description: """
+Graphlib is a generic library that extends a well known OCamlGraph
+library. Graphlib uses its own, more reach, Graph interface that
+is isomorphic to OCamlGraph's `Sigs.P` signature for persistant
+graphs. Two functors witness the isomorphism of the interfaces:
+`Graphlib.To_ocamlgraph` and `Graphlib.Of_ocamlgraph`. Thanks to
+these functors, any algorithm written for OCamlGraph can be used on
+`Graphlibs` graph and vice verse."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/monads/monads.2.0.0/opam
+++ b/packages/monads/monads.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "monads"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-monads"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "monads"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+]
+synopsis: "A missing monad library"
+description:
+  "Provides monad transformers for most (if not all) common monads."
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/ogre/ogre.2.0.0/opam
+++ b/packages/ogre/ogre.2.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "ogre"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-ogre"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "ogre"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+  "monads"
+]
+synopsis: "Open Generic REpresentation NoSQL Database"
+description: """
+OGRE is a NoSQL document-style database, that uses s-exp for data
+representation and provides a type safe monadic interface for quering
+and updating documents."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/regular/regular.2.0.0/opam
+++ b/packages/regular/regular.2.0.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+name: "regular"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-regular"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "regular"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+  "ppx_jane" {>= "v0.11" & < "v0.12"}
+]
+synopsis: "Library for regular data types"
+description: """
+Provides functors and typeclasses implementing functionality expected
+for a regular data type, like i/o, containers, printing, etc.
+
+In particular, the library includes:
+
+- module Data that adds generic i/o routines for each regular data type.
+- module Cache that adds caching service for data types
+- module Regular that glues everything together
+- module Opaque for regular but opaque data types
+- module Seq that extends Core_kernel's sequence module
+- module Bytes that provides a rich core-like interface for Bytes data type."""
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}

--- a/packages/text-tags/text-tags.2.0.0/opam
+++ b/packages/text-tags/text-tags.2.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "text-tags"
+version: "2.0.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-text-tags"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "text-tags"]]
+
+depends: [
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "oasis" {build & >= "0.4.7"}
+]
+synopsis: "A library for rich formatting using semantics tags"
+flags: light-uninstall
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.0.0.tar.gz"
+  checksum: "md5=d2fd697735fda1adb80d6aa5643e7acd"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.0.0/v2.0.0.tar.gz"
+}


### PR DESCRIPTION
This is a major update of the Binary Analysis Platform that brings lots of new features, libraries, and tools. We will properly advertise it later, using discuss and mailing list, but, so far, the most important and notable changes are:
- a new representation of program semantics (using tagless final embedding)
- a new backward chaining engine that runs co-dependent  analyses

Despite the fact that we bump the major version there are no real breaking changes in the interfaces (some purist might say there are, depending on what you mean by a breaking change wrt to OCaml). We were able to implement the old interfaces using the new engine. The semantics of some functions slightly changed. 

### Features

BinaryAnalysisPlatform/bap#1016 adds unknown architecture
BinaryAnalysisPlatform/bap#1014 restores postinstall and man pages
BinaryAnalysisPlatform/bap#1013 tweaks the cache plugin
BinaryAnalysisPlatform/bap#1011 tweaks the subroutine ordering in the run plugin
BinaryAnalysisPlatform/bap#1006 extends the test coverage on Travis
BinaryAnalysisPlatform/bap#1005 introduces Bap_main the entry point to BAP
BinaryAnalysisPlatform/bap#1005 new command line interface and library
BinaryAnalysisPlatform/bap#1005 a new `raw` loader for opening unknown files and raw code
BinaryAnalysisPlatform/bap#1005 a new `objdump` command for linearly disassembling binaries
BinaryAnalysisPlatform/bap#1005 a new Byteweight threshold using the Bayes Factors procedure
BinaryAnalysisPlatform/bap#1005 adds more control over byteweight thresholding
BinaryAnalysisPlatform/bap#1005 implements custom thresholding procedures for Byteweight
BinaryAnalysisPlatform/bap#1005 extends the Trie module with iterators and printers
BinaryAnalysisPlatform/bap#1005 new toplevel based on utop
BinaryAnalysisPlatform/bap#1005 new bytecode frontend for debugging
BinaryAnalysisPlatform/bap#1005 adds a central location for regular readers and writers
BinaryAnalysisPlatform/bap#999  tweaks Graphlibs fixpoint to preserve previous solution
BinaryAnalysisPlatform/bap#998  represents rep prefix with while in x86
BinaryAnalysisPlatform/bap#993  prevents Primus from going to deep into PLT entries
BinaryAnalysisPlatform/bap#991  tweaks the print plugin
BinaryAnalysisPlatform/bap#990  represents ARM conditionals with ite expressions when possible
BinaryAnalysisPlatform/bap#998  implements more fine granular view on the image memory
BinaryAnalysisPlatform/bap#979  parametrize Lisp malloc with an initialization strategy
BinaryAnalysisPlatform/bap#960  new subroutine packing algorithm
BinaryAnalysisPlatform/bap#960  new incremental disassembler
BinaryAnalysisPlatform/bap#960  new knowledge representation library
BinaryAnalysisPlatform/bap#960  new representation of program semantics
BinaryAnalysisPlatform/bap#960  new bitvectors library
BinaryAnalysisPlatform/bap#948  disables Primus' taint GC by default

### Bug fixes

BinaryAnalysisPlatform/bap#1013 resolves leaking files in the cache plugin
BinaryAnalysisPlatform/bap#1003 rectifies Primus semantics in case of exceptions
BinaryAnalysisPlatform/bap#1002 fixes bind operator in the Future library
BinaryAnalysisPlatform/bap#1000 fixes instruction properties computation for barriers
BinaryAnalysisPlatform/bap#985  fixes atexit Lisp stub
BinaryAnalysisPlatform/bap#980  fixes a bug in the configure script
BinaryAnalysisPlatform/bap#971  limits continuations at forks in the promiscuous mode
BinaryAnalysisPlatform/bap#970  fixes the argument evaluation order in call-return
BinaryAnalysisPlatform/bap#964  fixes Primus random generators
BinaryAnalysisPlatform/bap#962  fixes the semantics of signed division by zero in x86
BinaryAnalysisPlatform/bap#958  fixes Primus memory semantics with randomized memories
BinaryAnalysisPlatform/bap#955  improves stack handling in Primus for x86
BinaryAnalysisPlatform/bap#950  fixes the taint sanitization procedure

### Changes that may affect/break your programs
1. You won't see anymore ret terms in the IR, as exits from subroutines are now represented as calls.
Your plugins shall not perform any side-effects during evaluation except using the old Config.when_ready function or the new interface from the bap-main library.
2. If your application was a host program and was initializing the plugins manually, then you shall switch to the bap-main library. (It's easy, just do Bap_main.init instead of Plugins.run)
3. No more options for rooters, branchers, and reconstructors. They are subsumed with our new knowledge base and knowledge providers. The existing services and re-introduced via a backward compatibility layer. If you had a brancher of your own, then you will need to update it since we've changed their semantics, now a brancher shall not provide the fall-through edge.
4.If you were using custom command-line parsing in your plugins this won't work anymore, you have to use the new bap-main library to specify your configuration options or the old Config module from Bap.Std, which still works fine (it is implemented in terms of bap-main).
5. New command-line interface that may break your bap orchestration utilities. We were trying to keep it as backward compatible as possible, e.g., bap /bin/ls --run will still work as before, but some of your scripts may stop working.