### PR TITLE
[new release] fat-filesystem (0.14.0)

### DIFF
--- a/packages/fat-filesystem/fat-filesystem.0.14.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.14.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Anil Madhavapeddy"]
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-fat"
+doc: "https://mirage.github.io/ocaml-fat/"
+bug-reports: "https://github.com/mirage/ocaml-fat/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "ppx_cstruct"
+  "rresult"
+  "lwt" {>= "2.4.3"}
+  "mirage-fs" {>= "3.0.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-block-unix" {>= "2.5.0"}
+  "mirage-block-combinators" {with-test}
+  "io-page-unix" {>= "2.0.0"}
+  "io-page" {>= "2.0.0"}
+  "re" {>= "1.7.2"}
+  "cmdliner"
+  "astring"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-fat.git"
+synopsis: "Pure OCaml implementation of the FAT filesystem"
+description: """
+This library has two purposes:
+1. to allow the easy preparation of bootable disk images
+     containing [mirage](https://mirage.io) kernels
+2. to provide a simple filesystem layer for MirageOS applications
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-fat/releases/download/v0.14.0/fat-filesystem-v0.14.0.tbz"
+  checksum: [
+    "sha256=07312d63c0b215dc1db1036db7493500fe5fe20cad05f189a74b5c51e85d8af5"
+    "sha512=856514a926d451c74756b70910f9e06aa7b55a85b5e3c1306ce4de8b3f56b477332f9f81ea85b71a591eb0cdbc540debaa2d2f418fe07aa316abb68c4d314b1c"
+  ]
+}


### PR DESCRIPTION
Pure OCaml implementation of the FAT filesystem

- Project page: <a href="https://github.com/mirage/ocaml-fat">https://github.com/mirage/ocaml-fat</a>
- Documentation: <a href="https://mirage.github.io/ocaml-fat/">https://mirage.github.io/ocaml-fat/</a>

##### CHANGES:

- fix inconsistent sector size between block and fs (mirage/ocaml-fat#81, @ehirdoy)
- adapt to newer MirageOS 3.7.1 interfaces (mirage/ocaml-fat#82, @hannesm)
- Handle special dot and dotdot files (mirage/ocaml-fat#76, @ricarkol)
