### PR TITLE
Liquidsoap: ignore errors while installing bash completion files

### DIFF
--- a/packages/liquidsoap/liquidsoap.1.4.1-2/files/ignore-bash-completion-install-errors.patch
+++ b/packages/liquidsoap/liquidsoap.1.4.1-2/files/ignore-bash-completion-install-errors.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index 4dc8c797..c2c4c409 100644
+--- a/Makefile
++++ b/Makefile
+@@ -83,7 +83,7 @@ endif
+ 	$(INSTALL_DATA) examples/radio.liq ${sysconfdir}/liquidsoap/radio.liq.example
+ 	$(INSTALL_DIRECTORY) ${sysconfdir}/logrotate.d
+ 	$(INSTALL_DATA) scripts/liquidsoap.logrotate ${sysconfdir}/logrotate.d/liquidsoap
+-	$(INSTALL_DIRECTORY) ${bashcompdir}
+-	$(INSTALL_DATA) scripts/bash-completion ${bashcompdir}/liquidsoap
++	-$(INSTALL_DIRECTORY) ${bashcompdir}
++	-$(INSTALL_DATA) scripts/bash-completion ${bashcompdir}/liquidsoap
+ 	$(INSTALL_DIRECTORY) ${emacsdir}
+ 	$(INSTALL_DATA) scripts/liquidsoap-mode.el ${emacsdir}/

