### PR TITLE
obus: add upper bounds on Lwt < 5.0.0

### DIFF
--- a/packages/obus/obus.1.1.8/opam
+++ b/packages/obus/obus.1.1.8/opam
@@ -11,7 +11,7 @@ remove: [["ocamlfind" "remove" "obus"]]
 depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
-  "lwt" {>= "2.7.0"}
+  "lwt" {>= "2.7.0" & < "5.0.0"}
   "lwt_react"
   "lwt_camlp4"
   "lwt_log"


### PR DESCRIPTION
Fails to install. Error is:

    # ocamlfind: [WARNING] Package `threads': Linking problems may arise because of the missing -thread or -vmthread switch
    # File "_none_", line 1:
    # Error: Required module `Mutex' is unavailable

/cc @Freyr666 @aantron 