### PR TITLE
Package ppx_tools.6.0+4.08.0

### DIFF
--- a/packages/ppx_tools/ppx_tools.6.0+4.08.0/opam
+++ b/packages/ppx_tools/ppx_tools.6.0+4.08.0/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "Tools for authors of ppx rewriters and other syntactic tools"
+maintainer: "alain.frisch@lexifi.com"
+authors: "Alain Frisch <alain.frisch@lexifi.com>"
+license: "MIT"
+tags: [ "syntax" ]
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.6"}
+]
+url {
+  src: "https://github.com/ocaml-ppx/ppx_tools/archive/6.0+4.08.0.tar.gz"
+  checksum: [
+    "md5=801e82103fee7ce1e4a59ab670601952"
+    "sha512=b576398a0dfad76ea9874cc18550bb44078a7e8f8dc0c169a0441f75f3881e458c42316c96d816c6e81d5ef219fac3aa539471f006b46088c9b943ed8af8b947"
+  ]
+}


### PR DESCRIPTION
### `ppx_tools.6.0+4.08.0`
Tools for authors of ppx rewriters and other syntactic tools



---
* Homepage: https://github.com/ocaml-ppx/ppx_tools
* Source repo: git://github.com/ocaml-ppx/ppx_tools.git
* Bug tracker: https://github.com/ocaml-ppx/ppx_tools/issues

---
:camel: Pull-request generated by opam-publish v2.0.2