### PR TITLE
conf-gnome-icon-theme3: support gentoo (#15371)

### DIFF
--- a/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
+++ b/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["gnome-icon-theme"] {os-distribution = "alpine"}
   ["gnome-icon-theme"] {os-distribution = "nixos"}
   ["gnome-icon-theme"] {os-distribution = "ol"}
+  ["adwaita-icon-theme"] {os-distribution = "gentoo"}
 ]
 synopsis: "Virtual package relying on gnome-icon-theme"
 description:


### PR DESCRIPTION
Note this does not cover the report in https://github.com/ocaml/opam-repository/issues/15371#issuecomment-560139229 as I have no insight in that issue.