### PR TITLE
[new release] curve-sampling and curve-sampling-cairo (0.2)

### DIFF
--- a/packages/curve-sampling/curve-sampling.0.2/opam
+++ b/packages/curve-sampling/curve-sampling.0.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>" ]
+license: "GPL-3.0+"
+homepage: "https://github.com/Chris00/ocaml-curve-sampling"
+dev-repo: "git+https://github.com/Chris00/ocaml-curve-sampling.git"
+bug-reports: "https://github.com/Chris00/ocaml-curve-sampling/issues"
+doc: "https://Chris00.github.io/ocaml-curve-sampling/doc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os = "linux"}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "gg"
+  "dune" {>= "1.3"}
+  "cppo" {build}
+  "conf-gnuplot" {with-test & os = "linux"}
+  "gsl" {with-test & os = "linux"}
+]
+synopsis: "Sampling of parametric and implicit curves"
+description: """
+Adaptive sampling of parametric and implicit curves (the latter is WIP)."""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-curve-sampling/releases/download/0.2/curve-sampling-0.2.tbz"
+  checksum: [
+    "sha256=733ded91c05bae5b6e82c499c44c11a6eb8b016b2ac29d3670e2a0e984c2ad09"
+    "sha512=bee275149d51936bca3ef3aa06391ff6f095ac995f2beab458fa12eaa141cec731eb28415ef1ad02744886337f764946df224699fe7955576091b6c19c224138"
+  ]
+}


### PR DESCRIPTION
Sampling of parametric and implicit curves

- Project page: <a href="https://github.com/Chris00/ocaml-curve-sampling">https://github.com/Chris00/ocaml-curve-sampling</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-curve-sampling/doc">https://Chris00.github.io/ocaml-curve-sampling/doc</a>

##### CHANGES:

- New function `to_latex_channel`.
- Allow to specify the color when converting to LaTeX.
- Automatically divide the path into several PGF/TikZ paths when it is
  too long for LaTeX capacity.  This is configurable.
- LaTeX output can draw arrows on paths.
- Improve the sampling procedure: better determine the slope at
  endpoints, be less reactive to small zigzags that may be due to
  rough estimates, and use viewport scaling to estimate all costs.
- Use an internal random state and not the global one.
