### PR TITLE
Sync up the versionning of all js_of_ocaml packages

### DIFF
--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.1/opam
@@ -13,14 +13,10 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta12"}
   "lwt" {>= "2.4.4" & < "4.0.0"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" ]
-
-conflicts: [
-  "js_of_ocaml"             {<"3.0"}
-]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"
 url {

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.2/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.2/opam
@@ -13,14 +13,10 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta12"}
   "lwt" {>= "2.4.4" & < "4.0.0"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" ]
-
-conflicts: [
-  "js_of_ocaml"             {<"3.0"}
-]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"
 url {

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0/opam
@@ -13,14 +13,10 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta9"}
   "lwt" {>= "2.4.4" & < "4.0.0"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" ]
-
-conflicts: [
-  "js_of_ocaml"             {<"3.0"}
-]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"
 url {

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.1.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.1.0/opam
@@ -13,14 +13,10 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta17"}
   "lwt" {>= "2.4.4" & < "4.0.0"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" ]
-
-conflicts: [
-  "js_of_ocaml"             {<"3.0"}
-]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"
 url {

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.0/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta17"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2" & < "3.5.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" "lwt_log" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.1/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta17"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {= version}
-  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= "3.2.0"}
+  "js_of_ocaml-ppx" {= "3.2.0"}
 ]
 depopts: [ "graphics" "lwt_log" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.1/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta17"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2" & < "3.5.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" "lwt_log" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.3.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.3.0/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2" & < "3.5.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" "lwt_log" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.4.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.4.0/opam
@@ -17,8 +17,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2" & < "3.5.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" "lwt_log" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.0/opam
@@ -17,8 +17,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.11.1"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" "lwt_log" ]
 url {

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.1/opam
@@ -17,8 +17,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.11.1"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" "lwt_log" ]
 url {

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0.1/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {>= "1.0+beta12"}
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {= version}
 ]
 depopts: ["ppx_deriving" "ppx_tools"]
 

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0.2/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0.2/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {>= "1.0+beta12"}
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {= version}
 ]
 depopts: ["ppx_deriving" "ppx_tools"]
 

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.0/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {>= "1.0+beta9"}
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {= version}
 ]
 depopts: ["ppx_deriving" "ppx_tools"]
 

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.1.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {>= "1.0+beta17"}
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {= version}
 ]
 conflicts: [
   "ppx_tools_versioned"     {<="5.0beta0"}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.2.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {>= "1.0+beta17"}
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {= version}
 ]
 conflicts: [
   "ppx_tools_versioned"     {<="5.0beta0"}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.3.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.3.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "1.2"}
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {= version}
 ]
 conflicts: [
   "ppx_tools_versioned"     {<="5.0beta0"}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.4.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.2"}
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {= version}
 ]
 conflicts: [
   "ppx_tools_versioned"     {<="5.0beta0"}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.11.1"}
   "ocaml-migrate-parsetree" {>= "1.4"}
   "ppx_tools_versioned" {>= "5.2.3"}
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {= version}
 ]
 url {
   src:

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.1/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.5.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.11.1"}
   "ocaml-migrate-parsetree" {>= "1.4"}
   "ppx_tools_versioned" {>= "5.2.3"}
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {= version}
 ]
 url {
   src:

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.1.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.1.0/opam
@@ -10,7 +10,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.08.0"}
   "jbuilder" {>= "1.0+beta17"}
-  "js_of_ocaml"
+  "js_of_ocaml" {= version}
   "ppx_tools"
   "ppx_deriving"
 ]

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.2.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.2.0/opam
@@ -10,7 +10,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.08.0"}
   "jbuilder" {>= "1.0+beta17"}
-  "js_of_ocaml"
+  "js_of_ocaml" {= version}
   "ppx_tools"
   "ppx_deriving"
 ]

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.3.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.3.0/opam
@@ -10,7 +10,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.08.0"}
   "dune" {>= "1.2"}
-  "js_of_ocaml"
+  "js_of_ocaml" {= version}
   "ppx_tools"
   "ppx_deriving"
 ]

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.4.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.4.0/opam
@@ -16,7 +16,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {> "4.03.0"}
   "dune" {>= "1.2"}
-  "js_of_ocaml"
+  "js_of_ocaml" {= version}
   "ppx_tools"
   "ppx_deriving"
 ]

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.0/opam
@@ -16,7 +16,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.11.1"}
-  "js_of_ocaml"
+  "js_of_ocaml" {= version}
   "ocaml-migrate-parsetree"
   "ppxlib" {< "0.9.0"}
 ]

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.1/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.1/opam
@@ -16,7 +16,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.11.1"}
-  "js_of_ocaml"
+  "js_of_ocaml" {= version}
   "ocaml-migrate-parsetree"
   "ppxlib" {< "0.9.0"}
 ]

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.0.1/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.0.1/opam
@@ -13,9 +13,9 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta12"}
   "ocamlfind" {>= "1.5.1"}
