### PR TITLE
[new release] travesty (0.6.1)

### DIFF
--- a/packages/travesty/travesty.0.6.1/opam
+++ b/packages/travesty/travesty.0.6.1/opam
@@ -12,7 +12,7 @@ doc: "https://MattWindsor91.github.io/travesty/"
 bug-reports: "https://github.com/MattWindsor91/travesty/issues"
 depends: [
   "ocaml" {>= "4.07" & < "4.10"}
-  "dune" {build & >= "2.0" & < "3.0"}
+  "dune" {>= "2.0" & < "3.0"}
   "ppx_jane" {>= "v0.12.0" & < "v0.14.0"}
   "base" {>= "v0.12.0" & < "v0.14.0"}
 ]

--- a/packages/travesty/travesty.0.6.1/opam
+++ b/packages/travesty/travesty.0.6.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Monadically traversable containers"
+description: """
+'Travesty' is a library for defining containers with monadic traversals,
+inspired by Haskell's Traversable typeclass.  It sits on top of Jane Street's
+Base library and ecosystem."""
+maintainer: ["Matt Windsor <m.windsor@imperial.ac.uk>"]
+authors: ["Matt Windsor <m.windsor@imperial.ac.uk>"]
+license: "MIT"
+homepage: "https://MattWindsor91.github.io/travesty/"
+doc: "https://MattWindsor91.github.io/travesty/"
+bug-reports: "https://github.com/MattWindsor91/travesty/issues"
+depends: [
+  "ocaml" {>= "4.07" & < "4.10"}
+  "dune" {build & >= "2.0" & < "3.0"}
+  "ppx_jane" {>= "v0.12.0" & < "v0.14.0"}
+  "base" {>= "v0.12.0" & < "v0.14.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/MattWindsor91/travesty.git"
+url {
+  src:
+    "https://github.com/MattWindsor91/travesty/releases/download/v0.6.1/travesty-v0.6.1.tbz"
+  checksum: [
+    "sha256=9c7b3803620c54496a35983285242ec8e06a5efb1baa3523384d7184b7e9fab7"
+    "sha512=991646fe5bb899971d3f8c00432d4df6c45dbd81cbff885b28d30d9c228e5df61f1e8d61aadc164ec35c448093abb34fd7a7d571e1cdf4d3af25579bf400f167"
+  ]
+}


### PR DESCRIPTION
Monadically traversable containers

- Project page: <a href="https://MattWindsor91.github.io/travesty/">https://MattWindsor91.github.io/travesty/</a>
- Documentation: <a href="https://MattWindsor91.github.io/travesty/">https://MattWindsor91.github.io/travesty/</a>

##### CHANGES:

Minor release cut to relax various dependency pain-points caused by the last
release being more than 4 months ago.  (I intend to make a major release in
the near future with a migration from monads to applicative functors, but
this depends on enough free time being available.)

- Travesty now expects Dune 2.0 to build.  This is technically a breaking
  change, but I felt that bumping to 0.7 at this stage of Travesty's lifecycle
  would give the wrong impression.
- Travesty now lets itself be built with v0.13 of the Jane Street packages.
- Travesty now lets itself be built with OCaml v4.09.
- Minor code formatting changes.
