### PR TITLE
[new release] optint (0.0.4)

### DIFF
--- a/packages/optint/optint.0.0.4/opam
+++ b/packages/optint/optint.0.0.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   [ "romain.calascibetta@gmail.com" ]
+authors:      "Romain Calascibetta"
+license:      "ISC"
+homepage:     "https://github.com/mirage/optint"
+bug-reports:  "https://github.com/mirage/optint/issues"
+dev-repo:     "git+https://github.com/mirage/optint.git"
+doc:          "https://mirage.github.io/optint/"
+synopsis:     "Abstract type on integer between x64 and x86 architecture"
+description: """
+This library provide an abstract type which represents at least a 32-bits integer.
+On x64, this library use a native unboxed integer (63 bits).
+On x86, this library use a boxed int32.
+
+Implementation depends on target architecture.
+"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "crowbar" {with-test}
+  "fmt" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/optint/releases/download/v0.0.4/optint-v0.0.4.tbz"
+  checksum: [
+    "sha256=2ae8d1e9fa30838c3c620af6a9e94b50b43a48a72ce06e318a71bb8afb52efa8"
+    "sha512=6127f5d216a66a376b75a309627e2c52c08d655c4a88a2d1df2b622d98abfe011fb10175f5f99737e950c8095596ef8fd680fe2338f53383e2263edb2d3a5c49"
+  ]
+}


### PR DESCRIPTION
Abstract type on integer between x64 and x86 architecture

- Project page: <a href="https://github.com/mirage/optint">https://github.com/mirage/optint</a>
- Documentation: <a href="https://mirage.github.io/optint/">https://mirage.github.io/optint/</a>

##### CHANGES:

- Fix 32bit backend where we miss to fully apply
  an `invalid_arg`
- Fix 64bit backend where `Native.unsigned_compare`
  and `Nativeint.unsigned_div` exists (OCaml 4.08.0)
