### PR TITLE
Package zed.2.0.4

### DIFF
--- a/packages/zed/zed.2.0.4/opam
+++ b/packages/zed/zed.2.0.4/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml-community/zed"
+bug-reports: "https://github.com/ocaml-community/zed/issues"
+dev-repo: "git://github.com/ocaml-community/zed.git"
+license: "BSD-3-Clause"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.1.0"}
+  "base-bytes"
+  "camomile" {>= "1.0.1"}
+  "react"
+  "charInfo_width" {>= "1.1.0" & < "2.0~"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Abstract engine for text edition in OCaml"
+description: """
+Zed is an abstract engine for text edition. It can be used to write text
+editors, edition widgets, readlines, ... Zed uses Camomile to fully support the
+Unicode specification, and implements an UTF-8 encoded string type with
+validation, and a rope datastructure to achieve efficient operations on large
+Unicode buffers. Zed also features a regular expression search on ropes. To
+support efficient text edition capabilities, Zed provides macro recording and
+cursor management facilities."""
+url {
+  src: "https://github.com/ocaml-community/zed/releases/download/2.0.4/zed-2.0.4.tbz"
+  checksum: "c65b4de9f1374e72a8f80cc9cf752d90"
+}


### PR DESCRIPTION
# zed
Abstract engine for text edition in OCaml

2.0.4 (2019-12-31)
------------------

* add wanted\_column support for wide width character
* Zed\_lines: `get_idx_by_width set row column_width` return the offset of the character at `[row, column_width]`