### PR TITLE
[new release] dune-build-info, dune, dune-configurator, dune-action-plugin, dune-private-libs and dune-glob (2.1.2)

### DIFF
--- a/packages/dune-action-plugin/dune-action-plugin.2.1.2/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.1.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-glob"
+  "ppx_expect" {with-test}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.1.2/dune-2.1.2.tbz"
+  checksum: [
+    "sha256=9c3278ebb3ec14dc4b1880671371985edcd6cbb979260dd403f28acabbcc5faf"
+    "sha512=ab2d4a3817fbbe80de6a1fd8052c607e6f08489dd8f3b1f18f2a79260c8793472b4dfbfec232fc517d473f1d893ac3f797fdf35366c2d031c899a7db07097ee6"
+  ]
+}

--- a/packages/dune-build-info/dune-build-info.2.1.2/opam
+++ b/packages/dune-build-info/dune-build-info.2.1.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Embed build informations inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.1.2/dune-2.1.2.tbz"
+  checksum: [
+    "sha256=9c3278ebb3ec14dc4b1880671371985edcd6cbb979260dd403f28acabbcc5faf"
+    "sha512=ab2d4a3817fbbe80de6a1fd8052c607e6f08489dd8f3b1f18f2a79260c8793472b4dfbfec232fc517d473f1d893ac3f797fdf35366c2d031c899a7db07097ee6"
+  ]
+}

--- a/packages/dune-configurator/dune-configurator.2.1.2/opam
+++ b/packages/dune-configurator/dune-configurator.2.1.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.1.2/dune-2.1.2.tbz"
+  checksum: [
+    "sha256=9c3278ebb3ec14dc4b1880671371985edcd6cbb979260dd403f28acabbcc5faf"
+    "sha512=ab2d4a3817fbbe80de6a1fd8052c607e6f08489dd8f3b1f18f2a79260c8793472b4dfbfec232fc517d473f1d893ac3f797fdf35366c2d031c899a7db07097ee6"
+  ]
+}

--- a/packages/dune-glob/dune-glob.2.1.2/opam
+++ b/packages/dune-glob/dune-glob.2.1.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.1.2/dune-2.1.2.tbz"
+  checksum: [
+    "sha256=9c3278ebb3ec14dc4b1880671371985edcd6cbb979260dd403f28acabbcc5faf"
+    "sha512=ab2d4a3817fbbe80de6a1fd8052c607e6f08489dd8f3b1f18f2a79260c8793472b4dfbfec232fc517d473f1d893ac3f797fdf35366c2d031c899a7db07097ee6"
+  ]
+}

--- a/packages/dune-private-libs/dune-private-libs.2.1.2/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.1.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.07"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.1.2/dune-2.1.2.tbz"
+  checksum: [
+    "sha256=9c3278ebb3ec14dc4b1880671371985edcd6cbb979260dd403f28acabbcc5faf"
+    "sha512=ab2d4a3817fbbe80de6a1fd8052c607e6f08489dd8f3b1f18f2a79260c8793472b4dfbfec232fc517d473f1d893ac3f797fdf35366c2d031c899a7db07097ee6"
+  ]
+}

--- a/packages/dune/dune.2.1.2/opam
+++ b/packages/dune/dune.2.1.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "base-unix"
+  "base-threads"
+]
+conflicts: [
+  "odoc" {< "1.3.0"}
+  "dune-release" {< "1.3.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.1.2/dune-2.1.2.tbz"
+  checksum: [
+    "sha256=9c3278ebb3ec14dc4b1880671371985edcd6cbb979260dd403f28acabbcc5faf"
+    "sha512=ab2d4a3817fbbe80de6a1fd8052c607e6f08489dd8f3b1f18f2a79260c8793472b4dfbfec232fc517d473f1d893ac3f797fdf35366c2d031c899a7db07097ee6"
+  ]
+}


### PR DESCRIPTION
Embed build informations inside executable

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- Fix a bug in the `Fiber.finalize` function of the concurrency monad of Dune,
  causing a race condition at the user level (ocaml/dune#3009, fix ocaml/dune#2958, @diml)
