### PR TITLE
Package opam-publish.2.0.2

### DIFF
--- a/packages/opam-publish/opam-publish.2.0.2/opam
+++ b/packages/opam-publish/opam-publish.2.0.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A tool to ease contributions to opam repositories"
+description: """
+opam-publish automates publishing packages to package repositories: it checks that the
+opam file is complete using `opam lint`, verifies and adds the archive URL and its
+checksum and files a GitHub pull request for merging it."""
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+depends: [
+  "cmdliner"
+  "dune" {>= "1.0"}
+  "lwt_ssl"
+  "ocaml" {>= "4.03.0"}
+  "opam-core" {>= "2.0.0"}
+  "opam-format" {>= "2.0.0"}
+  "opam-state" {>= "2.0.0"}
+  "github" {>= "2.0.0"}
+  "github-unix"
+  ("ssl" {= "0.5.5"} | "tls")
+]
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+url {
+  src: "https://github.com/ocaml/opam-publish/archive/2.0.2.tar.gz"
+  checksum: [
+    "md5=427f0b07fccf62a817557df4a2808f58"
+    "sha512=7e17847725af22e4cdee2c998b798010e0486c27321e4fcf61adf5306536b784e71814f36b39eb9931105939a8e5009494fcd2d4840203344cdfc59d1f294a48"
+  ]
+}


### PR DESCRIPTION
### `opam-publish.2.0.2`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.0.2