### PR TITLE
remove conf-gcc from zarith

### DIFF
--- a/packages/zarith/zarith.1.7-1/opam
+++ b/packages/zarith/zarith.1.7-1/opam
@@ -33,7 +33,6 @@ depends: [
   "ocamlfind"
   "conf-gmp"
   "conf-perl" {build}
-  "conf-gcc" {build}
 ]
 patches: [ "absolute_CC.patch" ]
 synopsis:

--- a/packages/zarith/zarith.1.9.1/opam
+++ b/packages/zarith/zarith.1.9.1/opam
@@ -30,7 +30,6 @@ depends: [
   "ocamlfind" {build}
   "conf-gmp"
   "conf-perl" {build}
-  "conf-gcc" {build}
 ]
 synopsis:
   "Implements arithmetic and logical operations over arbitrary-precision integers"


### PR DESCRIPTION
This was added as it is needed by nix in #14477, but it adds an unnecessary dependency on gcc for other platforms where clang is the default. We can assume there is a `cc` in the environment if opam is initialised, so the Nix packages should be able to do it there.

cc @bobot