### PR TITLE
Package ocp-indent-nlfork.1.5.4

### DIFF
--- a/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.4/opam
+++ b/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "contact@ocamlpro.com"
+authors: [
+  "Grégoire Henry <gregoire.henry@ocamlpro.com>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Jun Furuse"
+]
+homepage: "http://www.typerex.org/ocp-indent.html"
+bug-reports: "https://github.com/OCamlPro/ocp-indent/issues"
+license: "LGPL-3.0-or-later"
+tags: ["org:ocamlpro" "org:typerex"]
+dev-repo: "git+https://github.com/OCamlPro/ocp-indent.git#nlfork"
+build: ["dune" "build" "-j" jobs "-p" name]
+depends: [
+  "ocaml"
+  "dune"
+  "cmdliner" {>= "1.0.0"}
+]
+synopsis: """ocp-indent library, "newline tokens" fork"""
+description: """
+This is a modified version of the ocp-indent library, which is based on a
+different lexer, using newline tokens and banning multi-line ones, which is more
+convenient for some applications.
+
+The library is exported as `ocp-indent-nlfork`, so as not to interfere with
+canonical ocp-indent installations.
+
+This package does *not* install an ocp-indent binary or related tools."""
+url {
+  src: "https://github.com/OCamlPro/ocp-indent/archive/nlfork-1.5.4.tar.gz"
+  checksum: [
+    "md5=e9d1a7de64e169536ddf16023b111409"
+    "sha512=4637eb4ac2a47001f7b236ad7fdcbf7fe1a659e947a46aacd7ff2f2e386c82c423468aabd6adcabed8caf869d4a8f3f592ea1134b4ba77b7d37080e01cc497dc"
+  ]
+}


### PR DESCRIPTION
### `ocp-indent-nlfork.1.5.4`
ocp-indent library, "newline tokens" fork
This is a modified version of the ocp-indent library, which is based on a
different lexer, using newline tokens and banning multi-line ones, which is more
convenient for some applications.

The library is exported as `ocp-indent-nlfork`, so as not to interfere with
canonical ocp-indent installations.

This package does *not* install an ocp-indent binary or related tools.



---
* Homepage: http://www.typerex.org/ocp-indent.html
* Source repo: git+https://github.com/OCamlPro/ocp-indent.git#nlfork
* Bug tracker: https://github.com/OCamlPro/ocp-indent/issues

---
:camel: Pull-request generated by opam-publish v2.0.2