### PR TITLE
[new release] rosetta (0.2.0)

### DIFF
--- a/packages/rosetta/rosetta.0.2.0/opam
+++ b/packages/rosetta/rosetta.0.2.0/opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "1.4"}
   "fmt"
   "bos"
   "uutf"

--- a/packages/rosetta/rosetta.0.2.0/opam
+++ b/packages/rosetta/rosetta.0.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name:         "rosetta"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/rosetta"
+bug-reports:  "https://github.com/mirage/rosetta/issues"
+dev-repo:     "git+https://github.com/mirage/rosetta.git"
+doc:          "https://mirage.github.io/rosetta/"
+license:      "MIT"
+synopsis:     "Universal mapper to Unicode"
+description:  "Universal mapper to Unicode (ISO-8859, KOI8, UTF-7)"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "fmt"
+  "bos"
+  "uutf"
+  "cmdliner"
+  "coin" {>= "0.1.1"}
+  "uuuu" {>= "0.1.1"}
+  "yuscii" {>= "0.2.1"}
+]
+url {
+  src:
+    "https://github.com/mirage/rosetta/releases/download/v0.2.0/rosetta-v0.2.0.tbz"
+  checksum: [
+    "sha256=d8a2b6b235b7c15025d3d72a87d05bf691fcf7f3d90a892cce9c5529f760498f"
+    "sha512=9a323cd5b05e9ae7ba1f572936a42948fbc42090e1be6557840652d9deddee4cb979691047f1b6814afc07e81ec74eb9b1fcab098ba6d525ae88530c790b967a"
+  ]
+}


### PR DESCRIPTION
Universal mapper to Unicode

- Project page: <a href="https://github.com/mirage/rosetta">https://github.com/mirage/rosetta</a>
- Documentation: <a href="https://mirage.github.io/rosetta/">https://mirage.github.io/rosetta/</a>

##### CHANGES:

* Move to `dune`
* Avoid clash of name with others binaries `to_utf8.exe`
* Update `README.md`
