### PR TITLE
[new release] emile (0.6)

### DIFF
--- a/packages/emile/emile.0.6/opam
+++ b/packages/emile/emile.0.6/opam
@@ -13,13 +13,9 @@ description:  """Parser of email address according RFC 822"""
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
 
-pin-depends: [
-  [ "mrmime.dev" "git+https://github.com/mirage/mrmime.git" ]
-]
-
 depends: [
   "ocaml"    {>= "4.03.0"}
-  "dune"     {build}
+  "dune"
   "angstrom" {>= "0.9.0"}
   "ipaddr"   {>= "2.7.0"}
   "base64"   {>= "3.0.0"}

--- a/packages/emile/emile.0.6/opam
+++ b/packages/emile/emile.0.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name:         "emile"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/emile"
+bug-reports:  "https://github.com/dinosaure/emile/issues"
+dev-repo:     "git+https://github.com/dinosaure/emile.git"
+doc:          "https://dinosaure.github.io/emile/"
+license:      "MIT"
+synopsis:     "Parser of email address according RFC 822"
+description:  """Parser of email address according RFC 822"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+
+pin-depends: [
+  [ "mrmime.dev" "git+https://github.com/mirage/mrmime.git" ]
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {build}
+  "angstrom" {>= "0.9.0"}
+  "ipaddr"   {>= "2.7.0"}
+  "base64"   {>= "3.0.0"}
+  "pecu"
+  "uutf"
+  "fmt"
+  "alcotest" {with-test}
+]
+depopts: [
+  "mrmime"
+]
+url {
+  src:
+    "https://github.com/dinosaure/emile/releases/download/v0.6/emile-v0.6.tbz"
+  checksum: [
+    "sha256=da1e2891c1e18937d7f742e49f34780c7c36d99fa313addb1a4a45a783cf6d1a"
+    "sha512=1e259da12932bb220df6d6d8aad3abb54a82bf74210938719f31f515442abad590fd774aa1aa60ee8cbfdc2783e3ec72431d543bef5cb2d5ef292b41de92fa5c"
+  ]
+}


### PR DESCRIPTION
Parser of email address according RFC 822

- Project page: <a href="https://github.com/dinosaure/emile">https://github.com/dinosaure/emile</a>
- Documentation: <a href="https://dinosaure.github.io/emile/">https://dinosaure.github.io/emile/</a>

##### CHANGES:

- Decomplexify parser and avoid FWS token
- Rewrite `compare` and `equal` functions
- Internal clean of parsers
