### PR TITLE
simplify cudf install/uninstall command

### DIFF
--- a/packages/cudf/cudf.0.9-1/opam
+++ b/packages/cudf/cudf.0.9-1/opam
@@ -5,14 +5,12 @@ homepage: "http://www.mancoosi.org/cudf/"
 bug-reports: "https://gforge.inria.fr/tracker/?atid=13811&group_id=4385&func=browse"
 dev-repo: "git+https://scm.gforge.inria.fr/anonscm/git/cudf/cudf.git"
 build: [make "all" "opt"]
-remove: [
- [make "uninstall" "BINDIR=%{bin}%"]
-]
 depends: [
   "ocaml"
   "conf-perl" {build}
   ("extlib" | "extlib-compat")
   "ocamlbuild" {build}
+  "ocamlfind" {build}
 ]
 install: [
   make

--- a/packages/cudf/cudf.0.9-1/opam
+++ b/packages/cudf/cudf.0.9-1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "roberto@dicosmo.org"
+authors: ["Roberto di Cosmo <roberto@dicosmo.org>" "Stefano Zacchiroli" "Pietro Abate"]
+homepage: "http://www.mancoosi.org/cudf/"
+bug-reports: "https://gforge.inria.fr/tracker/?atid=13811&group_id=4385&func=browse"
+dev-repo: "git+https://scm.gforge.inria.fr/anonscm/git/cudf/cudf.git"
+build: [make "all" "opt"]
+remove: [
+ [make "uninstall" "BINDIR=%{bin}%"]
+]
+depends: [
+  "ocaml"
+  "conf-perl" {build}
+  ("extlib" | "extlib-compat")
+  "ocamlbuild" {build}
+]
+install: [
+  make
+  "install"
+  "BINDIR=%{bin}%"
+]
+synopsis: "CUDF library (part of the Mancoosi tools)"
+description: """
+CUDF (for Common Upgradeability Description Format) is a format for
+describing upgrade scenarios in package-based Free and Open Source
+Software distribution."""
+url {
+  src: "https://gforge.inria.fr/frs/download.php/36602/cudf-0.9.tar.gz"
+  checksum: "md5=a4c0e652e56e74c7b388a43f9258d119"
+}


### PR DESCRIPTION
in [opam2nix](https://github.com/timbertson/opam2nix), the `lib` suffix is scoped per ocaml version to allow for multiple ocaml versions without conflict (e.g. `lib/ocaml/4.08.1/site-lib`). So the hardcoded `lib/` in cudf installs to the wrong location.

This PR leaves the install paths up to `ocamlfind` (which does the right thing in both contexts), but keeps `BINDIR` which is used by the Makefile itself.

I've verified this builds locally with opam and produces the same output (in lib/ and bin/)

/cc @rdicosmo 