### PR TITLE
vcaml.v0.13.0 - OCaml bindings for the Neovim API

### DIFF
--- a/packages/vcaml/vcaml.v0.13.0/opam
+++ b/packages/vcaml/vcaml.v0.13.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/vcaml"
+bug-reports: "https://github.com/janestreet/vcaml/issues"
+dev-repo: "git+https://github.com/janestreet/vcaml.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "async" {>= "v0.13" & < "v0.14"}
+  "async_extra" {>= "v0.13" & < "v0.14"}
+  "base" {>= "v0.13" & < "v0.14"}
+  "core" {>= "v0.13" & < "v0.14"}
+  "core_kernel" {>= "v0.13" & < "v0.14"}
+  "ppx_jane" {>= "v0.13" & < "v0.14"}
+  "angstrom"
+  "angstrom-async"
+  "dune"           {>= "2.0.0"}
+  "faraday"
+]
+synopsis: "OCaml bindings for the Neovim API"
+description: "
+The Neovim text editor comes with an RPC-based public API 
+which can be used to control the editor.  This set of libraries implements 
+an OCaml interface to those APIs, for the purpose of permitting neovim 
+plugins to be written in OCaml.
+"
+url {
+  src: "https://github.com/janestreet/vcaml/archive/v0.13.0.tar.gz"
+  checksum: "md5=f346c9fa625ca6068b1d24a474776669"
+}


### PR DESCRIPTION
The Neovim text editor comes with an RPC-based public API 
which can be used to control the editor.  This set of libraries implements 
an OCaml interface to those APIs, for the purpose of permitting neovim 
plugins to be written in OCaml.