### PR TITLE
First set of constraints for result 1.5

### DIFF
--- a/packages/alcotest/alcotest.0.8.0/opam
+++ b/packages/alcotest/alcotest.0.8.0/opam
@@ -17,7 +17,7 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "fmt" {>= "0.8.0"}
   "astring"
-  "result"
+  "result" {< "1.5"}
   "cmdliner"
 ]
 synopsis:

--- a/packages/alcotest/alcotest.0.8.1/opam
+++ b/packages/alcotest/alcotest.0.8.1/opam
@@ -17,7 +17,7 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "fmt" {>= "0.8.0"}
   "astring"
-  "result"
+  "result" {< "1.5"}
   "cmdliner"
 ]
 synopsis:

--- a/packages/alcotest/alcotest.0.8.3/opam
+++ b/packages/alcotest/alcotest.0.8.3/opam
@@ -17,7 +17,7 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "fmt" {>= "0.8.0"}
   "astring"
-  "result"
+  "result" {< "1.5"}
   "cmdliner"
 ]
 synopsis: "Alcotest is a lightweight and colourful test framework."

--- a/packages/alcotest/alcotest.0.8.4/opam
+++ b/packages/alcotest/alcotest.0.8.4/opam
@@ -21,7 +21,7 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "fmt" {>= "0.8.0"}
   "astring"
-  "result"
+  "result" {< "1.5"}
   "cmdliner"
   "uuidm"
 ]

--- a/packages/alcotest/alcotest.0.8.5/opam
+++ b/packages/alcotest/alcotest.0.8.5/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "fmt"   {>= "0.8.0"}
   "astring"
-  "result"
+  "result" {< "1.5"}
   "cmdliner"
   "uuidm"
 ]

--- a/packages/cmdliner/cmdliner.1.0.0/opam
+++ b/packages/cmdliner/cmdliner.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {>= "0.8.1" & build}
-  "result"
+  "result"  {< "1.5"}
 ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"

--- a/packages/cmdliner/cmdliner.1.0.1/opam
+++ b/packages/cmdliner/cmdliner.1.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {>= "0.8.1" & build}
-  "result"
+  "result"  {< "1.5"}
 ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"

--- a/packages/cmdliner/cmdliner.1.0.2/opam
+++ b/packages/cmdliner/cmdliner.1.0.2/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {>= "0.8.1" & build}
-  "result"
+  "result"  {< "1.5"}
 ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"

--- a/packages/datakit-client/datakit-client.0.12.0/opam
+++ b/packages/datakit-client/datakit-client.0.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml"
   "jbuilder" {>= "1.0+beta10"}
   "astring"
-  "result"
+  "result"  {< "1.5"}
   "fmt"
   "lwt"
   "cstruct" {> "2.2.0"}

--- a/packages/datakit-client/datakit-client.0.12.2/opam
+++ b/packages/datakit-client/datakit-client.0.12.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "dune"
   "astring"
-  "result"
+  "result"  {< "1.5"}
   "fmt"
   "lwt"
   "cstruct" {> "2.2.0"}

--- a/packages/datakit-client/datakit-client.0.12.3/opam
+++ b/packages/datakit-client/datakit-client.0.12.3/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "dune"
   "astring"
-  "result"
+  "result"  {< "1.5"}
   "fmt"
   "lwt"
   "cstruct" {> "2.2.0"}

--- a/packages/datakit-client/datakit-client.1.0.0/opam
+++ b/packages/datakit-client/datakit-client.1.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "dune"
   "astring"
-  "result"
+  "result"  {< "1.5"}
   "fmt"
   "lwt"
   "cstruct" {> "2.2.0"}

--- a/packages/depyt/depyt.0.2.0/opam
+++ b/packages/depyt/depyt.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "cstruct"
   "fmt"
-  "result"
+  "result" {< "1.5"}
   "jsonm"
   "ocplib-endian" {>= "0.7"}
   "alcotest" {with-test}

--- a/packages/irmin/irmin.1.3.2/opam
+++ b/packages/irmin/irmin.1.3.2/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
-  "result"
+  "result"  {< "1.5"}
   "fmt" {>= "0.8.0"}
   "uri" {>= "1.3.12"}
   "cstruct" {>= "1.6.0"}

--- a/packages/irmin/irmin.1.4.0/opam
+++ b/packages/irmin/irmin.1.4.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
-  "result"
+  "result" {< "1.5"}
   "fmt" {>= "0.8.0"}
   "uri" {>= "1.3.12"}
   "cstruct" {>= "1.6.0"}

