### PR TITLE
Add zarith-freestanding.1.7-3 which add zarith-freestanding.cm{,x}a

### DIFF
--- a/packages/zarith-freestanding/zarith-freestanding.1.7-3/files/fix-cma.patch
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-3/files/fix-cma.patch
@@ -1,0 +1,29 @@
+ocamlmklib put by default -lzarith into zarith.cmxa. By this
+way, any link with this zarith.cmxa, even if we compiled it with
+right flags requested by ocaml-freestanding, will link with
+libzarith.a (compiled by default flags).
+
+In our case, we want to link with -lzarith-freestanding according
+what mirage-install.sh does - the shell script copies libzarith.a
+to libzarith-freestanding.a. So we add a new option -oc to tell
+to ocamlmklib to link with -lzarith-freestanding correctly.
+
+Then, mirage-install.sh copies zarith.cmxa to zarith-freestanding.cmxa
+and add a new META information. zarith-freestanding.cmxa will be
+chosen if we want to link with zarith.freestanding.
+
+--- a/project.mak	2017-10-13 19:45:41.000000000 +0200
++++ b/project.mak	2018-11-30 19:11:16.205189144 +0100
+@@ -60,10 +60,10 @@
+ 	make -C tests test
+ 
+ zarith.cma: $(MLSRC:%.ml=%.cmo)
+-	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ -oc zarith-freestanding $(LIBS)
+ 
+ zarith.cmxa zarith.$(LIBSUFFIX): $(MLSRC:%.ml=%.cmx)
+-	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ -oc zarith-freestanding $(LIBS)
+ 
+ zarith.cmxs: zarith.cmxa libzarith.$(LIBSUFFIX)
+ 	(OCAMLOPT) -shared -o $@ -I . zarith.cmxa -linkall

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-3/files/mirage-build.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-3/files/mirage-build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+# WARNING: if you pass invalid cflags here, zarith will silently
+# fall back to compiling with the default flags instead!
+CFLAGS="$(pkg-config --cflags gmp-freestanding ocaml-freestanding)" \
+LDFLAGS="$(pkg-config --libs gmp-freestanding)" \
+CC=cc \
+./configure -nodynlink -gmp
+
+if [ `uname -s` = "FreeBSD" ] || [ `uname -s` = "OpenBSD" ]; then
+    gmake
+else
+    make
+fi

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-3/files/mirage-install.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-3/files/mirage-install.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+cp libzarith.a "$PREFIX/lib/zarith/libzarith-freestanding.a"
+cp zarith.cma  "$PREFIX/lib/zarith/zarith-freestanding.cma"
+cp zarith.cmxa "$PREFIX/lib/zarith/zarith-freestanding.cmxa"
+
+cat >>"$PREFIX/lib/zarith/META" <<EOM
+freestanding_linkopts = "-lzarith-freestanding -L@gmp-freestanding -lgmp-freestanding"
+
+package "freestanding" (
+  requires = "ocaml-freestanding gmp-freestanding"
+  archive(byte) = "zarith-freestanding.cma"
+  archive(native) = "zarith-freestanding.cmxa"
+)
+EOM

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-3/files/mirage-uninstall.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-3/files/mirage-uninstall.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+
+rm -f "$PREFIX/lib/zarith/libzarith-freestanding.a"
+
+mv "$PREFIX/lib/zarith/META" "$PREFIX/lib/zarith/META.tmp"
+cat "$PREFIX/lib/zarith/META.tmp" | grep -v freestanding_linkopts > "$PREFIX/lib/zarith/META"
+rm -f "$PREFIX/lib/zarith/META.tmp"

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-3/files/no-dynlink.patch
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-3/files/no-dynlink.patch
@@ -1,0 +1,85 @@
+This patch is required to build Zarith on an ocaml-freestanding type setup. It
+does three things:
+
+1. Add an option to configure to forcibly disable dynlink.
+2. Stop configure from adding a host -lgmp.
+3. In addition to (1), force project.mak to use "ocamlmklib -custom" instead of
+   "ocamlmklib -failsafe".
+
+We need all three because the Zarith build system is TOTALLY INSANE and has
+never even remotely heard of such a thing as cross compiling, and we need it to
+just shut up and build ONLY with the flags we pass it. KTHXBYE
+
+--- a/configure	2017-10-13 19:45:41.000000000 +0200
++++ b/configure	2018-11-30 19:12:36.809951317 +0100
+@@ -21,6 +21,7 @@
+ host='auto'
+ gmp='auto'
+ perf='no'
++nodynlink='no'
+ 
+ ar='ar'
+ ocaml='ocaml'
+@@ -59,6 +60,7 @@
+   -gmp                 use GMP library (default if found)
+   -mpir                use MPIR library instead of GMP
+   -perf                enable performance statistics
++  -nodynlink           disable dynamic linking
+ 
+ Environment variables that affect configuration:
+   CC                   C compiler to use (default: try gcc, then cc)
+@@ -99,6 +101,8 @@
+             gmp='mpir';;
+         -perf|--perf)
+             perf='yes';;
++        -nodynlink|--nodynlink)
++            nodynlink='yes';;
+         *)
+             echo "unknown option $1, try -help"
+             exit 2;;
+@@ -248,7 +252,7 @@
+ 
+ hasdynlink='no'
+ 
+-if test $hasocamlopt = yes
++if test $hasocamlopt = yes -a $nodynlink = no
+ then
+     checkcmxalib dynlink.cmxa
+     if test $? -eq 1; then hasdynlink='yes'; fi
+@@ -340,12 +344,8 @@
+ if test "$gmp" = 'gmp' -o "$gmp" = 'auto'; then
+     checkinc gmp.h
+     if test $? -eq 1; then
+-        checklib gmp
+-        if test $? -eq 1; then 
+-            gmp='OK'
+-            cclib="$cclib -lgmp"
+-            ccdef="-DHAS_GMP $ccdef"
+-        fi
++        gmp='OK'
++        ccdef="-DHAS_GMP $ccdef"
+     fi
+ fi
+ if test "$gmp" = 'mpir' -o "$gmp" = 'auto'; then
+--- a/project.mak	2017-10-13 19:45:41.000000000 +0200
++++ b/project.mak	2018-11-30 19:11:16.205189144 +0100
+@@ -60,16 +60,16 @@
+ 	make -C tests test
+ 
+ zarith.cma: $(MLSRC:%.ml=%.cmo)
+-	$(OCAMLMKLIB) -failsafe -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
+ 
+ zarith.cmxa zarith.$(LIBSUFFIX): $(MLSRC:%.ml=%.cmx)
+-	$(OCAMLMKLIB) -failsafe -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
+ 
+ zarith.cmxs: zarith.cmxa libzarith.$(LIBSUFFIX)
+ 	$(OCAMLOPT) -shared -o $@ -I . zarith.cmxa -linkall
+ 
+ libzarith.$(LIBSUFFIX) dllzarith.$(DLLSUFFIX): $(SSRC:%.S=%.$(OBJSUFFIX)) $(CSRC:%.c=%.$(OBJSUFFIX)) 
+-	$(OCAMLMKLIB) -failsafe -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
+ 
+ doc: $(MLISRC)
+ 	mkdir -p html

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-3/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+authors: "Xavier Leroy"
+maintainer: "mirageos-devel"
+homepage: "https://forge.ocamlcore.org/projects/zarith"
+bug-reports:  "mirageos-devel@lists.xenproject.org"
+build: ["sh" "-eux" "./mirage-build.sh"]
+install: ["sh" "-eux" "./mirage-install.sh"]
+remove: ["sh" "-eux" "./mirage-uninstall.sh"]
+depends: [
+  "ocaml"
+  "ocaml-freestanding" {>= "0.4.1"}
+  "gmp-freestanding" {>= "6.1.2-2"}
+  "zarith" {= "1.7"}
+  "ocamlfind" {build}
+]
+patches: [ "no-dynlink.patch" "fix-cma.patch" ]
+synopsis:
+  "Implements arithmetic and logical operations over arbitrary-precision integers"
+description: """
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy."""
+extra-files: [
+  ["mirage-uninstall.sh" "md5=de37d98a1987c89bc53a7a032b7278df"]
+  ["mirage-install.sh" "md5=9639b7ea9b12e77f7e0d7a9f9c4415bb"]
+  ["mirage-build.sh" "md5=d8585e00ab3353746f2fc4c15abe7cfa"]
+  ["no-dynlink.patch" "md5=eff128f04dd08b0e5a02e49c99dc518b"]
+  ["fix-cma.patch" "md5=d6c7b5b54502619b0542c08b2781971e"]
+]
+url {
+  src: "https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz"
+  checksum: "md5=80944e2755ebb848451a77dc2ad0651b"
+}


### PR DESCRIPTION
This new version of `zarith-freestanding` adds a patch which provides:
- `zarith-freestanding.cmxa`
- `zarith-freestanding.cma`

From a new `mirage-install.sh` script and a new patch `fix-cma.patch`. The goal is to provide a new sub-library (according `ocamlfind`/`dune`) `zarith.freestanding` which points to `zarith-freestanding.cm{,x}a` with expected flags (in our case, `-lzarith-freestanding`).

This new version should not break anything when the `linkopts_freestanding` still is here - so, MirageOS pre-dune should continue to work.