### PR TITLE
Package tiny_httpd.0.4

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.4/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Minimal HTTP server using good old threads"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" } # for now, since qtest needs old dune
+  "base-threads"
+  "ocaml" { >= "4.03.0" }
+  "odoc" {with-doc}
+  "qtest" { >= "2.9" & with-test}
+  "qcheck" {with-test}
+]
+tags: [ "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+post-messages: "tiny http server, with blocking IOs. Also ships with a `http_of_dir` program."
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/0.4.tar.gz"
+  checksum: [
+    "md5=ccd3b0d0276861d89c00cc8c6797f3de"
+    "sha512=48cc7ef660d648583b1bb4be37c545d2902ab2065ddefacf54bcf5fdc73c836aa0b3071e4c89e483a0382d1c49ee0dbd42f07c6849cc4dfcf6b1a5f09793f99e"
+  ]
+}


### PR DESCRIPTION
### `tiny_httpd.0.4`
Minimal HTTP server using good old threads



---
* Homepage: https://github.com/c-cube/tiny_httpd/
* Source repo: git+https://github.com/c-cube/tiny_httpd.git
* Bug tracker: https://github.com/c-cube/tiny_httpd/issues

---
:camel: Pull-request generated by opam-publish v2.0.2