### PR TITLE
[new release] asn1-combinators (0.2.2)

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.2.2/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+authors: "David Kaloper Meršinjak"
+maintainer: "David Kaloper Meršinjak <dk505@cam.ac.uk>"
+homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
+doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+synopsis: "Embed typed ASN.1 grammars in OCaml"
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+depends: [
+  "ocaml" {>="4.05.0"}
+  "dune" {>= "1.2.0"}
+  "cstruct" {>= "1.6.0"}
+  "zarith"
+  "bigarray-compat"
+  "stdlib-shims"
+  "ptime"
+  "alcotest" {with-test}
+]
+description: """
+asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
+part of ASN.1, and embed the abstract syntax directly in the language. These
+abstract syntax representations can be used for parsing, serialization, or
+random testing.
+
+The only ASN.1 encodings currently supported are BER and DER.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.2.2/asn1-combinators-v0.2.2.tbz"
+  checksum: [
+    "sha256=c9ebd5f9def090003918081cac680224eaefbf3def8aed8fe532b711a71d3631"
+    "sha512=199dda83814d7782183d67f9cdd6f5e8f036cbc1bcddec7ffd4adfd415ae024d1f7c720835eb173ab5e7455ed89acb99f88d0a30402c3edbfe6ca8a7182b217b"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* packaging improvements: add lower bound to dune dependency, improve test
  invocation, remove version from dune-project
  (reported by @kit-ty-kate in ocaml/opam-repository#15757 fixed by @hannesm)

superseeds #15757