### PR TITLE
4 packages from c-cube/calculon at 0.6

### DIFF
--- a/packages/calculon-redis-lib/calculon-redis-lib.0.6/opam
+++ b/packages/calculon-redis-lib/calculon-redis-lib.0.6/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "A library to interact with Calculon via Redis"
+authors: ["c-cube"]
+maintainer: "c-cube"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "redis" { >= "0.3" }
+  "calculon" { = version }
+  "redis-lwt"
+  "atdgen"
+  "yojson"
+]
+tags: [ "irc" "bot" "redis" ]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=94516071fdd6ee5bf206f153671987ff"
+    "sha512=fc5ffcca60fb7dc008c5963ec5865720c11153dcf14a93a7ef6db36182d556cde52c876fa7a9fb77e01474fb956753cb99520ec4939fa17c01ab079c367437de"
+  ]
+}

--- a/packages/calculon-redis/calculon-redis.0.6/opam
+++ b/packages/calculon-redis/calculon-redis.0.6/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "A redis plugin for Calculon"
+authors: ["c-cube"]
+maintainer: "c-cube"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "calculon" { = version }
+  "calculon-redis-lib" { = version }
+  "redis" { >= "0.3" }
+  "redis-lwt"
+]
+tags: [ "irc" "bot" "redis" ]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=94516071fdd6ee5bf206f153671987ff"
+    "sha512=fc5ffcca60fb7dc008c5963ec5865720c11153dcf14a93a7ef6db36182d556cde52c876fa7a9fb77e01474fb956753cb99520ec4939fa17c01ab079c367437de"
+  ]
+}

--- a/packages/calculon-web/calculon-web.0.6/opam
+++ b/packages/calculon-web/calculon-web.0.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "A collection of web plugins for Calculon"
+authors: ["Armael" "Enjolras" "c-cube"]
+maintainer: "c-cube"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "calculon" { = version }
+  "re" { >= "1.7.2" }
+  "uri"
+  "curly"
+  "atdgen"
+  "lambdasoup"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "irc" "bot" "factoids" ]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=94516071fdd6ee5bf206f153671987ff"
+    "sha512=fc5ffcca60fb7dc008c5963ec5865720c11153dcf14a93a7ef6db36182d556cde52c876fa7a9fb77e01474fb956753cb99520ec4939fa17c01ab079c367437de"
+  ]
+}

--- a/packages/calculon/calculon.0.6/opam
+++ b/packages/calculon/calculon.0.6/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Library for writing IRC bots in OCaml and a collection of plugins"
+authors: ["Armael" "Enjolras" "c-cube"]
+maintainer: "c-cube"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-unix"
+  "lwt"
+  "irc-client" { >= "0.6.0" }
+  "irc-client-lwt"
+  "irc-client-lwt-ssl"
+  "logs"
+  "yojson" { >= "1.6" }
+  "containers" { >= "1.0" }
+  "ISO8601"
+  "stringext"
+  "re" { >= "1.7.2" }
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+depopts: [
+  "iter"
+]
+tags: [ "irc" "bot" "factoids" ]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=94516071fdd6ee5bf206f153671987ff"
+    "sha512=fc5ffcca60fb7dc008c5963ec5865720c11153dcf14a93a7ef6db36182d556cde52c876fa7a9fb77e01474fb956753cb99520ec4939fa17c01ab079c367437de"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`calculon.0.6`: Library for writing IRC bots in OCaml and a collection of plugins
-`calculon-redis.0.6`: A redis plugin for Calculon
-`calculon-redis-lib.0.6`: A library to interact with Calculon via Redis
-`calculon-web.0.6`: A collection of web plugins for Calculon



---
* Homepage: https://github.com/c-cube/calculon
* Source repo: git+https://github.com/c-cube/calculon.git
* Bug tracker: https://github.com/c-cube/calculon/issues

---
:camel: Pull-request generated by opam-publish v2.0.0