### PR TITLE
[new release] mirage-nat (2.0.0)

### DIFF
--- a/packages/mirage-nat/mirage-nat.2.0.0/opam
+++ b/packages/mirage-nat/mirage-nat.2.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+name: "mirage-nat"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+homepage: "https://github.com/mirage/mirage-nat"
+bug-reports: "https://github.com/mirage/mirage-nat/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-nat.git"
+doc: "https://mirage.github.io/mirage-nat/"
+license: "ISC"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "ipaddr"
+  "cstruct"
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "lwt"
+  "rresult"
+  "logs"
+  "lru" {>= "0.3.0"}
+  "ppx_deriving" {build & >= "4.2" }
+  "dune" {>= "1.0"}
+  "tcpip" { >= "3.7.8" }
+  "ethernet" { >= "2.0.0" }
+  "arp"
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+]
+synopsis: "Mirage-nat is a library for network address translation to be used with MirageOS"
+description: """
+Mirage-nat is a library for [network address
+translation](https://tools.ietf.org/html/rfc2663).  It is intended for use in
+[MirageOS](https://mirage.io) and makes extensive use of
+[tcpip](https://github.com/mirage/mirage-tcpip), the network stack used by
+default in MirageOS unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-nat/releases/download/v2.0.0/mirage-nat-v2.0.0.tbz"
+  checksum: [
+    "sha256=375aa94af4855efb9bb6acf7967cc3eac6df335638d6f2dc36ae6f9991d5dc66"
+    "sha512=06adaac5922a48bf77ee2b5320bcb9e8ee0d2b330bd77f4828ca31918c94c67757879f2e7966a6e23ca3e0c456a3d900283e03158a747a22c67954601532e3aa"
+  ]
+}

--- a/packages/mirage-nat/mirage-nat.2.0.0/opam
+++ b/packages/mirage-nat/mirage-nat.2.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "rresult"
   "logs"
   "lru" {>= "0.3.0"}
-  "ppx_deriving" {build & >= "4.2" }
+  "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
   "tcpip" { >= "3.7.8" }
   "ethernet" { >= "2.0.0" }


### PR DESCRIPTION
CHANGES:

- support IPv4 fragmentation and reassembly (mirage/mirage-nat#36, by @hannesm)
- remove unused TIME and MCLOCK requirements (mirage/mirage-nat#33, by @yomimono)
- MirageOS 3.7 support (mirage/mirage-nat#34, by @hannesm)