### PR TITLE
Add upper bounds to reverse dependencies of JS packages.

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.10.0+0.7.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.10.0+0.7.0/opam
@@ -27,11 +27,11 @@ depends: [
   "coq"                 {           >= "8.10.0" & < "8.11" }
   "cmdliner"            {           >= "1.0.0"             }
   "ocamlfind"           {           >= "1.8.0"             }
-  "sexplib"             {           >= "v0.11.0"           }
+  "sexplib"             {           >= "v0.11.0" & < "v0.13" }
   "dune"                {           >= "1.2.0"             }
   "ppx_import"          { build   & >= "1.5-3"             }
   "ppx_deriving"        {           >= "4.2.1"             }
-  "ppx_sexp_conv"       {           >= "v0.11.0"           }
+  "ppx_sexp_conv"       {           >= "v0.11.0" & < "v0.13" }
   "yojson"              {           >= "1.7.0"             }
   "ppx_deriving_yojson" {           >= "3.4"               }
 ]


### PR DESCRIPTION
Follow-up to https://github.com/ocaml/opam-repository/pull/15140 and https://github.com/ocaml/opam-repository/pull/15258.