### PR TITLE
Mark various package as incompatible with OCaml 4.10

### DIFF
--- a/packages/links/links.0.9/opam
+++ b/packages/links/links.0.9/opam
@@ -17,7 +17,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "4.10"}
   "dune" {>= "1.10"}
   "dune-configurator"
   "ppx_deriving"

--- a/packages/ppxlib/ppxlib.0.7.0/opam
+++ b/packages/ppxlib/ppxlib.0.7.0/opam
@@ -14,7 +14,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml >= "4.06" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1"}
+  "ocaml"                   {>= "4.04.1" & < "4.10"}
   "base"                    {>= "v0.11.0" & < "v0.14"}
   "dune"
   "ocaml-compiler-libs"     {>= "v0.11.0"}

--- a/packages/ppxlib/ppxlib.0.8.0/opam
+++ b/packages/ppxlib/ppxlib.0.8.0/opam
@@ -14,7 +14,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml >= "4.06" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1"}
+  "ocaml"                   {>= "4.04.1" & < "4.10"}
   "base"                    {>= "v0.11.0" & < "v0.14"}
   "dune"
   "ocaml-compiler-libs"     {>= "v0.11.0"}

--- a/packages/ppxlib/ppxlib.0.8.1/opam
+++ b/packages/ppxlib/ppxlib.0.8.1/opam
@@ -14,7 +14,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.06" & ocaml:version < "4.08" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1"}
+  "ocaml"                   {>= "4.04.1" & < "4.10"}
   "base"                    {>= "v0.11.0"}
   "dune"
   "ocaml-compiler-libs"     {>= "v0.11.0"}


### PR DESCRIPTION
* `ppxlib` is already fixed
* `links` cc @SimonJF links is turning `warnings as errors` during releases. That should be avoided.