### PR TITLE
[new release] mirage-entropy (0.5.1)

### DIFF
--- a/packages/mirage-entropy/mirage-entropy.0.5.1/opam
+++ b/packages/mirage-entropy/mirage-entropy.0.5.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+name:         "mirage-entropy"
+homepage:     "https://github.com/mirage/mirage-entropy"
+dev-repo:     "git+https://github.com/mirage/mirage-entropy.git"
+bug-reports:  "https://github.com/mirage/mirage-entropy/issues"
+doc:          "https://mirage.github.io/mirage-entropy/"
+maintainer:   "david@numm.org"
+license:      "BSD2"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "conf-pkg-config" {build}
+  "dune" {>= "1.3.0"}
+  "ocaml" {>= "4.07.0"}
+  "cstruct" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.7.0"}
+  "lwt" {>= "4.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+]
+depopts: [
+  "ocaml-freestanding"
+  "mirage-xen-posix"
+]
+conflicts: [
+  "mirage-xen-posix" {<"3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+tags: [ "org:mirage"]
+available: [
+  arch = "arm" | arch = "x86_32" | arch = "x86_64" | arch = "arm64"
+]
+synopsis: "Entropy source for MirageOS unikernels"
+description: """
+mirage-entropy implements various entropy sources for MirageOS unikernels:
+- timer based ones (see [whirlwind RNG paper](https://www.ieee-security.org/TC/SP2014/papers/Not-So-RandomNumbersinVirtualizedLinuxandtheWhirlwindRNG.pdf))
+- rdseed and rdrand (x86/x86-64 only)
+"""
+authors: ["Hannes Mehnert" "David Kaloper" "Anil Madhavapeddy" "Dave Scott"]
+url {
+  src:
+    "https://github.com/mirage/mirage-entropy/releases/download/v0.5.1/mirage-entropy-v0.5.1.tbz"
+  checksum: [
+    "sha256=612b2c17f18a56ed5cacc35006be6869016c26668eeaf301fd068b6467755d40"
+    "sha512=194624c9084664b41fbac88c45542a862762e8c0eaec7aa8af2e9fed4b8a5dbaf91303676f279defb4f57eaf74d9e11550d0233a471ef61e0b9f278287ecb031"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* use dune for building this package (mirage/mirage-entropy#47 @hannesm)