### PR TITLE
[new release] dune-build-info, dune, dune-configurator, dune-action-plugin, dune-private-libs and dune-glob (2.2.0)

### DIFF
--- a/packages/dune-action-plugin/dune-action-plugin.2.2.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-glob"
+  "ppx_expect" {with-test}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.2.0/dune-2.2.0.tbz"
+  checksum: [
+    "sha256=ab5eb970c21641a6f3034448218cdc1c138512b906c7d2f67fea41ecd98d8bf4"
+    "sha512=b48812a478ad1b75992a0c53dbdfac34841e3d5e97c559d63e2dd41d1724c21736cc3159743f3d95d85e1060ee5aa88a0abb46f5b0e778f533b40dead20af95c"
+  ]
+}

--- a/packages/dune-build-info/dune-build-info.2.2.0/opam
+++ b/packages/dune-build-info/dune-build-info.2.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Embed build informations inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.2.0/dune-2.2.0.tbz"
+  checksum: [
+    "sha256=ab5eb970c21641a6f3034448218cdc1c138512b906c7d2f67fea41ecd98d8bf4"
+    "sha512=b48812a478ad1b75992a0c53dbdfac34841e3d5e97c559d63e2dd41d1724c21736cc3159743f3d95d85e1060ee5aa88a0abb46f5b0e778f533b40dead20af95c"
+  ]
+}

--- a/packages/dune-configurator/dune-configurator.2.2.0/opam
+++ b/packages/dune-configurator/dune-configurator.2.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.2.0/dune-2.2.0.tbz"
+  checksum: [
+    "sha256=ab5eb970c21641a6f3034448218cdc1c138512b906c7d2f67fea41ecd98d8bf4"
+    "sha512=b48812a478ad1b75992a0c53dbdfac34841e3d5e97c559d63e2dd41d1724c21736cc3159743f3d95d85e1060ee5aa88a0abb46f5b0e778f533b40dead20af95c"
+  ]
+}

--- a/packages/dune-glob/dune-glob.2.2.0/opam
+++ b/packages/dune-glob/dune-glob.2.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.2.0/dune-2.2.0.tbz"
+  checksum: [
+    "sha256=ab5eb970c21641a6f3034448218cdc1c138512b906c7d2f67fea41ecd98d8bf4"
+    "sha512=b48812a478ad1b75992a0c53dbdfac34841e3d5e97c559d63e2dd41d1724c21736cc3159743f3d95d85e1060ee5aa88a0abb46f5b0e778f533b40dead20af95c"
+  ]
+}

--- a/packages/dune-private-libs/dune-private-libs.2.2.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.07"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.2.0/dune-2.2.0.tbz"
+  checksum: [
+    "sha256=ab5eb970c21641a6f3034448218cdc1c138512b906c7d2f67fea41ecd98d8bf4"
+    "sha512=b48812a478ad1b75992a0c53dbdfac34841e3d5e97c559d63e2dd41d1724c21736cc3159743f3d95d85e1060ee5aa88a0abb46f5b0e778f533b40dead20af95c"
+  ]
+}

--- a/packages/dune/dune.2.2.0/opam
+++ b/packages/dune/dune.2.2.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "base-unix"
+  "base-threads"
+]
+conflicts: [
+  "odoc" {< "1.3.0"}
+  "dune-release" {< "1.3.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.2.0/dune-2.2.0.tbz"
+  checksum: [
+    "sha256=ab5eb970c21641a6f3034448218cdc1c138512b906c7d2f67fea41ecd98d8bf4"
+    "sha512=b48812a478ad1b75992a0c53dbdfac34841e3d5e97c559d63e2dd41d1724c21736cc3159743f3d95d85e1060ee5aa88a0abb46f5b0e778f533b40dead20af95c"
+  ]
+}


### PR DESCRIPTION
Embed build informations inside executable

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- `dune test` is now a command alias for `dune runtest`. This is to make the CLI
  less idiosyncratic (ocaml/dune#3006, @shonfeder)

- Allow to set menhir flags in the `env` stanza using the `menhir_flags` field.
  (ocaml/dune#2960, fix ocaml/dune#2924, @bschommer)

- By default, do not show the full command line of commands executed
  by `dune` when `dune` is executed inside `dune`. This is to make
  integration tests more reproducible (ocaml/dune#3042, @diml)

- `dune subst` now works even without opam files (ocaml/dune#2955, fixes ocaml/dune#2910,
  @fangyi-zhou and @diml)

- Hint when trying to execute an executable defined in the current directory
  without using the `./` prefix (ocaml/dune#3041, fixes ocaml/dune#1094, @voodoos).

- Extend the list of modifiers that can be nested under
  `with-accepted-exit-codes` with `chdir`,  `setenv`, `ignore-<outputs>`,
  `with-stdin-from` and `with-<outputs>-to` (ocaml/dune#3027, fixes ocaml/dune#3014, @voodoos)

- It is now an error to have a preprocessing dependency on a ppx rewriter
  library that is not marked as `(kind ppx_rewriter)` (ocaml/dune#3039, @snowleopard).

- Fix permissions of files promoted to the source tree when using the
  shared cache. In particular, make them writable by the user (ocaml/dune#3043,
  fixes ocaml/dune#3026, @diml)

- Only detect internal OCaml tools with `.opt` extensions. Previously, this
  detection applied to other binaries as well (@kit-ty-kate, @rgrinberg, ocaml/dune#3051).

- Give the user a proper error message when they try to promote into a source
  directory that doesn't exist. (ocaml/dune#3073, fix ocaml/dune#3069, @rgrinberg)

- Correctly build vendored packages in `-p` mode. These packages were
  incorrectly filtered out before. (ocaml/dune#3705, @diml)

- Do not install vendored packages (ocaml/dune#3704, @diml)

- `make` now prints a message explaining the main targets available
  (ocaml/dune#3085, fix ocaml/dune#3078, @diml)

- Add a `byte_complete` executable mode to build programs as
  self-contained bytecode programs
  (ocaml/dune#3076, fixes ocaml/dune#1519, @diml)
