### PR TITLE
[new release] mirage-nat (2.1.0)

### DIFF
--- a/packages/mirage-nat/mirage-nat.2.1.0/opam
+++ b/packages/mirage-nat/mirage-nat.2.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+name: "mirage-nat"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+homepage: "https://github.com/mirage/mirage-nat"
+bug-reports: "https://github.com/mirage/mirage-nat/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-nat.git"
+doc: "https://mirage.github.io/mirage-nat/"
+license: "ISC"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "ipaddr"
+  "cstruct"
+  "lwt"
+  "rresult"
+  "logs"
+  "lru" {>= "0.3.0"}
+  "ppx_deriving" {>= "4.2" }
+  "dune" {>= "1.0"}
+  "tcpip" { >= "4.1.0" }
+  "ethernet" { >= "2.0.0" }
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+]
+synopsis: "Mirage-nat is a library for network address translation to be used with MirageOS"
+description: """
+Mirage-nat is a library for [network address
+translation](https://tools.ietf.org/html/rfc2663).  It is intended for use in
+[MirageOS](https://mirage.io) and makes extensive use of
+[tcpip](https://github.com/mirage/mirage-tcpip), the network stack used by
+default in MirageOS unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-nat/releases/download/v2.1.0/mirage-nat-v2.1.0.tbz"
+  checksum: [
+    "sha256=df9a5feafaf008767b7ab709e9fdef0b92691f7873f7a32cd5da1cb2dd38d979"
+    "sha512=a6f5715aad6d01937d66413e2912c82b523faa89f94f23965bb92e8c9f4948bd8f8074e6d93d1a9568a37e825f6d425a7cce5252a70beb9e081f86f29a40edd5"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- support tcpip 4.1.0, which Ipv4.Fragments interface changed from LRU.M to LRU.F
- Mirage_nat_lru uses as well a LRU.F again
- breaking: Nat_packet.of_ipv4_frame / of_ethernet_frame output a pair of
  `Fragments.t * (t option, error) result`
- all in mirage/mirage-nat#37 by @hannesm