### PR TITLE
[new release] ppx_import (1.7.1)

### DIFF
--- a/packages/ppx_import/ppx_import.1.7.1/opam
+++ b/packages/ppx_import/ppx_import.1.7.1/opam
@@ -1,0 +1,34 @@
+description: "A syntax extension for importing declarations from interface files"
+synopsis: "A syntax extension for importing declarations from interface files"
+name: "ppx_import"
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_import"
+doc: "https://ocaml-ppx.github.io/ppx_import/"
+license: "MIT"
+bug-reports: "https://github.com/ocaml-ppx/ppx_import/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
+tags: [ "syntax" ]
+
+depends: [
+  "ocaml"                   {              >= "4.04.2" & < "4.11" }
+  "dune"                    {              >= "1.2.0"  }
+  "ppxlib"                  {              >= "0.3.1"  }
+  "ppx_tools_versioned"     {              >= "5.2.2"  }
+  "ocaml-migrate-parsetree" {              >= "1.2.0"  }
+  "ounit"                   { with-test                }
+  "ppx_deriving"            { with-test  & >= "4.2.1"  }
+]
+
+build:      [["dune" "build"   "-p" name "-j" jobs]
+             ["dune" "runtest" "-p" name "-j" jobs] { with-test }
+            ]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_import/releases/download/v1.7.1/ppx_import-v1.7.1.tbz"
+  checksum: [
+    "sha256=9b48c45e60727e51b1a9c49d86e73bf4efe2ad19d81f85732ae67b7d96ebbe99"
+    "sha512=087a61d828a9de31c279d3810ae9db4e9e0b65d22975ba07bc26ad51578bce9475077d34631ad4d2602a783d1febd2bbf38cde042ea43c5bed630c6720028346"
+  ]
+}


### PR DESCRIPTION
A syntax extension for importing declarations from interface files

- Project page: <a href="https://github.com/ocaml-ppx/ppx_import">https://github.com/ocaml-ppx/ppx_import</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_import/">https://ocaml-ppx.github.io/ppx_import/</a>

##### CHANGES:

* Support for OCaml 4.10
    ocaml-ppx/ppx_import#47
    (Emilio J. Gallego Arias)
