### PR TITLE
Package ocsigen-toolkit.2.5.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.5.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.5.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.10.1"}
+  "calendar"
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.5.0.tar.gz"
+  checksum: [
+    "md5=e2f10b10a52b9c6bca90cd3471ffd996"
+    "sha512=0be0cbc6f98e7c9136a0e876d56f2f824f59310a2c6d9c0a277d80dea10c4b6d6dad631cb4a64e246daf284bba11a0dfb08ab0e2754bd140017dbff0d0b6a85d"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.5.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.2