### PR TITLE
[new release] minicaml (transition)

### DIFF
--- a/packages/minicaml/minicaml.transition/opam
+++ b/packages/minicaml/minicaml.transition/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "sudo-woodo3@protonmail.com"
+authors: ["Alessandro Cheli"]
+homepage: "https://github.com/0x0f0f0f/minicaml"
+license: "MIT"
+synopsis: "Project has been renamed to gobba. This virtual package can be safely removed"
+description: "Project has been renamed to gobba. This virtual package can be safely removed"
+version: "transition"
+
+depends: [
+    "gobba"
+]
+url {
+  src:
+    "https://github.com/0x0f0f0f/minicaml/releases/download/transition/minicaml-transition.tbz"
+  checksum: [
+    "sha256=9416e3ad0a93fe6882d98e3c3eb378db7801cc5b13f7c465fd79f951f8516e3a"
+    "sha512=b1fa01fe7378dcb230a28f0f824c0295a6172d7f75afaff5fc0f09520eb2f25bdf397b9463ea5bdbf8412dc6b40437b4b7276620f7bd0605c3ad16ad96717ea1"
+  ]
+}


### PR DESCRIPTION
Project has been renamed to gobba. This virtual package can be safely removed

- Project page: <a href="https://github.com/0x0f0f0f/minicaml">https://github.com/0x0f0f0f/minicaml</a>

##### CHANGES:

- Renamed project to gobba
