### PR TITLE
added packages/cpu/cpu.2.0.0

### DIFF
--- a/packages/cpu/cpu.2.0.0/opam
+++ b/packages/cpu/cpu.2.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: "Roberto Di Cosmo <roberto@dicosmo.org>"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/cpu"
+dev-repo: "git+https://github.com/UnixJunkie/cpu.git"
+bug-reports: "https://github.com/UnixJunkie/cpu/issues"
+build: [
+  ["autoconf"]
+  ["autoheader"]
+  ["./configure"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "conf-autoconf" {build}
+  "ocaml"
+  "dune" {>= "1.11.0"}
+]
+synopsis: "Pin current process to given core number"
+description: "
+The module installed is called Cpu; in order to not conflic
+with the Setcore module that is installed by parmap.
+
+This library can also get the number of CPU cores online.
+"
+url {
+ src: "https://github.com/UnixJunkie/cpu/archive/v2.0.0.tar.gz"
+ checksum: "md5=644ca40ddbe7c34f8431ec3868958aec"
+}


### PR DESCRIPTION
The previous setcore package is deprecated because it could not coinstall with parmap.
This new package uses a different module name (Cpu instead of Setcore), so that
it can coexist with parmap.
