### PR TITLE
Package eigen.0.1.5

### DIFF
--- a/packages/eigen/eigen.0.1.5/opam
+++ b/packages/eigen/eigen.0.1.5/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Owl's OCaml interface to Eigen3 C++ library"
+description:
+  "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: "Liang Wang"
+license: "MIT"
+homepage: "https://github.com/owlbarn/eigen"
+doc: "https://owlbarn.github.io/eigen/eigen"
+bug-reports: "https://github.com/owlbarn/eigen/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "ctypes" {>= "0.14.0"}
+  "dune" {>= "1.5.0"}
+]
+build: [
+  ["dune" "build" "-p" name "eigen_cpp/libeigen_cpp_stubs.a"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/owlbarn/eigen.git"
+url {
+  src: "https://github.com/owlbarn/eigen/archive/0.1.5.tar.gz"
+  checksum: [
+    "md5=201555d4b7c6ca19632a0a99c907496f"
+    "sha512=4fdf1bf0ebb1fce548fcc782941f1d3ec3a1413574c3cbf58f1044a8a7481dc4208e7f397ac7e91f8d4bc97cc548f2fffe2ce2dc07540a268df96fe4b6bac362"
+  ]
+}

--- a/packages/eigen/eigen.0.1.5/opam
+++ b/packages/eigen/eigen.0.1.5/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/owlbarn/eigen"
 doc: "https://owlbarn.github.io/eigen/eigen"
 bug-reports: "https://github.com/owlbarn/eigen/issues"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.04"}
   "ctypes" {>= "0.14.0"}
   "dune" {>= "1.5.0"}
 ]


### PR DESCRIPTION
### `eigen.0.1.5`
Owl's OCaml interface to Eigen3 C++ library
Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations.



---
* Homepage: https://github.com/owlbarn/eigen
* Source repo: git+https://github.com/owlbarn/eigen.git
* Bug tracker: https://github.com/owlbarn/eigen/issues

---
:camel: Pull-request generated by opam-publish v2.0.0