### PR TITLE
Package lua-ml.0.9.1

### DIFF
--- a/packages/lua-ml/lua-ml.0.9.1/opam
+++ b/packages/lua-ml/lua-ml.0.9.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "An embeddable Lua 2.5 interpreter implemented in OCaml"
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: [
+  "Norman Ramsey <nr@cs.tufts.edu>"
+  "Christian Lindig <lindig@gmail.com>"
+]
+license: "Two-clause BSD"
+homepage: "https://github.com/lindig/lua-ml"
+bug-reports: "https://github.com/lindig/lua-ml/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "ocamlbuild"
+  "ocamlfind"
+]
+build:
+  [ make "lib" ]
+url {
+  src: "https://github.com/lindig/lua-ml/archive/0.9.1.tar.gz"
+  checksum: [
+    "md5=1010207b8c419a7b95a927d0d56c9171"
+    "sha512=5cb56cd96dbfae42835b3f10f275753685575472ace518e351e62e50a01c07a510203be21644fd3429680b926ecd9905d4dca1e101b762c442f7c6dc00b0f0ae"
+  ]
+}


### PR DESCRIPTION
### `lua-ml.0.9.1`
An embeddable Lua 2.5 interpreter implemented in OCaml



---
* Homepage: https://github.com/lindig/lua-ml
* Bug tracker: https://github.com/lindig/lua-ml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0