### PR TITLE
Package jupyter-kernel.0.5

### DIFF
--- a/packages/jupyter-kernel/jupyter-kernel.0.5/opam
+++ b/packages/jupyter-kernel/jupyter-kernel.0.5/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Andrew Ray"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Library to write jupyter kernels (interactive notebooks)"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+depends: [
+    "dune" { >= "1.1" }
+    "odoc" {with-doc}
+    "base-bytes"
+    "result"
+    "base-unix"
+    "zmq"
+    "atdgen"
+    "yojson" { >= "1.6" }
+    "uuidm"
+    "lwt"
+    "lwt-zmq"
+    "digestif"
+    "ISO8601"
+    "uutf"
+    "ocaml" {>= "4.03"}
+]
+depopts: [
+  "tyxml"
+]
+tags: [ "jupyter" "ipython" ]
+homepage: "https://github.com/ocaml-jupyter/jupyter-kernel"
+dev-repo: "git+https://github.com/ocaml-jupyter/jupyter-kernel.git"
+bug-reports: "https://github.com/ocaml-jupyter/jupyter-kernel/issues"
+url {
+  src: "https://github.com/ocaml-jupyter/jupyter-kernel/archive/0.5.tar.gz"
+  checksum: [
+    "md5=db484e3bb7245e5cfd7184ed1990d568"
+    "sha512=d5cd91d81c05da043b4362cbecd53e3c97724b481725a127267f7691d3d18d0ece923081b7229198bd65835f4c20be7f9a10bafadfd4fbf8f863f1acea2ff53c"
+  ]
+}


### PR DESCRIPTION
### `jupyter-kernel.0.5`
Library to write jupyter kernels (interactive notebooks)



---
* Homepage: https://github.com/ocaml-jupyter/jupyter-kernel
* Source repo: git+https://github.com/ocaml-jupyter/jupyter-kernel.git
* Bug tracker: https://github.com/ocaml-jupyter/jupyter-kernel/issues

---
:camel: Pull-request generated by opam-publish v2.0.0