### PR TITLE
[new release] printbox (5159c84)

### DIFF
--- a/packages/printbox/printbox.5159c84/opam
+++ b/packages/printbox/printbox.5159c84/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+version: "0.3"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Allows to print nested boxes, lists, arrays, tables in several formats"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03" }
+  "uutf" {with-test}
+  "uucp" {with-test}
+]
+depopts: [
+  "tyxml"
+  "uutf"
+  "uucp"
+]
+tags: [ "print" "box" "table" "tree" ]
+homepage: "https://github.com/c-cube/printbox/"
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/5159c84/printbox-5159c84.tbz"
+  checksum: [
+    "sha256=cbc7740aa6c1413f12b7dee67785d450ad8f2786394fc601a847a61afdcca988"
+    "sha512=6b5e8b1230e2b33003647e7ffdbfb155e82907523a6f71782df5703900239a74bf54436260202dffb97d6d2dfec3aafefd33929426f0c233a81c025e6892cf27"
+  ]
+}


### PR DESCRIPTION
Allows to print nested boxes, lists, arrays, tables in several formats

- Project page: <a href="https://github.com/c-cube/printbox/">https://github.com/c-cube/printbox/</a>

##### CHANGES:

## 0.3

- improve code readability in text rendering
- add `align` and `center`
- add basic styling for text (ansi codes/html styles)
- add `printbox_unicode` for setting up proper unicode printing
- add `grid_l`, `grid_text_l`, and `record` helpers

- use a more accurate length estimate for unicode, add test
- remove mdx as a test dep
- fix rendering bugs related to align right, and padding

## 0.2

- make the box type opaque, with a view function
- require OCaml 4.03

- add `PrintBox_text.pp`
- expose a few new functions to build boxes
- change `Text` type, work on string slices when rendering

- automatic testing using dune and mdx
- migrate to dune and opam 2

## 0.1

initial release
