### PR TITLE
[new release] alcotest-lwt, alcotest and alcotest-async (1.0.0)

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.0.0/opam
+++ b/packages/alcotest-async/alcotest-async.1.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:  "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "git+https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "async_unix" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0"}
+]
+
+synopsis: "Async-based helpers for Alcotest"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.0.0/alcotest-1.0.0.tbz"
+  checksum: [
+    "sha256=ddabff1722ddef4a521c89b9572b9d06f2440d89169db806bea848cb218d83a8"
+    "sha512=3c9dffbb5064cf3e9995110628c7fdf466651e9e022addc8eb1c79585863112a195c254994eb8f8384e183c9e2d9c946e28dcd4b1cac7ca48114a478de2362c0"
+  ]
+}

--- a/packages/alcotest-async/alcotest-async.1.0.0/opam
+++ b/packages/alcotest-async/alcotest-async.1.0.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.11"}
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}
   "async_unix" {>= "v0.9.0"}

--- a/packages/alcotest-lwt/alcotest-lwt.1.0.0/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:  "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "git+https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "lwt" "logs"
+]
+
+synopsis: "Lwt-based helpers for Alcotest"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.0.0/alcotest-1.0.0.tbz"
+  checksum: [
+    "sha256=ddabff1722ddef4a521c89b9572b9d06f2440d89169db806bea848cb218d83a8"
+    "sha512=3c9dffbb5064cf3e9995110628c7fdf466651e9e022addc8eb1c79585863112a195c254994eb8f8384e183c9e2d9c946e28dcd4b1cac7ca48114a478de2362c0"
+  ]
+}

--- a/packages/alcotest-lwt/alcotest-lwt.1.0.0/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.0.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.11"}
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}
   "lwt" "logs"

--- a/packages/alcotest/alcotest.1.0.0/opam
+++ b/packages/alcotest/alcotest.1.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:  "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "git+https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune"  {>= "1.1.0"}
+  "ocaml" {>= "4.03.0"}
+  "fmt"   {>= "0.8.0"}
+  "astring"
+  "cmdliner"
+  "uuidm"
+  "re"
+  "stdlib-shims"
+]
+
+synopsis: "Alcotest is a lightweight and colourful test framework"
+
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.0.0/alcotest-1.0.0.tbz"
+  checksum: [
+    "sha256=ddabff1722ddef4a521c89b9572b9d06f2440d89169db806bea848cb218d83a8"
+    "sha512=3c9dffbb5064cf3e9995110628c7fdf466651e9e022addc8eb1c79585863112a195c254994eb8f8384e183c9e2d9c946e28dcd4b1cac7ca48114a478de2362c0"
+  ]
+}

--- a/packages/alcotest/alcotest.1.0.0/opam
+++ b/packages/alcotest/alcotest.1.0.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune"  {>= "1.1.0"}
+  "dune"  {>= "1.11"}
   "ocaml" {>= "4.03.0"}
   "fmt"   {>= "0.8.0"}
   "astring"

