### PR TITLE
Normalize opam file for conf-gnome-icon-theme3 (fix #15371)

### DIFF
--- a/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
+++ b/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
@@ -3,7 +3,6 @@ homepage: "https://github.com/GNOME/adwaita-icon-theme"
 bug-reports: "https://gitlab.gnome.org/GNOME/adwaita-icon-theme/issues"
 authors: "GNU Project"
 license: ["LGPL-3.0-only" "CC-BY-SA-3.0"]
-build: []
 depexts: [
   ["gnome-icon-theme"] {os-family = "debian"}
   ["gnome-icon-theme"] {os-family = "fedora" | os-family = "rhel"}


### PR DESCRIPTION
Without this fix, `conf-gnome-icon-theme3` must always be upgraded due to non-existing "upstream changes".

This change appears to avoid the change locally, but I struggle to believe that's a real workaround.

EDIT2: I can also confirm this empty `build` field does not appear in either
`$(opam config var prefix)/.opam-switch/packages/conf-gnome-icon-theme3.0/opam`, or in any other package in this repository.