### PR TITLE
[new release] ANSITerminal (0.8.2)

### DIFF
--- a/packages/ANSITerminal/ANSITerminal.0.8.2/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler"
+           "Vincent Hugot" ]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ANSITerminal"
+dev-repo: "git+https://github.com/Chris00/ANSITerminal.git"
+bug-reports: "https://github.com/Chris00/ANSITerminal/issues"
+doc: "https://Chris00.github.io/ANSITerminal/doc"
+tags: [ "terminal"  ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune"
+  "base-bytes"
+  "base-unix"
+]
+synopsis: "Basic control of ANSI compliant terminals and the windows shell"
+description: """
+ANSITerminal is a module allowing to use the colors and cursor
+movements on ANSI terminals. It also works on the windows shell (but
+this part is currently work in progress)."""
+url {
+  src:
+    "https://github.com/Chris00/ANSITerminal/releases/download/0.8.2/ANSITerminal-0.8.2.tbz"
+  checksum: [
+    "sha256=88046cc8138cc78ca0878a896e472a353bd097fbf4ad3e21e50a0798e22cc112"
+    "sha512=df6b5bc31db966a9ec79d64a5aeae50fb23cf0ecdf11b805f3dba5d99bd62667bed0e69bdc1d53f773ec08254ec65e47a6fd9f839aa962a60cf4fd84f549d85f"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- Do not check the terminal at startup for the Windows version — so it
  can be used in a continuous integration environment.