### PR TITLE
Last constraint for result 1.5

### DIFF
--- a/packages/containers/containers.2.7/opam
+++ b/packages/containers/containers.2.7/opam
@@ -10,6 +10,7 @@ depends: [
   "dune"
   "dune-configurator"
   "result"
+  "result" { with-test & < "1.5" }
   "uchar"
   "qtest" { with-test }
   "qcheck" { with-test }


### PR DESCRIPTION
See [this log](https://ci.ocaml.org/log/saved/docker-run-0d3f187e951ac8341a63ccef7be9ec36/527837989c4a5d7f3cba38e3e9a09de009073fdd). After this, I think #15853 can be merged without a rebase, as probably nothing new can be learned from another set of revdeps builds.