### PR TITLE
added packages/linwrap/linwrap.2.0.0

### DIFF
--- a/packages/linwrap/linwrap.2.0.0/opam
+++ b/packages/linwrap/linwrap.2.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/linwrap"
+bug-reports: "https://github.com/UnixJunkie/linwrap/issues"
+dev-repo: "git+https://github.com/UnixJunkie/linwrap.git"
+license: "BSD-3"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "base-unix"
+  "batteries"
+  "cpm"
+  "dolog" {>= "4.0.0"}
+  "dune" {>= "1.10"}
+  "minicli"
+  "parany" {>= "6.0.0"}
+  "conf-liblinear-tools"
+  "dokeysto_camltc"
+]
+synopsis: "Wrapper around liblinear-tools"
+description: """
+Only L2-regularized logistic regression is supported currently.
+Each model is trained on balanced bootstraps from the training set
+(one bootstrap for the positive class, one for the negative class).
+The size of the bootstrap is the size of the smallest (under-represented)
+class. Bagging is supported and allows to obtain better models.
+
+usage: linwrap
+  -i <filename>: training set or DB to screen
+  [-o <filename>]: predictions output file
+  [-np <int>]: ncores
+  [-c <float>]: fix C
+  [-w <float>]: fix w1
+  [-k <int>]: number of bags for bagging (default=off)
+  [-n <int>]: folds of cross validation
+  [--seed <int>]: fix random seed
+  [-p <float>]: training set portion (in [0.0:1.0])
+  [{-l|--load} <filename>]: prod. mode; use trained models
+  [{-s|--save} <filename>]: train. mode; save trained models
+  [--scan-c]: scan for best C
+  [--scan-w]: scan weight to counter class imbalance
+  [--scan-k]: scan number of bags (advice: optim. k rather than w)
+"""
+url {
+  src: "https://github.com/UnixJunkie/linwrap/archive/v2.0.0.tar.gz"
+  checksum: "md5=ac460ea9915a488bc56d0acf9d966b04"
+}


### PR DESCRIPTION
Bug correction (out of mem) on large datasets.

There is a new dependency (dokeysto_camltc) to circumvent the bug; hence a new major release.
