### PR TITLE
relaxes ezjsonm constraints for sexplib

### DIFF
--- a/packages/ezjsonm/ezjsonm.1.1.0/opam
+++ b/packages/ezjsonm/ezjsonm.1.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "alcotest" {with-test & >= "0.4.0"}
   "jsonm" {>= "1.0.0"}
-  "sexplib" {< "v0.13"}
+  "sexplib" {< "v0.14"}
   "hex"
 ]
 build: [


### PR DESCRIPTION
It looks like that the constraint is superfluous as we can easily install ezjsonm with the latest core, e.g.,
`opam install ezjsonm --ignore-constraints-on=sexplib`
works without any issues.

cc @samoht 