### PR TITLE
[new release] crunch (3.2.0)

### DIFF
--- a/packages/crunch/crunch.3.2.0/opam
+++ b/packages/crunch/crunch.3.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "MirageOS team"
+authors:      ["Anil Madhavapeddy" "Thomas Gazagnaire" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/ocaml-crunch"
+bug-reports:  "https://github.com/mirage/ocaml-crunch/issues"
+doc:          "https://mirage.github.io/ocaml-crunch/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/ocaml-crunch.git"
+tags:         ["org:mirage" "org:xapi-project"]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "cmdliner"
+  "ptime"
+  "dune" {>= "1.0"}
+  "lwt" {with-test}
+  "mirage-kv" {with-test & >= "3.0.0"}
+  "mirage-kv-mem" {with-test & >= "3.0.0"}
+]
+conflicts: [
+  "mirage-kv" {< "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Convert a filesystem into a static OCaml module"
+description: """
+`ocaml-crunch` takes a directory of files and compiles them into a standalone
+OCaml module which serves the contents directly from memory.  This can be
+convenient for libraries that need a few embedded files (such as a web server)
+and do not want to deal with all the trouble of file configuration.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-crunch/releases/download/v3.2.0/crunch-v3.2.0.tbz"
+  checksum: [
+    "sha256=0a1a4ebb86ab643dd193b5c0046e4d168c6e1cb41e6e5e5b6fbd3b7492e8c6de"
+    "sha512=8666e4081c96b7e0820c621197cb02de2238ddc911e4e95f439c69a685a5791dd4f874ba1084f56c9b44d3d579b877b1ed1f7b0421cd56d3f36ad39c669ee4eb"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Make crunch reproducible: use a Map.Make(String) instead of Hashtbl.
  Iterating over the former is guaranteed to be sorted over the keys.
  (mirage/ocaml-crunch#51 @hannesm)
* The state (Map.t) is passed explicit to `scan_file`, `output_implementation`
  and `walk_directory_tree`. The value `empty` is provided to construct an
  empty `t`. (mirage/ocaml-crunch#51 @hannesm)