### PR TITLE
restore ocaml-migrate-parsetree 1.4.0 upstream url

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.4.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.4.0/opam
@@ -29,7 +29,7 @@ rewriters independent of a compiler version.
 """
 url {
   src:
-    "http://opam.ocaml.org/cache/sha256/23/231fbdc205187b3ee266b535d9cfe44b599067b2f6e97883c782ea7bb577d3b8"
+    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.4.0/ocaml-migrate-parsetree-v1.4.0.tbz"
   checksum: [
     "sha256=231fbdc205187b3ee266b535d9cfe44b599067b2f6e97883c782ea7bb577d3b8"
     "sha512=61ee91d2d146cc2d2ff2d5dc4ef5dea4dc4d3c8dbd8b4c9586d64b6ad7302327ab35547aa0a5b0103c3f07b66b13d416a1bee6d4d117293cd3cabe44113ec6d4"


### PR DESCRIPTION
@diml has restored the original tarball, which matches the checksum
from the archive, so moving the url back to the upstream version