### PR TITLE
Package naboris.0.0.6

### DIFF
--- a/packages/naboris/naboris.0.0.6/opam
+++ b/packages/naboris/naboris.0.0.6/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built using httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "reason" {>= "3.4.0"}
+  "httpaf" {>= "0.6.0"}
+  "httpaf-lwt-unix" {>= "0.6.0"}
+  "lwt" {>= "4.2.1"}
+  "uri" {>= "2.2.0"}
+  "bisect_ppx" {>= "1.4.1"}
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/0.0.6.tar.gz"
+  checksum: [
+    "md5=a9363137b59904fad722142f38c8f947"
+    "sha512=8c3ac87d82549bd6d342ede4fffe4121e1e88cfef34b8e6b7e7be404a9ca02835e6aaebe6aa0ab75f50b4136e4f476b19cca04c39fc1edee843bc9991f279971"
+  ]
+}


### PR DESCRIPTION
### `naboris.0.0.6`
Simple http server
Simple http server built using httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.0