### PR TITLE
Package yara.0.2

### DIFF
--- a/packages/yara/yara.0.2/opam
+++ b/packages/yara/yara.0.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Anton Kochkov <anton.kochkov@gmail.com>"
+homepage: "https://github.com/XVilka/yara-ocaml"
+bug-reports: "https://github.com/XVilka/yara-ocaml/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/XVilka/yara-ocaml.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune"
+  "ocaml-migrate-parsetree" {build}
+  "ppx_deriving" {>= "4.2.0"}
+  "core" {>= "v0.9.0" & < "v0.14"}
+  "ctypes" {>= "0.13.0"}
+  "ctypes-foreign"
+]
+depexts: [
+  ["libyara-dev"] {os-family = "debian"}
+  ["libyara-devel"] {os-distribution = "opensuse"}
+  ["epel-release" "yara-devel"] {os-distribution = "centos"}
+  ["yara-devel"] {os-distribution = "fedora"}
+  ["yara"] {os-distribution = "alpine"}
+  ["yara"] {os-distribution = "arch"}
+  ["yara"] {os-distribution = "gentoo"}
+  ["yara"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "OCaml bindings for YARA matching engine"
+description: """
+Provides a Ctypes bindings for
+YARA matching engine"""
+authors: "Anton Kochkov <anton.kochkov@gmail.com>"
+url {
+  src: "https://github.com/XVilka/yara-ocaml/archive/0.2.tar.gz"
+  checksum: [
+    "md5=d8e53111813bd2f969f05c8bbcb77920"
+    "sha512=f8421994d0d927cd05375184bc78ff0f5afb71672954eaba71c11295f73471ddc45c10d86490e43ebdc2b5ef8d5e41e6735837a50511fa8c1a5dd39be432be99"
+  ]
+}


### PR DESCRIPTION
### `yara.0.2`
OCaml bindings for YARA matching engine
Provides a Ctypes bindings for
YARA matching engine

Switched to Dune

---
* Homepage: https://github.com/XVilka/yara-ocaml
* Source repo: git+https://github.com/XVilka/yara-ocaml.git
* Bug tracker: https://github.com/XVilka/yara-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2