### PR TITLE
Release of pyml.20200222 and stdcompat.13

### DIFF
--- a/packages/pyml/pyml.20200222/opam
+++ b/packages/pyml/pyml.20200222/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "http://github.com/thierry-martinez/pyml"
+bug-reports: "http://github.com/thierry-martinez/pyml/issues"
+license: "BSD-3-Clause"
+dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
+build: [make "all" "pymltop" "pymlutop" {utop:installed} "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%"]
+synopsis: "OCaml bindings for Python"
+description: "OCaml bindings for Python 2 and Python 3"
+depends: [
+  "ocaml" {>= "3.12.1" & < "4.11.0"}
+  "ocamlfind" {build}
+  "stdcompat" {>= "13"}
+]
+depopts: ["utop"]
+url {
+  src: "https://github.com/thierry-martinez/pyml/archive/20200222.tar.gz"
+  checksum: "sha512=9d2a17e90393464b34fefba7fd123a9338f086358204c6b43493cb5eca9597d5ec668393c9c0d42063245985ddf62b8e04b13d10825491ddda6b882802c89637"
+}

--- a/packages/stdcompat/stdcompat.13/opam
+++ b/packages/stdcompat/stdcompat.13/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Compatibility module for OCaml standard library"
+description:
+  "Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml."
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+license: "BSD-3-Clause"
+homepage: "https://github.com/thierry-martinez/stdcompat"
+bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
+depends: [
+  "ocaml" {>= "3.07" & < "4.11.0"}
+]
+depopts: ["result" "seq" "uchar" "ocamlfind"]
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
+url {
+  src:
+    "https://github.com/thierry-martinez/stdcompat/releases/download/13/stdcompat-13.tar.gz"
+  checksum: [
+    "sha512=baebc1d95c0aa4dabeb44cda63d2c52406e7b71622c45890dee02435b0feaecf05f94e4d710e0633ae75716154d2828e46322cd6e5803a7b14d80ed1098e492f"
+  ]
+}


### PR DESCRIPTION
The new version of pyml requires an update of stdcompat. These two releases are bugfixes.

Changes for stdcompat
=====================

- Add: `stdcompat.h`, provides prototype for `caml_alloc_initialized_string` for OCaml <4.06.0 (already defined in a C library linked with stdcompat.{cma,cmxa}).

- Fix: module Format was not exported

- Fix: remove reference to suppressed module `Sort`

- Fix: reference to the native plugin (`.cmxs`) in `META`

Changes for pyml
================

- Fix: do not fail if GIL functions are unavailable

- Fix: include `stdcompat.h` provided with stdcompat version 13 for the prototype of `caml_alloc_initialized_string`.

- Fix: reference to the native plugin (`.cmxs`) in META