### PR TITLE
Lwt 4.5.0 - promises and concurrent I/O

### DIFF
--- a/packages/lwt/lwt.4.5.0/opam
+++ b/packages/lwt/lwt.4.5.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+
+version: "4.5.0"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.7.0"}
+  "dune-configurator"
+  "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0"}
+  "ocplib-endian"
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  "bisect_ppx" {dev & >= "1.3.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+post-messages: [
+  "Lwt 5.0.0 will make some breaking changes in December 2019. See
+  https://github.com/ocsigen/lwt/issues/584"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.5.0.tar.gz"
+  checksum: "md5=1b2fa7df39a70be1925acdabb8b3f8aa"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/ocsigen/lwt/releases/tag/4.5.0):

> Additions
>
> - Implement [`Lwt_unix.readv`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALreadv) and [`Lwt_unix.writev`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALwritev) on Windows using [`Lwt_unix.read`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALread) and [`Lwt_unix.write`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALwrite) (ocsigen/lwt#745, requested Ulrik Strid).
> - Implement [`Lwt_unix.wait4`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALwait4) on Android using [`Unix.waitpid`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Unix.html#VALwaitpid), as on Windows (ocsigen/lwt#752, @EduardoRFS).
> - `LWT_DISCOVER_ARGUMENTS=--verbose` flag, passed through environment variable, for debugging the feature discovery (configuration) process (ocsigen/lwt#740).
>
> Bugs fixed
>
> - To help with `fork`, don't call back into `Lwt_main` at process exit to call Lwt exit hooks when there are none (ocsigen/lwt#737, prompted Martin Jambon).
> - Properly retain references to buffers in [`Lwt_unix.readv`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALreadv), [`Lwt_unix.writev`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALwritev), [`Lwt_bytes.read`](http://ocsigen.org/lwt/dev/api/Lwt_bytes#VALread), [`Lwt_bytes.write`](http://ocsigen.org/lwt/dev/api/Lwt_bytes#VALwrite), and [`Lwt_bytes.mincore`](http://ocsigen.org/lwt/dev/api/Lwt_bytes#VALmincore); the references could be released too early in rare circumstances (ocsigen/lwt#742, prompted Olaf Hering).
> - Don't install a `SIGCHLD` handler when Lwt is linked in but not used (ocsigen/lwt#738, requested Sam Goldman, additional information Waleed Khan).
> - Link with `-lpthread` on more platforms that support and require the flag (ocsigen/lwt#748, Olivier Andrieu).
> - Fix syntax errors in feature test programs (ocsigen/lwt#748, Olivier Andrieu).
> - C warning with OCaml 4.10 (ocsigen/lwt#751, @kit-ty-kate).
>
> Miscellaneous
>
> - Make tests more reliable (ocsigen/lwt#726, ocsigen/lwt#743, prompted Olaf Hering).
> - Fix deprecation annotation on internal API (ocsigen/lwt#735, Antonio Nuno Monteiro).
> - Fix broken link in [`Lwt_mvar`](http://ocsigen.org/lwt/dev/api/Lwt_mvar) > docs (ocsigen/lwt#739, reported @tg-x).
> - Fix broken links in README (ocsigen/lwt#750, @imbsky).