### PR TITLE
Update conf-mariadb to work with recent alpine releases

### DIFF
--- a/packages/conf-mariadb/conf-mariadb.1/opam
+++ b/packages/conf-mariadb/conf-mariadb.1/opam
@@ -6,8 +6,8 @@ bug-reports: "https://jira.mariadb.org/projects/MDEV/issues"
 dev-repo: "git+https://github.com/MariaDB/server.git"
 license: "GPL-2.0-only"
 build: [
-  ["pkg-config" "mariadb"] {os != "macos" & os-distribution != "alpine"}
-  ["pkg-config" "libmariadb"] {os = "macos" | os-distribution = "alpine"}
+  ["pkg-config" "mariadb"] {os != "macos"}
+  ["pkg-config" "libmariadb"] {os = "macos"}
 ]
 depends: [
   "conf-pkg-config" {build}
@@ -16,7 +16,7 @@ depexts: [
   ["libmariadbclient-dev"] {os-family = "debian"}
   ["mariadb-devel"] {os-distribution = "centos"}
   ["mariadb-connector-c"] {os = "macos" & os-distribution = "homebrew"}
-  ["mariadb-connector-c-dev"] {os-distribution = "alpine"}
+  ["mariadb-dev"] {os-distribution = "alpine"}
 ]
 synopsis:
   "Virtual package relying on a libmariadbclient system installation"

--- a/packages/conf-mariadb/conf-mariadb.1/opam
+++ b/packages/conf-mariadb/conf-mariadb.1/opam
@@ -6,8 +6,8 @@ bug-reports: "https://jira.mariadb.org/projects/MDEV/issues"
 dev-repo: "git+https://github.com/MariaDB/server.git"
 license: "GPL-2.0-only"
 build: [
-  ["pkg-config" "mariadb"] {os != "macos"}
-  ["pkg-config" "libmariadb"] {os = "macos"}
+  ["pkg-config" "mariadb"] {os != "macos" & os-distribution != "alpine"}
+  ["pkg-config" "libmariadb"] {os = "macos" | os-distribution = "alpine"}
 ]
 depends: [
   "conf-pkg-config" {build}
@@ -16,7 +16,7 @@ depexts: [
   ["libmariadbclient-dev"] {os-family = "debian"}
   ["mariadb-devel"] {os-distribution = "centos"}
   ["mariadb-connector-c"] {os = "macos" & os-distribution = "homebrew"}
-  ["mariadb-dev"] {os-distribution = "alpine"}
+  ["mariadb-connector-c-dev"] {os-distribution = "alpine"}
 ]
 synopsis:
   "Virtual package relying on a libmariadbclient system installation"

--- a/packages/conf-mariadb/conf-mariadb.2/opam
+++ b/packages/conf-mariadb/conf-mariadb.2/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "ygrek"
+authors: ["MariaDB Foundation"]
+homepage: "https://mariadb.org/"
+bug-reports: "https://jira.mariadb.org/projects/MDEV/issues"
+dev-repo: "git+https://github.com/MariaDB/server.git"
+license: "GPL-2.0-only"
+build: [
+  ["pkg-config" "mariadb"] {os != "macos" & os-distribution != "alpine"}
+  ["pkg-config" "libmariadb"] {os = "macos" | os-distribution = "alpine"}
+]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["libmariadbclient-dev"] {os-family = "debian"}
+  ["mariadb-devel"] {os-distribution = "centos"}
+  ["mariadb-connector-c"] {os = "macos" & os-distribution = "homebrew"}
+  ["mariadb-connector-c-dev"] {os-distribution = "alpine"}
+]
+synopsis:
+  "Virtual package relying on a libmariadbclient system installation"
+description:
+  "This package can only install if the libmariadbclient is installed on the system."
+flags: conf


### PR DESCRIPTION
The recent #15265 update broke an internal alpine-based CI build with mysql 1.2.4 because of the new `conf-*` dependency.  I think this should work, but we'll see how it does with the repository CI checks!

If the alpine CI tests here in opam-repository don't pass then this probably shouldn't be merged.