### PR TITLE
[new release] asn1-combinators (0.2.1)

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.2.1/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+authors: "David Kaloper Meršinjak"
+maintainer: "David Kaloper Meršinjak <dk505@cam.ac.uk>"
+homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
+doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+synopsis: "Embed typed ASN.1 grammars in OCaml"
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest"] {with-test} ]
+depends: [
+  "ocaml" {>="4.05.0"}
+  "dune"
+  "cstruct" {>= "1.6.0"}
+  "zarith"
+  "bigarray-compat"
+  "stdlib-shims"
+  "ptime"
+  "alcotest" {with-test}
+]
+description: """
+asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
+part of ASN.1, and embed the abstract syntax directly in the language. These
+abstract syntax representations can be used for parsing, serialization, or
+random testing.
+
+The only ASN.1 encodings currently supported are BER and DER.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.2.1/asn1-combinators-v0.2.1.tbz"
+  checksum: [
+    "sha256=f55b7ba9d846b6991269ad0d04e54cbef534e16aa7b084426047880f6848bf6f"
+    "sha512=6c2296d2b454fc59f19278ab7644441a0c56e726d548dcc1b1e99c736f11c47ad219203e2d761357ead3e697c6ca48adff36bd9d14c553bb5adc687d386841fc"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* disallow various constructs as suggested by ITU-T Rec X.690 (by @pqwy)
  * redundant OID component forms (X.690 8.20.2)
  * redundant integer forms (X.690 8.3.2)
  * empty integer (X.690 8.3.1, reported in mirleft/ocaml-asn1-combinators#23 by @emillon)
  * constructed strings in DER
* deeper implict -> explicit over choice (follow-up to v0.2.0 entry, by @pqwy)
* handle long-form length overflow (reported in mirleft/ocaml-asn1-combinators#24 by @emillon, fixed by @pqwy)
* disallow primitive with indefinite length (introduced in the bugfix above,
  reported by @emillon, fixed in mirleft/ocaml-asn1-combinators#32 by @hannesm)
* disallow nonsensical bitstring unused values (X690 8.6.2, reported in mirleft/ocaml-asn1-combinators#26
  by @NathanReb, fixed by @pqwy)
* fix non-continuous bit_string_flags (X680 22.6, reported in mirleft/ocaml-asn1-combinators#25 by @wiml,
  fixed by @pqwy)
* use Alcotest instead of oUnit for unit tests (by @pqwy)
* use dune as build system (by @pqwy, superseeds mirleft/ocaml-asn1-combinators#22)
* use bigarray-compat (mirleft/ocaml-asn1-combinators#27 by @TheLortex) and stdlib-shims (mirleft/ocaml-asn1-combinators#29 by @XVilka)
* raise lower bound to OCaml 4.05.0 (mirleft/ocaml-asn1-combinators#31 by @hannesm)