### PR TITLE
[new release] ppx_blob (0.6.0)

### DIFF
--- a/packages/ppx_blob/ppx_blob.0.6.0/opam
+++ b/packages/ppx_blob/ppx_blob.0.6.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: "John Whitington"
+maintainer: "contact@coherentgraphics.co.uk"
+homepage: "https://github.com/johnwhitington/ppx_blob"
+dev-repo: "git+https://github.com/johnwhitington/ppx_blob.git"
+bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
+doc: "https://johnwhitington.github.io/ppx_blob/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune"
+  "ocaml-migrate-parsetree"
+  "alcotest" {with-test}
+]
+synopsis: "Include a file as a string at compile time"
+description:
+  "ppx_blob allows you to include a binary blob from a file as a string. Writing `[%blob \"filename\"]` will replace the string with the contents of the file at compile time. This allows the inclusion of arbitary, possibly compressed, data, without the need to respect OCaml's lexical conventions."
+url {
+  src:
+    "https://github.com/johnwhitington/ppx_blob/releases/download/0.6.0/ppx_blob-0.6.0.tbz"
+  checksum: [
+    "sha256=a6862862635afe58e964d7bcbbcb43cc595d47a89fa2c4dd31620273348d5bf5"
+    "sha512=1d6a4bf045b3629d388c9f630a022a982f51a381a404fa59b073902b5583c2d76d3a03e28437831a618c9f30d632da18cb7fcc583e579c717b4226d6e5c22f1f"
+  ]
+}


### PR DESCRIPTION
Include a file as a string at compile time

- Project page: <a href="https://github.com/johnwhitington/ppx_blob">https://github.com/johnwhitington/ppx_blob</a>
- Documentation: <a href="https://johnwhitington.github.io/ppx_blob/">https://johnwhitington.github.io/ppx_blob/</a>

##### CHANGES:

Migrate to dune and dune-release
