### PR TITLE
dune-private-libs is not using ocaml-secondary-compiler

### DIFF
--- a/packages/dune-private-libs/dune-private-libs.2.0.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.0.0/opam
@@ -17,6 +17,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.0"}
+  "ocaml" {>= "4.06"}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [


### PR DESCRIPTION
cc @dra27 
```

#=== ERROR while compiling dune-private-libs.2.0.0 ============================#
# context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.04.2 | git+file:///home/opam/opam-repository
# path                 ~/.opam/4.04/.opam-switch/build/dune-private-libs.2.0.0
# command              ~/.opam/4.04/bin/dune build -p dune-private-libs -j 2 @install
# exit-code            1
# env-file             ~/.opam/log/dune-private-libs-23-b5f6b6.env
# output-file          ~/.opam/log/dune-private-libs-23-b5f6b6.out
### output ###
#       ocamlc src/stdune/.stdune.objs/byte/stdune__Hashtbl.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.04/bin/ocamlc.opt -w -40 -g -bin-annot -I src/stdune/.stdune.objs/byte -I src/stdune/caml/.dune_caml.objs/byte -I src/stdune/caml/.dune_caml.objs/native -intf-suffix .ml -no-alias-deps -open Stdune__ -o src/stdune/.stdune.objs/byte/stdune__Hashtbl.cmo -c -impl src/stdune/hashtbl.pp.ml)
# File "src/stdune/hashtbl.ml", line 11, characters 13-21:
# Error: Unbound value find_opt
# Hint: Did you mean find_all?
#       ocamlc src/stdune/.stdune.objs/byte/stdune__Map.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.04/bin/ocamlc.opt -w -40 -g -bin-annot -I src/stdune/.stdune.objs/byte -I src/stdune/caml/.dune_caml.objs/byte -I src/stdune/caml/.dune_caml.objs/native -intf-suffix .ml -no-alias-deps -open Stdune__ -o src/stdune/.stdune.objs/byte/stdune__Map.cmo -c -impl src/stdune/map.pp.ml)
# File "src/stdune/map.ml", line 12, characters 19-27:
# Error: Unbound value find_opt
#       ocamlc src/stdune/.stdune.objs/byte/stdune__Set.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.04/bin/ocamlc.opt -w -40 -g -bin-annot -I src/stdune/.stdune.objs/byte -I src/stdune/caml/.dune_caml.objs/byte -I src/stdune/caml/.dune_caml.objs/native -intf-suffix .ml -no-alias-deps -open Stdune__ -o src/stdune/.stdune.objs/byte/stdune__Set.cmo -c -impl src/stdune/set.pp.ml)
# File "src/stdune/set.ml", line 39, characters 16-27:
# Error: Unbound value min_elt_opt
#     ocamlopt src/stdune/.stdune.objs/native/stdune__Hashtbl.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.04/bin/ocamlopt.opt -w -40 -g -I src/stdune/.stdune.objs/byte -I src/stdune/.stdune.objs/native -I src/stdune/caml/.dune_caml.objs/byte -I src/stdune/caml/.dune_caml.objs/native -intf-suffix .ml -no-alias-deps -open Stdune__ -o src/stdune/.stdune.objs/native/stdune__Hashtbl.cmx -c -impl src/stdune/hashtbl.pp.ml)
# File "src/stdune/hashtbl.ml", line 11, characters 13-21:
# Error: Unbound value find_opt
# Hint: Did you mean find_all?
#     ocamlopt src/stdune/.stdune.objs/native/stdune__Map.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.04/bin/ocamlopt.opt -w -40 -g -I src/stdune/.stdune.objs/byte -I src/stdune/.stdune.objs/native -I src/stdune/caml/.dune_caml.objs/byte -I src/stdune/caml/.dune_caml.objs/native -intf-suffix .ml -no-alias-deps -open Stdune__ -o src/stdune/.stdune.objs/native/stdune__Map.cmx -c -impl src/stdune/map.pp.ml)
# File "src/stdune/map.ml", line 12, characters 19-27:
# Error: Unbound value find_opt
#       ocamlc src/stdune/.stdune.objs/byte/stdune__String.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.04/bin/ocamlc.opt -w -40 -g -bin-annot -I src/stdune/.stdune.objs/byte -I src/stdune/caml/.dune_caml.objs/byte -I src/stdune/caml/.dune_caml.objs/native -intf-suffix .ml -no-alias-deps -open Stdune__ -o src/stdune/.stdune.objs/byte/stdune__String.cmo -c -impl src/stdune/string.pp.ml)
# File "src/stdune/string.ml", line 25, characters 17-33:
# Error: Unbound value capitalize_ascii
#     ocamlopt src/stdune/.stdune.objs/native/stdune__Set.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.04/bin/ocamlopt.opt -w -40 -g -I src/stdune/.stdune.objs/byte -I src/stdune/.stdune.objs/native -I src/stdune/caml/.dune_caml.objs/byte -I src/stdune/caml/.dune_caml.objs/native -intf-suffix .ml -no-alias-deps -open Stdune__ -o src/stdune/.stdune.objs/native/stdune__Set.cmx -c -impl src/stdune/set.pp.ml)
# File "src/stdune/set.ml", line 39, characters 16-27:
# Error: Unbound value min_elt_opt



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions were aborted
| - install azblob            0.1.0
| - install base              v0.12.2
| - install cohttp            2.4.0
| - install dune-configurator 2.0.0
| - install fieldslib         v0.12.0
| - install ppx_fields_conv   v0.12.0
| - install ppx_sexp_conv     v0.12.0
| - install ppxlib            0.8.1
| - install stdio             v0.12.0
| - install uri-sexp          3.1.0
+- 
+- The following actions failed
| - build dune-private-libs 2.0.0
+- 
+- The following changes have been performed (the rest was aborted)
| - install base-bytes              base
| - install base64                  3.2.0
| - install conf-gmp                1
| - install conf-gmp-powm-sec       1
| - install conf-m4                 1
| - install conf-perl               1
| - install conf-pkg-config         1.1
| - install conf-zlib               1
| - install cryptokit               1.14
| - install dune                    2.0.0
| - install jsonm                   1.0.1
| - install ocaml-compiler-libs     v0.12.1
| - install ocaml-migrate-parsetree 1.5.0
| - install ocamlbuild              0.14.0
| - install ocamlfind               1.8.1
| - install ocamlfind-secondary     1.8.1
| - install ppx_derivers            1.2.1
| - install re                      1.9.0
| - install result                  1.4
| - install seq                     0.2
| - install sexplib0                v0.12.0
| - install stdlib-shims            0.1.0
| - install stringext               1.6.0
| - install topkg                   1.0.1
| - install uchar                   0.0.2
| - install uri                     3.1.0
| - install uutf                    1.0.2
| - install zarith                  1.9.1
+- 
```