### PR TITLE
Package eigen.0.1.6

### DIFF
--- a/packages/eigen/eigen.0.1.6/opam
+++ b/packages/eigen/eigen.0.1.6/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Owl's OCaml interface to Eigen3 C++ library"
+description:
+  "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: "Liang Wang"
+license: "MIT"
+homepage: "https://github.com/owlbarn/eigen"
+doc: "https://owlbarn.github.io/eigen/eigen"
+bug-reports: "https://github.com/owlbarn/eigen/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "ctypes" {>= "0.14.0"}
+  "dune" {>= "2.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/owlbarn/eigen.git"
+url {
+  src:
+    "https://github.com/owlbarn/eigen/releases/download/0.1.6/eigen-0.1.6.tar.gz"
+  checksum: [
+    "md5=8cfe39ad1678bc7f961de0ade7dd8749"
+    "sha512=868a91a7f5b1e13a3ee391891db6f0718e5562f65bdb669a2f183e7668db106c9d2bfdc5efbbc80fe5e93faf2d30797535f36d9d8605229648c84bf6c0ea5695"
+  ]
+}


### PR DESCRIPTION
### `eigen.0.1.6`
Owl's OCaml interface to Eigen3 C++ library
Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations.



---
* Homepage: https://github.com/owlbarn/eigen
* Source repo: git+https://github.com/owlbarn/eigen.git
* Bug tracker: https://github.com/owlbarn/eigen/issues

---
:camel: Pull-request generated by opam-publish v2.0.2