### PR TITLE
Package tiny_httpd.0.2

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.2/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Minimal HTTP server using good old threads"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-threads"
+  "ocaml" { >= "4.03.0" }
+  "odoc" {with-doc}
+]
+tags: [ "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+post-messages: "tiny http server, with blocking IOs. Also ships with a `http_of_dir` program."
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/0.2.tar.gz"
+  checksum: [
+    "md5=cde7a9b5fef8917720ff1872211c69df"
+    "sha512=c989da0f165e8a1f3f9da818534568a546e285be825b21e85bf40f168f852fa21f751147e31acf0d5090437467c5797ec6f64fab5748918aa1fe32c512b23b11"
+  ]
+}


### PR DESCRIPTION
### `tiny_httpd.0.2`
Minimal HTTP server using good old threads



---
* Homepage: https://github.com/c-cube/tiny_httpd/
* Source repo: git+https://github.com/c-cube/tiny_httpd.git
* Bug tracker: https://github.com/c-cube/tiny_httpd/issues

---
:camel: Pull-request generated by opam-publish v2.0.0