### PR TITLE
Package naboris.0.0.7

### DIFF
--- a/packages/naboris/naboris.0.0.7/opam
+++ b/packages/naboris/naboris.0.0.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built on httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "reason" {>= "3.4.0"}
+  "httpaf" {>= "0.6.0"}
+  "httpaf-lwt-unix" {>= "0.6.0"}
+  "lwt" {>= "4.2.1"}
+  "uri" {>= "2.2.0"}
+  "bisect_ppx" {>= "1.4.1"}
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/0.0.7.tar.gz"
+  checksum: [
+    "md5=d6ec42aa4d58041da143f99cf4c60081"
+    "sha512=001f13f14587812e4a8288124f6cc6306fc7f4a74ede01f4bc7ab57f848aa27f7c642e070d4928c1654491b4c14f8227edb78f1033f23f3ac1a35d795fca49dc"
+  ]
+}


### PR DESCRIPTION
### `naboris.0.0.7`
Simple http server
Simple http server built on httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.0