### PR TITLE
musl+static+flambba ocaml: disable shared libraries in compiler config

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
@@ -23,11 +23,13 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "CC=musl-gcc -Os"
+    "CC=musl-gcc"
+    "CFLAGS=-Os"
     "ASPP=musl-gcc -c"
     "--enable-flambda"
     "LIBS=-static"
     "--disable-graph-lib"
+    "--disable-shared"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
@@ -27,10 +27,12 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "CC=musl-gcc -Os"
+    "CC=musl-gcc"
+    "CFLAGS=-Os"
     "ASPP=musl-gcc -c"
     "--enable-flambda"
     "LIBS=-static"
+    "--disable-shared"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+musl+static+flambda/opam
@@ -27,10 +27,12 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "CC=musl-gcc -Os"
+    "CC=musl-gcc"
+    "CFLAGS=-Os"
     "ASPP=musl-gcc -c"
     "--enable-flambda"
     "LIBS=-static"
+    "--disable-shared"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]


### PR DESCRIPTION
this fixes relocation errors when building on some distributions
(ocaml/ocaml#9131 #15344)