### PR TITLE
[new release] opazl (0.0.1)

### DIFF
--- a/packages/opazl/opazl.0.0.1/opam
+++ b/packages/opazl/opazl.0.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Library to parse ZNC logs"
+description:
+  "opazl is an OCaml library to parse ZNC logs. It can parse a log file encoded in utf-8, allows you to access time, user and content for each message and more."
+maintainer: ["Léo Andrès <contact@ndrs.fr>"]
+authors: ["Léo Andrès <contact@ndrs.fr>"]
+license: "ISC"
+homepage: "https://git.zapashcanon.fr/zapashcanon/opazl"
+doc: "https://doc.zapashcanon.fr/opazl/"
+bug-reports: "https://git.zapashcanon.fr/zapashcanon/opazl/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.11.0"}
+  "bisect_ppx" {>= "1.4.1"}
+  "sedlex" {>= "2.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://git.zapashcanon.fr/zapashcanon/opazl.git"
+url {
+  src: "https://fs.zapashcanon.fr/archive/opazl/opazl-0.0.1.tbz"
+  checksum: [
+    "sha256=04aef74af0a6fc999996fda0a687821ae4d33d20765ab89a3f5361cb620ca398"
+    "sha512=6d77fe93aa6e0b7a33abdb46373c6daed41a5867330da1e61168ebc05a5f25ae4e950c4f4b4e13b9ae1b5d353379883a643a5121138f70cd22a7c3fbda97d62e"
+  ]
+}


### PR DESCRIPTION
Library to parse ZNC logs

- Project page: <a href="https://git.zapashcanon.fr/zapashcanon/opazl">https://git.zapashcanon.fr/zapashcanon/opazl</a>
- Documentation: <a href="https://doc.zapashcanon.fr/opazl/">https://doc.zapashcanon.fr/opazl/</a>

##### CHANGES:

First release
