### PR TITLE
Release async_ssl.v0.13.0 and async_smtp.v0.13.0

### DIFF
--- a/packages/async_smtp/async_smtp.v0.13.0/opam
+++ b/packages/async_smtp/async_smtp.v0.13.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_smtp"
+bug-reports: "https://github.com/janestreet/async_smtp/issues"
+dev-repo: "git+https://github.com/janestreet/async_smtp.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/async_smtp/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"          {>= "4.08.0"}
+  "async"          {>= "v0.13" & < "v0.14"}
+  "async_extra"    {>= "v0.13" & < "v0.14"}
+  "async_inotify"  {>= "v0.13" & < "v0.14"}
+  "async_sendfile" {>= "v0.13" & < "v0.14"}
+  "async_shell"    {>= "v0.13" & < "v0.14"}
+  "async_ssl"      {>= "v0.13" & < "v0.14"}
+  "core"           {>= "v0.13" & < "v0.14"}
+  "email_message"  {>= "v0.13" & < "v0.14"}
+  "ppx_jane"       {>= "v0.13" & < "v0.14"}
+  "re2"            {>= "v0.13" & < "v0.14"}
+  "resource_cache" {>= "v0.13" & < "v0.14"}
+  "sexp_macro"     {>= "v0.13" & < "v0.14"}
+  "textutils"      {>= "v0.13" & < "v0.14"}
+  "base64"
+  "cryptokit"
+  "dune"           {>= "1.5.1"}
+]
+synopsis: "SMTP client and server"
+description: "
+"
+url {
+  src: "https://ocaml.janestreet.com/ocaml-core/v0.13/files/async_smtp-v0.13.0.tar.gz"
+  checksum: "md5=c1d8da85c95a31ccfe19bc25f90dabbe"
+}

--- a/packages/async_ssl/async_ssl.v0.13.0/opam
+++ b/packages/async_ssl/async_ssl.v0.13.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_ssl"
+bug-reports: "https://github.com/janestreet/async_ssl/issues"
+dev-repo: "git+https://github.com/janestreet/async_ssl.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/async_ssl/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"          {>= "4.08.0"}
+  "async"          {>= "v0.13" & < "v0.14"}
+  "base"           {>= "v0.13" & < "v0.14"}
+  "core"           {>= "v0.13" & < "v0.14"}
+  "ppx_jane"       {>= "v0.13" & < "v0.14"}
+  "stdio"          {>= "v0.13" & < "v0.14"}
+  "conf-libssl"
+  "ctypes"         {>= "0.16.0"}
+  "ctypes-foreign"
+  "dune"           {>= "1.5.1"}
+  "dune-configurator"
+]
+synopsis: "An Async-pipe-based interface with OpenSSL"
+description: "
+This library allows you to create an SSL client and server, with
+encrypted communication between both.
+"
+url {
+  src: "https://github.com/janestreet/async_ssl/archive/v0.13.0.tar.gz"
+  checksum: "md5=9972b8befbb353988411b21a5632a974"
+}


### PR DESCRIPTION
This pull request releases two Jane Street packages that could
not be released as part of v0.13 back in November because:

- `async_ssl` was based on a patched version of `ctypes`;
- `async_smtp` depends on `async_ssl`.

The recent versions of `ctypes` include what `async_ssl` needs,
hence this release.