### PR TITLE
[new release] irmin-indexeddb (2.0)

### DIFF
--- a/packages/irmin-indexeddb/irmin-indexeddb.2.0/opam
+++ b/packages/irmin-indexeddb/irmin-indexeddb.2.0/opam
@@ -8,6 +8,7 @@ homepage: "https://github.com/talex5/irmin-indexeddb"
 bug-reports: "https://github.com/talex5/irmin-indexeddb/issues"
 depends: [
   "ocaml" {>= "4.5.0"}
+  "dune" {>= "1.11"}
   "base64" {>= "3.0.0"}
   "irmin" {>= "2.0.0"}
   "irmin-git" {with-test}

--- a/packages/irmin-indexeddb/irmin-indexeddb.2.0/opam
+++ b/packages/irmin-indexeddb/irmin-indexeddb.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "irmin-indexeddb"
+synopsis: "Irmin backend using the web-browser's IndexedDB store"
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "ISC"
+homepage: "https://github.com/talex5/irmin-indexeddb"
+bug-reports: "https://github.com/talex5/irmin-indexeddb/issues"
+depends: [
+  "ocaml" {>= "4.5.0"}
+  "base64" {>= "3.0.0"}
+  "irmin" {>= "2.0.0"}
+  "irmin-git" {with-test}
+  "cstruct" {>= "1.7.0"}
+  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "git"
+  "lwt"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+dev-repo: "git+https://github.com/talex5/irmin-indexeddb.git"
+doc: "https://talex5.github.io/irmin-indexeddb/"
+description: """
+This is an Irmin backend that stores the data in the web-browser's IndexedDB store.
+For more information, see <http://roscidus.com/blog/blog/2015/06/22/cuekeeper-internals-irmin/>
+"""
+url {
+  src:
+    "https://github.com/talex5/irmin-indexeddb/releases/download/v2.0/irmin-indexeddb-v2.0.tbz"
+  checksum: [
+    "sha256=9397a500f5a3f83270921d95f861af0da6174d68516ce3fade725b13428ba41d"
+    "sha512=34d24e9eb04cd025e9b83b33a55d0341553f536593a837638e1ff8b75053b9ca5144466b9604a03d1d8bc99f33c34f8ae600d926fbe0b31e74230f78c3337f8c"
+  ]
+}


### PR DESCRIPTION
Irmin backend using the web-browser's IndexedDB store

- Project page: <a href="https://github.com/talex5/irmin-indexeddb">https://github.com/talex5/irmin-indexeddb</a>
- Documentation: <a href="https://talex5.github.io/irmin-indexeddb/">https://talex5.github.io/irmin-indexeddb/</a>

##### CHANGES:

Update to Irmin 2.0 API. This way that stores are constructed has changed in Irmin 2.0.
Now, irmin-indexeddb just provides the raw contents and branch stores and the application
uses these to create a full Irmin store. This means that you can use irmin-indexeddb to
create either Git-format or Irmin-format stores, and you can avoid a dependency on irmin-git
if you don't need Git-format stores.

For Irmin format, use e.g.:

```ocaml
module I = Irmin.Make(Irmin_indexeddb.Content_store)(Irmin_indexeddb.Branch_store)
    (Irmin.Metadata.None)(Irmin.Contents.String)
    (Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA256)
```

For a Git format store, use:

```ocaml
module I = Irmin_git.Generic(Irmin_indexeddb.Content_store)(Irmin_indexeddb.Branch_store)
    (Irmin.Contents.String)(Irmin.Path.String_list)(Irmin.Branch.String)
```

If you have an existing database created by an older version of
irmin-indexeddb, then you *must* create a Git-format store.
