### PR TITLE
Package uuseg.13.0.0

### DIFF
--- a/packages/uuseg/uuseg.13.0.0/opam
+++ b/packages/uuseg/uuseg.13.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The uuseg programmers"]
+homepage: "https://erratique.ch/software/uuseg"
+doc: "https://erratique.ch/software/uuseg"
+dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+tags: [ "segmentation" "text" "unicode" "org:erratique" ]
+license: "ISC"
+depends: [ "ocaml" {>= "4.03.0"}
+           "ocamlfind" {build}
+           "ocamlbuild" {build}
+           "topkg" {build}
+           "uucp" {>= "13.0.0" & < "14.0.0"} ]
+depopts: [ "uutf"
+           "cmdliner"
+           "uutf" {with-test}
+           "cmdliner" {with-test} ]
+conflicts: [ "uutf" {< "1.0.0"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+  "--pinned" "%{pinned}%"
+  "--with-uutf" "%{uutf:installed}%"
+  "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """Unicode text segmentation for OCaml"""
+description: """\
+
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the
+[Unicode line breaking algorithm][2] to detect line break
+opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
+optionally on [Uutf](http://erratique.ch/software/uutf) for support on
+OCaml UTF-X encoded strings. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+"""
+url {
+archive: "https://erratique.ch/software/uuseg/releases/uuseg-13.0.0.tbz"
+checksum: "a07a97fff61da604614ea8da0547ef6a"
+}


### PR DESCRIPTION
### `uuseg.13.0.0`
Unicode text segmentation for OCaml
Uuseg is an OCaml library for segmenting Unicode text. It implements
the locale independent [Unicode text segmentation algorithms][1] to
detect grapheme cluster, word and sentence boundaries and the
[Unicode line breaking algorithm][2] to detect line break
opportunities.

The library is independent from any IO mechanism or Unicode text data
structure and it can process text without a complete in-memory
representation.

Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
optionally on [Uutf](http://erratique.ch/software/uutf) for support on
OCaml UTF-X encoded strings. It is distributed under the ISC license.

[1]: http://www.unicode.org/reports/tr29/
[2]: http://www.unicode.org/reports/tr14/



---
* Homepage: https://erratique.ch/software/uuseg
* Source repo: git+https://erratique.ch/repos/uuseg.git
* Bug tracker: https://github.com/dbuenzli/uuseg/issues

---
v13.0.0 2019-03-11 La Forclaz (VS)
----------------------------------

- Unicode 13.0.0 support.
- Grapheme clusters and word boundaries w.r.t. emojis are segmented
  according to the specification (#5 is closed).
- Internal rewrite of word and line break boundaries. Implementations
  are less hairy, less ad-hoc (not there yet though) and more correct.
- Require OCaml >= 4.03.0.

---
:camel: Pull-request generated by opam-publish v2.0.2