### PR TITLE
Add {learn-ocaml, learn-ocaml-client} 0.12

### DIFF
--- a/packages/learn-ocaml-client/learn-ocaml-client.0.12/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.0.12/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp" {>= "1.0.0"}
   "cohttp-lwt-unix" {>= "1.0.0"}
   "digestif" {>= "0.7.1"}
-  "dune" {build & >= "1.1.1"}
+  "dune" {>= "1.1.1"}
   "ezjsonm"
   "lwt" {>= "3.2.0" & < "4.0.0"}
   "lwt_ssl"
@@ -34,7 +34,7 @@ depends: [
   "ppx_tools"
 ]
 build: [
-  ["dune" "build" "@install" "-p" name]
+  ["dune" "build" "@install" "-p" name "-j" jobs]
 ]
 synopsis: "The learn-ocaml client"
 description: """

--- a/packages/learn-ocaml-client/learn-ocaml-client.0.12/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.0.12/opam
@@ -12,25 +12,25 @@ homepage: "https://github.com/ocaml-sf/learn-ocaml"
 bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
 dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
 depends: [
-  "base" {= "v0.9.4"}
+  "base" {>= "v0.9.4"}
   "base64"
   "cmdliner"
   "omd"
   "asak"
-  "cohttp" {>= "1.0.0"}
-  "cohttp-lwt-unix" {>= "1.0.0"}
+  "cohttp" {>= "1.0.0" & < "2.0.0"}
+  "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}
   "digestif" {>= "0.7.1"}
   "dune" {>= "1.1.1"}
   "ezjsonm"
   "lwt" {>= "3.2.0" & < "4.0.0"}
   "lwt_ssl"
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {= "4.05.0"}
   "ocamlfind" {build}
   "ocp-indent-nlfork"
-  "ocp-ocamlres" {= "0.4"}
+  "ocp-ocamlres" {>= "0.4"}
   "ocplib-json-typed" {= "0.6"}
-  "ipaddr" {= "2.8.0" }
-  "cstruct" {= "3.3.0"}
+  "ipaddr" {>= "2.8.0" }
+  "cstruct" {>= "3.3.0"}
   "ppx_tools"
 ]
 build: [

--- a/packages/learn-ocaml-client/learn-ocaml-client.0.12/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.0.12/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+maintainer: "Yann Régis-Gianas"
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+depends: [
+  "base" {= "v0.9.4"}
+  "base64"
+  "cmdliner"
+  "omd"
+  "asak"
+  "cohttp" {>= "1.0.0"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "digestif" {>= "0.7.1"}
+  "dune" {build & >= "1.1.1"}
+  "ezjsonm"
+  "lwt" {>= "3.2.0" & < "4.0.0"}
+  "lwt_ssl"
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocp-indent-nlfork"
+  "ocp-ocamlres" {= "0.4"}
+  "ocplib-json-typed" {= "0.6"}
+  "ipaddr" {= "2.8.0" }
+  "cstruct" {= "3.3.0"}
+  "ppx_tools"
+]
+build: [
+  ["dune" "build" "@install" "-p" name]
+]
+synopsis: "The learn-ocaml client"
+description: """
+This contains the binaries to interact with the learn-ocaml
+platform from the command line.
+"""
+url {
+  src: "https://github.com/ocaml-sf/learn-ocaml/archive/0.12.tar.gz"
+  checksum: [
+    "sha512=81c1d6dda53850ba4fe30f34e85bcec239d694529cdb2e98fdf18b38b7d8d0a0b01aa4208d2b691f957f2874854e4b7eecc0c3e708d337f17d77acc2cf375070"
+  ]
+}

--- a/packages/learn-ocaml/learn-ocaml.0.12/opam
+++ b/packages/learn-ocaml/learn-ocaml.0.12/opam
@@ -12,20 +12,20 @@ homepage: "https://github.com/ocaml-sf/learn-ocaml"
 bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
 dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
 depends: [
-  "base" {= "v0.9.4"}
+  "base" {>= "v0.9.4"}
   "base64"
   "cmdliner"
-  "cohttp" {>= "1.0.0"}
-  "cohttp-lwt-unix" {>= "1.0.0"}
+  "cohttp" {>= "1.0.0" & < "2.0.0"}
+  "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}
   "conf-git"
   "decompress" {= "0.8.1"}
   "digestif" {>= "0.7.1"}
   "dune" {>= "1.1.1"}
   "easy-format" {>= "1.3.0" }
-  "ipaddr" {= "2.8.0" }
+  "ipaddr" {>= "2.8.0" }
   "ezjsonm"
   "js_of_ocaml" {>= "3.3.0"}
-  "js_of_ocaml-compiler" {= "3.3.0"}
+  "js_of_ocaml-compiler" {>= "3.3.0"}
   "js_of_ocaml-lwt"
   "js_of_ocaml-ppx"
   "js_of_ocaml-toplevel"
@@ -35,12 +35,12 @@ depends: [
   "lwt_ssl"
   "magic-mime"
   "markup"
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {= "4.05.0"}
   "ocamlfind" {build}
   "ocp-indent-nlfork"
-  "ocp-ocamlres" {= "0.4"}
+  "ocp-ocamlres" {>= "0.4"}
   "ocplib-json-typed" {= "0.6"}
-  "odoc" {build & = "1.3.0"}
+  "odoc" {build & >= "1.3.0"}
   "omd"
   "pprint"
   "ppx_cstruct"

--- a/packages/learn-ocaml/learn-ocaml.0.12/opam
+++ b/packages/learn-ocaml/learn-ocaml.0.12/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+maintainer: "Yann Régis-Gianas"
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+depends: [
+  "base" {= "v0.9.4"}
+  "base64"
+  "cmdliner"
+  "cohttp" {>= "1.0.0"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "conf-git"
+  "decompress" {= "0.8.1"}
+  "digestif" {>= "0.7.1"}
+  "dune" {build & >= "1.1.1"}
+  "easy-format" {>= "1.3.0" }
+  "ipaddr" {= "2.8.0" }
+  "ezjsonm"
+  "js_of_ocaml" {>= "3.3.0"}
+  "js_of_ocaml-compiler" {= "3.3.0"}
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-toplevel"
+  "js_of_ocaml-tyxml"
+  "lwt" {>= "3.2.0" & < "4.0.0"}
+  "lwt_react"
+  "lwt_ssl"
+  "magic-mime"
+  "markup"
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocp-indent-nlfork"
+  "ocp-ocamlres" {= "0.4"}
+  "ocplib-json-typed" {= "0.6"}
+  "odoc" {build & = "1.3.0"}
+  "omd"
+  "pprint"
+  "ppx_cstruct"
+  "ppx_tools"
+  "uutf" {>= "1.0" }
+  "yojson" {>= "1.4.0" }
+  "asak" {>= "0.1"}
+]
+build: [
+  [make "static"]
+  ["dune" "build" "-p" name]
+]
+install: [
+  ["mkdir" "-p" "%{_:share}%"]
+  ["cp" "-r" "demo-repository" "%{_:share}%/repository"]
+]
+synopsis: "The learn-ocaml online platform (engine)"
+description: """
+This contains the binaries forming the engine for the learn-ocaml platform, and
+the common files. A demo exercise repository is also provided as example.
+"""
+url {
+  src: "https://github.com/ocaml-sf/learn-ocaml/archive/0.12.tar.gz"
+  checksum: [
+    "sha512=81c1d6dda53850ba4fe30f34e85bcec239d694529cdb2e98fdf18b38b7d8d0a0b01aa4208d2b691f957f2874854e4b7eecc0c3e708d337f17d77acc2cf375070"
+  ]
+}

--- a/packages/learn-ocaml/learn-ocaml.0.12/opam
+++ b/packages/learn-ocaml/learn-ocaml.0.12/opam
@@ -20,7 +20,7 @@ depends: [
   "conf-git"
   "decompress" {= "0.8.1"}
   "digestif" {>= "0.7.1"}
-  "dune" {build & >= "1.1.1"}
+  "dune" {>= "1.1.1"}
   "easy-format" {>= "1.3.0" }
   "ipaddr" {= "2.8.0" }
   "ezjsonm"
@@ -51,7 +51,7 @@ depends: [
 ]
 build: [
   [make "static"]
-  ["dune" "build" "-p" name]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 install: [
   ["mkdir" "-p" "%{_:share}%"]


### PR DESCRIPTION
[learn-ocaml](https://github.com/ocaml-sf/learn-ocaml) 0.12 has just been released by @yurug, and this PR adds the 2 related opam packages (server and CLI client).