### PR TITLE
[new release] alcotest-lwt, alcotest and alcotest-async (1.0.1)

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.0.1/opam
+++ b/packages/alcotest-async/alcotest-async.1.0.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:  "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "git+https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "async_unix" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0"}
+]
+
+synopsis: "Async-based helpers for Alcotest"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.0.1/alcotest-1.0.1.tbz"
+  checksum: [
+    "sha256=0c8748838a89df6dee4850aa7ef5e46c573265a9bf1589dec255bd8156a793f6"
+    "sha512=f5f52dea5bb143e7001b8d0ac6131f8851389b080f46b9ad1ccacb95cc31a38143dd7122ccba59bb190abe559dbf81f33cc4dc3401ed95772d59be75fa566f19"
+  ]
+}

--- a/packages/alcotest-async/alcotest-async.1.0.1/opam
+++ b/packages/alcotest-async/alcotest-async.1.0.1/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.11"}
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}
   "async_unix" {>= "v0.9.0"}

--- a/packages/alcotest-lwt/alcotest-lwt.1.0.1/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:  "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "git+https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "lwt" "logs"
+]
+
+synopsis: "Lwt-based helpers for Alcotest"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.0.1/alcotest-1.0.1.tbz"
+  checksum: [
+    "sha256=0c8748838a89df6dee4850aa7ef5e46c573265a9bf1589dec255bd8156a793f6"
+    "sha512=f5f52dea5bb143e7001b8d0ac6131f8851389b080f46b9ad1ccacb95cc31a38143dd7122ccba59bb190abe559dbf81f33cc4dc3401ed95772d59be75fa566f19"
+  ]
+}

--- a/packages/alcotest-lwt/alcotest-lwt.1.0.1/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.0.1/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.11"}
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}
   "lwt" "logs"

--- a/packages/alcotest/alcotest.1.0.1/opam
+++ b/packages/alcotest/alcotest.1.0.1/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune"  {>= "1.1.0"}
+  "dune"  {>= "1.11"}
   "ocaml" {>= "4.03.0"}
   "fmt"   {>= "0.8.0"}
   "astring"

--- a/packages/alcotest/alcotest.1.0.1/opam
+++ b/packages/alcotest/alcotest.1.0.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:  "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "git+https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune"  {>= "1.1.0"}
+  "ocaml" {>= "4.03.0"}
+  "fmt"   {>= "0.8.0"}
+  "astring"
+  "cmdliner"
+  "uuidm"
+  "re"
+  "stdlib-shims"
+]
+
+synopsis: "Alcotest is a lightweight and colourful test framework"
+
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.0.1/alcotest-1.0.1.tbz"
+  checksum: [
+    "sha256=0c8748838a89df6dee4850aa7ef5e46c573265a9bf1589dec255bd8156a793f6"
+    "sha512=f5f52dea5bb143e7001b8d0ac6131f8851389b080f46b9ad1ccacb95cc31a38143dd7122ccba59bb190abe559dbf81f33cc4dc3401ed95772d59be75fa566f19"
+  ]
+}


### PR DESCRIPTION
Lwt-based helpers for Alcotest

- Project page: <a href="https://github.com/mirage/alcotest/">https://github.com/mirage/alcotest/</a>
- Documentation: <a href="https://mirage.github.io/alcotest/">https://mirage.github.io/alcotest/</a>

##### CHANGES:

- Add support for an `ALCOTEST_COLOR={auto,always,never}` environment variable
  to control the colorization of terminal output. (mirage/alcotest#209, @mjambon)
- Fix handling of exceptions in `Alcotest_{async,lwt}`. (mirage/alcotest#212,
  @CraigFe @talex5)
