### PR TITLE
[new release] cowabloga (0.5.0)

### DIFF
--- a/packages/cowabloga/cowabloga.0.5.0/opam
+++ b/packages/cowabloga/cowabloga.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "mort@cantab.net"
+authors: ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/cowabloga"
+doc: "https://mirage.github.io/cowabloga/"
+bug-reports: "https://github.com/mirage/cowabloga/issues"
+depends: [
+  "ocaml"
+  "re" {>= "1.7.2"}
+  "cow" {>= "2.3.0"}
+  "omd" {>= "0.8.2"}
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.0.1"}
+  "magic-mime"
+  "dune" {build & >= "1.0"}
+  "cohttp" {with-test & >= "0.5.0"}
+  "cohttp-lwt-unix" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/cowabloga.git"
+synopsis: "Simple static blogging support"
+description: """
+Helper OCaml libraries for setting up a blog and wiki, using the Zurb
+Foundation CSS/HTML templates.
+
+This is code extracted from the Mirage website, and is still being tidied
+up for general use.
+"""
+url {
+  src:
+    "https://github.com/mirage/cowabloga/releases/download/0.5.0/cowabloga-0.5.0.tbz"
+  checksum: [
+    "sha256=0ccc45811a8f88d46db11009179ac03e90fa04a942c9db55c417470a1e28a636"
+    "sha512=d490bbfc359b5e8ecbb62d9c742158eca09ec43f176191053e1698898cbbe5e55904971d4b2c7714f525fbf39de17ae430290ed3130a3d9b344f20733a1884f4"
+  ]
+}


### PR DESCRIPTION
Simple static blogging support

- Project page: <a href="https://github.com/mirage/cowabloga">https://github.com/mirage/cowabloga</a>
- Documentation: <a href="https://mirage.github.io/cowabloga/">https://mirage.github.io/cowabloga/</a>

##### CHANGES:

* upgrade to dune from jbuilder (@avsm)
* update to opam 2 metadata format (@avsm)
