### PR TITLE
Remove jbuilder.transition

### DIFF
--- a/packages/jbuilder/jbuilder.1.0+beta20.2/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta20.2/opam
@@ -37,3 +37,6 @@ url {
     "https://github.com/ocaml/dune/releases/download/1.0%2Bbeta20.2/jbuilder-1.0+beta20.2.tbz"
   checksum: "md5=fbe8c3b1facb206cac3fb8932b5dd5d9"
 }
+post-messages: [
+  "Jbuilder has been replaced by dune. Use the 'dune upgrade' command to migrate."
+]

--- a/packages/jbuilder/jbuilder.transition/opam
+++ b/packages/jbuilder/jbuilder.transition/opam
@@ -16,3 +16,4 @@ post-messages: [
 synopsis:
   "This is a transition package, jbuilder is now named dune. Use the dune"
 description: "package instead."
+available: false


### PR DESCRIPTION
This transition version was added back when dune was compatible with jbuilder, so it made sense to install dune in all cases. However, recent versions of dune no longer support jbuilder, so using this package just forces installation of an old version of dune, conflicting with packages that require a recent dune, which is generally undesirable.