### PR TITLE
Luv: binding to libuv — cross-platform async I/O and other system calls

### DIFF
--- a/packages/luv/luv.0.5.0/opam
+++ b/packages/luv/luv.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+
+synopsis: "Binding to libuv: cross-platform asynchronous I/O"
+
+version: "0.5.0"
+license: "MIT"
+homepage: "https://github.com/aantron/luv"
+doc: "https://aantron.github.io/luv"
+bug-reports: "https://github.com/aantron/luv/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/luv.git"
+
+depends: [
+  "base-unix" {build}
+  "conf-python-3" {build}
+  "ctypes" {>= "0.13.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.02.0"}
+  "result"
+
+  "alcotest" {dev & >= "0.8.1"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Luv is a binding to libuv, the cross-platform C library that does
+asynchronous I/O in Node.js and runs its main loop.
+
+Besides asynchronous I/O, libuv also supports multiprocessing and
+multithreading. Multiple event loops can be run in different threads. libuv also
+exposes a lot of other functionality, amounting to a full OS API, and an
+alternative to the standard module Unix."
+
+url {
+  src: "https://github.com/aantron/luv/releases/download/0.5.0/luv-0.5.0.tar.gz"
+  checksum: "md5=2b7caeeb0227e8854fd7cc1c0f22c9a4"
+}


### PR DESCRIPTION
[**Luv**](https://github.com/aantron/luv) is a binding to [**libuv**](https://github.com/libuv/libuv), which is the library that does I/O and system calls in Node.js, and runs Node's main loop. libuv is roughly equivalent to `Lwt_unix`, but, due to usage in Node, it is more cross-platform and more intensively maintained.

libuv supports event-driven I/O, multithreading (including multithreaded event-driven I/O), and multiprocessing. It also exposes a lot of miscellaneous system calls. Luv [**binds**](https://aantron.github.io/luv/luv/index.html#api-reference) all of this in OCaml.

See:

- [Project page](https://github.com/aantron/luv)
- [User guide](https://aantron.github.io/luv/index.html)
- [API docs](https://aantron.github.io/luv/luv/index.html#api-reference)
- [libuv docs](http://docs.libuv.org/en/v1.x/)

The project is named after `-luv`, the linker flag for linking with libuv, which is probably the reason why libuv has its name in the first place (in spite of any mention of "unicorn velociraptors" or the logo).