### PR TITLE
Release tcpip 4.1.0

### DIFF
--- a/packages/mirage-nat/mirage-nat.2.0.0/opam
+++ b/packages/mirage-nat/mirage-nat.2.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "lru" {>= "0.3.0"}
   "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
-  "tcpip" { >= "3.7.8" }
+  "tcpip" { >= "3.7.9" & < "4.1.0" }
   "ethernet" { >= "2.0.0" }
   "arp"
   "alcotest" {with-test}

--- a/packages/tcpip/tcpip.4.1.0/opam
+++ b/packages/tcpip/tcpip.4.1.0/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs]
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depopts: ["mirage-xen-ocaml"]
+depends: [
+  "dune"
+  "dune-configurator"
+  "ocaml" {>= "4.06.0"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {>= "3.2.0"}
+  "cstruct-lwt"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv"
+  "ethernet" {>= "2.0.0"}
+  "mirage-flow" {with-test & >= "2.0.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "alcotest" {with-test & >="0.7.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "arp-mirage" {with-test & >= "2.0.0"}
+  "lru" {>= "0.3.0"}
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v4.1.0/tcpip-v4.1.0.tbz"
+  checksum: [
+    "sha256=bf85f6341bfcfb4075868555cd2346c582f563f80383a2cb9ebcab5a1322dbdd"
+    "sha512=165f7ba7e55701b82926dab3fcdbff78de04e843cb8a6a1b155e85729ff9ce6ad91dc3dfea9f8ebc8bfcdbd3d3a18d37196ab5c0047c6a16c1b99c129dde9888"
+  ]
+}


### PR DESCRIPTION
[new release] tcpip (4.1.0)
    
CHANGES:
    
* Revert "Ipv4.Fragments use a Lru.M.t instead of Lru.F.t" (mirage/mirage-tcpip#423 by @hannesm)
      A Lru.M.t allocates a Hashtbl.t of size = capacity (= 256 * 1024 in our case),
      this leads to excessive ~2MB memory consumption for each Fragment cache,
      reported by @xaki23 in mirage/qubes-mirage-firewall#93
* use SOCK_RAW for an ICMP socket in the unix sockets API (previously used
      SOCK_DGRAM which did not work)
      reported by @justinc1 in mirage/mirage-tcpip#358, fixed in mirage/mirage-tcpip#424 by @hannesm
* tcp is now compatible with lwt >= 5.0.0 (where Lwt.async requires a function
      of (unit -> unit Lwt.t) (mirage/mirage-tcpip#370 mirage/mirage-tcpip#425 @cfcs @hannesm, issue mirage/mirage-tcpip#392 @emillon)
* Add a dependency on dune-configurator to support dune 2.0.0 (mirage/mirage-tcpip#421 @avsm)