### PR TITLE
Package eigen.0.2.0

### DIFF
--- a/packages/eigen/eigen.0.2.0/opam
+++ b/packages/eigen/eigen.0.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Owl's OCaml interface to Eigen3 C++ library"
+description:
+  "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: "Liang Wang"
+license: "MIT"
+homepage: "https://github.com/owlbarn/eigen"
+doc: "https://owlbarn.github.io/eigen/eigen"
+bug-reports: "https://github.com/owlbarn/eigen/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "ctypes" {>= "0.14.0"}
+  "dune" {>= "2.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/owlbarn/eigen.git"
+url {
+  src:
+    "https://github.com/owlbarn/eigen/releases/download/0.2.0/eigen-0.2.0.tar.gz"
+  checksum: [
+    "md5=69797ca3df6aca83843db88d6c2eabab"
+    "sha512=635cd2fa95dfef2adfb8ac3fa5ed0d47215e7b8299aa789844e8f3c83907b943767b984f49fc11d4e67ae29593fe543627645e1dffa800ff81d49026111e1952"
+  ]
+}


### PR DESCRIPTION
### `eigen.0.2.0`
Owl's OCaml interface to Eigen3 C++ library
Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations.



---
* Homepage: https://github.com/owlbarn/eigen
* Source repo: git+https://github.com/owlbarn/eigen.git
* Bug tracker: https://github.com/owlbarn/eigen/issues

---
:camel: Pull-request generated by opam-publish v2.0.2