### PR TITLE
[new release] git-http, git, git-unix and git-mirage (2.1.2)

### DIFF
--- a/packages/git-http/git-http.2.1.2/opam
+++ b/packages/git-http/git-http.2.1.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "Client implementation of the \"Smart\" HTTP Git protocol in pure OCaml"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"        {>= "4.03.0"}
+  "dune"
+  "git"          {= version}
+  "cohttp"       {>= "1.0.0"}
+  "cohttp-lwt"   {>= "1.0.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.2/git-2.1.2.tbz"
+  checksum: [
+    "sha256=b2fc7aae9735526eb11ecf7c2bfc02393327268a4d3327d8be679622a0a6cc7b"
+    "sha512=bb3306f2728d3ac4975b4ba347b53aec26a831a96445ed4812685e9991c46ed45393c107f1b4cb42ca77fed1cbb2a06ffb41036fd7284d812270630c3ac3dc6f"
+  ]
+}

--- a/packages/git-mirage/git-mirage.2.1.2/opam
+++ b/packages/git-mirage/git-mirage.2.1.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "MirageOS backend for the Git protocol(s)"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"            {>= "4.03.0"}
+  "dune"
+  "cohttp-mirage"    {>= "1.0.0"}
+  "mirage-flow"      {>= "2.0.0"}
+  "mirage-channel"   {>= "4.0.0"}
+  "conduit-mirage"
+  "git-http"         {= version}
+  "git"              {= version}
+  "alcotest"         {with-test & >= "0.8.1"}
+  "mtime"            {with-test & >= "1.0.0"}
+  "nocrypto"         {with-test & >= "0.5.4"}
+  "tls"              {with-test}
+  "io-page"          {with-test & >= "1.6.1"}
+  "tcpip"            {with-test & >= "3.3.0"}
+  "io-page-unix"     {with-test}
+  "mirage-stack" {with-test & >= "2.0.0"}
+  "mirage-random-test" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.2/git-2.1.2.tbz"
+  checksum: [
+    "sha256=b2fc7aae9735526eb11ecf7c2bfc02393327268a4d3327d8be679622a0a6cc7b"
+    "sha512=bb3306f2728d3ac4975b4ba347b53aec26a831a96445ed4812685e9991c46ed45393c107f1b4cb42ca77fed1cbb2a06ffb41036fd7284d812270630c3ac3dc6f"
+  ]
+}

--- a/packages/git-unix/git-unix.2.1.2/opam
+++ b/packages/git-unix/git-unix.2.1.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "Virtual package to install and configure ocaml-git's Unix backend"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+
+depends: [
+  "ocaml"           {>= "4.03.0"}
+  "dune"
+  "mmap"            {>= "1.1.0"}
+  "cmdliner"
+  "git-http"        {= version}
+  "cohttp"          {>= "1.0.0"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "mtime"           {>= "1.0.0"}
+  "base-unix"
+  "alcotest"        {with-test & >= "0.8.1"}
+  "nocrypto"        {with-test & >= "0.5.4"}
+  "tls"             {with-test}
+  "io-page"         {with-test & >= "1.6.1"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.2/git-2.1.2.tbz"
+  checksum: [
+    "sha256=b2fc7aae9735526eb11ecf7c2bfc02393327268a4d3327d8be679622a0a6cc7b"
+    "sha512=bb3306f2728d3ac4975b4ba347b53aec26a831a96445ed4812685e9991c46ed45393c107f1b4cb42ca77fed1cbb2a06ffb41036fd7284d812270630c3ac3dc6f"
+  ]
+}

--- a/packages/git/git.2.1.2/opam
+++ b/packages/git/git.2.1.2/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "Git format and protocol in pure OCaml"
+description: """
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"
+  "uri"        {>= "1.9.0"}
+  "lwt"        {>= "2.4.7"}
+  "angstrom"   {>= "0.9.0"}
+  "fpath"      {>= "0.7.0"}
+  "digestif"   {>= "0.7.2"}
+  "lru"        {>= "0.3.0"}
+  "decompress" {>= "0.9.0" & < "1.0.0"}
+  "checkseum"  {>= "0.0.9"}
+  "stdlib-shims"
+  "ke"
+  "encore"
+  "duff"
+  "hex"
+  "ocplib-endian"
+  "rresult"
+  "logs"
+  "fmt"
+  "astring"
+  "cstruct"
+  "ocamlgraph"
+  "alcotest" {with-test & >= "0.8.1"}
+  "nocrypto" {with-test & >= "0.5.4"}
+  "tls"      {with-test}
+  "mtime"    {with-test & >= "1.0.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.2/git-2.1.2.tbz"
+  checksum: [
+    "sha256=b2fc7aae9735526eb11ecf7c2bfc02393327268a4d3327d8be679622a0a6cc7b"
+    "sha512=bb3306f2728d3ac4975b4ba347b53aec26a831a96445ed4812685e9991c46ed45393c107f1b4cb42ca77fed1cbb2a06ffb41036fd7284d812270630c3ac3dc6f"
+  ]
+}


### PR DESCRIPTION
Client implementation of the "Smart" HTTP Git protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- unlock `git` to use, at least, `checkseum.0.0.9` (mirage/ocaml-git#373, @dinosaure)
- remove build directive on dune dependency (mirage/ocaml-git#374, @CraigFe)
- adapt to MirageOS 3.7.0 (mirage/ocaml-git#376, @hannesm)
- fix infinite loop with index file (version 2) (mirage/ocaml-git#378, @kit-ty-kate, @dinosaure)
