### PR TITLE
[new release] msgpck and msgpck-repr (1.5)

### DIFF
--- a/packages/msgpck-repr/msgpck-repr.1.5/opam
+++ b/packages/msgpck-repr/msgpck-repr.1.5/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "msgpck-repr"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-msgpck"
+license: "ISC"
+dev-repo: "git+https://github.com/vbmithr/ocaml-msgpck.git"
+bug-reports: "https://github.com/vbmithr/ocaml-msgpck/issues"
+depends: [
+  "dune" {build & >= "1.11.4"}
+  "msgpck" {= version}
+  "ocplib-json-typed" {>= "0.7.1"}
+  "ocaml" { >= "4.08.0" }
+]
+build:[ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Fast MessagePack (http://msgpack.org) library -- ocplib-json-typed interface"
+description: """
+Interface between msgpck and ocplib-json-typed.
+"""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-msgpck/releases/download/1.5/msgpck-1.5.tbz"
+  checksum: [
+    "sha256=c29b85458c6ce1ed141877ebe15d71f7d0c6051a2890f5157b242b3eb6b570a0"
+    "sha512=96e1cd55b2e68d082b48b760beb7efcb48b481f75a65778ba498f79c879cea7a2841aea3b0fb49284131ae9a9558faa7589e4b02b8959094be755ed1872ba850"
+  ]
+}

--- a/packages/msgpck-repr/msgpck-repr.1.5/opam
+++ b/packages/msgpck-repr/msgpck-repr.1.5/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "msgpck-repr"
 maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
 authors: "Vincent Bernardoff <vb@luminar.eu.org>"
 homepage: "https://github.com/vbmithr/ocaml-msgpck"
@@ -7,7 +6,7 @@ license: "ISC"
 dev-repo: "git+https://github.com/vbmithr/ocaml-msgpck.git"
 bug-reports: "https://github.com/vbmithr/ocaml-msgpck/issues"
 depends: [
-  "dune" {build & >= "1.11.4"}
+  "dune" {>= "1.11.4"}
   "msgpck" {= version}
   "ocplib-json-typed" {>= "0.7.1"}
   "ocaml" { >= "4.08.0" }

--- a/packages/msgpck/msgpck.1.5/opam
+++ b/packages/msgpck/msgpck.1.5/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "msgpck"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-msgpck"
+license: "ISC"
+dev-repo: "git+https://github.com/vbmithr/ocaml-msgpck.git"
+bug-reports: "https://github.com/vbmithr/ocaml-msgpck/issues"
+doc: "https://vbmithr.github.io/ocaml-msgpck/doc"
+tags: ["messagepack" "msgpack" "binary" "serialization"]
+depends: [
+  "dune" {build & >= "1.11.4"}
+  "ocplib-endian" {>= "1.0"}
+  "ocaml" { >= "4.08.0" }
+]
+build:[ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Fast MessagePack (http://msgpack.org) library"
+description: """
+msgpck is written in pure OCaml.
+
+MessagePack is an efficient binary serialization format. It lets you
+exchange data among multiple languages like JSON. But it's faster and
+smaller. Small integers are encoded into a single byte, and typical
+short strings require only one extra byte in addition to the strings
+themselves."""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-msgpck/releases/download/1.5/msgpck-1.5.tbz"
+  checksum: [
+    "sha256=c29b85458c6ce1ed141877ebe15d71f7d0c6051a2890f5157b242b3eb6b570a0"
+    "sha512=96e1cd55b2e68d082b48b760beb7efcb48b481f75a65778ba498f79c879cea7a2841aea3b0fb49284131ae9a9558faa7589e4b02b8959094be755ed1872ba850"
+  ]
+}

--- a/packages/msgpck/msgpck.1.5/opam
+++ b/packages/msgpck/msgpck.1.5/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "msgpck"
 maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
 authors: "Vincent Bernardoff <vb@luminar.eu.org>"
 homepage: "https://github.com/vbmithr/ocaml-msgpck"
@@ -9,7 +8,7 @@ bug-reports: "https://github.com/vbmithr/ocaml-msgpck/issues"
 doc: "https://vbmithr.github.io/ocaml-msgpck/doc"
 tags: ["messagepack" "msgpack" "binary" "serialization"]
 depends: [
-  "dune" {build & >= "1.11.4"}
+  "dune" {>= "1.11.4"}
   "ocplib-endian" {>= "1.0"}
   "ocaml" { >= "4.08.0" }
 ]


### PR DESCRIPTION
Fast MessagePack (http://msgpack.org) library

- Project page: <a href="https://github.com/vbmithr/ocaml-msgpck">https://github.com/vbmithr/ocaml-msgpck</a>
- Documentation: <a href="https://vbmithr.github.io/ocaml-msgpck/doc">https://vbmithr.github.io/ocaml-msgpck/doc</a>

##### CHANGES:

* use Buffer's binary encodings of integers (>= 4.08.0)
* bugfix: 32 bits architecture now working as well
* bugfix: fix computation of size for the Bytes type
