### PR TITLE
Package gnuplot.0.7

### DIFF
--- a/packages/gnuplot/gnuplot.0.7/opam
+++ b/packages/gnuplot/gnuplot.0.7/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "simon cruanes"
+authors: [ "Oliver Gu <gu.oliver@yahoo.com>" ]
+homepage: "https://github.com/c-cube/ocaml-gnuplot"
+bug-reports: "https://github.com/c-cube/ocaml-gnuplot/issues"
+dev-repo: "git+https://github.com/c-cube/ocaml-gnuplot.git"
+license: "LGPL-2.1+ with OCaml linking exception"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+depends: [
+  "base-unix"
+  "ISO8601"
+  "conf-gnuplot"
+  "dune" {>= "1.0"}
+  "ocaml" {>= "4.03"}
+  "odoc" {with-doc}
+]
+synopsis: "Simple interface to Gnuplot
+
+Gnuplot-OCaml provides a simple interface to Gnuplot from OCaml.
+The API supports only 2D graphs and was inspired by FnuPlot
+"
+url {
+  src: "https://github.com/c-cube/ocaml-gnuplot/archive/v0.7.tar.gz"
+  checksum: [
+    "md5=f2fe68341173273bb9dc43b9d09f5b56"
+    "sha512=38f2076f2d9365b8a7206981d4a08d21c2dded9dbec4357ad87349c0d74779fce35de885770e01d237bd9ca407287b0d321b3325968e93cb571ad714036939fa"
+  ]
+}


### PR DESCRIPTION
### `gnuplot.0.7`
Simple interface to Gnuplot

Gnuplot-OCaml provides a simple interface to Gnuplot from OCaml.
The API supports only 2D graphs and was inspired by FnuPlot



---
* Homepage: https://github.com/c-cube/ocaml-gnuplot
* Source repo: git+https://github.com/c-cube/ocaml-gnuplot.git
* Bug tracker: https://github.com/c-cube/ocaml-gnuplot/issues

---
:camel: Pull-request generated by opam-publish v2.0.0