### PR TITLE
[new release] lablgtk3-gtkspell3, lablgtk3-sourceview3 and lablgtk3 (3.0.beta8)

### DIFF
--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta8/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta8/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3, gtkspell library
+
+See https://garrigue.github.io/lablgtk/ for more information.
+
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                { >= "4.05.0" }
+  "dune"                 { >= "1.8.0"  }
+  "lablgtk3"             {  = version  }
+]
+depexts: [
+  ["gtkspell3-dev"] {os-distribution = "alpine"}
+  ["gtkspell3"] {os-distribution = "archlinux"}
+  ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
+  ["libgtkspell3-3-dev"] {os-distribution = "debian"}
+  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3"] {os = "freebsd"}
+  ["gtkspell3"] {os = "openbsd"}
+  ["gtkspell3-devel"] {os-family = "suse"}
+  ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
+  ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.0.beta8/lablgtk3-3.0.beta8.tbz"
+  checksum: [
+    "sha256=c6348c8b0e49722413bb56d9e401ecf0da08be0bc8cf34a967ca2c878e58f504"
+    "sha512=e130ae170c686fc04d58b7a843a18dee7ffd7be0108e8bdd9718f4cac347c78b4e5fdc80f110403aa19ef10052655ffdbbe89df472996d18a058ecb24c7dedd7"
+  ]
+}

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta8/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta8/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+ gtksourceview library"
+description: """
+OCaml interface to GTK+3, gtksourceview3 library.
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                {         >= "4.05.0" }
+  "dune"                 {         >= "1.8.0"  }
+  "lablgtk3"             {          = version  }
+  "conf-gtksourceview3"  { build & >= "0"      }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.0.beta8/lablgtk3-3.0.beta8.tbz"
+  checksum: [
+    "sha256=c6348c8b0e49722413bb56d9e401ecf0da08be0bc8cf34a967ca2c878e58f504"
+    "sha512=e130ae170c686fc04d58b7a843a18dee7ffd7be0108e8bdd9718f4cac347c78b4e5fdc80f110403aa19ef10052655ffdbbe89df472996d18a058ecb24c7dedd7"
+  ]
+}

--- a/packages/lablgtk3/lablgtk3.3.0.beta8/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta8/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL with linking exception"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3"
+
+depends: [
+  "ocaml"     {         >= "4.05.0" }
+  "dune"      {         >= "1.8.0"  }
+  "cairo2"    {         >= "0.6"    }
+  "conf-gtk3" { build & >= "18"     }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.0.beta8/lablgtk3-3.0.beta8.tbz"
+  checksum: [
+    "sha256=c6348c8b0e49722413bb56d9e401ecf0da08be0bc8cf34a967ca2c878e58f504"
+    "sha512=e130ae170c686fc04d58b7a843a18dee7ffd7be0108e8bdd9718f4cac347c78b4e5fdc80f110403aa19ef10052655ffdbbe89df472996d18a058ecb24c7dedd7"
+  ]
+}


### PR DESCRIPTION
OCaml interface to GTK+3

- Project page: <a href="https://github.com/garrigue/lablgtk">https://github.com/garrigue/lablgtk</a>
- Documentation: <a href="https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3">https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3</a>

##### CHANGES:

2019.12.03 [Jacques]
  * update toplevel loop instructions in README.md
  * keep Gtk{Th,}Init in tools for reference

2019.12.02 [Emilio]
  * remove Gtk{Th,}Init static initializers, applications should init
    Gtk manually instead of using a linking side-effect (garrigue/lablgtk#100)

2019.11.27 [Jacques]
  * remove declaration of young_start for ocaml 4.10 (garrigue/lablgtk#97)
  * add CI support for 4.10 [Emilio]

2019.11.26 [Emilio]
  * Require Dune 1.8, use improved configurator API (garrigue/lablgtk#95)
