### PR TITLE
Package glfw-ocaml (3.3~rc2)

### DIFF
--- a/packages/glfw-ocaml/glfw-ocaml.3.3~rc2/opam
+++ b/packages/glfw-ocaml/glfw-ocaml.3.3~rc2/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "A GLFW binding for OCaml"
+maintainer: "Sylvain BOILARD <boilard@crans.org>"
+authors: "Sylvain BOILARD <boilard@crans.org>"
+license: "Zlib"
+homepage: "https://github.com/SylvainBoilard/GLFW-OCaml"
+bug-reports: "https://github.com/SylvainBoilard/GLFW-OCaml/issues"
+depends: [
+  "conf-glfw3"
+  "base-bigarray"
+  "dune" {>= "1.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.02.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/SylvainBoilard/GLFW-OCaml.git"
+url {
+  src:
+    "https://github.com/SylvainBoilard/GLFW-OCaml/archive/3.3-rc2.tar.gz"
+  checksum: [
+    "md5=dae776270b98a88b43c380cdf732a75a"
+    "sha512=9820260781f4cb44da77ffa78a96a341405115bf2219d1190194f624b86627280022cfdfbc0f3a596324fa8fbae973b961c410c191f4a8f5a5bc517ffa234688"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Use a single type for window hints and attributes.