### PR TITLE
[new release] 0install (2.15.1)

### DIFF
--- a/packages/0install/0install.2.15.1/opam
+++ b/packages/0install/0install.2.15.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "talex5@gmail.com"
+authors: "zero-install-devel@lists.sourceforge.net"
+homepage: "http://0install.net/"
+bug-reports: "https://github.com/0install/0install/issues"
+dev-repo: "git+https://github.com/0install/0install.git"
+build: [
+  [make "all"]
+  [make "test"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "yojson"
+  "xmlm"
+  "ounit" {with-test}
+  "lwt"
+  "lwt_react"
+  "ocurl" {>= "0.7.9"}
+  "sha" {>= "1.9"}
+  "dune" {>= "1.11"}
+]
+depopts: ["obus" "lablgtk" "lwt_glib"]
+conflicts: [
+  "lablgtk" {< "2.18.2"}
+]
+depexts: [
+  ["gnupg" "unzip"] {os-family = "debian"}
+  ["gnupg" "unzip"] {os-distribution = "alpine"}
+  ["gnupg"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "The antidote to app-stores"
+description: """
+Zero Install is a decentralised cross-distribution software installation system.
+Other features include full support for shared libraries (with a SAT solver for
+dependency resolution), sharing between users, and integration with native platform
+package managers. It supports both binary and source packages, and works on Linux,
+Mac OS X, Unix and Windows systems."""
+url {
+  src: "https://downloads.sf.net/project/zero-install/0install/2.15.1/0install-2.15.1.tar.bz2"
+  checksum: [
+    "sha256=0111daef0d15848c909195143fd11cbdd674d09a07ca98727e60f260be53f1cf"
+    "sha512=e8c19bfe856b6461d4019609c9e6b7a0319e868adbb61ce1688771f8f25e8e8f20ecf8d92fe57a2ffb7607da8ce687214b6df715dd6d2e1d0794dedc9cbef2b2"
+  ]
+}


### PR DESCRIPTION
Decentralised installation system

- Project page: <a href="http://0install.net/">http://0install.net/</a>

##### CHANGES:

### Changes

- Replace `repo.roscidus.com` feeds with `apps.0install.net` (Bastian Eicher).

- Update fallback host-Python check for new URIs.
  `http://repo.roscidus.com/python/python` is now `https://apps.0install.net/python/python.xml`, etc.

### Bug fixes

- Fix use of nested `Lwt_main.run`. This is now an error with Lwt 5.0.0.

- Fix bad error message when running as root with invalid `$HOME`.
  If we're running as root then we check that `$HOME` is owned by root to avoid
  putting root-owned files in a user's home directory. However, if `$HOME`
  doesn't exist then the error `Unix.ENOENT` was unhelpful.

- Fix bad solver error. The diagnostics system didn't consider dependencies of
  `<command>` elements when trying to explain why a solve failed. It could
  therefore report `Reason for rejection unknown` if a solve failed due to a
  constraint inside one.

- When using `--may-compile` on a local selection, set `local-path`. We already
  gave the full path in `local-path` for other selections, and without this an
  exception is thrown if we try to print the resulting tree.
  e.g. `No digests found for '.'`

### Build system

- Move windows C code to its own library.
  This allows us to use the new `(enabled_if ...)` feature to enable it only on
  Windows, simplifying the `dune` files and avoiding the need for `cppo`.

- Get the `windows_api` object via the `system` object, rather than making it a
  special case.

- Remove windows-specific flags from `utils.c`.
  Looks like these were left over from when there was more code here.