--- a/packages/base64/base64.3.2.0/opam
+++ b/packages/base64/base64.3.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.0.1"}
   "bos" {with-test}
   "rresult" {with-test}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
 ]
 build: [
   ["dune" "subst"]

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.1/opam
@@ -20,7 +20,7 @@ depends: [
   "base64" {<"3.0.0"}
   "mirage-dns" {< "4.0.0"}
   "mirage-stack-lwt"
-  "alcotest-lwt" {with-test}
+  "alcotest-lwt" {with-test & < "1.0.0"}
   "io-page-unix" {with-test}
   "tcpip" {with-test & <"3.5.0"}
   "mirage-vnetif" {with-test}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.2/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.2/opam
@@ -19,7 +19,7 @@ depends: [
   "arp-mirage"
   "mirage-dns" {< "4.0.0"}
   "mirage-stack-lwt"
-  "alcotest-lwt" {with-test}
+  "alcotest-lwt" {with-test & < "1.0.0"}
   "io-page-unix" {with-test}
   "tcpip" {with-test}
   "mirage-vnetif" {with-test}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.3/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3.3/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-dns"
   "mirage-stack-lwt"
   "base64" {>= "3.0.0"}
-  "alcotest-lwt" {with-test}
+  "alcotest-lwt" {with-test & < "1.0.0"}
   "io-page-unix" {with-test}
   "tcpip" {with-test}
   "mirage-vnetif" {with-test}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.3/opam
@@ -20,7 +20,7 @@ depends: [
   "ipaddr" {<"3.0.0"}
   "base64" {<"3.0.0"}
   "mirage-stack-lwt"
-  "alcotest-lwt" {with-test}
+  "alcotest-lwt" {with-test & < "1.0.0"}
   "io-page-unix" {with-test}
   "tcpip" {with-test & <"3.5.0"}
   "mirage-vnetif" {with-test}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.4.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-dns"
   "mirage-stack-lwt"
   "base64" {>= "3.0.0"}
-  "alcotest-lwt" {with-test}
+  "alcotest-lwt" {with-test & < "1.0.0"}
   "io-page-unix" {with-test}
   "tcpip" {with-test}
   "mirage-vnetif" {with-test}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.5.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.5.0/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-dns"
   "mirage-stack-lwt"
   "base64" {>= "3.0.0"}
-  "alcotest-lwt" {with-test}
+  "alcotest-lwt" {with-test & < "1.0.0"}
   "io-page-unix" {with-test}
   "tcpip" {with-test}
   "mirage-vnetif" {with-test}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.2/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.2/opam
@@ -20,7 +20,7 @@ depends: [
   "fmt" {>= "0.8.4"}
   "logs"
   "dune" {>= "1.0"}
-  "alcotest-lwt" {with-test & >= "0.8.0"}
+  "alcotest-lwt" {with-test & >= "0.8.0" & < "1.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.3/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.3.3/opam
@@ -20,7 +20,7 @@ depends: [
   "logs"
   "base64" {>= "3.0.0"}
   "dune" {>= "1.0"}
-  "alcotest-lwt" {with-test & >= "0.8.0"}
+  "alcotest-lwt" {with-test & >= "0.8.0" & < "1.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.4.0/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "logs"
   "base64" {>= "3.0.0"}
   "dune" {>= "1.0"}
-  "alcotest-lwt" {with-test & >= "0.8.0"}
+  "alcotest-lwt" {with-test & >= "0.8.0" & < "1.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.5.0/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.5.0/opam
@@ -19,7 +19,7 @@ depends: [
   "logs"
   "base64" {>= "3.0.0"}
   "dune" {>= "1.0"}
-  "alcotest-lwt" {with-test & >= "0.8.0"}
+  "alcotest-lwt" {with-test & >= "0.8.0" & < "1.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/current/current.0.1/opam
+++ b/packages/current/current.0.1/opam
@@ -34,7 +34,7 @@ depends: [
   "dune" {>= "1.9"}
   "re"
   "lwt-dllist"
-  "alcotest-lwt" {with-test}
+  "alcotest-lwt" {with-test & < "1.0.0"}
 ]
 url {
   src:

--- a/packages/digestif/digestif.0.7.1/opam
+++ b/packages/digestif/digestif.0.7.1/opam
@@ -40,7 +40,7 @@ depends: [
   "base-bytes"
   "base-bigarray"
   "fmt"            {with-test}
-  "alcotest"       {with-test}
+  "alcotest"       {with-test & < "1.0.0"}
 ]
 
 depopts: [

--- a/packages/digestif/digestif.0.7.2/opam
+++ b/packages/digestif/digestif.0.7.2/opam
@@ -40,7 +40,7 @@ depends: [
   "base-bytes"
   "base-bigarray"
   "fmt"            {with-test}
-  "alcotest"       {with-test}
+  "alcotest"       {with-test & < "1.0.0"}
 ]
 
 depopts: [

--- a/packages/digestif/digestif.0.7.3/opam
+++ b/packages/digestif/digestif.0.7.3/opam
@@ -37,7 +37,7 @@ depends: [
   "base-bytes"
   "base-bigarray"
   "fmt"            {with-test}
-  "alcotest"       {with-test}
+  "alcotest"       {with-test & < "1.0.0"}
 ]
 
 depopts: [

--- a/packages/digestif/digestif.0.7.4/opam
+++ b/packages/digestif/digestif.0.7.4/opam
@@ -36,7 +36,7 @@ depends: [
   "base-bytes"
   "bigarray-compat"
   "fmt"            {with-test}
-  "alcotest"       {with-test}
+  "alcotest"       {with-test & < "1.0.0"}
 ]
 
 depopts: [

--- a/packages/digestif/digestif.0.7/opam
+++ b/packages/digestif/digestif.0.7/opam
@@ -44,7 +44,7 @@ depends: [
   "base-bytes"
   "base-bigarray"
   "fmt"            {with-test}
-  "alcotest"       {with-test}
+  "alcotest"       {with-test & < "1.0.0"}
 ]
 conflicts: [
   "eqaf" {= "0.3"}

--- a/packages/digestif/digestif.0.8.0/opam
+++ b/packages/digestif/digestif.0.8.0/opam
@@ -38,7 +38,7 @@ depends: [
   "bigarray-compat"
   "stdlib-shims"
   "fmt"            {with-test}
-  "alcotest"       {with-test}
+  "alcotest"       {with-test & < "1.0.0"}
 ]
 
 depopts: [

--- a/packages/graphql_parser/graphql_parser.0.11.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.11.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
   "menhir" {build}
-  "alcotest" {with-test & >= "0.8.1"}
+  "alcotest" {with-test & >= "0.8.1" & < "1.0.0"}
   "fmt" {< "0.8.6"} # Due to implicit result constraint
   "re" {>= "1.5.0"}
 ]

--- a/packages/icalendar/icalendar.0.1.0/opam
+++ b/packages/icalendar/icalendar.0.1.0/opam
@@ -22,7 +22,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune"
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "fmt"
   "angstrom"
   "re"

--- a/packages/icalendar/icalendar.0.1.1/opam
+++ b/packages/icalendar/icalendar.0.1.1/opam
@@ -22,7 +22,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune"
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "fmt"
   "angstrom"
   "re"

--- a/packages/icalendar/icalendar.0.1.2/opam
+++ b/packages/icalendar/icalendar.0.1.2/opam
@@ -22,7 +22,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune"
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "fmt"
   "angstrom"
   "re"

--- a/packages/icalendar/icalendar.0.1.3/opam
+++ b/packages/icalendar/icalendar.0.1.3/opam
@@ -22,7 +22,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.3"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "fmt"
   "angstrom"
   "re"

--- a/packages/irmin-chunk/irmin-chunk.1.3.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.1.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt"
   "irmin" {with-test & < "1.4.0"}
   "irmin-mem" {with-test & >= "1.3.0" & < "2.0.0"}
-  "alcotest" {with-test & >= "0.4.1"}
+  "alcotest" {with-test & >= "0.4.1" & < "1.0.0"}
   "mtime" {with-test}
 ]
 synopsis: "Irmin backend to store raw contents into chunks"

--- a/packages/irmin-fs/irmin-fs.1.3.0/opam
+++ b/packages/irmin-fs/irmin-fs.1.3.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "irmin" {>= "1.3.0" & < "2.0.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "mtime" {with-test & >= "1.0.0"}
 ]
 synopsis: "Generic file-system backend for Irmin"

--- a/packages/irmin-mem/irmin-mem.1.3.0/opam
+++ b/packages/irmin-mem/irmin-mem.1.3.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "irmin" {>= "1.3.0" & < "2.0.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.0.0"}
   "mtime" {with-test & >= "1.0.0"}
 ]
 synopsis: "In-memory backend for Irmin"

--- a/packages/logtk/logtk.1.5.1/opam
+++ b/packages/logtk/logtk.1.5.1/opam
@@ -15,7 +15,7 @@ depends: [
   "iter" { >= "1.2" }
   "menhir" {build}
   "dune" { >= "1.1" }
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "qcheck-core" {with-test & >= "0.9"}
   "qcheck-alcotest" {with-test & >= "0.9"}
   "ocaml" {>= "4.03"}

--- a/packages/minicaml/minicaml.0.3.3/opam
+++ b/packages/minicaml/minicaml.0.3.3/opam
@@ -20,7 +20,7 @@ depends: [
     "menhir"
     "ppx_deriving"
     "cmdliner"
-    "alcotest" {with-test & >= "0.8.5"}
+    "alcotest" {with-test & >= "0.8.5" & < "1.0.0"}
     "bisect_ppx" {with-test >= "1.4.1"}
 ]
 url {

--- a/packages/owl/owl.0.3.7/opam
+++ b/packages/owl/owl.0.3.7/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "base" {build & < "v0.14"}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}

--- a/packages/owl/owl.0.3.8/opam
+++ b/packages/owl/owl.0.3.8/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "base" {build & < "v0.14"}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}

--- a/packages/owl/owl.0.4.0/opam
+++ b/packages/owl/owl.0.4.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "base" {build & < "v0.14"}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}

--- a/packages/owl/owl.0.5.0/opam
+++ b/packages/owl/owl.0.5.0/opam
@@ -23,7 +23,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "base" {build & < "v0.14"}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}

--- a/packages/resp-unix/resp-unix.0.9.1/opam
+++ b/packages/resp-unix/resp-unix.0.9.1/opam
@@ -14,8 +14,8 @@ depends:
     "resp-client" {>= "0.9.1"}
     "resp-server" {>= "0.9.1"}
     "conduit-lwt-unix" {>= "1.3"}
-    "alcotest" {with-test}
-    "alcotest-lwt" {with-test}
+    "alcotest" {with-test & < "1.0.0"}
+    "alcotest-lwt" {with-test & < "1.0.0"}
 ]
 
 build:

--- a/packages/resp-unix/resp-unix.0.9/opam
+++ b/packages/resp-unix/resp-unix.0.9/opam
@@ -14,8 +14,8 @@ depends:
     "resp-client" {>= "0.9"}
     "resp-server" {>= "0.9"}
     "conduit-lwt-unix" {>= "1.3"}
-    "alcotest" {with-test}
-    "alcotest-lwt" {with-test}
+    "alcotest" {with-test & < "1.0.0"}
+    "alcotest-lwt" {with-test & < "1.0.0"}
 ]
 
 build:

--- a/packages/rpclib/rpclib.5.9.0/opam
+++ b/packages/rpclib/rpclib.5.9.0/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "jbuilder"
   "cmdliner"
   "rresult"

--- a/packages/rpclib/rpclib.6.0.0/opam
+++ b/packages/rpclib/rpclib.6.0.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0" < "4.10.0"}
   "jbuilder"
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "cmdliner"
   "rresult"
   "xmlm"

--- a/packages/rpclib/rpclib.6.1.0/opam
+++ b/packages/rpclib/rpclib.6.1.0/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-rpc/rpclib"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "dune" {>= "1.5.0"}
   "cmdliner"
   "rresult"

--- a/packages/rpclib/rpclib.7.0.0/opam
+++ b/packages/rpclib/rpclib.7.0.0/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-rpc/rpclib"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "dune" {>= "1.5.0"}
   "cmdliner"
   "rresult"

--- a/packages/yuscii/yuscii.0.2.0/opam
+++ b/packages/yuscii/yuscii.0.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "uutf"
   "rresult"
   "cmdliner"
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
 ]
 synopsis: "[Yuscii](https://en.wikipedia.org/wiki/YUSCII)"
 description: """

--- a/packages/yuscii/yuscii.0.2.1/opam
+++ b/packages/yuscii/yuscii.0.2.1/opam
@@ -22,7 +22,7 @@ depends: [
   "uutf"
   "rresult"
   "cmdliner"
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
 ]
 url {
   src:


### PR DESCRIPTION
**alcotest**: Alcotest is a lightweight and colourful test framework
**alcotest-async**: Async-based helpers for Alcotest
**alcotest-lwt**: Lwt-based helpers for Alcotest

- Project page: <a href="https://github.com/mirage/alcotest/">https://github.com/mirage/alcotest/</a>
- Documentation: <a href="https://mirage.github.io/alcotest/">https://mirage.github.io/alcotest/</a>

##### CHANGES:

- Require OCaml 4.03. (mirage/alcotest#159, @hannesm)
- Change `Alcotest_{async,lwt}.test_case` to return monadic values. These must
  be run with the new `Alcotest_{async,lwt}.run` functions. See
  [examples/lwt/test.ml](https://github.com/mirage/alcotest/blob/878c500f3b25f6ebbdafc7236ebc2b7756dafe9d/examples/lwt/test.ml#L85)
  for an example of the new API. (mirage/alcotest#167, @CraigFe)
- Add generation of `latest` symlinks in the `_test` directory which point to
  the most recent test output directory. (mirage/alcotest#155, @cfcs)
- Allow all CLI options to be passed directly to `Alcotest.{run,run_with_args}`
  without use of the `argv` parameter. (mirage/alcotest#182, @CraigFe)
- Add `--compact` option for more concise result reporting. (mirage/alcotest#149,
  @andersfugmann)
- Add `--tail-errors` option for limiting the size of error logs printed to
  standard output. (mirage/alcotest#200, @mjambon)
- Add support for executing subsets of tests via the `test` subcommand. (mirage/alcotest#158,
  @CraigFe)
- Change the `float` check to include equality of `isNaN` and infinities. See
  [examples/floats.ml](https://github.com/mirage/alcotest/blob/47908b1f576d65f4418bcf778d2a1db213f5a7ff/examples/floats.ml)
  for demonstrations of the new semantics. (mirage/alcotest#152, @psafont)
- Reject test suites with colliding output directories. (mirage/alcotest#176, @CraigFe)
- Restrict the set of characters allowed in test names to alphanumerics,
  hyphens, underscores and spaces. (mirage/alcotest#161, @CraigFe)
- Fix a race condition on creating output directories. (mirage/alcotest#150, @edwintorok)
- Report test suite durations in real time rather than system time. (mirage/alcotest#162,
  @CraigFe)
- Improve documentation of the `?argv` parameter. (mirage/alcotest#164, @ian-barnes)
- Remove version number from test binary help pages. (mirage/alcotest#186, @CraigFe)
- Remove dependency on `tput`. (mirage/alcotest#189, @samoht)
- Remove result dependency. (mirage/alcotest#159, @hannesm)
- Remove uses of deprecated `Pervasives.compare`. (mirage/alcotest#173, @CraigFe)
