### PR TITLE
jbuilder.1.0+beta20.2

### DIFF
--- a/packages/jbuilder/jbuilder.1.0+beta20.2/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta20.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "git+https://github.com/ocaml/dune.git"
+license: "Apache-2.0"
+build: [
+  ["ocaml" "configure.ml" "--libdir" lib]
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--subst"] {pinned}
+  ["./boot.exe" "-j" jobs]
+]
+synopsis: "Fast, portable and opinionated build system"
+description: """
+jbuilder is a build system that was designed to simplify the release
+of Jane Street packages. It reads metadata from "jbuild" files
+following a very simple s-expression syntax.
+
+jbuilder is fast, it has very low-overhead and support parallel builds
+on all platforms. It has no system dependencies, all you need to build
+jbuilder and packages using jbuilder is OCaml. You don't need or make
+or bash as long as the packages themselves don't use bash explicitely.
+
+jbuilder supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free."""
+depends: [
+  "ocaml" {>= "4.02.3"}
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/1.0%2Bbeta20.2/jbuilder-1.0+beta20.2.tbz"
+  checksum: "md5=fbe8c3b1facb206cac3fb8932b5dd5d9"
+}


### PR DESCRIPTION
A small change to help users who are stuck with jbuilder dependencies. It makes jbuilder install a `<lib>.dune` only when necessary, reducing a lot the amount of warnings printed by dune when using a library built by jbuilder.