### PR TITLE
[new release] prometheus and prometheus-app (0.7)

### DIFF
--- a/packages/prometheus-app/prometheus-app.0.7/opam
+++ b/packages/prometheus-app/prometheus-app.0.7/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Client library for Prometheus monitoring"
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.0"}
+  "prometheus" {=version}
+  "fmt"
+  "re"
+  "cohttp" {>= "1.0.0"}
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "lwt" {>= "2.5.0"}
+  "cmdliner"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+description: """
+Applications can enable metric reporting using the `prometheus-app` opam package.
+This depends on cohttp and can serve the metrics collected above over HTTP.
+
+The `prometheus-app.unix` ocamlfind library provides the `Prometheus_unix` module,
+which includes a cmdliner option and pre-configured web-server.
+See the `examples/example.ml` program for an example, which can be run as:
+
+```shell
+$ dune exec -- examples/example.exe --listen-prometheus=9090
+If run with the option --listen-prometheus=9090, this program serves metrics at
+http://localhost:9090/metrics
+Tick!
+Tick!
+...
+```
+
+Unikernels can use `Prometheus_app` instead of `Prometheus_unix` to avoid the `Unix` dependency.
+"""
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v0.7/prometheus-v0.7.tbz"
+  checksum: [
+    "sha256=e2894de14ab9f9a095b1359581d84094123a1214f76e1563f7ce5a16c69c6ac5"
+    "sha512=6a4d81fef6514400ecf7e16a9871db0aba83a8cd52deaaaa3d07517ecbb460a638684326fc1087c4a57dfd830a609ae7486b69a9f77d07ab5e0eada663191228"
+  ]
+}

--- a/packages/prometheus/prometheus.0.7/opam
+++ b/packages/prometheus/prometheus.0.7/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Client library for Prometheus monitoring"
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "dune"
+  "astring"
+  "asetmap"
+  "fmt"
+  "re"
+  "lwt" {>= "2.5.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+description: """
+To run services reliably, it is useful if they can report various metrics
+(for example, heap size, queue lengths, number of warnings logged, etc).
+
+A monitoring service can be configured to collect this data regularly.
+The data can be graphed to help understand the performance of the service over time,
+or to help debug problems quickly.
+It can also be used to send alerts if a service is down or behaving poorly.
+"""
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v0.7/prometheus-v0.7.tbz"
+  checksum: [
+    "sha256=e2894de14ab9f9a095b1359581d84094123a1214f76e1563f7ce5a16c69c6ac5"
+    "sha512=6a4d81fef6514400ecf7e16a9871db0aba83a8cd52deaaaa3d07517ecbb460a638684326fc1087c4a57dfd830a609ae7486b69a9f77d07ab5e0eada663191228"
+  ]
+}


### PR DESCRIPTION
Client library for Prometheus monitoring

- Project page: <a href="https://github.com/mirage/prometheus">https://github.com/mirage/prometheus</a>
- Documentation: <a href="https://mirage.github.io/prometheus/">https://mirage.github.io/prometheus/</a>

##### CHANGES:

- switch float representation to OCaml's default `"%f"` (mirage/prometheus#22, @toots)
- use `Gc.quick_stat` for faster stats (mirage/prometheus#25, @talex5)
