### PR TITLE
[new release] mirage (3.7.3)

### DIFF
--- a/packages/mirage/mirage.3.7.3/opam
+++ b/packages/mirage/mirage.3.7.3/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria"          {>= "3.0.2"}
+  "bos"
+  "astring"
+  "logs"
+  "stdlib-shims"
+  "mirage-runtime"     {>= "3.7.0" & < "3.8.0"}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.7.3/mirage-v3.7.3.tbz"
+  checksum: [
+    "sha256=271ae720a61d3f3091310da7fd1bfe2fe095d6934b8dff0aa61cc20c008b062a"
+    "sha512=202be57545c75d34736b1f71f8b447095915548064a34853ee545c3692e22f7bdaf7590e07be075d522f51a8c9560ab90204e34cf2d9ed38971ba44ca217db17"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* `mirage configure` now emits build and install steps into generated opam file
  this allows to use `opam install .` to actually install a unikernel.
  (mirage/mirage#1022 @hannesm)
* refactor configure, build and link step into separate modules (mirage/mirage#1017 @dinosaure)