### PR TITLE
Package javalib.3.2

### DIFF
--- a/packages/javalib/javalib.3.2/opam
+++ b/packages/javalib/javalib.3.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Nicolas Barré <nicolas.barre@irisa.fr>"
+authors: "Javalib Development team"
+homepage: "https://javalib-team.github.io/javalib/"
+bug-reports: "https://github.com/javalib-team/javalib/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/javalib-team/javalib.git"
+build: [
+  ["./configure.sh"]
+  [make]
+]
+install: [make "install"]
+depends: [
+  "ocaml" {>= "4.04"}
+  "conf-which" {build}
+  "ocamlfind" {build}
+  "camlzip" {>= "1.05"}
+  "extlib"
+]
+
+synopsis: "Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files"
+
+description: """
+Thus it stands for a good starting point for people who want to
+develop static analyses for Java byte-code programs, benefiting from
+the strength of OCaml language.
+"""
+url {
+  src: "https://github.com/javalib-team/javalib/archive/v3.2.tar.gz"
+  checksum: [
+    "md5=59119bcd5d4e963665a6529227237eb0"
+    "sha512=48331b4a0f8870e9efbb8eb7fd4abeac89d057692abe2f61327e77c268805f7fb296399af6e859a2ae7772f596ce8450f2692ac4385ebb6be6b95d7239b4cec1"
+  ]
+}


### PR DESCRIPTION
### `javalib.3.2`
Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files
Thus it stands for a good starting point for people who want to
develop static analyses for Java byte-code programs, benefiting from
the strength of OCaml language.



---
* Homepage: https://javalib-team.github.io/javalib/
* Source repo: git+https://github.com/javalib-team/javalib.git
* Bug tracker: https://github.com/javalib-team/javalib/issues

---
:camel: Pull-request generated by opam-publish v2.0.0