### PR TITLE
Lambda Soup 0.6.4 - HTML scraper with CSS syntax

### DIFF
--- a/packages/lambdasoup/lambdasoup.0.6.4/opam
+++ b/packages/lambdasoup/lambdasoup.0.6.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+
+synopsis: "Easy functional HTML scraping and manipulation with CSS selectors"
+
+version: "0.6.4"
+license: "MIT"
+homepage: "https://github.com/aantron/lambdasoup"
+doc: "https://aantron.github.io/lambdasoup"
+bug-reports: "https://github.com/aantron/lambdasoup/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/lambdasoup.git"
+
+depends: [
+  # As a consequence of depending on Dune, Lambda Soup requires OCaml 4.02.3.
+  "dune"
+  "markup" {>= "0.7.1"}
+  "ocaml" {>= "4.02.0"}
+
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "ounit" {dev}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: """
+Lambda Soup is an HTML scraping library inspired by Python's Beautiful Soup. It
+provides lazy traversals from HTML nodes to their parents, children, siblings,
+etc., and to nodes matching CSS selectors. The traversals can be manipulated
+using standard functional combinators such as fold, filter, and map.
+
+The DOM tree is mutable. You can use Lambda Soup for automatic HTML rewriting in
+scripts. Lambda Soup rewrites its own ocamldoc page this way.
+
+A major goal of Lambda Soup is to be easy to use, including in interactive
+sessions, and to have a minimal learning curve. It is a very simple library.
+"""
+
+url {
+  src: "https://github.com/aantron/lambda-soup/archive/0.6.4.tar.gz"
+  checksum: "md5=b697aec8575bcc543558d89317e8e047"
+}


### PR DESCRIPTION
- Convert from Jbuilder to Dune (aantron/lambdasoup@7a69a59).
- Change license to MIT (aantron/lambdasoup@311005f).
- Support CSS escape sequences in selector identifiers (aantron/lambdasoup#27, prompted @sanette and Christophe Troestler).
- Improve `Soup.select` error message (aantron/lambdasoup#22, suggested James Somers).
- Add `Lambdasoup` alias module to match repo and opam package name (aantron/lambdasoup#17, requested Fabian Hemmer).