### PR TITLE
Revert "conf-openssl.1 should not be installable by default"

### DIFF
--- a/packages/conf-openssl/conf-openssl.1/opam
+++ b/packages/conf-openssl/conf-openssl.1/opam
@@ -14,4 +14,3 @@ This package can only install if the OpenSSL library is installed on the system.
 This version of this metapackage is left here for compatibility purpose only.
 """
 flags: conf
-available: false


### PR DESCRIPTION
This reverts commit 5b777b15bd69f639658273ba8ff7c8abd816957d.

Fixes https://github.com/ocaml/opam-repository/issues/15329