### PR TITLE
Package ocsigen-toolkit.2.3.3

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.3/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "js_of_ocaml" {< "3.5.0"}
+  "js_of_ocaml-lwt" {< "3.5.0"}
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.7.0"}
+  "calendar"
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.3.3.tar.gz"
+  checksum: [
+    "md5=1a905aa8d1f1eee43460b5cbd80eecda"
+    "sha512=5a05f2f7dcc6d45a115cd0a3cbf524e0079968b5cbe70b53fa16d61501474046e4c5735bc678b6f2c585872cb83d04734d9ae126e53ddd944410a18821b175c7"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.3.3`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0