### PR TITLE
[new release] current_examples, current, current_ansi, current_slack, current_git, current_web, current_github, current_docker and current_rpc (0.1)

### DIFF
--- a/packages/current/current.0.1/opam
+++ b/packages/current/current.0.1/opam
@@ -31,7 +31,7 @@ depends: [
   "sqlite3"
   "duration"
   "prometheus"
-  "dune"
+  "dune" {>= "1.9"}
   "re"
   "lwt-dllist"
   "alcotest-lwt" {with-test}

--- a/packages/current/current.0.1/opam
+++ b/packages/current/current.0.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Pipeline language for keeping things up-to-date"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+It is used in ocaml-ci (which provides CI for OCaml projects on GitHub),
+and in docker-base-images (a pipeline that builds Docker images for various
+Linux distributions, OCaml compiler versions and CPU types, and pushes them
+to Docker Hub).
+
+A pipeline is written much like you would write a one-shot sequential script,
+but OCurrent will automatically re-run steps when the inputs change, and will
+run steps in parallel where possible."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "bos"
+  "ppx_deriving"
+  "lwt"
+  "cmdliner"
+  "sqlite3"
+  "duration"
+  "prometheus"
+  "dune"
+  "re"
+  "lwt-dllist"
+  "alcotest-lwt" {with-test}
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.1/current-v0.1.tbz"
+  checksum: [
+    "sha256=dbe8e3a4dfbb2983f003b1404618eca2f46a5499f337fe685848648f3bc2ba89"
+    "sha512=0fd67431cea61ba5645a465ac248aca5156de4e57e6e3afc525202e20d6f53504f786546138b85f64abecb45397a14056d483103d730b94fb5af28f5c34f550e"
+  ]
+}

--- a/packages/current_ansi/current_ansi.0.1/opam
+++ b/packages/current_ansi/current_ansi.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "fmt"
   "tyxml"
   "fpath" {with-test}
-  "dune"
+  "dune" {>= "1.9"}
 ]
 url {
   src:

--- a/packages/current_ansi/current_ansi.0.1/opam
+++ b/packages/current_ansi/current_ansi.0.1/opam
@@ -20,6 +20,7 @@ depends: [
   "astring"
   "fmt"
   "tyxml"
+  "fpath" {with-test}
   "dune"
 ]
 url {

--- a/packages/current_ansi/current_ansi.0.1/opam
+++ b/packages/current_ansi/current_ansi.0.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "ANSI escape sequence parser"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a basic ANSI escape parser,
+allowing the OCurrent web UI to show logs in colour."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "astring"
+  "fmt"
+  "tyxml"
+  "dune"
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.1/current-v0.1.tbz"
+  checksum: [
+    "sha256=dbe8e3a4dfbb2983f003b1404618eca2f46a5499f337fe685848648f3bc2ba89"
+    "sha512=0fd67431cea61ba5645a465ac248aca5156de4e57e6e3afc525202e20d6f53504f786546138b85f64abecb45397a14056d483103d730b94fb5af28f5c34f550e"
+  ]
+}

--- a/packages/current_docker/current_docker.0.1/opam
+++ b/packages/current_docker/current_docker.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "OCurrent Docker plugin"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a plugin for interacting with Docker.
+It can pull, build, run and push images, and can coordinate
+multiple Docker Engine instances."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "ppx_deriving"
+  "lwt"
+  "dockerfile"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune"
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.1/current-v0.1.tbz"
+  checksum: [
+    "sha256=dbe8e3a4dfbb2983f003b1404618eca2f46a5499f337fe685848648f3bc2ba89"
+    "sha512=0fd67431cea61ba5645a465ac248aca5156de4e57e6e3afc525202e20d6f53504f786546138b85f64abecb45397a14056d483103d730b94fb5af28f5c34f550e"
+  ]
+}

--- a/packages/current_docker/current_docker.0.1/opam
+++ b/packages/current_docker/current_docker.0.1/opam
@@ -26,7 +26,7 @@ depends: [
   "dockerfile"
   "ppx_deriving_yojson" {>= "3.5.1"}
   "yojson"
-  "dune"
+  "dune" {>= "1.9"}
 ]
 url {
   src:

--- a/packages/current_examples/current_examples.0.1/opam
+++ b/packages/current_examples/current_examples.0.1/opam
@@ -29,7 +29,7 @@ depends: [
   "current_docker" {= version}
   "current_rpc" {= version}
   "capnp-rpc-unix" {>= "0.5"}
-  "dune"
+  "dune" {>= "1.9"}
 ]
 url {
   src:

--- a/packages/current_examples/current_examples.0.1/opam
+++ b/packages/current_examples/current_examples.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Example pipelines for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides some example pipelines.
+It exists mainly to test the integration of various OCurrent
+plugins."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "lwt"
+  "cmdliner"
+  "duration"
+  "current" {= version}
+  "current_web" {= version}
+  "current_git" {= version}
+  "current_github" {= version}
+  "current_docker" {= version}
+  "current_rpc" {= version}
+  "capnp-rpc-unix" {>= "0.5"}
+  "dune"
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.1/current-v0.1.tbz"
+  checksum: [
+    "sha256=dbe8e3a4dfbb2983f003b1404618eca2f46a5499f337fe685848648f3bc2ba89"
+    "sha512=0fd67431cea61ba5645a465ac248aca5156de4e57e6e3afc525202e20d6f53504f786546138b85f64abecb45397a14056d483103d730b94fb5af28f5c34f550e"
+  ]
+}

--- a/packages/current_git/current_git.0.1/opam
+++ b/packages/current_git/current_git.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Git plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Git.
+It can pull from remote repositories, or monitor local ones for changes."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "ppx_deriving"
+  "lwt"
+  "irmin-watcher"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune"
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.1/current-v0.1.tbz"
+  checksum: [
+    "sha256=dbe8e3a4dfbb2983f003b1404618eca2f46a5499f337fe685848648f3bc2ba89"
+    "sha512=0fd67431cea61ba5645a465ac248aca5156de4e57e6e3afc525202e20d6f53504f786546138b85f64abecb45397a14056d483103d730b94fb5af28f5c34f550e"
+  ]
+}

