### PR TITLE
[new release] ppx_import (1.7.0)

### DIFF
--- a/packages/ppx_import/ppx_import.1.7.0/opam
+++ b/packages/ppx_import/ppx_import.1.7.0/opam
@@ -1,0 +1,34 @@
+description: "A syntax extension for importing declarations from interface files"
+synopsis: "A syntax extension for importing declarations from interface files"
+name: "ppx_import"
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_import"
+doc: "https://ocaml-ppx.github.io/ppx_import/"
+license: "MIT"
+bug-reports: "https://github.com/ocaml-ppx/ppx_import/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
+tags: [ "syntax" ]
+
+depends: [
+  "ocaml"                   {              >= "4.04.2" & < "4.10.0" }
+  "dune"                    {              >= "1.2.0"  }
+  "ppxlib"                  {              >= "0.3.1"  }
+  "ppx_tools_versioned"     {              >= "5.2.2"  }
+  "ocaml-migrate-parsetree" {              >= "1.2.0"  }
+  "ounit"                   { with-test                }
+  "ppx_deriving"            { with-test  & >= "4.2.1"  }
+]
+
+build:      [["dune" "build"   "-p" name "-j" jobs]
+             ["dune" "runtest" "-p" name "-j" jobs] { with-test }
+            ]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_import/releases/download/v1.7.0/ppx_import-v1.7.0.tbz"
+  checksum: [
+    "sha256=fac41fab50619e7510b0d2cb573400d276757d2a448a6cc47ac449310877c3de"
+    "sha512=5c36a84220b8b7a3a5a634e65937ba083ab34c39f164b3fdc5cbbe8681e1cfa125f9d2ef091f3392477232cc4c09a4e19e6def5b52ff12532ef56180ff6ee651"
+  ]
+}


### PR DESCRIPTION
A syntax extension for importing declarations from interface files

- Project page: <a href="https://github.com/ocaml-ppx/ppx_import">https://github.com/ocaml-ppx/ppx_import</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_import/">https://ocaml-ppx.github.io/ppx_import/</a>

##### CHANGES:

* OCaml 4.08 and 4.09 support
    ocaml-ppx/ppx_import#46
    (Etienne Millon)
