### PR TITLE
LablTk 8.06.8 and OCamlBrowser 4.10.0

### DIFF
--- a/packages/labltk/labltk.8.06.8/opam
+++ b/packages/labltk/labltk.8.06.8/opam
@@ -12,7 +12,6 @@ build: [
 install: [
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "labltk"]]
 depends: [
   "ocaml" {>= "4.07"}
   "ocamlfind" {build}
@@ -25,7 +24,6 @@ post-messages: [
 synopsis: "OCaml interface to Tcl/Tk"
 description: "ocamlbrowser is now a separate package.\n\
              For details, see https://garrigue.github.io/labltk/"
-flags: light-uninstall
 url {
   src: "https://github.com/garrigue/labltk/archive/8.06.8.tar.gz"
   checksum: "md5=ec4e7ed25f0938a9b6f9207d15e1f982"

--- a/packages/labltk/labltk.8.06.8/opam
+++ b/packages/labltk/labltk.8.06.8/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "http://labltk.forge.ocamlcore.org/"
+bug-reports: "https://github.com/garrigue/labltk/issues"
+dev-repo: "git+https://github.com/garrigue/labltk.git"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "-use-findlib" "-verbose" "-installbindir" bin]
+  [make "library" "opt"]
+]
+install: [
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "labltk"]]
+depends: [
+  "ocaml" {>= "4.07"}
+  "ocamlfind" {build}
+  "conf-tcl"
+  "conf-tk"
+]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]
+synopsis: "OCaml interface to Tcl/Tk"
+description: "ocamlbrowser is now a separate package.\n\
+             For details, see https://garrigue.github.io/labltk/"
+flags: light-uninstall
+url {
+  src: "https://github.com/garrigue/labltk/archive/8.06.8.tar.gz"
+  checksum: "md5=ec4e7ed25f0938a9b6f9207d15e1f982"
+}

--- a/packages/ocamlbrowser/ocamlbrowser.4.10.0/opam
+++ b/packages/ocamlbrowser/ocamlbrowser.4.10.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "http://labltk.forge.ocamlcore.org/"
+bug-reports: "https://github.com/garrigue/labltk/issues"
+dev-repo: "git+https://github.com/garrigue/labltk.git"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "-use-findlib" "-installbindir" bin]
+  [make "all"]
+]
+install: [
+  [make "install-browser"]
+]
+remove: [["rm" "-f" "%{bin}%/ocamlbrowser"]]
+depends: [
+  "ocaml" {>= "4.10" & < "4.11"}
+  "labltk" {= "8.06.8"}
+  "ocamlfind" {build}
+  "conf-tcl"
+  "conf-tk"
+]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]
+synopsis: "OCamlBrowser Library Explorer"
+description: "Require LablTk. For details, see https://forge.ocamlcore.org/projects/labltk/"
+flags: light-uninstall
+url {
+  src: "https://github.com/garrigue/labltk/archive/8.06.8.tar.gz"
+  checksum: "md5=ec4e7ed25f0938a9b6f9207d15e1f982"
+}

--- a/packages/ocamlbrowser/ocamlbrowser.4.10.0/opam
+++ b/packages/ocamlbrowser/ocamlbrowser.4.10.0/opam
@@ -12,7 +12,6 @@ build: [
 install: [
   [make "install-browser"]
 ]
-remove: [["rm" "-f" "%{bin}%/ocamlbrowser"]]
 depends: [
   "ocaml" {>= "4.10" & < "4.11"}
   "labltk" {= "8.06.8"}
@@ -25,7 +24,6 @@ post-messages: [
 ]
 synopsis: "OCamlBrowser Library Explorer"
 description: "Require LablTk. For details, see https://forge.ocamlcore.org/projects/labltk/"
-flags: light-uninstall
 url {
   src: "https://github.com/garrigue/labltk/archive/8.06.8.tar.gz"
   checksum: "md5=ec4e7ed25f0938a9b6f9207d15e1f982"


### PR DESCRIPTION
New version of OCamlBrowser for OCaml 4.10.0.

The changes are only in OCamlBrowser, but update also LablTk since they share the same archive.