### PR TITLE
Package curses.1.0.5

### DIFF
--- a/packages/curses/curses.1.0.5/opam
+++ b/packages/curses/curses.1.0.5/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "michael.bacarella@gmail.com"
+authors: ["Nicolas George"]
+homepage: "https://github.com/mbacarella/curses"
+bug-reports: "http://github.com/mbacarella/curses/issues"
+dev-repo: "git+https://github.com/mbacarella/curses"
+build: [
+  ["./configure" "--enable-widec"]
+  [make "OCAMLMAKEFILE=OCamlMakefile" "byte"]
+  [make "OCAMLMAKEFILE=OCamlMakefile" "opt"]
+]
+depends: [
+    "ocaml"
+    "ocamlfind" {build}
+    "conf-ncurses"
+]
+install: [make "OCAMLMAKEFILE=OCamlMakefile" "install"]
+synopsis: "Bindings to curses/ncurses"
+description: "Tools for building terminal-based user interfaces"
+url {
+  src: "https://github.com/mbacarella/curses/archive/1.0.5.tar.gz"
+  checksum: [
+    "md5=4e1da43a469057afd505c92f46483f09"
+    "sha512=b77418ffdcff0e8a01184cfed4311765ff92399f1d3d75ba281d27ea669a6cee789ea7e5e1dfa044e55d900370393f9ae4b63fb9b6bf7af978681dcf58ca34c2"
+  ]
+}


### PR DESCRIPTION
### `curses.1.0.5`
Bindings to curses/ncurses
Tools for building terminal-based user interfaces



---
* Homepage: https://github.com/mbacarella/curses
* Source repo: git+https://github.com/mbacarella/curses
* Bug tracker: http://github.com/mbacarella/curses/issues

---
:camel: Pull-request generated by opam-publish v2.0.2