### PR TITLE
jbuilder 1.11.4

### DIFF
--- a/packages/jbuilder/jbuilder.1.11.4/opam
+++ b/packages/jbuilder/jbuilder.1.11.4/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Fast, portable and opinionated build system (deprecated)"
+description: """
+
+This package is deprecated, please use dune instead.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/diml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/diml/dune/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-unix"
+  "base-threads"
+  "dune" {>= "2.0.0"}
+]
+dev-repo: "git+https://github.com/diml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs "@install"]
+]
+url {
+  src:
+    "https://github.com/diml/dune/releases/download/jbuilder-1.11.4/jbuilder-1.11.4.tbz"
+  checksum: "md5=b298b0869a03ca19b2f44ab7023e62c6"
+}


### PR DESCRIPTION
This is a one of release. It is the jbuilder binary extracted from dune 1.11.4 as a separate package. This is to allow the following packages to be co-installed:

- dune >= 2.0.0
- ocaml >= 4.08
- jbuilder

In particular, this allows to co-install both dune >= 2.0.0 in conjunction with packages that haven't upgraded to dune when using a recent compiler.