### PR TITLE
[new release] h2, h2-lwt, h2-lwt-unix and h2-mirage (0.5.0)

### DIFF
--- a/packages/h2-lwt-unix/h2-lwt-unix.0.1.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.1.0/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "faraday-lwt-unix"
-  "h2-lwt"
+  "h2-lwt" {< "0.5.0"}
   "dune"
   "ocamlfind" {build}
   "lwt"

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.5.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.5.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "faraday-lwt-unix"
   "h2-lwt" {= version}
-  "dune" {>= "1.5"}
+  "dune" {>= "1.7"}
   "lwt"
 ]
 depopts: ["tls" "lwt_ssl"]

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.5.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.5.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "faraday-lwt-unix"
+  "h2-lwt" {= version}
+  "dune" {>= "1.5"}
+  "lwt"
+]
+depopts: ["tls" "lwt_ssl"]
+synopsis: "Lwt + UNIX support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-lwt-unix provides an Lwt runtime implementation for h2 that targets UNIX
+binaries.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.5.0/h2-0.5.0.tbz"
+  checksum: [
+    "sha256=cc7517d73b0b24425afcedd258c09d7ebb6c2c20075137cb6f6eb7b63c8e7ad3"
+    "sha512=7c36532f127194e7bac8080ac667a0d01860071d3a5bd85ebc67ec91841d494a3a048dab424747c185e4fc6ea323548c7375af895bf70b5b720ee845df8944f0"
+  ]
+}

--- a/packages/h2-lwt/h2-lwt.0.5.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.5.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06"}
   "h2" {= version}
-  "dune" {>= "1.5"}
+  "dune" {>= "1.7"}
   "lwt"
 ]
 synopsis: "Lwt support for h2"

--- a/packages/h2-lwt/h2-lwt.0.5.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.5.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "h2" {= version}
+  "dune" {>= "1.5"}
+  "lwt"
+]
+synopsis: "Lwt support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-lwt
+provides an Lwt runtime implementation for h2.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.5.0/h2-0.5.0.tbz"
+  checksum: [
+    "sha256=cc7517d73b0b24425afcedd258c09d7ebb6c2c20075137cb6f6eb7b63c8e7ad3"
+    "sha512=7c36532f127194e7bac8080ac667a0d01860071d3a5bd85ebc67ec91841d494a3a048dab424747c185e4fc6ea323548c7375af895bf70b5b720ee845df8944f0"
+  ]
+}

--- a/packages/h2-mirage/h2-mirage.0.1.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.1.0/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "faraday-lwt"
-  "h2-lwt"
+  "h2-lwt" {< "0.5.0"}
   "dune"
   "lwt"
   "mirage-conduit"

--- a/packages/h2-mirage/h2-mirage.0.5.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.5.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "faraday-lwt"
+  "h2-lwt" {= version}
+  "dune" {>= "1.5"}
+  "lwt"
+  "conduit-mirage" {>= "2.0.2"}
+  "mirage-flow" {>= "2.0.0"}
+  "cstruct"
+]
+synopsis: "Mirage support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-mirage provides an Lwt runtime implementation for h2 that targets MirageOS
+unikernels.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.5.0/h2-0.5.0.tbz"
+  checksum: [
+    "sha256=cc7517d73b0b24425afcedd258c09d7ebb6c2c20075137cb6f6eb7b63c8e7ad3"
+    "sha512=7c36532f127194e7bac8080ac667a0d01860071d3a5bd85ebc67ec91841d494a3a048dab424747c185e4fc6ea323548c7375af895bf70b5b720ee845df8944f0"
+  ]
+}

--- a/packages/h2-mirage/h2-mirage.0.5.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.5.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "faraday-lwt"
   "h2-lwt" {= version}
-  "dune" {>= "1.5"}
+  "dune" {>= "1.7"}
   "lwt"
   "conduit-mirage" {>= "2.0.2"}
   "mirage-flow" {>= "2.0.0"}

--- a/packages/h2/h2.0.5.0/opam
+++ b/packages/h2/h2.0.5.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06"}
-  "dune" {>= "1.5"}
+  "dune" {>= "1.7"}
   "alcotest" {with-test}
   "yojson" {with-test}
   "hex" {with-test}

