### PR TITLE
[new release] rpclib, rpclib-lwt, rpclib-async, rpclib-html, rpclib-js and ppx_deriving_rpc (6.1.0)

### DIFF
--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.6.1.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.6.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for ocaml-rpc, a library to deal with RPCs in OCaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/ppx_deriving_rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.5.0"}
+  "rpclib" {>= "5.0.0"}
+  "rresult"
+  "ppxlib" {< "0.9.0"}
+  "rpclib-lwt" {with-test & >= "5.0.0"}
+  "rpclib-async" {with-test & >= "5.0.0"}
+  "lwt" {with-test & >= "3.0.0"}
+  "async" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v6.1.0/rpclib-v6.1.0.tbz"
+  checksum: [
+    "sha256=8eac73ff90c4edaa2dbc697126a81217dafad6ed1ad99046fd357a0539a565f9"
+    "sha512=f82d1dc189fb734cf0635ff0fd556211463e933763b604342882f319bee59cc2f8ae05f2d1155c90ee186b269d7560b08ea51282a01e3c8fd0d7b36f7bd321b2"
+  ]
+}

--- a/packages/rpclib-async/rpclib-async.6.1.0/opam
+++ b/packages/rpclib-async/rpclib-async.6.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Async interface"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-async"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune" {>= "1.5.0"}
+  "rpclib" {=version}
+  "async"
+]
+conflicts: [
+  "core" {< "v0.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v6.1.0/rpclib-v6.1.0.tbz"
+  checksum: [
+    "sha256=8eac73ff90c4edaa2dbc697126a81217dafad6ed1ad99046fd357a0539a565f9"
+    "sha512=f82d1dc189fb734cf0635ff0fd556211463e933763b604342882f319bee59cc2f8ae05f2d1155c90ee186b269d7560b08ea51282a01e3c8fd0d7b36f7bd321b2"
+  ]
+}

--- a/packages/rpclib-html/rpclib-html.6.1.0/opam
+++ b/packages/rpclib-html/rpclib-html.6.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis:
+  "A library to deal with RPCs in OCaml - html documentation generator"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-html"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.5.0"}
+  "rpclib" {=version}
+  "cow"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v6.1.0/rpclib-v6.1.0.tbz"
+  checksum: [
+    "sha256=8eac73ff90c4edaa2dbc697126a81217dafad6ed1ad99046fd357a0539a565f9"
+    "sha512=f82d1dc189fb734cf0635ff0fd556211463e933763b604342882f319bee59cc2f8ae05f2d1155c90ee186b269d7560b08ea51282a01e3c8fd0d7b36f7bd321b2"
+  ]
+}

--- a/packages/rpclib-js/rpclib-js.6.1.0/opam
+++ b/packages/rpclib-js/rpclib-js.6.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Bindings for js_of_ocaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-js"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.5.0"}
+  "rpclib" {=version}
+  "js_of_ocaml" {>= "3.5.0"}
+  "js_of_ocaml-ppx" {>= "3.5.0"}
+  "lwt"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v6.1.0/rpclib-v6.1.0.tbz"
+  checksum: [
+    "sha256=8eac73ff90c4edaa2dbc697126a81217dafad6ed1ad99046fd357a0539a565f9"
+    "sha512=f82d1dc189fb734cf0635ff0fd556211463e933763b604342882f319bee59cc2f8ae05f2d1155c90ee186b269d7560b08ea51282a01e3c8fd0d7b36f7bd321b2"
+  ]
+}

--- a/packages/rpclib-lwt/rpclib-lwt.6.1.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.6.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Lwt interface"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-lwt"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune" {>= "1.5.0"}
+  "rpclib" {=version}
+  "lwt" {>= "3.0.0"}
+  "alcotest-lwt" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v6.1.0/rpclib-v6.1.0.tbz"
+  checksum: [
+    "sha256=8eac73ff90c4edaa2dbc697126a81217dafad6ed1ad99046fd357a0539a565f9"
+    "sha512=f82d1dc189fb734cf0635ff0fd556211463e933763b604342882f319bee59cc2f8ae05f2d1155c90ee186b269d7560b08ea51282a01e3c8fd0d7b36f7bd321b2"
+  ]
+}

--- a/packages/rpclib/rpclib.6.1.0/opam
+++ b/packages/rpclib/rpclib.6.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "alcotest" {with-test}
+  "dune" {>= "1.5.0"}
+  "cmdliner"
+  "rresult"
+  "xmlm"
+  "yojson" {>= "1.7.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v6.1.0/rpclib-v6.1.0.tbz"
+  checksum: [
+    "sha256=8eac73ff90c4edaa2dbc697126a81217dafad6ed1ad99046fd357a0539a565f9"
+    "sha512=f82d1dc189fb734cf0635ff0fd556211463e933763b604342882f319bee59cc2f8ae05f2d1155c90ee186b269d7560b08ea51282a01e3c8fd0d7b36f7bd321b2"
+  ]
+}


### PR DESCRIPTION
A library to deal with RPCs in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-rpc">https://github.com/mirage/ocaml-rpc</a>
- Documentation: <a href="https://mirage.github.io/ocaml-rpc/rpclib">https://mirage.github.io/ocaml-rpc/rpclib</a>

##### CHANGES:

* opam: updated bounds on a more conservative basis
* travis: tests more compilers
* tests: disable useless-object-inheritance on pylint checks
* pythongen: generate python2-3 compatible bindings
* Add ISC license
* Incremented the upper bound for async's version.
* Added lower bound for js_of_ocaml in related .opam file.
* Fixed compilation issue with js_of_ocaml 3.5.0 and 3.5.1.
* opam: remove the 'build' directive on dune dependency
* opam: remove unnecessary flag
* port to dune
