### PR TITLE
Package ocsigen-toolkit.2.4.1

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.4.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.4.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.7.0"}
+  "calendar"
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.4.1.tar.gz"
+  checksum: [
+    "md5=7066c396902d06e747e2262c0829aa7d"
+    "sha512=cd61410979cde9d1fe981e0f87a024ff1c92b4b6c33b382333b22f5e40c25b013e9c660c219b81f67a4e64cd67bc54be827663d71c960d45d39b98f5d5fc0108"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.4.1`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0