### PR TITLE
[new release] github-unix, github-jsoo and github (4.3.0)

### DIFF
--- a/packages/github-jsoo/github-jsoo.4.3.0/opam
+++ b/packages/github-jsoo/github-jsoo.4.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 JavaScript library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+(JSON). This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "github" {= version}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt-jsoo" {>= "0.99.0"}
+  "js_of_ocaml-lwt" {>= "3.4.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.3.0/github-unix-4.3.0.tbz"
+  checksum: [
+    "sha256=4e0d71d04fb4db9f07068cda61a60412a74f153a923878fafe261a42d3a6efbc"
+    "sha512=4d7beeb4a86198605c04df46f7460c80fde746fb2a4173c3de753758510d74ec19269ace22cbd6d8d9cc752f818bf964225865d62328a344e547d0f13919cc22"
+  ]
+}

--- a/packages/github-unix/github-unix.4.3.0/opam
+++ b/packages/github-unix/github-unix.4.3.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 Unix library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+(JSON).  This package installs the Unix (Lwt) version."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "github" {= version}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt-unix" {>= "0.99.0"}
+  "stringext"
+  "lambda-term" {>= "2.0"}
+  "cmdliner" {>= "0.9.8"}
+  "base-unix"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.3.0/github-unix-4.3.0.tbz"
+  checksum: [
+    "sha256=4e0d71d04fb4db9f07068cda61a60412a74f153a923878fafe261a42d3a6efbc"
+    "sha512=4d7beeb4a86198605c04df46f7460c80fde746fb2a4173c3de753758510d74ec19269ace22cbd6d8d9cc752f818bf964225865d62328a344e547d0f13919cc22"
+  ]
+}

--- a/packages/github/github.4.3.0/opam
+++ b/packages/github/github.4.3.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 OCaml library"
+description: """
+This library provides an OCaml interface to the
+[GitHub APIv3](https://developer.github.com/v3/) (JSON).
+
+It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
+JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt" {>= "0.99"}
+  "lwt" {>= "2.4.4"}
+  "atdgen" {>= "2.0.0"}
+  "yojson" {>= "1.6.0"}
+  "stringext"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.3.0/github-unix-4.3.0.tbz"
+  checksum: [
+    "sha256=4e0d71d04fb4db9f07068cda61a60412a74f153a923878fafe261a42d3a6efbc"
+    "sha512=4d7beeb4a86198605c04df46f7460c80fde746fb2a4173c3de753758510d74ec19269ace22cbd6d8d9cc752f818bf964225865d62328a344e547d0f13919cc22"
+  ]
+}


### PR DESCRIPTION
GitHub APIv3 Unix library

- Project page: <a href="https://github.com/mirage/ocaml-github">https://github.com/mirage/ocaml-github</a>
- Documentation: <a href="https://mirage.github.io/ocaml-github/">https://mirage.github.io/ocaml-github/</a>

##### CHANGES:

- Remove deprecated authentication method as GitHub has removed
  support for it (mirage/ocaml-github#230 @Aaylor)
- Reintroduce `user_type` to distinguish organisations and
  users (mirage/ocaml-github#228 @Aaylor)
