### PR TITLE
[new release] rpclib, rpclib-lwt, rpclib-async, rpclib-html, rpclib-js and ppx_deriving_rpc (7.0.0)

### DIFF
--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.7.0.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.7.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for ocaml-rpc, a library to deal with RPCs in OCaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/ppx_deriving_rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.5.0"}
+  "rpclib" {>= "5.0.0"}
+  "rresult"
+  "ppxlib" {< "0.9.0"}
+  "rpclib-lwt" {with-test & >= "5.0.0"}
+  "rpclib-async" {with-test & >= "5.0.0"}
+  "lwt" {with-test & >= "3.0.0"}
+  "async" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.0.0/rpclib-v7.0.0.tbz"
+  checksum: [
+    "sha256=c6c7edce885b1529a24e8506080704e19cb240e2f1b0b6c6a8608d094f37c41d"
+    "sha512=1541dfc39f00f3f690ff2055d50c880101b295d513fe1ec3e9df03aec02427ce8fa61d6d80698b122f0c97358e4555d2c8299a194de5c49802bcb8b19d352050"
+  ]
+}

--- a/packages/rpclib-async/rpclib-async.7.0.0/opam
+++ b/packages/rpclib-async/rpclib-async.7.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Async interface"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-async"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune" {>= "1.5.0"}
+  "rpclib" {=version}
+  "async"
+]
+conflicts: [
+  "core" {< "v0.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.0.0/rpclib-v7.0.0.tbz"
+  checksum: [
+    "sha256=c6c7edce885b1529a24e8506080704e19cb240e2f1b0b6c6a8608d094f37c41d"
+    "sha512=1541dfc39f00f3f690ff2055d50c880101b295d513fe1ec3e9df03aec02427ce8fa61d6d80698b122f0c97358e4555d2c8299a194de5c49802bcb8b19d352050"
+  ]
+}

--- a/packages/rpclib-html/rpclib-html.7.0.0/opam
+++ b/packages/rpclib-html/rpclib-html.7.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis:
+  "A library to deal with RPCs in OCaml - html documentation generator"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-html"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.5.0"}
+  "rpclib" {=version}
+  "cow"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.0.0/rpclib-v7.0.0.tbz"
+  checksum: [
+    "sha256=c6c7edce885b1529a24e8506080704e19cb240e2f1b0b6c6a8608d094f37c41d"
+    "sha512=1541dfc39f00f3f690ff2055d50c880101b295d513fe1ec3e9df03aec02427ce8fa61d6d80698b122f0c97358e4555d2c8299a194de5c49802bcb8b19d352050"
+  ]
+}

--- a/packages/rpclib-js/rpclib-js.7.0.0/opam
+++ b/packages/rpclib-js/rpclib-js.7.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Bindings for js_of_ocaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-js"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.5.0"}
+  "rpclib" {=version}
+  "js_of_ocaml" {>= "3.5.0"}
+  "js_of_ocaml-ppx" {>= "3.5.0"}
+  "lwt"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.0.0/rpclib-v7.0.0.tbz"
+  checksum: [
+    "sha256=c6c7edce885b1529a24e8506080704e19cb240e2f1b0b6c6a8608d094f37c41d"
+    "sha512=1541dfc39f00f3f690ff2055d50c880101b295d513fe1ec3e9df03aec02427ce8fa61d6d80698b122f0c97358e4555d2c8299a194de5c49802bcb8b19d352050"
+  ]
+}

--- a/packages/rpclib-lwt/rpclib-lwt.7.0.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.7.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Lwt interface"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-lwt"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune" {>= "1.5.0"}
+  "rpclib" {=version}
+  "lwt" {>= "3.0.0"}
+  "alcotest-lwt" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.0.0/rpclib-v7.0.0.tbz"
+  checksum: [
+    "sha256=c6c7edce885b1529a24e8506080704e19cb240e2f1b0b6c6a8608d094f37c41d"
+    "sha512=1541dfc39f00f3f690ff2055d50c880101b295d513fe1ec3e9df03aec02427ce8fa61d6d80698b122f0c97358e4555d2c8299a194de5c49802bcb8b19d352050"
+  ]
+}

--- a/packages/rpclib/rpclib.7.0.0/opam
+++ b/packages/rpclib/rpclib.7.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "alcotest" {with-test}
+  "dune" {>= "1.5.0"}
+  "cmdliner"
+  "rresult"
+  "xmlm"
+  "yojson" {>= "1.7.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.0.0/rpclib-v7.0.0.tbz"
+  checksum: [
+    "sha256=c6c7edce885b1529a24e8506080704e19cb240e2f1b0b6c6a8608d094f37c41d"
+    "sha512=1541dfc39f00f3f690ff2055d50c880101b295d513fe1ec3e9df03aec02427ce8fa61d6d80698b122f0c97358e4555d2c8299a194de5c49802bcb8b19d352050"
+  ]
+}


### PR DESCRIPTION
A library to deal with RPCs in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-rpc">https://github.com/mirage/ocaml-rpc</a>
- Documentation: <a href="https://mirage.github.io/ocaml-rpc/rpclib">https://mirage.github.io/ocaml-rpc/rpclib</a>

##### CHANGES:

* Add basic support for JSON-RPC notifications
