### PR TITLE
[new release] lablgtk3-gtkspell3, lablgtk3-sourceview3 and lablgtk3 (3.0.beta7)

### DIFF
--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3, gtkspell library
+
+See http://lablgtk.forge.ocamlcore.org/ for more information.
+
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                {         >= "4.05.0"    }
+  "dune"                 { build & >= "1.6.0"
+                                 & != "1.7.0"
+                                 & != "1.7.1"     } # Due to dune/dune#1833
+  "lablgtk3"             {         >= "3.0.beta5" }
+]
+depexts: [
+  ["gtkspell3-dev"] {os-distribution = "alpine"}
+  ["gtkspell3"] {os-distribution = "archlinux"}
+  ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
+  ["libgtkspell3-3-dev"] {os-distribution = "debian"}
+  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3"] {os = "freebsd"}
+  ["gtkspell3"] {os = "openbsd"}
+  ["gtkspell3-devel"] {os-family = "suse"}
+  ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
+  ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.0.beta7/lablgtk3-3.0.beta7.tbz"
+  checksum: [
+    "sha256=d8649337faa63d6132d7af4582db835653b142cdf7ca3e23633bcd2e055bb80f"
+    "sha512=54fafe132386c5475102a69ff96669930a5cc454934d61d53becde0bfb8515934aa7b2424d917c0f27115cc39afd8b3172080f3a43db5f314ef3bec7b59d0168"
+  ]
+}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
@@ -21,7 +21,7 @@ depends: [
   "dune"                 { build & >= "1.6.0"
                                  & != "1.7.0"
                                  & != "1.7.1"     } # Due to dune/dune#1833
-  "lablgtk3"             {         >= "3.0.beta5" }
+  "lablgtk3"             {          = version     }
 ]
 depexts: [
   ["gtkspell3-dev"] {os-distribution = "alpine"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
@@ -18,7 +18,7 @@ license: "LGPL with linking exception"
 
 depends: [
   "ocaml"                {         >= "4.05.0"    }
-  "dune"                 { build & >= "1.6.0"
+  "dune"                 {         >= "1.6.0"
                                  & != "1.7.0"
                                  & != "1.7.1"     } # Due to dune/dune#1833
   "lablgtk3"             {          = version     }

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta7/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta7/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+ gtksourceview library"
+description: """
+OCaml interface to GTK+3, gtksourceview3 library.
+
+See http://lablgtk.forge.ocamlcore.org/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                {         >= "4.05.0"    }
+  "dune"                 { build & >= "1.6.0"
+                                 & != "1.7.0"
+                                 & != "1.7.1"     } # Due to dune/dune#1833
+  "lablgtk3"             {         >= "3.0.beta5" }
+  "conf-gtksourceview3"  { build & >= "0"         }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.0.beta7/lablgtk3-3.0.beta7.tbz"
+  checksum: [
+    "sha256=d8649337faa63d6132d7af4582db835653b142cdf7ca3e23633bcd2e055bb80f"
+    "sha512=54fafe132386c5475102a69ff96669930a5cc454934d61d53becde0bfb8515934aa7b2424d917c0f27115cc39afd8b3172080f3a43db5f314ef3bec7b59d0168"
+  ]
+}

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta7/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta7/opam
@@ -17,7 +17,7 @@ license: "LGPL with linking exception"
 
 depends: [
   "ocaml"                {         >= "4.05.0"    }
-  "dune"                 { build & >= "1.6.0"
+  "dune"                 {         >= "1.6.0"
                                  & != "1.7.0"
                                  & != "1.7.1"     } # Due to dune/dune#1833
   "lablgtk3"             {          = version     }

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta7/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta7/opam
@@ -20,7 +20,7 @@ depends: [
   "dune"                 { build & >= "1.6.0"
                                  & != "1.7.0"
                                  & != "1.7.1"     } # Due to dune/dune#1833
-  "lablgtk3"             {         >= "3.0.beta5" }
+  "lablgtk3"             {          = version     }
   "conf-gtksourceview3"  { build & >= "0"         }
 ]
 

--- a/packages/lablgtk3/lablgtk3.3.0.beta7/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta7/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3
+
+See http://lablgtk.forge.ocamlcore.org/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL with linking exception"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3"
+
+depends: [
+  "ocaml"     {         >= "4.05.0" }
+  "dune"      { build & >= "1.6.0"
+                      & != "1.7.0"
+                      & != "1.7.1"  } # Due to dune/dune#1833
+  "conf-gtk3" { build & >= "18"     }
+  "cairo2"    {         >= "0.6"    }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.0.beta7/lablgtk3-3.0.beta7.tbz"
+  checksum: [
+    "sha256=d8649337faa63d6132d7af4582db835653b142cdf7ca3e23633bcd2e055bb80f"
+    "sha512=54fafe132386c5475102a69ff96669930a5cc454934d61d53becde0bfb8515934aa7b2424d917c0f27115cc39afd8b3172080f3a43db5f314ef3bec7b59d0168"
+  ]
+}

--- a/packages/lablgtk3/lablgtk3.3.0.beta7/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta7/opam
@@ -17,7 +17,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
   "ocaml"     {         >= "4.05.0" }
-  "dune"      { build & >= "1.6.0"
+  "dune"      {         >= "1.6.0"
                       & != "1.7.0"
                       & != "1.7.1"  } # Due to dune/dune#1833
   "conf-gtk3" { build & >= "18"     }

--- a/packages/why3-ide/why3-ide.1.2.0/opam
+++ b/packages/why3-ide/why3-ide.1.2.0/opam
@@ -51,6 +51,7 @@ depends: [
 
 conflicts: [
   "lablgtk" {< "2.14.2"}
+  "lablgtk3" {>= "3.0.beta7"}
 ]
 
 synopsis: "Why3 environment for deductive program verification"

--- a/packages/why3-ide/why3-ide.1.2.1/opam
+++ b/packages/why3-ide/why3-ide.1.2.1/opam
@@ -44,6 +44,7 @@ depends: [
 
 conflicts: [
   "lablgtk" {< "2.14.2"}
+  "lablgtk3" {>= "3.0.beta7"}
 ]
 
 synopsis: "Why3 environment for deductive program verification"


### PR DESCRIPTION
OCaml interface to GTK+3

- Project page: <a href="https://github.com/garrigue/lablgtk">https://github.com/garrigue/lablgtk</a>
- Documentation: <a href="https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3">https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3</a>

##### CHANGES:

2019.11.25 [Jacques]
  * Split source code in terms of packages (garrigue/lablgtk#77) [Emilio]
  * Update README to better document build system (garrigue/lablgtk#80) [Emilio]
  * Switch from camlp4 to camlp5 (required for 4.09)
  * Add `[@warnerror "-3"]` to call to `Obj.truncate`
  * Move `COPYING` to `LICENSE`

2019.09.25 [Jacques]
  * Fix several gtk3 examples, and remove some obsolete ones
   (garrigue/lablgtk#84) [Martin de Mello]
  * Disable -warn-error 3 in src/dune, because of Obj.truncate

2019.09.23 [Martin de Mello]
  * Add the LinkButton activate-link signal garrigue/lablgtk#83

2019.08.12 [Emilio J. Gallego Arias]
  * Reorganize source code, move orphaned files to unsupported,
    bump to Dune >= 1.6
2019.08.12 [Emilio J. Gallego Arias]
  * Remove stale makefiles, lablgtk must be built using Dune now.

2019.07.07 [Emilio J. Gallego Arias]
  * Include extended Cairo Support from garrigue/lablgtk#33 in the Dune build.

2019.06.27 [Anton Kochkov]
  * Upgrade CI to OCaml 4.08
