### PR TITLE
async_websocket.v0.13.1

### DIFF
--- a/packages/async_websocket/async_websocket.v0.13.1/opam
+++ b/packages/async_websocket/async_websocket.v0.13.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_websocket"
+bug-reports: "https://github.com/janestreet/async_websocket/issues"
+dev-repo: "git+https://github.com/janestreet/async_websocket.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/async_websocket/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "async" {>= "v0.13" & < "v0.14"}
+  "core_kernel" {>= "v0.13" & < "v0.14"}
+  "ppx_jane" {>= "v0.13" & < "v0.14"}
+  "cryptokit"
+  "dune"  {>= "1.5.1"}
+]
+synopsis: "A library that implements the websocket protocol on top of Async"
+description: "
+This library implements both the server and client side of 
+                the websocket protocol.
+"
+url {
+  src: "https://ocaml.janestreet.com/ocaml-core/v0.13/files/async_websocket-v0.13.0.tar.gz"
+  checksum: "md5=754df4fbcf767270c84f988812250541"
+}

--- a/packages/async_websocket/async_websocket.v0.13.1/opam
+++ b/packages/async_websocket/async_websocket.v0.13.1/opam
@@ -23,6 +23,6 @@ This library implements both the server and client side of
                 the websocket protocol.
 "
 url {
-  src: "https://ocaml.janestreet.com/ocaml-core/v0.13/files/async_websocket-v0.13.0.tar.gz"
-  checksum: "md5=754df4fbcf767270c84f988812250541"
+  src: "https://github.com/janestreet/async_websocket/archive/v0.13.1.tar.gz"
+  checksum: "md5=1e04c3b110456826a05865bba8561496"
 }


### PR DESCRIPTION
This release fixes a problem with metadata
(no public package in the previous version).