--- a/packages/logs/logs.0.6.2/opam
+++ b/packages/logs/logs.0.6.2/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "result"
+  "result" {< "1.5"}
   "mtime" {with-test}
 ]
 depopts: [

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "lwt"
   "logs"
   "mirage-block" {= "1.0.0"}
-  "result"
+  "result" {< "1.5"}
 ]
 tags: "org:mirage"
 synopsis: "Utilities and module definitions for dealing with block devices."

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.1.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "logs"
   "mirage-block" {>= "1.0.0" & < "2.0.0"}
-  "result"
+  "result" {< "1.5"}
 ]
 tags: "org:mirage"
 synopsis: "Utilities and module definitions for dealing with block devices."

--- a/packages/ocaml-version/ocaml-version.2.3.0/opam
+++ b/packages/ocaml-version/ocaml-version.2.3.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/avsm/ocaml-version/issues"
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune"
-  "result"
+  "result" {< "1.5"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/promise/promise.1.0.2/opam
+++ b/packages/promise/promise.1.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"
   "ocaml"
   "reason" {build & >= "3.3.2"}
-  "result"
+  "result" {< "1.5"}
 ]
 
 build: [

--- a/packages/tsdl-image/tsdl-image.0.2.0/opam
+++ b/packages/tsdl-image/tsdl-image.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ctypes" {>= "0.4.0"}
   "ctypes-foreign"
   "tsdl" {>= "0.9.0"}
-  "result"
+  "result" {< "1.5"}
   "oasis" {build}
 ]
 depexts: [

--- a/packages/tsdl/tsdl.0.9.1/opam
+++ b/packages/tsdl/tsdl.0.9.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "conf-sdl2"
-  "result"
+  "result" {< "1.5"}
   "ctypes" {>= "0.9.0"}
   "ctypes-foreign"
 ]

--- a/packages/tsdl/tsdl.0.9.2/opam
+++ b/packages/tsdl/tsdl.0.9.2/opam
@@ -15,7 +15,7 @@ depends: [
   "topkg" {build}
   "ocb-stubblr" {build}
   "conf-sdl2"
-  "result"
+  "result" {< "1.5"}
   "ctypes" {>= "0.9.0"}
   "ctypes-foreign"
 ]

--- a/packages/tsdl/tsdl.0.9.3/opam
+++ b/packages/tsdl/tsdl.0.9.3/opam
@@ -15,7 +15,7 @@ depends: [
   "topkg" {build}
   "ocb-stubblr" {build}
   "conf-sdl2"
-  "result"
+  "result" {< "1.5"}
   "ctypes" {>= "0.9.0"}
   "ctypes-foreign"
 ]

--- a/packages/tsdl/tsdl.0.9.4/opam
+++ b/packages/tsdl/tsdl.0.9.4/opam
@@ -15,7 +15,7 @@ depends: [
   "topkg" {build}
   "ocb-stubblr" {build}
   "conf-sdl2"
-  "result"
+  "result" {< "1.5"}
   "ctypes" {>= "0.9.0"}
   "ctypes-foreign"
 ]

--- a/packages/tsdl/tsdl.0.9.5/opam
+++ b/packages/tsdl/tsdl.0.9.5/opam
@@ -15,7 +15,7 @@ depends: [
   "topkg" {build}
   "ocb-stubblr" {build}
   "conf-sdl2"
-  "result"
+  "result" {< "1.5"}
   "ctypes" {>= "0.9.0"}
   "ctypes-foreign"
 ]

--- a/packages/tsdl/tsdl.0.9.6/opam
+++ b/packages/tsdl/tsdl.0.9.6/opam
@@ -15,7 +15,7 @@ depends: [
   "topkg" {build}
   "ocb-stubblr" {build}
   "conf-sdl2"
-  "result"
+  "result" {< "1.5"}
   "ctypes" {>= "0.9.0"}
   "ctypes-foreign"
 ]


### PR DESCRIPTION
These are the constraints due to https://github.com/ocaml/opam-repository/pull/15853, for packages that already failed due to `open Result` on 4.08+ shadowing other identifiers. See the [revdeps logs](https://ci.ocaml.org/ocaml/opam-repository/pr/15853?test=2%20Revdeps) of each package from this PR for the error message.

Most packages that failed failed with a different error, which is [addressed](https://github.com/janestreet/result/commit/b0b9cd6e9cce8d2b7ad11127a6135540ec3f8a92) in `result` `master`, and `result` 1.5 will be retagged to include the fix. I'll do that after this PR is merged, to decrease noise in the revdeps logs.

Of the packages constrained by this PR, only `datakit-client`, `depyt`, `ocaml-version`, `promise`, `tsdl-image` need patching upstream. The rest of the packages have newer releases which are not affected, typically because they no longer support 4.02 and no longer depend on `result`. I will send PRs to the affected packages separately.