### PR TITLE
2 packages from cryptosense/ocaml-mock at 0.1.1

### DIFF
--- a/packages/mock-ounit/mock-ounit.0.1.1/opam
+++ b/packages/mock-ounit/mock-ounit.0.1.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: ["Cryptosense <opensource@cryptosense.com>"]
+authors: ["Cryptosense <opensource@cryptosense.com>"]
+homepage: "https://github.com/cryptosense/ocaml-mock"
+bug-reports: "https://github.com/cryptosense/ocaml-mock/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/ocaml-mock.git"
+doc: "https://cryptosense.github.io/ocaml-mock/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune"
+  "mock"
+  "ocaml" {>= "4.04.0"}
+  "ounit"
+  "ppx_deriving" {with-test}
+]
+synopsis: "OUnit wrapper for OCaml mock"
+url {
+  src: "https://github.com/cryptosense/ocaml-mock/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=582b08650d480a1773a70169b942992c"
+    "sha512=1c86066859534c2900a95659f3be299e8646ae1240f796f5d4c579370ede39db19e103945a366c2c316d46459cb17d99ac85fe340b74d1bbc1646e1e20ab857a"
+  ]
+}

--- a/packages/mock/mock.0.1.1/opam
+++ b/packages/mock/mock.0.1.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: ["Cryptosense <opensource@cryptosense.com>"]
+authors: ["Cryptosense <opensource@cryptosense.com>"]
+homepage: "https://github.com/cryptosense/ocaml-mock"
+bug-reports: "https://github.com/cryptosense/ocaml-mock/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/ocaml-mock.git"
+doc: "https://cryptosense.github.io/ocaml-mock/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune"
+  "ocaml" {>= "4.04.0"}
+]
+synopsis: "Configurable functions to test impure code"
+description: """
+This package provides "mocks", fake functions that can be configured to return
+values or raise exceptions. It is possible to inspect their arguments after
+their execution. The API is greatly inspired by unittest.mock in Python.
+"""
+url {
+  src: "https://github.com/cryptosense/ocaml-mock/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=582b08650d480a1773a70169b942992c"
+    "sha512=1c86066859534c2900a95659f3be299e8646ae1240f796f5d4c579370ede39db19e103945a366c2c316d46459cb17d99ac85fe340b74d1bbc1646e1e20ab857a"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`mock.0.1.1`: Configurable functions to test impure code
-`mock-ounit.0.1.1`: OUnit wrapper for OCaml mock



---
* Homepage: https://github.com/cryptosense/ocaml-mock
* Source repo: git+https://github.com/cryptosense/ocaml-mock.git
* Bug tracker: https://github.com/cryptosense/ocaml-mock/issues

---
:camel: Pull-request generated by opam-publish v2.0.2