### PR TITLE
Allow dune 2.1 and 2.2 on OCaml 4.06.0 and earlier

### DIFF
--- a/packages/dune/dune.2.1.1/opam
+++ b/packages/dune/dune.2.1.1/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "ocaml" {>= "4.07"}
+  ("ocaml" {>= "4.07"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.1.2/opam
+++ b/packages/dune/dune.2.1.2/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "ocaml" {>= "4.07"}
+  ("ocaml" {>= "4.07"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.1.3/opam
+++ b/packages/dune/dune.2.1.3/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "ocaml" {>= "4.07"}
+  ("ocaml" {>= "4.07"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.2.0/opam
+++ b/packages/dune/dune.2.2.0/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "ocaml" {>= "4.07"}
+  ("ocaml" {>= "4.07"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]


### PR DESCRIPTION
Manual tweaks to the `opam` files missing