### PR TITLE
Package grain_dypgen.0.1

### DIFF
--- a/packages/grain_dypgen/grain_dypgen.0.1/files/dypgen.install
+++ b/packages/grain_dypgen/grain_dypgen.0.1/files/dypgen.install
@@ -1,0 +1,5 @@
+bin: [
+  "dypgen/dypgen.opt"
+  "dypgen/dypgen"
+  "dyp2gram.pl" {"dyp2gram"}
+]

--- a/packages/grain_dypgen/grain_dypgen.0.1/files/install-bsd-compatible.patch
+++ b/packages/grain_dypgen/grain_dypgen.0.1/files/install-bsd-compatible.patch
@@ -1,0 +1,62 @@
+--- dypgen.20120619-1/Makefile.orig	2013-04-02 16:17:00.000000000 +0200
++++ dypgen.20120619-1/Makefile	2013-04-02 16:21:59.000000000 +0200
+@@ -22,20 +22,24 @@
+ 
+ #install with ocaml-findlib
+ install: install_opt
+-	install -D --mode=755 dypgen/dypgen $(BINDIR)
+-	install -D --mode=755 dyp2gram.pl $(BINDIR)/dyp2gram
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dypgen.1
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dypgen.opt.1
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dyp2gram.1
++	install -d $(BINDIR)
++	install -m 755 dypgen/dypgen $(BINDIR)
++	install -m 755 dyp2gram.pl $(BINDIR)/dyp2gram
++	install -d $(MANDIR)
++	install -m 644 doc/dypgen.1 $(MANDIR)/dypgen.1
++	install -m 644 doc/dypgen.1 $(MANDIR)/dypgen.opt.1
++	install -m 644 doc/dypgen.1 $(MANDIR)/dyp2gram.1
+ 	cd dyplib; $(MAKE) install
+ 
+ #install without ocaml-findlib
+ install2: install_opt
+-	install -D --mode=755 dypgen/dypgen $(BINDIR)
+-	install -D --mode=755 dyp2gram.pl $(BINDIR)/dyp2gram
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dypgen.1
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dypgen.opt.1
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dyp2gram.1
++	install -d $(BINDIR)
++	install -m 755 dypgen/dypgen $(BINDIR)
++	install -m 755 dyp2gram.pl $(BINDIR)/dyp2gram
++	install -d $(MANDIR)
++	install -m 644 doc/dypgen.1 $(MANDIR)/dypgen.1
++	install -m 644 doc/dypgen.1 $(MANDIR)/dypgen.opt.1
++	install -m 644 doc/dypgen.1 $(MANDIR)/dyp2gram.1
+ 	cd dyplib; $(MAKE) install2
+ 
+ ifdef CAMLOPT
+--- dypgen.20120619-1/dyplib/Makefile.orig	2013-04-02 16:15:48.000000000 +0200
++++ dypgen.20120619-1/dyplib/Makefile	2013-04-02 16:16:41.000000000 +0200
+@@ -28,15 +28,18 @@
+ 	- $(OCAMLFIND) remove -destdir $(DYPGENLIBDIR) dyp
+ 
+ install2: install_dyp install_opt
+-	install -D --mode=644 dyp.cmi $(DYPGENLIBDIR)/dyp
++	install -d $(DYPGENLIBDIR)/dyp
++	install -m 644 dyp.cmi $(DYPGENLIBDIR)/dyp
+ 
+ install_dyp:
+-	install -D --mode=644 dyp.cma $(DYPGENLIBDIR)/dyp
++	install -d $(DYPGENLIBDIR)/dyp
++	install -m 644 dyp.cma $(DYPGENLIBDIR)/dyp
+ 
+ ifdef CAMLOPT
+ install_opt:
+-	install -D --mode=644 dyp.cmxa $(DYPGENLIBDIR)/dyp
+-	install -D --mode=644 dyp.a $(DYPGENLIBDIR)/dyp
++	install -d $(DYPGENLIBDIR)/dyp
++	install -m 644 dyp.cmxa $(DYPGENLIBDIR)/dyp
++	install -m 644 dyp.a $(DYPGENLIBDIR)/dyp
+ else
+ install_opt:
+ endif

