### PR TITLE
[new release] msgpck and msgpck-repr (1.5)

### DIFF
--- a/packages/msgpck-repr/msgpck-repr.1.5/opam
+++ b/packages/msgpck-repr/msgpck-repr.1.5/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+name: "msgpck-repr"
+version: "1.3"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+synopsis: "Interface between msgpck and ocplib-json-typed"
+homepage: "https://github.com/vbmithr/ocaml-msgpck"
+license: "ISC"
+dev-repo: "git+https://github.com/vbmithr/ocaml-msgpck.git"
+bug-reports: "https://github.com/vbmithr/ocaml-msgpck/issues"
+depends: [
+  "dune" {build & >= "1.0"}
+  "msgpck" {= version}
+  "ocplib-json-typed" {>= "0.6"}
+  "ocaml" { >= "4.02.0" }
+]
+build:[ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-msgpck/releases/download/1.5/msgpck-1.5.tbz"
+  checksum: [
+    "sha256=cba190c7ca1c92932fb9d305eacc9153b3e7fca7c6a6c88bd3a4f6cae7f206e6"
+    "sha512=4f5cd67c62dbe529fb19443710ab9995557195e579a0b1130a3d74d1f2015ddd8b8ed2f6a98e05168495e31b8dd8695f42a2cc3b23a9e19a58464d70245e230e"
+  ]
+}

--- a/packages/msgpck/msgpck.1.5/opam
+++ b/packages/msgpck/msgpck.1.5/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "msgpck"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-msgpck"
+license: "ISC"
+dev-repo: "git+https://github.com/vbmithr/ocaml-msgpck.git"
+bug-reports: "https://github.com/vbmithr/ocaml-msgpck/issues"
+doc: "https://vbmithr.github.io/ocaml-msgpck/doc"
+tags: ["messagepack" "msgpack" "binary" "serialization"]
+depends: [
+  "dune" {build & >= "1.11.4"}
+  "ocplib-endian" {>= "1.0"}
+  "ocaml" { >= "4.08.0" }
+]
+build:[ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Fast MessagePack (http://msgpack.org) library"
+description: """
+msgpck is written in pure OCaml.
+
+MessagePack is an efficient binary serialization format. It lets you
+exchange data among multiple languages like JSON. But it's faster and
+smaller. Small integers are encoded into a single byte, and typical
+short strings require only one extra byte in addition to the strings
+themselves."""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-msgpck/releases/download/1.5/msgpck-1.5.tbz"
+  checksum: [
+    "sha256=cba190c7ca1c92932fb9d305eacc9153b3e7fca7c6a6c88bd3a4f6cae7f206e6"
+    "sha512=4f5cd67c62dbe529fb19443710ab9995557195e579a0b1130a3d74d1f2015ddd8b8ed2f6a98e05168495e31b8dd8695f42a2cc3b23a9e19a58464d70245e230e"
+  ]
+}


### PR DESCRIPTION
Fast MessagePack (http://msgpack.org) library

- Project page: <a href="https://github.com/vbmithr/ocaml-msgpck">https://github.com/vbmithr/ocaml-msgpck</a>
- Documentation: <a href="https://vbmithr.github.io/ocaml-msgpck/doc">https://vbmithr.github.io/ocaml-msgpck/doc</a>

##### CHANGES:

* compile in dev mode (removed dead code and unused variables)
* add optional `Msgpck_repr` module compatible with `ocplib-json-typed`
* tests: switch to alcotest
* add compare and equal functions
* bugfix: uint64 were previously written as int64
