### PR TITLE
constrain jsoo-lwt to the same version as jsoo

### DIFF
--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.1/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta12"}
   "lwt" {>= "2.4.4" & < "4.0.0"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {=version}
+  "js_of_ocaml-ppx" {=version}
 ]
 depopts: [ "graphics" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.2/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0.2/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta12"}
   "lwt" {>= "2.4.4" & < "4.0.0"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {=version}
+  "js_of_ocaml-ppx" {=version}
 ]
 depopts: [ "graphics" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.0/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta9"}
   "lwt" {>= "2.4.4" & < "4.0.0"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {=version}
+  "js_of_ocaml-ppx" {=version}
 ]
 depopts: [ "graphics" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.1.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.1.0/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta17"}
   "lwt" {>= "2.4.4" & < "4.0.0"}
-  "js_of_ocaml" {>= "3.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {=version}
+  "js_of_ocaml-ppx" {=version}
 ]
 depopts: [ "graphics" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.0/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "jbuilder" {>= "1.0+beta17"}
   "lwt" {>= "2.4.4" & < "5.0.0"}
-  "js_of_ocaml" {>= "3.2" & < "3.5.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {=version}
+  "js_of_ocaml-ppx" {=version}
 ]
 depopts: [ "graphics" "lwt_log" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.2.1/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {>= "1.0+beta17"}
   "lwt" {>= "2.4.4" & < "5.0.0"}
   "js_of_ocaml" {>= "3.2" & < "3.5.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml-ppx" {=version}
 ]
 depopts: [ "graphics" "lwt_log" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.3.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.3.0/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2"}
   "lwt" {>= "2.4.4" & < "5.0.0"}
-  "js_of_ocaml" {>= "3.2" & < "3.5.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {=version}
+  "js_of_ocaml-ppx" {=version}
 ]
 depopts: [ "graphics" "lwt_log" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.4.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.4.0/opam
@@ -17,8 +17,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2"}
   "lwt" {>= "2.4.4" & < "5.0.0"}
-  "js_of_ocaml" {>= "3.2" & < "3.5.0"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {=version}
+  "js_of_ocaml-ppx" {=version}
 ]
 depopts: [ "graphics" "lwt_log" ]
 

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.0/opam
@@ -17,8 +17,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.11.1"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
 ]
 depopts: [ "graphics" "lwt_log" ]
 url {

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.5.1/opam
@@ -17,8 +17,9 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.11.1"}
   "lwt" {>= "2.4.4"}
-  "js_of_ocaml" {>= "3.2"}
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+
 ]
 depopts: [ "graphics" "lwt_log" ]
 url {


### PR DESCRIPTION
This is done in the latest releases, but not historical ones.
The lack of constraint leads to a failure in 4.03.0 due to a very
new jsoo-lwt being installed with an older jsoo.  Its just safer
to not mix these versions...