### PR TITLE
core_kernel.v0.13.0 is not compatible with OCaml 4.10

### DIFF
--- a/packages/core_kernel/core_kernel.v0.13.0/opam
+++ b/packages/core_kernel/core_kernel.v0.13.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"               {>= "4.08.0"}
+  "ocaml"               {>= "4.08.0" & < "4.10.0"}
   "base"                {>= "v0.13" & < "v0.14"}
   "base_bigstring"      {>= "v0.13" & < "v0.14"}
   "base_quickcheck"     {>= "v0.13" & < "v0.14"}


### PR DESCRIPTION
(The incompatibility cannot be observed right now because
`core_kernel` depends on `base` and we currently have no
`base >= v0.13 & < v0.14` compatible with OCaml 4.10.)