--- a/packages/current_git/current_git.0.1/opam
+++ b/packages/current_git/current_git.0.1/opam
@@ -24,7 +24,7 @@ depends: [
   "irmin-watcher"
   "ppx_deriving_yojson" {>= "3.5.1"}
   "yojson"
-  "dune"
+  "dune" {>= "1.9"}
 ]
 url {
   src:

--- a/packages/current_github/current_github.0.1/opam
+++ b/packages/current_github/current_github.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "GitHub plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with GitHub.
+It can monitor and clone remote GitHub repositories, and can
+push GitHub status messages to show the results of testing
+PRs and branches."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "lwt"
+  "yojson"
+  "cohttp-lwt-unix"
+  "nocrypto"
+  "x509" {>= "0.7.0"}
+  "tls"
+  "dune"
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.1/current-v0.1.tbz"
+  checksum: [
+    "sha256=dbe8e3a4dfbb2983f003b1404618eca2f46a5499f337fe685848648f3bc2ba89"
+    "sha512=0fd67431cea61ba5645a465ac248aca5156de4e57e6e3afc525202e20d6f53504f786546138b85f64abecb45397a14056d483103d730b94fb5af28f5c34f550e"
+  ]
+}

--- a/packages/current_github/current_github.0.1/opam
+++ b/packages/current_github/current_github.0.1/opam
@@ -27,7 +27,7 @@ depends: [
   "nocrypto"
   "x509" {>= "0.7.0"}
   "tls"
-  "dune"
+  "dune" {>= "1.9"}
 ]
 url {
   src:

--- a/packages/current_rpc/current_rpc.0.1/opam
+++ b/packages/current_rpc/current_rpc.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "capnp-rpc-lwt" {>= "0.4"}
   "fpath"
-  "dune"
+  "dune" {>= "1.9"}
 ]
 url {
   src:

--- a/packages/current_rpc/current_rpc.0.1/opam
+++ b/packages/current_rpc/current_rpc.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Cap'n Proto RPC plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a Cap'n Proto RPC interface, allowing
+an OCurrent engine to be controlled remotely."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp-rpc-lwt" {>= "0.4"}
+  "fpath"
+  "dune"
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.1/current-v0.1.tbz"
+  checksum: [
+    "sha256=dbe8e3a4dfbb2983f003b1404618eca2f46a5499f337fe685848648f3bc2ba89"
+    "sha512=0fd67431cea61ba5645a465ac248aca5156de4e57e6e3afc525202e20d6f53504f786546138b85f64abecb45397a14056d483103d730b94fb5af28f5c34f550e"
+  ]
+}

--- a/packages/current_slack/current_slack.0.1/opam
+++ b/packages/current_slack/current_slack.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "tls"
   "cohttp-lwt-unix"
-  "dune"
+  "dune" {>= "1.9"}
 ]
 url {
   src:

--- a/packages/current_slack/current_slack.0.1/opam
+++ b/packages/current_slack/current_slack.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Slack plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Slack.
+It can post messages to slack channels."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "yojson"
+  "lwt"
+  "tls"
+  "cohttp-lwt-unix"
+  "dune"
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.1/current-v0.1.tbz"
+  checksum: [
+    "sha256=dbe8e3a4dfbb2983f003b1404618eca2f46a5499f337fe685848648f3bc2ba89"
+    "sha512=0fd67431cea61ba5645a465ac248aca5156de4e57e6e3afc525202e20d6f53504f786546138b85f64abecb45397a14056d483103d730b94fb5af28f5c34f550e"
+  ]
+}

--- a/packages/current_web/current_web.0.1/opam
+++ b/packages/current_web/current_web.0.1/opam
@@ -26,7 +26,7 @@ depends: [
   "prometheus-app"
   "cohttp-lwt-unix" {>= "2.2.0"}
   "tyxml"
-  "dune"
+  "dune" {>= "1.9"}
 ]
 url {
   src:

--- a/packages/current_web/current_web.0.1/opam
+++ b/packages/current_web/current_web.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Test web UI for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a basic web UI for service administrators.
+It shows the current pipeline visually and allows viewing job
+logs and configuring the log analyser."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "current" {= version}
+  "current_ansi" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "bos"
+  "lwt"
+  "cmdliner"
+  "prometheus-app"
+  "cohttp-lwt-unix" {>= "2.2.0"}
+  "tyxml"
+  "dune"
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.1/current-v0.1.tbz"
+  checksum: [
+    "sha256=dbe8e3a4dfbb2983f003b1404618eca2f46a5499f337fe685848648f3bc2ba89"
+    "sha512=0fd67431cea61ba5645a465ac248aca5156de4e57e6e3afc525202e20d6f53504f786546138b85f64abecb45397a14056d483103d730b94fb5af28f5c34f550e"
+  ]
+}


### PR DESCRIPTION
Example pipelines for OCurrent

- Project page: <a href="https://github.com/ocurrent/ocurrent">https://github.com/ocurrent/ocurrent</a>
- Documentation: <a href="https://ocurrent.github.io/ocurrent/">https://ocurrent.github.io/ocurrent/</a>

##### CHANGES:

Initial release.
