### PR TITLE
Package jupyter-kernel.0.6

### DIFF
--- a/packages/jupyter-kernel/jupyter-kernel.0.6/opam
+++ b/packages/jupyter-kernel/jupyter-kernel.0.6/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Andrew Ray"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Library to write jupyter kernels (interactive notebooks)"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+depends: [
+    "dune" { >= "1.1" }
+    "odoc" {with-doc}
+    "base-bytes"
+    "result"
+    "base-unix"
+    "zmq"
+    "atdgen"
+    "yojson" { >= "1.6" }
+    "uuidm"
+    "lwt"
+    "lwt-zmq"
+    "digestif"
+    "ISO8601"
+    "uutf"
+    "logs"
+    "ocaml" {>= "4.03"}
+]
+depopts: [
+  "tyxml"
+]
+tags: [ "jupyter" "ipython" ]
+homepage: "https://github.com/ocaml-jupyter/jupyter-kernel"
+dev-repo: "git+https://github.com/ocaml-jupyter/jupyter-kernel.git"
+bug-reports: "https://github.com/ocaml-jupyter/jupyter-kernel/issues"
+url {
+  src: "https://github.com/ocaml-jupyter/jupyter-kernel/archive/0.6.tar.gz"
+  checksum: [
+    "md5=a6ce3af2d012278e1d63ecdb48b45ecd"
+    "sha512=14f402023ee49c30346c6c14e0f21eda3b1889fb9b3c5e5a1b412c4278b13561abfbd8b79707d384bf4a8dde70ec3f3bf16663f9a4d56518866f130f6b971f73"
+  ]
+}


### PR DESCRIPTION
### `jupyter-kernel.0.6`
Library to write jupyter kernels (interactive notebooks)



---
* Homepage: https://github.com/ocaml-jupyter/jupyter-kernel
* Source repo: git+https://github.com/ocaml-jupyter/jupyter-kernel.git
* Bug tracker: https://github.com/ocaml-jupyter/jupyter-kernel/issues

---
:camel: Pull-request generated by opam-publish v2.0.0