### PR TITLE
added packages/pardi/pardi.2.0.3

### DIFF
--- a/packages/pardi/pardi.2.0.3/opam
+++ b/packages/pardi/pardi.2.0.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/pardi"
+bug-reports: "https://github.com/UnixJunkie/pardi/issues"
+dev-repo: "git+https://github.com/UnixJunkie/pardi.git"
+license: "GPL-1.0-or-later"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "1.11"}
+  "batteries"
+  "dolog" {>= "4.0.0"}
+  "parany" {>= "6.0.0"}
+  "minicli"
+  "lz4"
+  "cryptokit"
+  "zmq"
+  "ocaml" {>= "4.05.0"}
+]
+synopsis: "Parallel and distributed execution of command lines, pardi!"
+description: """
+Almost like GNU parallel; just better.
+
+Pardi pushes further the point at which you have to use a supercomputer.
+Alternatively, it can be used on a supercomputer to make life in there
+much more fun and productive.
+
+Put back the fun into computing: use pardi!
+"""
+url {
+  src: "https://github.com/UnixJunkie/pardi/archive/v2.0.3.tar.gz"
+  checksum: "md5=2788d3c08b76e71b2add8f0e5f690bd4"
+}


### PR DESCRIPTION
bug correction for macs, where the output of 'wc -l some_file' doesn't have
the same format than on Linux. String stripping is needed prior to parsing
the command output.