### PR TITLE
Fix various packages

### DIFF
--- a/packages/asak/asak.0.2/opam
+++ b/packages/asak/asak.0.2/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/nobrakal/asak/issues"
 dev-repo: "git+https://github.com/nobrakal/asak.git"
 
 depends: [
-  "ocaml"    {>= "4.05"}
+  "ocaml"    {>= "4.05" & < "4.10"}
   "cmdliner" {>= "1.0.0"}
   "dune"     {> "1.5"}
   "cppo"     {build & >= "1.6.0"}

--- a/packages/brotli/brotli.1.3.0/opam
+++ b/packages/brotli/brotli.1.3.0/opam
@@ -18,7 +18,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "brotli"]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.10"}
   "oasis" {build}
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/eigen/eigen.0.0.1/opam
+++ b/packages/eigen/eigen.0.0.1/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "ctypes" {>= "0.6.0"}
+  "ctypes" {>= "0.6.0" & < "0.17.0"}
   "oasis" {build & >= "0.4"}
   "ocamlbuild" {build}
   "ocamlfind" {build}

--- a/packages/eigen/eigen.0.0.2/opam
+++ b/packages/eigen/eigen.0.0.2/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "ctypes" {>= "0.6.0"}
+  "ctypes" {>= "0.6.0" & < "0.17.0"}
   "oasis" {build & >= "0.4"}
   "ocamlbuild" {build}
   "ocamlfind" {build}

--- a/packages/eigen/eigen.0.0.3/opam
+++ b/packages/eigen/eigen.0.0.3/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.02"}
-  "ctypes" {>= "0.6.0"}
+  "ctypes" {>= "0.6.0" & < "0.17.0"}
   "oasis" {build & >= "0.4"}
   "ocamlbuild" {build}
   "ocamlfind" {build}

--- a/packages/eigen/eigen.0.0.4/opam
+++ b/packages/eigen/eigen.0.0.4/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.02"}
-  "ctypes" {>= "0.6.0"}
+  "ctypes" {>= "0.6.0" & < "0.17.0"}
   "oasis" {build & >= "0.4"}
   "ocamlbuild" {build}
   "ocamlfind" {build}

--- a/packages/eigen/eigen.0.0.5/opam
+++ b/packages/eigen/eigen.0.0.5/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.02"}
-  "ctypes" {>= "0.14.0"}
+  "ctypes" {>= "0.14.0" & < "0.17.0"}
   "oasis" {build & >= "0.4"}
   "ocamlbuild" {build}
   "ocamlfind" {build}

--- a/packages/eigen/eigen.0.0.6/opam
+++ b/packages/eigen/eigen.0.0.6/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.02"}
-  "ctypes" {>= "0.14.0"}
+  "ctypes" {>= "0.14.0" & < "0.17.0"}
   "oasis" {build & >= "0.4"}
   "ocamlbuild" {build}
   "ocamlfind" {build}

--- a/packages/mmseg/mmseg.0.1.1/opam
+++ b/packages/mmseg/mmseg.0.1.1/opam
@@ -20,7 +20,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.00.1"}
   "ocamlfind" {build}
-  "core_kernel" {< "v0.14"}
+  "core_kernel" {< "v0.13"}
   "trie"
   "camomile"
 ]

--- a/packages/oml/oml.0.0.5/opam
+++ b/packages/oml/oml.0.0.5/opam
@@ -9,7 +9,7 @@ build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "oml"]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "4.10"}
   "ocamlfind" {build}
   "lacaml" {>= "7.2.5" & <= "7.6.2"}
   "lbfgs"

--- a/packages/oml/oml.0.0.6/opam
+++ b/packages/oml/oml.0.0.6/opam
@@ -9,7 +9,7 @@ build: [make "build"]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "oml"]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "4.10"}
   "ocamlfind" {build}
   "cppo" {build & >= "1.6.0"}
   "cppo_ocamlbuild" {build}

