### PR TITLE
[new release] pkcs11-cli, pkcs11-driver, pkcs11-rev and pkcs11 (1.0.0)

### DIFF
--- a/packages/pkcs11-cli/pkcs11-cli.1.0.0/opam
+++ b/packages/pkcs11-cli/pkcs11-cli.1.0.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "cmdliner"
+  "pkcs11" {>= "0.18.0"}
+  "dune" {>= "1.3.0"}
+]
+tags: ["org:cryptosense"]
+synopsis: "Cmdliner arguments to initialize a PKCS#11 session"
+url {
+  src:
+    "https://github.com/cryptosense/pkcs11/releases/download/v1.0.0/pkcs11-v1.0.0.tbz"
+  checksum: [
+    "sha256=eee2e67fff116d747d1d0f6229af9e952cbb4f9a56765c069c63c1e1bbbc67a3"
+    "sha512=3a1090b0cd53b09dffb4c2a2d591e290ff3fe9add1217797f9746a1a6af0d41239b217f1dd45354e3ee457ff007d68bb4d8d83f07001d6ad9870e7aaba4fd434"
+  ]
+}

--- a/packages/pkcs11-driver/pkcs11-driver.1.0.0/opam
+++ b/packages/pkcs11-driver/pkcs11-driver.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "ctypes"
+  "ctypes-foreign"
+  "dune" {>= "1.3.0"}
+  "pkcs11" {>= "0.18.0"}
+  "ppx_deriving" { >= "4.0" }
+  "ppx_deriving_yojson" { >= "3.0" }
+  "ocaml" {>= "4.04.0"}
+  "ounit" {with-test}
+]
+conflicts: [
+  "ctypes" { < "0.12.0" }
+]
+tags: ["org:cryptosense"]
+available: [os != "macos"]
+synopsis: "Bindings to the PKCS#11 cryptographic API"
+description: """
+This library contains ctypes bindings to the PKCS#11 API.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/pkcs11/releases/download/v1.0.0/pkcs11-v1.0.0.tbz"
+  checksum: [
+    "sha256=eee2e67fff116d747d1d0f6229af9e952cbb4f9a56765c069c63c1e1bbbc67a3"
+    "sha512=3a1090b0cd53b09dffb4c2a2d591e290ff3fe9add1217797f9746a1a6af0d41239b217f1dd45354e3ee457ff007d68bb4d8d83f07001d6ad9870e7aaba4fd434"
+  ]
+}

--- a/packages/pkcs11-rev/pkcs11-rev.0.18.0/opam
+++ b/packages/pkcs11-rev/pkcs11-rev.0.18.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
   "pkcs11" {>= "0.18.0"}
-  "pkcs11-driver"
+  "pkcs11-driver" {<= "0.18.0"}
 ]
 conflicts: [
   "ctypes" { < "0.12.0" }

--- a/packages/pkcs11-rev/pkcs11-rev.1.0.0/opam
+++ b/packages/pkcs11-rev/pkcs11-rev.1.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ctypes"
+  "ctypes-foreign"
+  "dune" {>= "1.3.0"}
+  "pkcs11" {>= "0.18.0"}
+  "pkcs11-driver" {>= "1.0.0"}
+]
+conflicts: [
+  "ctypes" { < "0.12.0" }
+]
+tags: ["org:cryptosense"]
+available: [os != "macos"]
+synopsis: "Reverse bindings to pkcs11"
+description: """
+This library contains helpers to write reverse PKCS#11 bindings.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/pkcs11/releases/download/v1.0.0/pkcs11-v1.0.0.tbz"
+  checksum: [
+    "sha256=eee2e67fff116d747d1d0f6229af9e952cbb4f9a56765c069c63c1e1bbbc67a3"
+    "sha512=3a1090b0cd53b09dffb4c2a2d591e290ff3fe9add1217797f9746a1a6af0d41239b217f1dd45354e3ee457ff007d68bb4d8d83f07001d6ad9870e7aaba4fd434"
+  ]
+}

--- a/packages/pkcs11/pkcs11.1.0.0/opam
+++ b/packages/pkcs11/pkcs11.1.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Nathan Rebours <nathan@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "https://github.com/cryptosense/pkcs11"
+bug-reports: "https://github.com/cryptosense/pkcs11/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/pkcs11.git"
+doc: "https://cryptosense.github.io/pkcs11/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "1.3.0"}
+  "hex" { >= "1.0.0" }
+  "integers"
+  "ppx_deriving" { >= "4.0" }
+  "ppx_deriving_yojson" { >= "3.4" }
+  "ppx_variants_conv"
+  "zarith"
+  "ocaml" {>= "4.04.0"}
+  "ounit" {with-test}
+]
+tags: ["org:cryptosense"]
+available: [os != "macos"]
+synopsis: "PKCS#11 ocaml types"
+description: """
+This library contains type definitions for the PKCS#11 API.
+
+This API is used by smartcards and Hardware Security Modules to perform
+cryptographic operations such as signature or encryption.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/pkcs11/releases/download/v1.0.0/pkcs11-v1.0.0.tbz"
+  checksum: [
+    "sha256=eee2e67fff116d747d1d0f6229af9e952cbb4f9a56765c069c63c1e1bbbc67a3"
+    "sha512=3a1090b0cd53b09dffb4c2a2d591e290ff3fe9add1217797f9746a1a6af0d41239b217f1dd45354e3ee457ff007d68bb4d8d83f07001d6ad9870e7aaba4fd434"
+  ]
+}


### PR DESCRIPTION
Cmdliner arguments to initialize a PKCS#11 session

- Project page: <a href="https://github.com/cryptosense/pkcs11">https://github.com/cryptosense/pkcs11</a>
- Documentation: <a href="https://cryptosense.github.io/pkcs11/doc">https://cryptosense.github.io/pkcs11/doc</a>

##### CHANGES:

*2019-11-21*

## Additions

- Add a new `initialize_nss` function to `pkcs11-driver` to perform a C_Initialize call with the extra parameters that NSS requires (see https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/PKCS11/Module_Specs for more information)

## Changes

- (Breaking) Rename `P11_driver.Make` to `P11_driver.Wrap_low_level_bindings`
- (Breaking) Rename `Pkcs11.RAW` to `Pkcs11.LOW_LEVEL_BINDINGS`
- (Breaking) Rename `Pkcs11.S` to `Pkcs11.LOW_LEVEL_WRAPPER`
- (Breaking) Rename `Pkcs11.Make` to `Pkcs11.Wrap_low_level_bindings`
