### PR TITLE
3 packages from 0xffea/ocaml-redis at 0.4

### DIFF
--- a/packages/redis-lwt/redis-lwt.0.4/opam
+++ b/packages/redis-lwt/redis-lwt.0.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes"
+authors: [
+  "Mike Wells"
+  "David Höppner"
+  "Aleksandr Dinu"
+]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD3"
+tags: ["redis" "lwt"]
+dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
+synopsis: "Redis client (lwt interface)"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "redis" { = version }
+  "lwt"
+  "ocaml" { >= "4.02.3" }
+  "ounit" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/0xffea/ocaml-redis/archive/0.4.tar.gz"
+  checksum: [
+    "md5=6b54f6d5e97ad9c532d44909fa1957f4"
+    "sha512=5f59fe20d28aefa37756eb4bf472ccec2adc5898740c9c1ee9fa5fe602a18220312e6a6a90d0b402f18043166149e66ad1ea407cadec5328917d65bc5c7666c9"
+  ]
+}

--- a/packages/redis-sync/redis-sync.0.4/opam
+++ b/packages/redis-sync/redis-sync.0.4/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes"
+authors: [
+  "Mike Wells"
+  "David Höppner"
+  "Aleksandr Dinu"
+]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD3"
+tags: ["redis" "unix"]
+synopsis: "Redis client (blocking)"
+dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "redis" { = version }
+  "ocaml" { >= "4.02.3" }
+  "ounit" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/0xffea/ocaml-redis/archive/0.4.tar.gz"
+  checksum: [
+    "md5=6b54f6d5e97ad9c532d44909fa1957f4"
+    "sha512=5f59fe20d28aefa37756eb4bf472ccec2adc5898740c9c1ee9fa5fe602a18220312e6a6a90d0b402f18043166149e66ad1ea407cadec5328917d65bc5c7666c9"
+  ]
+}

--- a/packages/redis/redis.0.4/opam
+++ b/packages/redis/redis.0.4/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes"
+authors: [
+  "Mike Wells"
+  "David Höppner"
+  "Aleksandr Dinu"
+]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD3"
+tags: ["redis"]
+dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
+synopsis: "Redis client"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.0" }
+  "base-unix"
+  "uuidm"
+  "re"
+  "ocaml" { >= "4.02.3" }
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/0xffea/ocaml-redis/archive/0.4.tar.gz"
+  checksum: [
+    "md5=6b54f6d5e97ad9c532d44909fa1957f4"
+    "sha512=5f59fe20d28aefa37756eb4bf472ccec2adc5898740c9c1ee9fa5fe602a18220312e6a6a90d0b402f18043166149e66ad1ea407cadec5328917d65bc5c7666c9"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`redis.0.4`: Redis client
-`redis-lwt.0.4`: Redis client (lwt interface)
-`redis-sync.0.4`: Redis client (blocking)



---
* Homepage: https://github.com/0xffea/ocaml-redis
* Source repo: git+https://github.com/0xffea/ocaml-redis.git
* Bug tracker: https://github.com/0xffea/ocaml-redis/issues

---
:camel: Pull-request generated by opam-publish v2.0.0