### PR TITLE
[new release] js_of_ocaml, js_of_ocaml-ocamlbuild, js_of_ocaml-ppx_deriving_json, js_of_ocaml-tyxml, js_of_ocaml-ppx, js_of_ocaml-lwt, js_of_ocaml-compiler and js_of_ocaml-toplevel (3.5.2)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.2/opam
@@ -16,7 +16,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.11.1"}
-  "ppx_expect" {with-test & >= "0.12.0"}
+  "ppx_expect" {with-test & >= "v0.12.0"}
   "cmdliner"
   "ocaml-migrate-parsetree"
   "yojson" # It's optional, but we want users to be able to use source-map without pain.

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.11.1"}
+  "ppx_expect" {with-test & >= "0.12.0"}
+  "cmdliner"
+  "ocaml-migrate-parsetree"
+  "yojson" # It's optional, but we want users to be able to use source-map without pain.
+]
+
+depopts: [ "ocamlfind" ]
+
+conflicts: [
+  "ocamlfind"   {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.2/js_of_ocaml-3.5.2.tbz"
+  checksum: [
+    "sha256=8275a923385e87a33183d35fe5a8d9c1f88780b05069fa39046bb65ecd9cecb7"
+    "sha512=5e31ff9d74841241b090d7f385953a46480987bbdd2fe59934c517b3e4ba345a5a6cd590a8305ebdb4040d737f751b3e926664bfea8069a5c92a45f8c1fe8201"
+  ]
+}

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.2/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.11.1"}
   "lwt" {>= "2.4.4"}
   "js_of_ocaml" {>= "3.2"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" "lwt_log" ]
 url {

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.2/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.11.1"}
+  "lwt" {>= "2.4.4"}
+  "js_of_ocaml" {>= "3.2"}
+  "js_of_ocaml-ppx"
+]
+depopts: [ "graphics" "lwt_log" ]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.2/js_of_ocaml-3.5.2.tbz"
+  checksum: [
+    "sha256=8275a923385e87a33183d35fe5a8d9c1f88780b05069fa39046bb65ecd9cecb7"
+    "sha512=5e31ff9d74841241b090d7f385953a46480987bbdd2fe59934c517b3e4ba345a5a6cd590a8305ebdb4040d737f751b3e926664bfea8069a5c92a45f8c1fe8201"
+  ]
+}

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.2/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.11.1"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2"}
+  "js_of_ocaml" {= version}
   "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" "lwt_log" ]

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.2/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.5.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "dune" {>= "1.11.1"}
+  "ocamlbuild"
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.2/js_of_ocaml-3.5.2.tbz"
+  checksum: [
+    "sha256=8275a923385e87a33183d35fe5a8d9c1f88780b05069fa39046bb65ecd9cecb7"
+    "sha512=5e31ff9d74841241b090d7f385953a46480987bbdd2fe59934c517b3e4ba345a5a6cd590a8305ebdb4040d737f751b3e926664bfea8069a5c92a45f8c1fe8201"
+  ]
+}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.2/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.11.1"}
   "ocaml-migrate-parsetree" {>= "1.4"}
   "ppx_tools_versioned" {>= "5.2.3"}
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {= version}
 ]
 url {
   src:

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.2/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.11.1"}
+  "ocaml-migrate-parsetree" {>= "1.4"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "js_of_ocaml" {>= "3.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.2/js_of_ocaml-3.5.2.tbz"
+  checksum: [
+    "sha256=8275a923385e87a33183d35fe5a8d9c1f88780b05069fa39046bb65ecd9cecb7"
+    "sha512=5e31ff9d74841241b090d7f385953a46480987bbdd2fe59934c517b3e4ba345a5a6cd590a8305ebdb4040d737f751b3e926664bfea8069a5c92a45f8c1fe8201"
+  ]
+}

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.2/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.11.1"}
+  "js_of_ocaml"
+  "ocaml-migrate-parsetree"
+  "ppxlib" {>= "0.9.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.2/js_of_ocaml-3.5.2.tbz"
+  checksum: [
+    "sha256=8275a923385e87a33183d35fe5a8d9c1f88780b05069fa39046bb65ecd9cecb7"
+    "sha512=5e31ff9d74841241b090d7f385953a46480987bbdd2fe59934c517b3e4ba345a5a6cd590a8305ebdb4040d737f751b3e926664bfea8069a5c92a45f8c1fe8201"
+  ]
+}

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.2/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.2/opam
@@ -16,7 +16,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.11.1"}
-  "js_of_ocaml"
+  "js_of_ocaml" {= version}
   "ocaml-migrate-parsetree"
   "ppxlib" {>= "0.9.0"}
 ]

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.2/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.2/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind" {>= "1.5.1"}
   "js_of_ocaml-compiler"
   "js_of_ocaml-ppx"
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {= version}
 ]
 url {
   src:

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.2/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.11.1"}
+  "ocamlfind" {>= "1.5.1"}
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml" {>= "3.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.2/js_of_ocaml-3.5.2.tbz"
+  checksum: [
+    "sha256=8275a923385e87a33183d35fe5a8d9c1f88780b05069fa39046bb65ecd9cecb7"
+    "sha512=5e31ff9d74841241b090d7f385953a46480987bbdd2fe59934c517b3e4ba345a5a6cd590a8305ebdb4040d737f751b3e926664bfea8069a5c92a45f8c1fe8201"
+  ]
+}

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.2/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.11.1"}
   "ocamlfind" {>= "1.5.1"}
