### PR TITLE
added packages/dokeysto/dokeysto.4.0.0

### DIFF
--- a/packages/dokeysto/dokeysto.4.0.0/opam
+++ b/packages/dokeysto/dokeysto.4.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/dokeysto"
+bug-reports: "https://github.com/UnixJunkie/dokeysto/issues"
+dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
+license: "LGPL-2.1"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "exec" "-p" name "-j" jobs "src/test.exe"] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "base-bytes"
+  "base-unix"
+  "extunix"
+]
+synopsis: "The dumb OCaml key-value store"
+description: """Persistent hash table (i.e. in a file on disk) for string keys
+and string values."""
+url {
+  src: "https://github.com/UnixJunkie/dokeysto/archive/v4.0.0.tar.gz"
+  checksum: "md5=01278d2a0f672bb326595c9791b9ecdb"
+}

--- a/packages/dokeysto/dokeysto.4.0.0/opam
+++ b/packages/dokeysto/dokeysto.4.0.0/opam
@@ -17,8 +17,7 @@ depends: [
   "extunix"
 ]
 synopsis: "The dumb OCaml key-value store"
-description: """Persistent hash table (i.e. in a file on disk) for string keys
-and string values."""
+description: """Persistent hash table (i.e. in a file on disk)."""
 url {
   src: "https://github.com/UnixJunkie/dokeysto/archive/v4.0.0.tar.gz"
   checksum: "md5=01278d2a0f672bb326595c9791b9ecdb"

--- a/packages/dokeysto_camltc/dokeysto_camltc.4.0.0/opam
+++ b/packages/dokeysto_camltc/dokeysto_camltc.4.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/dokeysto"
+bug-reports: "https://github.com/UnixJunkie/dokeysto/issues"
+dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
+license: "LGPL-2.1"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "exec" "-p" name "-j" jobs "src/test_camltc.exe"] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "dokeysto"
+  "camltc"
+]
+synopsis: "The dumb OCaml key-value store w/ tokyocabinet backend"
+description: "dokeysto with tokyocabinet backend (camltc package in opam)"
+url {
+  src: "https://github.com/UnixJunkie/dokeysto/archive/v4.0.0.tar.gz"
+  checksum: "md5=01278d2a0f672bb326595c9791b9ecdb"
+}

--- a/packages/dokeysto_lz4/dokeysto_lz4.4.0.0/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.4.0.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+name: "dokeysto_lz4"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/dokeysto"
+bug-reports: "https://github.com/UnixJunkie/dokeysto/issues"
+dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
+license: "LGPL-2.1"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "exec" "-p" name "-j" jobs "src/test_lz4.exe"] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "dokeysto"
+  "minicli" {>= "5.0.0"}
+  "lz4"
+]
+synopsis: "The dumb OCaml key-value store w/ LZ4 compression"
+description:
+  "dokeysto with on-the-fly compression/decompression of values via LZ4"
+url {
+  src: "https://github.com/UnixJunkie/dokeysto/archive/v4.0.0.tar.gz"
+  checksum: "md5=01278d2a0f672bb326595c9791b9ecdb"
+}


### PR DESCRIPTION
Dokeysto is no more bound to only string keys and string values
generic keys ('k) and values ('v) are now supported by the newly introduced
*_gen modules.
From my little tests, dokeysto_camltc is the fastest backend.
