### PR TITLE
Add lower bound on Logs in Index

### DIFF
--- a/packages/index/index.1.0.0/opam
+++ b/packages/index/index.1.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml"   {>= "4.06.0"}
   "dune"    {>= "1.11.0"}
   "fmt"
-  "logs"
+  "logs"    {>= "0.7.0"}
   "alcotest" {with-test}
   "crowbar" {with-test}
   "re" {with-test}

--- a/packages/index/index.1.0.1/opam
+++ b/packages/index/index.1.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml"   {>= "4.06.0"}
   "dune"    {>= "1.11.0"}
   "fmt"
-  "logs"
+  "logs"    {>= "0.7.0"}
   "alcotest" {with-test}
   "crowbar" {with-test}
   "re" {with-test}

--- a/packages/index/index.1.1.0/opam
+++ b/packages/index/index.1.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml"   {>= "4.06.0"}
   "dune"    {>= "1.11.0"}
   "fmt"
-  "logs"
+  "logs"    {>= "0.7.0"}
   "alcotest" {with-test}
   "crowbar" {with-test}
   "re" {with-test}


### PR DESCRIPTION
Index relies on the optional module `Logs_threaded`, which was introduced in `Logs.0.7.0`. The corresponding PR in `mirage/index` is https://github.com/mirage/index/pull/156.