### PR TITLE
[new release] irmin-fs, irmin-unix, irmin, irmin-mem, irmin-mirage-git, irmin-chunk, irmin-pack, irmin-mirage-graphql, irmin-mirage, irmin-graphql, irmin-http, irmin-git and irmin-test (2.0.0)

### DIFF
--- a/packages/irmin-chunk/irmin-chunk.2.0.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Mounir Nasr Allah" "Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.1.0"}
+  "irmin"      {>= "2.0.0"}
+  "lwt"
+  "irmin-mem"  {with-test & >= "2.0.0"}
+  "irmin-test" {with-test & >= "2.0.0"}
+]
+
+synopsis: "Irmin backend which allow to store values into chunks"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}

--- a/packages/irmin-fs/irmin-fs.2.0.0/opam
+++ b/packages/irmin-fs/irmin-fs.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "1.1.0"}
+  "irmin"      {>= "2.0.0"}
+  "irmin-test" {with-test & >= "2.0.0"}
+]
+
+synopsis: "Generic file-system backend for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}

--- a/packages/irmin-git/irmin-git.2.0.0/opam
+++ b/packages/irmin-git/irmin-git.2.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.1.0"}
+  "irmin"      {= version}
+  "git"        {>= "2.1.1"}
+  "digestif"   {>= "0.7.3"}
+  "irmin-test" {with-test & >= "2.0.0"}
+  "irmin-mem"  {with-test & >= "2.0.0"}
+  "git-unix"   {with-test & >= "2.1.1"}
+  "mtime"      {with-test & >= "1.0.0"}
+]
+
+synopsis: "Git backend for Irmin"
+description: """
+`Irmin_git` expose a bi-directional bridge between Git repositories and
+Irmin stores.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}

--- a/packages/irmin-graphql/irmin-graphql.2.0.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors:      "Andreas Garnaes <andreas.garnaes@gmail.com>"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.03.0"}
+  "dune"    {>= "1.1.0"}
+  "irmin"   {>= "2.0.0"}
+  "graphql" {>= "0.13.0"}
+  "graphql-lwt" {>= "0.13.0"}
+  "graphql-cohttp" {>= "0.13.0"}
+  "cohttp-lwt"
+  "graphql_parser" {>= "0.13.0"}
+]
+
+
+synopsis: "GraphQL server for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}

--- a/packages/irmin-http/irmin-http.2.0.0/opam
+++ b/packages/irmin-http/irmin-http.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.1.0"}
+  "crunch"     {>= "2.2.0"}
+  "webmachine" {>= "0.6.0"}
+  "irmin"      {>= "2.0.0"}
+  "cohttp-lwt" {>= "1.0.0"}
+  "irmin-git"  {with-test & >= "2.0.0"}
+  "irmin-mem"  {with-test & >= "2.0.0"}
+  "irmin-test" {with-test & >= "2.0.0"}
+  "git-unix"   {with-test}
+  "digestif"   {with-test & >= "0.6.1"}
+]
+
+synopsis: "HTTP client and server for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}

--- a/packages/irmin-mem/irmin-mem.2.0.0/opam
+++ b/packages/irmin-mem/irmin-mem.2.0.0/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml"      {>= "4.03.0"}
   "dune"       {>= "1.1.0"}
-  "irmin"      {>= "1.3.0"}
+  "irmin"      {>= "2.0.0"}
   "irmin-test" {with-test}
 ]
 

--- a/packages/irmin-mem/irmin-mem.2.0.0/opam
+++ b/packages/irmin-mem/irmin-mem.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "1.1.0"}
+  "irmin"      {>= "1.3.0"}
+  "irmin-test" {with-test}
+]
+
+
+synopsis: "Generic in-memory Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.0.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.0.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "dune"       {>= "1.1.0"}
   "irmin-mirage"
-  "irmin-git"  {>= "1.3.0"}
+  "irmin-git"  {>= "2.0.0"}
   "git-mirage" {>= "2.1.2"}
   "mirage-kv" {>= "3.0.0"}
 ]

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.0.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"       {>= "1.1.0"}
+  "irmin-mirage"
+  "irmin-git"  {>= "1.3.0"}
+  "git-mirage" {>= "2.1.2"}
+  "mirage-kv" {>= "3.0.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.0.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"    {>= "1.1.0"}
+  "irmin-mirage"
+  "git-mirage" {>= "2.1.1"}
+  "irmin-graphql"
+  "mirage-clock"
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}

--- a/packages/irmin-mirage/irmin-mirage.2.0.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"       {>= "1.1.0"}
+  "irmin"      {>= "2.0.0"}
+  "irmin-mem"  {>= "2.0.0"}
+  "ptime"
+  "mirage-clock" {>= "3.0.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}

--- a/packages/irmin-pack/irmin-pack.2.0.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.1.0"}
+  "irmin"      {>= "2.0.0"}
+  "index"      {>= "1.0.0"}
+  "lwt"
+  "irmin-test" {with-test & >= "2.0.0"}
+  "alcotest-lwt" {with-test}
+]
+
+synopsis: "Irmin backend which stores values in a pack file"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}

--- a/packages/irmin-test/irmin-test.2.0.0/opam
+++ b/packages/irmin-test/irmin-test.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"    {>= "4.02.3"}
+  "dune"     {>= "1.1.0"}
+  "irmin"    {>= "2.0.0"}
+  "alcotest"
+  "mtime"    {>= "1.0.0"}
+  "metrics-unix"
+]
+
+synopsis: "Irmin test suite"
+description: """
+`irmin-test` provides access to the Irmin test suite for testing storage backend
+implementations.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}

