### PR TITLE
2 packages from Gbury/mSAT at 0.8.2

### DIFF
--- a/packages/msat-bin/msat-bin.0.8.2/opam
+++ b/packages/msat-bin/msat-bin.0.8.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "SAT solver binary based on the msat library"
+license: "Apache"
+maintainer: ["guillaume.bury@gmail.com" "simon.cruanes.2007@m4x.org"]
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  #["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.1" }
+  "msat" { = version }
+  "containers" { >= "2.0" }
+  "camlzip"
+]
+tags: [ "sat" ]
+homepage: "https://github.com/Gbury/mSAT"
+dev-repo: "git+https://github.com/Gbury/mSAT.git"
+bug-reports: "https://github.com/Gbury/mSAT/issues/"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+url {
+  src: "https://github.com/Gbury/mSAT/archive/v0.8.2.tar.gz"
+  checksum: [
+    "md5=c02d63bf45357aa1d1b85846da373f48"
+    "sha512=e6f0d7f6e4fe69938ec2cc3233b0cb72dd577bfb4cc4824afe8247f5db0b6ffea2d38d73a65e7ede500d21ff8db27ed12f2c4f3245df4451d02864260ae2ddaf"
+  ]
+}

--- a/packages/msat/msat.0.8.2/opam
+++ b/packages/msat/msat.0.8.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Library containing a SAT solver that can be parametrized by a theory"
+license: "Apache"
+maintainer: ["guillaume.bury@gmail.com" "simon.cruanes.2007@m4x.org"]
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.1" }
+  "iter" { >= "1.2" }
+  "containers" {with-test}
+  "mdx" {with-test}
+]
+tags: [ "sat" "smt" "cdcl" "functor" ]
+homepage: "https://github.com/Gbury/mSAT"
+dev-repo: "git+https://github.com/Gbury/mSAT.git"
+bug-reports: "https://github.com/Gbury/mSAT/issues/"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+url {
+  src: "https://github.com/Gbury/mSAT/archive/v0.8.2.tar.gz"
+  checksum: [
+    "md5=c02d63bf45357aa1d1b85846da373f48"
+    "sha512=e6f0d7f6e4fe69938ec2cc3233b0cb72dd577bfb4cc4824afe8247f5db0b6ffea2d38d73a65e7ede500d21ff8db27ed12f2c4f3245df4451d02864260ae2ddaf"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`msat.0.8.2`: Library containing a SAT solver that can be parametrized by a theory
-`msat-bin.0.8.2`: SAT solver binary based on the msat library



---
* Homepage: https://github.com/Gbury/mSAT
* Source repo: git+https://github.com/Gbury/mSAT.git
* Bug tracker: https://github.com/Gbury/mSAT/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0