### PR TITLE
Package naboris.0.0.8

### DIFF
--- a/packages/naboris/naboris.0.0.8/opam
+++ b/packages/naboris/naboris.0.0.8/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built on httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6"}
+  "reason" {>= "3.4.0"}
+  "httpaf" {>= "0.6.0"}
+  "httpaf-lwt-unix" {>= "0.6.0"}
+  "lwt" {>= "4.2.1"}
+  "uri" {>= "2.2.0"}
+  "bisect_ppx" {dev}
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=68517cecc0d98293b9b4a44afa316d79"
+    "sha512=ad87a311112bd755f2de86f1846e9de477ee3589956a1ff20fd384787b70fecd1da191983b891591d10dc0ce847e861ef529054152bf741dabfad8999a9a3024"
+  ]
+}


### PR DESCRIPTION
### `naboris.0.0.8`
Simple http server
Simple http server built on httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.0