### PR TITLE
'zed' 2.0.x doesn't support recent 'result' 1.5

### DIFF
--- a/packages/zed/zed.2.0.1/opam
+++ b/packages/zed/zed.2.0.1/opam
@@ -12,6 +12,7 @@ depends: [
   "camomile" {>= "1.0.1"}
   "react"
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
+  "result" {< "1.5"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/zed/zed.2.0.2/opam
+++ b/packages/zed/zed.2.0.2/opam
@@ -12,6 +12,7 @@ depends: [
   "camomile" {>= "1.0.1"}
   "react"
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
+  "result" {< "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/zed/zed.2.0.3/opam
+++ b/packages/zed/zed.2.0.3/opam
@@ -12,6 +12,7 @@ depends: [
   "camomile" {>= "1.0.1"}
   "react"
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
+  "result" {< "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/zed/zed.2.0.4/opam
+++ b/packages/zed/zed.2.0.4/opam
@@ -12,6 +12,7 @@ depends: [
   "camomile" {>= "1.0.1"}
   "react"
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
+  "result" {< "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/zed/zed.2.0.5/opam
+++ b/packages/zed/zed.2.0.5/opam
@@ -12,6 +12,7 @@ depends: [
   "camomile" {>= "1.0.1"}
   "react"
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
+  "result" {< "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Hello there,

This fixes an immediate incompatibility between zed 2.0 and the recently released result.1.5. This also adds an explicit dependency on the result package.

The error is with ocaml 4.08.0. I didn't check other versions.
```
# Error: The implementation src/zed_string.ml
# [...]
#          val compare_index :
#            t ->
#            ('a, 'b) result ->
#            ('a, 'b) result ->
#            ok:('a -> 'a -> int) -> error:('b -> 'b -> int) -> int
#        is not included in
#          val compare_index : t -> index -> index -> int
#        File "src/zed_string.mli", line 184, characters 0-46:
#          Expected declaration
#        File "src/zed_string.ml", line 454, characters 6-19:
#          Actual declaration
```

cc @diml
(I'm looking into a fix for the error)
