### PR TITLE
remove orphaned files (not used by opam):

### DIFF
--- a/packages/cloudi/cloudi.1.7.3/cloudi.install
+++ b/packages/cloudi/cloudi.1.7.3/cloudi.install
@@ -1,6 +1,0 @@
-lib: [
-  "erlang.cmi"
-  "cloudi.cmi"
-  "erlang.cmx"
-  "cloudi.cmx"
-]

--- a/packages/weberizer/weberizer.0.7.2/weberizer.install
+++ b/packages/weberizer/weberizer.0.7.2/weberizer.install
@@ -1,4 +1,0 @@
-bin: [
-  "?_build/src/app/weberizer_compile.byte" {"weberizer"}
-  "?_build/src/app/weberizer_compile.native" {"weberizer"}
-]


### PR DESCRIPTION
weberizer.0.7.2 refers to weberizer.install, which is present in weberizer.0.7.2/files/weberizer.install, the weberizer.0.7.2 /weberizer.install removed in this PR is unused (same content as the other copy)
cloudi.1.7.3/cloudi.install is not referenced at all