### PR TITLE
Make dune.2.1.1 availble to OCaml < 4.07

### DIFF
--- a/packages/dune/dune.2.1.1/opam
+++ b/packages/dune/dune.2.1.1/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "ocaml" {>= "4.07"}
+  ("ocaml" {>= "4.07"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]


### PR DESCRIPTION
I basically reused the constraint from dune.2.0.1 as it seems it is working fine for this version but I might have gotten it wrong.

My understanding is that without this change opam doesn't know it has to fallback to building dune with a secondary compiler if you're using ocaml < 4.07.