### PR TITLE
ppxlib.0.{9,10}.0 are incompatible with OCaml 4.10

### DIFF
--- a/packages/ppxlib/ppxlib.0.10.0/opam
+++ b/packages/ppxlib/ppxlib.0.10.0/opam
@@ -14,7 +14,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.06" & ocaml:version < "4.08" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1"}
+  "ocaml"                   {>= "4.04.1" & < "4.10.0"}
   "base"                    {>= "v0.11.0"}
   "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}

--- a/packages/ppxlib/ppxlib.0.9.0/opam
+++ b/packages/ppxlib/ppxlib.0.9.0/opam
@@ -14,7 +14,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.06" & ocaml:version < "4.09" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1"}
+  "ocaml"                   {>= "4.04.1" & < "4.10.0"}
   "base"                    {>= "v0.11.0"}
   "dune"
   "ocaml-compiler-libs"     {>= "v0.11.0"}


### PR DESCRIPTION
(See [this CI log](http://check.ocamllabs.io/log/1574696611-eec32e8750d18eaf1eb0d416d0f03b9e0f1df40f/4.10/partial/async.v0.13.0) for instance.)

(If people want to use OCaml 4.10, https://github.com/ocaml-ppx/ppxlib/pull/109 is expected to provide a fix.)