### PR TITLE
Package javalib.3.2.1

### DIFF
--- a/packages/javalib/javalib.3.2.1/opam
+++ b/packages/javalib/javalib.3.2.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Nicolas Barré <nicolas.barre@irisa.fr>"
+authors: "Javalib Development team"
+homepage: "https://javalib-team.github.io/javalib/"
+bug-reports: "https://github.com/javalib-team/javalib/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/javalib-team/javalib.git"
+build: [
+  ["./configure.sh"]
+  [make]
+]
+install: [make "install"]
+depends: [
+  "ocaml" {>= "4.04"}
+  "conf-which" {build}
+  "ocamlfind" {build}
+  "camlzip" {>= "1.05"}
+  "extlib"
+]
+
+synopsis: "Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files"
+
+description: """
+Thus it stands for a good starting point for people who want to
+develop static analyses for Java byte-code programs, benefiting from
+the strength of OCaml language.
+"""
+url {
+  src: "https://github.com/javalib-team/javalib/archive/v3.2.1.tar.gz"
+  checksum: [
+    "md5=0970ddb7c418f6b16184a329e49ba31c"
+    "sha512=92f8d2c988704a5e148c5bfe1bc0e3a948ecdc6e2ac40c3b7b083a55fb7da15475f4ac35d242751276d72f4fa96f0b0631f6df87d78b1b0d62619773481edfee"
+  ]
+}


### PR DESCRIPTION
### `javalib.3.2.1`
Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files
Thus it stands for a good starting point for people who want to
develop static analyses for Java byte-code programs, benefiting from
the strength of OCaml language.



---
* Homepage: https://javalib-team.github.io/javalib/
* Source repo: git+https://github.com/javalib-team/javalib.git
* Bug tracker: https://github.com/javalib-team/javalib/issues

---
:camel: Pull-request generated by opam-publish v2.0.2