### PR TITLE
relax ocamlformat constraint on base/stdio

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.12/opam
+++ b/packages/ocamlformat/ocamlformat.0.12/opam
@@ -19,7 +19,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06"}
-  "base" {>= "v0.11.0" & < "v0.13"}
+  "base" {>= "v0.11.0" & < "v0.14"}
   "base-unix"
   "cmdliner"
   "dune" {>= "1.11.1"}
@@ -27,7 +27,7 @@ depends: [
   "ocaml-migrate-parsetree" {>= "1.3.1"}
   "odoc" {>= "1.4.2"}
   "re"
-  "stdio" {< "v0.13"}
+  "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
 ]


### PR DESCRIPTION
This is handy to have before the mass relaxation of other upper
bounds, since ocamlformat is needed early