### PR TITLE
[new release] lablgtk3-gtkspell3, lablgtk3-sourceview3 and lablgtk3 (3.1.0)

### DIFF
--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.0/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3, gtkspell library
+
+See https://garrigue.github.io/lablgtk/ for more information.
+
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                { >= "4.05.0" }
+  "dune"                 { >= "1.8.0"  }
+  "lablgtk3"             {  = version  }
+]
+depexts: [
+  ["gtkspell3-dev"] {os-distribution = "alpine"}
+  ["gtkspell3"] {os-distribution = "archlinux"}
+  ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
+  ["libgtkspell3-3-dev"] {os-distribution = "debian"}
+  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3"] {os = "freebsd"}
+  ["gtkspell3"] {os = "openbsd"}
+  ["gtkspell3-devel"] {os-family = "suse"}
+  ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
+  ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.1.0/lablgtk3-3.1.0.tbz"
+  checksum: [
+    "sha256=5b1fb2d7618c050995fdeeb15ac3d552abcafa26db66daac3488f1f93826c0ba"
+    "sha512=4bda466717414567a8833c40b06f9b48253035c4580addf4f34de50c9335bc9eecec34165b00aa63c0f4b8c29f21fbc7620e67b83501e385dfa5bd5875d7e0a6"
+  ]
+}

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.1.0/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+ gtksourceview library"
+description: """
+OCaml interface to GTK+3, gtksourceview3 library.
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                {         >= "4.05.0" }
+  "dune"                 {         >= "1.8.0"  }
+  "lablgtk3"             {          = version  }
+  "conf-gtksourceview3"  { build & >= "0"      }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.1.0/lablgtk3-3.1.0.tbz"
+  checksum: [
+    "sha256=5b1fb2d7618c050995fdeeb15ac3d552abcafa26db66daac3488f1f93826c0ba"
+    "sha512=4bda466717414567a8833c40b06f9b48253035c4580addf4f34de50c9335bc9eecec34165b00aa63c0f4b8c29f21fbc7620e67b83501e385dfa5bd5875d7e0a6"
+  ]
+}

--- a/packages/lablgtk3/lablgtk3.3.1.0/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL with linking exception"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3"
+
+depends: [
+  "ocaml"     {         >= "4.05.0" }
+  "dune"      {         >= "1.8.0"  }
+  "cairo2"    {         >= "0.6"    }
+  "conf-gtk3" { build & >= "18"     }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.1.0/lablgtk3-3.1.0.tbz"
+  checksum: [
+    "sha256=5b1fb2d7618c050995fdeeb15ac3d552abcafa26db66daac3488f1f93826c0ba"
+    "sha512=4bda466717414567a8833c40b06f9b48253035c4580addf4f34de50c9335bc9eecec34165b00aa63c0f4b8c29f21fbc7620e67b83501e385dfa5bd5875d7e0a6"
+  ]
+}


### PR DESCRIPTION
OCaml interface to GTK+3

- Project page: <a href="https://github.com/garrigue/lablgtk">https://github.com/garrigue/lablgtk</a>
- Documentation: <a href="https://garrigue.github.io/lablgtk/lablgtk3">https://garrigue.github.io/lablgtk/lablgtk3</a>

##### CHANGES:

2020.01.23 [Jacques]
  * headers changed again in ocaml 4.10.0beta2
  * fix C compilation warnings
  * fix SourceMarkAttributes.new_attribute

2020.01.14 [Jacques]
  * remove GtkDialog#has_separator property (report by Thomas Leonard, garrigue/lablgtk#68)
  * add GMisc.icon_status#set_tooltip_markup/text (report by T. Leonard, garrigue/lablgtk#69)
  * add #orientation to GPack.box/paned, GRange.range and GMisc.separator
    (report by Martin de Mello, garrigue/lablgtk#73)
