### PR TITLE
mirage 3.7.2: relax bounds on mirage-runtime

### DIFF
--- a/packages/mirage/mirage.3.7.2/opam
+++ b/packages/mirage/mirage.3.7.2/opam
@@ -25,7 +25,7 @@ depends: [
   "astring"
   "logs"
   "stdlib-shims"
-  "mirage-runtime"     {= version}
+  "mirage-runtime"     {>= "3.7.0" & < "3.8.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """


### PR DESCRIPTION
/cc @samoht I suspect this is why mirage 3.7.1 still gets installed in mirage-www travis job. I'm not entirely sure what to do in the mirage/mirage repository with this dependency -- a `=version` is for sure the safest since others may need to be modified upon release.. if we'd always release mirage, mirage-runtime, mirage-types, mirage-types-lwt at once, we would not run into this issue at all...