### PR TITLE
Package ocsigen-toolkit.2.1.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.1.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.1.0/opam
@@ -6,19 +6,21 @@ authors: "dev@ocsigen.org"
 homepage: "http://www.ocsigen.org"
 bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
 dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1 with OCaml linking exception"
 build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
 remove: [ make "uninstall" ]
 depends: [
-  "ocaml" {>= "4.06.1"}
+  "js_of_ocaml" {< "3.5.0"}
+  "js_of_ocaml-lwt" {< "3.5.0"}
+  "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}
   "calendar"
 ]
 url {
   src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.1.0.tar.gz"
   checksum: [
-    "md5=7102b6a677340f9082e76464069462fc"
-    "sha512=1d47d04b8eba6bcd07f8c7425b0afda759e3777aba49fb319e51f5591ef1ad22da4f0dd901a47c96783511959fec7d314b2902145eb9adb419bb645ba40e3bbe"
+    "md5=81e731c89ce8d13d543e012872b3e743"
+    "sha512=47bedba08f4594a604704eeb65b1f975c168012b57a016c54e3bab2184c4d819dfa6f0fb76470fd91444c26e98949f797d604c1cc3be020b69c25926eebc0ca3"
   ]
 }


### PR DESCRIPTION
### `ocsigen-toolkit.2.1.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0