### PR TITLE
Package uunf.13.0.0

### DIFF
--- a/packages/uunf/uunf.13.0.0/opam
+++ b/packages/uunf/uunf.13.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The uunf programmers"]
+homepage: "https://erratique.ch/software/uunf"
+doc: "https://erratique.ch/software/uunf/doc/Uunf"
+dev-repo: "git+http://erratique.ch/repos/uunf.git"
+bug-reports: "https://github.com/dbuenzli/uunf/issues"
+tags: [ "unicode" "text" "normalization" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+]
+depopts: [ "uutf" "cmdliner" ]
+conflicts: [ "uutf" {< "1.0.0"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+  "--pinned" "%{pinned}%"
+  "--with-uutf" "%{uutf:installed}%"
+  "--with-cmdliner" "%{cmdliner:installed}%" ]]
+synopsis: """Unicode text normalization for OCaml"""
+description: """\
+
+Uunf is an OCaml library for normalizing Unicode text. It supports all
+Unicode [normalization forms][nf]. The library is independent from any
+IO mechanism or Unicode text data structure and it can process text
+without a complete in-memory representation.
+
+Uunf has no dependency. It may optionally depend on [Uutf][uutf] for
+support on OCaml UTF-X encoded strings. It is distributed under the
+ISC license.
+
+[nf]: http://www.unicode.org/reports/tr15/
+[uutf]: http://erratique.ch/software/uutf
+"""
+url {
+archive: "https://erratique.ch/software/uunf/releases/uunf-13.0.0.tbz"
+checksum: "d90f2ffe12ca17e6804d2e3f1f59fdd9"
+}


### PR DESCRIPTION
### `uunf.13.0.0`
Unicode text normalization for OCaml
Uunf is an OCaml library for normalizing Unicode text. It supports all
Unicode [normalization forms][nf]. The library is independent from any
IO mechanism or Unicode text data structure and it can process text
without a complete in-memory representation.

Uunf has no dependency. It may optionally depend on [Uutf][uutf] for
support on OCaml UTF-X encoded strings. It is distributed under the
ISC license.

[nf]: http://www.unicode.org/reports/tr15/
[uutf]: http://erratique.ch/software/uutf



---
* Homepage: https://erratique.ch/software/uunf
* Source repo: git+http://erratique.ch/repos/uunf.git
* Bug tracker: https://github.com/dbuenzli/uunf/issues

---
v13.0.0 2020-03-11 La Forclaz (VS)
---------------------------------

- Unicode 13.0.0 support.
- Require OCaml >= 4.03.0.

---
:camel: Pull-request generated by opam-publish v2.0.2