### PR TITLE
[new release] mdx (1.5.0)

### DIFF
--- a/packages/containers/containers.2.6.1/opam
+++ b/packages/containers/containers.2.6.1/opam
@@ -18,7 +18,7 @@ depends: [
   "iter" {with-test}
   "gen" {with-test}
   "uutf" {with-test}
-  "mdx" {with-test}
+  "mdx" {with-test & < "1.5.0"}
   "odoc" {with-doc}
   "ocaml" {>= "4.02.0"}
 ]

--- a/packages/containers/containers.2.6/opam
+++ b/packages/containers/containers.2.6/opam
@@ -18,7 +18,7 @@ depends: [
   "iter" {with-test}
   "gen" {with-test}
   "uutf" {with-test}
-  "mdx" {with-test}
+  "mdx" {with-test & < "1.5.0"}
   "odoc" {with-doc}
   "ocaml" {>= "4.02.0"}
 ]

--- a/packages/mdx/mdx.1.5.0/opam
+++ b/packages/mdx/mdx.1.5.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org"]
+homepage:     "https://github.com/realworldocaml/mdx"
+license:      "ISC"
+dev-repo:     "git+https://github.com/realworldocaml/mdx.git"
+bug-reports:  "https://github.com/realworldocaml/mdx/issues"
+doc:          "https://realworldocaml.github.io/mdx/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune"
+  "ocamlfind"
+  "fmt"
+  "cppo" {build}
+  "astring"
+  "logs"
+  "cmdliner"
+  "re" {>= "1.7.2"}
+  "result"
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+  "ocaml-version" {>= "2.3.0"}
+  "lwt" {with-test}
+]
+
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date.
+
+`ocaml-mdx` is released as two binaries called `ocaml-mdx` and `mdx` which are
+the same, mdx being the deprecated name, kept for now for compatibility.
+"""
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/1.5.0/mdx-1.5.0.tbz"
+  checksum: [
+    "sha256=b68fea7235aa95a407bccea76352a8a32dee0441a72f701f3aa19d4f1cbd853c"
+    "sha512=2853e68f2e91ea36f3f22459ff1cd512237e6380163434e2bd59eee1946d166119663aaafb5acd672cbf285d9f191aee2e39fa5f587cbd41020eeae8815887cf"
+  ]
+}

--- a/packages/mdx/mdx.1.5.0/opam
+++ b/packages/mdx/mdx.1.5.0/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune"
+  "dune" {>= "1.11"}
   "ocamlfind"
   "fmt"
   "cppo" {build}

--- a/packages/routes/routes.0.5.2/opam
+++ b/packages/routes/routes.0.5.2/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.05"}
   "dune" { >= "1.1" }
   "alcotest" {with-test}
-  "mdx" { with-test }
+  "mdx" { with-test & < "1.5.0" }
 ]
 synopsis: "Typed routing for OCaml applications"
 description: """


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>
- Documentation: <a href="https://realworldocaml.github.io/mdx/">https://realworldocaml.github.io/mdx/</a>

##### CHANGES:

#### Added

- Add a `--output`/`-o` option to the `test` subcommand to allow specifying a different
  output file to write the corrected to, or to write it to the standard output (realworldocaml/mdx#194, @NathanReb)
- Migrate to OCaml 4.08 AST to add support for `let*` bindings (realworldocaml/mdx#190, @gpetiot)
- Add `--syntax` option to `rule` subcommand to allow generating rules for cram
  tests (realworldocaml/mdx#177, @craigfe)
- Add a `require-package` label to explicitly declare dune `package` dependencies of a code block
  (realworldocaml/mdx#149, @Julow)
- Add an `unset-` label to unset env variables in shell blocks (realworldocaml/mdx#132, @clecat)

#### Changed

- Format rules generated by `ocaml-mdx rule` using `dune format-dune-file` (realworldocaml/mdx#184, @NathanReb)
- Run promotion of markdown files before `.ml` files in generated dune rules (realworldocaml/mdx#140, @clecat)

#### Fixed

- Use module_presence information on Env.summary to prevent fetching absent modules from the
  toplevel env (realworldocaml/mdx#186, @clecat)
- Remove trailing whitespaces at the end of toplevel or bash evaluation lines
  (realworldocaml/mdx#166, @clecat)
- Improve error reporting of ocaml-mdx test (realworldocaml/mdx#172, @Julow)
- Rule: Pass the --section option to `test` (realworldocaml/mdx#176, @Julow)
- Remove trailing whitespaces from shell outputs and toplevel evals (realworldocaml/mdx#166, @clecat)
- Remove inappropriate empty lines in generated dune rules (realworldocaml/mdx#163, @Julow)
- Fix ignored `skip` label in `ocaml-mdx pp` (realworldocaml/mdx#1561, @CraigFe)
- Fix synchronization of new parts from markdown to `.ml` (realworldocaml/mdx#156, @Julow)
- Fix ignored `[@@@parts ...]` markers within module definitions (realworldocaml/mdx#155, @Julow)
- Fix a bug in internal OCaml version comparison that lead to crashes in some cases (realworldocaml/mdx#145, @gpetiot)
- Promote to empty `.ml` file when using `to-ml` direction (realworldocaml/mdx#139, @clecat)
- Apply `--force-output` to `.ml` file as well (realworldocaml/mdx#137, @clecat)
- Fix a bug preventing `.corrected` files to be written in some cases (realworldocaml/mdx#136, @clecat)
- Add compatibility with `4.09.0` (realworldocaml/mdx#133, @xclerc)

#### Removed

- Remove the `output` subcommand as it was very specific to RealWorldOCaml needs (realworldocaml/mdx#195, @NathanReb)
- Remove the `infer-timestamp` direction (realworldocaml/mdx#171 @Julow)
