### PR TITLE
[new release] owl-zoo, owl-top, owl-base, owl and owl-plplot (0.8.0)

### DIFF
--- a/packages/owl-base/owl-base.0.8.0/opam
+++ b/packages/owl-base/owl-base.0.8.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/"
+synopsis: "OCaml Scientific and Engineering Computing - Base"
+description: "Owl is an OCaml scientific library."
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "base-bigarray"
+  "dune" {>= "2.0.0"}
+  "stdlib-shims"
+]
+url {
+  src: "https://github.com/owlbarn/owl/releases/download/0.8.0/owl-0.8.0.tbz"
+  checksum: [
+    "sha256=862af251e2a3e7a6b79724a4020a0c9308b36f12c85cd0a52385c4df82132c66"
+    "sha512=c1dabbf467a587757b11a28b9c6e8f68a86ce799d07c7ab5f2afa92d20145ba9e4282975aeb269b7324f5ba90d1576db156006f4d58177a860def773f9d974f2"
+  ]
+}

--- a/packages/owl-plplot/owl-plplot.0.8.0/opam
+++ b/packages/owl-plplot/owl-plplot.0.8.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/owl/"
+synopsis: "OCaml Scientific and Engineering Computing"
+description: """
+Owl: OCaml Scientific and Engineering Computing
+
+Owl is an OCaml numerical library.
+It supports N-dimensional arrays, both dense and sparse matrix operations, linear algebra, regressions, fast Fourier transforms, and many advanced mathematical and statistical functions (such as Markov chain Monte Carlo methods).
+Recently, Owl has implemented algorithmic differentiation which essentially makes developing machine learning and neural network algorithms trivial.
+"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.0.0"}
+  "owl" {>= "0.5.0"}
+  "plplot"
+]
+url {
+  src: "https://github.com/owlbarn/owl/releases/download/0.8.0/owl-0.8.0.tbz"
+  checksum: [
+    "sha256=862af251e2a3e7a6b79724a4020a0c9308b36f12c85cd0a52385c4df82132c66"
+    "sha512=c1dabbf467a587757b11a28b9c6e8f68a86ce799d07c7ab5f2afa92d20145ba9e4282975aeb269b7324f5ba90d1576db156006f4d58177a860def773f9d974f2"
+  ]
+}

--- a/packages/owl-top/owl-top.0.8.0/opam
+++ b/packages/owl-top/owl-top.0.8.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/"
+synopsis: "OCaml Scientific and Engineering Computing - Top"
+description: "Owl is an OCaml scientific library."
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml-compiler-libs"
+  "owl" {>= version}
+  "owl-zoo"
+]
+url {
+  src: "https://github.com/owlbarn/owl/releases/download/0.8.0/owl-0.8.0.tbz"
+  checksum: [
+    "sha256=862af251e2a3e7a6b79724a4020a0c9308b36f12c85cd0a52385c4df82132c66"
+    "sha512=c1dabbf467a587757b11a28b9c6e8f68a86ce799d07c7ab5f2afa92d20145ba9e4282975aeb269b7324f5ba90d1576db156006f4d58177a860def773f9d974f2"
+  ]
+}

--- a/packages/owl-zoo/owl-zoo.0.8.0/opam
+++ b/packages/owl-zoo/owl-zoo.0.8.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/"
+synopsis: "OCaml Scientific and Engineering Computing - Zoo"
+description: """
+Owl's Zoo System
+
+The Zoo System is Owl's customised toplevel.
+It is used for scripting numerical applications and sharing small code snippets via gist among users.
+The Zoo system introduces a zoo directive into toplevel, the referred gist id will be automatically downloaded and imported as a module in the script.
+The nested zoo reference is also supported.
+"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml-compiler-libs"
+  "owl" {>= version}
+]
+url {
+  src: "https://github.com/owlbarn/owl/releases/download/0.8.0/owl-0.8.0.tbz"
+  checksum: [
+    "sha256=862af251e2a3e7a6b79724a4020a0c9308b36f12c85cd0a52385c4df82132c66"
+    "sha512=c1dabbf467a587757b11a28b9c6e8f68a86ce799d07c7ab5f2afa92d20145ba9e4282975aeb269b7324f5ba90d1576db156006f4d58177a860def773f9d974f2"
+  ]
+}

