### PR TITLE
why3 is not compatible with menhir >= 20200123

### DIFF
--- a/packages/why3/why3.1.0.0/opam
+++ b/packages/why3/why3.1.0.0/opam
@@ -48,7 +48,7 @@ flags: [ light-uninstall ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.09.0"}
   "ocamlfind" {build}
-  "menhir" {>= "20151112"}
+  "menhir" {>= "20151112" & < "20200123"}
   "num"
 ]
 depopts: [

--- a/packages/why3/why3.1.1.0/opam
+++ b/packages/why3/why3.1.1.0/opam
@@ -49,7 +49,7 @@ flags: [ light-uninstall ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.09.0"}
   "ocamlfind" {build}
-  "menhir" {>= "20151112"}
+  "menhir" {>= "20151112" & < "20200123"}
   "num"
 ]
 

--- a/packages/why3/why3.1.1.1/opam
+++ b/packages/why3/why3.1.1.1/opam
@@ -49,7 +49,7 @@ flags: [ light-uninstall ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.09.0"}
   "ocamlfind" {build}
-  "menhir" {>= "20151112"}
+  "menhir" {>= "20151112" & < "20200123"}
   "num"
 ]
 

--- a/packages/why3/why3.1.2.0/opam
+++ b/packages/why3/why3.1.2.0/opam
@@ -51,7 +51,7 @@ flags: [ light-uninstall ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.09.0"}
   "ocamlfind" {build}
-  "menhir" {>= "20151112"}
+  "menhir" {>= "20151112" & < "20200123"}
   "num"
 ]
 

--- a/packages/why3/why3.1.2.1/opam
+++ b/packages/why3/why3.1.2.1/opam
@@ -42,7 +42,7 @@ install: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
-  "menhir" {>= "20151112"}
+  "menhir" {>= "20151112" & < "20200123"}
   "num"
 ]
 


### PR DESCRIPTION
Revdeps failures in https://github.com/ocaml/opam-repository/pull/15714 show that why3 is not compatible with this version of menhir as it relies on a particular file being installed (`menhirLib.cmo`)

Issue reported in https://gitlab.inria.fr/why3/why3/issues/436