### PR TITLE
markup-lwt 0.5.0 requires markup >= 0.8.0

### DIFF
--- a/packages/markup-lwt/markup-lwt.0.5.0/opam
+++ b/packages/markup-lwt/markup-lwt.0.5.0/opam
@@ -13,7 +13,7 @@ depends: [
   "base-unix"
   "dune"
   "lwt"
-  "markup"
+  "markup" {>= "0.8.0"}
 ]
 
 build: [


### PR DESCRIPTION
It was factored out of markup in that version.