### PR TITLE
[new release] emile (0.7)

### DIFF
--- a/packages/emile/emile.0.7/opam
+++ b/packages/emile/emile.0.7/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/emile"
+bug-reports:  "https://github.com/dinosaure/emile/issues"
+dev-repo:     "git+https://github.com/dinosaure/emile.git"
+doc:          "https://dinosaure.github.io/emile/"
+license:      "MIT"
+synopsis:     "Parser of email address according RFC 822"
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {>= "1.0"}
+  "angstrom" {>= "0.9.0"}
+  "ipaddr"   {>= "2.7.0"}
+  "base64"   {>= "3.0.0"}
+  "pecu"
+  "uutf"
+  "fmt"
+  "alcotest" {with-test}
+]
+depopts: [ "cmdliner" ]
+url {
+  src:
+    "https://github.com/dinosaure/emile/releases/download/v0.7/emile-v0.7.tbz"
+  checksum: [
+    "sha256=f084d5f6f27b327f17cbdccf27374a0d3dcaedd25e5ffa1611d0e7542a658c73"
+    "sha512=02619876d14abd9f986c9c86079b4258f15d2134692bff6b06a88b0a204d053972359234ed5071a748fcd796889d91c489edd2064762a326f2cb6f740e40d868"
+  ]
+}


### PR DESCRIPTION
Parser of email address according RFC 822

- Project page: <a href="https://github.com/dinosaure/emile">https://github.com/dinosaure/emile</a>
- Documentation: <a href="https://dinosaure.github.io/emile/">https://dinosaure.github.io/emile/</a>

##### CHANGES:

- Fix support of UTF-8 (@dinosaure)
- Remove support of `mrmime`
  `mrmime` will finally use `emile` as the parser of email address.
- Externalize some parsers:
	+ `address_list`
	+ `mailbox_list`
	+ `group`
	+ `address`
- Handle general-address (domain part) according RFC 5321 and split
  tests about the correctness of IPv6 values
