### PR TITLE
Lwt 5.1.1 - promises and concurrent I/O

### DIFF
--- a/packages/lwt/lwt.5.1.1/opam
+++ b/packages/lwt/lwt.5.1.1/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+
+version: "5.1.1"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.7.0"}
+  "dune-configurator"
+  "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0"}
+  "ocplib-endian"
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  "bisect_ppx" {dev & >= "1.3.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+post-messages: [
+  "Lwt 5.0.0 has made some minor breaking changes. See
+  https://github.com/ocsigen/lwt/issues/584"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.1.1.tar.gz"
+  checksum: "md5=4ddec0f42b7aa4a310175a14c47c60a3"
+}


### PR DESCRIPTION
Bugs fixed

- Exception raised by [`Lwt_main.run`](https://github.com/ocsigen/lwt/blob/8d8f63423b42ddd705918ae26ba3bb41b2582a82/src/unix/lwt_main.mli#L10-L43) upon call to `exit` (ocsigen/lwt#758, reported Gal Schlezinger).