### PR TITLE
Package naboris.0.1.0

### DIFF
--- a/packages/naboris/naboris.0.1.0/opam
+++ b/packages/naboris/naboris.0.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built on httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6"}
+  "reason" {>= "3.4.0"}
+  "httpaf" {>= "0.6.0"}
+  "httpaf-lwt-unix" {>= "0.6.0"}
+  "lwt" {>= "4.2.1"}
+  "uri" {>= "2.2.0"}
+  "bisect_ppx" {dev}
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=b6b8897cc613beb3166f947a8a45284b"
+    "sha512=aa858f845ec217b6fea65d06167d50f2ab51300a0c45a1fc7124771ccb1d770c30903ad6de40e1f4fc62be9702a11b33ad599fca2b1ca715fb6fd9bcff944623"
+  ]
+}


### PR DESCRIPTION
### `naboris.0.1.0`
Simple http server
Simple http server built on httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.0