### PR TITLE
mariadb.1.1.4: ctypes-foreign dependency is not needed

### DIFF
--- a/packages/mariadb/mariadb.1.1.4/opam
+++ b/packages/mariadb/mariadb.1.1.4/opam
@@ -18,7 +18,6 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
-  "ctypes-foreign" {>= "0.4.0"}
 ]
 depexts: [
   ["libmariadb-dev"] {os-family = "debian"}


### PR DESCRIPTION
https://github.com/andrenth/ocaml-mariadb/issues/26