### PR TITLE
Lwt 5.2.0, Lwt_ppx 2.0.1

### DIFF
--- a/packages/lwt/lwt.5.2.0/opam
+++ b/packages/lwt/lwt.5.2.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+
+version: "5.2.0"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.7.0"}
+  "dune-configurator"
+  "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0"}
+  "ocplib-endian"
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  "bisect_ppx" {dev & >= "1.3.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+build: [
+  ["dune" "exec" "src/unix/config/discover.exe" "--root" "." "--" "--save"
+    "--use-libev" "%{conf-libev:installed}%"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.2.0.tar.gz"
+  checksum: "md5=d5783fcff4fbfa7f79c9303776e4d144"
+}

--- a/packages/lwt_ppx/lwt_ppx.2.0.1/opam
+++ b/packages/lwt_ppx/lwt_ppx.2.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "PPX syntax for Lwt, providing something similar to async/await from JavaScript"
+
+version: "2.0.1"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/dev/api/Ppx_lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Gabriel Radanne"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune" {>= "1.1.0"}
+  "lwt"
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ppx_tools_versioned" {>= "5.3.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.2.0.tar.gz"
+  checksum: "md5=d5783fcff4fbfa7f79c9303776e4d144"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/ocsigen/lwt/releases/tag/5.2.0):

> - Add [`Lwt_unix.pread`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALpread), [`Lwt_unix.pwrite`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALpwrite), and [`Lwt_unix.pwrite_string`](http://ocsigen.org/lwt/dev/api/Lwt_unix#VALpwrite_string) (ocsigen/lwt#768, Pierre Chambart).
> - Internally use `accept4(2)` when available (ocsigen/lwt#769, Pierre Chambart).
> - PPX: internally use 4.10 ASTs (ocsigen/lwt#765).