--- a/packages/owl/owl.0.8.0/opam
+++ b/packages/owl/owl.0.8.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/owl/"
+synopsis: "OCaml Scientific and Engineering Computing"
+description: """
+Owl: OCaml Scientific and Engineering Computing
+
+Owl is an OCaml numerical library.
+It supports N-dimensional arrays, both dense and sparse matrix operations, linear algebra, regressions, fast Fourier transforms, and many advanced mathematical and statistical functions (such as Markov chain Monte Carlo methods).
+Recently, Owl has implemented algorithmic differentiation which essentially makes developing machine learning and neural network algorithms trivial.
+"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "alcotest" {with-test}
+  "base" {build}
+  "base-bigarray"
+  "conf-openblas" {>= "0.2.0"}
+  "ctypes"
+  "dune" {>= "2.0.0"}
+  "dune-configurator"
+  "eigen" {>= "0.1.0"}
+  "owl-base" {= version}
+  "stdio" {build}
+  "stdlib-shims"
+  "npy"
+]
+url {
+  src: "https://github.com/owlbarn/owl/releases/download/0.8.0/owl-0.8.0.tbz"
+  checksum: [
+    "sha256=862af251e2a3e7a6b79724a4020a0c9308b36f12c85cd0a52385c4df82132c66"
+    "sha512=c1dabbf467a587757b11a28b9c6e8f68a86ce799d07c7ab5f2afa92d20145ba9e4282975aeb269b7324f5ba90d1576db156006f4d58177a860def773f9d974f2"
+  ]
+}

--- a/packages/owl/owl.0.8.0/opam
+++ b/packages/owl/owl.0.8.0/opam
@@ -27,7 +27,7 @@ depends: [
   "base" {build}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
-  "ctypes"
+  "ctypes" {< "0.17.0"}
   "dune" {>= "2.0.0"}
   "dune-configurator"
   "eigen" {>= "0.1.0"}


### PR DESCRIPTION
OCaml Scientific and Engineering Computing - Zoo

- Project page: <a href="https://github.com/owlbarn/owl">https://github.com/owlbarn/owl</a>
- Documentation: <a href="https://owlbarn.github.io/">https://owlbarn.github.io/</a>

##### CHANGES:

*  Fix bug in _squeeze_broadcast (owlbarn/owl#503)
*  Added the Dawson function (Ndarray + Matrix + Algodiff op) (owlbarn/owl#502)
*  Fix bug in reverse mode gradients of aiso operations and pow (owlbarn/owl#501)
*  Added poisson_rvs to Owl_distribution (owlbarn/owl#499)
*  Draw poisson RVs in Ndarray and Mat modules (owlbarn/owl#498)
*  Broadcast bug for higher order derivatives (owlbarn/owl#495)
*  add sem to dense ndarray and matrix (owlbarn/owl#497)
*  Avoid input duplication with Graph.model and multi-input nn (owlbarn/owl#494)
*  Added Graph.get_subnetwork for constructing subnetworks (owlbarn/owl#491)
*  Make Graph.inputs give unique names to inputs (owlbarn/owl#493)
*  modify nlp interfaces
*  Re-add removed DiffSharp acknowledgment (owlbarn/owl#486)
*  add pretty printer for hypothesis type
*  update lambda neuron (owlbarn/owl#485)
*  fix example due to owlbarn/owl#476
*  Extend base linalg functions to complex numbers (owlbarn/owl#479)
*  [breaking] use a separate module for algodiff instead of ndarray directly (owlbarn/owl#476)
*  temp workaround and unittest (owlbarn/owl#478)
*  [breaking] Interface files for base/dense and base/linalg (owlbarn/owl#472)
*  Port code to dune2 (owlbarn/owl#474)
*  [breaking]  interface files to simplify .mli files in owl/dense (owlbarn/owl#471)
*  Save and load Npy files (owlbarn/owl#470)
*  Owl: relax bounds on base and stdio (owlbarn/owl#469)
*  Merged tests for different AD operations into one big test + autoformat tests with ocamlformat (owlbarn/owl#468)
