### PR TITLE
[new release] exit (0.0.1)

### DIFF
--- a/packages/exit/exit.0.0.1/opam
+++ b/packages/exit/exit.0.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Get exit status as declared in `stdlib.h`"
+description:
+  "exit is an OCaml library to get exit status as declared in `stdlib.h`. It gives access to the values of `EXIT_SUCCESS` and `EXIT_FAILURE` macros and provides some functions built around them."
+maintainer: ["Léo Andrès <contact@ndrs.fr>"]
+authors: ["Léo Andrès <contact@ndrs.fr>"]
+license: "ISC"
+homepage: "https://git.zapashcanon.fr/zapashcanon/exit"
+doc: "https://doc.zapashcanon.fr/exit/"
+bug-reports: "https://git.zapashcanon.fr/zapashcanon/exit/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "2.0"}
+  "bisect_ppx" {>= "1.4"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://git.zapashcanon.fr/zapashcanon/exit.git"
+url {
+  src: "https://fs.zapashcanon.fr/archive/exit/exit-0.0.1.tbz"
+  checksum: [
+    "sha256=6ffcd3c7099966b285b6cf6fa35c6c0103a83082f70204bca2df68b63cd2954b"
+    "sha512=94a4fb875761ee9ee602eb3347f5d4e5225c4e1f8ce925785a8a65377ed73a4d276c4f7de0e9d2d8108ccd40ac619dbea801ff5039a77465096037db11a32048"
+  ]
+}


### PR DESCRIPTION
Get exit status as declared in `stdlib.h`

- Project page: <a href="https://git.zapashcanon.fr/zapashcanon/exit">https://git.zapashcanon.fr/zapashcanon/exit</a>
- Documentation: <a href="https://doc.zapashcanon.fr/exit/">https://doc.zapashcanon.fr/exit/</a>

##### CHANGES:

First release
