### PR TITLE
Update checksum of brotli 1.3.0

### DIFF
--- a/packages/brotli/brotli.1.3.0/opam
+++ b/packages/brotli/brotli.1.3.0/opam
@@ -32,5 +32,5 @@ http://www.ietf.org/id/draft-alakuijala-brotli"""
 flags: light-uninstall
 url {
   src: "https://github.com/fxfactorial/ocaml-brotli/archive/v1.3.0.tar.gz"
-  checksum: "md5=f852a6d07741a614f17de9eff4972371"
+  checksum: "md5=065fbba326706290c29be4f4d5b8c0b5"
 }


### PR DESCRIPTION
GitHub repacked the archive when the source repo name changed.