### PR TITLE
[new release] printbox (0.3)

### DIFF
--- a/packages/printbox/printbox.0.3/opam
+++ b/packages/printbox/printbox.0.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Allows to print nested boxes, lists, arrays, tables in several formats"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-bytes"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03" }
+  "uutf" {with-test}
+  "uucp" {with-test}
+]
+depopts: [
+  "tyxml"
+  "uutf"
+  "uucp"
+]
+tags: [ "print" "box" "table" "tree" ]
+homepage: "https://github.com/c-cube/printbox/"
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/0.3/printbox-0.3.tbz"
+  checksum: [
+    "sha256=7dda76f4f9de0eb4fe08acb363c337a26b3c1b5b03dfa1d7a26c9b0c3f463309"
+    "sha512=a3532ed203a1aaeae4767546cfdbaeb5f171e6a737b439dfa9186538a22b5cae716a73ae91b381bf2b46de38a9d0926a992b0c70c7fba183745e50654f1a3872"
+  ]
+}


### PR DESCRIPTION
Allows to print nested boxes, lists, arrays, tables in several formats

- Project page: <a href="https://github.com/c-cube/printbox/">https://github.com/c-cube/printbox/</a>

##### CHANGES:

## 0.3

- improve code readability in text rendering
- add `align` and `center`
- add basic styling for text (ansi codes/html styles)
- add `printbox_unicode` for setting up proper unicode printing
- add `grid_l`, `grid_text_l`, and `record` helpers

- use a more accurate length estimate for unicode, add test
- remove mdx as a test dep
- fix rendering bugs related to align right, and padding

## 0.2

- make the box type opaque, with a view function
- require OCaml 4.03

- add `PrintBox_text.pp`
- expose a few new functions to build boxes
- change `Text` type, work on string slices when rendering

- automatic testing using dune and mdx
- migrate to dune and opam 2

## 0.1

initial release
