### PR TITLE
ppx_pattern_bind.v0.13.1

### DIFF
--- a/packages/ppx_pattern_bind/ppx_pattern_bind.v0.13.1/opam
+++ b/packages/ppx_pattern_bind/ppx_pattern_bind.v0.13.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_pattern_bind"
+bug-reports: "https://github.com/janestreet/ppx_pattern_bind/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_pattern_bind.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_pattern_bind/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "base" {>= "v0.13" & < "v0.14"}
+  "ppx_let" {>= "v0.13" & < "v0.14"}
+  "dune"    {>= "1.5.1"}
+  "ppxlib"  {>= "0.9.0"}
+]
+synopsis: "A ppx for writing fast incremental bind nodes in a pattern match"
+description: "
+A ppx rewriter that is intended for use with Incremental. It makes it
+easier to write incremental computations using pattern-matching in a
+way that causes incremental nodes to fire as little as possible.
+"
+url {
+  src: "https://github.com/janestreet/ppx_pattern_bind/archive/v0.13.1.tar.gz"
+  checksum: "md5=8096399ed6d898af4d62e9630ac90f37"
+}


### PR DESCRIPTION
There has been a problem with our export script, and
`ppx_pattern_bind.v0.13.0` happens to be essentially
empty. This release hopefully fixes the problem, as
reported in _e.g._ https://github.com/janestreet/ppx_pattern_bind/issues/1.