### PR TITLE
Package lua-ml.0.9

### DIFF
--- a/packages/lua-ml/lua-ml.0.9/opam
+++ b/packages/lua-ml/lua-ml.0.9/opam
@@ -10,8 +10,7 @@ bug-reports: "https://github.com/lindig/lua-ml/issues"
 dev-repo: "git+https://github.com/lindig/lua-ml.git"
 depends: [
   "ocaml" {>= "4.07"}
-  "ocamlbuild"
-  "ocamlfind"
+  "ocamlbuild" {build}
 ]
 build: [make "lib"]
 url {

--- a/packages/lua-ml/lua-ml.0.9/opam
+++ b/packages/lua-ml/lua-ml.0.9/opam
@@ -7,6 +7,7 @@ authors: [
 license: "Two-clause BSD"
 homepage: "https://github.com/lindig/lua-ml"
 bug-reports: "https://github.com/lindig/lua-ml/issues"
+dev-repo: "git+https://github.com/lindig/lua-ml.git"
 depends: [
   "ocaml" {>= "4.07"}
   "ocamlbuild"

--- a/packages/lua-ml/lua-ml.0.9/opam
+++ b/packages/lua-ml/lua-ml.0.9/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "An embeddable Lua 2.5 interpreter implemented in OCaml"
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: [
+  "Norman Ramsey <nr@cs.tufts.edu>" "Christian Lindig <lindig@gmail.com>"
+]
+license: "Two-clause BSD"
+homepage: "https://github.com/lindig/lua-ml"
+bug-reports: "https://github.com/lindig/lua-ml/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "ocamlbuild"
+  "ocamlfind"
+]
+build: [make "lib"]
+url {
+  src: "https://github.com/lindig/lua-ml/archive/0.9.zip"
+  checksum: [
+    "md5=fc6537165afb3c6d702b9ae9aeeab01d"
+    "sha512=e8a841dd03256d29eb22868c5cb317db34cfb3de54037605a88812ce4a2d2600de35579af7b627f06c32583510b72e7e02da4bed212658af1edd454a767a1aa7"
+  ]
+}


### PR DESCRIPTION
### `lua-ml.0.9`
An embeddable Lua 2.5 interpreter implemented in OCaml



---
* Homepage: https://github.com/lindig/lua-ml
* Bug tracker: https://github.com/lindig/lua-ml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0