### PR TITLE
[new release] merlin (3.3.3)

### DIFF
--- a/packages/conf-jq/conf-jq.1/opam
+++ b/packages/conf-jq/conf-jq.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://github.com/stedolan/jq"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "Stephen Dolan"
+license: "MIT"
+build: ["jq" "--version"]
+depexts: [
+  ["jq"] {os-family = "debian"}
+  ["jq"] {os-distribution = "fedora"}
+  ["jq"] {os-distribution = "rhel"}
+  ["jq"] {os-distribution = "centos"}
+  ["jq"] {os-distribution = "alpine"}
+  ["jq"] {os-family = "suse"}
+  ["jq"] {os-distribution = "ol"}
+  ["jq"] {os-distribution = "arch"}
+  ["jq"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on jq"
+description:
+  "This package can only install if the jq binary is installed on the system."
+flags: conf

--- a/packages/merlin/merlin.3.3.3/opam
+++ b/packages/merlin/merlin.3.3.3/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.1" & < "4.10"}
+  "dune" {>= "1.8.0"}
+  "ocamlfind" {>= "1.5.2"}
+  "yojson" {>= "1.6.0"}
+  "mdx" {with-test & >= "1.3.0"}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam config var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v3.3.3/merlin-v3.3.3.tbz"
+  checksum: [
+    "sha256=72909ef47eea1f6fca13b4109a34dccf8fe3923a3c026f1ed1db9eb5ee9aae15"
+    "sha512=2a5f39d966be56c1322982effc05bc98fd5f66cd12f1f76953f8daa9eca74a58c92a186854f4e601e2f0bb038720691446e7591b4613982accded3e579fedb23"
+  ]
+}

--- a/packages/merlin/merlin.3.3.3/opam
+++ b/packages/merlin/merlin.3.3.3/opam
@@ -15,6 +15,7 @@ depends: [
   "ocamlfind" {>= "1.5.2"}
   "yojson" {>= "1.6.0"}
   "mdx" {with-test & >= "1.3.0"}
+  "conf-jq" {with-test}
 ]
 synopsis:
   "Editor helper, provides completion, typing and source browsing in Vim and Emacs"


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Fri Nov 29 17:35:58 CET 2019

  + backend
    - support OCaml 4.09 (ocaml/merlin#1055)
    - fix parse errors in 4.08 (ocaml/merlin#1037)
    - update 4.08 support to OCaml 4.08.1 (ocaml/merlin#1053)
    - support `without_cmis` 
    - separate reading from caching in file-cache, use caching in
      `Env.check_state_consistency` (ocaml/merlin#1044)
    - simplify compiler state management (ocaml/merlin#1056, ocaml/merlin#1059)
    - fix creation of initial environment, improve compatibility with
      upstream 4.08 (ocaml/merlin#1052)
  + frontend
    - code re-organization (ocaml/merlin#1042)
    - error command: select which kind of errors to show (ocaml/merlin#995)
    - print value types in outline (ocaml/merlin#1014)
    - fix process handling in windows (ocaml/merlin#1005)
  + editor modes
    - emacs
      + bugfixes in merlin-imenu, merlin-xref (ocaml/merlin#1000, ocaml/merlin#1021, ocaml/merlin#1001)
      + show types in merlin-imenu (ocaml/merlin#1013)
      + reset buffer local configurations when resetting server (ocaml/merlin#1004)
      + remove merlin-use-tuareg-imenu
      + fix stack overflow (ocaml/merlin#1024)
      + fix merlin-occurrence (ocaml/merlin#1043)
    - vim
      + display warn-error warnings as errors (ocaml/merlin#1009)
  + testsuite
    - cover file-cache and `check_state_consistency` (ocaml/merlin#1044)
    - check inconsistent assumptions, test server versus single modes (ocaml/merlin#1047)