-  "js_of_ocaml-compiler" {< "3.4" }
-  "js_of_ocaml-ppx" {< "3.4" }
-  "js_of_ocaml" {>= "3.0" & < "3.4"}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= version}
 ]
 depopts: [ "camlp4" ]
 

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.0.2/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.0.2/opam
@@ -13,9 +13,9 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta12"}
   "ocamlfind" {>= "1.5.1"}
-  "js_of_ocaml-compiler" {< "3.4" }
-  "js_of_ocaml-ppx" {< "3.4" }
-  "js_of_ocaml" {>= "3.0" & < "3.4"}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= version}
 ]
 depopts: [ "camlp4" ]
 

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.0/opam
@@ -13,9 +13,9 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta9"}
   "ocamlfind" {>= "1.5.1"}
-  "js_of_ocaml-compiler" {< "3.4" }
-  "js_of_ocaml-ppx" {< "3.4" }
-  "js_of_ocaml" {>= "3.0" & < "3.4"}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= version}
 ]
 depopts: [ "camlp4" ]
 

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.1.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.1.0/opam
@@ -13,9 +13,9 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta17"}
   "ocamlfind" {>= "1.5.1"}
-  "js_of_ocaml-compiler" {< "3.4" }
-  "js_of_ocaml-ppx" {< "3.4" }
-  "js_of_ocaml" {>= "3.0" & < "3.4"}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= version}
 ]
 depopts: [ "camlp4" ]
 

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.2.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.2.0/opam
@@ -13,9 +13,9 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta17"}
   "ocamlfind" {>= "1.5.1"}
-  "js_of_ocaml-compiler" {< "3.4" }
-  "js_of_ocaml-ppx" {< "3.4" }
-  "js_of_ocaml" {>= "3.0" & < "3.4"}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= version}
 ]
 depopts: [ "camlp4" ]
 

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.3.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.3.0/opam
@@ -13,9 +13,9 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2"}
   "ocamlfind" {>= "1.5.1"}
-  "js_of_ocaml-compiler" {< "3.4"}
-  "js_of_ocaml-ppx" {< "3.4"}
-  "js_of_ocaml" {>= "3.0" & < "3.4"}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= version}
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.4.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.4.0/opam
@@ -17,9 +17,9 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.09.0"}
   "dune" {>= "1.2"}
   "ocamlfind" {>= "1.5.1"}
