### PR TITLE
Package ocsigen-toolkit.2.4.3

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.4.3/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.4.3/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.10.1"}
+  "calendar"
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.4.3.tar.gz"
+  checksum: [
+    "md5=1ea11e0d14d1d90b1924d1b9b2066440"
+    "sha512=71b7d709700300695ee9774170316d4d704a6b6e9c3d045a43d028c702becb19142390d3d6af3b54f35f4dc62066af7bc4185018975dd678b5d7bd6dbecd2dc3"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.4.3`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.2