### PR TITLE
Fix asak

### DIFF
--- a/packages/asak/asak.0.1/opam
+++ b/packages/asak/asak.0.1/opam
@@ -26,7 +26,7 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "build" "@doc"] {with-doc}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 
 url {

--- a/packages/asak/asak.0.2/opam
+++ b/packages/asak/asak.0.2/opam
@@ -19,7 +19,7 @@ dev-repo: "git+https://github.com/nobrakal/asak.git"
 depends: [
   "ocaml"    {>= "4.05"}
   "cmdliner" {>= "1.0.0"}
-  "dune"     {build & > "1.5"}
+  "dune"     {> "1.5"}
   "cppo"     {build & >= "1.6.0"}
   "odoc"     {with-doc  & >= "1.2.0"}
   "alcotest" {with-test & >= "0.8.0"}
@@ -28,13 +28,10 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "build" "@runtest"] {with-test}
-  ["dune" "build" "@doc"] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 
-run-test: [
-  ["dune" "runtest"]
-]
 url {
   src: "https://github.com/nobrakal/asak/archive/0.2.tar.gz"
   checksum: [


### PR DESCRIPTION
Fix issues introduced in https://github.com/ocaml/opam-repository/pull/15671

cc @nobrakal 

Dune should not be tagged as a build dependencies (see #14266).
In releases, dune should never be called without either `--profile=release` or `-p name`. By default dune turns some warnings as errors and this should never be the case in releases as it would break packages very easily.