### PR TITLE
Package naboris.1.0.0

### DIFF
--- a/packages/naboris/naboris.1.0.0/opam
+++ b/packages/naboris/naboris.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built on httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build}
+  "reason" {>= "3.4.0"}
+  "httpaf" {>= "0.6.0"}
+  "httpaf-lwt-unix" {>= "0.6.0"}
+  "lwt" {>= "4.2.1"}
+  "uri" {>= "2.2.0"}
+  "bisect_ppx" {>= "1.4.1"}
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/1.0.0.tar.gz"
+  checksum: [
+    "md5=d7cf46f1c62f20ac18b157b418c6214f"
+    "sha512=fd4870a2472a8f640c3f912da2c71fdcd3c7a94cd1d353a7a648b4f188ef7e4a2877a0c22b1abae8bef6128d8c5e8111fec203288fe6374552052617ec8991f5"
+  ]
+}


### PR DESCRIPTION
### `naboris.1.0.0`
Simple http server
Simple http server built on httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.0