### PR TITLE
Package soupault.1.6

### DIFF
--- a/packages/soupault/soupault.1.6/opam
+++ b/packages/soupault/soupault.1.6/opam
@@ -19,7 +19,7 @@ homepage: "https://soupault.neocities.org"
 bug-reports: "https://github.com/dmbaturin/soupault/issues"
 depends: [
   "ocaml" {>= "4.07"}
-  "dune" {build & >= "1.9.0"}
+  "dune" {>= "1.9.0"}
   "lambdasoup"
   "toml"
   "fileutils"

--- a/packages/soupault/soupault.1.6/opam
+++ b/packages/soupault/soupault.1.6/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Static website generator based on HTML rewriting"
+description: """
+A website generator that works with page element tree rather than text
+and allows you to manipulate pages and retrieve metadata from
+existing HTML using arbitrary CSS selectors.
+
+Built-in functionality includes setting page title, generating ToC and footnotes,
+inserting files/HTML snippets or output of external programs into pages etc.
+
+Metadata extracted from pages can be rendered using Mustache templates or exported to JSON
+and processed with an external script.
+
+Extensible with Lua (2.5) plugins. Can also be used as an HTML processor for existing pages."""
+maintainer: "Daniil Baturin <daniil@baturin.org>"
+authors: "Daniil Baturin <daniil@baturin.org>"
+license: "MIT"
+homepage: "https://soupault.neocities.org"
+bug-reports: "https://github.com/dmbaturin/soupault/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {build & >= "1.9.0"}
+  "lambdasoup"
+  "toml"
+  "fileutils"
+  "logs"
+  "fmt"
+  "re"
+  "ezjsonm"
+  "ocaml-monadic" {build}
+  "containers"
+  "stringext"
+  "calendar"
+  "spelll"
+  "mustache"
+  "tsort"
+  "lua-ml"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name]
+]
+dev-repo: "git+https://github.com/dmbaturin/soupalt"
+url {
+  src: "https://github.com/dmbaturin/soupault/archive/1.6.zip"
+  checksum: [
+    "md5=3bcb2284a96ead3799f2b4a84ae14658"
+    "sha512=8f9c21b62aecb24311157a5f56518355a372a2c146640062cbcbac425fc41dba7c7d40c12a9149b8671e2ae6e1147062c1a154b6e88c7f112d796d1f71818b6f"
+  ]
+}

--- a/packages/soupault/soupault.1.6/opam
+++ b/packages/soupault/soupault.1.6/opam
@@ -12,8 +12,8 @@ Metadata extracted from pages can be rendered using Mustache templates or export
 and processed with an external script.
 
 Extensible with Lua (2.5) plugins. Can also be used as an HTML processor for existing pages."""
-maintainer: "Daniil Baturin <daniil@baturin.org>"
-authors: "Daniil Baturin <daniil@baturin.org>"
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: "Daniil Baturin <daniil+soupault@baturin.org>"
 license: "MIT"
 homepage: "https://soupault.neocities.org"
 bug-reports: "https://github.com/dmbaturin/soupault/issues"
@@ -40,7 +40,7 @@ build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name]
 ]
-dev-repo: "git+https://github.com/dmbaturin/soupalt"
+dev-repo: "git+https://github.com/dmbaturin/soupault"
 url {
   src: "https://github.com/dmbaturin/soupault/archive/1.6.zip"
   checksum: [


### PR DESCRIPTION
### `soupault.1.6`
Static website generator based on HTML rewriting
A website generator that works with page element tree rather than text
and allows you to manipulate pages and retrieve metadata from
existing HTML using arbitrary CSS selectors.

Built-in functionality includes setting page title, generating ToC and footnotes,
inserting files/HTML snippets or output of external programs into pages etc.

Metadata extracted from pages can be rendered using Mustache templates or exported to JSON
and processed with an external script.

Extensible with Lua (2.5) plugins. Can also be used as an HTML processor for existing pages.



---
* Homepage: https://soupault.neocities.org
* Source repo: git+https://github.com/dmbaturin/soupault
* Bug tracker: https://github.com/dmbaturin/soupault/issues

---
:camel: Pull-request generated by opam-publish v2.0.0