### PR TITLE
[new release] coq-serapi (8.11.0+0.11.0)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.11.0+0.11.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.11.0+0.11.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.07.0"            }
+  "coq"                 {           >= "8.11.0" & < "8.12" }
+  "cmdliner"            {           >= "1.0.0"             }
+  "ocamlfind"           {           >= "1.8.0"             }
+  "sexplib"             {           >= "v0.11.0"           }
+  "dune"                {           >= "1.2.0"             }
+  "ppx_import"          { build   & >= "1.5-3"             }
+  "ppx_deriving"        {           >= "4.2.1"             }
+  "ppx_sexp_conv"       {           >= "v0.11.0"           }
+  "yojson"              {           >= "1.7.0"             }
+  "ppx_deriving_yojson" {           >= "3.4"               }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.11.0%2B0.11.0/coq-serapi-8.11.0.0.11.0.tbz"
+  checksum: [
+    "sha256=59d38d716fda7cb1d89e2e1519c93d22deaf14da4f0f2feccd45886317f3424c"
+    "sha512=21b0ccaf75b497e13662c3fa2c618413dfccf6abfaabbab1d27926836447a0fcdc0e2a92929401359321018a4a867124caad27e9db52c4f3e5040aff698999ef"
+  ]
+}


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

* [general] (!) support Coq 8.11, a few datatypes have changed, in
             particular `CoqAst` handles locations as an AST node, and
             the kernel type includes primitive floats (@ejgallego).
 * [general] (!) Now the `sertop` and `serapi` OCaml libraries are
             built packed, we've also bumped their compat version number
             (ejgallego/coq-serapi#192 @ejgallego)
