### PR TITLE
[new release] ppxlib (0.10.0)

### DIFF
--- a/packages/ppxlib/ppxlib.0.10.0/opam
+++ b/packages/ppxlib/ppxlib.0.10.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.06" & ocaml:version < "4.08" }
+]
+depends: [
+  "ocaml"                   {>= "4.04.1"}
+  "base"                    {>= "v0.11.0"}
+  "dune"
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "1.3.1"}
+  "ppx_derivers"            {>= "1.0"}
+  "stdio"                   {>= "v0.11.0"}
+  "ocamlfind"               {with-test}
+  "cinaps"                  {with-test & >= "v0.12.1"}
+]
+synopsis: "Base library and tools for ppx rewriters"
+description: """
+A comprehensive toolbox for ppx development. It features:
+- a OCaml AST / parser / pretty-printer snapshot,to create a full
+   frontend independent of the version of OCaml;
+- a library for library for ppx rewriters in general, and type-driven
+  code generators in particular;
+- a feature-full driver for OCaml AST transformers;
+- a quotation mechanism allowing  to write values representing the
+   OCaml AST in the OCaml syntax;
+- a generator of open recursion classes from type definitions.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.10.0/ppxlib-0.10.0.tbz"
+  checksum: [
+    "sha256=588e85c759688742ae0bd2cb1a53f0f555a76d8810ad9a9dbb026a076a0c10af"
+    "sha512=8e3e9399b260e16fb537cdd58706875933ecbf28e3bcddc1bf3e607a33307eb2191a7d3c315e8e4b51ec6f548779a0fad118826f709de65dddd3b2510f3e4bcc"
+  ]
+}


### PR DESCRIPTION
Base library and tools for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Do not produce a suprious empty correction when deriving_inline
  expands into an extension that undergoes further expansion (ocaml-ppx/ppxlib#86,
  @aalekseyev)

- Add `Ppxlib.Quoter`. This module allows to generate hygienic code fragments in
  the spirit of ppx_deriving. (ocaml-ppx/ppxlib#92, @rgrinberg)

- Allow for registering derivers on module type declarations. (ocaml-ppx/ppxlib#94, fix ocaml-ppx/ppxlib#83,
  @rgrinberg)

- Fix parsing long idenitifiers. (ocaml-ppx/ppxlib#98, @NathanReb)
