### PR TITLE
[new release] pg_query-ocaml

### DIFF
--- a/packages/pg_query-ocaml/pg_query-ocaml.0.9/opam
+++ b/packages/pg_query-ocaml/pg_query-ocaml.0.9/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Bindings for pg_query for parsing PostgreSQL"
+maintainer: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+authors: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+license: "MIT"
+homepage: "https://github.com/roddyyaga/pg_query-ocaml"
+doc: "https://roddyyaga.github.io/pg_query-ocaml/pg_query-ocaml/index.html"
+bug-reports: "https://github.com/roddyyaga/pg_query-ocaml/issues"
+depends: ["dune" "core" "ctypes" "ctypes-foreign" "ppx_deriving"]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/roddyyaga/pg_query-ocaml.git"
+url {
+  src: "https://github.com/roddyyaga/pg_query-ocaml/archive/v0.9.tar.gz"
+  checksum: [
+    "md5=e0473ccb919b7b315b1023777992f7b7"
+    "sha512=4bfc551a03171f855b60e2b3d1395e27d39de618b12f44402f65cc81c414f23ed69975274094152679d31c842ad13348c064015396ea21605f4c1fd430f3e93d"
+  ]
+}

--- a/packages/pg_query-ocaml/pg_query-ocaml.0.9/opam
+++ b/packages/pg_query-ocaml/pg_query-ocaml.0.9/opam
@@ -10,7 +10,7 @@ depends: ["dune" "core" "ctypes" "ctypes-foreign" "ppx_deriving"]
 build: [
   ["dune" "subst"] {pinned}
   [
-    "dune"
+    "dune" {>= "2.0"}
     "build"
     "-p"
     name

--- a/packages/pg_query-ocaml/pg_query-ocaml.0.9/opam
+++ b/packages/pg_query-ocaml/pg_query-ocaml.0.9/opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/roddyyaga/pg_query-ocaml"
 doc: "https://roddyyaga.github.io/pg_query-ocaml/pg_query-ocaml/index.html"
 bug-reports: "https://github.com/roddyyaga/pg_query-ocaml/issues"
 depends: [
+  "ocaml" {>= "4.07"}
   "dune" {>= "2.0"}
   "core"
   "ctypes"

--- a/packages/pg_query-ocaml/pg_query-ocaml.0.9/opam
+++ b/packages/pg_query-ocaml/pg_query-ocaml.0.9/opam
@@ -6,11 +6,17 @@ license: "MIT"
 homepage: "https://github.com/roddyyaga/pg_query-ocaml"
 doc: "https://roddyyaga.github.io/pg_query-ocaml/pg_query-ocaml/index.html"
 bug-reports: "https://github.com/roddyyaga/pg_query-ocaml/issues"
-depends: ["dune" "core" "ctypes" "ctypes-foreign" "ppx_deriving"]
+depends: [
+  "dune" {>= "2.0"}
+  "core"
+  "ctypes"
+  "ctypes-foreign"
+  "ppx_deriving"
+]
 build: [
   ["dune" "subst"] {pinned}
   [
-    "dune" {>= "2.0"}
+    "dune"
     "build"
     "-p"
     name


### PR DESCRIPTION
### `pg_query-ocaml`
Bindings for [pg_query](https://github.com/lfittl/libpg_query) for parsing PostgreSQL



---
* Homepage: https://github.com/roddyyaga/pg_query-ocaml
* Source repo: git+https://github.com/roddyyaga/pg_query-ocaml.git
* Bug tracker: https://github.com/roddyyaga/pg_query-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2