### PR TITLE
Package herdtools7.7.55

### DIFF
--- a/packages/herdtools7/herdtools7.7.55/opam
+++ b/packages/herdtools7/herdtools7.7.55/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "The herdtools suite for simulating and studying weak memory models"
+maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
+authors: [
+  "Luc Maranget <Luc.Maranget@inria.fr>"
+  "Jade Alglave <j.alglave@ucl.ac.uk>"
+  "Vincent Jacques <vincent@russian-dolls-sunflowers.com>"
+]
+homepage: "http://diy.inria.fr/"
+bug-reports: "http://github.com/herd/herdtools7/issues/"
+doc: "http://diy.inria.fr/doc/index.html"
+dev-repo: "git+https://github.com/herd/herdtools7.git"
+build: ["sh" "./dune-build.sh" "%{prefix}%"]
+install: ["sh" "./dune-install.sh" "%{prefix}%"]
+# @todo Add "build-doc" field
+# @todo Add "build-test" field
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune"  {>= "1.2" }
+  "ocamlfind" { build }
+  "menhir" {>= "20180530"}
+]
+url {
+  src: "https://github.com/herd/herdtools7/archive/7.55.tar.gz"
+  checksum: [
+    "md5=bfbc6a65be8774f07714745f25072996"
+    "sha512=cc0ad17af5f74433e442e4fc1a82227002cb00b5ff6d1eb3f80673001075e0fe26e654db5c7ee8eb53fc5a650c6eb76d586660f9099f2622894479946d1b0116"
+  ]
+}


### PR DESCRIPTION
### `herdtools7.7.55`
The herdtools suite for simulating and studying weak memory models



---
* Homepage: http://diy.inria.fr/
* Source repo: git+https://github.com/herd/herdtools7.git
* Bug tracker: http://github.com/herd/herdtools7/issues/

---
:camel: Pull-request generated by opam-publish v2.0.2