### PR TITLE
Lwt 5.0.0 - promises and concurrent I/O; Lwt_ppx 2.0.0

### DIFF
--- a/packages/lwt/lwt.5.0.0/opam
+++ b/packages/lwt/lwt.5.0.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+
+version: "5.0.0"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.7.0"}
+  "dune-configurator"
+  "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0"}
+  "ocplib-endian"
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  "bisect_ppx" {dev & >= "1.3.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+post-messages: [
+  "Lwt 5.0.0 has made some minor breaking changes. See
+  https://github.com/ocsigen/lwt/issues/584"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.0.0.tar.gz"
+  checksum: "md5=a4ffc0e3aa692d2e7d800f4cf2dd3db0"
+}

--- a/packages/lwt_ppx/lwt_ppx.2.0.0/opam
+++ b/packages/lwt_ppx/lwt_ppx.2.0.0/opam
@@ -17,7 +17,7 @@ maintainer: [
 dev-repo: "git+https://github.com/ocsigen/lwt.git"
 
 depends: [
-  "dune"
+  "dune" {>= "1.1"}
   "lwt"
   "ocaml" {>= "4.02.0"}
   "ocaml-migrate-parsetree" {>= "1.4.0"}

--- a/packages/lwt_ppx/lwt_ppx.2.0.0/opam
+++ b/packages/lwt_ppx/lwt_ppx.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "PPX syntax for Lwt, providing something similar to async/await from JavaScript"
+
+version: "2.0.0"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Ppx_lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Gabriel Radanne"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune"
+  "lwt"
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.0.0.tar.gz"
+  checksum: "md5=a4ffc0e3aa692d2e7d800f4cf2dd3db0"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/ocsigen/lwt/releases/tag/5.0.0):

> Breaking
>
> *See ocsigen/lwt#584 for an extended summary and discussion of this release as a whole, or individual issues for each change specifically.*
>
> - The callback passed to [`Lwt.async`](http://ocsigen.org/lwt/dev/api/Lwt#VALasync) must now evaluate to `unit Lwt.t`, rather than `_ Lwt.t` (ocsigen/lwt#603, requested @cfcs).
> - [`Lwt.choose`](http://ocsigen.org/lwt/dev/api/Lwt#VALchoose), [`Lwt.nchoose`](http://ocsigen.org/lwt/dev/api/Lwt#VALnchoose), [`Lwt.nchoose_split`](http://ocsigen.org/lwt/dev/api/Lwt#VALnchoose_split), [`Lwt.pick`](http://ocsigen.org/lwt/dev/api/Lwt#VALpick), and [`Lwt.npick`](http://ocsigen.org/lwt/dev/api/Lwt#VALnpick) now raise `Invalid_argument` if given the empty list (ocsigen/lwt#557, Tim Reinke).
> - Catch nested calls to [`Lwt_main.run`](http://ocsigen.org/lwt/dev/api/Lwt_main#VALrun) (ocsigen/lwt#607, ocsigen/lwt#609, prompted François-René Rideau).
> - Use the new [`Lwt_unix.IO_vectors`](http://ocsigen.org/lwt/dev/api/Lwt_unix.IO_vectors) in [`Lwt_unix.recv_msg`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALrecv_msg) and [`Lwt_unix.send_msg`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALsend_msg) (ocsigen/lwt#594, prompted Marcello Seri).
> - Make [`Lwt_unix.Async_switch`](http://ocsigen.org/lwt/dev/api/Lwt_unix#TYPEasync_method) a synonym for `Lwt_unix.Async_detach` (ocsigen/lwt#572).
> - Remove the redundant `configure.ml` (ocsigen/lwt#700).
> - PPX: remove support for general `[%lwt ...]` expressions (ocsigen/lwt#527).
> - PPX: remove support for `Lwt_log` and the `-log` option (ocsigen/lwt#520).
> - PPX: remove the `-no-debug` option (ocsigen/lwt#528).