### PR TITLE
[new release] letsencrypt (0.1.1)

### DIFF
--- a/packages/letsencrypt/letsencrypt.0.1.1/opam
+++ b/packages/letsencrypt/letsencrypt.0.1.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An implementation of the ACME protocol for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "astring"
+  "rresult"
+  "base64" {>= "3.1.0"}
+  "cmdliner"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "zarith"
+  "logs"
+  "fmt"
+  "lwt" {>= "2.6.0"}
+  "nocrypto"
+  "x509" {>= "0.9.0"}
+  "yojson" {>= "1.6.0"}
+  "ounit" {with-test}
+  "dns"
+  "dns-tsig"
+  "ptime"
+  "bos"
+  "fpath"
+  "randomconv"
+  "domain-name" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.1.1/letsencrypt-v0.1.1.tbz"
+  checksum: [
+    "sha256=0443c4f3c29d4440e975cc9f3da611a3a3bea6d7fdef523f90eeae48d6dc58d3"
+    "sha512=1d362892a44dd2678b2dd788d8164688e1b44f95a09610e2e80afdb6fb24dcb0e88b550786e679840e8ae4ba8a92922164407cad1c63fede67c4a87b5f5b85d0"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* use X509.Signing_request.hostnames, introduced in x509 v0.9.0
* provide a custom log source