### PR TITLE
Bisect_ppx 1.4.2 - code coverage

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.1.4.2/opam
+++ b/packages/bisect_ppx/bisect_ppx.1.4.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+
+synopsis: "Code coverage for OCaml"
+version: "1.4.2"
+license: "MPL-2.0"
+homepage: "https://github.com/aantron/bisect_ppx"
+doc: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+
+dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+
+depends: [
+  "base-unix"
+  "dune"
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+
+  "ocamlfind" {dev}
+  "ounit" {dev}
+]
+conflicts: [
+  "ocveralls" {<= "0.3.2"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+url {
+  src: "https://github.com/aantron/bisect_ppx/archive/1.4.2.tar.gz"
+  checksum: "md5=8b20abf343d34dd00eaf60670f87ee7d"
+}


### PR DESCRIPTION
> Changes
>
> - Use OCaml 4.09 ASTs during preprocessing (aantron/bisect_ppx@88d24c5, aantron/bisect_ppx@02dfb10).

This release cherry-picks a few commits from `master` onto Bisect_ppx 1.4.1, prompted by https://github.com/aantron/bisect_ppx/issues/266. cc @jobjo
