### PR TITLE
Package lwt-pipe.0.1

### DIFF
--- a/packages/lwt-pipe/lwt-pipe.0.1/opam
+++ b/packages/lwt-pipe/lwt-pipe.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "An alternative to `Lwt_stream` with interfaces for producers and consumers and a bounded internal buffer"
+build: [
+  ["dune" "build" "@install" "-p" name]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" {build}
+  "lwt"
+  "ocaml" { >= "4.03.0" }
+  "mdx" {with-test}
+  "qcheck" {with-test}
+  "qtest" {with-test}
+  "odoc" {with-doc}
+]
+tags: [ "lwt" "pipe" "stream" "blocking" ]
+homepage: "https://github.com/c-cube/lwt-pipe/"
+dev-repo: "git+https://github.com/c-cube/lwt-pipe.git"
+bug-reports: "https://github.com/c-cube/lwt-pipe/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/lwt-pipe/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=46cfc88c4220d40356f6bea7c535be6e"
+    "sha512=ebc04adf58d913aac8caf43d76b2191fa76101c60a48f6c992a396e5bc8b0756d1c6ca0f9038141b77a40185c8cdb03a9de62252b1d23b06e12f201a9dff914b"
+  ]
+}

--- a/packages/lwt-pipe/lwt-pipe.0.1/opam
+++ b/packages/lwt-pipe/lwt-pipe.0.1/opam
@@ -2,12 +2,12 @@ opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
 synopsis: "An alternative to `Lwt_stream` with interfaces for producers and consumers and a bounded internal buffer"
 build: [
-  ["dune" "build" "@install" "-p" name]
-  ["dune" "build" "@doc" "-p" name] {with-doc}
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" nam "-j" jobse] {with-test}
 ]
 depends: [
-  "dune" {build}
+  "dune" {>= "1.1"}
   "lwt"
   "ocaml" { >= "4.03.0" }
   "mdx" {with-test}


### PR DESCRIPTION
### `lwt-pipe.0.1`
An alternative to `Lwt_stream` with interfaces for producers and consumers and a bounded internal buffer



---
* Homepage: https://github.com/c-cube/lwt-pipe/
* Source repo: git+https://github.com/c-cube/lwt-pipe.git
* Bug tracker: https://github.com/c-cube/lwt-pipe/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0