### PR TITLE
bitstring.3.1.1 is unusable with OCaml < 4.07

### DIFF
--- a/packages/bitstring/bitstring.3.1.1/opam
+++ b/packages/bitstring/bitstring.3.1.1/opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.07.0"}
   "dune"
   "ppx_tools_versioned" {build}
   "ocaml-migrate-parsetree" {>= "1.0.5"}


### PR DESCRIPTION
@xguerin this commit (https://bitbucket.org/thanatonauts/bitstring/commits/a0ee5f1d42d7d62834210dee0265a53dc44a01bb) makes `bitstring.3.1.1` unusable with OCaml < 4.07 as it makes use of the `Stdlib` module in the code created by the ppx.

Example of failure:
```
#=== ERROR while compiling obeam.0.1.2 ========================================#
# context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.06.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.06.1/.opam-switch/build/obeam.0.1.2
# command              ~/.opam/4.06.1/bin/dune build -p obeam -j 71
# exit-code            1
# env-file             ~/.opam/log/obeam-6-80fea7.env
# output-file          ~/.opam/log/obeam-6-80fea7.out
### output ###
#       ocamlc lib/.obeam.objs/byte/obeam__Aux.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.06.1/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.obeam.objs/byte -I /home/opam/.opam/4.06.1/lib/base -I /home/opam/.opam/4.06.1/lib/base/base_internalhash_types -I /home/opam/.opam/4.06.1/lib/base/caml -I /home/opam/.opam/4.06.1/lib/base/shadow_stdlib -I /home/opam/.opam/4.06.1/lib/bitstring -I /home/opam/.opam/4.06.1/lib/camlzip -I /home/opam/.opam/4.[...]
# File "lib/aux.ml", line 23, characters 4-63:
# Error: Unbound module Stdlib
```