### PR TITLE
Package tiny_httpd.0.3

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.3/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Minimal HTTP server using good old threads"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" } # for now, since qtest needs old dune
+  "base-threads"
+  "ocaml" { >= "4.03.0" }
+  "odoc" {with-doc}
+  "qtest" { >= "2.9" & with-test}
+  "qcheck" {with-test}
+]
+tags: [ "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+post-messages: "tiny http server, with blocking IOs. Also ships with a `http_of_dir` program."
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/0.3.tar.gz"
+  checksum: [
+    "md5=18a547b6cfaa02c68968cd914cacaf21"
+    "sha512=5df12019799a39c91c2394d1ae1f5b595cf26973371545c6056dca5cf7213bdcc9a046ae6db7f6fc9a9693641b4c456f82c416507b6d1f1e541e7f8a8af0ace7"
+  ]
+}


### PR DESCRIPTION
### `tiny_httpd.0.3`
Minimal HTTP server using good old threads



---
* Homepage: https://github.com/c-cube/tiny_httpd/
* Source repo: git+https://github.com/c-cube/tiny_httpd.git
* Bug tracker: https://github.com/c-cube/tiny_httpd/issues

---
:camel: Pull-request generated by opam-publish v2.0.0