### PR TITLE
Package tiny_httpd.0.1

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.1/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Minimal HTTP server using good old threads"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-threads"
+  "ocaml" { >= "4.03.0" }
+  "odoc" {with-doc}
+]
+tags: [ "http" "thread" "server" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+post-messages: "tiny http server, with blocking IOs. Also ships with a `http_of_dir` program."
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=691a48a4c2b9c52a8c48a5e058957181"
+    "sha512=ba2728e49b409468e3c5d665010afbfbc5651209df2ccf548a0125f7c5f9e0f29517ef42be48ab62f9dbc3ee300724d4dc9bd4f6f4261d351f2474c947d07810"
+  ]
+}


### PR DESCRIPTION
### `tiny_httpd.0.1`
Minimal HTTP server using good old threads



---
* Homepage: https://github.com/c-cube/tiny_httpd/
* Source repo: git+https://github.com/c-cube/tiny_httpd.git
* Bug tracker: https://github.com/c-cube/tiny_httpd/issues

---
:camel: Pull-request generated by opam-publish v2.0.0