### PR TITLE
4 packages from sneeuwballen/zipperposition at 1.6

### DIFF
--- a/packages/libzipperposition/libzipperposition.1.6/opam
+++ b/packages/libzipperposition/libzipperposition.1.6/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "Petar Vukmirovic" "Alexander Bentkamp" "Sophie Tourret" "Visa Nummelin"]
+homepage: "https://github.com/sneeuwballen/zipperposition"
+synopsis: "Library for Zipperposition"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "base-bytes"
+  "base-unix"
+  "zarith"
+  "logtk" { = version }
+  "containers" { >= "1.0" }
+  "iter" { >= "1.2" }
+  "oseq"
+  "dune" { >= "1.1" }
+  "msat" { >= "0.8" < "0.9" }
+  "menhir" {build}
+  "logtk"
+  "ocaml" {>= "4.03"}
+]
+tags: [ "logic" "unification" "term" "superposition" "prover" ]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/1.6.tar.gz"
+  checksum: [
+    "md5=97cdb2f90468e9e27c7bbe3b4fb160bb"
+    "sha512=fee73369f673a91dfa9e265fc69be08b32235e10a495f3af6477d404fcd01e3452a0d012b150f3d7f97c00af2f6045019ad039164bf698f70d771231cc4efe5d"
+  ]
+}

--- a/packages/logtk/logtk.1.6/opam
+++ b/packages/logtk/logtk.1.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "Petar Vukmirovic" "Alexander Bentkamp" "Sophie Tourret" "Visa Nummelin"]
+homepage: "https://github.com/sneeuwballen/zipperposition"
+synopsis: "Core types and algorithms for logic"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "base-bytes"
+  "base-unix"
+  "zarith"
+  "oseq"
+  "containers" { >= "1.0" }
+  "iter" { >= "1.2" }
+  "menhir" {build}
+  "dune" { >= "1.1" }
+  "alcotest" {with-test}
+  "qcheck-core" {with-test & >= "0.9"}
+  "qcheck-alcotest" {with-test & >= "0.9"}
+  "ocaml" {>= "4.03"}
+]
+depopts: [
+  "msat"
+]
+conflicts: [
+  "msat" { < "0.8" }
+  "msat" { >= "0.9" }
+]
+tags: [ "logic" "unification" "term" ]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/1.6.tar.gz"
+  checksum: [
+    "md5=97cdb2f90468e9e27c7bbe3b4fb160bb"
+    "sha512=fee73369f673a91dfa9e265fc69be08b32235e10a495f3af6477d404fcd01e3452a0d012b150f3d7f97c00af2f6045019ad039164bf698f70d771231cc4efe5d"
+  ]
+}

--- a/packages/zipperposition-tools/zipperposition-tools.1.6/opam
+++ b/packages/zipperposition-tools/zipperposition-tools.1.6/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "Petar Vukmirovic" "Alexander Bentkamp" "Sophie Tourret" "Visa Nummelin"]
+homepage: "https://github.com/sneeuwballen/zipperposition"
+synopsis: "Support tools for Zipperposition"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "containers" { >= "1.0" }
+  "iter" { >= "1.2" }
+  "oseq" { >= "0.2" }
+  "msat" { >= "0.8" < "0.9" }
+  "zarith"
+  "logtk" { = version }
+  "libzipperposition" { = version }
+  "ocaml" {>= "4.03"}
+]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/1.6.tar.gz"
+  checksum: [
+    "md5=97cdb2f90468e9e27c7bbe3b4fb160bb"
+    "sha512=fee73369f673a91dfa9e265fc69be08b32235e10a495f3af6477d404fcd01e3452a0d012b150f3d7f97c00af2f6045019ad039164bf698f70d771231cc4efe5d"
+  ]
+}

--- a/packages/zipperposition/zipperposition.1.6/opam
+++ b/packages/zipperposition/zipperposition.1.6/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "Petar Vukmirovic" "Alexander Bentkamp" "Sophie Tourret" "Visa Nummelin"]
+homepage: "https://github.com/sneeuwballen/zipperposition"
+synopsis: "A fully automatic theorem prover for typed higher-order and beyond"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "base-unix"
+  "zarith"
+  "logtk" { = version }
+  "libzipperposition" { = version }
+  "containers" { >= "1.0" }
+  "iter" { >= "1.2" }
+  "oseq"
+  "dune" { >= "1.1" }
+  "msat" { >= "0.8" < "0.9" }
+  "menhir" {build}
+  "ocaml" {>= "4.03"}
+]
+tags: [ "logic" "unification" "term" "superposition" "prover" ]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/1.6.tar.gz"
+  checksum: [
+    "md5=97cdb2f90468e9e27c7bbe3b4fb160bb"
+    "sha512=fee73369f673a91dfa9e265fc69be08b32235e10a495f3af6477d404fcd01e3452a0d012b150f3d7f97c00af2f6045019ad039164bf698f70d771231cc4efe5d"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`libzipperposition.1.6`: Library for Zipperposition
-`logtk.1.6`: Core types and algorithms for logic
-`zipperposition.1.6`: A fully automatic theorem prover for typed higher-order and beyond
-`zipperposition-tools.1.6`: Support tools for Zipperposition



---
* Homepage: https://github.com/sneeuwballen/zipperposition
* Source repo: git+https://github.com/sneeuwballen/zipperposition.git
* Bug tracker: https://github.com/sneeuwballen/zipperposition/issues

---
:camel: Pull-request generated by opam-publish v2.0.0