### PR TITLE
[new release] websocket-lwt-unix, websocket and websocket-async (2.14)

### DIFF
--- a/packages/websocket-async/websocket-async.2.14/opam
+++ b/packages/websocket-async/websocket-async.2.14/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-websocket"
+bug-reports: "https://github.com/vbmithr/ocaml-websocket/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-websocket"
+doc: "https://vbmithr.github.io/ocaml-websocket/doc"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [ "dune" "build" "-j" jobs "-p" name ]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.3.0"}
+  "websocket" {= version}
+  "core" {>= "v0.13.0"}
+  "async" {>= "v0.13.0"}
+  "cohttp-async" {>= "2.5.1"}
+  "logs-async" {>= "1.1"}
+  "logs-async-reporter" {>= "1.0"}
+]
+synopsis: "Websocket library (Async)"
+description: """
+The WebSocket Protocol enables two-way communication between a client
+running untrusted code in a controlled environment to a remote host
+that has opted-in to communications from that code.
+
+The security model used for this is the origin-based security model
+commonly used by web browsers. The protocol consists of an opening
+handshake followed by basic message framing, layered over TCP.
+
+The goal of this technology is to provide a mechanism for
+browser-based applications that need two-way communication with
+servers that does not rely on opening multiple HTTP connections (e.g.,
+using XMLHttpRequest or <iframe>s and long polling)."""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-websocket/releases/download/2.14/websocket-2.14.tbz"
+  checksum: [
+    "sha256=30e40d098da86fb5f6b2adbc53211503c6e0c20422c21a7b41c8ac83168ca439"
+    "sha512=ae4246f66a15cc3eb9a8fbd11bb5551fe77fb5ae93d31e8d8636c0b254e2d93ac3d5663604731a5b6ed28897cdb5677b6a96b1ce3d993b4720fd09549f1bf9ad"
+  ]
+}

--- a/packages/websocket-lwt-unix/websocket-lwt-unix.2.14/opam
+++ b/packages/websocket-lwt-unix/websocket-lwt-unix.2.14/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-websocket"
+bug-reports: "https://github.com/vbmithr/ocaml-websocket/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-websocket"
+doc: "https://vbmithr.github.io/ocaml-websocket/doc"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [ "dune" "build" "-j" jobs "-p" name ]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.3.0"}
+  "websocket" {= version}
+  "lwt_log" {>= "1.1.1"}
+  "cohttp-lwt-unix" {>= "2.5.1"}
+]
+synopsis: "Websocket library (Lwt)"
+description: """
+The WebSocket Protocol enables two-way communication between a client
+running untrusted code in a controlled environment to a remote host
+that has opted-in to communications from that code.
+
+The security model used for this is the origin-based security model
+commonly used by web browsers. The protocol consists of an opening
+handshake followed by basic message framing, layered over TCP.
+
+The goal of this technology is to provide a mechanism for
+browser-based applications that need two-way communication with
+servers that does not rely on opening multiple HTTP connections (e.g.,
+using XMLHttpRequest or <iframe>s and long polling)."""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-websocket/releases/download/2.14/websocket-2.14.tbz"
+  checksum: [
+    "sha256=30e40d098da86fb5f6b2adbc53211503c6e0c20422c21a7b41c8ac83168ca439"
+    "sha512=ae4246f66a15cc3eb9a8fbd11bb5551fe77fb5ae93d31e8d8636c0b254e2d93ac3d5663604731a5b6ed28897cdb5677b6a96b1ce3d993b4720fd09549f1bf9ad"
+  ]
+}

--- a/packages/websocket/websocket.2.14/opam
+++ b/packages/websocket/websocket.2.14/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-websocket"
+bug-reports: "https://github.com/vbmithr/ocaml-websocket/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-websocket"
+doc: "https://vbmithr.github.io/ocaml-websocket/doc"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [ "dune" "build" "-j" jobs "-p" name ]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.3.0"}
+  "base64" {>= "3.3.0"}
+  "conduit" {>= "2.0.2"}
+  "cohttp" {>= "2.5.1"}
+  "ocplib-endian" {>= "1.0"}
+  "astring" {>= "0.8.3"}
+]
+synopsis: "Websocket library"
+description: """
+The WebSocket Protocol enables two-way communication between a client
+running untrusted code in a controlled environment to a remote host
+that has opted-in to communications from that code.
+
+The security model used for this is the origin-based security model
+commonly used by web browsers. The protocol consists of an opening
+handshake followed by basic message framing, layered over TCP.
+
+The goal of this technology is to provide a mechanism for
+browser-based applications that need two-way communication with
+servers that does not rely on opening multiple HTTP connections (e.g.,
+using XMLHttpRequest or <iframe>s and long polling)."""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-websocket/releases/download/2.14/websocket-2.14.tbz"
+  checksum: [
+    "sha256=30e40d098da86fb5f6b2adbc53211503c6e0c20422c21a7b41c8ac83168ca439"
+    "sha512=ae4246f66a15cc3eb9a8fbd11bb5551fe77fb5ae93d31e8d8636c0b254e2d93ac3d5663604731a5b6ed28897cdb5677b6a96b1ce3d993b4720fd09549f1bf9ad"
+  ]
+}


### PR DESCRIPTION
Websocket library (Lwt)

- Project page: <a href="https://github.com/vbmithr/ocaml-websocket">https://github.com/vbmithr/ocaml-websocket</a>
- Documentation: <a href="https://vbmithr.github.io/ocaml-websocket/doc">https://vbmithr.github.io/ocaml-websocket/doc</a>

##### CHANGES:

- bugfix: cohttp_lwt: call conn_closed on fd close (@NightBlues)
- fix compilation with newer async (@copy)
- fix compilation with newer conduit (@tizoc)
