### PR TITLE
[new release] coq-serapi (8.10.0+0.7.0)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.10.0+0.7.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.10.0+0.7.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.07.0"            }
+  "coq"                 {           >= "8.10.0" & < "8.11" }
+  "cmdliner"            {           >= "1.0.0"             }
+  "ocamlfind"           {           >= "1.8.0"             }
+  "sexplib"             {           >= "v0.11.0"           }
+  "dune"                {           >= "1.2.0"             }
+  "ppx_import"          { build   & >= "1.5-3"             }
+  "ppx_deriving"        {           >= "4.2.1"             }
+  "ppx_sexp_conv"       {           >= "v0.11.0"           }
+  "yojson"              {           >= "1.7.0"             }
+  "ppx_deriving_yojson" {           >= "3.4"               }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.10.0%2B0.7.0/coq-serapi-8.10.0.0.7.0.tbz"
+  checksum: [
+    "sha256=4448c2b45a6975d7a90d3e07ce75386103d3e17c8ad96c566da854ac1e56802c"
+    "sha512=19027ca59703c8b74abd372e14403d22d07e9e8c248a50ae8f880647c10ee1f22cee93587583374c96971a667e10546b4997ff7b6a91aea51b51bbacb3052ee4"
+  ]
+}


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

* [general] (!) support Coq 8.10,
 * [serapi]  (!) `Goals` query return type has been modified due to
             upstream changes. (@ejgallego)
 * [serlib]  Complete (hopefully) serialization for ssreflect ASTs.
             (ejgallego/coq-serapi#73 @ejgallego)
 * [general] Drop support for OCaml < 4.07 (ejgallego/coq-serapi#140 @ejgallego)
 * [serlib ] JSON serialization for kernel and AST terms (@ejgallego)
 * [serapi ] Add `Complete` support (@ejgallego
             c.f. https://github.com/coq/coq/pull/8766)
 * [serlib ] Serlib is now built as a wrapped module (@ejgallego)
 * [serapi ] (!) Goals info has been extended to print name metadata if available,
             cc ejgallego/coq-serapi#151 (@ejgallego , suggested by @cpitclaudel)
 * [serlib ] JSON support for vernac_expr (@ejgallego)
 * [sertop ] (!) Do as Coq upstream and load Coq's stdlib with `-R` (closes ejgallego/coq-serapi#56)
 * [sertop ] Follow Coq upstream and unset `indices_matter` (closes ejgallego/coq-serapi#157,
             thanks to @palmskog for the report)
 * [serapi ] (!) Improve CoqExn answer to have pretty-printed message (improves ejgallego/coq-serapi#162,
             thanks to @cpitclaudel for the request)
 * [serlib ] (!) Fix capitalization conventions for a few types in `Names`
             (closes ejgallego/coq-serapi#167 thanks to @corwin-of-amber for the report)
 * [serapi ] (!) Add bullet suggest information to goal query (@corwin-of-amber)
 * [sertop ] Add `--no_prelude` option (closes ejgallego/coq-serapi#176, @ejgallego, request of @darbyhaller)
 * [serlib ] (!) Add index to `MBId` serialization (fixes ejgallego/coq-serapi#150, @ejgallego)
 * [serapi ] (!) Add `sid` parameter to `Print` (helps ejgallego/coq-serapi#150, @ejgallego, reported by @cpitclaudel)
 * [sertop ] Add `sertok` program for batch serialization of tokens and their source locations (@palmskog)
 * [serapi ] (!) Add string-formatted messages to `CoqExn` and `Message`
             (@ejgallego closes ejgallego/coq-serapi#184 , closes ejgallego/coq-serapi#162)
