### PR TITLE
Add an OCaml upper bound to cinaps.v0.9.1

### DIFF
--- a/packages/cinaps/cinaps.v0.9.1/opam
+++ b/packages/cinaps/cinaps.v0.9.1/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.10.0" }
   "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Trivial metaprogramming tool"


### PR DESCRIPTION
According to http://check.ocamllabs.io/, `cinaps.v0.9.1`
is not compatible with OCaml 4.10.0.