### PR TITLE
Make liquidsoap bash completion installation directory explicit

### DIFF
--- a/packages/liquidsoap/liquidsoap.1.4.1-1/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1-1/opam
@@ -4,7 +4,18 @@ homepage: "https://github.com/savonet/liquidsoap"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 build: [
   ["./bootstrap"] {dev}
-  ["./configure" "--prefix" prefix "--sbindir=%{lib}%/liquidsoap/sbin" "--libexecdir=%{lib}%/liquidsoap/libexec" "--sysconfdir=%{lib}%/liquidsoap/etc" "--sharedstatedir=%{lib}%/liquidsoap/com" "--localstatedir=%{lib}%/liquidsoap/var" "--libdir=%{lib}%/liquidsoap/lib" "--includedir=%{lib}%/liquidsoap/include" "--datarootdir=%{lib}%/liquidsoap/share" "--disable-graphics" "--with-user=dummy" "--with-group=dummy"]
+  ["./configure" "--prefix" prefix
+                 "--sbindir=%{lib}%/liquidsoap/sbin"
+                 "--libexecdir=%{lib}%/liquidsoap/libexec"
+                 "--sysconfdir=%{lib}%/liquidsoap/etc"
+                 "--sharedstatedir=%{lib}%/liquidsoap/com"
+                 "--localstatedir=%{lib}%/liquidsoap/var"
+                 "--libdir=%{lib}%/liquidsoap/lib"
+                 "--includedir=%{lib}%/liquidsoap/include"
+                 "--datarootdir=%{lib}%/liquidsoap/share"
+                 "--with-bash-completion-dir=%{lib}%/liquidsoap/etc/bash_completion.d"
+                 "--with-user=dummy"
+                 "--with-group=dummy"]
   [make "clean"] {dev}
   [make]
 ]

--- a/packages/liquidsoap/liquidsoap.1.4.1/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1/opam
@@ -4,7 +4,18 @@ homepage: "https://github.com/savonet/liquidsoap"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 build: [
   ["./bootstrap"] {dev}
-  ["./configure" "--prefix" prefix "--sbindir=%{lib}%/liquidsoap/sbin" "--libexecdir=%{lib}%/liquidsoap/libexec" "--sysconfdir=%{lib}%/liquidsoap/etc" "--sharedstatedir=%{lib}%/liquidsoap/com" "--localstatedir=%{lib}%/liquidsoap/var" "--libdir=%{lib}%/liquidsoap/lib" "--includedir=%{lib}%/liquidsoap/include" "--datarootdir=%{lib}%/liquidsoap/share" "--disable-graphics" "--with-user=dummy" "--with-group=dummy"]
+  ["./configure" "--prefix" prefix
+                 "--sbindir=%{lib}%/liquidsoap/sbin"
+                 "--libexecdir=%{lib}%/liquidsoap/libexec"
+                 "--sysconfdir=%{lib}%/liquidsoap/etc"
+                 "--sharedstatedir=%{lib}%/liquidsoap/com"
+                 "--localstatedir=%{lib}%/liquidsoap/var"
+                 "--libdir=%{lib}%/liquidsoap/lib"
+                 "--includedir=%{lib}%/liquidsoap/include"
+                 "--datarootdir=%{lib}%/liquidsoap/share"
+                 "--with-bash-completion-dir=%{lib}%/liquidsoap/etc/bash_completion.d"
+                 "--with-user=dummy"
+                 "--with-group=dummy"]
   [make "clean"] {dev}
   [make]
 ]


### PR DESCRIPTION
This PR fixes installation issues on some platforms where `pkg-config` does not honor the `prefix` where bash completion should be installed. See for instance: https://github.com/savonet/liquidsoap/issues/1095