### PR TITLE
Release pyml.20200115

### DIFF
--- a/packages/pyml/pyml.20200115/opam
+++ b/packages/pyml/pyml.20200115/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "http://github.com/thierry-martinez/pyml"
+bug-reports: "http://github.com/thierry-martinez/pyml/issues"
+license: "BSD-3-Clause"
+dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
+build: [make "all" "pymltop" "pymlutop" {utop:installed} "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%"]
+synopsis: "OCaml bindings for Python"
+description: "OCaml bindings for Python 2 and Python 3"
+depends: [
+  "ocaml" {>= "3.12.1" & < "4.11.0"}
+  "ocamlfind" {build}
+  "stdcompat" {>= "11"}
+]
+depopts: ["utop"]
+url {
+  src: "https://github.com/thierry-martinez/pyml/archive/20200115.tar.gz"
+  checksum: "sha512=601702d09ea7e30943948ad1daf7f348b476f6f6dc3a9b539cd7d2d21d0435eeac0c4b3e1197f127582e3ae6ed0a2a6b5cef6d7abea2e8a8eb09961578314680"
+}


### PR DESCRIPTION
- Compatible with OCaml 4.10.0.

- [PR 36] GC issue when registering a function with a dynamically allocated docstring.
  (Fixed by Laurent Mazare, https://github.com/thierry-martinez/pyml/pull/36)

- [PR 34] Ensure that every function starting with `CAMLparamK` ends with `CAMLreturnX`.
  (Fixed by Xavier Clerc, https://github.com/thierry-martinez/pyml/pull/34)

- [GitHub issue #37] Fix test suite: `list` object has no attribute `clear`
  (Reported by Olaf Hering, https://github.com/thierry-martinez/pyml/issues/37)

- [PR 38] Check for executable called `python3`.
  (Fixed by Olaf Hering, https://github.com/thierry-martinez/pyml/pull/38)

- [PR 39] Expose `is-instance` and `is-subclass`.
  (Contribution by Laurent Mazare, https://github.com/thierry-martinez/pyml/pull/39)

- [PR 44] Expose some GIL functions (functions from the Python C API related to the global interpreter lock.
  (Contribution by Laurent Mazare, https://github.com/thierry-martinez/pyml/pull/44)

- Fix dynamic loading of stubs.
  (Fixed by Stéphane Glondu)