### PR TITLE
[new release] stdint (0.6.0)

### DIFF
--- a/packages/stdint/stdint.0.6.0/opam
+++ b/packages/stdint/stdint.0.6.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Signed and unsigned integer types having specified widths"
+description: """
+The stdint library provides signed and unsigned integer types of various fixed
+widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
+
+This interface is similar to Int32 and Int64 from the base library but provides
+more functions and constants like arithmetic and bit-wise operations, constants
+like maximum and minimum values, infix operators conversion to and from every
+other integer type (including int, float and nativeint), parsing from and
+conversion to readable strings (binary, octal, decimal, hexademical), conversion
+to and from buffers in both big endian and little endian byte order."""
+maintainer: ["Markus W. Weissmann <markus.weissmann@in.tum.de>"]
+authors: [
+  "Andre Nathan <andre@digirati.com.br>"
+  "Jeff Shaw <shawjef3@msu.edu>"
+  "Markus W. Weissmann <markus.weissmann@in.tum.de>"
+  "Florian Pichlmeier <florian.pichlmeier@mytum.de>"
+]
+license: "MIT"
+homepage: "https://github.com/andrenth/ocaml-stdint"
+doc: "https://andrenth.github.io/ocaml-stdint/"
+bug-reports: "https://github.com/andrenth/ocaml-stdint/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "1.11"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/andrenth/ocaml-stdint.git"
+url {
+  src:
+    "https://github.com/andrenth/ocaml-stdint/releases/download/0.6.0/stdint-0.6.0.tbz"
+  checksum: [
+    "sha256=1f0bbabc769c10053165c5ec80feb4faaab42a54c610307247845be5918d13cd"
+    "sha512=00d1f864d0f353c4922c4c743df209893e3558a7cee9a1e7e51be5da691657ad5f1d22acf8bee583573c08166f8b2705632fd955e100dd0dea8be4e9d2fbcc48"
+  ]
+}


### PR DESCRIPTION
Signed and unsigned integer types having specified widths

- Project page: <a href="https://github.com/andrenth/ocaml-stdint">https://github.com/andrenth/ocaml-stdint</a>
- Documentation: <a href="https://andrenth.github.io/ocaml-stdint/">https://andrenth.github.io/ocaml-stdint/</a>

##### CHANGES:

* Speed up generic comparison of int backed types (andrenth/ocaml-stdint#34, @rixed)
* Port to dune (andrenth/ocaml-stdint#35, @tuncer)
* Move to stdlib from pervasives (andrenth/ocaml-stdint#36, @tuncer)
