### PR TITLE
[new release] letsencrypt (0.2.0)

### DIFF
--- a/packages/letsencrypt/letsencrypt.0.2.0/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.2.0"}
+  "astring"
+  "rresult"
+  "base64" {>= "3.1.0"}
+  "cmdliner"
+  "cohttp"
+  "cohttp-lwt" {>= "2.5.1"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "zarith"
+  "logs"
+  "fmt"
+  "lwt" {>= "2.6.0"}
+  "nocrypto"
+  "x509" {>= "0.9.0"}
+  "yojson" {>= "1.6.0"}
+  "ounit" {with-test}
+  "dns"
+  "dns-tsig"
+  "ptime"
+  "bos"
+  "fpath"
+  "randomconv"
+  "domain-name" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.2.0/letsencrypt-v0.2.0.tbz"
+  checksum: [
+    "sha256=381fcc0c75f191accfe1cac9019e8de15402e3037ab680487ade6b70353e1257"
+    "sha512=91d5c293f9a1173c593a4bd7cb6655328e10f0a836b22c54e08d2bad40b62e20e10cdcc83a16ffb49eb7907d53b5fee63ac3b813b99f5fafee021e5f3dded1f7"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* support ACME as specified in RFC 8555 (letsencrypt v2 endpoints) mmaker/ocaml-letsencrypt#19
* support for the ALPN challenge as well mmaker/ocaml-letsencrypt#19