### PR TITLE
Revert "zed: not compatible with result.1.5.0 so constrain upper bound"

### DIFF
--- a/packages/zed/zed.1.6/opam
+++ b/packages/zed/zed.1.6/opam
@@ -11,7 +11,6 @@ depends: [
   "base-bytes"
   "camomile" {>= "0.8"}
   "react"
-  "result" {<"1.5.0"}
 ]
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}

--- a/packages/zed/zed.2.0.1/opam
+++ b/packages/zed/zed.2.0.1/opam
@@ -11,7 +11,6 @@ depends: [
   "base-bytes"
   "camomile" {>= "1.0.1"}
   "react"
-  "result" {<"1.5.0"}
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
   "result" {< "1.5"}
 ]

--- a/packages/zed/zed.2.0.2/opam
+++ b/packages/zed/zed.2.0.2/opam
@@ -11,7 +11,6 @@ depends: [
   "base-bytes"
   "camomile" {>= "1.0.1"}
   "react"
-  "result" {<"1.5.0"}
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
   "result" {< "1.5"}
 ]

--- a/packages/zed/zed.2.0.3/opam
+++ b/packages/zed/zed.2.0.3/opam
@@ -11,7 +11,6 @@ depends: [
   "base-bytes"
   "camomile" {>= "1.0.1"}
   "react"
-  "result" {<"1.5.0"}
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
   "result" {< "1.5"}
 ]

--- a/packages/zed/zed.2.0.4/opam
+++ b/packages/zed/zed.2.0.4/opam
@@ -11,7 +11,6 @@ depends: [
   "base-bytes"
   "camomile" {>= "1.0.1"}
   "react"
-  "result" {<"1.5.0"}
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
   "result" {< "1.5"}
 ]

--- a/packages/zed/zed.2.0.5/opam
+++ b/packages/zed/zed.2.0.5/opam
@@ -11,7 +11,6 @@ depends: [
   "base-bytes"
   "camomile" {>= "1.0.1"}
   "react"
-  "result" {<"1.5.0"}
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
   "result" {< "1.5"}
 ]

--- a/packages/zed/zed.2.0/opam
+++ b/packages/zed/zed.2.0/opam
@@ -11,7 +11,6 @@ depends: [
   "base-bytes"
   "camomile" {>= "1.0.1"}
   "react"
-  "result" {<"1.5.0"}
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
 ]
 build: [


### PR DESCRIPTION
Reverts ocaml/opam-repository#15906

As per comment in https://github.com/ocaml/opam-repository/pull/15909#issuecomment-592640245