### PR TITLE
Coq 8.10.2: Add description from 8.10.1

### DIFF
--- a/packages/coq/coq.8.10.2/opam
+++ b/packages/coq/coq.8.10.2/opam
@@ -6,6 +6,16 @@ bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 synopsis: "Formal proof management system"
+description: """
+The Coq proof assistant provides a formal language to write
+mathematical definitions, executable algorithms, and theorems, together
+with an environment for semi-interactive development of machine-checked
+proofs. Typical applications include the certification of properties of programming
+languages (e.g., the CompCert compiler certification project and the
+Bedrock verified low-level programming library), the formalization of
+mathematics (e.g., the full formalization of the Feit-Thompson theorem
+and homotopy type theory) and teaching.
+"""
 
 depends: [
   "ocaml" {>= "4.05.0"}


### PR DESCRIPTION
I had copy-pasted the wrong version, sorry. Now resynced with coq-8.10.1. Thanks @palmskog for noticing!

/cc @kit-ty-kate Sorry for the bother. Maybe this needn't wait for a full CI?