### PR TITLE
[new release] printbox (v0.3)

### DIFF
--- a/packages/printbox/printbox.v0.3/opam
+++ b/packages/printbox/printbox.v0.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+version: "0.3"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Allows to print nested boxes, lists, arrays, tables in several formats"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {build}
+  "base-bytes"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03" }
+  "uutf" {with-test}
+  "uucp" {with-test}
+]
+depopts: [
+  "tyxml"
+  "uutf"
+  "uucp"
+]
+tags: [ "print" "box" "table" "tree" ]
+homepage: "https://github.com/c-cube/printbox/"
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.3/printbox-v0.3.tbz"
+  checksum: [
+    "sha256=cc6e5392196c595a4a76414bb0b4fe12907b005adf2f586e8a7bc1da0dee3ccb"
+    "sha512=2921e21940718829a214fa83f8e7298ab0f7fd2bba43831200c4c169c53329bc0656a1a05c50bf9e0afdb3be4e571605b01154b863eda6fd003932c81dfadf28"
+  ]
+}


### PR DESCRIPTION
Allows to print nested boxes, lists, arrays, tables in several formats

- Project page: <a href="https://github.com/c-cube/printbox/">https://github.com/c-cube/printbox/</a>

##### CHANGES:

## 0.3

- improve code readability in text rendering
- add `align` and `center`
- add basic styling for text (ansi codes/html styles)
- add `printbox_unicode` for setting up proper unicode printing
- add `grid_l`, `grid_text_l`, and `record` helpers

- use a more accurate length estimate for unicode, add test
- remove mdx as a test dep
- fix rendering bugs related to align right, and padding

## 0.2

- make the box type opaque, with a view function
- require OCaml 4.03

- add `PrintBox_text.pp`
- expose a few new functions to build boxes
- change `Text` type, work on string slices when rendering

- automatic testing using dune and mdx
- migrate to dune and opam 2

## 0.1

initial release
