### PR TITLE
Package pprint.20200226

### DIFF
--- a/packages/pprint/pprint.20200226/opam
+++ b/packages/pprint/pprint.20200226/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "A pretty-printing combinator library and rendering engine"
+description: """
+This library offers a set of combinators for building so-called documents as
+well as an efficient engine for converting documents to a textual, fixed-width
+format. The engine takes care of indentation and line breaks, while respecting
+the constraints imposed by the structure of the document and by the text width."""
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+  "Nicolas Pouillard <np@nicolaspouillard.fr>"
+]
+homepage: "https://github.com/fpottier/pprint"
+bug-reports: "francois.pottier@inria.fr"
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "1.3"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+ssh://git@github.com/fpottier/pprint.git"
+url {
+  src: "https://github.com/fpottier/pprint/archive/20200226.tar.gz"
+  checksum: [
+    "md5=06fc2d4c448df83d4c73438b9b0c4af7"
+    "sha512=17170014d8878589956d11dfa8a8c3602266689af5b70e6c8822f5c8c3093c932ec5d82f9cac3023988bb1234f9c088e065905bb3298a698b61fcaa45d6f25ce"
+  ]
+}


### PR DESCRIPTION
### `pprint.20200226`
A pretty-printing combinator library and rendering engine
This library offers a set of combinators for building so-called documents as
well as an efficient engine for converting documents to a textual, fixed-width
format. The engine takes care of indentation and line breaks, while respecting
the constraints imposed by the structure of the document and by the text width.



---
* Homepage: https://github.com/fpottier/pprint
* Source repo: git+ssh://git@github.com/fpottier/pprint.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.2