### PR TITLE
Package eliom.6.10.1

### DIFF
--- a/packages/eliom/eliom.6.10.1/opam
+++ b/packages/eliom/eliom.6.10.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: "Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppx_tools" {>= "0.99.3"}
+  "js_of_ocaml-compiler" {>= "3.5.1"}
+  "js_of_ocaml" {>= "3.5.1"}
+  "js_of_ocaml-lwt" {>= "3.5.1"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx" {>= "3.5.1"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1"}
+  "js_of_ocaml-tyxml" {>= "3.5.1"}
+  "lwt_log"
+  "lwt_ppx"
+  "tyxml" {>= "4.3.0"}
+  "ocsigenserver" {>= "2.10"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+]
+url {
+  src: "https://github.com/ocsigen/eliom/archive/6.10.1.tar.gz"
+  checksum: [
+    "md5=975091e1f3dd6db6bb24d08e2f6dd960"
+    "sha512=6e98845f3788df62e8782321418dad0b9a896fbf60894c017433b8810470dbf15122ac2f6eac2f958e427cce9e52641fd8c7092dd92ac0f03ece3e214584e266"
+  ]
+}


### PR DESCRIPTION
### `eliom.6.10.1`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.0.2