### PR TITLE
3 packages from 0xffea/ocaml-redis at 0.4

### DIFF
--- a/packages/redis-lwt/redis-lwt.0.4/opam
+++ b/packages/redis-lwt/redis-lwt.0.4/opam
@@ -13,7 +13,6 @@ dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
 synopsis: "Redis client (lwt interface)"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [

--- a/packages/redis-lwt/redis-lwt.0.4/opam
+++ b/packages/redis-lwt/redis-lwt.0.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes"
+authors: [
+  "Mike Wells"
+  "David Höppner"
+  "Aleksandr Dinu"
+]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD3"
+tags: ["redis" "lwt"]
+dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
+synopsis: "Redis client (lwt interface)"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "redis" { = version }
+  "lwt"
+  "ocaml" { >= "4.02.3" }
+  "ounit" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/0xffea/ocaml-redis/archive/0.4.tar.gz"
+  checksum: [
+    "md5=14ed13367ece237de7fb881436762356"
+    "sha512=cca4d4ed74c3551d87fc52aa75196f96bfddc511086af8133123becf1e981f14f712cf6232c656371e23f8e8f18babf9f2f0494f50023bb5068d2c7c7785fa2c"
+  ]
+}

--- a/packages/redis-sync/redis-sync.0.4/opam
+++ b/packages/redis-sync/redis-sync.0.4/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes"
+authors: [
+  "Mike Wells"
+  "David Höppner"
+  "Aleksandr Dinu"
+]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD3"
+tags: ["redis" "unix"]
+synopsis: "Redis client (blocking)"
+dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "redis" { = version }
+  "ocaml" { >= "4.02.3" }
+  "ounit" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/0xffea/ocaml-redis/archive/0.4.tar.gz"
+  checksum: [
+    "md5=14ed13367ece237de7fb881436762356"
+    "sha512=cca4d4ed74c3551d87fc52aa75196f96bfddc511086af8133123becf1e981f14f712cf6232c656371e23f8e8f18babf9f2f0494f50023bb5068d2c7c7785fa2c"
+  ]
+}

--- a/packages/redis-sync/redis-sync.0.4/opam
+++ b/packages/redis-sync/redis-sync.0.4/opam
@@ -13,7 +13,6 @@ synopsis: "Redis client (blocking)"
 dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [

--- a/packages/redis/redis.0.4/opam
+++ b/packages/redis/redis.0.4/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes"
+authors: [
+  "Mike Wells"
+  "David Höppner"
+  "Aleksandr Dinu"
+]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD3"
+tags: ["redis"]
+dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
+synopsis: "Redis client"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.0" }
+  "base-unix"
+  "uuidm"
+  "re"
+  "ocaml" { >= "4.02.3" }
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/0xffea/ocaml-redis/archive/0.4.tar.gz"
+  checksum: [
+    "md5=14ed13367ece237de7fb881436762356"
+    "sha512=cca4d4ed74c3551d87fc52aa75196f96bfddc511086af8133123becf1e981f14f712cf6232c656371e23f8e8f18babf9f2f0494f50023bb5068d2c7c7785fa2c"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`redis.0.4`: Redis client
-`redis-lwt.0.4`: Redis client (lwt interface)
-`redis-sync.0.4`: Redis client (blocking)



---
* Homepage: https://github.com/0xffea/ocaml-redis
* Source repo: git+https://github.com/0xffea/ocaml-redis.git
* Bug tracker: https://github.com/0xffea/ocaml-redis/issues

---
:camel: Pull-request generated by opam-publish v2.0.0