### PR TITLE
[new release] ocamlformat (0.13.0)

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.13.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.13.0/opam
@@ -16,7 +16,7 @@ license: "MIT"
 build: [
   ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test & ocaml:version >= "4.08"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.06"}

--- a/packages/ocamlformat/ocamlformat.0.13.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.13.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.13.0/ocamlformat-0.13.0.tbz"
+  checksum: [
+    "sha256=3f7bc85bb26284b49a818a6ea4e13919e709a24cded67f674f1aa61347703464"
+    "sha512=3939bb3b6103e020b046c7ec7ff7134e4ea37f27f694bb426c30bbf6574eb4daeb58ffd5631331680512fb68ed425c34ab2f5c54d38b808960e8c95b7af80530"
+  ]
+}
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test & ocaml:version >= "4.08"}
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "ocaml" {with-test & >= "4.08"}
+  "alcotest" {with-test}
+  "base" {>= "v0.11.0"}
+  "base-unix"
+  "cmdliner"
+  "dune" {>= "1.11.1"}
+  "fpath"
+  "ocaml-migrate-parsetree" {>= "1.3.1"}
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "re"
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."

--- a/packages/ocamlformat/ocamlformat.0.13.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.13.0/opam
@@ -8,8 +8,8 @@ url {
   src:
     "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.13.0/ocamlformat-0.13.0.tbz"
   checksum: [
-    "sha256=3f7bc85bb26284b49a818a6ea4e13919e709a24cded67f674f1aa61347703464"
-    "sha512=3939bb3b6103e020b046c7ec7ff7134e4ea37f27f694bb426c30bbf6574eb4daeb58ffd5631331680512fb68ed425c34ab2f5c54d38b808960e8c95b7af80530"
+    "sha256=4eaa21cde7b691e40ceaecaa38b3960e49daeae108970f6f5dfd6587a7d3c627"
+    "sha512=06a69765d486ced6b4b77731b0089ffde209369bd12423e7f6f4254c21f3bd2aa0b71f0d601d37eb0ac83ca862d1da4ae6f3a4af3d8fddfdfd0b58243dc61871"
   ]
 }
 license: "MIT"


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### New features

  + Add an option `--margin-check` to emit a warning if the formatted output exceeds the margin (ocaml-ppx/ocamlformat#1110) (Guillaume Petiot)
  + Preserve comment indentation when `wrap-comments` is unset (ocaml-ppx/ocamlformat#1138, ocaml-ppx/ocamlformat#1159) (Jules Aguillon)
  + Improve error messages (ocaml-ppx/ocamlformat#1147) (Jules Aguillon)
  + Display standard output in the emacs plugin even when ocamlformat does not fail (ocaml-ppx/ocamlformat#1189) (Guillaume Petiot)

#### Removed

  + Remove `ocamlformat_reason` (ocaml-ppx/ocamlformat#254, ocaml-ppx/ocamlformat#1185) (Etienne Millon).
    This tool has never been released to opam, has no known users, and overlaps
    with what `refmt` can do.
  + Remove `ocamlformat-diff` (ocaml-ppx/ocamlformat#1205) (Guillaume Petiot)
    This tool has never been released to opam, has no known users, and overlaps
    with what `merge-fmt` can do.

#### Packaging

  + Work with base v0.13.0 (ocaml-ppx/ocamlformat#1163) (Jules Aguillon)

#### Bug fixes

  + Fix placement of comments just before a '|' (ocaml-ppx/ocamlformat#1203) (Jules Aguillon)
  + Fix build version detection when building in the absence of a git root (ocaml-ppx/ocamlformat#1198) (Anil Madhavapeddy)
  + Fix wrapping of or-patterns in presence of comments with `break-cases=fit` (ocaml-ppx/ocamlformat#1167) (Jules Aguillon)
    This also fixes an unstable comment bug in or-patterns
  + Fix an unstable comment bug in variant declarations (ocaml-ppx/ocamlformat#1108) (Jules Aguillon)
  + Fix: break multiline comments (ocaml-ppx/ocamlformat#1122) (Guillaume Petiot)
  + Fix: types on named arguments were wrapped incorrectly when preceding comments (ocaml-ppx/ocamlformat#1124) (Guillaume Petiot)
  + Fix the indentation produced by max-indent (ocaml-ppx/ocamlformat#1118) (Guillaume Petiot)
  + Fix break after Psig_include depending on presence of docstring (ocaml-ppx/ocamlformat#1125) (Guillaume Petiot)
  + Remove some calls to if_newline and break_unless_newline and fix break before closing brackets (ocaml-ppx/ocamlformat#1168) (Guillaume Petiot)
  + Fix unstable cmt in or-pattern (ocaml-ppx/ocamlformat#1173) (Guillaume Petiot)
  + Fix location of comment attached to the underscore of an open record (ocaml-ppx/ocamlformat#1208) (Guillaume Petiot)
  + Fix parentheses around optional module parameter (ocaml-ppx/ocamlformat#1212) (Christian Barcenas)
  + Fix grouping of horizontally aligned comments (ocaml-ppx/ocamlformat#1209) (Guillaume Petiot)
  + Fix dropped comments around module pack expressions (ocaml-ppx/ocamlformat#1214) (Jules Aguillon)
  + Fix regression of comment position in list patterns (ocaml-ppx/ocamlformat#1141) (Josh Berdine)
  + Fix: adjust definition of Location.is_single_line to reflect margin (ocaml-ppx/ocamlformat#1102) (Josh Berdine)

#### Documentation

  + Fix documentation of option `version-check` (ocaml-ppx/ocamlformat#1135) (Wilfred Hughes)
  + Fix hint when using `break-separators=after-and-docked` (ocaml-ppx/ocamlformat#1130) (Greta Yorsh)
