### PR TITLE
Package visitors.20200210

### DIFF
--- a/packages/visitors/visitors.20200210/opam
+++ b/packages/visitors/visitors.20200210/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/visitors"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/visitors.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3" }
+  "cppo" {build}
+  "ppx_tools"
+  "ppx_deriving" {>= "4.4"}
+  "result"
+  "dune" {>= "2.0"}
+]
+synopsis: "An OCaml syntax extension for generating visitor classes"
+description: """
+Annotating an algebraic data type definition with [@@deriving visitors { ... }]
+causes visitor classes to be automatically generated. A visitor is an object
+that knows how to traverse and transform a data structure."""
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/visitors/repository/20200210/archive.tar.gz"
+  checksum: [
+    "md5=67e71ef359301a52f38223f6e1ece7d3"
+    "sha512=1635a676c27a6ee4422d56546369b41eb7a611500fb8e3bb32934acd2d7e44b2250c95537e2570291c25940379e683e8f6a54ee443d3b1ebdaadad4f6c6ec973"
+  ]
+}


### PR DESCRIPTION
### `visitors.20200210`
An OCaml syntax extension for generating visitor classes
Annotating an algebraic data type definition with [@@deriving visitors { ... }]
causes visitor classes to be automatically generated. A visitor is an object
that knows how to traverse and transform a data structure.



---
* Homepage: https://gitlab.inria.fr/fpottier/visitors
* Source repo: git+https://gitlab.inria.fr/fpottier/visitors.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.2