### PR TITLE
[new release] minicaml (0.4)

### DIFF
--- a/packages/minicaml/minicaml.0.4/opam
+++ b/packages/minicaml/minicaml.0.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "sudo-woodo3@protonmail.com"
+authors: ["Alessandro Cheli"]
+homepage: "https://github.com/0x0f0f0f/minicaml"
+bug-reports: "https://github.com/0x0f0f0f/minicaml/issues"
+dev-repo: "git+https://github.com/0x0f0f0f/minicaml.git"
+license: "MIT"
+synopsis: "A simple, didactical, purely functional programming language"
+description: "A simple, didactical, purely functional programming language written for the programming 2 course at the University of Pisa, extended with a simple parser made with Menhir and ocamllex"
+doc: "https://0x0f0f0f.github.io/minicaml"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  [make "test" "-j" jobs] {with-test}
+]
+depends: [
+    "dune" {>= "2.0"}
+    "ocaml" {>= "4.05.0"}
+    "ANSITerminal"
+    "ocamline" {>= "1.0"}
+    "menhir"
+    "ppx_deriving"
+    "cmdliner"
+    "alcotest" {with-test & >= "0.8.5"}
+    "bisect_ppx" {with-test >= "1.4.1"}
+]
+url {
+  src:
+    "https://github.com/0x0f0f0f/minicaml/releases/download/0.4/minicaml-0.4.tbz"
+  checksum: [
+    "sha256=d363b413abc43d1ee991b5ad06128e2a02d758324f2b83709aab4955c80cfbb4"
+    "sha512=445c2f822b497d9e198a47df887c7708812c877d3ac23c6a409d4289fee02d7337c4f2020a14f105ad2443349056fc82eb809d39a02a02799b0f9963dfce90aa"
+  ]
+}


### PR DESCRIPTION
A simple, didactical, purely functional programming language

- Project page: <a href="https://github.com/0x0f0f0f/minicaml">https://github.com/0x0f0f0f/minicaml</a>
- Documentation: <a href="https://0x0f0f0f.github.io/minicaml">https://0x0f0f0f.github.io/minicaml</a>

##### CHANGES:

- Multiline REPL
- New dictionary syntax
- Static purity inference algorithm
- `map`, `foldl` and `foldr` are implemented in the language
- Integer division now returns a float if the modulo between the two numbers is 0
- Print the type in the REPL result
- Directives on the toplevel: `#include filename` and `#import` to load and run files,
  `#verbose n` to set a verbosity level, `#pure`, `#impure` and `#uncertain` to set the global purity context.
- Minicaml and OCaml Stack traces on errors!
- Removed the `let rec` and `let rec lazy` statements.
- `lazy`-ness is now meant for each single assignment in a let statement, and they
  can be mixed; This is now valid: `let a = ... and lazy b = ... ;;`
- A LOT of internal optimizations.
- `Lambda` and `Closure` abstractions for function now have a single parameter
  and can be nested. This means that `(fun x y z -> ...) = (fun x -> (fun y -> (fun z -> ...)))` is now true, and the
  evaluation gets quite simplified (for example, in partial evaluation)
- Composition and reverse composition are back and working with `<=<` and `>=>`
- Purity inference is now done before evaluation
- Capability of recursion is now inferred automatically basing on the location of a `fun` expression.
