### PR TITLE
Package archetype.0.1.11

### DIFF
--- a/packages/archetype/archetype.0.1.11/opam
+++ b/packages/archetype/archetype.0.1.11/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["The Archetype development team <archetype-dev@edukera.com>"]
+authors: [
+  "Benoit Rognier <benoit.rognier@edukera.com>"
+  "Guillaume Duhamel <guillaume.duhamel@edukera.com>"
+  "Pierre-Yves Strub <pierre-yves.strub@polytechnique.edu>"
+]
+bug-reports: "https://github.com/edukera/archetype-lang/issues"
+homepage: "https://github.com/edukera/archetype-lang"
+doc: "https://docs.archetype-lang.org/"
+license: "MIT"
+dev-repo: "git+https://github.com/edukera/archetype-lang.git"
+synopsis: "Archetype language compiler"
+description: """
+Archetype is a domain-specific language (DSL) to develop smart contracts
+on the Tezos blockchain, with a specific focus on contract security
+"""
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.10.0"}
+  "menhir"
+  "digestif"
+  "num"
+  "yojson"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "visitors"
+]
+conflicts: [
+  "digestif" {= "0.7.4"}
+]
+url {
+  src: "https://github.com/edukera/archetype-lang/archive/0.1.11.tar.gz"
+  checksum: [
+    "md5=1f9f40a1731711ca8ab93c3c41e2bc7d"
+    "sha512=6555e1e54f19665ba2ffdde7d714ce967c95acd4ad590d61fb7d18131b0e5fc7e7522d0799f62e8cffa21ddc62e9afa04f1d1841c0f73574944954d57b9736c9"
+  ]
+}


### PR DESCRIPTION
### `archetype.0.1.11`
Archetype language compiler
Archetype is a domain-specific language (DSL) to develop smart contracts
on the Tezos blockchain, with a specific focus on contract security



---
* Homepage: https://github.com/edukera/archetype-lang
* Source repo: git+https://github.com/edukera/archetype-lang.git
* Bug tracker: https://github.com/edukera/archetype-lang/issues

---
:camel: Pull-request generated by opam-publish v2.0.0