### PR TITLE
ocsigen-toolkit & eliom: upper version bounds on js_of_ocaml-ppx_deriving_json

### DIFF
--- a/packages/eliom/eliom.6.3.0/opam
+++ b/packages/eliom/eliom.6.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "lwt_log"
   "js_of_ocaml-ocamlbuild" {build}
   "js_of_ocaml-ppx"
-  "js_of_ocaml-ppx" {<= "3.0.2"} | "js_of_ocaml-ppx_deriving_json"
+  "js_of_ocaml-ppx" {<= "3.0.2"} | "js_of_ocaml-ppx_deriving_json" {< "3.5"}
   "js_of_ocaml-tyxml"
   "tyxml" {>= "4.0.0" & < "4.3"}
   "ocsigenserver" {>= "2.9" & < "2.10"}

--- a/packages/eliom/eliom.6.4.0/opam
+++ b/packages/eliom/eliom.6.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "js_of_ocaml-lwt" {< "3.3"}
   "js_of_ocaml-ocamlbuild" {build}
   "js_of_ocaml-ppx"
-  "js_of_ocaml-ppx" {<= "3.0.2"} | "js_of_ocaml-ppx_deriving_json"
+  "js_of_ocaml-ppx" {<= "3.0.2"} | "js_of_ocaml-ppx_deriving_json" {< "3.5"}
   "js_of_ocaml-tyxml" {< "3.2.0"}
   "lwt_log"
   "lwt_ppx"

--- a/packages/eliom/eliom.6.5.0/opam
+++ b/packages/eliom/eliom.6.5.0/opam
@@ -18,7 +18,7 @@ depends: [
   "js_of_ocaml-lwt" {>= "3.3"}
   "js_of_ocaml-ocamlbuild" {build}
   "js_of_ocaml-ppx"
-  "js_of_ocaml-ppx_deriving_json" {>= "3.3"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.3" & < "3.5"}
   "js_of_ocaml-tyxml" {>= "3.3"}
   "lwt_log"
   "lwt_ppx"

--- a/packages/eliom/eliom.6.6.0/opam
+++ b/packages/eliom/eliom.6.6.0/opam
@@ -18,7 +18,7 @@ depends: [
   "js_of_ocaml-lwt" {>= "3.3"}
   "js_of_ocaml-ocamlbuild" {build}
   "js_of_ocaml-ppx"
-  "js_of_ocaml-ppx_deriving_json" {>= "3.3"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.3" & < "3.5"}
   "js_of_ocaml-tyxml" {>= "3.3"}
   "lwt_log"
   "lwt_ppx"

--- a/packages/eliom/eliom.6.7.0/opam
+++ b/packages/eliom/eliom.6.7.0/opam
@@ -18,7 +18,7 @@ depends: [
   "js_of_ocaml-lwt" {>= "3.3"}
   "js_of_ocaml-ocamlbuild" {build}
   "js_of_ocaml-ppx"
-  "js_of_ocaml-ppx_deriving_json" {>= "3.3"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.3" & < "3.5"}
   "js_of_ocaml-tyxml" {>= "3.3"}
   "lwt_log"
   "lwt_ppx"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.0.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.0.0/opam
@@ -15,6 +15,7 @@ depends: [
   "eliom" {>= "6.4"}
   "calendar"
   "js_of_ocaml" {< "3.4.0"}
+  "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 url {
   src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.0.0.tar.gz"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.1.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.1.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "4.06.1"}
   "eliom" {>= "6.7.0"}
   "calendar"
+  "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 available: false
 url {

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.2.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.2.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "4.06.1"}
   "eliom" {>= "6.7.0"}
   "calendar"
+  "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 available: false
 url {

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.2.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.2.1/opam
@@ -16,6 +16,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}
   "calendar"
+  "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 url {
   src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.2.1.tar.gz"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.1/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}
   "calendar"
+  "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 url {
   src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.3.1.tar.gz"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.2/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.2/opam
@@ -16,6 +16,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}
   "calendar"
+  "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 url {
   src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.3.2.tar.gz"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.3/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.3/opam
@@ -16,6 +16,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}
   "calendar"
+  "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 url {
   src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.3.3.tar.gz"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.4.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.4.1/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}
   "calendar"
+  "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 url {
   src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.4.1.tar.gz"


### PR DESCRIPTION
All the affected versions use the old [%derive.json: ...] syntax.