### PR TITLE
jsoo: older jsoo need older lwt due to Lwt.async interface change

### DIFF
--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.0/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta17"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "5.0.0"}
   "js_of_ocaml" {>= "3.2" & < "3.5.0"}
   "js_of_ocaml-ppx"
 ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.1/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta17"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "5.0.0"}
   "js_of_ocaml" {>= "3.2" & < "3.5.0"}
   "js_of_ocaml-ppx"
 ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.3.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.3.0/opam
@@ -12,7 +12,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "5.0.0"}
   "js_of_ocaml" {>= "3.2" & < "3.5.0"}
   "js_of_ocaml-ppx"
 ]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.4.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.4.0/opam
@@ -16,7 +16,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2"}
-  "lwt" {>= "2.4.4"}
+  "lwt" {>= "2.4.4" & < "5.0.0"}
   "js_of_ocaml" {>= "3.2" & < "3.5.0"}
   "js_of_ocaml-ppx"
 ]


### PR DESCRIPTION
otherwise with lwt 5 you get:

```
Error: The implementation lib/lwt/lwt_js_events.pp.ml
        does not match the interface lib/lwt/.js_of_ocaml_lwt.objs/byte/js_of_ocaml_lwt__Lwt_js_events.cmi:
        Values do not match:
          val async : (unit -> unit Lwt.t) -> unit
        is not included in
          val async : (unit -> 'a Lwt.t) -> unit
        File "lib/lwt/lwt_js_events.mli", line 140, characters 0-38:
          Expected declaration
        File "lib/lwt/lwt_js_events.ml", line 25, characters 4-9:
          Actual declaration
```