### PR TITLE
Package seq.0.2.1

### DIFF
--- a/packages/seq/seq.0.2.1/opam
+++ b/packages/seq/seq.0.2.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis:
+  "Compatibility package for OCaml's standard iterator type starting from 4.07"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "LGPL2.1"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "1.1.0"}
+  # opam-repo contains a version for 4.07 and above that does nothing,
+  # because OCaml starts having a `Seq` module in the stdlib
+  "ocaml" {< "4.07.0"}
+]
+tags: [ "iterator" "seq" "pure" "list" "compatibility" "cascade" ]
+homepage: "https://github.com/c-cube/seq/"
+bug-reports: "https://github.com/c-cube/seq/issues"
+dev-repo: "git+https://github.com/c-cube/seq.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/seq/archive/0.2.1.tar.gz"
+  checksum: [
+    "md5=9b2c81be728b3edb3abe729d64fd5f65"
+    "sha512=b5d23f85a24e1f59b191e0a59ac341eca41acd67c2b2f8da820e9064441de17716f7c2716f65db5c2a550325e03efd3e15d1bfa5b4df451c995d95693ca28dea"
+  ]
+}


### PR DESCRIPTION
### `seq.0.2.1`
Compatibility package for OCaml's standard iterator type starting from 4.07



---
* Homepage: https://github.com/c-cube/seq/
* Source repo: git+https://github.com/c-cube/seq.git
* Bug tracker: https://github.com/c-cube/seq/issues

---
:camel: Pull-request generated by opam-publish v2.0.0