### PR TITLE
6 packages from andersfugmann/ppx_protocol_conv at 5.1.0

### DIFF
--- a/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "base"
+  "dune" {>= "1.2"}
+  "ppxlib" {>= "0.9.0"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis:
+  "Ppx for generating serialisation and de-serialisation functions of ocaml types"
+description: """
+Ppx_protocol_conv generates code to serialize and de-serialize
+types. The ppx itself does not contain any protocol specific code,
+but relies on 'drivers' that defines serialisation and
+de-serialisation of basic types and structures.
+
+Pre-defined drivers are available in separate packages:
+ppx_protocol_conv_json (Yojson.Safe.json)
+ppx_protocol_conv_jsonm (Ezjson.value)
+ppx_protocol_conv_msgpack (Msgpck.t)
+ppx_protocol_conv_xml-light (Xml.xml)
+ppx_protocol_conv_yaml (Yaml.value)"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.1.0.tar.gz"
+  checksum: [
+    "md5=5eddd4cc3ef4fce45dacc1add7f82ff7"
+    "sha512=f947bfb488b62114b765c8479ae06818c6823ca8be14c454273f09d9390cb405be7add78953291cfc3a9ffbcc79418c57b35144136c17f4c458ab52be8185ed4"
+  ]
+}

--- a/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.5.1.0/opam
+++ b/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.5.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {= version}
+  "yojson" {>= "1.5.0" & < "2.0.0"}
+  "dune" {>= "1.2"}
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Json driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for json (Yojson.Safe.json)
+serialization and de-serialization using the yojson library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.1.0.tar.gz"
+  checksum: [
+    "md5=5eddd4cc3ef4fce45dacc1add7f82ff7"
+    "sha512=f947bfb488b62114b765c8479ae06818c6823ca8be14c454273f09d9390cb405be7add78953291cfc3a9ffbcc79418c57b35144136c17f4c458ab52be8185ed4"
+  ]
+}

--- a/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.5.1.0/opam
+++ b/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.5.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "ppx_protocol_conv" {= version}
+  "ezjsonm"
+  "dune" {>= "1.2"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Jsonm driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for json (Ezjson.value)
+serialization and de-serialization using the Ezjson library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.1.0.tar.gz"
+  checksum: [
+    "md5=5eddd4cc3ef4fce45dacc1add7f82ff7"
+    "sha512=f947bfb488b62114b765c8479ae06818c6823ca8be14c454273f09d9390cb405be7add78953291cfc3a9ffbcc79418c57b35144136c17f4c458ab52be8185ed4"
+  ]
+}

--- a/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.5.1.0/opam
+++ b/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.5.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {= version}
+  "msgpck"
+  "dune" {>= "1.2"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "MessagePack driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for message pack (Msgpck.t)
+serialization and deserialization using the msgpck library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.1.0.tar.gz"
+  checksum: [
+    "md5=5eddd4cc3ef4fce45dacc1add7f82ff7"
+    "sha512=f947bfb488b62114b765c8479ae06818c6823ca8be14c454273f09d9390cb405be7add78953291cfc3a9ffbcc79418c57b35144136c17f4c458ab52be8185ed4"
+  ]
+}

--- a/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.5.1.0/opam
+++ b/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.5.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {= version}
+  "xml-light"
+  "dune" {>= "1.2"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Xml driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for xml (Xml.t) serialization and
+de-serialization using the xml-light library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.1.0.tar.gz"
+  checksum: [
+    "md5=5eddd4cc3ef4fce45dacc1add7f82ff7"
+    "sha512=f947bfb488b62114b765c8479ae06818c6823ca8be14c454273f09d9390cb405be7add78953291cfc3a9ffbcc79418c57b35144136c17f4c458ab52be8185ed4"
+  ]
+}

--- a/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.5.1.0/opam
+++ b/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.5.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2"}
+  "ppx_protocol_conv" {= version}
+  "yaml" { >= "2.0.0"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Json driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for yaml (Yaml.value)
+serialization and de-serialization using the Yaml"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.1.0.tar.gz"
+  checksum: [
+    "md5=5eddd4cc3ef4fce45dacc1add7f82ff7"
+    "sha512=f947bfb488b62114b765c8479ae06818c6823ca8be14c454273f09d9390cb405be7add78953291cfc3a9ffbcc79418c57b35144136c17f4c458ab52be8185ed4"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ppx_protocol_conv.5.1.0`: Ppx for generating serialisation and de-serialisation functions of ocaml types
-`ppx_protocol_conv_json.5.1.0`: Json driver for Ppx_protocol_conv
-`ppx_protocol_conv_jsonm.5.1.0`: Jsonm driver for Ppx_protocol_conv
-`ppx_protocol_conv_msgpack.5.1.0`: MessagePack driver for Ppx_protocol_conv
-`ppx_protocol_conv_xml_light.5.1.0`: Xml driver for Ppx_protocol_conv
-`ppx_protocol_conv_yaml.5.1.0`: Json driver for Ppx_protocol_conv



---
* Homepage: https://github.com/andersfugmann/ppx_protocol_conv
* Source repo: git+https://github.com/andersfugmann/ppx_protocol_conv
* Bug tracker: https://github.com/andersfugmann/ppx_protocol_conv/issues

---
:camel: Pull-request generated by opam-publish v2.0.0