### PR TITLE
Package tracking_bigraph.0.2

### DIFF
--- a/packages/tracking_bigraph/tracking_bigraph.0.2/opam
+++ b/packages/tracking_bigraph/tracking_bigraph.0.2/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Tracking Reactive System"
+description: """
+Tracking_bigraph is an extension of the OCaml library \"bigraph\" made by Michele Sevegnani.
+It allows designing and evaluating bigraphical reactive systems with nodes tracking.
+Additionally it allows for export of calculated state space to a file.
+It also tries to parallelize some of computations.
+"""
+maintainer: "Piotr Cybulski <pikus3@list.pl>"
+authors: "Piotr Cybulski <pikus3@list.pl>"
+license: "BSD-2-Clause"
+homepage: "https://github.com/zajer/trs"
+bug-reports: "https://github.com/zajer/trs/issues"
+depends: [ "ocaml" "dune" "bigraph" "parmap" "csv"]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/zajer/trs/archive/0.2.tar.gz"
+  checksum: [
+    "md5=cfd77e50d0a17f89cc0b776a2920fb7f"
+    "sha512=2acaebdf362f9e167b311a8b9f2a062d98c6448468b3bd91354b3e39b641141a930d75acf8cd521188a25a0a7c27911134dd458189ac9faf3555d10581284d03"
+  ]
+}


### PR DESCRIPTION
### `tracking_bigraph.0.2`
Tracking Reactive System
Tracking_bigraph is an extension of the OCaml library "bigraph" made by Michele Sevegnani.
It allows designing and evaluating bigraphical reactive systems with nodes tracking.
Additionally it allows for export of calculated state space to a file.
It also tries to parallelize some of computations.



---
* Homepage: https://github.com/zajer/trs
* Bug tracker: https://github.com/zajer/trs/issues

---
:camel: Pull-request generated by opam-publish v2.0.2