--- a/packages/grain_dypgen/grain_dypgen.0.1/opam
+++ b/packages/grain_dypgen/grain_dypgen.0.1/opam
@@ -29,7 +29,7 @@ extra-files: [
 url {
   src: "https://github.com/grain-lang/dypgen/archive/0.1.tar.gz"
   checksum: [
-    "md5=11aca8109d761acd212a4d7cf35424fb"
-    "sha512=82d066df384c378349f0798e00fb9cff1931a5d95db2d7ea83df32cb6f9150e32217158c6bc921667a5e79e6b4420f01cbc0cfc342f890cc8e92da8bde9f7a5d"
+    "md5=d366de4723b209b7d6e802e588eb96b9"
+    "sha512=f8b25655d47b1a69e89b1342db38dacf147309e9dae6604f5e46f400ebbbad2af99689ff7508a340eb7fec7d0b7bd693d38aeb86ce1e5e717855f6bea2afeca7"
   ]
 }

--- a/packages/grain_dypgen/grain_dypgen.0.1/opam
+++ b/packages/grain_dypgen/grain_dypgen.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Emmanuel Onzo" "Philip Blair"]
+homepage: "https://github.com/grain-lang/dypgen"
+license: "CeCILL-B"
+build: make
+remove: [
+  ["ocamlfind" "remove" "dypgen"]
+  ["ocamlfind" "remove" "dyp"]
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "ocamlfind"
+]
+patches: ["files/install-bsd-compatible.patch"]
+install: [
+  make
+  "install"
+  "DYPGENLIBDIR=%{lib}%"
+  "BINDIR=%{bin}%"
+  "MANDIR=%{man}%/man1"
+]
+synopsis: "Self-extensible parsers and lexers for OCaml"
+description: """
+dypgen is a GLR parser generator for OCaml, it is able to
+generate self-extensible parsers (also called adaptive parsers) as
+well as extensible lexers for the parsers it produces.
+(fork of pre-4.06 dypgen: http://dypgen.free.fr/)"""
+flags: light-uninstall
+extra-files: [
+  ["install-bsd-compatible.patch" "md5=f4885881bb9e16bae3f9e88ebb54c582"]
+  ["dypgen.install" "md5=3af2bc7343588caf1a6de8af49a3b1b5"]
+]
+url {
+  src: "https://github.com/grain-lang/dypgen/archive/0.1.tar.gz"
+  checksum: [
+    "md5=11aca8109d761acd212a4d7cf35424fb"
+    "sha512=82d066df384c378349f0798e00fb9cff1931a5d95db2d7ea83df32cb6f9150e32217158c6bc921667a5e79e6b4420f01cbc0cfc342f890cc8e92da8bde9f7a5d"
+  ]
+}

--- a/packages/grain_dypgen/grain_dypgen.0.1/opam
+++ b/packages/grain_dypgen/grain_dypgen.0.1/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/grain-lang/dypgen"
 license: "CeCILL-B"
 build: make
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.07.0"}
   "ocamlfind"
 ]
 patches: ["install-bsd-compatible.patch"]
@@ -29,7 +29,7 @@ extra-files: [
 url {
   src: "https://github.com/grain-lang/dypgen/archive/0.1.tar.gz"
   checksum: [
-    "md5=d366de4723b209b7d6e802e588eb96b9"
-    "sha512=f8b25655d47b1a69e89b1342db38dacf147309e9dae6604f5e46f400ebbbad2af99689ff7508a340eb7fec7d0b7bd693d38aeb86ce1e5e717855f6bea2afeca7"
+    "md5=abf5514b873721d675f6568378b605c9"
+    "sha512=0e742efc003b9d974e7d1e82f51af7e550d25fc77bd024a6fc8f7d1a148678bdee1c58c14e6ef3bf335d7e4176446ff5b41d695020c7bd08bb960b14ef278831"
   ]
 }

--- a/packages/grain_dypgen/grain_dypgen.0.1/opam
+++ b/packages/grain_dypgen/grain_dypgen.0.1/opam
@@ -4,15 +4,11 @@ authors: ["Emmanuel Onzo" "Philip Blair"]
 homepage: "https://github.com/grain-lang/dypgen"
 license: "CeCILL-B"
 build: make
-remove: [
-  ["ocamlfind" "remove" "dypgen"]
-  ["ocamlfind" "remove" "dyp"]
-]
 depends: [
   "ocaml" {>= "4.06.0"}
   "ocamlfind"
 ]
-patches: ["files/install-bsd-compatible.patch"]
+patches: ["install-bsd-compatible.patch"]
 install: [
   make
   "install"
@@ -26,7 +22,6 @@ dypgen is a GLR parser generator for OCaml, it is able to
 generate self-extensible parsers (also called adaptive parsers) as
 well as extensible lexers for the parsers it produces.
 (fork of pre-4.06 dypgen: http://dypgen.free.fr/)"""
-flags: light-uninstall
 extra-files: [
   ["install-bsd-compatible.patch" "md5=f4885881bb9e16bae3f9e88ebb54c582"]
   ["dypgen.install" "md5=3af2bc7343588caf1a6de8af49a3b1b5"]

--- a/packages/grain_dypgen/grain_dypgen.0.1/opam
+++ b/packages/grain_dypgen/grain_dypgen.0.1/opam
@@ -6,7 +6,7 @@ license: "CeCILL-B"
 build: make
 depends: [
   "ocaml" {>= "4.07.0"}
-  "ocamlfind"
+  "ocamlfind" {build}
 ]
 patches: ["install-bsd-compatible.patch"]
 install: [


### PR DESCRIPTION
### `grain_dypgen.0.1`
Self-extensible parsers and lexers for OCaml
dypgen is a GLR parser generator for OCaml, it is able to
generate self-extensible parsers (also called adaptive parsers) as
well as extensible lexers for the parsers it produces.
(fork of pre-4.06 dypgen: http://dypgen.free.fr/)



---
* Homepage: https://github.com/grain-lang/dypgen

---
:camel: Pull-request generated by opam-publish v2.0.0