-  "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
-  "js_of_ocaml-ppx"
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= version}
 ]
 
 url {

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.0/opam
@@ -17,9 +17,9 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.11.1"}
   "ocamlfind" {>= "1.5.1"}
-  "js_of_ocaml-compiler"
-  "js_of_ocaml-ppx"
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= version}
 ]
 url {
   src:

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.1/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.5.1/opam
@@ -17,9 +17,9 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.11.1"}
   "ocamlfind" {>= "1.5.1"}
-  "js_of_ocaml-compiler"
-  "js_of_ocaml-ppx"
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= version}
 ]
 url {
   src:

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.0.1/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.0.1/opam
@@ -14,11 +14,8 @@ depends: [
   "jbuilder" {>= "1.0+beta12"}
   "tyxml" {>= "4.0.0" & < "4.3"}
   "reactiveData" {>= "0.2"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
-]
-conflicts: [
-  "js_of_ocaml"             {<"3.0"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.0.2/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.0.2/opam
@@ -14,11 +14,8 @@ depends: [
   "jbuilder" {>= "1.0+beta12"}
   "tyxml" {>= "4.0.0" & < "4.3"}
   "reactiveData" {>= "0.2"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
-]
-conflicts: [
-  "js_of_ocaml"             {<"3.0"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.0/opam
@@ -14,11 +14,8 @@ depends: [
   "jbuilder" {>= "1.0+beta7"}
   "tyxml" {>= "4.0.0" & < "4.3"}
   "reactiveData" {>= "0.2"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
-]
-conflicts: [
-  "js_of_ocaml"             {<"3.0"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.1.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.1.0/opam
@@ -14,11 +14,8 @@ depends: [
   "jbuilder" {>= "1.0+beta17"}
   "tyxml" {>= "4.0.0" & < "4.3"}
   "reactiveData" {>= "0.2"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
-]
-conflicts: [
-  "js_of_ocaml"             {<"3.0"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.2.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.2.0/opam
@@ -14,11 +14,8 @@ depends: [
   "jbuilder" {>= "1.0+beta17"}
   "tyxml" {>= "4.0.0" & < "4.3"}
   "reactiveData" {>= "0.2"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
-]
-conflicts: [
-  "js_of_ocaml"             {<"3.0"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.3.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.3.0/opam
@@ -14,11 +14,8 @@ depends: [
   "dune" {>= "1.2"}
   "tyxml" {>= "4.3"}
   "reactiveData" {>= "0.2"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
-]
-conflicts: [
-  "js_of_ocaml"             {<"3.0"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.4.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.4.0/opam
@@ -18,11 +18,8 @@ depends: [
   "dune" {>= "1.2"}
   "tyxml" {>= "4.3"}
   "reactiveData" {>= "0.2"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
-]
-conflicts: [
-  "js_of_ocaml"             {<"3.0"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 
 url {

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.0/opam
@@ -18,8 +18,8 @@ depends: [
   "dune" {>= "1.11.1"}
   "tyxml" {>= "4.3"}
   "reactiveData" {>= "0.2"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 url {
   src:

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.1/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.5.1/opam
@@ -18,8 +18,8 @@ depends: [
   "dune" {>= "1.11.1"}
   "tyxml" {>= "4.3"}
   "reactiveData" {>= "0.2"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 url {
   src:

--- a/packages/js_of_ocaml/js_of_ocaml.3.0.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
   "uchar"
-  "js_of_ocaml-compiler"
+  "js_of_ocaml-compiler" {= version}
 ]
 conflicts: [
   "ppx_tools_versioned"     {<= "5.0beta0"}

--- a/packages/js_of_ocaml/js_of_ocaml.3.0.2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
   "uchar"
-  "js_of_ocaml-compiler"
+  "js_of_ocaml-compiler" {= version}
 ]
 conflicts: [
   "ppx_tools_versioned"     {<= "5.0beta0"}

--- a/packages/js_of_ocaml/js_of_ocaml.3.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
   "uchar"
-  "js_of_ocaml-compiler"
+  "js_of_ocaml-compiler" {= version}
 ]
 conflicts: [
   "ppx_tools_versioned"     {<= "5.0beta0"}

--- a/packages/js_of_ocaml/js_of_ocaml.3.1.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
   "uchar"
-  "js_of_ocaml-compiler"
+  "js_of_ocaml-compiler" {= version}
 ]
 conflicts: [
   "ppx_tools_versioned"     {<= "5.0beta0"}

--- a/packages/js_of_ocaml/js_of_ocaml.3.2.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
   "uchar"
-  "js_of_ocaml-compiler" {>= "3.2.0"}
+  "js_of_ocaml-compiler" {= version}
 ]
 conflicts: [
   "ppx_tools_versioned"     {<= "5.0beta0"}

--- a/packages/js_of_ocaml/js_of_ocaml.3.3.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.3.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
   "uchar"
-  "js_of_ocaml-compiler"
+  "js_of_ocaml-compiler" {= version}
 ]
 conflicts: [
   "ppx_tools_versioned"     {<= "5.0beta0"}

--- a/packages/js_of_ocaml/js_of_ocaml.3.4.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.4.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
   "uchar"
-  "js_of_ocaml-compiler"
+  "js_of_ocaml-compiler" {= version}
 ]
 conflicts: [
   "ppx_tools_versioned"     {<= "5.0beta0"}

--- a/packages/js_of_ocaml/js_of_ocaml.3.5.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.5.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-migrate-parsetree" {>= "1.4"}
   "ppx_tools_versioned" {>= "5.2.3"}
   "uchar"
-  "js_of_ocaml-compiler"
+  "js_of_ocaml-compiler" {= version}
 ]
 url {
   src:

--- a/packages/js_of_ocaml/js_of_ocaml.3.5.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.5.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-migrate-parsetree" {>= "1.4"}
   "ppx_tools_versioned" {>= "5.2.3"}
   "uchar"
-  "js_of_ocaml-compiler"
+  "js_of_ocaml-compiler" {= version}
 ]
 url {
   src:


### PR DESCRIPTION
Since `js_of_ocaml.3.5.2` all of the js_of_ocaml sub-packages are sync up with their own versions (meaning they're going to require js_of_ocaml packages that have the same version)

This PR backports the change to older version of js_of_ocaml as a lot of failures have been observed due to the mismatching of version (for instance https://github.com/ocaml/opam-repository/pull/15701 but many others exist). This is just a draft as this should be agreed with the dev team first. cc @hhugo @jrochel 