### PR TITLE
4 packages from c-cube/calculon at 0.6

### DIFF
--- a/packages/calculon-redis-lib/calculon-redis-lib.0.6/opam
+++ b/packages/calculon-redis-lib/calculon-redis-lib.0.6/opam
@@ -22,7 +22,7 @@ dev-repo: "git+https://github.com/c-cube/calculon.git"
 url {
   src: "https://github.com/c-cube/calculon/archive/v0.6.tar.gz"
   checksum: [
-    "md5=94516071fdd6ee5bf206f153671987ff"
-    "sha512=fc5ffcca60fb7dc008c5963ec5865720c11153dcf14a93a7ef6db36182d556cde52c876fa7a9fb77e01474fb956753cb99520ec4939fa17c01ab079c367437de"
+    "md5=16ad257c16f82a2acfab5e10c7c8ef8a"
+    "sha512=c460994c0ffabf0d756cdbb0cdd77b99d3b4844f597c894bb2c8ed22d1038b44f1be4d76721a956a76cc953d915fb76324f0fdb385e6a2e531da7fd4cc832836"
   ]
 }

--- a/packages/calculon-redis/calculon-redis.0.6/opam
+++ b/packages/calculon-redis/calculon-redis.0.6/opam
@@ -21,7 +21,7 @@ dev-repo: "git+https://github.com/c-cube/calculon.git"
 url {
   src: "https://github.com/c-cube/calculon/archive/v0.6.tar.gz"
   checksum: [
-    "md5=94516071fdd6ee5bf206f153671987ff"
-    "sha512=fc5ffcca60fb7dc008c5963ec5865720c11153dcf14a93a7ef6db36182d556cde52c876fa7a9fb77e01474fb956753cb99520ec4939fa17c01ab079c367437de"
+    "md5=16ad257c16f82a2acfab5e10c7c8ef8a"
+    "sha512=c460994c0ffabf0d756cdbb0cdd77b99d3b4844f597c894bb2c8ed22d1038b44f1be4d76721a956a76cc953d915fb76324f0fdb385e6a2e531da7fd4cc832836"
   ]
 }

--- a/packages/calculon-web/calculon-web.0.6/opam
+++ b/packages/calculon-web/calculon-web.0.6/opam
@@ -25,7 +25,7 @@ dev-repo: "git+https://github.com/c-cube/calculon.git"
 url {
   src: "https://github.com/c-cube/calculon/archive/v0.6.tar.gz"
   checksum: [
-    "md5=94516071fdd6ee5bf206f153671987ff"
-    "sha512=fc5ffcca60fb7dc008c5963ec5865720c11153dcf14a93a7ef6db36182d556cde52c876fa7a9fb77e01474fb956753cb99520ec4939fa17c01ab079c367437de"
+    "md5=16ad257c16f82a2acfab5e10c7c8ef8a"
+    "sha512=c460994c0ffabf0d756cdbb0cdd77b99d3b4844f597c894bb2c8ed22d1038b44f1be4d76721a956a76cc953d915fb76324f0fdb385e6a2e531da7fd4cc832836"
   ]
 }

--- a/packages/calculon/calculon.0.6/opam
+++ b/packages/calculon/calculon.0.6/opam
@@ -33,7 +33,7 @@ dev-repo: "git+https://github.com/c-cube/calculon.git"
 url {
   src: "https://github.com/c-cube/calculon/archive/v0.6.tar.gz"
   checksum: [
-    "md5=94516071fdd6ee5bf206f153671987ff"
-    "sha512=fc5ffcca60fb7dc008c5963ec5865720c11153dcf14a93a7ef6db36182d556cde52c876fa7a9fb77e01474fb956753cb99520ec4939fa17c01ab079c367437de"
+    "md5=16ad257c16f82a2acfab5e10c7c8ef8a"
+    "sha512=c460994c0ffabf0d756cdbb0cdd77b99d3b4844f597c894bb2c8ed22d1038b44f1be4d76721a956a76cc953d915fb76324f0fdb385e6a2e531da7fd4cc832836"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-`calculon.0.6`: Library for writing IRC bots in OCaml and a collection of plugins
-`calculon-redis.0.6`: A redis plugin for Calculon
-`calculon-redis-lib.0.6`: A library to interact with Calculon via Redis
-`calculon-web.0.6`: A collection of web plugins for Calculon



---
* Homepage: https://github.com/c-cube/calculon
* Source repo: git+https://github.com/c-cube/calculon.git
* Bug tracker: https://github.com/c-cube/calculon/issues

---
:camel: Pull-request generated by opam-publish v2.0.0