### PR TITLE
Package naboris.0.0.8

### DIFF
--- a/packages/naboris/naboris.0.0.8/opam
+++ b/packages/naboris/naboris.0.0.8/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built on httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {build}
+  "reason" {>= "3.4.0"}
+  "httpaf" {>= "0.6.0"}
+  "httpaf-lwt-unix" {>= "0.6.0"}
+  "lwt" {>= "4.2.1"}
+  "uri" {>= "2.2.0"}
+  "bisect_ppx" {build}
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/0.0.8.tar.gz"
+  checksum: [
+    "md5=696fba999dd624d1b023020fd58e7588"
+    "sha512=0867c1d883ef40ec19e6f7045ab784a04d3fb068d0449d3a5cb21f00918f75e07222d56d98077ab067d3d3c5c561c4c37dde94c693a55b22de2f0de251014875"
+  ]
+}


### PR DESCRIPTION
### `naboris.0.0.8`
Simple http server
Simple http server built on httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.0