### PR TITLE
[new release] syslog-rfc5424 (0.1)

### DIFF
--- a/packages/syslog-rfc5424/syslog-rfc5424.0.1/opam
+++ b/packages/syslog-rfc5424/syslog-rfc5424.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-syslog-rfc5424"
+bug-reports: "https://github.com/vbmithr/ocaml-syslog-rfc5424/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-syslog-rfc5424"
+doc: "https://vbmithr.github.io/ocaml-syslog-rfc5424/doc"
+build: [ "dune" "build" "-j" jobs "-p" name ]
+run-test: [ "dune" "runtest" "-j" jobs "-p" name ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.11.4"}
+  "uint" {>= "2.0.1"}
+  "rresult" {>= "0.6.0"}
+  "logs" {>= "0.7.0"}
+  "syslog-message" {>= "1.1.0"}
+  "ptime" {>= "0.8.5"}
+  "tyre" {>= "0.4.1"}
+  "astring" {with-test & >= "0.8.3"}
+  "alcotest" {with-test & >= "0.8.5"}
+]
+synopsis: "Syslog Protocol (RFC5424) parser and pretty-printer"
+description:"""This is a library for parsing and generating
+[RFC5424](https://tools.ietf.org/html/rfc5424) Syslog
+messages (obsoletes RFC3164).
+"""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-syslog-rfc5424/releases/download/0.1/syslog-rfc5424-0.1.tbz"
+  checksum: [
+    "sha256=7d5b8c05a77c211eeac3816bb1a988c6c651e7235348b17450df0b8034530a07"
+    "sha512=310acc0429d3e8f67b010a331e0b3f90bd41c04af3de2d8a4abe24e4028e16c1987954c4285b170013767254509d5b6ce580ca4181e8e2d2099080575a1fd4a4"
+  ]
+}


### PR DESCRIPTION
Syslog Protocol (RFC5424) parser and pretty-printer

- Project page: <a href="https://github.com/vbmithr/ocaml-syslog-rfc5424">https://github.com/vbmithr/ocaml-syslog-rfc5424</a>
- Documentation: <a href="https://vbmithr.github.io/ocaml-syslog-rfc5424/doc">https://vbmithr.github.io/ocaml-syslog-rfc5424/doc</a>

##### CHANGES:

- Initial release.
