### PR TITLE
Constrain various packages not compatible with OCaml 4.10

### DIFF
--- a/packages/lens/lens.1.2.0/opam
+++ b/packages/lens/lens.1.2.0/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "lens"]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.10"}
   "ocamlfind" {build}
   "ounit" {build}
   "ocamlbuild" {build}

--- a/packages/lens/lens.1.2.1/opam
+++ b/packages/lens/lens.1.2.1/opam
@@ -13,7 +13,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.10"}
   "ppx_deriving" {build}
   "ppx_tools" {build}
   "ppxfind" {build}

--- a/packages/lens/lens.1.2.2/opam
+++ b/packages/lens/lens.1.2.2/opam
@@ -11,7 +11,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.10"}
   "ppx_deriving" {build}
   "ppx_tools" {build}
   "ppxfind" {build}

--- a/packages/lens/lens.1.2.3/opam
+++ b/packages/lens/lens.1.2.3/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.10"}
   "ppx_deriving" {build}
   "ppx_tools" {build}
   "ppxfind" {build}

--- a/packages/linwrap/linwrap.0.0.1/opam
+++ b/packages/linwrap/linwrap.0.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "dolog" {>= "4.0.0"}
   "dune" {>= "1.10"}
   "minicli"
-  "parany"
+  "parany" {>= "6.0.0"}
   "conf-liblinear-tools"
 ]
 synopsis: "Wrapper around liblinear-tools"

--- a/packages/mlcuddidl/mlcuddidl.3.0.4/opam
+++ b/packages/mlcuddidl/mlcuddidl.3.0.4/opam
@@ -19,7 +19,7 @@ remove: [
   ["ocamlfind" "remove" "cudd"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "4.10"}
   "ocamlfind"  {build}
   "camlidl"    {build}
   "ocamlbuild" {build}

--- a/packages/mlcuddidl/mlcuddidl.3.0.5/opam
+++ b/packages/mlcuddidl/mlcuddidl.3.0.5/opam
@@ -16,7 +16,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "4.10"}
   "ocamlfind"  {build}
   "camlidl"    {build}
   "ocamlbuild" {build}

--- a/packages/orpie/orpie.1.6.0/opam
+++ b/packages/orpie/orpie.1.6.0/opam
@@ -7,7 +7,7 @@ license: "GPL-3.0-only"
 dev-repo: "git+https://github.com/pelzlpj/orpie.git"
 build: ["dune" "build" "-p" "orpie"]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.10"}
   "camlp5" {build}
   "dune" {>= "1.1"}
   "curses" {>= "1.0.3"}

--- a/packages/override/override.0.2.2/opam
+++ b/packages/override/override.0.2.2/opam
@@ -18,6 +18,7 @@ PPX extensions [%%override], [%%import], [%%include] and [%%rewrite] to import
 and change module interfaces.
 """
 depends: [
+  "ocaml" {< "4.10"}
   "dune" {>= "1.10.0"}
   "ppxlib" {>= "0.9.0"}
   "stdcompat" {>= "9"}

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.0.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.0.0/opam
@@ -15,7 +15,7 @@ build: [
   "native-dynlink=%{ocaml:native-dynlink}%"
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.10"}
   "cmdliner"
   "result"
   "ppx_deriving" {>= "4.0" & < "4.3"}

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.2.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.2.0/opam
@@ -15,7 +15,7 @@ build: [
   "native-dynlink=%{ocaml:native-dynlink}%"
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.10"}
   "cmdliner"
   "result"
   "ppx_deriving" {>= "4.0" & < "4.3"}

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.3.1/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.3.1/opam
@@ -15,7 +15,7 @@ build: [
   "native-dynlink=%{ocaml:native-dynlink}%"
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.10"}
   "cmdliner" {>= "1.0.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "4.3"}

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.4.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.4.0/opam
@@ -15,7 +15,7 @@ build: [
   "native-dynlink=%{ocaml:native-dynlink}%"
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.10"}
   "cmdliner" {>= "1.0.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "4.3"}

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.4.1/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.4.1/opam
@@ -22,7 +22,7 @@ run-test: [
   ["jbuilder" "runtest" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "4.10"}
   "cmdliner" {>= "1.0.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}


### PR DESCRIPTION
* cc @pdonadeo for `lens`
* cc @UnixJunkie for `linwrap` (it's actually just a constraint fix but might as well)
* cc @pelzlpj for `orpie`
* cc @smondet for `ppx_deriving_cmdliner`
* cc @nberth for `mlcuddidl`
* cc @thierry-martinez for `override`

The reason for each breakage is stated in each commit messages.