### PR TITLE
Package ocsigen-i18n.3.5.0

### DIFF
--- a/packages/ocsigen-i18n/ocsigen-i18n.3.5.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.5.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis:     "I18n made easy for web sites written with eliom"
+description:  "Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file"
+maintainer:   "Jan Rochel <jan@besport.com>"
+
+homepage: "https://github.com/besport/ocsigen-i18n"
+bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
+dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+build:   [ make "build" ]
+install: [ make "bindir=%{bin}%" "install" ]
+
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind" {build}
+  "tyxml" { >= "4.3.0" }
+  "ppx_tools"
+]
+authors: "Julien Sagot"
+url {
+  src: "https://github.com/besport/ocsigen-i18n/archive/3.5.0.tar.gz"
+  checksum: [
+    "md5=ff4dee60c1cf5e3ce4449bc2fb803924"
+    "sha512=39d6a88fa5068d3c090696c757e43255b094da56fc49966ef2c89d4e1b9bcc1e2115d929f609a43a63402a2e6ab71866d1bb642d89655ba4ba5775004219dac9"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-i18n.3.5.0`
I18n made easy for web sites written with eliom
Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file



---
* Homepage: https://github.com/besport/ocsigen-i18n
* Source repo: git+https://github.com/besport/ocsigen-i18n.git
* Bug tracker: https://github.com/besport/ocsigen-i18n/issues

---
:camel: Pull-request generated by opam-publish v2.0.0