### PR TITLE
Fix checksum for brotli 2.0.0

### DIFF
--- a/packages/brotli/brotli.2.0.0/opam
+++ b/packages/brotli/brotli.2.0.0/opam
@@ -23,6 +23,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "conf-brotli"
+  "base-unsafe-string"
 ]
 post-messages: [
   "Be sure to have libbrotli installed on your machine" {failure}

--- a/packages/brotli/brotli.2.0.0/opam
+++ b/packages/brotli/brotli.2.0.0/opam
@@ -35,5 +35,5 @@ http://www.ietf.org/id/draft-alakuijala-brotli"""
 flags: light-uninstall
 url {
   src: "https://github.com/fxfactorial/ocaml-brotli/archive/v2.0.0.tar.gz"
-  checksum: "md5=cbb3f3a3c0e70c818233f014a7902ce9"
+  checksum: "md5=1c04be7faf48eb4b1af25d22f81257e9"
 }


### PR DESCRIPTION
GitHub repacked the archive when the repo name changed. This produced [this failure](https://ci.ocaml.org/log/saved/docker-run-a979e4614266a16b022d7328836e1f0e/fb4879f5f81518e0383a9ca4eb0d6ad1a0d191a6).