### PR TITLE
[new release] ppx_irmin, irmin-unix, irmin, irmin-pack and irmin-graphql (2.1.0)

### DIFF
--- a/packages/irmin-graphql/irmin-graphql.2.1.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors:      "Andreas Garnaes <andreas.garnaes@gmail.com>"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.03.0"}
+  "dune"    {>= "1.8.0"}
+  "irmin"   {>= "2.0.0"}
+  "graphql" {>= "0.13.0"}
+  "graphql-lwt" {>= "0.13.0"}
+  "graphql-cohttp" {>= "0.13.0"}
+  "cohttp-lwt"
+  "graphql_parser" {>= "0.13.0"}
+]
+
+
+synopsis: "GraphQL server for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.1.0/irmin-2.1.0.tbz"
+  checksum: [
+    "sha256=af3837ddeaaabdde6c77cc46b87e8edbdef3539b1a0a8e329a0bd6b6fec928ca"
+    "sha512=5bd2be34d61acf42a6c4e29f7b87fc15223ffa46546d6fb411f7519824ca8fd51f0db001787298f31c702998e73145c314b30e3e994154d0b3f63efe5f038976"
+  ]
+}

--- a/packages/irmin-pack/irmin-pack.2.1.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.8.0"}
+  "irmin"      {>= "2.0.0"}
+  "index"      {>= "1.2.0"}
+  "lwt"
+  "irmin-test" {with-test & >= "2.0.0"}
+  "alcotest-lwt" {with-test}
+]
+
+synopsis: "Irmin backend which stores values in a pack file"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.1.0/irmin-2.1.0.tbz"
+  checksum: [
+    "sha256=af3837ddeaaabdde6c77cc46b87e8edbdef3539b1a0a8e329a0bd6b6fec928ca"
+    "sha512=5bd2be34d61acf42a6c4e29f7b87fc15223ffa46546d6fb411f7519824ca8fd51f0db001787298f31c702998e73145c314b30e3e994154d0b3f63efe5f038976"
+  ]
+}

--- a/packages/irmin-unix/irmin-unix.2.1.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.01.0"}
+  "dune"          {>= "1.8.0"}
+  "irmin"         {>= "2.0.0"}
+  "irmin-mem"     {>= "2.0.0"}
+  "irmin-git"     {>= "2.0.0"}
+  "irmin-http"    {>= "2.0.0"}
+  "irmin-fs"      {>= "2.0.0"}
+  "irmin-pack"    {>= "2.0.0"}
+  "irmin-graphql"
+  "git-unix"      {>= "1.11.4"}
+  "digestif"      {>= "0.6.1"}
+  "irmin-watcher" {>= "0.2.0"}
+  "yaml"          {>= "0.1.0"}
+  "irmin-test"    {with-test & >= "2.0.0"}
+]
+
+synopsis: "Unix backends for Irmin"
+description: """
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.1.0/irmin-2.1.0.tbz"
+  checksum: [
+    "sha256=af3837ddeaaabdde6c77cc46b87e8edbdef3539b1a0a8e329a0bd6b6fec928ca"
+    "sha512=5bd2be34d61acf42a6c4e29f7b87fc15223ffa46546d6fb411f7519824ca8fd51f0db001787298f31c702998e73145c314b30e3e994154d0b3f63efe5f038976"
+  ]
+}

--- a/packages/irmin-unix/irmin-unix.2.1.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.1.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"         {>= "4.01.0"}
   "dune"          {>= "1.8.0"}
-  "irmin"         {>= "2.0.0"}
+  "irmin"         {>= "2.1.0"}
   "irmin-mem"     {>= "2.0.0"}
   "irmin-git"     {>= "2.0.0"}
   "irmin-http"    {>= "2.0.0"}

--- a/packages/irmin/irmin.2.1.0/opam
+++ b/packages/irmin/irmin.2.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.06.0"}
+  "dune"    {>= "1.8.0"}
+  "fmt"     {>= "0.8.0"}
+  "uri"     {>= "1.3.12"}
+  "jsonm"   {>= "1.0.0"}
+  "lwt"     {>= "2.4.7"}
+  "base64"  {>= "2.0.0"}
+  "digestif"
+  "ocamlgraph"
+  "logs"    {>= "0.5.0"}
+  "astring"
+  "hex"      {with-test}
+  "alcotest" {with-test}
+]
+synopsis: """
+Irmin, a distributed database that follows the same design principles as Git
+"""
+description: """
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.1.0/irmin-2.1.0.tbz"
+  checksum: [
+    "sha256=af3837ddeaaabdde6c77cc46b87e8edbdef3539b1a0a8e329a0bd6b6fec928ca"
+    "sha512=5bd2be34d61acf42a6c4e29f7b87fc15223ffa46546d6fb411f7519824ca8fd51f0db001787298f31c702998e73145c314b30e3e994154d0b3f63efe5f038976"
+  ]
+}

