### PR TITLE
[new release] conex-nocrypto and conex (0.11.0)

### DIFF
--- a/packages/conex-nocrypto/conex-nocrypto.0.10.0/opam
+++ b/packages/conex-nocrypto/conex-nocrypto.0.10.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"
   "alcotest" {with-test}
   "cmdliner"
-  "conex" {>= "0.10.0"}
+  "conex" {= version}
   "cstruct" {>= "1.6.0" & <"5.0.0"}
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.4.0" & < "0.7.0"}

--- a/packages/conex-nocrypto/conex-nocrypto.0.10.1/opam
+++ b/packages/conex-nocrypto/conex-nocrypto.0.10.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"
   "alcotest" {with-test}
   "cmdliner"
-  "conex" {>= "0.10.0"}
+  "conex" {= version}
   "cstruct" {>= "1.6.0" & <"5.0.0"}
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.4.0" & < "0.7.0"}

--- a/packages/conex-nocrypto/conex-nocrypto.0.11.0/opam
+++ b/packages/conex-nocrypto/conex-nocrypto.0.11.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD2"
+homepage: "https://github.com/hannesm/conex"
+doc: "https://hannesm.github.io/conex/doc"
+bug-reports: "https://github.com/hannesm/conex/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune"
+  "alcotest" {with-test}
+  "cmdliner"
+  "conex" {= version}
+  "cstruct" {>= "1.6.0"}
+  "nocrypto" {>= "0.5.4"}
+  "x509" {>= "0.7.0"}
+  "logs"
+  "fmt"
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/conex.git"
+synopsis: "Establishing trust in community repositories: crypto provided via nocrypto"
+description: """
+Conex is a system based on [TUF](https://theupdateframework.github.io/) to
+establish trust in community repositories. Since opam2, the required hooks
+are present.
+
+This package uses the crypto primitives provided by nocrypto.
+"""
+url {
+  src:
+    "https://github.com/hannesm/conex/releases/download/v0.11.0/conex-v0.11.0.tbz"
+  checksum: [
+    "sha256=9b64ab189a68ebb37daed618ce0c201f082469f4b4efa8cc9099442a169d924b"
+    "sha512=30caad9a0a8d45d24933652733349e251c0e8decb6ac4c7de18fc4ae8a621865f8af5b2d02a5c9fcca0cc122e6a443ba91f2f7a350f729633923f9c1b5cf913d"
+  ]
+}

--- a/packages/conex/conex.0.11.0/opam
+++ b/packages/conex/conex.0.11.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD2"
+homepage: "https://github.com/hannesm/conex"
+doc: "https://hannesm.github.io/conex/doc"
+bug-reports: "https://github.com/hannesm/conex/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune"
+  "cmdliner"
+  "opam-file-format" {>= "2.0.0~rc2"}
+  "stdlib-shims"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/hannesm/conex.git"
+synopsis: "Establishing trust in community repositories"
+description: """
+Conex is a system based on [TUF](https://theupdateframework.github.io/) to
+establish trust in community repositories. Since opam2, the required hooks
+are present.
+
+This package uses openssl for the required crypto primitives (>=1.0.0u for RSA-PSS).
+"""
+url {
+  src:
+    "https://github.com/hannesm/conex/releases/download/v0.11.0/conex-v0.11.0.tbz"
+  checksum: [
+    "sha256=9b64ab189a68ebb37daed618ce0c201f082469f4b4efa8cc9099442a169d924b"
+    "sha512=30caad9a0a8d45d24933652733349e251c0e8decb6ac4c7de18fc4ae8a621865f8af5b2d02a5c9fcca0cc122e6a443ba91f2f7a350f729633923f9c1b5cf913d"
+  ]
+}


### PR DESCRIPTION
Establishing trust in community repositories: crypto provided via nocrypto

- Project page: <a href="https://github.com/hannesm/conex">https://github.com/hannesm/conex</a>
- Documentation: <a href="https://hannesm.github.io/conex/doc">https://hannesm.github.io/conex/doc</a>

##### CHANGES:

* Adapt to X509 0.7.0 API
* Avoid deprecation warnings by using stdlib-shims
* Adjust opam repository file locations hannesm/conex#13, now the whitelist is:
  packages/NV/opam and packages/NV/files/*
  where NV is either name.version or name/name.version
* Various fixes for diff in the real world hannesm/conex#13
