### PR TITLE
Result 1.5 - improved 4.08 compatibility

### DIFF
--- a/packages/result/result.1.5/opam
+++ b/packages/result/result.1.5/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/result"
+dev-repo: "git+https://github.com/janestreet/result.git"
+bug-reports: "https://github.com/janestreet/result/issues"
+license: "BSD-3-Clause"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "ocaml"
+  "dune" {>= "1.0"}
+]
+synopsis: "Compatibility Result module"
+description: """
+Projects that want to use the new result type defined in OCaml >= 4.03
+while staying compatible with older version of OCaml should use the
+Result module defined in this library."""
+url {
+  src:
+    "https://github.com/janestreet/result/releases/download/1.5/result-1.5.tbz"
+  checksum: "md5=1b82dec78849680b49ae9a8a365b831b"
+}


### PR DESCRIPTION
This release mainly addresses https://github.com/janestreet/result/issues/8, which is that `Result` from `result` shadows `Result` from `Stdlib`, which is available starting from 4.08.

`Stdlib.Result` has more values declared and a different type name, and all of these become inaccessible because of the shadowing, unless one consistently writes `Stdlib.Result` instead of just `Result`. This was a great annoyance if `result` appeared anywhere in the dependency graph of a project, especially if it was introduced at a late stage in development, which could cause a large amount of code to break.

EDIT: This release makes `Result` from `result` include `Stdlib.Result` on OCaml >= 4.08.

cc @diml