### PR TITLE
[new release] graphics (5.1.0)

### DIFF
--- a/packages/graphics/graphics.5.1.0/opam
+++ b/packages/graphics/graphics.5.1.0/opam
@@ -17,6 +17,7 @@ doc: "https://ocaml.github.io/graphics/"
 bug-reports: "https://github.com/ocaml/graphics/issues"
 depends: [
   "dune" {>= "2.0"}
+  "dune-configurator"
   "conf-libX11"
   "ocaml" {>= "4.09.0~~"}
 ]

--- a/packages/graphics/graphics.5.1.0/opam
+++ b/packages/graphics/graphics.5.1.0/opam
@@ -20,6 +20,7 @@ depends: [
   "dune-configurator"
   "conf-libX11"
   "ocaml" {>= "4.09.0~~"}
+  "conf-pkg-config"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/graphics/graphics.5.1.0/opam
+++ b/packages/graphics/graphics.5.1.0/opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/ocaml/graphics"
 doc: "https://ocaml.github.io/graphics/"
 bug-reports: "https://github.com/ocaml/graphics/issues"
 depends: [
-  "dune" {>= "1.11"}
+  "dune" {>= "2.0"}
   "conf-libX11"
   "ocaml" {>= "4.09.0~~"}
 ]

--- a/packages/graphics/graphics.5.1.0/opam
+++ b/packages/graphics/graphics.5.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "The OCaml graphics library"
+description: """
+The graphics library provides a set of portable drawing
+primitives. Drawing takes place in a separate window that is created
+when Graphics.open_graph is called.
+
+This library used to be distributed with OCaml up to OCaml 4.08.
+"""
+maintainer: ["jeremie@dimino.org" "david.allsopp@metastack.com"]
+authors: [
+  "Xavier Leroy" "Jun Furuse" "J-M Geffroy" "Jacob Navia" "Pierre Weis"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/ocaml/graphics"
+doc: "https://ocaml.github.io/graphics/"
+bug-reports: "https://github.com/ocaml/graphics/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "conf-libX11"
+  "ocaml" {>= "4.09.0~~"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/graphics.git"
+url {
+  src:
+    "https://github.com/ocaml/graphics/releases/download/5.1.0/graphics-5.1.0.tbz"
+  checksum: [
+    "sha256=c596ed036574c64bdaa313a7198953f081becfe5e3d78db1a2913170eb49e99b"
+    "sha512=4783a8609ec1fbe09deac083856ac6c3fc656edcd8e417b026352068a45a3246db1e0ee73ef21759c971516dd33e40c69d14220a7a9092af7e522239c35c6c9e"
+  ]
+}


### PR DESCRIPTION
The OCaml graphics library

- Project page: <a href="https://github.com/ocaml/graphics">https://github.com/ocaml/graphics</a>
- Documentation: <a href="https://ocaml.github.io/graphics/">https://ocaml.github.io/graphics/</a>

##### CHANGES:

- Use pkg-config to query x11 compilation and linking flags + hardcode
  a few pkg-config paths for OSX (ocaml/graphics#17, fixes ocaml/graphics#16, @diml)
