### PR TITLE
Package ppx_wideopen.0.0.1

### DIFF
--- a/packages/ppx_wideopen/ppx_wideopen.0.0.1/opam
+++ b/packages/ppx_wideopen/ppx_wideopen.0.0.1/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "ppx_deriving"
   "ppx_tools_versioned"
-  "ppxfind"
   "dune" {>= "1.2"}
   "zarith" {with-test}
 ]

--- a/packages/ppx_wideopen/ppx_wideopen.0.0.1/opam
+++ b/packages/ppx_wideopen/ppx_wideopen.0.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Ghiles Ziat <ghiles.ziat@lip6.fr>"
+authors: [
+  "Ghiles Ziat <ghiles.ziat@lip6.fr>"
+]
+homepage: "https://github.com/ghilesZ/parsley"
+bug-reports: "https://github.com/ghilesZ/parsley/issues"
+dev-repo: "git+https://github.com/ghilesZ/parsley"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_deriving"
+  "ppx_tools"
+  "ppx_tools_versioned"
+  "ppxfind"
+  "dune"
+  "zarith" {with-test}
+]
+synopsis:"Ppx_wideopen syntax extension"
+description:"Wideopen is a syntax-extension that allows you to
+  annotate an open statement in order to use a custom parsing utility
+  for OCaml's litterals. It uses by default the 'of_string' function of the
+  specified module."
+url {
+  src: "https://github.com/ghilesZ/ppx_wideopen/archive/0.0.1.tar.gz"
+  checksum: [
+    "md5=0d03ea635e6a4ea32a12b9b2384d019a"
+    "sha512=7f1d8f98dda9e57b90a7f87247bc5e03e69b41dbe6b9fcacb789e32c03b622c0e99495980dea7fcc70827f58ea3718347ca10e6cff5e47373f77ada2b83bf1bf"
+  ]
+}

--- a/packages/ppx_wideopen/ppx_wideopen.0.0.1/opam
+++ b/packages/ppx_wideopen/ppx_wideopen.0.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ppx_tools"
   "ppx_tools_versioned"
   "ppxfind"
-  "dune"
+  "dune" {>= "1.2"}
   "zarith" {with-test}
 ]
 synopsis:"Ppx_wideopen syntax extension"

--- a/packages/ppx_wideopen/ppx_wideopen.0.0.1/opam
+++ b/packages/ppx_wideopen/ppx_wideopen.0.0.1/opam
@@ -14,7 +14,6 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "ppx_deriving"
   "ppx_tools_versioned"
   "dune" {>= "1.2"}
   "zarith" {with-test}

--- a/packages/ppx_wideopen/ppx_wideopen.0.0.1/opam
+++ b/packages/ppx_wideopen/ppx_wideopen.0.0.1/opam
@@ -15,7 +15,6 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "ppx_deriving"
-  "ppx_tools"
   "ppx_tools_versioned"
   "ppxfind"
   "dune" {>= "1.2"}


### PR DESCRIPTION
### `ppx_wideopen.0.0.1`
Ppx_wideopen syntax extension
Wideopen is a syntax-extension that allows you to
  annotate an open statement in order to use a custom parsing utility
  for OCaml's litterals. It uses by default the 'of_string' function of the
  specified module.



---
* Homepage: https://github.com/ghilesZ/parsley
* Source repo: git+https://github.com/ghilesZ/parsley
* Bug tracker: https://github.com/ghilesZ/parsley/issues

---
:camel: Pull-request generated by opam-publish v2.0.0