--- a/packages/h2/h2.0.5.0/opam
+++ b/packages/h2/h2.0.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.5"}
+  "alcotest" {with-test}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "base64"
+  "bigstringaf" {>= "0.5.0"}
+  "angstrom" {>= "0.11.2"}
+  "faraday" {>= "0.5.0"}
+  "psq"
+  "hpack"
+  "httpaf"
+]
+synopsis:
+  "A high-performance, memory-efficient, and scalable HTTP/2 library for for OCaml"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. It
+is based on the concepts in http/af, and therefore uses the Angstrom and
+Faraday libraries to implement the parsing and serialization layers of the
+HTTP/2 standard as a state machine that is agnostic to the underlying I/O
+specifics. It also preserves the same API as http/af wherever possible.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.5.0/h2-0.5.0.tbz"
+  checksum: [
+    "sha256=cc7517d73b0b24425afcedd258c09d7ebb6c2c20075137cb6f6eb7b63c8e7ad3"
+    "sha512=7c36532f127194e7bac8080ac667a0d01860071d3a5bd85ebc67ec91841d494a3a048dab424747c185e4fc6ea323548c7375af895bf70b5b720ee845df8944f0"
+  ]
+}


### PR DESCRIPTION
A high-performance, memory-efficient, and scalable HTTP/2 library for for OCaml

- Project page: <a href="https://github.com/anmonteiro/ocaml-h2">https://github.com/anmonteiro/ocaml-h2</a>
- Documentation: <a href="https://anmonteiro.github.io/ocaml-h2/">https://anmonteiro.github.io/ocaml-h2/</a>

##### CHANGES:

- h2, h2-lwt, h2-lwt-unix, h2-mirage: Remove support for versions of OCaml
  lower than 4.06 ([#74](https://github.com/anmonteiro/ocaml-h2/pull/74))
- h2: Expose more information in client error handlers when initiating a
  connection ([#80](https://github.com/anmonteiro/ocaml-h2/pull/80))
- h2: Make H2.Status.t a strict superset of Httpaf.Status.t
  ([#83](https://github.com/anmonteiro/ocaml-h2/pull/83))
- h2-lwt, h2-lwt-unix: split HTTPS functions in 2: one that sets up a default
  secure connection and performs the TLS handshake / accept, and one that is
  more "raw", i.e. leaves that responsibility to the caller. Also exposes the
  `socket` type to make it easier to abstract over HTTP / HTTPS
  ([#84](https://github.com/anmonteiro/httpaf/pull/84))
- h2-lwt, h2-lwt-unix, h2-mirage: Improve the `H2_lwt.IO` interface, don't
  require a `report_exn` function, only a `state` function that returns the
  socket state ([#85](https://github.com/anmonteiro/httpaf/pull/85))
- h2, h2-lwt, h2-lwt-unix, h2-mirage: Add support for starting HTTP/2 for
  "http" URIs. Covers [section 3.2](https://tools.ietf.org/html/rfc7540#section-3.2)
  of the HTTP/2 specification
  ([#87](https://github.com/anmonteiro/httpaf/pull/87))
- h2: Fix misinterpretation of the spec where h2 would consider a request /
  response malformed if it had a non-zero `content-length` header and no DATA
  frames ([#89](https://github.com/anmonteiro/httpaf/pull/89))
- h2: Add `Request.body_length` and `Response.body_length`
  ([#90](https://github.com/anmonteiro/httpaf/pull/90))
- h2: Fix a bug that caused DATA frames to be incorrectly chunked when
  returning a streaming response
  ([#91](https://github.com/anmonteiro/httpaf/pull/91))
- h2: Drain pending bytes after getting a `Close` report from the runtime
  ([#92](https://github.com/anmonteiro/httpaf/pull/92))
- h2: Report connection errors for unknown frames that exceed the maximum
  payload size -- they may not be speaking HTTP/2
 ([#93](https://github.com/anmonteiro/httpaf/pull/93))

