### PR TITLE
Package ocsigen-toolkit.2.2.1

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.2.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.2.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "js_of_ocaml" {< "3.5.0"}
+  "js_of_ocaml-lwt" {< "3.5.0"}
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.7.0"}
+  "calendar"
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.2.1.tar.gz"
+  checksum: [
+    "md5=0c32876c657c702210be1e3c41b1287a"
+    "sha512=068b9ed93e88ecbdf7aa539f8579c352a5a9c61bc59561353c869cd6ad030324ddf2695526496faea88d4b6480f9f949fa229a5c1d67fbc0c82cedf2a7cfd993"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.2.1`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0