### PR TITLE
[new release] randomconv (0.1.3)

### DIFF
--- a/packages/randomconv/randomconv.0.1.3/opam
+++ b/packages/randomconv/randomconv.0.1.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/hannesm/randomconv"
+doc: "https://hannesm.github.io/randomconv/doc"
+bug-reports: "https://github.com/hannesm/randomconv/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"
+  "cstruct" {>= "1.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/hannesm/randomconv.git"
+synopsis: "Convert from random byte vectors (Cstruct.t) to random native numbers"
+description: """
+Given a function which produces random byte vectors, convert it to
+a number of your choice (int8/int16/int32/int64/int/float).
+"""
+url {
+  src:
+    "https://github.com/hannesm/randomconv/releases/download/v0.1.3/randomconv-v0.1.3.tbz"
+  checksum: [
+    "sha256=9b286aaac68fe3e5f69ed34115153ce74c613270a534b04642bae35934c863c7"
+    "sha512=f5186f7669a6b1b943442fdcfcdb37cf6c8199a1c644ed815f351f50428b9b7e1e5408ff4a0fcdfb093451b5237e48602af60f87a1b93e49897576c8aa2cd23f"
+  ]
+}


### PR DESCRIPTION
Convert from random byte vectors (Cstruct.t) to random native numbers

- Project page: <a href="https://github.com/hannesm/randomconv">https://github.com/hannesm/randomconv</a>
- Documentation: <a href="https://hannesm.github.io/randomconv/doc">https://hannesm.github.io/randomconv/doc</a>

##### CHANGES:

* `int` now allows a bound of 1 (returning 0)
