### PR TITLE
Package pg_query.0.9.3

### DIFF
--- a/packages/pg_query/pg_query.0.9.3/opam
+++ b/packages/pg_query/pg_query.0.9.3/opam
@@ -6,7 +6,14 @@ license: "MIT"
 homepage: "https://github.com/roddyyaga/pg_query-ocaml"
 doc: "https://roddyyaga.github.io/pg_query-ocaml/pg_query-ocaml/index.html"
 bug-reports: "https://github.com/roddyyaga/pg_query-ocaml/issues"
-depends: ["dune" "core" "ctypes" "ctypes-foreign" "ppx_deriving"]
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "2.0"}
+  "core"
+  "ctypes"
+  "ctypes-foreign"
+  "ppx_deriving"
+]
 build: [
   ["dune" "subst"] {pinned}
   [

--- a/packages/pg_query/pg_query.0.9.3/opam
+++ b/packages/pg_query/pg_query.0.9.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Bindings for pg_query for parsing PostgreSQL"
+maintainer: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+authors: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+license: "MIT"
+homepage: "https://github.com/roddyyaga/pg_query-ocaml"
+doc: "https://roddyyaga.github.io/pg_query-ocaml/pg_query-ocaml/index.html"
+bug-reports: "https://github.com/roddyyaga/pg_query-ocaml/issues"
+depends: ["dune" "core" "ctypes" "ctypes-foreign" "ppx_deriving"]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/roddyyaga/pg_query-ocaml.git"
+url {
+  src: "https://github.com/roddyyaga/pg_query-ocaml/archive/0.9.3.tar.gz"
+  checksum: [
+    "md5=2c9718078f6956a8bdb87cd6885c7fae"
+    "sha512=ac2e76ac5efc07056e28ab71515b26d187f77c2f7c2bf802cfaf3f658d7cf29db635382497cdae64d895c27e32c785f3cc4a68e082507e529da1e344a6ef231d"
+  ]
+}


### PR DESCRIPTION
### `pg_query.0.9.3`
Bindings for [pg_query](https://github.com/lfittl/libpg_query) for parsing PostgreSQL



---
* Homepage: https://github.com/roddyyaga/pg_query-ocaml
* Source repo: git+https://github.com/roddyyaga/pg_query-ocaml.git
* Bug tracker: https://github.com/roddyyaga/pg_query-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2