### PR TITLE
3 packages from gitlab.com/nomadic-labs/json-data-encoding/-/archive/v0.8/json-data-encoding-v0.8.tar.gz

### DIFF
--- a/packages/json-data-encoding-browser/json-data-encoding-browser.0.8/opam
+++ b/packages/json-data-encoding-browser/json-data-encoding-browser.0.8/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (browser support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.7"}
+  "json-data-encoding" {= version }
+  "js_of_ocaml" {>= "3.3.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/v0.8/json-data-encoding-v0.8.tar.gz"
+  checksum: [
+    "md5=24fcb7feb10395eaaf840d1f8ccf162f"
+    "sha512=f6d2a00008a0cd88bfae2458f56dde8f45c4e209ece9805d3e8d2c74401e4a5f9e12f99d5318f58a30a4579d9c9e9f204a75269c2110bb16a3e1036b2599b7a5"
+  ]
+}

--- a/packages/json-data-encoding-bson/json-data-encoding-bson.0.8/opam
+++ b/packages/json-data-encoding-bson/json-data-encoding-bson.0.8/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (bson support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.7"}
+  "json-data-encoding" {= version }
+  "ocplib-endian" {>= "1.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/v0.8/json-data-encoding-v0.8.tar.gz"
+  checksum: [
+    "md5=24fcb7feb10395eaaf840d1f8ccf162f"
+    "sha512=f6d2a00008a0cd88bfae2458f56dde8f45c4e209ece9805d3e8d2c74401e4a5f9e12f99d5318f58a30a4579d9c9e9f204a75269c2110bb16a3e1036b2599b7a5"
+  ]
+}

--- a/packages/json-data-encoding/json-data-encoding.0.8/opam
+++ b/packages/json-data-encoding/json-data-encoding.0.8/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.7"}
+  "uri" {>= "1.9.0" }
+  "crowbar" { with-test }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/v0.8/json-data-encoding-v0.8.tar.gz"
+  checksum: [
+    "md5=24fcb7feb10395eaaf840d1f8ccf162f"
+    "sha512=f6d2a00008a0cd88bfae2458f56dde8f45c4e209ece9805d3e8d2c74401e4a5f9e12f99d5318f58a30a4579d9c9e9f204a75269c2110bb16a3e1036b2599b7a5"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`json-data-encoding.0.8`: Type-safe encoding to and decoding from JSON
-`json-data-encoding-browser.0.8`: Type-safe encoding to and decoding from JSON (browser support)
-`json-data-encoding-bson.0.8`: Type-safe encoding to and decoding from JSON (bson support)



---
* Homepage: https://gitlab.com/nomadic-labs/json-data-encoding
* Source repo: git+https://gitlab.com/nomadic-labs/json-data-encoding
* Bug tracker: https://gitlab.com/nomadic-labs/json-data-encoding/issues

---
:camel: Pull-request generated by opam-publish v2.0.0