### PR TITLE
[new release] dns, dns-certify, dns-mirage, dns-resolver, dns-client, dns-server, dns-tsig and dns-cli (4.2.0)

### DIFF
--- a/packages/dns-certify/dns-certify.4.2.0/opam
+++ b/packages/dns-certify/dns-certify.4.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "0.8.0"}
+  "lwt" {>= "4.2.1"}
+  "tls" {>= "0.10.3"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.2.0/dns-v4.2.0.tbz"
+  checksum: [
+    "sha256=855ad12589b41e84ca5ec833452e9253ae213450d037957a7ff7941290c5daf3"
+    "sha512=4414a713fd26960e426d3eb379c085f5da576a2a4b43002620791d6e498f91b3a096c5b77e55196c528d5aa9c65a7e899a49a56d280214c1f4dc8bc5ec32b626"
+  ]
+}

--- a/packages/dns-cli/dns-cli.4.2.0/opam
+++ b/packages/dns-cli/dns-cli.4.2.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-client" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "rresult" {>= "0.6.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "0.8.0"}
+  "nocrypto" {>= "0.5.4"}
+  "hex" {>= "1.4.0"}
+  "ptime" {>= "0.8.5"}
+  "mtime" {>= "1.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.2.0/dns-v4.2.0.tbz"
+  checksum: [
+    "sha256=855ad12589b41e84ca5ec833452e9253ae213450d037957a7ff7941290c5daf3"
+    "sha512=4414a713fd26960e426d3eb379c085f5da576a2a4b43002620791d6e498f91b3a096c5b77e55196c528d5aa9c65a7e899a49a56d280214c1f4dc8bc5ec32b626"
+  ]
+}

--- a/packages/dns-client/dns-client.4.2.0/opam
+++ b/packages/dns-client/dns-client.4.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD2"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {>="1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt" {>= "0.8.8"}
+  "logs" {>= "0.6.3"}
+  "dns" {= version}
+  "rresult" {>= "0.6.0"}
+  "randomconv" {>= "0.1.2"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mtime" {>= "1.2.0"}
+]
+synopsis: "Pure DNS resolver API"
+description: """
+A pure resolver implementation using uDNS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.2.0/dns-v4.2.0.tbz"
+  checksum: [
+    "sha256=855ad12589b41e84ca5ec833452e9253ae213450d037957a7ff7941290c5daf3"
+    "sha512=4414a713fd26960e426d3eb379c085f5da576a2a4b43002620791d6e498f91b3a096c5b77e55196c528d5aa9c65a7e899a49a56d280214c1f4dc8bc5ec32b626"
+  ]
+}

--- a/packages/dns-mirage/dns-mirage.4.2.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack" {>= "2.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  In a similar vein, wildcard records are _not_ supported, and it is
+unlikely they'll ever be in this library.  Truncated hmac in `TSIG` are not
+supported (always the full length of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.2.0/dns-v4.2.0.tbz"
+  checksum: [
+    "sha256=855ad12589b41e84ca5ec833452e9253ae213450d037957a7ff7941290c5daf3"
+    "sha512=4414a713fd26960e426d3eb379c085f5da576a2a4b43002620791d6e498f91b3a096c5b77e55196c528d5aa9c65a7e899a49a56d280214c1f4dc8bc5ec32b626"
+  ]
+}

--- a/packages/dns-resolver/dns-resolver.4.2.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.2.0/dns-v4.2.0.tbz"
+  checksum: [
+    "sha256=855ad12589b41e84ca5ec833452e9253ae213450d037957a7ff7941290c5daf3"
+    "sha512=4414a713fd26960e426d3eb379c085f5da576a2a4b43002620791d6e498f91b3a096c5b77e55196c528d5aa9c65a7e899a49a56d280214c1f4dc8bc5ec32b626"
+  ]
+}

--- a/packages/dns-server/dns-server.4.2.0/opam
+++ b/packages/dns-server/dns-server.4.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "nocrypto" {with-test}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.2.0/dns-v4.2.0.tbz"
+  checksum: [
+    "sha256=855ad12589b41e84ca5ec833452e9253ae213450d037957a7ff7941290c5daf3"
+    "sha512=4414a713fd26960e426d3eb379c085f5da576a2a4b43002620791d6e498f91b3a096c5b77e55196c528d5aa9c65a7e899a49a56d280214c1f4dc8bc5ec32b626"
+  ]
+}

--- a/packages/dns-tsig/dns-tsig.4.2.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "nocrypto" {>= "0.5.4"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.2.0/dns-v4.2.0.tbz"
+  checksum: [
+    "sha256=855ad12589b41e84ca5ec833452e9253ae213450d037957a7ff7941290c5daf3"
+    "sha512=4414a713fd26960e426d3eb379c085f5da576a2a4b43002620791d6e498f91b3a096c5b77e55196c528d5aa9c65a7e899a49a56d280214c1f4dc8bc5ec32b626"
+  ]
+}

--- a/packages/dns/dns.4.2.0/opam
+++ b/packages/dns/dns.4.2.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "rresult" "astring" "fmt" "logs" "ptime"
+  "domain-name" {>= "0.3.0"}
+  "gmap" {>= "0.3.0"}
+  "cstruct" {>= "3.2.0"}
+  "ipaddr" {>= "3.0.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  In a similar vein, wildcard records are _not_ supported, and it is
+unlikely they'll ever be in this library.  Truncated hmac in `TSIG` are not
+supported (always the full length of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.2.0/dns-v4.2.0.tbz"
+  checksum: [
+    "sha256=855ad12589b41e84ca5ec833452e9253ae213450d037957a7ff7941290c5daf3"
+    "sha512=4414a713fd26960e426d3eb379c085f5da576a2a4b43002620791d6e498f91b3a096c5b77e55196c528d5aa9c65a7e899a49a56d280214c1f4dc8bc5ec32b626"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* dns
  relax resource record parsing, don't require the name to be a hostname it
  used to be strict on the parser, but that violates RFC 2181 Sec 11
  > The DNS itself places only one restriction on the particular labels that can
  > be used to identify resource records.  That one restriction relates to the
  > length of the label and the full name.
  previous code had already exceptions for DNSKEY, TXT, CNAME, TLSA (service
  name or host name), SRV (service name) (mirage/ocaml-dns#201 @hannesm)
* dns-certify
  BUGFIX provide signing_request to create certificate signing requests,
         now including all hostnames in subjectAlternativeName (previously, the
         common name was left out which is not what RFC 5280 recommends)
         (mirage/ocaml-dns#198 @hannesm)
* dns-server.mirage
  - provide metrics (using the metrics library) of connections and actions (mirage/ocaml-dns#199 @hannesm)
  - BREAKING the `on_update` callback passed to `primary` has more arguments (mirage/ocaml-dns#200 @hannesm)
    `~authenticated_key` : [`raw] Domain_name.t option
    `~update_source` : Ipaddr.V4.t
* dns-server
  - BREAKING handle_buf: returns Domain_name.t of key used for authentication (mirage/ocaml-dns#200 @hannesm)
  - BUGFIX handle_update: allow modification of multiple zones at once
           still, each name must be within the zone given in Query.name (which
           is authenticated against), allowing hidden let's encrypt secondary
           for multiple zones, using a keys authorized for the root zone (mirage/ocaml-dns#200 @hannesm)
  - BUGFIX Dns_trie.zone returns the zone (Domain_name.t * Soa.t) of a
           provided Domain_name.t, it now works for non-existing names, tests
           were added (mirage/ocaml-dns#200 @hannesm)
* dns-mirage: log packets on debug level instead of info (mirage/ocaml-dns#198 @hannesm)