### PR TITLE
[new release] index (1.1.0)

### DIFF
--- a/packages/index/index.1.1.0/opam
+++ b/packages/index/index.1.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      [
+   "Craig Ferguson <craig@tarides.com>"
+   "Thomas Gazagnaire <thomas@tarides.com>"
+   "Ioana Cristescu <ioana@tarides.com>"
+   "Clément Pascutto <clement@tarides.com>"
+]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+doc:          "https://mirage.github.io/index/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.06.0"}
+  "dune"    {>= "1.11.0"}
+  "fmt"
+  "logs"
+  "alcotest" {with-test}
+  "crowbar" {with-test}
+  "re" {with-test}
+]
+synopsis: "A platform-agnostic multi-level index for OCaml"
+description:"""
+Index is a scalable implementation of persistent indices in OCaml.
+
+It takes an arbitrary IO implementation and user-supplied content
+types and supplies a standard key-value interface for persistent
+storage. Index provides instance sharing by default: each OCaml
+run-time shares a common singleton instance.
+
+Index supports multiple-reader/single-writer access. Concurrent access
+is safely managed using lock files."""
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.1.0/index-1.1.0.tbz"
+  checksum: [
+    "sha256=a2966d8aa7d318daea3474ca53c6f0239759ca5c966d36e084758adc49eadfef"
+    "sha512=45cff0b3665ca375dfc329faad3a598fe306e47a715ce0abf7842fd119af20591d1568b9c8779ff1a382ed089bdbdf167bf5712ae8da7d86cac9afaebafb8324"
+  ]
+}


### PR DESCRIPTION
A platform-agnostic multi-level index for OCaml

- Project page: <a href="https://github.com/mirage/index">https://github.com/mirage/index</a>
- Documentation: <a href="https://mirage.github.io/index/">https://mirage.github.io/index/</a>

##### CHANGES:

## Changed

- Improve the cooperativeness of the `merge` operation, allowing concurrent read
  operations to share CPU resources with ongoing merges. (mirage/index#152)
  
- Improve speed of read operations for read-only instances. (mirage/index#141)

## Removed

 - Remove `force_merge` from `Index.S`, due to difficulties with guaranteeing
   sensible semantics to this function under MRSW access patterns. (mirage/index#147, mirage/index#150)
