### PR TITLE
New package metapp.0.1.0

### DIFF
--- a/packages/metapp/metapp.0.1.0/opam
+++ b/packages/metapp/metapp.0.1.0/opam
@@ -21,5 +21,5 @@ depends: [
 dev-repo: "git+https://github.com/thierry-martinez/metapp.git"
 url {
   src: "https://github.com/thierry-martinez/metapp/archive/0.1.0.tar.gz"
-  checksum: "sha512=bac26fcc86cc46605a06a8b6dce7ff6d8b99e3b08c5d1a1c05b69bdd07c9600a7b9c767984b467227c11766fb1fed5a6b36b40b19f7a43f7d67b9af049c11c3a"
+  checksum: "sha512=9d383a8751fbe6514ba1cee4efde0172f86268eb65758936d29e6b86f96df01d9eeaca4ed44bf8d318bf56c62a98650e2e64fbbdc359d6c120d5311dda97377a"
 }

--- a/packages/metapp/metapp.0.1.0/opam
+++ b/packages/metapp/metapp.0.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Meta-preprocessor for OCaml"
+description: """
+Meta-preprocessor for OCaml: extends the language with [%meta ... ]
+construction where ... stands for OCaml code evaluated at
+compile-time.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD"
+homepage: "https://github.com/thierry-martinez/metapp"
+doc: "https://github.com/thierry-martinez/metapp"
+bug-reports: "https://github.com/thierry-martinez/metapp"
+depends: [
+  "ocaml" {>= "4.03.0" & < "4.11.0"}
+  "stdcompat" {>= "12"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "dune" {>= "1.11.0"}
+]
+dev-repo: "git+https://github.com/thierry-martinez/metapp.git"
+url {
+  src: "https://github.com/thierry-martinez/metapp/archive/0.1.0.tar.gz"
+  checksum: "sha512=bac26fcc86cc46605a06a8b6dce7ff6d8b99e3b08c5d1a1c05b69bdd07c9600a7b9c767984b467227c11766fb1fed5a6b36b40b19f7a43f7d67b9af049c11c3a"
+}


### PR DESCRIPTION
`metapp` is a PPX rewriter that provides a `[%meta ...]` extension, where the dots `...` are arbitrary OCaml expressions that are substituted at compile-time by the AST nodes they evaluate into.
These expressions build AST nodes either by quoting some code directly, or by using `compiler-libs` ([`Parsetree`], [`Ast_helper`], ...).