### PR TITLE
Fix license of fstar and kremlin.

### DIFF
--- a/packages/fstar/fstar.0.9.0/opam
+++ b/packages/fstar/fstar.0.9.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "protz@microsoft.com"
 authors: "Nik Swamy <nswamy@microsoft.com>"
 homepage: "http://fstar-lang.org"
-license: "Apache-1.0+"
+license: "Apache-2.0"
 depends: [
   "ocaml" {>= "4.02.1" & < "4.06.0"}
   "ocamlfind"

--- a/packages/fstar/fstar.0.9.1.1/opam
+++ b/packages/fstar/fstar.0.9.1.1/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "protz@microsoft.com"
 authors: "Nik Swamy <nswamy@microsoft.com>"
 homepage: "http://fstar-lang.org"
-license: "Apache-1.0+"
+license: "Apache-2.0"
 depends: [
   "ocaml" {>= "4.02.1" & < "4.06.0"}
   "ocamlfind"

--- a/packages/fstar/fstar.0.9.2.0/opam
+++ b/packages/fstar/fstar.0.9.2.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "protz@microsoft.com"
 authors: "Nik Swamy <nswamy@microsoft.com>"
 homepage: "http://fstar-lang.org"
-license: "Apache-1.0+"
+license: "Apache-2.0"
 depends: [
   "ocaml" {>= "4.02.1" & < "4.06.0"}
   "ocamlfind"

--- a/packages/fstar/fstar.0.9.3.0-beta1/opam
+++ b/packages/fstar/fstar.0.9.3.0-beta1/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "protz@microsoft.com"
 authors: "Nik Swamy <nswamy@microsoft.com>"
 homepage: "http://fstar-lang.org"
-license: "Apache-1.0+"
+license: "Apache-2.0"
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
   "ocamlfind"

--- a/packages/fstar/fstar.0.9.4.0-beta0/opam
+++ b/packages/fstar/fstar.0.9.4.0-beta0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "protz@microsoft.com"
 authors: "Nik Swamy <nswamy@microsoft.com>"
 homepage: "http://fstar-lang.org"
-license: "Apache-1.0+"
+license: "Apache-2.0"
 depends: [
   "ocaml" {>= "4.02.3" & < "4.05.0"}
   "ocamlfind"

--- a/packages/fstar/fstar.0.9.5.0/opam
+++ b/packages/fstar/fstar.0.9.5.0/opam
@@ -3,7 +3,7 @@ version: "0.9.5.0"
 maintainer: "taramana@microsoft.com"
 authors: "Nik Swamy <nswamy@microsoft.com>,Jonathan Protzenko <protz@microsoft.com>,Tahina Ramananandro <taramana@microsoft.com>"
 homepage: "http://fstar-lang.org"
-license: "Apache-1.0+"
+license: "Apache-2.0"
 depends: [
   "ocaml" {>= "4.02.3" & (< "4.03.0" | >= "4.04.0" & < "4.07.0")}
   "ocamlfind"

--- a/packages/fstar/fstar.0.9.6.0/opam
+++ b/packages/fstar/fstar.0.9.6.0/opam
@@ -3,7 +3,7 @@ version: "0.9.6.0"
 maintainer: "taramana@microsoft.com"
 authors: "Nik Swamy <nswamy@microsoft.com>,Jonathan Protzenko <protz@microsoft.com>,Tahina Ramananandro <taramana@microsoft.com>"
 homepage: "http://fstar-lang.org"
-license: "Apache-1.0+"
+license: "Apache-2.0"
 depends: [
   "ocaml" {>= "4.04.0" & < "4.08.0"}
   "ocamlfind"

--- a/packages/fstar/fstar.0.9.6.0~alpha1/opam
+++ b/packages/fstar/fstar.0.9.6.0~alpha1/opam
@@ -3,7 +3,7 @@ version: "0.9.6.0~alpha1"
 maintainer: "taramana@microsoft.com"
 authors: "Nik Swamy <nswamy@microsoft.com>,Jonathan Protzenko <protz@microsoft.com>,Tahina Ramananandro <taramana@microsoft.com>"
 homepage: "http://fstar-lang.org"
-license: "Apache-1.0+"
+license: "Apache-2.0"
 depends: [
   "ocaml" {>= "4.04.0" & < "4.07.0"}
   "ocamlfind" {build}

--- a/packages/fstar/fstar.0.9.7.0-alpha1/opam
+++ b/packages/fstar/fstar.0.9.7.0-alpha1/opam
@@ -3,7 +3,7 @@ version: "0.9.7.0-alpha1"
 maintainer: "taramana@microsoft.com"
 authors: "Nik Swamy <nswamy@microsoft.com>,Jonathan Protzenko <protz@microsoft.com>,Tahina Ramananandro <taramana@microsoft.com>"
 homepage: "http://fstar-lang.org"
-license: "Apache-1.0+"
+license: "Apache-2.0"
 depends: [
   "ocaml" {>= "4.04.0" & < "4.08.0"}
   "ocamlfind"

--- a/packages/kremlin/kremlin.0.9.6.0/opam
+++ b/packages/kremlin/kremlin.0.9.6.0/opam
@@ -3,7 +3,7 @@ version: "0.9.6.0"
 maintainer: "protz@microsoft.com"
 authors: "Jonathan Protzenko <jonathan.protzenko@gmail.com>"
 homepage: "https://github.com/fstarlang/kremlin"
-license: "Apache-1.0+"
+license: "Apache-2.0"
 depends: [
   "ocaml" {>= "4.04.0" & < "4.07.0"}
   "ocamlfind" {build}


### PR DESCRIPTION
They are incorrectly classified as Apache-1.0+ during SPDX License Identifier normalization.

References:
https://github.com/FStarLang/FStar/blob/master/LICENSE
https://github.com/FStarLang/kremlin/blob/master/LICENSE