### PR TITLE
[new release] ppx_distr_guards (0.2)

### DIFF
--- a/packages/ppx_distr_guards/ppx_distr_guards.0.2/opam
+++ b/packages/ppx_distr_guards/ppx_distr_guards.0.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Extension to distribute guards over or-patterns"
+description:
+  "`function%distr A x, _ | _, A x when p x -> e` will result in `function A x, _ when p x -> e | _, A x when p x -> e`"
+maintainer: ["Ralf Vogler <ralf.vogler@gmail.com>"]
+authors: ["Ralf Vogler <ralf.vogler@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/vogler/ppx_distr_guards"
+doc: "https://vogler.github.io/ppx_distr_guards"
+bug-reports: "https://github.com/vogler/ppx_distr_guards/issues"
+depends: [
+  "dune" {>= "2.3.0"}
+  "ocaml-migrate-parsetree" {>= "1.6.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/vogler/ppx_distr_guards.git"
+url {
+  src:
+    "https://github.com/vogler/ppx_distr_guards/releases/download/v0.2/ppx_distr_guards-v0.2.tbz"
+  checksum: [
+    "sha256=a6e7efa882e0492648e0d08f5c8c4fdaa3fc47b546d15ea3aebecc0736c36e1f"
+    "sha512=4fbfa77d3947106dbe384eb5f6e61e235b2c4a13e7f49ca59e9479eb9ce4f75239be26a5f0633e17cf41bf7d1e53d3d50808ca53e145e847e61380602d0e9b84"
+  ]
+}

--- a/packages/ppx_distr_guards/ppx_distr_guards.0.2/opam
+++ b/packages/ppx_distr_guards/ppx_distr_guards.0.2/opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/vogler/ppx_distr_guards"
 doc: "https://vogler.github.io/ppx_distr_guards"
 bug-reports: "https://github.com/vogler/ppx_distr_guards/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.3.0"}
   "ocaml-migrate-parsetree" {>= "1.6.0"}
 ]
@@ -22,7 +23,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version >= "4.06"}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
Extension to distribute guards over or-patterns

- Project page: <a href="https://github.com/vogler/ppx_distr_guards">https://github.com/vogler/ppx_distr_guards</a>
- Documentation: <a href="https://vogler.github.io/ppx_distr_guards">https://vogler.github.io/ppx_distr_guards</a>

##### CHANGES:

- Initial version.
