### PR TITLE
8 packages from ocaml/opam at 2.0.6

### DIFF
--- a/packages/opam-client/opam-client.2.0.6/opam
+++ b/packages/opam-client/opam-client.2.0.6/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-state" {= "2.0.6"}
+  "opam-solver" {= "2.0.6"}
+  "re" {>= "1.7.2"}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.6.tar.gz"
+  checksum: [
+    "md5=4412f3af8f0af354dcd8519ba8f30ee5"
+    "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
+  ]
+}

--- a/packages/opam-client/opam-client.2.0.6/opam
+++ b/packages/opam-client/opam-client.2.0.6/opam
@@ -34,3 +34,8 @@ url {
     "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
   ]
 }
+description:"""
+opam 2.0 development libraries
+
+Actions on the opam root, switches, installations, and front-end.
+"""

--- a/packages/opam-client/opam-client.2.0.6/opam
+++ b/packages/opam-client/opam-client.2.0.6/opam
@@ -20,7 +20,7 @@ depends: [
   "opam-solver" {= "2.0.6"}
   "re" {>= "1.7.2"}
   "cmdliner" {>= "0.9.8"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-core/opam-core.2.0.6/opam
+++ b/packages/opam-core/opam-core.2.0.6/opam
@@ -20,7 +20,7 @@ depends: [
   "base-bigarray"
   "ocamlgraph"
   "re" {>= "1.5.0"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
   "cppo" {build}
 ]
 conflicts: ["extlib-compat"]

--- a/packages/opam-core/opam-core.2.0.6/opam
+++ b/packages/opam-core/opam-core.2.0.6/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.5.0"}
+  "dune" {build & >= "1.2.1"}
+  "cppo" {build}
+]
+conflicts: ["extlib-compat"]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.6.tar.gz"
+  checksum: [
+    "md5=4412f3af8f0af354dcd8519ba8f30ee5"
+    "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
+  ]
+}

--- a/packages/opam-core/opam-core.2.0.6/opam
+++ b/packages/opam-core/opam-core.2.0.6/opam
@@ -36,3 +36,9 @@ url {
     "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
   ]
 }
+description:"""
+opam 2.0 development libraries
+
+Small standard library extensions, and generic system interaction modules used
+by opam.
+"""

--- a/packages/opam-devel/opam-devel.2.0.6/opam
+++ b/packages/opam-devel/opam-devel.2.0.6/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-client" {= "2.0.6"}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+  [make "tests"] {with-test}
+]
+post-messages:
+  """
+The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/opam /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2="OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""""
+    {success}
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.6.tar.gz"
+  checksum: [
+    "md5=4412f3af8f0af354dcd8519ba8f30ee5"
+    "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
+  ]
+}

--- a/packages/opam-devel/opam-devel.2.0.6/opam
+++ b/packages/opam-devel/opam-devel.2.0.6/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= "2.0.6"}
   "cmdliner" {>= "0.9.8"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-devel/opam-devel.2.0.6/opam
+++ b/packages/opam-devel/opam-devel.2.0.6/opam
@@ -41,3 +41,10 @@ url {
     "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
   ]
 }
+description:"""
+opam 2.0.6 development version
+
+This package compiles (bootstraps) opam 2.0.6. For consistency and safety of the
+installation, the binaries are not installed into the PATH, but into
+lib/opam-devel, from where the user can manually install them system-wide.
+"""

--- a/packages/opam-format/opam-format.2.0.6/opam
+++ b/packages/opam-format/opam-format.2.0.6/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= "2.0.6"}
   "opam-file-format" {>= "2.0.0~rc2"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-format/opam-format.2.0.6/opam
+++ b/packages/opam-format/opam-format.2.0.6/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-core" {= "2.0.6"}
+  "opam-file-format" {>= "2.0.0~rc2"}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.6.tar.gz"
+  checksum: [
+    "md5=4412f3af8f0af354dcd8519ba8f30ee5"
+    "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
+  ]
+}

--- a/packages/opam-format/opam-format.2.0.6/opam
+++ b/packages/opam-format/opam-format.2.0.6/opam
@@ -32,3 +32,8 @@ url {
     "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
   ]
 }
+description:"""
+opam 2.0 development libraries
+
+Definition of opam datastructures and its file interface.
+"""

--- a/packages/opam-installer/opam-installer.2.0.6/opam
+++ b/packages/opam-installer/opam-installer.2.0.6/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= "2.0.6"}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "DUNE_ARGS=-p %{name}%" "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.6.tar.gz"
+  checksum: [
+    "md5=4412f3af8f0af354dcd8519ba8f30ee5"
+    "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
+  ]
+}

