### PR TITLE
Package pixel_pusher.1.0

### DIFF
--- a/packages/pixel_pusher/pixel_pusher.1.0/opam
+++ b/packages/pixel_pusher/pixel_pusher.1.0/opam
@@ -10,6 +10,8 @@ bug-reports: "https://github.com/mbacarella/pixel_pusher/issues"
 dev-repo: "git+https://github.com/mbacarella/pixel_pusher.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
   "async_udp"   {>= "v0.12.0"}
   "core"        {>= "v0.12.0"}
   "bitstring"   {>= "3.1.1"}

--- a/packages/pixel_pusher/pixel_pusher.1.0/opam
+++ b/packages/pixel_pusher/pixel_pusher.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Control LED strips on Pixel Pusher hardware"
+description: """
+Light up LED strips by driving Pixel Pusher hardware modules over UDP/IP networks
+"""
+maintainer: "Michael Bacarella <michael.bacarella@gmail.com>"
+authors: ["Michael Bacarella <michael.bacarella@gmail.com>"]
+homepage: "https://github.com/mbacarella/pixel_pusher"
+bug-reports: "https://github.com/mbacarella/pixel_pusher/issues"
+dev-repo: "git+https://github.com/mbacarella/pixel_pusher.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "async_udp"   {>= "v0.12.0"}
+  "core"        {>= "v0.12.0"}
+  "bitstring"   {>= "v3.1.1"}
+]
+url {
+  src: "https://github.com/mbacarella/pixel_pusher/archive/1.0.tar.gz"
+  checksum: [
+    "md5=a68f3424b4027b102b6e40d1f65c17f5"
+    "sha512=0506033b36d0974255573d87c62cd6514369d6610587e3e26f047c2dbb11b2e1c1a074304df771ba555c4d97044651ad3503e4d335538182b8a8081dd3945bf8"
+  ]
+}

--- a/packages/pixel_pusher/pixel_pusher.1.0/opam
+++ b/packages/pixel_pusher/pixel_pusher.1.0/opam
@@ -12,7 +12,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "async_udp"   {>= "v0.12.0"}
   "core"        {>= "v0.12.0"}
-  "bitstring"   {>= "v3.1.1"}
+  "bitstring"   {>= "3.1.1"}
 ]
 url {
   src: "https://github.com/mbacarella/pixel_pusher/archive/1.0.tar.gz"


### PR DESCRIPTION
### `pixel_pusher.1.0`
Control LED strips on Pixel Pusher hardware
Light up LED strips by driving Pixel Pusher hardware modules over UDP/IP networks



---
* Homepage: https://github.com/mbacarella/pixel_pusher
* Source repo: git+https://github.com/mbacarella/pixel_pusher.git
* Bug tracker: https://github.com/mbacarella/pixel_pusher/issues

---
:camel: Pull-request generated by opam-publish v2.0.0