### PR TITLE
Install Stog binaries

### DIFF
--- a/packages/stog/stog.0.18.0-1/opam
+++ b/packages/stog/stog.0.18.0-1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "zoggy@bat8.org"
+authors: "Maxence Guesdon"
+homepage: "https://www.good-eris.net/stog/"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+license: "GPL-3.0-only"
+doc: "https://www.good-eris.net/stog/doc.html"
+tags: ["publication" "xml" "documentation" "blog" "web" "website"]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install-lib" "install-share" "install-bin"]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind"
+  "xtmpl" {>= "0.17.0"}
+  "ocf" {>= "0.5.0"}
+  "higlo" {>= "0.6"}
+  "ppx_blob" {>= "0.1"}
+  "ptime" {>= "0.8.2"}
+  "uri" {>= "1.9.2"}
+  "omd" {>= "1.3.0"}
+  "lwt" {>= "2.5"}
+  "uutf" {>= "1.0.0"}
+]
+depopts: ["js_of_ocaml" "xmldiff" "websocket" "ojs-base" "cryptokit"]
+conflicts: [
+  "js_of_ocaml" {>= "3.4.0"} ]
+synopsis:
+  "A static web site compiler, handling blog posts, or XML document in general."
+description: """
+Main features:
+- generate static XML/HTML documents: easy to deploy, less security problems,
+- handling of blog posts, with dates, topics, keywords and associated RSS feeds,
+- no new syntax,
+- based on a XML rewrite engine allowing to apply substitutions (rewrite rules)
+  on some tags. Some substitutions are pre-defined, and others can be defined
+  in your documents or added by plugins. Content can then be written with
+  semantic tags,
+- support multi-language sites,
+- a lot of predefined functions can be used to handle sectionning, table of
+  contents, verified cross-references, ...,
+- OCaml code can be interpreted at compilation time and the result included in
+  the generated documents, which is nice to write tutorials on OCaml libraries,
+- some plugins ease the inclusion of graphviz graphs, and pictures generated
+  by Aysmptote or LaTeX,
+- ..."""
+flags: light-uninstall
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.18.0/stog-0.18.0.tar.gz"
+  checksum: "md5=014dcec7fabf0beb546ff490ed54b909"
+}

--- a/packages/stog/stog.0.18.0-1/opam
+++ b/packages/stog/stog.0.18.0-1/opam
@@ -47,7 +47,6 @@ Main features:
 - some plugins ease the inclusion of graphviz graphs, and pictures generated
   by Aysmptote or LaTeX,
 - ..."""
-flags: light-uninstall
 url {
   src: "https://framagit.org/zoggy/stog/-/archive/0.18.0/stog-0.18.0.tar.gz"
   checksum: "md5=014dcec7fabf0beb546ff490ed54b909"

--- a/packages/stog/stog.0.18.0/opam
+++ b/packages/stog/stog.0.18.0/opam
@@ -11,7 +11,7 @@ build: [
   ["./configure" "--prefix" prefix]
   [make "all"]
 ]
-install: [make "install-lib" "install-share"]
+install: [make "install-lib" "install-share" "install-bin"]
 remove: ["ocamlfind" "remove" "stog"]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/stog/stog.0.18.0/opam
+++ b/packages/stog/stog.0.18.0/opam
@@ -12,7 +12,6 @@ build: [
   [make "all"]
 ]
 install: [make "install-lib" "install-share" "install-bin"]
-remove: ["ocamlfind" "remove" "stog"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind"

--- a/packages/stog/stog.0.18.0/opam
+++ b/packages/stog/stog.0.18.0/opam
@@ -12,6 +12,7 @@ build: [
   [make "all"]
 ]
 install: [make "install-lib" "install-share" "install-bin"]
+remove: ["ocamlfind" "remove" "stog"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind"

--- a/packages/stog/stog.0.18.0/opam
+++ b/packages/stog/stog.0.18.0/opam
@@ -11,7 +11,7 @@ build: [
   ["./configure" "--prefix" prefix]
   [make "all"]
 ]
-install: [make "install-lib" "install-share" "install-bin"]
+install: [make "install-lib" "install-share"]
 remove: ["ocamlfind" "remove" "stog"]
 depends: [
   "ocaml" {>= "4.03.0"}


### PR DESCRIPTION
There was a complaint on IRC stog was missing its binaries. This is due to for some reason not installing them in the opam file.

This PR just adds the call to do so via the Makefile.