### PR TITLE
[new release] cstruct-async, ppx_cstruct, cstruct, cstruct-unix, cstruct-sexp and cstruct-lwt (5.1.0)

### DIFF
--- a/packages/cstruct-async/cstruct-async.5.1.0/opam
+++ b/packages/cstruct-async/cstruct-async.5.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+doc: "https://mirage.github.io/ocaml-cstruct/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "async_kernel" {>= "v0.9.0"}
+  "async_unix" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0"}
+  "cstruct" {=version}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v5.1.0/cstruct-v5.1.0.tbz"
+  checksum: [
+    "sha256=cb86d405d98d2d2fde06e09e691bb76719accab9cb38871077e4c000a94935bd"
+    "sha512=5c58b2a2b32bbd65ac7f08bc1c7bbaa891c0e3c85521ca0a8967ffb88c3ca53e446cebd06107d80f1545c75c06dc4c7da4608aa67f2d3cc41be60e4be946343f"
+  ]
+}

--- a/packages/cstruct-lwt/cstruct-lwt.5.1.0/opam
+++ b/packages/cstruct-lwt/cstruct-lwt.5.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-unix"
+  "dune"
+  "lwt"
+  "cstruct" {=version}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v5.1.0/cstruct-v5.1.0.tbz"
+  checksum: [
+    "sha256=cb86d405d98d2d2fde06e09e691bb76719accab9cb38871077e4c000a94935bd"
+    "sha512=5c58b2a2b32bbd65ac7f08bc1c7bbaa891c0e3c85521ca0a8967ffb88c3ca53e446cebd06107d80f1545c75c06dc4c7da4608aa67f2d3cc41be60e4be946343f"
+  ]
+}

--- a/packages/cstruct-sexp/cstruct-sexp.5.1.0/opam
+++ b/packages/cstruct-sexp/cstruct-sexp.5.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Anton Kochkov" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "sexplib"
+  "cstruct" {=version}
+  "alcotest" {with-test}
+]
+synopsis: "S-expression serialisers for C-like structures"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.
+
+This library provides Sexplib serialisers for the Cstruct.t values."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v5.1.0/cstruct-v5.1.0.tbz"
+  checksum: [
+    "sha256=cb86d405d98d2d2fde06e09e691bb76719accab9cb38871077e4c000a94935bd"
+    "sha512=5c58b2a2b32bbd65ac7f08bc1c7bbaa891c0e3c85521ca0a8967ffb88c3ca53e446cebd06107d80f1545c75c06dc4c7da4608aa67f2d3cc41be60e4be946343f"
+  ]
+}

--- a/packages/cstruct-unix/cstruct-unix.5.1.0/opam
+++ b/packages/cstruct-unix/cstruct-unix.5.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "base-unix"
+  "cstruct" {=version}
+]
+synopsis: "Access C-like structures directly from OCaml"
+
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml. It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v5.1.0/cstruct-v5.1.0.tbz"
+  checksum: [
+    "sha256=cb86d405d98d2d2fde06e09e691bb76719accab9cb38871077e4c000a94935bd"
+    "sha512=5c58b2a2b32bbd65ac7f08bc1c7bbaa891c0e3c85521ca0a8967ffb88c3ca53e446cebd06107d80f1545c75c06dc4c7da4608aa67f2d3cc41be60e4be946343f"
+  ]
+}

--- a/packages/cstruct/cstruct.5.1.0/opam
+++ b/packages/cstruct/cstruct.5.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Anton Kochkov" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "bigarray-compat"
+  "alcotest" {with-test}
+]
+conflicts: [ "js_of_ocaml" {<"3.5.0"} ]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v5.1.0/cstruct-v5.1.0.tbz"
+  checksum: [
+    "sha256=cb86d405d98d2d2fde06e09e691bb76719accab9cb38871077e4c000a94935bd"
+    "sha512=5c58b2a2b32bbd65ac7f08bc1c7bbaa891c0e3c85521ca0a8967ffb88c3ca53e446cebd06107d80f1545c75c06dc4c7da4608aa67f2d3cc41be60e4be946343f"
+  ]
+}

--- a/packages/ppx_cstruct/ppx_cstruct.5.1.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.5.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "cstruct" {=version}
+  "ounit" {with-test}
+  "ppx_tools_versioned" {>= "5.0.1"}
+  "ocaml-migrate-parsetree"
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {>="v0.9.0"}
+  "cstruct-sexp" {with-test}
+  "cstruct-unix" {with-test & =version}
+  "stdlib-shims"
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v5.1.0/cstruct-v5.1.0.tbz"
+  checksum: [
+    "sha256=cb86d405d98d2d2fde06e09e691bb76719accab9cb38871077e4c000a94935bd"
+    "sha512=5c58b2a2b32bbd65ac7f08bc1c7bbaa891c0e3c85521ca0a8967ffb88c3ca53e446cebd06107d80f1545c75c06dc4c7da4608aa67f2d3cc41be60e4be946343f"
+  ]
+}


### PR DESCRIPTION
Access C-like structures directly from OCaml

- Project page: <a href="https://github.com/mirage/ocaml-cstruct">https://github.com/mirage/ocaml-cstruct</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cstruct/">https://mirage.github.io/ocaml-cstruct/</a>

##### CHANGES:

- Do not issue deprecation warnings when using OCaml 4.08.0
  and cstruct-ppx with enums due to `Pervasives` (mirage/ocaml-cstruct#269 @cypheon @hannesm)

- Tighten parsing of the `[@len]` attribute to ensure it is a
  valid, positive integer (mirage/ocaml-cstruct#265 @emillon)

- Update JavaScript bindings to latest `Js_of_ocaml` 3.5.0
  interfaces (@hhugo mirage/ocaml-cstruct#268)
