### PR TITLE
[new release] sqlite3 (5.0.0)

### DIFF
--- a/packages/sqlite3/sqlite3.5.0.0/opam
+++ b/packages/sqlite3/sqlite3.5.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christian Szegedy <csdontspam@metamatix.com>"
+]
+bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
+homepage: "https://mmottl.github.io/sqlite3-ocaml"
+doc: "https://mmottl.github.io/sqlite3-ocaml/api"
+license: "Expat"
+dev-repo: "git+https://github.com/mmottl/sqlite3-ocaml.git"
+synopsis: "SQLite3 bindings for OCaml"
+description: """
+sqlite3-ocaml is an OCaml library with bindings to the SQLite3 client API.
+Sqlite3 is a self-contained, serverless, zero-configuration, transactional SQL
+database engine with outstanding performance for many use cases."""
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "1.11"}
+  "conf-sqlite3" {build}
+  "base" {build}
+  "stdio" {build}
+]
+url {
+  src:
+    "https://github.com/mmottl/sqlite3-ocaml/releases/download/5.0.0/sqlite3-5.0.0.tbz"
+  checksum: [
+    "sha256=389ed121c5e36c2a53ef4ec0b867b3800e6bd7bacce021168db180745f63e000"
+    "sha512=23b2464d8b207670bc5b29cc0686b2692aede7d58bda382247d0b5b5d74d1ff8e7d725ac5b2616042658b2bee697845653e5b6557eac6d978a5c5068df4b68ac"
+  ]
+}

--- a/packages/sqlite3/sqlite3.5.0.0/opam
+++ b/packages/sqlite3/sqlite3.5.0.0/opam
@@ -26,6 +26,7 @@ depends: [
   "conf-sqlite3" {build}
   "base" {build}
   "stdio" {build}
+  "ppx_inline_test" {with-test}
 ]
 url {
   src:


### PR DESCRIPTION
SQLite3 bindings for OCaml

- Project page: <a href="https://mmottl.github.io/sqlite3-ocaml">https://mmottl.github.io/sqlite3-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/sqlite3-ocaml/api">https://mmottl.github.io/sqlite3-ocaml/api</a>

##### CHANGES:

* Breaking change:

      * `Data.to_string` is now `Data.to_string_coerce` to more clearly reflect
        that non-string data will be converted to strings.

  * Added support for SQLite3 window functions.

  * Added `Sqlite3.Rc.check` and `Sqlite3.Rc.is_success` for easier return
    code checking.

  * Added `Sqlite3.prepare_or_reset` for reusing prepared statements in loops.

  * Added `Sqlite3.iter` and `Sqlite3.fold` for more convenient handling of
    row data.

  * Added more data conversion functions, also for direct access to column data.

  * Added more data binding functions.

  * Improved closing behavior of database using new SQLite3 API.

  * Improved testing framework using `ppx_inline_test`.

  * Each test case now has its own database for parallel testing.

  * Switched from `caml_alloc_custom` to `caml_alloc_custom_mem`.

  * Switched to OPAM file generation via `dune-project`.

  * Improved compatibility with older OCaml versions.  Thanks to Simon Cruanes
    for this patch!

  Thanks to Shawn <shawnw.mobile@gmail.com> and Ted Spence <tspence@fb.com>
  for their work on many of these contributions!
