### PR TITLE
2 packages from darioteixeira/pgocaml at 4.2

### DIFF
--- a/packages/pgocaml/pgocaml.4.2/opam
+++ b/packages/pgocaml/pgocaml.4.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Native OCaml interface to PostgreSQL databases"
+description: """
+PGOCaml provides an interface to PostgreSQL databases for OCaml applications.
+Note that it speaks the PostgreSQL wire protocol directly, and therefore does
+not need to create bindings to the PostgreSQL libpq C library.
+The PPX syntax extension is now packaged separately as 'pgocaml_ppx'.
+You will want to take a look at it if you're considering using PGOCaml.
+"""
+maintainer: "dario.teixeira@nleyten.com"
+authors: ["Richard W.M. Jones <rich@annexia.org>"]
+homepage: "https://github.com/darioteixeira/pgocaml"
+bug-reports: "https://github.com/darioteixeira/pgocaml/issues"
+dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
+license: "LGPL-2.0 with OCaml linking exception"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "calendar"
+  "csv"
+  "dune" {>= "1.10"}
+  "hex"
+  "ocaml" {>= "4.07"}
+  "ppx_sexp_conv"
+  "re"
+  "ppx_deriving" {>= "4.0"}
+  "rresult"
+  "sexplib"
+]
+url {
+  src: "https://github.com/darioteixeira/pgocaml/archive/4.0.tar.gz"
+  checksum: [
+    "md5=592f4981041fcb7bbe76ccb9977d9e32"
+    "sha512=fe6d1e24ad471c4e4a0abe5f7718881c8bc4de4c7c2e76285ca4c77997a2e5cfd625fa159f35b5892dd88e5a4b5444b7aa98fd7683e0fd94aa1636be4b657b69"
+  ]
+}

--- a/packages/pgocaml_ppx/pgocaml_ppx.4.2/opam
+++ b/packages/pgocaml_ppx/pgocaml_ppx.4.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "PPX extension for PGOCaml"
+description: """
+PGOCaml provides an interface to PostgreSQL databases for OCaml applications.
+This PPX syntax extension enables one to directly embed SQL statements inside
+the OCaml code. The extension uses the 'describe' feature of PostgreSQL to
+obtain type information about the database. This allows PGOCaml to check at
+compile-time if the program is indeed consistent with the database structure.
+"""
+maintainer: "dario.teixeira@nleyten.com"
+authors: ["Richard W.M. Jones <rich@annexia.org>"]
+homepage: "https://github.com/darioteixeira/pgocaml"
+bug-reports: "https://github.com/darioteixeira/pgocaml/issues"
+dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
+license: "LGPL-2.0 with OCaml linking exception"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {>= "1.10"}
+  "ocaml" {>= "4.07"}
+  "ocaml-migrate-parsetree"
+  "pgocaml" {= version}
+  "ppx_optcomp"
+  "ppx_sexp_conv"
+  "ppx_tools"
+  "ppx_tools_versioned"
+  "ppx_deriving" {>= "4.0"}
+  "rresult"
+  "sexplib"
+]
+url {
+  src: "https://github.com/darioteixeira/pgocaml/archive/4.0.tar.gz"
+  checksum: [
+    "md5=592f4981041fcb7bbe76ccb9977d9e32"
+    "sha512=fe6d1e24ad471c4e4a0abe5f7718881c8bc4de4c7c2e76285ca4c77997a2e5cfd625fa159f35b5892dd88e5a4b5444b7aa98fd7683e0fd94aa1636be4b657b69"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`pgocaml.4.2`: Native OCaml interface to PostgreSQL databases
-`pgocaml_ppx.4.2`: PPX extension for PGOCaml



---
* Homepage: https://github.com/darioteixeira/pgocaml
* Source repo: git+https://github.com/darioteixeira/pgocaml.git
* Bug tracker: https://github.com/darioteixeira/pgocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2