### PR TITLE
[new release] xenstore (2.1.1)

### DIFF
--- a/packages/xenstore/xenstore.2.1.1/opam
+++ b/packages/xenstore/xenstore.2.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Dave Scott"
+  "Anil Madhavapeddy"
+  "Vincent Bernardoff"
+]
+homepage: "https://github.com/mirage/ocaml-xenstore"
+doc: "https://mirage.github.io/ocaml-xenstore/"
+bug-reports: "https://github.com/mirage/ocaml-xenstore/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "3.2.0"}
+  "ppx_cstruct" {>= "3.2.0"}
+  "lwt"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-xenstore.git"
+synopsis: "Xenstore protocol in pure OCaml"
+description: """
+This repo contains:
+1. a xenstore client library, a merge of the Mirage and XCP ones
+2. a xenstore server library
+3. a xenstore server instance which runs under Unix with libxc
+4. a xenstore server instance which runs on mirage.
+
+The client and the server libraries have sets of unit-tests.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-xenstore/releases/download/2.1.1/xenstore-2.1.1.tbz"
+  checksum: [
+    "sha256=283814ea21adc345c4d59cfcb17b2f7c1185004ecaecc3871557c961874c84f5"
+    "sha512=9cd80f7912a77f628fd346b30790981a8802528a6240dc5faeeb83e61aa4a2e2ee9a1cafbc4058eb9f6c38f1a4ac6c59408fdc92b545633cde06369d2c1e1890"
+  ]
+}


### PR DESCRIPTION
Xenstore protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-xenstore">https://github.com/mirage/ocaml-xenstore</a>
- Documentation: <a href="https://mirage.github.io/ocaml-xenstore/">https://mirage.github.io/ocaml-xenstore/</a>

##### CHANGES:

* Do not open Pervasives unnecessarily. Avoids a warning on
  4.08 in dev builds on Dune (mirage/ocaml-xenstore#44 @talex5)
* Update opam metadata to remove the `build`-only dep on Dune
  (mirage/ocaml-xenstore#45 @craigfe)
