### PR TITLE
Package naboris.0.1.0

### DIFF
--- a/packages/naboris/naboris.0.1.0/opam
+++ b/packages/naboris/naboris.0.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built on httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6"}
+  "reason" {>= "3.4.0"}
+  "httpaf" {>= "0.6.0"}
+  "httpaf-lwt-unix" {>= "0.6.0"}
+  "lwt" {>= "4.2.1"}
+  "uri" {>= "2.2.0"}
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=28e6b49e0dbc0b6ff988babcb79f6e68"
+    "sha512=db4b65483de06b1bdab2740be878a8a4fc356490fae19af4e433f18df0872169842f5241aee0cb339bebf6dce129b72ff7e0d28fff8bdfeb542f2680cacb18e5"
+  ]
+}


### PR DESCRIPTION
### `naboris.0.1.0`
Simple http server
Simple http server built on httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.0