### PR TITLE
Revert "'zed' 2.0.x doesn't support recent 'result' 1.5"

### DIFF
--- a/packages/zed/zed.2.0.1/opam
+++ b/packages/zed/zed.2.0.1/opam
@@ -13,7 +13,6 @@ depends: [
   "react"
   "result" {<"1.5.0"}
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
-  "result" {< "1.5"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/zed/zed.2.0.2/opam
+++ b/packages/zed/zed.2.0.2/opam
@@ -13,7 +13,6 @@ depends: [
   "react"
   "result" {<"1.5.0"}
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
-  "result" {< "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/zed/zed.2.0.3/opam
+++ b/packages/zed/zed.2.0.3/opam
@@ -13,7 +13,6 @@ depends: [
   "react"
   "result" {<"1.5.0"}
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
-  "result" {< "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/zed/zed.2.0.4/opam
+++ b/packages/zed/zed.2.0.4/opam
@@ -13,7 +13,6 @@ depends: [
   "react"
   "result" {<"1.5.0"}
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
-  "result" {< "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/zed/zed.2.0.5/opam
+++ b/packages/zed/zed.2.0.5/opam
@@ -13,7 +13,6 @@ depends: [
   "react"
   "result" {<"1.5.0"}
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
-  "result" {< "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Reverts ocaml/opam-repository#15909