### PR TITLE
mirage-qubes 0.8.0: restrict to cstruct < 5.1.0 (since 5.1.0 @len 0 is forbidden)

### DIFF
--- a/packages/mirage-qubes/mirage-qubes.0.8.0/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.8.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "cstruct" { >= "2.2.0" }
-  "ppx_cstruct"
+  "ppx_cstruct" { < "5.1.0"}
   "vchan-xen" { >= "5.0.0" }
   "xen-evtchn"
   "xen-gnt"


### PR DESCRIPTION
reported upstream https://github.com/mirage/mirage-qubes/issues/47