### PR TITLE
js_of_ocaml-ppx_deriving_json: Add missing dependency

### DIFF
--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.2/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.2/opam
@@ -19,6 +19,7 @@ depends: [
   "js_of_ocaml" {= version}
   "ocaml-migrate-parsetree"
   "ppxlib" {>= "0.9.0"}
+  "ppx_deriving"
 ]
 url {
   src:


### PR DESCRIPTION
Error was:
  ocamlfind: Package `ppx_deriving' not found - required by `js_of_ocaml-ppx_deriving_json'