### PR TITLE
Package sawja.1.5.8

### DIFF
--- a/packages/sawja/sawja.1.5.8/opam
+++ b/packages/sawja/sawja.1.5.8/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "sawja@inria.fr"
+authors: "Sawja development team"
+homepage: "http://sawja.inria.fr"
+bug-reports: "https://github.com/javalib-team/sawja/issues"
+license: "GPL-3.0"
+dev-repo: "git+https://github.com/javalib-team/sawja.git"
+build: [
+  ["./configure.sh"]
+  [make]
+]
+remove: [
+  ["ocamlfind" "remove" "sawja"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "ocamlfind" {build}
+  "javalib" {>= "3.2.1" & < "3.3"}
+]
+
+synopsis: "Sawja provides a high level representation of Java bytecode programs and static analysis tools"
+
+description: """
+Sawja is a library written in OCaml, relying on Javalib to provide a high level representation of Java bytecode programs. Its name stands for Static Analysis Workshop for JAva. Whereas Javalib is dedicated to isolated classes, Sawja handles bytecode programs with their class hierarchy and control flow algorithms.
+Moreover, Sawja provides some stackless intermediate representations of code, called JBir and A3Bir. The transformation algorithm, common to these representations, has been formalized and proved to be semantics-preserving.
+"""
+url {
+  src: "https://github.com/javalib-team/sawja/archive/v1.5.8.tar.gz"
+  checksum: [
+    "md5=52e6d8750afb4a84632e311f906dc954"
+    "sha512=51b851421d690bfc3421ec79039ffd9c1585541f43ceca7c861d9a752b54a676fd929f9a54c8584668a593df38aaa52636835d1b2e5081fbc8639d0b24a8ecfd"
+  ]
+}


### PR DESCRIPTION
### `sawja.1.5.8`
Sawja provides a high level representation of Java bytecode programs and static analysis tools
Sawja is a library written in OCaml, relying on Javalib to provide a high level representation of Java bytecode programs. Its name stands for Static Analysis Workshop for JAva. Whereas Javalib is dedicated to isolated classes, Sawja handles bytecode programs with their class hierarchy and control flow algorithms.
Moreover, Sawja provides some stackless intermediate representations of code, called JBir and A3Bir. The transformation algorithm, common to these representations, has been formalized and proved to be semantics-preserving.



---
* Homepage: http://sawja.inria.fr
* Source repo: git+https://github.com/javalib-team/sawja.git
* Bug tracker: https://github.com/javalib-team/sawja/issues

---
:camel: Pull-request generated by opam-publish v2.0.0