### PR TITLE
async_js.v0.11.0 is not compatible with js_of_ocaml 3.5.0+

### DIFF
--- a/packages/async_js/async_js.v0.11.0/opam
+++ b/packages/async_js/async_js.v0.11.0/opam
@@ -15,7 +15,7 @@ depends: [
   "async_rpc_kernel" {>= "v0.11" & < "v0.12"}
   "ppx_jane" {>= "v0.11" & < "v0.12"}
   "jbuilder" {>= "1.0+beta18.1"}
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {>= "3.0" & < "3.5.0"}
   "js_of_ocaml-ppx"
   "ocaml-migrate-parsetree" {>= "1.0"}
   "uri" {< "2.0.0"}


### PR DESCRIPTION
See for instance [this log](http://check.ocamllabs.io/log/1576115449-7b7ade392f48458c5399b9d5420146ef1b8605d2/4.07/bad/async_js.v0.11.0).