### PR TITLE
[release] rpc metapackage (5.9.0, 6.0.0, 6.1.0, 7.0.0)

### DIFF
--- a/packages/rpc/rpc.5.9.0/opam
+++ b/packages/rpc/rpc.5.9.0/opam
@@ -19,8 +19,8 @@ depends: [
   "ppx_deriving_rpc" {= version}
   "async" {>= "v0.9.0" & <= "v0.11.0"}
   "lwt"
-  "alcotest" {with-test}
-  "alcotest-lwt" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
+  "alcotest-lwt" {with-test & < "1.0.0"}
 ]
 conflicts: [ "core" {< "v0.9.0"} ]
 build: ["jbuilder" "runtest" "-p" name] {with-test}

--- a/packages/rpc/rpc.5.9.0/opam
+++ b/packages/rpc/rpc.5.9.0/opam
@@ -12,7 +12,7 @@ tags: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder" {build}
+  "jbuilder"
   "rpclib" {= version}
   "rpclib-async" {= version}
   "rpclib-lwt" {= version}
@@ -23,7 +23,7 @@ depends: [
   "alcotest-lwt" {with-test & < "1.0.0"}
 ]
 conflicts: [ "core" {< "v0.9.0"} ]
-build: ["jbuilder" "runtest" "-p" name] {with-test}
+build: ["jbuilder" "build" "-p" name "-j" jobs]
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpc/rpc.5.9.0/opam
+++ b/packages/rpc/rpc.5.9.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - meta-package"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+homepage: "https://github.com/mirage/ocaml-rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpc"
+tags: [
+    "org:mirage"
+    "org:xapi-project"
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "jbuilder" {build}
+  "rpclib" {= version}
+  "rpclib-async" {= version}
+  "rpclib-lwt" {= version}
+  "ppx_deriving_rpc" {= version}
+  "async" {>= "v0.9.0" & <= "v0.11.0"}
+  "lwt"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+conflicts: [ "core" {< "v0.9.0"} ]
+build: ["jbuilder" "runtest" "-p" name] {with-test}
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+
+This is a dummy package installing the main library components.
+"""
+url {
+  src: "https://github.com/mirage/ocaml-rpc/archive/v5.9.0.tar.gz"
+  checksum: [
+    "sha256=06e3798dd900c1356c4080e91587e96c98f49b0bb4068fbbb53eb4f52c169f97"
+    "sha512=e0272935cf3131f60c8af86427228f57a94e35e2b25f1201adda602629c0aafd9c9e78461b060d1b4babbec83056d6bc3c4a2652060b44b6c1d358d32a5ccdb5"
+  ]
+}

--- a/packages/rpc/rpc.6.0.0/opam
+++ b/packages/rpc/rpc.6.0.0/opam
@@ -19,8 +19,8 @@ depends: [
   "ppx_deriving_rpc" {= version}
   "async" {>= "v0.9.0" & <= "v0.11.0"}
   "lwt"
-  "alcotest" {with-test}
-  "alcotest-lwt" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
+  "alcotest-lwt" {with-test & < "1.0.0"}
 ]
 conflicts: [ "core" {< "v0.9.0"} ]
 build: ["jbuilder" "runtest" "-p" name] {with-test}

--- a/packages/rpc/rpc.6.0.0/opam
+++ b/packages/rpc/rpc.6.0.0/opam
@@ -12,7 +12,7 @@ tags: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder" {build}
+  "jbuilder"
   "rpclib" {= version}
   "rpclib-async" {= version}
   "rpclib-lwt" {= version}
@@ -23,7 +23,7 @@ depends: [
   "alcotest-lwt" {with-test & < "1.0.0"}
 ]
 conflicts: [ "core" {< "v0.9.0"} ]
-build: ["jbuilder" "runtest" "-p" name] {with-test}
+build: ["jbuilder" "build" "-p" name "-j" jobs]
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpc/rpc.6.0.0/opam
+++ b/packages/rpc/rpc.6.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - meta-package"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+homepage: "https://github.com/mirage/ocaml-rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpc"
+tags: [
+    "org:mirage"
+    "org:xapi-project"
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "jbuilder" {build}
+  "rpclib" {= version}
+  "rpclib-async" {= version}
+  "rpclib-lwt" {= version}
+  "ppx_deriving_rpc" {= version}
+  "async" {>= "v0.9.0" & <= "v0.11.0"}
+  "lwt"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+conflicts: [ "core" {< "v0.9.0"} ]
+build: ["jbuilder" "runtest" "-p" name] {with-test}
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+
+This is a dummy package installing the main library components.
+"""
+url {
+  src: "https://github.com/mirage/ocaml-rpc/archive/v6.0.0.tar.gz"
+  checksum: [
+    "sha256=ec4ba5bfbdbc11f0d3292f8e08af28354da1a6812243263136e7c7357d6b1935"
+    "sha512=e5897ccfca8ebfa93cb47e54ae1eb80c9b4e4293f694a0c152232dfad180ce763ab863c6d31c2bb0507e9c62baeb5a9534dd363a41d9a2a60231b079927d0e7f"
+  ]
+}

--- a/packages/rpc/rpc.6.1.0/opam
+++ b/packages/rpc/rpc.6.1.0/opam
@@ -15,8 +15,8 @@ depends: [
   "ppx_deriving_rpc" {=version}
   "async" {>= "v0.9.0"}
   "lwt"
-  "alcotest" {with-test}
-  "alcotest-lwt" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
+  "alcotest-lwt" {with-test & < "1.0.0"}
   "md2mld" {with-doc & >= "0.3.0"}
 ]
 conflicts: [

--- a/packages/rpc/rpc.6.1.0/opam
+++ b/packages/rpc/rpc.6.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt"
   "alcotest" {with-test & < "1.0.0"}
   "alcotest-lwt" {with-test & < "1.0.0"}
-  "md2mld" {with-doc & >= "0.3.0"}
+  "md2mld" {>= "0.3.0"}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/packages/rpc/rpc.6.1.0/opam
+++ b/packages/rpc/rpc.6.1.0/opam
@@ -18,13 +18,14 @@ depends: [
   "alcotest" {with-test & < "1.0.0"}
   "alcotest-lwt" {with-test & < "1.0.0"}
   "md2mld" {with-doc & >= "0.3.0"}
+  "odoc" {with-doc}
 ]
 conflicts: [
   "core" {< "v0.9.0"}
 ]
 build: [
-    ["dune" "runtest" "-p" name] {with-test}
-    ["dune" "build" "@doc"] {with-doc}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"
 description: """

--- a/packages/rpc/rpc.6.1.0/opam
+++ b/packages/rpc/rpc.6.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - meta-package"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.5.0"}
+  "rpclib" {=version}
+  "rpclib-async" {=version}
+  "rpclib-lwt" {=version}
+  "ppx_deriving_rpc" {=version}
+  "async" {>= "v0.9.0"}
+  "lwt"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "md2mld" {with-doc & >= "0.3.0"}
+]
+conflicts: [
+  "core" {< "v0.9.0"}
+]
+build: [
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc"] {with-doc}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+ 
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+ 
+This is a dummy package installing the main library components.
+"""
+url {
+  src: "https://github.com/mirage/ocaml-rpc/archive/v6.1.0.tar.gz"
+  checksum: [
+    "sha256=d1a2bed3d1c1b2ad19d55400ceaa474931f322739aad91fc09641a58580f4552"
+    "sha512=b00beb6bbef2832859eeceea515f5011eba225384cd4b8c1a88c51bf629598c81c65a1e9342b3e1b27f50efb99653c0980ab9a1c5e2c0df7c6827b3fb15c3a41"
+  ]
+}

--- a/packages/rpc/rpc.7.0.0/opam
+++ b/packages/rpc/rpc.7.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - meta-package"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.5.0"}
+  "rpclib" {=version}
+  "rpclib-async" {=version}
+  "rpclib-lwt" {=version}
+  "ppx_deriving_rpc" {=version}
+  "async" {>= "v0.9.0"}
+  "lwt"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "md2mld" {with-doc & >= "0.3.0"}
+]
+conflicts: [
+  "core" {< "v0.9.0"}
+]
+build: [
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc"] {with-doc}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+ 
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+ 
+This is a dummy package installing the main library components.
+"""
+url {
+  src: "https://github.com/mirage/ocaml-rpc/archive/v7.0.0.tar.gz"
+  checksum: [
+    "sha256=9d0aaccb84bc09586fe4a56a724378620b659bfc2e2a31fe0793c33d7a48e14a"
+    "sha512=e17b69c2e86179885e48a8b4314f8ed7209ae42f4981a13b75f9b6a176a338fa565b0e3868288e3016145109d7752ccb9a5b16df1851de8c8456fc722d1303bc"
+  ]
+}

--- a/packages/rpc/rpc.7.0.0/opam
+++ b/packages/rpc/rpc.7.0.0/opam
@@ -15,8 +15,8 @@ depends: [
   "ppx_deriving_rpc" {=version}
   "async" {>= "v0.9.0"}
   "lwt"
-  "alcotest" {with-test}
-  "alcotest-lwt" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
+  "alcotest-lwt" {with-test & < "1.0.0"}
   "md2mld" {with-doc & >= "0.3.0"}
 ]
 conflicts: [

--- a/packages/rpc/rpc.7.0.0/opam
+++ b/packages/rpc/rpc.7.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt"
   "alcotest" {with-test & < "1.0.0"}
   "alcotest-lwt" {with-test & < "1.0.0"}
-  "md2mld" {with-doc & >= "0.3.0"}
+  "md2mld" {>= "0.3.0"}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/packages/rpc/rpc.7.0.0/opam
+++ b/packages/rpc/rpc.7.0.0/opam
@@ -18,13 +18,14 @@ depends: [
   "alcotest" {with-test & < "1.0.0"}
   "alcotest-lwt" {with-test & < "1.0.0"}
   "md2mld" {with-doc & >= "0.3.0"}
+  "odoc" {with-doc}
 ]
 conflicts: [
   "core" {< "v0.9.0"}
 ]
 build: [
-    ["dune" "runtest" "-p" name] {with-test}
-    ["dune" "build" "@doc"] {with-doc}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"
 description: """


### PR DESCRIPTION
Without the metapackage being available it's difficult to develop on the package while using this repo as the first one in the active opam switch, see https://github.com/mirage/ocaml-rpc/issues/150

- Project page: https://github.com/mirage/ocaml-rpc
- Documentation: 

Changes: 
7.0.0
- Add basic support for JSON-RPC notifications (@vycastor)

6.1.0
- opam: updated bounds on a more conservative basis
- travis: tests more compilers
- tests: disable useless-object-inheritance on pylint checks
- pythongen: generate python2-3 compatible bindings
- Add ISC license
- Incremented the upper bound for async's version.
- Added lower bound for js_of_ocaml in related .opam file.
- Fixed compilation issue with js_of_ocaml 3.5.0 and 3.5.1.
- opam: remove the 'build' directive on dune dependency
- opam: remove unnecessary flag
- port to dune

6.0.0
- Switch to ppxlib from ppx_deriving

5.9.0
- Optional named params fix