### PR TITLE
Package gnuplot.0.6

### DIFF
--- a/packages/gnuplot/gnuplot.0.6/opam
+++ b/packages/gnuplot/gnuplot.0.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "simon cruanes"
+authors: [ "Oliver Gu <gu.oliver@yahoo.com>" ]
+homepage: "https://github.com/c-cube/ocaml-gnuplot"
+bug-reports: "https://github.com/c-cube/ocaml-gnuplot/issues"
+dev-repo: "git+https://github.com/c-cube/ocaml-gnuplot.git"
+license: "LGPL-2.1+ with OCaml linking exception"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+depends: [
+  "base-unix"
+  "ISO8601"
+  "conf-gnuplot"
+  "dune" {>= "1.0"}
+  "ocaml" {>= "4.03"}
+  "odoc" {with-doc}
+]
+synopsis: "Simple interface to Gnuplot
+
+Gnuplot-OCaml provides a simple interface to Gnuplot from OCaml.
+The API supports only 2D graphs and was inspired by FnuPlot
+"
+url {
+  src: "https://github.com/c-cube/ocaml-gnuplot/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=8fe3760b78c5f9d06c295a693aaed95e"
+    "sha512=41d1c20afaa039e6f7b9fccabd2de6ed2d78b6f820878ab34822f69b5a771fb57da4ebab0da13c7ec0e48f2fdbdae5f75c9953d142fc52740462c8321a22f767"
+  ]
+}


### PR DESCRIPTION
### `gnuplot.0.6`
Simple interface to Gnuplot

Gnuplot-OCaml provides a simple interface to Gnuplot from OCaml.
The API supports only 2D graphs and was inspired by FnuPlot



---
* Homepage: https://github.com/c-cube/ocaml-gnuplot
* Source repo: git+https://github.com/c-cube/ocaml-gnuplot.git
* Bug tracker: https://github.com/c-cube/ocaml-gnuplot/issues

---
:camel: Pull-request generated by opam-publish v2.0.0