### PR TITLE
Release caqti-async.1.2.2.

### DIFF
--- a/packages/caqti-async/caqti-async.1.2.2/opam
+++ b/packages/caqti-async/caqti-async.1.2.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "caqti-async"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "async_kernel" {>= "v0.11.0" & < "v0.14.0~"}
+  "async_unix" {>= "v0.11.0" & < "v0.14.0~"}
+  "caqti" {>= "1.2.0" & < "1.3.0~"}
+  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "core_kernel" {>= "v0.11.0" & < "v0.14.0~"}
+  "dune" {>= "1.11"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Async support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.2.2/caqti-v1.2.2.tbz"
+  checksum: [
+    "sha256=097e3e14a15b93620cf033c44801384dd5e725cd28d077750969c221a67c63bc"
+    "sha512=a8f44d3148b3a89a472d4e2234f7c496b82904c337f6e5177ee843f7ad1121d46ac2d66c8bf0e4732d66811712dcce31b384dece8b2e7e7d846b17b6255c9056"
+  ]
+}


### PR DESCRIPTION
This release fixes compatibility with core.v0.13 (#15469).