### PR TITLE
Package visitors.20200207

### DIFF
--- a/packages/visitors/visitors.20200207/opam
+++ b/packages/visitors/visitors.20200207/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/visitors"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/visitors.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3" }
+  "cppo" {build}
+  "ppx_tools"
+  "ppx_deriving" {>= "4.4"}
+  "result"
+  "dune" {>= "2.0"}
+]
+synopsis: "An OCaml syntax extension for generating visitor classes"
+description: """
+Annotating an algebraic data type definition with [@@deriving visitors { ... }]
+causes visitor classes to be automatically generated. A visitor is an object
+that knows how to traverse and transform a data structure."""
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/visitors/repository/20200207/archive.tar.gz"
+  checksum: [
+    "md5=37a67faaa74c2cb9647d3fd25a979b6c"
+    "sha512=feea43ccc6e2b7c48a5cceca7f38a78dcbf82fc8e334b22d643f4ce449b11fc4dcb1e500858a818a9b47dd4e30304bb90a450aff19daef969cc36e1f03af99a7"
+  ]
+}


### PR DESCRIPTION
### `visitors.20200207`
An OCaml syntax extension for generating visitor classes
Annotating an algebraic data type definition with [@@deriving visitors { ... }]
causes visitor classes to be automatically generated. A visitor is an object
that knows how to traverse and transform a data structure.



---
* Homepage: https://gitlab.inria.fr/fpottier/visitors
* Source repo: git+https://gitlab.inria.fr/fpottier/visitors.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.2