### PR TITLE
angstrom-async is compatible with async.v0.13.0

### DIFF
--- a/packages/angstrom-async/angstrom-async.0.10.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.10.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom" {>= "0.7.0" & < "0.11.0"}
-  "async" {>= "v0.9.0" & < "v0.13"}
+  "async" {>= "v0.9.0"}
 ]
 synopsis: "Angstrom - Async-specific support"
 url {

--- a/packages/angstrom-async/angstrom-async.0.11.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.11.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom" {>= "0.7.0"}
-  "async" {>= "v0.9.0" & < "v0.13"}
+  "async" {>= "v0.9.0"}
 ]
 synopsis: "Async support for Angstrom"
 url {

--- a/packages/angstrom-async/angstrom-async.0.11.1/opam
+++ b/packages/angstrom-async/angstrom-async.0.11.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.0"}
   "angstrom" {>= "0.7.0"}
-  "async" {>= "v0.10.0" & < "v0.13"}
+  "async" {>= "v0.10.0"}
 ]
 synopsis: "Async support for Angstrom"
 url {

--- a/packages/angstrom-async/angstrom-async.0.11.2/opam
+++ b/packages/angstrom-async/angstrom-async.0.11.2/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.0"}
   "angstrom" {>= "0.7.0"}
-  "async" {>= "v0.10.0" & < "v0.13"}
+  "async" {>= "v0.10.0"}
 ]
 synopsis: "Async support for Angstrom"
 url {

--- a/packages/angstrom-async/angstrom-async.0.12.1/opam
+++ b/packages/angstrom-async/angstrom-async.0.12.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.0"}
   "angstrom" {>= "0.7.0"}
-  "async" {>= "v0.10.0" & < "v0.13"}
+  "async" {>= "v0.10.0"}
 ]
 synopsis: "Async support for Angstrom"
 url {

--- a/packages/angstrom-async/angstrom-async.0.7.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.7.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom" {>= "0.7.0" & < "0.9.0"}
-  "async" {>= "v0.9.0" & < "v0.13"}
+  "async" {>= "v0.9.0"}
 ]
 synopsis: "Angstrom - Async-specific support"
 url {

--- a/packages/angstrom-async/angstrom-async.0.8.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.8.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom" {>= "0.7.0" & < "0.9.0"}
-  "async" {>= "v0.9.0" & < "v0.13"}
+  "async" {>= "v0.9.0"}
 ]
 synopsis: "Angstrom - Async-specific support"
 url {

--- a/packages/angstrom-async/angstrom-async.0.8.1/opam
+++ b/packages/angstrom-async/angstrom-async.0.8.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom" {>= "0.7.0" & < "0.9.0"}
-  "async" {>= "v0.9.0" & < "v0.13"}
+  "async" {>= "v0.9.0"}
 ]
 synopsis: "Angstrom - Async-specific support"
 url {

--- a/packages/angstrom-async/angstrom-async.0.9.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.9.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom" {>= "0.9.0" & < "0.11.0"}
-  "async" {>= "v0.9.0" & < "v0.13"}
+  "async" {>= "v0.9.0"}
 ]
 synopsis: "Angstrom - Async-specific support"
 url {


### PR DESCRIPTION
(We need to relax these constraints for an upcoming JS package.)