### PR TITLE
Package asli.0.1

### DIFF
--- a/packages/asli/asli.0.1/opam
+++ b/packages/asli/asli.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "linenoise"
   "menhir"
   "ocamlbuild" {build}
-  "ocamlfind"
+  "ocamlfind" {build}
   "ott"
   "pprint"
   "zarith"

--- a/packages/asli/asli.0.1/opam
+++ b/packages/asli/asli.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Interpreter for Arm's Architecture Specification Language (ASL)"
+description: """
+Interpreter for the language ASL that Arm uses to write their ISA specifications.
+
+Currently supports reading/typechecking the specification,
+interactive execution of ASL statements and expressions,
+executing opcodes one at a time,
+loading ELF files and executing Arm binaries."""
+maintainer: "Alastair Reid <alastair.d.reid@gmail.com>"
+authors: "Alastair Reid"
+license: "BSD3"
+homepage: "https://github.com/alastairreid/asl-interpreter"
+bug-reports: "https://github.com/alastairreid/asl-interpreter/issues"
+depends: [
+  "ocaml" {>= "4.09"}
+  "linenoise"
+  "menhir"
+  "ocamlfind"
+  "ott"
+  "pprint"
+  "zarith"
+  "z3" {<= "4.7.1"}
+]
+build: [make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{asli:share}%" "asli"]
+install: [make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{asli:share}%" "install"]
+remove: [
+  make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{asli:share}%" "uninstall"
+]
+dev-repo: "git+https://github.com/alastairreid/asl-interpreter.git"
+url {
+  src: "https://github.com/alastairreid/asl-interpreter/archive/0.1.tar.gz"
+  checksum: [
+    "md5=61ddc6521cdf481b774bec0dc5e82a35"
+    "sha512=b1baddfef9697933700e692a332d4ebdb791d1e294827071485d96939b22fb1594fc66b315f2692ac641287cefd418ac4897fc658817c8afc7dbc056b433be26"
+  ]
+}

--- a/packages/asli/asli.0.1/opam
+++ b/packages/asli/asli.0.1/opam
@@ -16,6 +16,7 @@ depends: [
   "ocaml" {>= "4.09"}
   "linenoise"
   "menhir"
+  "ocamlbuild" {build}
   "ocamlfind"
   "ott"
   "pprint"

--- a/packages/asli/asli.0.1/opam
+++ b/packages/asli/asli.0.1/opam
@@ -25,9 +25,6 @@ depends: [
 ]
 build: [make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{asli:share}%" "asli"]
 install: [make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{asli:share}%" "install"]
-remove: [
-  make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{asli:share}%" "uninstall"
-]
 dev-repo: "git+https://github.com/alastairreid/asl-interpreter.git"
 url {
   src: "https://github.com/alastairreid/asl-interpreter/archive/0.1.tar.gz"


### PR DESCRIPTION
### `asli.0.1`
Interpreter for Arm's Architecture Specification Language (ASL)
Interpreter for the language ASL that Arm uses to write their ISA specifications.

Currently supports reading/typechecking the specification,
interactive execution of ASL statements and expressions,
executing opcodes one at a time,
loading ELF files and executing Arm binaries.



---
* Homepage: https://github.com/alastairreid/asl-interpreter
* Source repo: git+https://github.com/alastairreid/asl-interpreter.git
* Bug tracker: https://github.com/alastairreid/asl-interpreter/issues

---
:camel: Pull-request generated by opam-publish v2.0.2