### PR TITLE
Amend OCamlformat 0.13.0

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.13.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.13.0/opam
@@ -6,10 +6,10 @@ bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.13.0/ocamlformat-0.13.0.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.13.0/ocamlformat-0.13.0-2.tbz"
   checksum: [
-    "sha256=4eaa21cde7b691e40ceaecaa38b3960e49daeae108970f6f5dfd6587a7d3c627"
-    "sha512=06a69765d486ced6b4b77731b0089ffde209369bd12423e7f6f4254c21f3bd2aa0b71f0d601d37eb0ac83ca862d1da4ae6f3a4af3d8fddfdfd0b58243dc61871"
+    "sha256=b84b694ef7c957bc05f938c98c687da77645cddab1c5ec6ae270f6113175224e"
+    "sha512=88d0c4c1746c08f3bd34a0d1e1e34dda1496d1d96f613e2523923ce7d9e9e31b0e5cc7ab7f6634d04ea6354aa777972a248b9c7bc4f817b4ad357277e4da781e"
   ]
 }
 license: "MIT"


### PR DESCRIPTION
Something went wrong while releasing, the version string embedded in the program was wrong.
The code didn't change but the distribution did.

The diff of the distribution is:

```diff
diff --git a/a/ocamlformat-0.13.0/dune-project b/b/ocamlformat-0.13.0/dune-project
index b708c93..96293b8 100644
--- a/a/ocamlformat-0.13.0/dune-project
+++ b/b/ocamlformat-0.13.0/dune-project
@@ -12,5 +12,5 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (name ocamlformat)
-(version 0.12-62-g7b58536)
+(version 0.13.0)
 (using fmt 1.2)
diff --git a/a/ocamlformat-0.13.0/ocamlformat.opam b/b/ocamlformat-0.13.0/ocamlformat.opam
index b535816..f68021c 100644
--- a/a/ocamlformat-0.13.0/ocamlformat.opam
+++ b/b/ocamlformat-0.13.0/ocamlformat.opam
@@ -16,7 +16,7 @@ authors: "Josh Berdine <jjb@fb.com>"
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
-url { archive: "https://github.com/ocaml-ppx/ocamlformat/archive/0.12-62-g7b58536.tar.gz" }
+url { archive: "https://github.com/ocaml-ppx/ocamlformat/archive/0.13.0.tar.gz" }
 license: "MIT"
 build: [
   ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
diff --git a/a/ocamlformat-0.13.0/tools/gen_version.mlt b/b/ocamlformat-0.13.0/tools/gen_version.mlt
index 497ad23..ff74ccf 100644
--- a/a/ocamlformat-0.13.0/tools/gen_version.mlt
+++ b/b/ocamlformat-0.13.0/tools/gen_version.mlt
@@ -16,7 +16,7 @@
 
 let fake_watermark = "%%" ^ "VERSION" ^ "%%"
 
-let real_watermark = "0.12-62-g7b58536"
+let real_watermark = "0.13.0"
 
 let file, version =
   match Sys.argv with
```

The wrong distribution is still available to avoid breaking users that did `opam update` recently.