### PR TITLE
Digestif 0.8.0 and MirageOS

### DIFF
--- a/packages/digestif/digestif.0.8.0/files/mirage.patch
+++ b/packages/digestif/digestif.0.8.0/files/mirage.patch
@@ -1,0 +1,11 @@
+diff --git a/_build/default/META.digestif b/_build/default/META.digestif
+--- a/_build/default/META.digestif
++++ b/_build/default/META.digestif
+@@ -55,3 +55,6 @@
+     plugin(native) = "rakia_xen.cmxs"
+   )
+ )
++
++xen_linkopts = "-l:rakia/xen/librakia_xen_stubs.a"
++freestanding_linkopts = "-l:rakia/freestanding/librakia_freestanding_stubs.a"
+--

--- a/packages/digestif/digestif.0.8.0/opam
+++ b/packages/digestif/digestif.0.8.0/opam
@@ -29,6 +29,9 @@ We provides implementation of:
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
 run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+extra-files: [
+  [ "mirage.patch" "md5=6f2e091200d1ba9cb63910e9c0b33416" ]
+]
 
 depends: [
   "ocaml"          {>= "4.03.0"}
@@ -49,7 +52,6 @@ depopts: [
 conflicts: [
   "mirage-xen-posix" {< "3.1.0"}
   "ocaml-freestanding" {< "0.4.3"}
-  "mirage-runtime" {< "4.0.0"}
 ]
 url {
   src:


### PR DESCRIPTION
/cc @hannesm 

This is an unconventional way to keep a compatibility with MirageOS 3.7. I'm not sure if it's ok and if we should go to this way. This patch unlocks `digestif.0.8.0` to be usable by MirageOS 3.7 (and keep the trick on the META file) by applying a patch at the end of the _build_ process.