### PR TITLE
Blacklist lablgtk3 3.0.beta7 also from Coq 8.10.{0,1}

### DIFF
--- a/packages/coqide/coqide.8.10.0/opam
+++ b/packages/coqide/coqide.8.10.0/opam
@@ -9,7 +9,8 @@ synopsis: "IDE of the Coq formal proof management system"
 
 depends: [
   "coq" {= version}
-  "lablgtk3-sourceview3"
+  "lablgtk3" {!= "3.0.beta7"}
+  "lablgtk3-sourceview3" {!= "3.0.beta7"}
   "conf-findutils" {build}
   "conf-gnome-icon-theme3"
 ]

--- a/packages/coqide/coqide.8.10.0/opam
+++ b/packages/coqide/coqide.8.10.0/opam
@@ -9,7 +9,6 @@ synopsis: "IDE of the Coq formal proof management system"
 
 depends: [
   "coq" {= version}
-  "lablgtk3" {!= "3.0.beta7"}
   "lablgtk3-sourceview3" {!= "3.0.beta7"}
   "conf-findutils" {build}
   "conf-gnome-icon-theme3"

--- a/packages/coqide/coqide.8.10.1/opam
+++ b/packages/coqide/coqide.8.10.1/opam
@@ -14,7 +14,8 @@ using the Coq proof assistant.
 
 depends: [
   "coq" {= version}
-  "lablgtk3-sourceview3"
+  "lablgtk3" {!= "3.0.beta7"}
+  "lablgtk3-sourceview3" {!= "3.0.beta7"}
   "conf-findutils" {build}
   "conf-gnome-icon-theme3"
 ]

--- a/packages/coqide/coqide.8.10.1/opam
+++ b/packages/coqide/coqide.8.10.1/opam
@@ -14,7 +14,6 @@ using the Coq proof assistant.
 
 depends: [
   "coq" {= version}
-  "lablgtk3" {!= "3.0.beta7"}
   "lablgtk3-sourceview3" {!= "3.0.beta7"}
   "conf-findutils" {build}
   "conf-gnome-icon-theme3"

--- a/packages/coqide/coqide.8.10.2/opam
+++ b/packages/coqide/coqide.8.10.2/opam
@@ -14,7 +14,6 @@ using the Coq proof assistant.
 
 depends: [
   "coq" {= version}
-  "lablgtk3" {!= "3.0.beta7"}
   "lablgtk3-sourceview3" {!= "3.0.beta7"}
   "conf-findutils" {build}
   "conf-gnome-icon-theme3"


### PR DESCRIPTION
Workaround for coq/coq#11217; I've confirmed it affects those versions as well.