### PR TITLE
Package cwe_checker.0.3

### DIFF
--- a/packages/cwe_checker/cwe_checker.0.3/opam
+++ b/packages/cwe_checker/cwe_checker.0.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "BAP plugin collection to detect common bug classes"
+description: """
+cwe_checker is a suite of tools to detect common bug classes such as use of dangerous functions and simple integer overflows. These bug classes are formally known as Common Weakness Enumerations (CWEs).
+"""
+maintainer: "CWE_checker Team <nils-edvin.enkelmann@fkie.fraunhofer.de>"
+authors: [ "Thomas Barabosch <thomas.barabosch@fkie.fraunhofer.de>" "Nils-Edvin Enkelmann <nils-edvin.enkelmann@fkie.fraunhofer.de>" ]
+license: "LGPL-3.0"
+homepage: "https://github.com/fkie-cad/cwe_checker"
+bug-reports: "https://github.com/fkie-cad/cwe_checker/issues"
+dev-repo: "git+https://github.com/fkie-cad/cwe_checker"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "1.6"}
+  "yojson" {>= "1.6.0"}
+  "bap" {>= "1.6" & < "2.0"}
+  "alcotest" {>= "0.8.3"}
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ppx_jane" {>= "v0.11" & < "v0.12"}
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "odoc" {>= "1.4"}
+]
+depexts: [
+  "binutils"
+]
+conflicts: [
+  "fkie-cad-cwe-checker" {!= "0.2"}
+]
+build: [
+  [ "dune" "build" "--profile" "release" ]
+]
+install: [
+  [ make "uninstall" ]
+  [ make "clean" ]
+  [ make "all" ]
+]
+url {
+  src: "https://github.com/fkie-cad/cwe_checker/archive/v0.3.tar.gz"
+  checksum: [
+    "md5=fc1ae520b8865426b4c00d319889a639"
+    "sha512=4d2d7f81e782baf462b47a3f12b8c5c639338bf29f7555bb9696cf7b4699d89a175351861c75b77c1b76621cd1f1fc03650da3bad493638b6de03d20c4426282"
+  ]
+}


### PR DESCRIPTION
### `cwe_checker.0.3`
BAP plugin collection to detect common bug classes
cwe_checker is a suite of tools to detect common bug classes such as use of dangerous functions and simple integer overflows. These bug classes are formally known as Common Weakness Enumerations (CWEs).



---
* Homepage: https://github.com/fkie-cad/cwe_checker
* Source repo: git+https://github.com/fkie-cad/cwe_checker
* Bug tracker: https://github.com/fkie-cad/cwe_checker/issues

---
:camel: Pull-request generated by opam-publish v2.0.0