### PR TITLE
[new release] lacaml (11.0.6)

### DIFF
--- a/packages/lacaml/lacaml.11.0.6/opam
+++ b/packages/lacaml/lacaml.11.0.6/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+authors: [
+  "Egbert Ammicht <eammicht@lucent.com>"
+  "Patrick Cousot <Patrick.Cousot@ens.fr>"
+  "Sam Ehrlichman <sehrlichman@janestreet.com>"
+  "Florent Hoareau <h.florent@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Liam Stewart <liam@cs.toronto.edu>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Oleg Trott <ot14@columbia.edu>"
+  "Martin Willensdorfer <ma.wi@gmx.at>"
+]
+bug-reports: "https://github.com/mmottl/lacaml/issues"
+homepage: "https://mmottl.github.io/lacaml"
+doc: "https://mmottl.github.io/lacaml/api"
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/mmottl/lacaml.git"
+synopsis: "Lacaml - OCaml-bindings to BLAS and LAPACK"
+description: """
+Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
+LAPACK-library (Linear Algebra routines).  It also contains many additional
+convenience functions for vectors and matrices."""
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "dune-configurator"
+  "conf-blas" {build}
+  "conf-lapack" {build}
+  "base" {build}
+  "stdio" {build}
+  "base-bytes"
+  "base-bigarray"
+]
+url {
+  src:
+    "https://github.com/mmottl/lacaml/releases/download/11.0.6/lacaml-11.0.6.tbz"
+  checksum: [
+    "sha256=852c5ea28ad0526dd5fa4474b8d512fb22b7e43ff24d157cba418e5f77a5b178"
+    "sha512=15579052306403e10524a2615d7fbdcb286ec02a1a510f255e4292c40c115ce96f18c19cab8295b71a94cb556f025c5115c049579493bd7ff8e50fa4d5e6b2c3"
+  ]
+}


### PR DESCRIPTION
Lacaml - OCaml-bindings to BLAS and LAPACK

- Project page: <a href="https://mmottl.github.io/lacaml">https://mmottl.github.io/lacaml</a>
- Documentation: <a href="https://mmottl.github.io/lacaml/api">https://mmottl.github.io/lacaml/api</a>

##### CHANGES:

* Switched to OPAM file generation via `dune-project`

  * Added missing autogenerated dependencies to `dune` file to avoid
    build system race conditions.