--- a/packages/ppx_irmin/ppx_irmin.2.1.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.2.1.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.8.0"}
   "ocaml" {>= "4.06.0"}
   "ocaml-syntax-shims"
   "ppxlib" {= "0.9.0"}

--- a/packages/ppx_irmin/ppx_irmin.2.1.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.2.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Craig Ferguson <craig@tarides.com>"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/mirage/irmin.git"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.06.0"}
+  "ocaml-syntax-shims"
+  "ppxlib" {= "0.9.0"}
+  "fmt" {with-test}
+]
+
+synopsis: "PPX deriver for Irmin generics"
+authors: "Craig Ferguson <craig@tarides.com>"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.1.0/irmin-2.1.0.tbz"
+  checksum: [
+    "sha256=af3837ddeaaabdde6c77cc46b87e8edbdef3539b1a0a8e329a0bd6b6fec928ca"
+    "sha512=5bd2be34d61acf42a6c4e29f7b87fc15223ffa46546d6fb411f7519824ca8fd51f0db001787298f31c702998e73145c314b30e3e994154d0b3f63efe5f038976"
+  ]
+}


### PR DESCRIPTION
Irmin

- Project page: <a href="https://github.com/mirage/irmin">https://github.com/mirage/irmin</a>

##### CHANGES:

#### Added

- **ppx_irmin** (_new_):
  - Created a new package, `ppx_irmin`, which provides a PPX deriving plugin
    for generating Irmin generics.

- **irmin-unix**:
  - Added a `--hash` parameter to the command-line interface, allowing the hash
    function to be specified. For BLAKE2b and BLAKE2s, the bit-length may be
    specified with a trailing slash, as in `--hash=blake2b/16`. The `hash`
    function may also be specified in the configuration file. (CraigFe/ppx_irmin#898, @craigfe)
 
- **irmin**:
  - Added `Irmin.Hash.Make_BLAKE2B` and `Irmin.Hash.Make_BLAKE2S` functors for
    customizing the bit-length of these hash functions. (CraigFe/ppx_irmin#898, @craigfe)
  - Added `iter` function over a closure graph (CraigFe/ppx_irmin#912, @ioana)
  - Added `Type.pp_ty` for pretty-printing Irmin generics. (CraigFe/ppx_irmin#926, @craigfe)
  - Added `Merge.with_conflict` for modifying the conflict error message of a
    merge function. (CraigFe/ppx_irmin#926, @craigfe)

#### Changed

- **irmin-pack**:
  - Changed the bit-length of serialized hashes from 60 to 30. (CraigFe/ppx_irmin#897,
    @icristescu)
  - `integrity_check` can now try to repair corrupted values. (CraigFe/ppx_irmin#947, @pascutto)

- **irmin-graphql**:
  - Changed default GraphQL type names to ensure uniqueness. (CraigFe/ppx_irmin#944, @andreas)
