### PR TITLE
tidy 5.6

### DIFF
--- a/packages/tidy/tidy.5.6-0.1/opam
+++ b/packages/tidy/tidy.5.6-0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "conf-tidy"
   "core_kernel" {>= "v0.10.0" & < "v0.14"}
-  "dune" {build}
+  "dune" {>= "1.4"}
 ]
 
 synopsis: "Bindings for libtidy5 -- HTML/XML syntax checker and reformatter"
@@ -23,4 +23,3 @@ url {
   src:"https://github.com/kandu/ocaml-tidy/archive/5.6-0.1.tar.gz"
   checksum: "md5=0217928dd1d082b11f9e30e8ad3dc2c6"
 }
-

--- a/packages/tidy/tidy.5.6-0.1/opam
+++ b/packages/tidy/tidy.5.6-0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/ocaml-tidy/"
+bug-reports: "https://github.com/kandu/ocaml-tidy/issues"
+license: "MIT"
+dev-repo: "git://github.com/kandu/ocaml-tidy"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "conf-tidy"
+  "core_kernel" {>= "v0.10.0" & < "v0.14"}
+  "dune" {build}
+]
+
+synopsis: "Bindings for libtidy5 -- HTML/XML syntax checker and reformatter"
+description: """
+tidy corrects and cleans up HTML and XML documents by fixing markup errors and upgrading legacy code to modern standards. Tidy is a product of the World Wide Web Consortium and the HTML Tidy Advocacy Community Group."""
+
+url {
+  src:"https://github.com/kandu/ocaml-tidy/archive/5.6-0.1.tar.gz"
+  checksum: "md5=0217928dd1d082b11f9e30e8ad3dc2c6"
+}
+


### PR DESCRIPTION
libtidy 5.6 removed some functions and changed some return type of them thus caused backward incompatibility

this new release fixed these problems and it's now compatible with core_kernel v0.13