--- a/packages/opam-installer/opam-installer.2.0.6/opam
+++ b/packages/opam-installer/opam-installer.2.0.6/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= "2.0.6"}
   "cmdliner" {>= "0.9.8"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-installer/opam-installer.2.0.6/opam
+++ b/packages/opam-installer/opam-installer.2.0.6/opam
@@ -32,3 +32,12 @@ url {
     "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
   ]
 }
+description:"""
+Installation of files to a prefix, following opam conventions
+
+opam-installer is a small tool that can read *.install files, as defined by
+opam [1], and execute them to install or remove package files without going
+through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
+"""

--- a/packages/opam-installer/opam-installer.2.0.6/opam
+++ b/packages/opam-installer/opam-installer.2.0.6/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
-  [make "DUNE_ARGS=-p %{name}%" "%{name}%.install"]
+  [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"
 url {

--- a/packages/opam-repository/opam-repository.2.0.6/opam
+++ b/packages/opam-repository/opam-repository.2.0.6/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= "2.0.6"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-repository/opam-repository.2.0.6/opam
+++ b/packages/opam-repository/opam-repository.2.0.6/opam
@@ -31,3 +31,9 @@ url {
     "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
   ]
 }
+description:"""
+opam 2.0 development libraries
+
+This library includes repository and remote sources handling, including
+curl/wget, rsync, git, mercurial, darcs backends.
+"""

--- a/packages/opam-repository/opam-repository.2.0.6/opam
+++ b/packages/opam-repository/opam-repository.2.0.6/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= "2.0.6"}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.6.tar.gz"
+  checksum: [
+    "md5=4412f3af8f0af354dcd8519ba8f30ee5"
+    "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
+  ]
+}

--- a/packages/opam-solver/opam-solver.2.0.6/opam
+++ b/packages/opam-solver/opam-solver.2.0.6/opam
@@ -20,7 +20,7 @@ depends: [
   "mccs" {>= "1.1+9"}
   "dose3" {>= "5"}
   "cudf" {>= "0.7"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-solver/opam-solver.2.0.6/opam
+++ b/packages/opam-solver/opam-solver.2.0.6/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= "2.0.6"}
+  "mccs" {>= "1.1+9"}
+  "dose3" {>= "5"}
+  "cudf" {>= "0.7"}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.6.tar.gz"
+  checksum: [
+    "md5=4412f3af8f0af354dcd8519ba8f30ee5"
+    "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
+  ]
+}

--- a/packages/opam-solver/opam-solver.2.0.6/opam
+++ b/packages/opam-solver/opam-solver.2.0.6/opam
@@ -34,3 +34,9 @@ url {
     "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
   ]
 }
+description:"""
+opam 2.0 development libraries
+
+Solver and Cudf interaction. This library is based on the Cudf and Dose
+libraries, and handles calls to the external solver from opam.
+"""

--- a/packages/opam-state/opam-state.2.0.6/opam
+++ b/packages/opam-state/opam-state.2.0.6/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-repository" {= "2.0.6"}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.6.tar.gz"
+  checksum: [
+    "md5=4412f3af8f0af354dcd8519ba8f30ee5"
+    "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
+  ]
+}

--- a/packages/opam-state/opam-state.2.0.6/opam
+++ b/packages/opam-state/opam-state.2.0.6/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-repository" {= "2.0.6"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-state/opam-state.2.0.6/opam
+++ b/packages/opam-state/opam-state.2.0.6/opam
@@ -31,3 +31,8 @@ url {
     "sha512=c3dbd315550817d15e3d5dd4b5b030b725e5d65e36450f8ac064555e4710bda90df6fab457c386c7a334689e50d240de19992565ce325bc8a18163f145f09dfd"
   ]
 }
+description:"""
+opam 2.0 development libraries
+
+Handling of the ~/.opam hierarchy, repository and switch states.
+"""


### PR DESCRIPTION
This pull-request concerns:
-`opam-client.2.0.6`
-`opam-core.2.0.6`
-`opam-devel.2.0.6`
-`opam-format.2.0.6`
-`opam-installer.2.0.6`
-`opam-repository.2.0.6`
-`opam-solver.2.0.6`
-`opam-state.2.0.6`



---
* Source repo: git+https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---
:camel: Pull-request generated by opam-publish v2.0.2