### PR TITLE
Mercurial repositories for Conjury and Orsetto are moving temporarily.

### DIFF
--- a/packages/conjury/conjury.2.0/opam
+++ b/packages/conjury/conjury.2.0/opam
@@ -3,9 +3,9 @@ name: "conjury" version: "2.0"
 synopsis: "Conjury library for OMake"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
-homepage: "https://bitbucket.org/jhw/conjury/"
-bug-reports: "https://bitbucket.org/jhw/conjury/issues"
-dev-repo: "hg+https://bitbucket.org/jhw/conjury"
+homepage: "https://bitbucket.org/jhw/conjury-hg/"
+bug-reports: "https://bitbucket.org/jhw/conjury-hg/issues"
+dev-repo: "hg+https://bitbucket.org/jhw/conjury-hg"
 tags: [ "org:conjury.org" ]
 depends: [
     "ocaml" { with-test & >= "4.04" }
@@ -18,6 +18,6 @@ build: [
 ]
 install: [ "omake" "install" ]
 url {
-    src: "https://bitbucket.org/jhw/conjury/get/r2.0.tar.gz"
-    checksum: "md5=e88b496c0e76260af2ab359fae850e45"
+    src: "https://bitbucket.org/jhw/conjury-hg/get/r2.0.tar.gz"
+    checksum: "md5=5485ea44e4a11b0203ec07c08d56c7c0"
 }

--- a/packages/orsetto/orsetto.1.0.1/opam
+++ b/packages/orsetto/orsetto.1.0.1/opam
@@ -2,9 +2,9 @@ opam-version: "2.0"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
-homepage: "https://bitbucket.org/jhw/orsetto/"
-bug-reports: "https://bitbucket.org/jhw/orsetto/issues"
-dev-repo: "hg+https://bitbucket.org/jhw/orsetto"
+homepage: "https://bitbucket.org/jhw/orsetto-hg/"
+bug-reports: "https://bitbucket.org/jhw/orsetto-hg/issues"
+dev-repo: "hg+https://bitbucket.org/jhw/orsetto-hg"
 tags: [ "org:conjury.org" ]
 depends: [
     ("ocaml" { >= "4.07" & < "4.09" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
@@ -22,8 +22,8 @@ install: [
     [ "omake" "--verbose" "install" "MODE=develop" ] { dev }
 ]
 url {
-    src: "https://bitbucket.org/jhw/orsetto/get/r1.0.1.tar.gz"
-    checksum: "md5=a1b80cf90ac1937dd672726bcf5930be"
+    src: "https://bitbucket.org/jhw/orsetto-hg/get/r1.0.1.tar.gz"
+    checksum: "md5=81e0f8a5f2c0cf364e3c8e9acbadef93"
 }
 extra-source "ucd.all.grouped.zip" {
     src: "http://www.unicode.org/Public/12.0.0/ucdxml/ucd.all.grouped.zip"

--- a/packages/orsetto/orsetto.1.0.2/opam
+++ b/packages/orsetto/orsetto.1.0.2/opam
@@ -2,9 +2,9 @@ opam-version: "2.0"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
-homepage: "https://bitbucket.org/jhw/orsetto/"
-bug-reports: "https://bitbucket.org/jhw/orsetto/issues"
-dev-repo: "hg+https://bitbucket.org/jhw/orsetto"
+homepage: "https://bitbucket.org/jhw/orsetto-hg/"
+bug-reports: "https://bitbucket.org/jhw/orsetto-hg/issues"
+dev-repo: "hg+https://bitbucket.org/jhw/orsetto-hg"
 tags: [ "org:conjury.org" ]
 depends: [
     ("ocaml" { >= "4.07" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
@@ -22,8 +22,8 @@ install: [
     [ "omake" "--verbose" "install" "MODE=develop" ] { dev }
 ]
 url {
-    src: "https://bitbucket.org/jhw/orsetto/get/r1.0.2.tar.gz"
-    checksum: "md5=8a7162382e7c6f4a6de22b102c6c7385"
+    src: "https://bitbucket.org/jhw/orsetto-hg/get/r1.0.2.tar.gz"
+    checksum: "md5=658a468c734f2825773e810177cd9020"
 }
 extra-source "ucd.all.grouped.zip" {
     src: "http://www.unicode.org/Public/12.0.0/ucdxml/ucd.all.grouped.zip"

--- a/packages/orsetto/orsetto.1.0/opam
+++ b/packages/orsetto/orsetto.1.0/opam
@@ -3,9 +3,9 @@ name: "orsetto" version: "1.0"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
-homepage: "https://bitbucket.org/jhw/orsetto/"
-bug-reports: "https://bitbucket.org/jhw/orsetto/issues"
-dev-repo: "hg+https://bitbucket.org/jhw/orsetto"
+homepage: "https://bitbucket.org/jhw/orsetto-hg/"
+bug-reports: "https://bitbucket.org/jhw/orsetto-hg/issues"
+dev-repo: "hg+https://bitbucket.org/jhw/orsetto-hg"
 tags: [ "org:conjury.org" ]
 depends: [
     ("ocaml" { >= "4.07" & < "4.09" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
@@ -23,8 +23,8 @@ install: [
     [ "omake" "--verbose" "install" "MODE=develop" ] { dev }
 ]
 url {
-    src: "https://bitbucket.org/jhw/orsetto/get/r1.0.tar.gz"
-    checksum: "md5=97d3f1e4a2ea97c739e3b4b9d658d318"
+    src: "https://bitbucket.org/jhw/orsetto-hg/get/r1.0.tar.gz"
+    checksum: "md5=af03ca5123daf40860d6a0e16f5fb565"
 }
 extra-source "ucd.all.grouped.zip" {
     src: "http://www.unicode.org/Public/12.0.0/ucdxml/ucd.all.grouped.zip"


### PR DESCRIPTION
Atlassian is removing support for Mercurial from its Bitbucket Cloud
service. At the end of January, the old Conjury and Orsetto repositories
will be replaced with Git conversions. At the end of May, these existing
transitional Mercurial repositories will be automatically deleted.