### PR TITLE
[new release] ocaml-version (2.4.0)

### DIFF
--- a/packages/ocaml-version/ocaml-version.2.4.0/opam
+++ b/packages/ocaml-version/ocaml-version.2.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune"
+  "result"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v2.4.0/ocaml-version-v2.4.0.tbz"
+  checksum: [
+    "sha256=23ec774824213bdad20e1bba623ccaa8b2e3d26e95142e617febd0f4dc32f81c"
+    "sha512=c88da171a798e3200a580f3d160afcf3d09672eefb2c843ad61238d84ac050ec94559f372a2a6f085904b7e59caac3b96c9dd6a34d24ae85125c61652ed32edb"
+  ]
+}


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/ocurrent/ocaml-version">https://github.com/ocurrent/ocaml-version</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-version/doc">https://ocurrent.github.io/ocaml-version/doc</a>

##### CHANGES:

* Add `unreleased_betas` list to enumerate the latest release-candidate
  version for each unreleased minor OCaml series (ocurrent/ocaml-version#4 @craigfe).
* Do not `open Result` to clean up internal code (ocurrent/ocaml-version#5 @avsm).
