### PR TITLE
4 packages from c-cube/qcheck at 0.13

### DIFF
--- a/packages/qcheck-alcotest/qcheck-alcotest.0.13/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.13/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+synopsis: "Alcotest backend for qcheck"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "quickcheck"
+  "qcheck"
+  "alcotest"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "alcotest"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.13.tar.gz"
+  checksum: [
+    "md5=134c6b4ffc90076eef3041dbc01181f1"
+    "sha512=eab2f5a4ef79d061c2c708ea481b735f106752b1c7797b61d5d3c11e5003e57c103b0e3260e2797521d4faa6f4d9d6ce343b499d032fd65fd1bba4a94ab996eb"
+  ]
+}

--- a/packages/qcheck-core/qcheck-core.0.13/opam
+++ b/packages/qcheck-core/qcheck-core.0.13/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+synopsis: "Core qcheck library"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.13.tar.gz"
+  checksum: [
+    "md5=134c6b4ffc90076eef3041dbc01181f1"
+    "sha512=eab2f5a4ef79d061c2c708ea481b735f106752b1c7797b61d5d3c11e5003e57c103b0e3260e2797521d4faa6f4d9d6ce343b499d032fd65fd1bba4a94ab996eb"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.13/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.13/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://c-cube.github.io/qcheck/"]
+synopsis: "OUnit backend for qcheck"
+tags: [
+  "qcheck"
+  "quickcheck"
+  "ounit"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "ounit" {>= "2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.13.tar.gz"
+  checksum: [
+    "md5=134c6b4ffc90076eef3041dbc01181f1"
+    "sha512=eab2f5a4ef79d061c2c708ea481b735f106752b1c7797b61d5d3c11e5003e57c103b0e3260e2797521d4faa6f4d9d6ce343b499d032fd65fd1bba4a94ab996eb"
+  ]
+}

--- a/packages/qcheck/qcheck.0.13/opam
+++ b/packages/qcheck/qcheck.0.13/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Compatibility package for qcheck"
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "qcheck-ounit" { = version }
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.13.tar.gz"
+  checksum: [
+    "md5=134c6b4ffc90076eef3041dbc01181f1"
+    "sha512=eab2f5a4ef79d061c2c708ea481b735f106752b1c7797b61d5d3c11e5003e57c103b0e3260e2797521d4faa6f4d9d6ce343b499d032fd65fd1bba4a94ab996eb"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`qcheck.0.13`: Compatibility package for qcheck
-`qcheck-alcotest.0.13`: Alcotest backend for qcheck
-`qcheck-core.0.13`: Core qcheck library
-`qcheck-ounit.0.13`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.0.0