### PR TITLE
tcpip: support dune-configurator so dune 2.0 works as well

### DIFF
--- a/packages/tcpip/tcpip.3.7.8/opam
+++ b/packages/tcpip/tcpip.3.7.8/opam
@@ -20,7 +20,7 @@ build: [
 
 depopts: ["mirage-xen-ocaml"]
 depends: [
-  "dune" {>= "1.0"}
+  "dune"
   "dune-configurator"
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}

--- a/packages/tcpip/tcpip.3.7.9/opam
+++ b/packages/tcpip/tcpip.3.7.9/opam
@@ -20,7 +20,8 @@ build: [
 
 depopts: ["mirage-xen-ocaml"]
 depends: [
-  "dune" {>= "1.0"}
+  "dune"
+  "dune-configurator"
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.2.0"}

--- a/packages/tcpip/tcpip.4.0.0/opam
+++ b/packages/tcpip/tcpip.4.0.0/opam
@@ -20,7 +20,8 @@ build: [
 
 depopts: ["mirage-xen-ocaml"]
 depends: [
-  "dune"     {>= "1.0"}
+  "dune"
+  "dune-configurator"
   "ocaml" {>= "4.06.0"}
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.2.0"}


### PR DESCRIPTION
upstream at https://github.com/mirage/mirage-tcpip/pull/422
cc @dinosaure