--- a/packages/irmin-unix/irmin-unix.2.0.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.01.0"}
+  "dune"          {>= "1.1.0"}
+  "irmin"         {>= "2.0.0"}
+  "irmin-mem"     {>= "2.0.0"}
+  "irmin-git"     {>= "2.0.0"}
+  "irmin-http"    {>= "2.0.0"}
+  "irmin-fs"      {>= "2.0.0"}
+  "irmin-pack"    {>= "2.0.0"}
+  "irmin-graphql"
+  "git-unix"      {>= "1.11.4"}
+  "digestif"      {>= "0.6.1"}
+  "irmin-watcher" {>= "0.2.0"}
+  "yaml"          {>= "0.1.0"}
+  "irmin-test"    {with-test & >= "2.0.0"}
+]
+
+synopsis: "Unix backends for Irmin"
+description: """
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}

--- a/packages/irmin/irmin.2.0.0/opam
+++ b/packages/irmin/irmin.2.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+version:      "dev"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.06.0"}
+  "dune"    {>= "1.1.0"}
+  "fmt"     {>= "0.8.0"}
+  "uri"     {>= "1.3.12"}
+  "jsonm"   {>= "1.0.0"}
+  "lwt"     {>= "2.4.7"}
+  "base64"  {>= "2.0.0"}
+  "digestif"
+  "ocamlgraph"
+  "logs"    {>= "0.5.0"}
+  "astring"
+  "hex"      {with-test}
+  "alcotest" {with-test}
+]
+synopsis: """
+Irmin, a distributed database that follows the same design principles as Git
+"""
+description: """
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.0.0/irmin-2.0.0.tbz"
+  checksum: [
+    "sha256=b90957bf1b03488447105659694b2fab234f256c8b721fe11b35fb12df760e27"
+    "sha512=68e7a772f46c4b93779b4d9e234b60c71b04b7b72f6f8f528e402caa78d5576c1aa92836cf6a940611e3729b6b48d0a6de93c40aec1dcea5c46937f8b3b4331e"
+  ]
+}


### PR DESCRIPTION
Generic file-system backend for Irmin

- Project page: <a href="https://github.com/mirage/irmin">https://github.com/mirage/irmin</a>
- Documentation: <a href="https://mirage.github.io/irmin/">https://mirage.github.io/irmin/</a>

##### CHANGES:

#### Added

- **irmin-pack** (_new_):
  - Created a new Irmin backend, `irmin-pack`, which uses a space-optimised
    on-disk format.

