### PR TITLE
Package ocsigenserver.2.15.0

### DIFF
--- a/packages/ocsigenserver/ocsigenserver.2.15.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.15.0/opam
@@ -5,7 +5,7 @@ description: "Ocsigen Server implements most features of the HTTP protocol, and 
 authors: "dev@ocsigen.org"
 homepage: "http://ocsigen.org/ocsigenserver/"
 bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1 with OCaml linking exception"
 dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
 build: [
   [
@@ -60,11 +60,12 @@ depopts: "camlzip"
 conflicts: [
   "camlzip" {< "1.04"}
   "pgocaml" {< "2.2"}
+  "pgocaml" {>= "4.0"}
 ]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.15.0.tar.gz"
   checksum: [
-    "md5=01227e2df5fad6774c9b549057fadf35"
-    "sha512=4ba56d41c27243732ce818cf14abe8cc0965fb97453d2fc2fa2eafe6cc6143079ea50294410bcf8a7d677d63c199b085795174a43571a3a6d7a214845b9da95f"
+    "md5=6a065139727349be494d49c5b2c46fbc"
+    "sha512=b7ac0f21074de7ed8ff86fe5365a501e490429c6ed276e65ed0f899a475787a72099a04238339cb64a6b429504c4efd0bc95f1907c65dd4205ccda1c0e2584b9"
   ]
 }


### PR DESCRIPTION
### `ocsigenserver.2.15.0`
A full-featured and extensible Web server
Ocsigen Server implements most features of the HTTP protocol, and has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc.



---
* Homepage: http://ocsigen.org/ocsigenserver/
* Source repo: git+https://github.com/ocsigen/ocsigenserver.git
* Bug tracker: https://github.com/ocsigen/ocsigenserver/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0