### PR TITLE
[new release] dune-build-info, dune, dune-configurator, dune-action-plugin, dune-private-libs and dune-glob (2.0.1)

### DIFF
--- a/packages/dune-action-plugin/dune-action-plugin.2.0.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.0.0/opam
@@ -42,3 +42,4 @@ url {
     "sha512=369e2173bfb41c7ea27f5120c92ab5849c533bd7fe58f31e4519daf669d9e468ee47dfd3593dc810b21869fe1d5ad33cda2aa039fad86d2a3cacc4f765c5a8eb"
   ]
 }
+available: false

--- a/packages/dune-action-plugin/dune-action-plugin.2.0.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-glob"
+  "ppx_expect" {with-test}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.0.1/dune-2.0.1.tbz"
+  checksum: [
+    "sha256=e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7"
+    "sha512=8c973ccfa1de0ff7173e17dac74ea850446a057866d47c7a100b271c7e440d5e607f1bfaa8fa5b756e0439492276e8c6615fac30cbff9ea900dc8e891f7ba4d3"
+  ]
+}

--- a/packages/dune-build-info/dune-build-info.2.0.0/opam
+++ b/packages/dune-build-info/dune-build-info.2.0.0/opam
@@ -38,3 +38,4 @@ url {
     "sha512=369e2173bfb41c7ea27f5120c92ab5849c533bd7fe58f31e4519daf669d9e468ee47dfd3593dc810b21869fe1d5ad33cda2aa039fad86d2a3cacc4f765c5a8eb"
   ]
 }
+available: false

--- a/packages/dune-build-info/dune-build-info.2.0.1/opam
+++ b/packages/dune-build-info/dune-build-info.2.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Embed build informations inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.0.1/dune-2.0.1.tbz"
+  checksum: [
+    "sha256=e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7"
+    "sha512=8c973ccfa1de0ff7173e17dac74ea850446a057866d47c7a100b271c7e440d5e607f1bfaa8fa5b756e0439492276e8c6615fac30cbff9ea900dc8e891f7ba4d3"
+  ]
+}

--- a/packages/dune-configurator/dune-configurator.2.0.0/opam
+++ b/packages/dune-configurator/dune-configurator.2.0.0/opam
@@ -41,3 +41,4 @@ url {
     "sha512=369e2173bfb41c7ea27f5120c92ab5849c533bd7fe58f31e4519daf669d9e468ee47dfd3593dc810b21869fe1d5ad33cda2aa039fad86d2a3cacc4f765c5a8eb"
   ]
 }
+available: false

--- a/packages/dune-configurator/dune-configurator.2.0.1/opam
+++ b/packages/dune-configurator/dune-configurator.2.0.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.0.1/dune-2.0.1.tbz"
+  checksum: [
+    "sha256=e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7"
+    "sha512=8c973ccfa1de0ff7173e17dac74ea850446a057866d47c7a100b271c7e440d5e607f1bfaa8fa5b756e0439492276e8c6615fac30cbff9ea900dc8e891f7ba4d3"
+  ]
+}

--- a/packages/dune-glob/dune-glob.2.0.0/opam
+++ b/packages/dune-glob/dune-glob.2.0.0/opam
@@ -33,3 +33,4 @@ url {
     "sha512=369e2173bfb41c7ea27f5120c92ab5849c533bd7fe58f31e4519daf669d9e468ee47dfd3593dc810b21869fe1d5ad33cda2aa039fad86d2a3cacc4f765c5a8eb"
   ]
 }
+available: false

--- a/packages/dune-glob/dune-glob.2.0.1/opam
+++ b/packages/dune-glob/dune-glob.2.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.0.1/dune-2.0.1.tbz"
+  checksum: [
+    "sha256=e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7"
+    "sha512=8c973ccfa1de0ff7173e17dac74ea850446a057866d47c7a100b271c7e440d5e607f1bfaa8fa5b756e0439492276e8c6615fac30cbff9ea900dc8e891f7ba4d3"
+  ]
+}

--- a/packages/dune-private-libs/dune-private-libs.2.0.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.0.0/opam
@@ -40,3 +40,4 @@ url {
     "sha512=369e2173bfb41c7ea27f5120c92ab5849c533bd7fe58f31e4519daf669d9e468ee47dfd3593dc810b21869fe1d5ad33cda2aa039fad86d2a3cacc4f765c5a8eb"
   ]
 }
+available: false

--- a/packages/dune-private-libs/dune-private-libs.2.0.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.07"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.0.1/dune-2.0.1.tbz"
+  checksum: [
+    "sha256=e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7"
+    "sha512=8c973ccfa1de0ff7173e17dac74ea850446a057866d47c7a100b271c7e440d5e607f1bfaa8fa5b756e0439492276e8c6615fac30cbff9ea900dc8e891f7ba4d3"
+  ]
+}

--- a/packages/dune-private-libs/dune-private-libs.2.0.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.0.1/opam
@@ -17,7 +17,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.06"}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [

--- a/packages/dune/dune.2.0.0/opam
+++ b/packages/dune/dune.2.0.0/opam
@@ -49,3 +49,4 @@ url {
     "sha512=369e2173bfb41c7ea27f5120c92ab5849c533bd7fe58f31e4519daf669d9e468ee47dfd3593dc810b21869fe1d5ad33cda2aa039fad86d2a3cacc4f765c5a8eb"
   ]
 }
+available: false

--- a/packages/dune/dune.2.0.1/opam
+++ b/packages/dune/dune.2.0.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "ocaml" {>= "4.06"}
+  "base-unix"
+  "base-threads"
+]
+conflicts: [
+  "odoc" {< "1.3.0"}
+  "dune-release" {< "1.3.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.0.1/dune-2.0.1.tbz"
+  checksum: [
+    "sha256=e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7"
+    "sha512=8c973ccfa1de0ff7173e17dac74ea850446a057866d47c7a100b271c7e440d5e607f1bfaa8fa5b756e0439492276e8c6615fac30cbff9ea900dc8e891f7ba4d3"
+  ]
+}

--- a/packages/dune/dune.2.0.1/opam
+++ b/packages/dune/dune.2.0.1/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "ocaml" {>= "4.06"}
+  ("ocaml" {>= "4.06"} | ("ocaml" {< "4.06~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]


### PR DESCRIPTION
Embed build informations inside executable

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- Delay errors raised by invalid `dune-package` files. The error is now raised
  only if the invalid package is treated as a library and used to build
  something. (ocaml/dune#2972, @rgrinberg)
