### PR TITLE
nice_parser: fixed checksums

### DIFF
--- a/packages/nice_parser/nice_parser.1.0.0/opam
+++ b/packages/nice_parser/nice_parser.1.0.0/opam
@@ -29,7 +29,7 @@ depends: [
 url {
   src: "https://github.com/smolkaj/ocaml-parsing/archive/1.0.0.tar.gz"
   checksum: [
-    "md5=9ac52ebf61b297e0eed7821e714efa23"
-    "sha512=ad72f446fd42fe43ea1fe754d2f15c25fc46f235402012a3d45d3121bb9bd44151e864ea0221432d4e80606a2b0421bccee42d98bff7ac21a20718ea0353f890"
+    "md5=56355492a47db73a577e2cc692d164ab"
+    "sha512=b6aec833d73da71468cad54696f8e1a2be5a6eb77437eca7e533d1f83af426c841f3789d6c71cff79bf5852e94008f6f03bdea1096e10747c00c1e46456a100f"
   ]
 }


### PR DESCRIPTION
Not sure why, but the checksum for this package were wrong.
@cakoch10 