### PR TITLE
[new release] odoc (1.5.0)

### DIFF
--- a/packages/odoc/odoc.1.5.0/opam
+++ b/packages/odoc/odoc.1.5.0/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 
-version: "dev"
 homepage: "http://github.com/ocaml/odoc"
 doc: "https://ocaml.github.io/odoc/"
 bug-reports: "https://github.com/ocaml/odoc/issues"

--- a/packages/odoc/odoc.1.5.0/opam
+++ b/packages/odoc/odoc.1.5.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+
+version: "dev"
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Jon Ludlam <jon@recoil.org>"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+description: """
+Odoc is a documentation generator for OCaml. It reads doc comments,
+delimited with `(** ... *)`, and outputs HTML. 
+"""
+
+depends: [
+  "astring"
+  "cmdliner"
+  "cppo" {build}
+  "dune"
+  "fpath"
+  "ocaml" {>= "4.02.0"}
+  "result"
+  "tyxml" {>= "4.3.0"}
+
+  "alcotest" {dev & >= "0.8.3"}
+  "markup" {dev & >= "0.8.0"}
+  "ocamlfind" {dev}
+  "sexplib" {dev & >= "113.33.00"}
+
+  "bisect_ppx" {with-test & >= "1.3.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/1.5.0/odoc-1.5.0.tbz"
+  checksum: [
+    "sha256=857759be968070bfda208add3ae2c2bc87826ca2bfc39cebab1cc1e13db7a140"
+    "sha512=9573230f6ebd7f95d44a5e34f6de68f6b1b530cc7987402f84532e339498dde702082517066c4db428a334510af625db8055ecd03d91b57dd599fd5b3ac53f49"
+  ]
+}


### PR DESCRIPTION
OCaml documentation generator

- Project page: <a href="http://github.com/ocaml/odoc">http://github.com/ocaml/odoc</a>
- Documentation: <a href="https://ocaml.github.io/odoc/">https://ocaml.github.io/odoc/</a>

##### CHANGES:

Additions

- Add option to turn warnings into errors (ocaml/odoc#398, Jules Aguillon)

Bugs fixed

- Emit quote before identifier in alias type expr (Fixes ocaml/odoc#391, Anton Bachin)
- Handle generalized open statements introduced in 4.08 (ocaml/odoc#393, Jon Ludlam)
- Refactor error reporting to avoid exiting the program in library code
  (ocaml/odoc#400, Jules Aguillon)
- Build on OCaml 4.10 (ocaml/odoc#408, Jon Ludlam)
