### PR TITLE
Constrain existing releases of ppxfind

### DIFF
--- a/packages/ppxfind/ppxfind.1.1/opam
+++ b/packages/ppxfind/ppxfind.1.1/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder" {>= "1.0+beta16"}
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "1.6.0"}
   "ocamlfind"
 ]
 synopsis: "ocamlfind ppx tool"

--- a/packages/ppxfind/ppxfind.1.2/opam
+++ b/packages/ppxfind/ppxfind.1.2/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta16"}
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "1.6.0"}
   "ocamlfind"
 ]
 synopsis: "ocamlfind ppx tool"

--- a/packages/ppxfind/ppxfind.1.3/opam
+++ b/packages/ppxfind/ppxfind.1.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "dune" {>= "1.0"}
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "1.6.0"}
   "ocamlfind"
   "ocaml" {>= "4.02.3"}
 ]


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/15821 for OMP 1.6.0 and https://github.com/ocaml/opam-repository/pull/15830 for a new release of ppxfind that is compatible with it.