### PR TITLE
[new release] js_of_ocaml, js_of_ocaml-ocamlbuild, js_of_ocaml-ppx_deriving_json, js_of_ocaml-tyxml, js_of_ocaml-ppx, js_of_ocaml-lwt, js_of_ocaml-compiler and js_of_ocaml-toplevel (3.5.1)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.11.1"}
+  "ppx_expect" {with-test & >= "0.12.0"}
+  "cmdliner"
+  "ocaml-migrate-parsetree"
+  "yojson" # It's optional, but we want users to be able to use source-map without pain.
+]
+
+depopts: [ "ocamlfind" ]
+
+conflicts: [
+  "ocamlfind"   {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.1/js_of_ocaml-3.5.1.tbz"
+  checksum: [
+    "sha256=3a050eb9507058164431c8e1f1c86b3c61e30a5d0b0cf2c5f48b959b87eaade9"
+    "sha512=0bbca03ac220f28adf060d4c2d8f726801bce80461aa73724a6c53b4979af919c820cc723b0a7e9bda93270cef5c0485aea942aa527010a3c386a13b7e2d4842"
+  ]
+}

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.11.1"}
+  "lwt" {>= "2.4.4"}
+  "js_of_ocaml" {>= "3.2"}
+  "js_of_ocaml-ppx"
+]
+depopts: [ "graphics" "lwt_log" ]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.1/js_of_ocaml-3.5.1.tbz"
+  checksum: [
+    "sha256=3a050eb9507058164431c8e1f1c86b3c61e30a5d0b0cf2c5f48b959b87eaade9"
+    "sha512=0bbca03ac220f28adf060d4c2d8f726801bce80461aa73724a6c53b4979af919c820cc723b0a7e9bda93270cef5c0485aea942aa527010a3c386a13b7e2d4842"
+  ]
+}

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.1/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "dune" {>= "1.11.1"}
+  "ocamlbuild"
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.1/js_of_ocaml-3.5.1.tbz"
+  checksum: [
+    "sha256=3a050eb9507058164431c8e1f1c86b3c61e30a5d0b0cf2c5f48b959b87eaade9"
+    "sha512=0bbca03ac220f28adf060d4c2d8f726801bce80461aa73724a6c53b4979af919c820cc723b0a7e9bda93270cef5c0485aea942aa527010a3c386a13b7e2d4842"
+  ]
+}

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.1/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.1/opam
@@ -14,6 +14,7 @@ environment like browsers and Node.js
 build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
+  "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11.1"}
   "ocamlbuild"
 ]

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.1/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.11.1"}
+  "ocaml-migrate-parsetree" {>= "1.4"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "js_of_ocaml" {>= "3.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.1/js_of_ocaml-3.5.1.tbz"
+  checksum: [
+    "sha256=3a050eb9507058164431c8e1f1c86b3c61e30a5d0b0cf2c5f48b959b87eaade9"
+    "sha512=0bbca03ac220f28adf060d4c2d8f726801bce80461aa73724a6c53b4979af919c820cc723b0a7e9bda93270cef5c0485aea942aa527010a3c386a13b7e2d4842"
+  ]
+}

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.1/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.11.1"}
+  "js_of_ocaml"
+  "ocaml-migrate-parsetree"
+  "ppxlib" {< "0.9.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.1/js_of_ocaml-3.5.1.tbz"
+  checksum: [
+    "sha256=3a050eb9507058164431c8e1f1c86b3c61e30a5d0b0cf2c5f48b959b87eaade9"
+    "sha512=0bbca03ac220f28adf060d4c2d8f726801bce80461aa73724a6c53b4979af919c820cc723b0a7e9bda93270cef5c0485aea942aa527010a3c386a13b7e2d4842"
+  ]
+}

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.1/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.11.1"}
+  "ocamlfind" {>= "1.5.1"}
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml" {>= "3.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.1/js_of_ocaml-3.5.1.tbz"
+  checksum: [
+    "sha256=3a050eb9507058164431c8e1f1c86b3c61e30a5d0b0cf2c5f48b959b87eaade9"
+    "sha512=0bbca03ac220f28adf060d4c2d8f726801bce80461aa73724a6c53b4979af919c820cc723b0a7e9bda93270cef5c0485aea942aa527010a3c386a13b7e2d4842"
+  ]
+}

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.1/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.11.1"}
+  "tyxml" {>= "4.3"}
+  "reactiveData" {>= "0.2"}
+  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml-ppx"
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.1/js_of_ocaml-3.5.1.tbz"
+  checksum: [
+    "sha256=3a050eb9507058164431c8e1f1c86b3c61e30a5d0b0cf2c5f48b959b87eaade9"
+    "sha512=0bbca03ac220f28adf060d4c2d8f726801bce80461aa73724a6c53b4979af919c820cc723b0a7e9bda93270cef5c0485aea942aa527010a3c386a13b7e2d4842"
+  ]
+}

--- a/packages/js_of_ocaml/js_of_ocaml.3.5.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.5.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+name: "js_of_ocaml"
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.11.1"}
+  "ocaml-migrate-parsetree" {>= "1.4"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "uchar"
+  "js_of_ocaml-compiler"
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.1/js_of_ocaml-3.5.1.tbz"
+  checksum: [
+    "sha256=3a050eb9507058164431c8e1f1c86b3c61e30a5d0b0cf2c5f48b959b87eaade9"
+    "sha512=0bbca03ac220f28adf060d4c2d8f726801bce80461aa73724a6c53b4979af919c820cc723b0a7e9bda93270cef5c0485aea942aa527010a3c386a13b7e2d4842"
+  ]
+}


### PR DESCRIPTION
Compiler from OCaml bytecode to Javascript

- Project page: <a href="http://ocsigen.github.io/js_of_ocaml">http://ocsigen.github.io/js_of_ocaml</a>

##### CHANGES:

## Features/Changes

## Bug fixes
* Runtime: fix poly compare with null and undefined (ocsigen/js_of_ocaml#920)
* Lib: Deriving Json does not export an [import] unit
* Dynlink/toplevel: export all units when no export file is specified (ocsigen/js_of_ocaml#921)
* Ppx: ppx_deriving_json should allow [%to_json: t] syntax
