### PR TITLE
Package multipart-form-data.0.3.0

### DIFF
--- a/packages/multipart-form-data/multipart-form-data.0.3.0/opam
+++ b/packages/multipart-form-data/multipart-form-data.0.3.0/opam
@@ -14,10 +14,9 @@ run-test: [
 ]
 depends: [
   "alcotest" {with-test}
-  "dune" {build}
+  "dune"
   "lwt"
   "lwt_ppx"
-  "ocaml-migrate-parsetree" {build}
   "stringext"
 ]
 synopsis: "Parser for multipart/form-data (RFC2388)"

--- a/packages/multipart-form-data/multipart-form-data.0.3.0/opam
+++ b/packages/multipart-form-data/multipart-form-data.0.3.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: ["Cryptosense <opensource@cryptosense.com>"]
+authors: ["Cryptosense <opensource@cryptosense.com>"]
+homepage: "https://github.com/cryptosense/multipart-form-data"
+bug-reports: "https://github.com/cryptosense/multipart-form-data/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/multipart-form-data.git"
+doc: "https://cryptosense.github.io/multipart-form-data/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "alcotest" {with-test}
+  "dune" {build}
+  "lwt"
+  "lwt_ppx"
+  "ocaml-migrate-parsetree" {build}
+  "stringext"
+]
+synopsis: "Parser for multipart/form-data (RFC2388)"
+description: """
+This is a parser for structured form data based on `Lwt_stream` in order to use
+it with cohttp. You can use it to send POST parameters.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/multipart-form-data/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=9f7088e64d2889191f9269b03ea2c5f6"
+    "sha512=fa1a8cb8adda2fa5fff1dbeda76ba294aeb254118db5019d0249b4afecc9fb012ae3566074bbc29d38b53d2196fc5395034db64e4b8d5406ebda56b58707bf75"
+  ]
+}


### PR DESCRIPTION
### `multipart-form-data.0.3.0`
Parser for multipart/form-data (RFC2388)
This is a parser for structured form data based on `Lwt_stream` in order to use
it with cohttp. You can use it to send POST parameters.



---
* Homepage: https://github.com/cryptosense/multipart-form-data
* Source repo: git+https://github.com/cryptosense/multipart-form-data.git
* Bug tracker: https://github.com/cryptosense/multipart-form-data/issues

---
:camel: Pull-request generated by opam-publish v2.0.2