### PR TITLE
[new release] spin (0.5.0)

### DIFF
--- a/packages/spin/spin.0.5.0/opam
+++ b/packages/spin/spin.0.5.0/opam
@@ -14,10 +14,6 @@ depends: [
   "ocaml" {>= "4.06.0" & < "4.10.0"}
   "dune" {>= "2.0"}
   "odoc" {with-doc}
-  "dune-release" {dev}
-  "merlin" {dev}
-  "ocamlformat" {dev}
-  "utop" {dev}
   "reason" {build}
   "base"
   "stdio"

--- a/packages/spin/spin.0.5.0/opam
+++ b/packages/spin/spin.0.5.0/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/tmattio/spin"
 doc: "https://tmattio.github.io/spin"
 bug-reports: "https://github.com/tmattio/spin/issues"
 depends: [
-  "ocaml" {>= "4.06.0" & < "4.10.0"}
+  "ocaml" {>= "4.06.0"}
   "dune" {>= "2.0"}
   "odoc" {with-doc}
   "reason" {build}

--- a/packages/spin/spin.0.5.0/opam
+++ b/packages/spin/spin.0.5.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis:
+  "Project scaffolding tool and set of templates for Reason and OCaml"
+description: """
+Project scaffolding tool and set of templates for Reason and OCaml
+"""
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/tmattio/spin"
+doc: "https://tmattio.github.io/spin"
+bug-reports: "https://github.com/tmattio/spin/issues"
+depends: [
+  "ocaml" {>= "4.06.0" & < "4.10.0"}
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+  "dune-release" {dev}
+  "merlin" {dev}
+  "ocamlformat" {dev}
+  "utop" {dev}
+  "reason" {build}
+  "base"
+  "stdio"
+  "cmdliner"
+  "fileutils"
+  "jingoo"
+  "lwt"
+  "ppx_sexp_conv"
+  "sexplib"
+]
+dev-repo: "git+https://github.com/tmattio/spin.git"
+# We need to avoid "@runtest", since it depends on rely
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/tmattio/spin/releases/download/0.5.0/spin-0.5.0.tbz"
+  checksum: [
+    "sha256=99368bedae2b37dc243027c49b8465ea4891864cf01a193d6b99751458428443"
+    "sha512=55de0b9d973ac6de9586950b314ef2d396c52e8cc61427b48c9b65a25770305053a2c274497649e37cb1b8584f9b3a2d2b9b03427437344ca250649ab51dc3c6"
+  ]
+}


### PR DESCRIPTION
Project scaffolding tool and set of templates for Reason and OCaml

- Project page: <a href="https://github.com/tmattio/spin">https://github.com/tmattio/spin</a>
- Documentation: <a href="https://tmattio.github.io/spin">https://tmattio.github.io/spin</a>

##### CHANGES:

## Added

- Before generating a template, Spin will check if the user has all the dependencies installed and exit gracefully if not. (by [@citizen428](https://github.com/citizen428))
- Add a `condition` field in the `postinstall` stanza for the templates.

## Changed

- Print a warning when the update of the official templates failed, but continue the execution.
- Do not update the official templates when running new with a local path or a git repository.
- Remove some runtime dependencies to reduce Spin's binary size.

## Fixed

- Trying to generate a file that already exists now raises an error instead of overwritting the file.
- Fix to output a proper message when no generator exist for the current project.
- Exit gracefully when failing to download a git repository or the initial templates for the first time. (by [@citizen428](https://github.com/citizen428))