- **irmin-graphql** (_new_):
  - Created a new package, `irmin-graphql`, which provides a GraphQL server
    implementation that can be used with both the MirageOS and Unix backends.
    Additionally, a `graphql` command has been added to the command-line
    interface for starting `irmin-graphql` servers. (mirage/irmin#558, @andreas, @zshipko)

  - Contents can now be queried directly using `irmin-graphql` with
    `Irmin_graphql.Server.Make_ext` and the `Irmin_graphql.Server.PRESENTER`
    interface. (mirage/irmin#643, @andreas)

- **irmin-test** (_new_):
  - Added a new package, `irmin-test`, which allows for packages to access the
    Irmin test-suite. This package can now be used for new packages that
    implement custom backends to test their implementations against the same
    tests that the core backends are tested against. (mirage/irmin#508, @zshipko)

- **irmin-unix**:
  - Add `Cli` module to expose some methods to simplify building command-line
    interfaces using Irmin. (mirage/irmin#517, @zshipko)

  - Add global config file `$HOME/.irmin/config.yml` which may be overridden by
    either `$PWD/.irmin.yml` or by passing `--config <PATH>`. See `irmin help
    irmin.yml` for details. (mirage/irmin#513, @zshipko)

- **irmin-git**:
  - Allow import/export of Git repositories using Irmin slices. (mirage/irmin#561, @samoht)

- **irmin-http**:
  - Expose a `/trees/merge` route for server-side merge operations. (mirage/irmin#714,
    @samoht)

- **irmin**:
  - Add `Json_value` and `Json` content types. (mirage/irmin#516 mirage/irmin#694, @zshipko)

  - Add optional seed parameter to the `Irmin.Type` generic hash functions.
    (mirage/irmin#712, @samoht)

  - Add `V1` submodules in `Commit`, `Contents` and `Hash` to provide
    compatibility with 1.x serialisation formats. (mirage/irmin#644 mirage/irmin#666, @samoht)

  - Add `Store.last_modified` function, which provides a list of commits where
    the given key was modified last. (mirage/irmin#617, @pascutto)

  - Add a `Content_addressable.unsafe_add` function allowing the key of the new
    value to be specified explicitly (for performance reasons). (mirage/irmin#783, @samoht)

  - Add `save_contents` function for saving contents to the database. (mirage/irmin#689,
    @samoht)

  - Add pretty-printers for the results of Sync operations. (mirage/irmin#789, @craigfe)

  - `Private.Lock` now exposes a `stats` function returning the number of held
    locks. (mirage/irmin#704, @samoht)

#### Changed

- **irmin-unix**:
  - Rename `irmin read` to `irmin get` and `irmin write` to `irmin set`. (mirage/irmin#501,
  @zshipko)

  - Switch from custom configuration format to YAML. (mirage/irmin#504, @zshipko)

- **irmin-git**:
  - Require `ocaml-git >= 2.0`. (mirage/irmin#545, @samoht)

  - Cleanup handling of remote stores. (mirage/irmin#552, @samoht)

- **irmin-http**:
  - Rename `CLIENT` to `HTTP_CLIENT` and simplify the signatures necessary to
    construct HTTP clients and servers. (mirage/irmin#701, @samoht)

- **irmin-mirage**
  - Split `irmin-mirage` into `irmin-{mirage,mirage-git,mirage-graphql}` to
    allow for more granular dependency selection. Any instances of
    `Irmin_mirage.Git` should be replaced with `Irmin_mirage_git`. (mirage/irmin#686,
    @zshipko)

- **irmin**:
  - Update to use dune (mirage/irmin#534, @samoht) and opam 2.0. (mirage/irmin#583, @samoht)

  - Replace `Irmin.Contents.S0` with `Irmin.Type.S`.

  - Rename `Type.pre_digest` -> `Type.pre_hash` and `Type.hash` ->
    `Type.short_hash`. (mirage/irmin#720, @samoht)

  - Change `Irmin.Type` to use _incremental_ hash functions (functions of type
    `'a -> (string -> unit) -> unit`) for performance reasons. (mirage/irmin#751, @samoht)

  - Simplify the `Irmin.Type.like` constructor and add a new `Irmin.Type.map`
    with the previous behaviour.

  - Improvements to `Irmin.Type` combinators. (mirage/irmin#550 mirage/irmin#538 mirage/irmin#652 mirage/irmin#653 mirage/irmin#655 mirage/irmin#656
    mirage/irmin#688, @samoht)

  - Modify `Store.set` to return a result type and create a new `Store.set_exn`
    with the previous exception-raising behaviour. (mirage/irmin#572, @samoht)

  - Rename store module types to be more descriptive:
     - replace `Irmin.AO` with `Irmin.CONTENT_ADDRESSABLE_STORE`;
     - replace `Irmin.AO_MAKER` with `Irmin.CONTENT_ADDRESSABLE_STORE_MAKER`;
     - replace `Irmin.RW` with `Irmin.ATOMIC_WRITE_STORE`;
     - replace `Irmin.RW_MAKER` with `Irmin.ATOMIC_WRITE_STORE_MAKER`. (mirage/irmin#601,
       @samoht)

  - Rename `export_tree` to `save_tree` (mirage/irmin#689, @samoht) and add an option to
    conditionally clear the tree cache (mirage/irmin#702 mirage/irmin#725, @samoht).

  - Change hash function for `Irmin_{fs,mem,unix}.KV` to BLAKE2b rather than
    SHA1 for security reasons. (mirage/irmin#811, @craigfe)

  - Move `Irmin.remote_uri` to `Store.remote`, for stores that support remote
    operations. (mirage/irmin#552, @samoht)

  - Simplify the error cases of fetch/pull/push operations. (mirage/irmin#684, @zshipko)

  - A `batch` function has been added to the backend definition to allow for
    better control over how groups of operations are processed. (mirage/irmin#609, @samoht)

  - A `close` function has been added to allow backends to close any held
    resources (e.g. file descriptors for the `FS` backend). (mirage/irmin#845, @samoht)

  - Simplify `Private.Node.Make` parameters to use a simpler notion of 'path' in
    terms of a list of steps. (mirage/irmin#645, @samoht)

  - Rename `Node.update` to `Node.add`. (mirage/irmin#713, @samoht)

#### Fixed

- **irmin-unix**:
   - Fix parsing of commit hashes in `revert` command. (mirage/irmin#496, @zshipko)

- **irmin-git**:
  - Fix `Node.add` to preserve sharing. (mirage/irmin#802, @samoht)

- **irmin-http**:
  - Respond with a 404 if a non-existent resource is requested. (mirage/irmin#706, @samoht)

- **irmin**:
  - Fix a bug whereby `S.History.is_empty` would return `true` for a store with
    exactly one commit. (mirage/irmin#865, @pascutto)

#### Removed

- **irmin**:
  - Remove `pp` and `of_string` functions from `Irmin.Contents.S` in favour of
    `Irmin.Type.to_string` and `Irmin.Type.of_string`.

  - Remove `Bytes` content type. (mirage/irmin#708, @samoht)

  - Remove `Cstruct` dependency and content type. If possible, switch to
    `Irmin.Contents.String` or else use `Irmin.Type.map` to wrap the Cstruct
    type. (mirage/irmin#544, @samoht)
