### PR TITLE
mark checkseum 0.1.1-1 and digestif 0.8.0-1 unavailable on freebsd

### DIFF
--- a/packages/checkseum/checkseum.0.1.1-1/opam
+++ b/packages/checkseum/checkseum.0.1.1-1/opam
@@ -14,6 +14,7 @@ This library use the linking trick to choose between the C implementation (check
 This library is on top of optint to get the best representation of an int32.
 """
 
+available: os != "freebsd"
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
   [ "patch" "-p1" "-i" "mirage.patch" ]

--- a/packages/digestif/digestif.0.8.0-1/opam
+++ b/packages/digestif/digestif.0.8.0-1/opam
@@ -27,6 +27,7 @@ We provides implementation of:
  * RIPEMD160
 """
 
+available: os != "freebsd"
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
   [ "patch" "-p1" "-i" "mirage.patch" ]


### PR DESCRIPTION
the 'patch -p1 -i mirage.patch' does not work there

//cc @dinosaure see report in https://github.com/ocaml/opam-repository/pull/15858