### PR TITLE
[new release] travis-opam (1.5.0)

### DIFF
--- a/packages/travis-opam/travis-opam.1.5.0/opam
+++ b/packages/travis-opam/travis-opam.1.5.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Scripts for OCaml projects"
+description: """
+Supported CI:
+
+- **stable**: [Travis CI](/README-travis.md) Ubuntu, Debian and macOS workers.
+- **experimental**: [Appveyor](/README-appveyor.md) Windows Server 2012 R2 (x64) workers."""
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Richard Mortier" "David Sheets" "Anil Madhavapeddy"]
+homepage: "https://github.com/ocaml/ocaml-ci-scripts"
+doc: "https://ocaml.github.io/ocaml-ci-scripts/"
+bug-reports: "https://github.com/ocaml/ocaml-ci-scripts/issues"
+depends: [
+  "dune"
+  "ocaml"
+  "jsonm" {build}
+  "opam-file-format" {build}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-ci-scripts.git"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-ci-scripts/releases/download/1.5.0/travis-opam-1.5.0.tbz"
+  checksum: [
+    "sha256=4b878eccad8eb3bf0d7d3e0c144e4eacfb8075c058bafafd1a1f3c122d3ca012"
+    "sha512=d9db97ab55f036e136594d8390159a77d66ec8e17ec8bc17dc905b5c7c7e0a7789a91de1bc1568ae5923142698b62b74e53d23e12330c10fbd174d1ffe62942a"
+  ]
+}


### PR DESCRIPTION
Scripts for OCaml projects

- Project page: <a href="https://github.com/ocaml/ocaml-ci-scripts">https://github.com/ocaml/ocaml-ci-scripts</a>
- Documentation: <a href="https://ocaml.github.io/ocaml-ci-scripts/">https://ocaml.github.io/ocaml-ci-scripts/</a>

##### CHANGES:

* Port to dune (@dra27 @avsm)
* Support empty `PACKAGE` variables (@dra27)
* More verbose install to keep Travis jobs from suspending (@liyishuai)
