### PR TITLE
Add ocaml-src.4.10.0~beta1

### DIFF
--- a/packages/ocaml-src/ocaml-src.4.10.0~beta1/files/META
+++ b/packages/ocaml-src/ocaml-src.4.10.0~beta1/files/META
@@ -1,0 +1,1 @@
+version = "4.10.0~beta1"

--- a/packages/ocaml-src/ocaml-src.4.10.0~beta1/opam
+++ b/packages/ocaml-src/ocaml-src.4.10.0~beta1/opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: "OCaml contributors"
+homepage: "http://ocaml.org/"
+install: ["cp" "-r" "." "%{lib}%/ocaml-src"]
+synopsis: "Compiler sources"
+depends: [
+  "ocaml" {= "4.10.0"}
+]
+extra-files: ["META" "md5=23ef2e01a78f781316159f1d774449c0"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.0+beta1.tar.gz"
+  checksum: "sha256=b881ea32c9db6b555bfa4c88f8c6ad14a4fcbf57e00a66e87a576adb4477ecb4"
+}


### PR DESCRIPTION
This is a draft for now as it would be the first time ocaml-src gets a beta version and I'm not its maintainer, @hannesm what do you think? This would unlock a lot of mirage packages without the use of this opam overlay: https://github.com/kit-ty-kate/opam-alpha-repository/ But I'm not too sure about adding a beta version to the repository so maybe it's not a good idea? Should we restrict to `ocaml-variants.4.10.0+beta1` or something like that?