### PR TITLE
Package radare2.0.0.3

### DIFF
--- a/packages/radare2/radare2.0.0.3/opam
+++ b/packages/radare2/radare2.0.0.3/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: [ "Edgar Aroutiounian <edgar.factorial@gmail.com>" ]
+license: "BSD-3-Clause"
+homepage: "https://github.com/fxfactorial/ocaml-radare2"
+dev-repo: "git+https://github.com/fxfactorial/ocaml-radare2.git"
+bug-reports: "https://github.com/fxfactorial/ocaml-radare2/issues"
+build: [
+	["dune" "subst"] {pinned}
+	["dune" "build" "-p" name "-j" jobs]
+]
+depexts: [
+  ["radare2"] {os-family = "debian"}
+  ["radare2"] {os-distribution = "fedora"}
+  ["radare2"] {os-distribution = "arch"}
+  ["radare2"] {os-distribution = "gentoo"}
+  ["radare2"] {os-distribution = "homebrew" & os = "macos"}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.2"}
+  "base-unix"
+  "yojson" {>= "1.3.2"} | "yojson-android" {>= "1.3.2"}
+]
+messages:[
+"You need to have r2 (radare2) installed and in your path"
+"Use `opam depext radare2` to get it installed with your system package manager"
+]
+
+post-messages:[
+"Play with radare2 interactively from within an OCaml repl like utop"
+"Example in utop:"
+""
+"#require \"radare2\";;"
+"let result = R2.with_command_j ~cmd:\"/j chown\" \"/bin/ls\";;
+val result : Yojson.Basic.json =
+`List
+  [`Assoc
+       [(\"offset\", `Int 4294987375); (\"id:\", `Int 0);
+        (\"data\", `String \"ywritesecuritychownfile_inheritdi\")]]"
+{success}]
+synopsis: "OCaml interface to r2"
+description: """
+Interact with radare2,
+See the mli for documentation, example usage in utop:
+
+#require "radare2";;
+let result = R2.with_command_j ~cmd:"/j chown" "/bin/ls";;
+val result : Yojson.Basic.json =
+`List
+  [`Assoc
+    [("offset", `Int 4294987375); ("id:", `Int 0);
+     ("data", `String "ywritesecuritychownfile_inheritdi")]]\""""
+url {
+  src: "https://github.com/fxfactorial/ocaml-radare2/archive/v0.0.3.tar.gz"
+  checksum: [
+    "md5=6ecfc6fe053f21e526ad2ecf185cffce"
+    "sha512=353979cdac9322817dc55991a4d5d07c655219a02c2b2127581ec3dfddf760e24da7b99a2e8af06235676c05ba21daa6033543de2a1b8b7893a7d8b8b1f80ad3"
+  ]
+}


### PR DESCRIPTION
### `radare2.0.0.3`
OCaml interface to r2
Interact with radare2,
See the mli for documentation, example usage in utop:

#require "radare2";;
let result = R2.with_command_j ~cmd:"/j chown" "/bin/ls";;
val result : Yojson.Basic.json =
`List
  [`Assoc
    [("offset", `Int 4294987375); ("id:", `Int 0);
     ("data", `String "ywritesecuritychownfile_inheritdi")]]"



---
* Homepage: https://github.com/fxfactorial/ocaml-radare2
* Source repo: git+https://github.com/fxfactorial/ocaml-radare2.git
* Bug tracker: https://github.com/fxfactorial/ocaml-radare2/issues

---
:camel: Pull-request generated by opam-publish v2.0.2