### PR TITLE
Package pg_query.0.9.4

### DIFF
--- a/packages/pg_query/pg_query.0.9.4/opam
+++ b/packages/pg_query/pg_query.0.9.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Bindings to libpg_query for parsing PostgreSQL"
+description:
+  "OCaml bindings to libpg_query for parsing PostgreSQL, and a command-line tool that uses them"
+maintainer: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+authors: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+license: "MIT"
+homepage: "https://github.com/roddyyaga/pg_query-ocaml"
+doc: "https://roddyyaga.github.io/pg_query-ocaml/pg_query-ocaml/index.html"
+bug-reports: "https://github.com/roddyyaga/pg_query-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "2.0"}
+  "core"
+  "ctypes"
+  "ctypes-foreign"
+  "ppx_deriving"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/roddyyaga/pg_query-ocaml.git"
+url {
+  src: "https://github.com/roddyyaga/pg_query-ocaml/archive/0.9.4.tar.gz"
+  checksum: [
+    "md5=219f416bcaa6b3a25dcc088b408d559f"
+    "sha512=64aa1d4b99a0afe564155283fcbec6f3b59c6c0c34688cc1a2859603dd9a32ecc0a4a519bdda6437724b4263d78b4d0c3e972b4f301e203e0703cb2c326efaf0"
+  ]
+}


### PR DESCRIPTION
### `pg_query.0.9.4`
New version with patch to allow builds on FreeBSD.



---
* Homepage: https://github.com/roddyyaga/pg_query-ocaml
* Source repo: git+https://github.com/roddyyaga/pg_query-ocaml.git
* Bug tracker: https://github.com/roddyyaga/pg_query-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2