### PR TITLE
[new release] tyxml-ppx, tyxml-syntax, tyxml and tyxml-jsx (4.4.0)

### DIFF
--- a/packages/tyxml-jsx/tyxml-jsx.4.4.0/opam
+++ b/packages/tyxml-jsx/tyxml-jsx.4.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+homepage: "https://github.com/ocsigen/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "git+https://github.com/ocsigen/tyxml.git"
+license: "LGPL-2.1 with OCaml linking exception"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune"
+  "alcotest" {with-test}
+  "tyxml" {= version}
+  "tyxml-syntax" {= version}
+  "ppx_tools_versioned"
+  "reason" {with-test}
+]
+
+synopsis:"JSX syntax to write TyXML documents"
+description:"""
+
+```reason
+open Tyxml;
+let to_reason = <a href="reasonml.github.io/"> "Reason!" </a>
+```
+
+Allow to write any TyXML documents with reason's JSX syntax, from textual trees
+to reactive virtual DOM trees.
+"""
+authors: "The ocsigen team"
+url {
+  src:
+    "https://github.com/ocsigen/tyxml/releases/download/4.4.0/tyxml-4.4.0.tbz"
+  checksum: [
+    "sha256=516394dd4a5c31726997c51d66aa31cacb91e3c46d4e16c7699130e204042530"
+    "sha512=d5f2187f8410524cec7a14b28e8950837070eb0b6571b015dd06076c2841eb7ccaffa86d5d2307eaf1950ee62f9fb926477dac01c870d9c1a2f525853cb44d0c"
+  ]
+}

--- a/packages/tyxml-ppx/tyxml-ppx.4.4.0/opam
+++ b/packages/tyxml-ppx/tyxml-ppx.4.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+homepage: "https://github.com/ocsigen/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "git+https://github.com/ocsigen/tyxml.git"
+license: "LGPL-2.1 with OCaml linking exception"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune"
+  "alcotest" {with-test}
+  "tyxml" {= version}
+  "tyxml-syntax" {= version}
+  "markup" {>= "0.7.2"}
+  "ppx_tools_versioned"
+]
+
+synopsis:"PPX that allows to write TyXML documents with the HTML syntax"
+description:"""
+
+```ocaml
+open Tyxml
+let%html to_ocaml = "<a href='ocaml.org'>OCaml!</a>"
+```
+
+The TyXML PPX is compatible with all TyXML instance, from textual trees
+to reactive virtual DOM trees.
+"""
+authors: "The ocsigen team"
+url {
+  src:
+    "https://github.com/ocsigen/tyxml/releases/download/4.4.0/tyxml-4.4.0.tbz"
+  checksum: [
+    "sha256=516394dd4a5c31726997c51d66aa31cacb91e3c46d4e16c7699130e204042530"
+    "sha512=d5f2187f8410524cec7a14b28e8950837070eb0b6571b015dd06076c2841eb7ccaffa86d5d2307eaf1950ee62f9fb926477dac01c870d9c1a2f525853cb44d0c"
+  ]
+}

--- a/packages/tyxml-syntax/tyxml-syntax.4.4.0/opam
+++ b/packages/tyxml-syntax/tyxml-syntax.4.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+homepage: "https://github.com/ocsigen/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "git+https://github.com/ocsigen/tyxml.git"
+license: "LGPL-2.1 with OCaml linking exception"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune"
+  "uutf" {>= "1.0.0"}
+  "re" {>= "1.5.0"}
+  "alcotest" {with-test}
+  "ppx_tools_versioned"
+]
+
+synopsis:"Common layer for the JSX and PPX syntaxes for Tyxml"
+authors: "The ocsigen team"
+url {
+  src:
+    "https://github.com/ocsigen/tyxml/releases/download/4.4.0/tyxml-4.4.0.tbz"
+  checksum: [
+    "sha256=516394dd4a5c31726997c51d66aa31cacb91e3c46d4e16c7699130e204042530"
+    "sha512=d5f2187f8410524cec7a14b28e8950837070eb0b6571b015dd06076c2841eb7ccaffa86d5d2307eaf1950ee62f9fb926477dac01c870d9c1a2f525853cb44d0c"
+  ]
+}

--- a/packages/tyxml/tyxml.4.4.0/opam
+++ b/packages/tyxml/tyxml.4.4.0/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02"}
-  "dune" {build}
+  "dune"
   "alcotest" {with-test}
   "seq"
   "uutf" {>= "1.0.0"}

--- a/packages/tyxml/tyxml.4.4.0/opam
+++ b/packages/tyxml/tyxml.4.4.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+homepage: "https://github.com/ocsigen/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "git+https://github.com/ocsigen/tyxml.git"
+license: "LGPL-2.1 with OCaml linking exception"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {build}
+  "alcotest" {with-test}
+  "seq"
+  "uutf" {>= "1.0.0"}
+  "re" {>= "1.5.0"}
+]
+
+synopsis:"TyXML is a library for building correct HTML and SVG documents"
+description:"""
+TyXML provides a set of convenient combinators that uses the OCaml
+type system to ensure the validity of the generated documents. TyXML
+can be used with any representation of HTML and SVG: the textual one,
+provided directly by this package, or DOM trees (`js_of_ocaml-tyxml`)
+virtual DOM (`virtual-dom`) and reactive or replicated trees
+(`eliom`). You can also create your own representation and use it to
+instantiate a new set of combinators.
+
+```ocaml
+open Tyxml
+let to_ocaml = Html.(a ~a:[a_href "ocaml.org"] [txt "OCaml!"])
+```
+"""
+authors: "The ocsigen team"
+url {
+  src:
+    "https://github.com/ocsigen/tyxml/releases/download/4.4.0/tyxml-4.4.0.tbz"
+  checksum: [
+    "sha256=516394dd4a5c31726997c51d66aa31cacb91e3c46d4e16c7699130e204042530"
+    "sha512=d5f2187f8410524cec7a14b28e8950837070eb0b6571b015dd06076c2841eb7ccaffa86d5d2307eaf1950ee62f9fb926477dac01c870d9c1a2f525853cb44d0c"
+  ]
+}


### PR DESCRIPTION
:tada: A reasonable tyxml release :tada: 

------

CHANGES:

* Add support for Reason's JSX syntax with a new `tyxml-jsx` package
  (ocsigen/tyxml#254 by Joris Giovannangeli and Gabriel Radanne
   with help from Ulrik Strid and Louis Roché)
* Modernize the handling of toplevel printers for utop.
  (Gabriel Radanne)

## Elements and attributes

* Add `allowfullscreen`, `allowpaymentrequest`, `referrerpolicy` attributes
  (ocsigen/tyxml#242 by Thibault Suzanne)
* Allow `crossorigin` attribute for script element
  (ocsigen/tyxml#243 by Thibault Suzanne)
* Greatly improved support of whitespaces in the PPX
  (ocsigen/tyxml#225 by Jules Aguillon)
* Add preliminary support for ARIA attributes
  (ocsigen/tyxml#253 by Stéphane Legrand and Gabriel Radanne)
* Add `template` element
  (ocsigen/tyxml#239 Stéphane Legrand)

* Several bug fixes for types and PPX