### PR TITLE
os-distribution archlinux should be arch

### DIFF
--- a/packages/binsec/binsec.0.3/opam
+++ b/packages/binsec/binsec.0.3/opam
@@ -75,7 +75,7 @@ depends: [
 depexts: [
   [ "z3" "protobuf-compiler" ] { os-family = "debian" }
   [ "z3" "protobuf-compiler" ] { os-family = "fedora" }
-  [ "z3" "protobuf" ] { os-family = "archlinux" }
+  [ "z3" "protobuf" ] { os-family = "arch" }
   [ "z3" "protobuf" ] { os-family = "openbsd" }
 ]
 

--- a/packages/conf-haveged/conf-haveged.1.0.0/opam
+++ b/packages/conf-haveged/conf-haveged.1.0.0/opam
@@ -11,7 +11,7 @@ depexts: [
   ["haveged"] {os-distribution = "centos"}
   ["haveged"] {os-distribution = "fedora"}
   ["haveged"] {os-distribution = "alpine"}
-  ["haveged"] {os-distribution = "archlinux"}
+  ["haveged"] {os-distribution = "arch"}
   ["haveged"] {os-distribution = "gentoo"}
   ["haveged"] {os-family = "suse"}
 ]

--- a/packages/conf-libX11/conf-libX11.1/opam
+++ b/packages/conf-libX11/conf-libX11.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["libx11-dev"] {os-family = "debian"}
   ["libX11-devel"] {os-distribution = "centos" | os-distribution = "oraclelinux" | os-distribution = "fedora" | os-distribution = "opensuse"}
   ["libx11-dev"] {os-distribution = "alpine"}
-  ["libx11`"] {os-distribution = "archlinux"}
+  ["libx11`"] {os-distribution = "arch"}
   ["libX11-dev"] {os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on an Xlib system installation"

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
@@ -25,7 +25,7 @@ depends: [
 ]
 depexts: [
   ["gtkspell3-dev"] {os-distribution = "alpine"}
-  ["gtkspell3"] {os-distribution = "archlinux"}
+  ["gtkspell3"] {os-distribution = "arch"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-family = "debian"}
   ["gtkspell3-devel"] {os-distribution = "fedora"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
@@ -25,7 +25,7 @@ depends: [
 ]
 depexts: [
   ["gtkspell3-dev"] {os-distribution = "alpine"}
-  ["gtkspell3"] {os-distribution = "archlinux"}
+  ["gtkspell3"] {os-distribution = "arch"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-distribution = "debian"}
   ["gtkspell3-devel"] {os-distribution = "fedora"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta8/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta8/opam
@@ -23,7 +23,7 @@ depends: [
 ]
 depexts: [
   ["gtkspell3-dev"] {os-distribution = "alpine"}
-  ["gtkspell3"] {os-distribution = "archlinux"}
+  ["gtkspell3"] {os-distribution = "arch"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-distribution = "debian"}
   ["gtkspell3-devel"] {os-distribution = "fedora"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.0/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.0/opam
@@ -23,7 +23,7 @@ depends: [
 ]
 depexts: [
   ["gtkspell3-dev"] {os-distribution = "alpine"}
-  ["gtkspell3"] {os-distribution = "archlinux"}
+  ["gtkspell3"] {os-distribution = "arch"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-distribution = "debian"}
   ["gtkspell3-devel"] {os-distribution = "fedora"}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+flambda/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 depexts: [
   ["musl-tools"] {os-family = "debian"}
-  ["musl"] {os-distribution = "archlinux"}
+  ["musl"] {os-distribution = "arch"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 depexts: [
   ["musl-tools"] {os-family = "debian"}
-  ["musl"] {os-distribution = "archlinux"}
+  ["musl"] {os-distribution = "arch"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+flambda/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 depexts: [
   ["musl-tools"] {os-family = "debian"}
-  ["musl"] {os-distribution = "archlinux"}
+  ["musl"] {os-distribution = "arch"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 depexts: [
   ["musl-tools"] {os-family = "debian"}
-  ["musl"] {os-distribution = "archlinux"}
+  ["musl"] {os-distribution = "arch"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.1.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.1.0/opam
@@ -25,7 +25,7 @@ depexts: [
   ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-gnt.git"
 synopsis: "Xen grant table bindings for OCaml"

--- a/packages/xen-gnt-unix/xen-gnt-unix.4.0.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.4.0.0/opam
@@ -25,7 +25,7 @@ depexts: [
   ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xenstore"] {os-distribution = "archlinux"}
+  ["xenstore"] {os-distribution = "arch"}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-gnt.git"
 synopsis: "Xen grant table bindings for OCaml"


### PR DESCRIPTION
`docker run archlinux cat /usr/lib/os-release` shows that ID=arch.
Both are used in opam-repository, so correct archlinux to arch in
this PR.