### PR TITLE
Package gobject-introspection.0.2

### DIFF
--- a/packages/gobject-introspection/gobject-introspection.0.2/opam
+++ b/packages/gobject-introspection/gobject-introspection.0.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Cédric Le Moigne <cedlemo@gmx.com>"
+authors: "Cédric Le Moigne <cedlemo@gmx.com>"
+homepage: "https://github.com/cedlemo/OCaml-GObject-Introspection"
+bug-reports: "https://github.com/cedlemo/OCaml-GObject-Introspection/issues"
+license: "GPL3"
+dev-repo: "git+https://github.com/cedlemo/OCaml-GObject-Introspection.git"
+synopsis: "OCaml bindings for the GObject-Introspection library (https://gi.readthedocs.io/en/latest/)"
+description: "This library provides bindings based on Ctypes for the libgirepository API (see https://developer.gnome.org/gi/stable/)"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.2"}
+  "ctypes"
+  "ctypes-foreign"
+  "ounit"
+  "base"
+  "stdio"
+  "configurator"
+  "conf-pkg-config" {build}
+  "conf-gobject-introspection" {build}
+  "conf-glib-2" {build}
+  "conf-gtk3" {build}
+]
+url {
+  src:
+    "https://github.com/cedlemo/OCaml-GObject-Introspection/archive/0.2.tar.gz"
+  checksum: [
+    "md5=35761efc459125e899ac653eb179999f"
+    "sha512=dec3f04c08744ddcb6d5194f97026d6b90edb03d582fb1e11767e73c9cbd71e3134d69f12426e485706b15a111037a3b096abc722da62b1dcee8d99d775c0863"
+  ]
+}


### PR DESCRIPTION
### `gobject-introspection.0.2`
OCaml bindings for the GObject-Introspection library (https://gi.readthedocs.io/en/latest/)
This library provides bindings based on Ctypes for the libgirepository API (see https://developer.gnome.org/gi/stable/)



---
* Homepage: https://github.com/cedlemo/OCaml-GObject-Introspection
* Source repo: git+https://github.com/cedlemo/OCaml-GObject-Introspection.git
* Bug tracker: https://github.com/cedlemo/OCaml-GObject-Introspection/issues

---
:camel: Pull-request generated by opam-publish v2.0.2