### PR TITLE
Constrain Alcotest to use Fmt >=0.8.6

### DIFF
--- a/packages/alcotest/alcotest.1.0.0/opam
+++ b/packages/alcotest/alcotest.1.0.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "dune"  {>= "1.11"}
   "ocaml" {>= "4.03.0"}
-  "fmt"   {>= "0.8.0"}
+  "fmt"   {>= "0.8.6"}
   "astring"
   "cmdliner"
   "uuidm"

--- a/packages/alcotest/alcotest.1.0.1/opam
+++ b/packages/alcotest/alcotest.1.0.1/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "dune"  {>= "1.11"}
   "ocaml" {>= "4.03.0"}
-  "fmt"   {>= "0.8.0"}
+  "fmt"   {>= "0.8.6"}
   "astring"
   "cmdliner"
   "uuidm"


### PR DESCRIPTION
The corresponding change upstream is https://github.com/mirage/alcotest/pull/219.