### PR TITLE
[new release] ppx_inline_test (0.13.1)

### DIFF
--- a/packages/ppx_inline_test/ppx_inline_test.0.13.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.0.13.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.13" & < "v0.14"}
-  "dune"   {>= "1.5.1"}
+  "dune"   {>= "1.10"}
   "ppxlib" {>= "0.9.0"}
 ]
 synopsis: "Syntax extension for writing in-line tests in ocaml code"

--- a/packages/ppx_inline_test/ppx_inline_test.0.13.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.0.13.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_inline_test"
+bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"  {>= "4.04.2"}
+  "base"   {>= "v0.13" & < "v0.14"}
+  "dune"   {>= "1.5.1"}
+  "ppxlib" {>= "0.9.0"}
+]
+synopsis: "Syntax extension for writing in-line tests in ocaml code"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_inline_test/releases/download/v0.13.1/ppx_inline_test-v0.13.1.tbz"
+  checksum: [
+    "sha256=e75c9df9b33e20655fd2f728df5e332794bdd9a2f5a62fc08e44fb6ca1beda6c"
+    "sha512=402e4d6113368da37464d64ae145f5a58af751275bb92d4a4bdd16f41fbada9311ca9f8da7aeb86537bdf25710fcb1df3cd983717935f1cd5ca663f27aaa3b6b"
+  ]
+}


### PR DESCRIPTION
Syntax extension for writing in-line tests in ocaml code

- Project page: <a href="https://github.com/janestreet/ppx_inline_test">https://github.com/janestreet/ppx_inline_test</a>
- Documentation: <a href="https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.html">https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.html</a>

##### CHANGES:

- Honor the `inline_tests` Dune variable so that inline tests are
  dropped in release builds
