### PR TITLE
0install: add upper bound on Lwt < 5.0.0

### DIFF
--- a/packages/0install/0install.2.14.1/opam
+++ b/packages/0install/0install.2.14.1/opam
@@ -13,6 +13,7 @@ depends: [
   "yojson"
   "xmlm"
   "ounit" {with-test}
+  "lwt" {< "5.0.0"}
   "lwt_react"
   "ocurl" {>= "0.7.9"}
   "sha" {>= "1.9"}

--- a/packages/0install/0install.2.14/opam
+++ b/packages/0install/0install.2.14/opam
@@ -13,6 +13,7 @@ depends: [
   "yojson"
   "xmlm"
   "ounit" {with-test}
+  "lwt" {< "5.0.0"}
   "lwt_react"
   "ocurl" {>= "0.7.9"}
   "sha" {>= "1.9"}


### PR DESCRIPTION
`0install search` doesn't work with 5.0.0. Now sure why the revdeps check didn't find this, as the unit-tests fail.