### PR TITLE
[new release] mdx (1.6.0)

### DIFF
--- a/packages/mdx/mdx.1.6.0/opam
+++ b/packages/mdx/mdx.1.6.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org"]
+homepage:     "https://github.com/realworldocaml/mdx"
+license:      "ISC"
+dev-repo:     "git+https://github.com/realworldocaml/mdx.git"
+bug-reports:  "https://github.com/realworldocaml/mdx/issues"
+doc:          "https://realworldocaml.github.io/mdx/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.11"}
+  "ocamlfind"
+  "fmt"
+  "cppo" {build}
+  "astring"
+  "logs"
+  "cmdliner"
+  "re" {>= "1.7.2"}
+  "result"
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+  "ocaml-version" {>= "2.3.0"}
+  "lwt" {with-test}
+  "alcotest" {with-test}
+]
+
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date.
+
+`ocaml-mdx` is released as two binaries called `ocaml-mdx` and `mdx` which are
+the same, mdx being the deprecated name, kept for now for compatibility.
+"""
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/1.6.0/mdx-1.6.0.tbz"
+  checksum: [
+    "sha256=6b4c51c91953218b5b5b14f8e5d3dd6d0c50995b46c571b97d8b37238457a4a2"
+    "sha512=f86619905828bbdaa8a93d6605308436211e26ac850cad319d92cca971e6f548e5ac07a38d01f8098f87ea7f6a40d0f4bc0c6867c3a416b2b956042423997432"
+  ]
+}


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>
- Documentation: <a href="https://realworldocaml.github.io/mdx/">https://realworldocaml.github.io/mdx/</a>

##### CHANGES:

#### Added

- Add a `--duniverse-mode` to `ocaml-mdx rule` so that the generated rules work
  within a duniverse
- Allow to import arbitrary files (not only .ml/.mli ones) into code blocks using
  the `file` label. (realworldocaml/mdx#203, realworldocaml/mdx#207, @voodoos)
- Allow to set the `--non-deterministic` option through the `MDX_RUN_NON_DETERMINISTIC`
  env variables (realworldocaml/mdx#208, @NathanReb)
- Add support for OCaml 4.10 (realworldocaml/mdx#204, @kit-ty-kate)
- Infer syntax kind when `--syntax` is not set, and add 'markdown' as an alias to 'normal' (realworldocaml/mdx#222, @gpetiot)
- Add `ocaml-mdx deps` command to be used by dune to compute file and dir dependencies of an
  mdx file. (realworldocaml/mdx#217, @voodoos)
- Add new delimiters syntax using comments for partial OCaml files include (realworldocaml/mdx#212, @voodoos).

#### Changed

- Do not unset `INSIDE_DUNE` when executing shell commands by default (realworldocaml/mdx#224, @NathanReb)

#### Fixed

- Fix a bug that could cause `ocaml-mdx test` to crash on some `include` in toplevel code blocks
  (realworldocaml/mdx#202, @trefis)

#### Removed

- Remove the `direction` option, only synchronize from .ml to .md files (realworldocaml/mdx#214, @gpetiot)
