### PR TITLE
Release stdcompat.12

### DIFF
--- a/packages/stdcompat/stdcompat.12/opam
+++ b/packages/stdcompat/stdcompat.12/opam
@@ -21,6 +21,6 @@ url {
   src:
     "https://github.com/thierry-martinez/stdcompat/releases/download/12/stdcompat-12.tar.gz"
   checksum: [
-    "sha512=58a2877a5bf6dd098c9cf2efc474d803798e5aa5fbcaf3bb41a484ef5f035a8af67f07d17650e192c234e29269815f3778614fa9662044924ee03be3c86c1c17"
+    "sha512=5f699bb11b76be3c0a73172d58eed857f150717a5c868bc92f0a6f3bc084317b55c3f4e8bdfb451959feb9744831fd8be4e126afcc1c8dbca929a298ab427df9"
   ]
 }

--- a/packages/stdcompat/stdcompat.12/opam
+++ b/packages/stdcompat/stdcompat.12/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Compatibility module for OCaml standard library"
+description:
+  "Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml."
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+license: "BSD-3-Clause"
+homepage: "https://github.com/thierry-martinez/stdcompat"
+bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
+depends: [
+  "ocaml" {>= "3.07" & < "4.11.0"}
+]
+depopts: ["result" "seq" "uchar" "ocamlfind"]
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
+url {
+  src:
+    "https://github.com/thierry-martinez/stdcompat/releases/download/12/stdcompat-12.tar.gz"
+  checksum: [
+    "sha512=58a2877a5bf6dd098c9cf2efc474d803798e5aa5fbcaf3bb41a484ef5f035a8af67f07d17650e192c234e29269815f3778614fa9662044924ee03be3c86c1c17"
+  ]
+}


### PR DESCRIPTION
- Support for OCaml 4.10.0

- Support for Windows

- Added `Bytes.unsafe_blit_string`, `Filename.quote_command`, `List.concat_map`, `List.find_map`, `Sys.Immediate64`

- Equality `Lexing.lexbuf = Stdcompat.Lexing.lexbuf` is available even for OCaml <4.02.0 (before the introduction of bytes)