### PR TITLE
Package naboris.0.1.1

### DIFF
--- a/packages/naboris/naboris.0.1.1/opam
+++ b/packages/naboris/naboris.0.1.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built on httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "1.6"}
+  "reason" {>= "3.4.0"}
+  "httpaf" {>= "0.6.0"}
+  "httpaf-lwt-unix" {>= "0.6.0"}
+  "lwt" {>= "5.1.1"}
+  "uri" {>= "2.2.0"}
+]
+depopts: [
+  "conf-libev"
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=f880806d42c05278f17c286b7e14c0b9"
+    "sha512=0e75a342b785eef92b6d099aa90a886467ad64fa24371b34ce4b430499c9afe80457cb59a5d4eed0300db789c16d5c96ff1e9d33b95a2a1698eb477ff3cb8490"
+  ]
+}


### PR DESCRIPTION
### `naboris.0.1.1`
Simple http server
Simple http server built on httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.0