### PR TITLE
Package ppx_monoid.0.3.2

### DIFF
--- a/packages/ppx_monoid/ppx_monoid.0.3.2/opam
+++ b/packages/ppx_monoid/ppx_monoid.0.3.2/opam
@@ -43,7 +43,7 @@ dev-repo: "git+https://github.com/bobatkey/ppx-monoid.git"
 url {
   src: "https://github.com/bobatkey/ppx-monoid/archive/0.3.2.tar.gz"
   checksum: [
-    "md5=40edc2ad9c393750db750d73fad5ecee"
-    "sha512=43d42e52fe1233110b6ce658310f0312c2bca13b70e303f70fcee3c863aa8e41b8c92cec83aa9ec507a5f1e3d7b981be0dfb1d1bc87bfa3d2ae11051eaadcbef"
+    "md5=de413a86ef336834a30e9f53c6794d81"
+    "sha512=3b594411e424c2db7d3c3edf62fb1ac04f0a24b3aaf20f9df47eaa43fc696b72ec0b66ee94f824a1c5148bf93fe133c605430fe5e7ddf2df5e694ca4ec7724a8"
   ]
 }

--- a/packages/ppx_monoid/ppx_monoid.0.3.2/opam
+++ b/packages/ppx_monoid/ppx_monoid.0.3.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Syntax extension for building values of monoids"
+description: """
+This is a syntax extension for OCaml to make building values of
+monoids easier. Assumes the existence of two operations in scope for
+some type `t`:
+
+````ocaml
+empty : t
+(^^)  : t -> t -> t
+````
+
+`ppx-monoid`, triggered by the PPX extension point `monoid`,
+reinterprets the semicolon `;` to mean the monoid operation `^^` and
+the unit expression `()` to mean `empty`."""
+maintainer: ["bob.atkey@gmail.com"]
+authors: ["Robert Atkey"]
+license: "MIT"
+homepage: "https://github.com/bobatkey/ppx-monoid"
+bug-reports: "https://github.com/bobatkey/ppx-monoid/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.04.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "ounit" {dev}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobatkey/ppx-monoid.git"
+url {
+  src: "https://github.com/bobatkey/ppx-monoid/archive/0.3.2.tar.gz"
+  checksum: [
+    "md5=40edc2ad9c393750db750d73fad5ecee"
+    "sha512=43d42e52fe1233110b6ce658310f0312c2bca13b70e303f70fcee3c863aa8e41b8c92cec83aa9ec507a5f1e3d7b981be0dfb1d1bc87bfa3d2ae11051eaadcbef"
+  ]
+}

--- a/packages/ppx_monoid/ppx_monoid.0.3.2/opam
+++ b/packages/ppx_monoid/ppx_monoid.0.3.2/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "ocaml-migrate-parsetree" {>= "1.5.0"}
   "ppx_tools_versioned" {>= "5.2.3"}
-  "ounit" {dev}
+  "ounit" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
### `ppx_monoid.0.3.2`
Syntax extension for building values of monoids
This is a syntax extension for OCaml to make building values of
monoids easier. Assumes the existence of two operations in scope for
some type `t`:

````ocaml
empty : t
(^^)  : t -> t -> t
````

`ppx-monoid`, triggered by the PPX extension point `monoid`,
reinterprets the semicolon `;` to mean the monoid operation `^^` and
the unit expression `()` to mean `empty`.



---
* Homepage: https://github.com/bobatkey/ppx-monoid
* Source repo: git+https://github.com/bobatkey/ppx-monoid.git
* Bug tracker: https://github.com/bobatkey/ppx-monoid/issues

---
:camel: Pull-request generated by opam-publish v2.0.2