### PR TITLE
Fix the package description for cduce 0.5.5.

### DIFF
--- a/packages/cduce/cduce.0.5.5/opam
+++ b/packages/cduce/cduce.0.5.5/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind"
   "pcre"
   "ulex"
-  "ocamlnet"
+  "ocamlnet" {< "4.0.1"}
   "pxp"
 ]
 depopts: ["ocaml-src"]


### PR DESCRIPTION
cduce does not compile with ocamlnet 4.0.1 or later.
It does compile with ocamlnet 3.7.7.
The error message is:
```
  File "parser/cduce_netclient.ml", line 13, characters 6-38:
  Error: Unbound module Http_client
```
