### PR TITLE
2 packages from c-cube/ocaml-bigstring at 0.3

### DIFF
--- a/packages/bigstring-unix/bigstring-unix.0.3/opam
+++ b/packages/bigstring-unix/bigstring-unix.0.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+maintainer: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+synopsis: "I/O functions for bigstrings using file descriptors and memory-maps"
+tags: [ "bigstring" "bigarray" ]
+homepage: "https://github.com/c-cube/ocaml-bigstring/"
+bug-reports: "https://github.com/c-cube/ocaml-bigstring/issues"
+dev-repo: "git://github.com/c-cube/ocaml-bigstring.git"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+depends: [
+  "dune" {>= "1.2"}
+  "base-bigarray"
+  "base-unix"
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {with-test}
+  "bigstring" {with-test}
+]
+url {
+  src: "https://github.com/c-cube/ocaml-bigstring/archive/0.3.tar.gz"
+  checksum: [
+    "md5=dff09605881c7f6efd4a8a1a71790889"
+    "sha512=d0c530603e9bb37a704d736137953e4f2a1b1e16517587010f2fb323a5c3e4d887f558775349231ea15a98d3c085ed9daaf0a7603f165cdd0097ff2548ce790a"
+  ]
+}

--- a/packages/bigstring/bigstring.0.3/opam
+++ b/packages/bigstring/bigstring.0.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "A set of utils for dealing with `bigarrays` of `char`"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+maintainer: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: [ "bigstring" "bigarray" ]
+homepage: "https://github.com/c-cube/ocaml-bigstring/"
+bug-reports: "https://github.com/c-cube/ocaml-bigstring/issues"
+dev-repo: "git://github.com/c-cube/ocaml-bigstring.git"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+depends: [
+  "dune" {>= "1.2"}
+  "base-bigarray"
+  "base-bytes"
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {with-test}
+  "bigstring-unix" {with-test}
+]
+url {
+  src: "https://github.com/c-cube/ocaml-bigstring/archive/0.3.tar.gz"
+  checksum: [
+    "md5=dff09605881c7f6efd4a8a1a71790889"
+    "sha512=d0c530603e9bb37a704d736137953e4f2a1b1e16517587010f2fb323a5c3e4d887f558775349231ea15a98d3c085ed9daaf0a7603f165cdd0097ff2548ce790a"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`bigstring.0.3`: A set of utils for dealing with `bigarrays` of `char`
-`bigstring-unix.0.3`: I/O functions for bigstrings using file descriptors and memory-maps



---
* Homepage: https://github.com/c-cube/ocaml-bigstring/
* Source repo: git://github.com/c-cube/ocaml-bigstring.git
* Bug tracker: https://github.com/c-cube/ocaml-bigstring/issues

---
:camel: Pull-request generated by opam-publish v2.0.2