-  "js_of_ocaml-compiler"
+  "js_of_ocaml-compiler" {= version}
   "js_of_ocaml-ppx"
   "js_of_ocaml" {= version}
 ]

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.2/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.11.1"}
   "ocamlfind" {>= "1.5.1"}
   "js_of_ocaml-compiler" {= version}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml-ppx" {= version}
   "js_of_ocaml" {= version}
 ]
 url {

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.2/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.11.1"}
+  "tyxml" {>= "4.3"}
+  "reactiveData" {>= "0.2"}
+  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml-ppx"
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.2/js_of_ocaml-3.5.2.tbz"
+  checksum: [
+    "sha256=8275a923385e87a33183d35fe5a8d9c1f88780b05069fa39046bb65ecd9cecb7"
+    "sha512=5e31ff9d74841241b090d7f385953a46480987bbdd2fe59934c517b3e4ba345a5a6cd590a8305ebdb4040d737f751b3e926664bfea8069a5c92a45f8c1fe8201"
+  ]
+}

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.2/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.2/opam
@@ -19,7 +19,7 @@ depends: [
   "tyxml" {>= "4.3"}
   "reactiveData" {>= "0.2"}
   "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml-ppx" {= version}
 ]
 url {
   src:

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.2/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.11.1"}
   "tyxml" {>= "4.3"}
   "reactiveData" {>= "0.2"}
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {= version}
   "js_of_ocaml-ppx" {= version}
 ]
 url {

--- a/packages/js_of_ocaml/js_of_ocaml.3.5.2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.5.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+name: "js_of_ocaml"
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.11.1"}
+  "ocaml-migrate-parsetree" {>= "1.4"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "uchar"
+  "js_of_ocaml-compiler"
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.5.2/js_of_ocaml-3.5.2.tbz"
+  checksum: [
+    "sha256=8275a923385e87a33183d35fe5a8d9c1f88780b05069fa39046bb65ecd9cecb7"
+    "sha512=5e31ff9d74841241b090d7f385953a46480987bbdd2fe59934c517b3e4ba345a5a6cd590a8305ebdb4040d737f751b3e926664bfea8069a5c92a45f8c1fe8201"
+  ]
+}

--- a/packages/js_of_ocaml/js_of_ocaml.3.5.2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.5.2/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-migrate-parsetree" {>= "1.4"}
   "ppx_tools_versioned" {>= "5.2.3"}
   "uchar"
-  "js_of_ocaml-compiler"
+  "js_of_ocaml-compiler" {= version}
 ]
 url {
   src:


### PR DESCRIPTION
Compiler from OCaml bytecode to Javascript

- Project page: <a href="http://ocsigen.github.io/js_of_ocaml">http://ocsigen.github.io/js_of_ocaml</a>

##### CHANGES:

## Features/Changes
* Misc: support for ocaml 4.10
* Misc: ppx_deriving_json uses ppxlib >= 0.9

## Bug fixes
* Runtime: fix pseudo fs initialization (ocsigen/js_of_ocaml#931)
