### PR TITLE
Release ppx_regexp.0.4.3 and ppx_tyre.0.4.3.

### DIFF
--- a/packages/ppx_regexp/ppx_regexp.0.4.3/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.4.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "Gabriel Radanne <drupyog@zoho.com>"
+]
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ppx_regexp"
+bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.11"}
+  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "re" {>= "1.7.1"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "qcheck" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/paurkedal/ppx_regexp.git"
+synopsis: "Matching Regular Expressions with OCaml Patterns"
+description: """
+This syntax extension turns
+
+    match%pcre x with
+    | {|re1|} -> e1
+    ...
+    | {|reN|} -> eN
+    | _ -> e0
+
+into suitable invocations to the ocaml-re library.  The patterns are plain
+strings of the form accepted by `Re_pcre`, except groups can be bound to
+variables using the syntax `(?<var>...)`.  The type of `var` will be
+`string` if a match is of the groups is guaranteed given a match of the
+whole pattern, and `string option` if the variable is bound to or nested
+below an optionally matched group.
+"""
+url {
+  src:
+    "https://github.com/paurkedal/ppx_regexp/releases/download/v0.4.3/ppx_regexp-v0.4.3.tbz"
+  checksum: [
+    "sha256=70cbf4495de5e8ca4aada49c4fe25c586858dade8448efef29fd2d2ea620d413"
+    "sha512=284f4b7c99125e26697f1691909fb2ba6e9d6c7fb74c6272c442bee84211486d566183db928b1bc5b3a2c385372e830cfec3e6fb3cb4184f16805bb420bc85be"
+  ]
+}

--- a/packages/ppx_tyre/ppx_tyre.0.4.3/opam
+++ b/packages/ppx_tyre/ppx_tyre.0.4.3/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Gabriel Radanne <drupyog@zoho.com>"
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ppx_regexp"
+bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.11"}
+  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "re" {>= "1.7.1"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "tyre" {>= "0.4.1"}
+  "qcheck" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/paurkedal/ppx_regexp.git"
+synopsis: "PPX syntax for tyre regular expressions and routes"
+description: """
+This PPX compiles
+
+    [%tyre {|re|}]
+
+into `'a Tyre.t` and
+
+    function%tyre
+    | {|re1|} as x1 -> e1
+    ...
+    | {|reN|} as x2 -> eN
+
+into `'a Type.route`, where `re`, `re1`, ... are regular expressions
+expressed in a slightly extended subset of PCRE.  The interpretations are:
+
+- `re?` extracts an option of what `re` extracts.
+- `re+`, `re*`, `re{n,m}` extracts a list of what `re` extracts.
+- `(?@qname)` refers to any identifier bound to a typed regular expression
+  of type `'a Tyre.t`.
+- One or more `(?<v>re)` at the top level can be used to bind variables
+  instead of `as ...`.
+- One or more `(?<v>re)` in a sequence extracts an object where each method
+  `v` is bound to what `re` extracts.
+- An alternative with one `(?<v>re)` per branch extracts a polymorphic
+  variant where each constructor `` `v`` receives what `re` extracts as its
+  argument.
+- `(?&v:qname)` is a shortcut for `(?<v>(?&qname))`.
+"""
+url {
+  src:
+    "https://github.com/paurkedal/ppx_regexp/releases/download/v0.4.3/ppx_regexp-v0.4.3.tbz"
+  checksum: [
+    "sha256=70cbf4495de5e8ca4aada49c4fe25c586858dade8448efef29fd2d2ea620d413"
+    "sha512=284f4b7c99125e26697f1691909fb2ba6e9d6c7fb74c6272c442bee84211486d566183db928b1bc5b3a2c385372e830cfec3e6fb3cb4184f16805bb420bc85be"
+  ]
+}


### PR DESCRIPTION
This a fix and compiler upgrade for two PPXes built from the same repo. From the change log:

- Fixed nested `[%pcre]` usage for `ppx_regexp`.
- Extended compiler support to 4.02.3 up to 4.09.0 (at least) for both PPXes.
- Upgrade to AST 4.09 to support newer compiler features.
