### PR TITLE
[new release] mirage (3.7.4)

### DIFF
--- a/packages/mirage/mirage.3.7.4/opam
+++ b/packages/mirage/mirage.3.7.4/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria"          {>= "3.0.2"}
+  "bos"
+  "astring"
+  "logs"
+  "stdlib-shims"
+  "mirage-runtime"     {>= "3.7.0" & < "3.8.0"}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.7.4/mirage-v3.7.4.tbz"
+  checksum: [
+    "sha256=794dc4ed3a85430efd1a04a2b96a14f971aeef76716f2340e639ff0864ecb9a9"
+    "sha512=a0783f9cfd06003627c49b2ddc17a57b977966afc6e74514daa93e5de362dfdb361ec0712989da6052e54be01f4be35a1f9a6545608166fc54d855437ff7da13"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* use `git rev-parse --abbrev-ref HEAD` instead of `git branch --show-current`
  for emitting branch information into the opam file. The latter is only
  available in git 2.22 or later, while the former seems to be supported by
  old git releases. (mirage/mirage#1024, @hannesm)