### PR TITLE
[new release] yaml (2.1.0)

### DIFF
--- a/packages/yaml/yaml.2.1.0/opam
+++ b/packages/yaml/yaml.2.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>" "Rizo Isrof <rizo@odis.io>"]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-yaml"
+doc: "https://avsm.github.io/ocaml-yaml/"
+bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >="1.3"}
+  "dune-configurator"
+  "ctypes" {>= "0.12.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "rresult"
+  "fmt"
+  "logs"
+  "bos"
+  "mdx" {with-test}
+  "alcotest" {with-test}
+  "junit_alcotest" {with-test}
+  "ezjsonm" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/avsm/ocaml-yaml.git"
+synopsis: "Parse and generate YAML 1.1 files"
+description: """
+This is an OCaml library to parse and generate the YAML file
+format.  It is intended to interoperable with the [Ezjsonm](https://github.com/mirage/ezjsonm)
+JSON handling library, if the simple common subset of Yaml
+is used.  Anchors and other advanced Yaml features are not
+implemented in the JSON compatibility layer.
+
+The [Yaml module docs](http://anil-code.recoil.org/ocaml-yaml/yaml/Yaml/index.html) are browseable online.
+"""
+url {
+  src:
+    "https://github.com/avsm/ocaml-yaml/releases/download/v2.1.0/yaml-v2.1.0.tbz"
+  checksum: [
+    "sha256=05153817981ea97b62d8c49eeb42ba2e7efba82e61a3834b65213e59a0dee80d"
+    "sha512=339dc197615c8894d7e1031f425d328e6e81f6466688d30db1db21038cd49b33491980b49dccf3eb508bc6a90047296f801f3e03b9a521c00b0919c6a44c09e3"
+  ]
+}

--- a/packages/yaml/yaml.2.1.0/opam
+++ b/packages/yaml/yaml.2.1.0/opam
@@ -8,7 +8,7 @@ doc: "https://avsm.github.io/ocaml-yaml/"
 bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >="1.3"}
+  "dune" {>= "1.3"}
   "dune-configurator"
   "ctypes" {>= "0.12.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}


### PR DESCRIPTION
Parse and generate YAML 1.1 files

- Project page: <a href="https://github.com/avsm/ocaml-yaml">https://github.com/avsm/ocaml-yaml</a>
- Documentation: <a href="https://avsm.github.io/ocaml-yaml/">https://avsm.github.io/ocaml-yaml/</a>

##### CHANGES:

* Fix a memory unsoundness issue with larger files in the
  bindings to libyaml, which fixes spurious errors when parsing
  larger YAML files (avsm/ocaml-yaml#35 marcinkoziej)
* Expose more information about error locations while parsing
  a Yaml file (avsm/ocaml-yaml#34 @marcinkoziej)
* Add test for a large Yaml file (avsm/ocaml-yaml#30 @pmonson711)
* Bump size of internal serialisation buffer in `to_string`
  to 64KB from 16KB (@avsm).
* Switch CI to GitHub Actions (@avsm)
* Depend on dune-configurator in the build to be compatible
  with dune 2.0 and higher (@avsm)
