### PR TITLE
[new release] dune-build-info, dune, dune-configurator, dune-action-plugin, dune-private-libs and dune-glob (2.4.0)

### DIFF
--- a/packages/dune-action-plugin/dune-action-plugin.2.4.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "dune-glob"
+  "ppx_expect" {with-test}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.4.0/dune-2.4.0.tbz"
+  checksum: [
+    "sha256=28f1484a798103021833d544f1a79b0234cca77add49bba073013eae94b9dc24"
+    "sha512=aa8561d7174f8435a0e86fbd165005a121797e5e5e46d50d5dc75c863bde0e2945311222cadb8ac27e75052bedbae9edf418cb1130f50d807705218ee284a19b"
+  ]
+}

--- a/packages/dune-build-info/dune-build-info.2.4.0/opam
+++ b/packages/dune-build-info/dune-build-info.2.4.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Embed build informations inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.3"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.4.0/dune-2.4.0.tbz"
+  checksum: [
+    "sha256=28f1484a798103021833d544f1a79b0234cca77add49bba073013eae94b9dc24"
+    "sha512=aa8561d7174f8435a0e86fbd165005a121797e5e5e46d50d5dc75c863bde0e2945311222cadb8ac27e75052bedbae9edf418cb1130f50d807705218ee284a19b"
+  ]
+}

--- a/packages/dune-configurator/dune-configurator.2.4.0/opam
+++ b/packages/dune-configurator/dune-configurator.2.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.4.0/dune-2.4.0.tbz"
+  checksum: [
+    "sha256=28f1484a798103021833d544f1a79b0234cca77add49bba073013eae94b9dc24"
+    "sha512=aa8561d7174f8435a0e86fbd165005a121797e5e5e46d50d5dc75c863bde0e2945311222cadb8ac27e75052bedbae9edf418cb1130f50d807705218ee284a19b"
+  ]
+}

--- a/packages/dune-glob/dune-glob.2.4.0/opam
+++ b/packages/dune-glob/dune-glob.2.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.4.0/dune-2.4.0.tbz"
+  checksum: [
+    "sha256=28f1484a798103021833d544f1a79b0234cca77add49bba073013eae94b9dc24"
+    "sha512=aa8561d7174f8435a0e86fbd165005a121797e5e5e46d50d5dc75c863bde0e2945311222cadb8ac27e75052bedbae9edf418cb1130f50d807705218ee284a19b"
+  ]
+}

--- a/packages/dune-private-libs/dune-private-libs.2.4.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.07"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.4.0/dune-2.4.0.tbz"
+  checksum: [
+    "sha256=28f1484a798103021833d544f1a79b0234cca77add49bba073013eae94b9dc24"
+    "sha512=aa8561d7174f8435a0e86fbd165005a121797e5e5e46d50d5dc75c863bde0e2945311222cadb8ac27e75052bedbae9edf418cb1130f50d807705218ee284a19b"
+  ]
+}

--- a/packages/dune/dune.2.4.0/opam
+++ b/packages/dune/dune.2.4.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "1.3.0"}
+  "dune-release" {< "1.3.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .travis.yml, dune-project
+  # and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.07"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.4.0/dune-2.4.0.tbz"
+  checksum: [
+    "sha256=28f1484a798103021833d544f1a79b0234cca77add49bba073013eae94b9dc24"
+    "sha512=aa8561d7174f8435a0e86fbd165005a121797e5e5e46d50d5dc75c863bde0e2945311222cadb8ac27e75052bedbae9edf418cb1130f50d807705218ee284a19b"
+  ]
+}


### PR DESCRIPTION
Embed build informations inside executable

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- Add `mdx` extension and stanza version 0.1 (ocaml/dune#3094, @NathanReb)

- Allow to make Odoc warnings fatal. This is configured from the `(env ...)`
  stanza. (ocaml/dune#3029, @Julow)

- Fix separate compilation of JS when findlib is not installed. (ocaml/dune#3177, @nojb)

- Add a `dune describe` command to obtain the topology of a dune workspace, for
  projects such as ROTOR. (ocaml/dune#3128, @diml)

- Add `plugin` linking mode for executables and the `(embed_in_plugin_libraries
  ...)` field. (ocaml/dune#3141, @nojb)

- Add an `%{ext_plugin}` variable (ocaml/dune#3141, @nojb)

- Dune will no longer build shared objects for stubs if
  `supports_shared_libraries` is false (ocaml/dune#3225, fixes ocaml/dune#3222, @rgrinberg)

- Fix a memory leak in the file-watching mode (`dune build -w`)
  (ocaml/dune#3220, @snowleopard and @aalekseyev)