--- a/packages/owl/owl.0.1.0/opam
+++ b/packages/owl/owl.0.1.0/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {< "4.06.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dolog" {< "4.0.0"}
   "gsl" {< "1.20.0"}
   "conf-gsl"

--- a/packages/owl/owl.0.2.0/opam
+++ b/packages/owl/owl.0.2.0/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.06.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dolog" {< "4.0.0"}
   "gsl" {< "1.20.0"}
   "conf-gsl"

--- a/packages/owl/owl.0.2.1/opam
+++ b/packages/owl/owl.0.2.1/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.06.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dolog" {< "4.0.0"}
   "gsl" {< "1.20.0"}
   "conf-gsl"

--- a/packages/owl/owl.0.2.2/opam
+++ b/packages/owl/owl.0.2.2/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.06.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dolog" {< "4.0.0"}
   "gsl" {< "1.20.0"}
   "conf-gsl"

--- a/packages/owl/owl.0.2.3/opam
+++ b/packages/owl/owl.0.2.3/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.06.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dolog" {< "4.0.0"}
   "gsl" {< "1.20.0"}
   "conf-gsl"

--- a/packages/owl/owl.0.2.4/opam
+++ b/packages/owl/owl.0.2.4/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.06.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dolog" {< "4.0.0"}
   "gsl" {< "1.20.0"}
   "conf-gsl"

--- a/packages/owl/owl.0.2.5/opam
+++ b/packages/owl/owl.0.2.5/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.06.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dolog" {< "4.0.0"}
   "gsl" {< "1.20.0"}
   "conf-gsl"

--- a/packages/owl/owl.0.2.6/opam
+++ b/packages/owl/owl.0.2.6/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.06.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dolog" {< "4.0.0"}
   "gsl" {< "1.20.0"}
   "conf-gsl"

--- a/packages/owl/owl.0.2.9/opam
+++ b/packages/owl/owl.0.2.9/opam
@@ -22,7 +22,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.04.0" & < "4.06.0"}
   "atdgen" {< "1.13.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dolog" {>= "3.0" & < "4.0.0"}
   "gsl" {>= "1.20.0"}
   "conf-gsl"

--- a/packages/owl/owl.0.3.0/opam
+++ b/packages/owl/owl.0.3.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.08.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dolog" {>= "3.0" & < "4.0.0"}
   "gsl" {>= "1.20.0"}
   "conf-gsl"

--- a/packages/owl/owl.0.3.7/opam
+++ b/packages/owl/owl.0.3.7/opam
@@ -19,7 +19,7 @@ depends: [
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
   "configurator" {build & < "v0.14"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "eigen" {>= "0.0.3" & < "0.1.0"}
   "jbuilder"
   "owl-base" {= version}

--- a/packages/owl/owl.0.3.8/opam
+++ b/packages/owl/owl.0.3.8/opam
@@ -19,7 +19,7 @@ depends: [
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
   "configurator" {build & < "v0.14"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "eigen" {>= "0.0.3" & < "0.1.0"}
   "jbuilder"
   "owl-base" {>= "0.3.8" & < "0.4.0"}

--- a/packages/owl/owl.0.4.0/opam
+++ b/packages/owl/owl.0.4.0/opam
@@ -19,7 +19,7 @@ depends: [
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
   "configurator" {build & < "v0.14"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dune"
   "eigen" {>= "0.0.3" & < "0.1.0"}
   "owl-base" {< "0.5.0"}

--- a/packages/owl/owl.0.5.0/opam
+++ b/packages/owl/owl.0.5.0/opam
@@ -27,7 +27,7 @@ depends: [
   "base" {build & < "v0.14"}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dune" {>= "1.2.1"}
   "dune-configurator"
   "eigen" {>= "0.1.0"}

--- a/packages/owl/owl.0.6.0/opam
+++ b/packages/owl/owl.0.6.0/opam
@@ -26,7 +26,7 @@ depends: [
   "base" {build & < "v0.14"}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dune" {>= "1.2.1"}
   "dune-configurator"
   "eigen" {>= "0.1.0"}

--- a/packages/owl/owl.0.7.0/opam
+++ b/packages/owl/owl.0.7.0/opam
@@ -26,7 +26,7 @@ depends: [
   "base" {build & < "v0.14"}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dune" {>= "1.7.0"}
   "dune-configurator"
   "eigen" {>= "0.1.0"}

--- a/packages/owl/owl.0.7.1/opam
+++ b/packages/owl/owl.0.7.1/opam
@@ -26,7 +26,7 @@ depends: [
   "base" {build & < "v0.14"}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dune" {>= "1.7.0"}
   "dune-configurator"
   "eigen" {>= "0.1.0"}

--- a/packages/owl/owl.0.7.2/opam
+++ b/packages/owl/owl.0.7.2/opam
@@ -27,7 +27,7 @@ depends: [
   "base" {build}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dune" {>= "1.7.0"}
   "dune-configurator"
   "eigen" {>= "0.1.0"}


### PR DESCRIPTION
* cc @mseri for `eigen` and `owl`. ctypes master has removed `CI.cptr` used in both of those packages. `0.17.0` is just a guess on what the next version number of ctypes is gonna be (cc @yallop). If it's not going to be the case I'll revert this change as fast as possible.
* cc @nobrakal for `asak`
* cc @kandu for `mmseg`