--- a/packages/liquidsoap/liquidsoap.1.4.1-2/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1-2/opam
@@ -1,0 +1,157 @@
+opam-version: "2.0"
+maintainer: "romain.beauxis@gmail.com"
+homepage: "https://github.com/savonet/liquidsoap"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+patches: [
+  "ignore-bash-completion-install-errors.patch"
+]
+build: [
+  ["./bootstrap"] {dev}
+  ["./configure" "--prefix" prefix
+                 "--sbindir=%{lib}%/liquidsoap/sbin"
+                 "--libexecdir=%{lib}%/liquidsoap/libexec"
+                 "--sysconfdir=%{lib}%/liquidsoap/etc"
+                 "--sharedstatedir=%{lib}%/liquidsoap/com"
+                 "--localstatedir=%{lib}%/liquidsoap/var"
+                 "--libdir=%{lib}%/liquidsoap/lib"
+                 "--includedir=%{lib}%/liquidsoap/include"
+                 "--datarootdir=%{lib}%/liquidsoap/share"
+                 "--with-bash-completion-dir=%{lib}%/liquidsoap/etc/bash_completion.d"
+                 "--with-user=dummy"
+                 "--with-group=dummy"]
+  [make "clean"] {dev}
+  [make]
+]
+install: [
+  [make "install"]
+]
+post-messages: [
+"We're sorry that your liquidsoap install failed. Check out our installation
+instructions at: https://www.liquidsoap.info/doc-%{version}%/install.html#opam
+for more information." {failure}
+
+"✨ Congratulations on installing liquidsoap! ✨" {success}
+
+"We noticed that you did not install any mp3 decoder. This is a feature most
+users want. You might need to install the mad or ffmpeg package." {success & !mad-enabled & !ffmpeg-enabled}
+
+"We noticed that you did not install any mp3 encoder. This is a feature most
+users want. You might need to install the lame or shine package." {success & !lame-enabled & !shine-enabled}
+
+"We noticed that you did not install the taglib package that provides support
+for reading metatadata in audio files. This is a feature most users want." {success & !taglib-enabled}
+
+"We noticed that you did not install the samplerate package. We stronly
+recommend this package for audio samplerate conversion." {success & !samperate-enabled}
+
+"We noticed that you did not install the cry package that provides icecast
+output. This is a feature most users want." {success & !cry-enabled}
+
+"We noticed that you did not install any ssl support package. Liquidsoap won't
+be able to use any HTTPS feature. You might want to install one of ssl or
+osx-secure-transport package." {success & !ssl-enabled & !secure-transport-enabled}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "camomile" {>= "1.0.0"}
+  "dtools" {>= "0.4.1"}
+  "duppy" {>= "0.8.0"}
+  "menhir"
+  "mm" {>= "0.5.0"}
+  "ocamlfind" {build}
+  "pcre"
+  "sedlex" {>= "2.0"}
+]
+depopts: [
+  "alsa"
+  "ao"
+  "bjack"
+  "camlimages"
+  "cry"
+  "dssi"
+  "faad"
+  "fdkaac"
+  "ffmpeg"
+  "flac"
+  "frei0r"
+  "gavl"
+  "gd"
+  "graphics"
+  "gstreamer"
+  "inotify"
+  "ladspa"
+  "lame"
+  "lastfm"
+  "lo"
+  "mad"
+  "magic"
+  "sdl-liquidsoap"
+  "ogg"
+  "opus"
+  "osx-secure-transport"
+  "portaudio"
+  "pulseaudio"
+  "samplerate"
+  "shine"
+  "soundtouch"
+  "speex"
+  "ssl"
+  "taglib"
+  "theora"
+  "vorbis"
+  "xmlplaylist"
+  "yojson" 
+]
+conflicts: [
+  "alsa" {< "0.2.1"}
+  "ao" {< "0.2.0"}
+  "bjack" {< "0.1.3"}
+  "cry" {< "0.6.0"}
+  "dssi" {< "0.1.1"}
+  "faad" {< "0.4.0"}
+  "fdkaac" {< "0.3.1"}
+  "ffmpeg" {< "0.2.0"}
+  "flac" {< "0.1.5"}
+  "frei0r" {< "0.1.0"}
+  "gavl" {< "0.1.4"}
+  "gstreamer" {< "0.3.0"}
+  "inotify" {< "1.0"}
+  "ladspa" {< "0.1.4"}
+  "lame" {< "0.3.2"}
+  "lastfm" {< "0.3.0"}
+  "lo" {< "0.1.2"}
+  "mad" {< "0.1.4"}
+  "magic" {< "0.6"}
+  "ogg" {< "0.5.0"}
+  "opus" {< "0.1.3"}
+  "portaudio" {< "0.2.0"}
+  "pulseaudio" {< "0.1.2"}
+  "samplerate" {< "0.1.1"}
+  "shine" {< "0.2.0"}
+  "soundtouch" {< "0.1.7"}
+  "speex" {< "0.2.1"}
+  "ssl" {< "0.5.2"}
+  "taglib" {< "0.3.0"}
+  "theora" {< "0.3.1"}
+  "vorbis" {< "0.7.0"}
+  "xmlplaylist" {< "0.1.3"}
+]
+extra-files: ["ignore-bash-completion-install-errors.patch" "md5=b43419de6e3225f59a42f330f557e877"]
+bug-reports: "https://github.com/savonet/liquidsoap/issues"
+dev-repo: "git+https://github.com/savonet/liquidsoap.git"
+synopsis: "Swiss-army knife for multimedia streaming"
+description: """
+Liquidsoap is a powerful and flexible language for describing your
+streams. It offers a rich collection of operators that you can combine
+at will, giving you more power than you need for creating or
+transforming streams. But liquidsoap is still very light and easy to
+use, in the Unix tradition of simple strong components working
+together."""
+url {
+  src:
+    "https://github.com/savonet/liquidsoap/releases/download/1.4.1/liquidsoap-1.4.1.tar.bz2"
+  checksum: [
+    "md5=a14a955872916b0b712f804bffce0cc2"
+    "sha512=1bd885a3de902cde15a96d19132c774a70954f2afa9eb45d007577fe317fa83aabaadcccce43869007b211d82b25f8db50bc42a563fbe043a47ab66deb173168"
+  ]
+}


### PR DESCRIPTION
Hi there!

Apologize but it looks like the previous update on liquidsoap did not fix all cases of the issue. This one should hopefully put it to bed for good this time. I've tested it on Debian/testing where it was still occurring.

Thanks for your consideration!