### PR TITLE
lablqml.0.6.2: Fix installation (dune install uses ocamlfind)

### DIFF
--- a/packages/lablqml/lablqml.0.6.2/opam
+++ b/packages/lablqml/lablqml.0.6.2/opam
@@ -18,7 +18,7 @@ install: [make "install"]
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "ocamlfind" {with-test}
+  "ocamlfind" {build}
   "dune" {>= "1.0"}
   "configurator" {build & < "v0.14"}
   "conf-qt" {>= "5.2.1"}


### PR DESCRIPTION
cc @FardaleM @Kakadu 

The installation fails when ocamlfind is not installed in the current switch but can be found elsewhere. This is because `dune install` used by `make install` uses ocamlfind to detect the destination.