### PR TITLE
Lwt 5.1.2 - concurrent I/O

### DIFF
--- a/packages/lwt/lwt.5.1.2/opam
+++ b/packages/lwt/lwt.5.1.2/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+
+version: "5.1.2"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.7.0"}
+  "dune-configurator"
+  "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0"}
+  "ocplib-endian"
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  "bisect_ppx" {dev & >= "1.3.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+build: [
+  ["dune" "exec" "src/unix/config/discover.exe" "--root" "." "--" "--save"
+    "--use-libev" "%{conf-libev:installed}%"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.1.2.tar.gz"
+  checksum: "md5=dc4005582a6ab32227f5ff90cb480dbe"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/ocsigen/lwt/releases/tag/5.1.2):

> Bugs fixed
>
> - Do not run C exit hooks after failed `exec` (ocsigen/lwt#764, diagnosed Lucian Wischik).
> - `discover.ml`: don't add flags for missing system libraries (ocsigen/lwt#760, ocsigen/lwt#761, Olaf Hering).
> - `discover.ml`: don't run the `opam` binary (ocsigen/lwt#761).