### PR TITLE
lablgtk3 < 3.0.beta8 is incompatible with OCaml 4.10

### DIFF
--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta5/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta5/opam
@@ -17,7 +17,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 
 depends: [
-  "ocaml"                {         >= "4.05.0"    }
+  "ocaml"                {         >= "4.05.0" & < "4.10" }
   "dune"                 {         >= "1.4.0"
                                  & != "1.7.0"
                                  & != "1.7.1"     } # Due to dune/dune#1833

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
@@ -17,7 +17,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 
 depends: [
-  "ocaml"                {         >= "4.05.0"    }
+  "ocaml"                {         >= "4.05.0" & < "4.10" }
   "dune"                 {         >= "1.4.0"
                                  & != "1.7.0"
                                  & != "1.7.1"     } # Due to dune/dune#1833

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
@@ -17,7 +17,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3"
 license: "LGPL with linking exception"
 
 depends: [
-  "ocaml"                {         >= "4.05.0"    }
+  "ocaml"                {         >= "4.05.0" & < "4.10" }
   "dune"                 {         >= "1.6.0"
                                  & != "1.7.0"
                                  & != "1.7.1"     } # Due to dune/dune#1833

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta4/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta4/opam
@@ -12,7 +12,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk-sourceview"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 
 depends: [
-  "ocaml"                {         >= "4.05.0"    }
+  "ocaml"                {         >= "4.05.0" & < "4.10" }
   "dune"                 { >= "1.4.0"     }
   "lablgtk3"             {         >= "3.0.beta4" }
   "conf-gtksourceview3"  { build & >= "0"         }

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta5/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta5/opam
@@ -16,7 +16,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 
 depends: [
-  "ocaml"                {         >= "4.05.0"    }
+  "ocaml"                {         >= "4.05.0" & < "4.10" }
   "dune"                 {         >= "1.4.0"
                                  & != "1.7.0"
                                  & != "1.7.1"     } # Due to dune/dune#1833

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta6/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta6/opam
@@ -16,7 +16,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 
 depends: [
-  "ocaml"                {         >= "4.05.0"    }
+  "ocaml"                {         >= "4.05.0" & < "4.10" }
   "dune"                 {         >= "1.4.0"
                                  & != "1.7.0"
                                  & != "1.7.1"     } # Due to dune/dune#1833

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta7/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.0.beta7/opam
@@ -16,7 +16,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
 license: "LGPL with linking exception"
 
 depends: [
-  "ocaml"                {         >= "4.05.0"    }
+  "ocaml"                {         >= "4.05.0" & < "4.10" }
   "dune"                 {         >= "1.6.0"
                                  & != "1.7.0"
                                  & != "1.7.1"     } # Due to dune/dune#1833

--- a/packages/lablgtk3/lablgtk3.0.beta1/opam
+++ b/packages/lablgtk3/lablgtk3.0.beta1/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "lablgtk3"]]
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "4.10"}
   "ocamlfind" {build & >= "1.2.1"}
   "conf-gtk3" {>= "18"}
 ]

--- a/packages/lablgtk3/lablgtk3.0.beta2/opam
+++ b/packages/lablgtk3/lablgtk3.0.beta2/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "lablgtk3"]]
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "4.10"}
   "ocamlfind" {build & >= "1.2.1"}
   "conf-gtk3" {>= "18"}
 ]

--- a/packages/lablgtk3/lablgtk3.0.beta3/opam
+++ b/packages/lablgtk3/lablgtk3.0.beta3/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "lablgtk3"]]
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "4.10"}
   "ocamlfind" {build & >= "1.2.1"}
   "conf-gtk3" {>= "18"}
 ]

--- a/packages/lablgtk3/lablgtk3.3.0.beta4/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta4/opam
@@ -12,7 +12,7 @@ license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk"
 
 depends: [
-  "ocaml"     {         >= "4.05.0" }
+  "ocaml"     {         >= "4.05.0" & < "4.10" }
   "dune"      { >= "1.4.0"  }
   "dune-configurator"
   "conf-gtk3" { build & >= "18"     }

--- a/packages/lablgtk3/lablgtk3.3.0.beta5/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta5/opam
@@ -16,7 +16,7 @@ license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
-  "ocaml"     {         >= "4.05.0" }
+  "ocaml"     {         >= "4.05.0" & < "4.10" }
   "dune"      {         >= "1.4.0"
                       & != "1.7.0"
                       & != "1.7.1"  } # Due to dune/dune#1833

--- a/packages/lablgtk3/lablgtk3.3.0.beta6/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta6/opam
@@ -16,7 +16,7 @@ license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
-  "ocaml"     {         >= "4.05.0" }
+  "ocaml"     {         >= "4.05.0" & < "4.10" }
   "dune"      {         >= "1.4.0"
                       & != "1.7.0"
                       & != "1.7.1"  } # Due to dune/dune#1833

--- a/packages/lablgtk3/lablgtk3.3.0.beta7/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta7/opam
@@ -16,7 +16,7 @@ license: "LGPL with linking exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
-  "ocaml"     {         >= "4.05.0" }
+  "ocaml"     {         >= "4.05.0" & < "4.10" }
   "dune"      {         >= "1.6.0"
                       & != "1.7.0"
                       & != "1.7.1"  } # Due to dune/dune#1833


### PR DESCRIPTION
Fix in 3.0.beta8. See https://github.com/garrigue/lablgtk/issues/92