### PR TITLE
Package ocsigen-toolkit.2.3.1

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.1/opam
@@ -6,10 +6,13 @@ authors: "dev@ocsigen.org"
 homepage: "http://www.ocsigen.org"
 bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
 dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1 with OCaml linking exception"
 build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
+remove: [ make "uninstall" ]
 depends: [
+  "js_of_ocaml" {< "3.5.0"}
+  "js_of_ocaml-lwt" {< "3.5.0"}
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}
   "calendar"
@@ -17,7 +20,7 @@ depends: [
 url {
   src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.3.1.tar.gz"
   checksum: [
-    "md5=81a683e96b76bc86d943894a36f90b61"
-    "sha512=9280c7eb2c96bbef0b8d07bbc4473cf8309042efd9d461ce7dace579680a6e0a8860cfe2a0148250625405896fcbee0400fb92370b58eefef8485cd78aecb9b8"
+    "md5=f5c1b7f6972df7bac46b8fbbdf0beebb"
+    "sha512=b0ceac7ec15e455bd2b4f9c7bc3761784c4940124d19674aa2f9edaf1f61d4e14bd7822ecc1744b09a1a8a5bfd5e625b25023f9d510e4f4da200f3c70b7218c7"
   ]
 }


### PR DESCRIPTION
### `ocsigen-toolkit.2.3.1`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0