### PR TITLE
Package ppx_cstubs.0.3.0

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.3.0/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://fdopen.github.io/ppx_cstubs/"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+doc: "https://fdopen.github.io/ppx_cstubs/"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ctypes" {>= "0.13.0" & < "0.17.0"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.02.3" & < "4.11.0"}
+  "ocaml-migrate-parsetree"
+  "ocamlfind" # not only a build dependency, it depends on findlib.top
+  "dune-configurator"
+  "dune" {>= "1.6"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: """
+Preprocessor for easier stub generation with ctypes
+"""
+
+description: """
+ppx_cstubs is a ppx-based preprocessor for stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file
+with c stub code and an OCaml file with all additional boilerplate
+code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=fccf304eaf4157ce009e3879678c077b"
+    "sha512=dc2a4b19c1dc798944b1f748d3a96af9ba06ca623589481176f7a3170e2edd88227749c4480ce069bcfa20bda3040f11d2aafe9bcd6f2fd7fa9b660e8d109002"
+  ]
+}


### PR DESCRIPTION
### `ppx_cstubs.0.3.0`
Preprocessor for easier stub generation with ctypes
ppx_cstubs is a ppx-based preprocessor for stub generation with
ctypes. ppx_cstubs creates two files from a single ml file: a file
with c stub code and an OCaml file with all additional boilerplate
code.



---
* Homepage: https://fdopen.github.io/ppx_cstubs/
* Source repo: git+https://github.com/fdopen/ppx_cstubs.git
* Bug tracker: https://github.com/fdopen/ppx_cstubs/issues

---
:camel: Pull-request generated by opam-publish v2.0.2