### PR TITLE
Fix rpclib's dependencies

### DIFF
--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.5.9.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.5.9.0/opam
@@ -17,13 +17,13 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}
   "jbuilder"
   "cppo" {build}
-  "rpclib" {>= "5.0.0"}
+  "rpclib" {= version}
   "rresult"
   "ppx_deriving"
   "ppx_tools"
   "ppxfind"
-  "rpclib-lwt" {with-test & >= "5.0.0"}
-  "rpclib-async" {with-test & >= "5.0.0"}
+  "rpclib-lwt" {with-test & = version}
+  "rpclib-async" {with-test & = version}
   "lwt" {with-test & >= "3.0.0"}
   "async" {with-test & < "v0.13"}
   "alcotest" {with-test}

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.6.0.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.6.0.0/opam
@@ -16,11 +16,11 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0" & < "4.10.0"}
   "jbuilder"
-  "rpclib" {>= "6.0.0"}
+  "rpclib" {= version}
   "rresult"
   "ppxlib" {< "0.9.0"}
-  "rpclib-lwt" {with-test & >= "6.0.0"}
-  "rpclib-async" {with-test & >= "6.0.0"}
+  "rpclib-lwt" {with-test & = version}
+  "rpclib-async" {with-test & = version}
   "lwt" {with-test & >= "3.0.0"}
   "async" {with-test & < "v0.13"}
   "alcotest" {with-test}

--- a/packages/rpclib-async/rpclib-async.5.9.0/opam
+++ b/packages/rpclib-async/rpclib-async.5.9.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"
   "alcotest" {with-test}
   "jbuilder"
-  "rpclib" {>= "5.0.0"}
+  "rpclib" {= version}
   "async" {< "v0.13"}
 ]
 conflicts: [ "core" {< "v0.9.0"} ]

--- a/packages/rpclib-async/rpclib-async.6.0.0/opam
+++ b/packages/rpclib-async/rpclib-async.6.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.04.0" < "4.10.0"}
   "jbuilder"
   "alcotest" {with-test}
-  "rpclib" {>= "6.0.0"}
+  "rpclib" {= version}
   "async" {< "v0.13"}
 ]
 conflicts: [ "core" {< "v0.9.0"} ]

--- a/packages/rpclib-lwt/rpclib-lwt.5.9.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.5.9.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"
   "alcotest" {with-test}
   "jbuilder"
-  "rpclib" {>= "5.0.0"}
+  "rpclib" {= version}
   "lwt" {>= "3.0.0"}
   "alcotest-lwt" {with-test}
 ]

--- a/packages/rpclib-lwt/rpclib-lwt.6.0.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.6.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "jbuilder"
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
-  "rpclib" {>= "6.0.0"}
+  "rpclib" {= version}
   "lwt" {>= "3.0.0"}
 ]
 synopsis: "Driver for rpclib using lwt"


### PR DESCRIPTION
Otherwise e.g. ppx_deriving_rpc 5.9.0 installs with rpclib 6.0.0, causing a build error.
This is a followup PR on #15436.