### PR TITLE
[new release] minicaml (0.2.2)

### DIFF
--- a/packages/minicaml/minicaml.0.2.2/opam
+++ b/packages/minicaml/minicaml.0.2.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+version: "0.2.2"
+maintainer: "sudo-woodo3@protonmail.com"
+authors: ["Alessandro Cheli"]
+homepage: "https://github.com/0x0f0f0f/minicaml"
+bug-reports: "https://github.com/0x0f0f0f/minicaml/issues"
+dev-repo: "git+https://github.com/0x0f0f0f/minicaml.git"
+license: "MIT"
+synopsis: "A simple, didactical, purely functional programming language"
+description: "A simple, didactical, purely functional programming language written for the programming 2 course at the University of Pisa, extended with a simple parser made with Menhir and ocamllex"
+doc: "https://github.com/0x0f0f0f/minicaml"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+    "dune" {>= "2.0"}
+    "ocaml"
+    "ANSITerminal"
+    "menhir"
+    "ppx_deriving"
+    "cmdliner"
+]
+url {
+  src:
+    "https://github.com/0x0f0f0f/minicaml/releases/download/0.2.2/minicaml-0.2.2.tbz"
+  checksum: [
+    "sha256=1e15b97c814611675c66638f4d13ef92da42b83a986dbcd97f4ac325ac42169c"
+    "sha512=52e09178a6b92550a70caa9e0c292c40df02823223368911dc0fc748671dbe0a4164a597861046edd82ff9a71e45047de7619cabffb7210f79f6e90800b49cb1"
+  ]
+}


### PR DESCRIPTION
A simple, didactical, purely functional programming language

- Project page: <a href="https://github.com/0x0f0f0f/minicaml">https://github.com/0x0f0f0f/minicaml</a>
- Documentation: <a href="https://github.com/0x0f0f0f/minicaml">https://github.com/0x0f0f0f/minicaml</a>

##### CHANGES:

### Added
- `let lazy rec` (or `let rec lazy`) to define recursive lazy functions
- Command line option parser and man page
- Command line option `-v` (`--verbose`) to tell the REPL to show the AST and
  reduction steps.
- Evaluation step printing is now done in correct order and nesting. 
### Bugfixes
- Fixed boolean primitives.
### Removed
- `lazyfun` and `lazylambda` statements.
