### PR TITLE
Package ocaml-curses.1.0.5

### DIFF
--- a/packages/ocaml-curses/ocaml-curses.1.0.5/opam
+++ b/packages/ocaml-curses/ocaml-curses.1.0.5/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "michael.bacarella@gmail.com"
+authors: ["Nicolas George"]
+homepage: "https://github.com/mbacarella/ocaml-curses"
+bug-reports: "http://github.com/mbacarella/ocaml-curses#issues"
+dev-repo: "git+https://github.com/mbacarella/ocaml-curses"
+build: [
+  ["./configure" "--enable-widec"]
+  [make "OCAMLMAKEFILE=OCamlMakefile" "byte"]
+  [make "OCAMLMAKEFILE=OCamlMakefile" "opt"]
+]
+remove: [["ocamlfind" "remove" "curses"]]
+depends: [
+    "ocaml"
+    "ocamlfind" {build}
+    "conf-ncurses"
+]
+install: [make "OCAMLMAKEFILE=OCamlMakefile" "install"]
+synopsis: "Bindings to curses/ncurses"
+description: "Tools for building terminal-based user interfaces"
+flags: light-uninstall
+url {
+  src: "https://github.com/mbacarella/ocaml-curses/archive/1.0.5.tar.gz"
+  checksum: [
+    "md5=25647e6991d389a47cd7d376fde7087c"
+    "sha512=32c14d49d8d59f0ced261923055ccbdbe47a08f92c69f4c6f412f9214f629c90e34e310519c2d3fd79e4d46d7279dffc1cde868dacc0f87295c84c293ee3976e"
+  ]
+}


### PR DESCRIPTION
### `ocaml-curses.1.0.5`
Bindings to curses/ncurses
Tools for building terminal-based user interfaces



---
* Homepage: https://github.com/mbacarella/ocaml-curses
* Source repo: git+https://github.com/mbacarella/ocaml-curses
* Bug tracker: http://github.com/mbacarella/ocaml-curses#issues

---
:camel: Pull-request generated by opam-publish v2.0.2