### PR TITLE
Package zmq.5.1.3

### DIFF
--- a/packages/zmq-async/zmq-async.5.1.3/opam
+++ b/packages/zmq-async/zmq-async.5.1.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "anders@fugmann.net"
+authors: ["Rudi Grinberg"]
+license: "MIT"
+homepage: "https://github.com/issuu/ocaml-zmq"
+doc: "https://issuu.github.io/ocaml-zmq/"
+dev-repo:
+  "git+https://github.com/issuu/ocaml-zmq.git"
+bug-reports: "https://github.com/issuu/ocaml-zmq/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "zmq" {= version}
+  "dune"
+  "async_unix" {>= "v0.11.0" & < "v0.13"}
+  "async_kernel" {>= "v0.11.0" & < "v0.13"}
+  "base" {>= "v0.11.0" & < "v0.13"}
+  "ounit2" {with-test}
+]
+synopsis: "Async aware bindings to zmq"
+url {
+  src:
+    "https://github.com/issuu/ocaml-zmq/releases/download/5.1.3/zmq-5.1.3.tbz"
+  checksum: [
+    "sha256=24b32de3829a103e548f37e00f7e03fca72a00e1b67d6ee6d3d75fbae31b8806"
+    "sha512=7b4c1e7bce06d7f340603c7d56ffc1714c5a0601040d72bbe5591e3ae5cf24e7835b5da7bd525c19632db45059544ddcdeecd507298e993b7b761a764c1d8ff7"
+  ]
+}

--- a/packages/zmq-async/zmq-async.5.1.3/opam
+++ b/packages/zmq-async/zmq-async.5.1.3/opam
@@ -15,9 +15,9 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "zmq" {= version}
   "dune"
-  "async_unix" {>= "v0.11.0" & < "v0.13"}
-  "async_kernel" {>= "v0.11.0" & < "v0.13"}
-  "base" {>= "v0.11.0" & < "v0.13"}
+  "async_unix" {>= "v0.11.0"}
+  "async_kernel" {>= "v0.11.0"}
+  "base" {>= "v0.11.0"}
   "ounit2" {with-test}
 ]
 synopsis: "Async aware bindings to zmq"

--- a/packages/zmq-lwt/zmq-lwt.5.1.3/opam
+++ b/packages/zmq-lwt/zmq-lwt.5.1.3/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: ["Anders Fugmann <anders@fugmann.net>"]
+license: "MIT"
+homepage: "https://github.com/issuu/ocaml-zmq"
+doc: "https://issuu.github.io/ocaml-zmq/"
+dev-repo:
+  "git+https://github.com/issuu/ocaml-zmq.git"
+bug-reports: "https://github.com/issuu/ocaml-zmq/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "zmq" {= version}
+  "ounit2" {with-test}
+  "dune"
+  "lwt"
+]
+synopsis: "Lwt aware bindings to zmq"
+url {
+  src:
+    "https://github.com/issuu/ocaml-zmq/releases/download/5.1.3/zmq-5.1.3.tbz"
+  checksum: [
+    "sha256=24b32de3829a103e548f37e00f7e03fca72a00e1b67d6ee6d3d75fbae31b8806"
+    "sha512=7b4c1e7bce06d7f340603c7d56ffc1714c5a0601040d72bbe5591e3ae5cf24e7835b5da7bd525c19632db45059544ddcdeecd507298e993b7b761a764c1d8ff7"
+  ]
+}

--- a/packages/zmq/zmq.5.1.3/opam
+++ b/packages/zmq/zmq.5.1.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "anders@fugmann.net"
+authors: [ "Anders Fugmann" "Pedro Borges" "Peter Zotov" ]
+license: "MIT"
+homepage: "https://github.com/issuu/ocaml-zmq"
+doc: "https://issuu.github.io/ocaml-zmq/"
+dev-repo:
+  "git+https://github.com/issuu/ocaml-zmq.git"
+bug-reports: "https://github.com/issuu/ocaml-zmq/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-zmq"
+  "dune"
+  "ounit2" {with-test}
+  "base-unix"
+  "stdint" {>= "0.4.2"}
+  "dune-configurator"
+]
+conflicts: [
+  "ocaml-zmq"
+]
+synopsis: "OCaml bindings for ZeroMQ 4.x"
+description: """
+This library contains basic bindings for zmq.
+Lwt aware bindings to zmq are availble though package zmq-lwt
+Async aware bindings to zmq are availble though package zmq-async
+
+Api documentation can be found at https://issuu.github.io/ocaml-zmq"""
+url {
+  src:
+    "https://github.com/issuu/ocaml-zmq/releases/download/5.1.3/zmq-5.1.3.tbz"
+  checksum: [
+    "sha256=24b32de3829a103e548f37e00f7e03fca72a00e1b67d6ee6d3d75fbae31b8806"
+    "sha512=7b4c1e7bce06d7f340603c7d56ffc1714c5a0601040d72bbe5591e3ae5cf24e7835b5da7bd525c19632db45059544ddcdeecd507298e993b7b761a764c1d8ff7"
+  ]
+}


### PR DESCRIPTION
> ### `zmq.5.1.3`

A new release which supports building with dune 1.x and 2.x as well as restoring most of the compatibility with OCaml 4.03.

🐫 Pull-request not generated by opam-publish v2.0.0

