### PR TITLE
[new release] eqaf (0.6)

### DIFF
--- a/packages/eqaf/eqaf.0.6/opam
+++ b/packages/eqaf/eqaf.0.6/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name:         "eqaf"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/eqaf"
+bug-reports:  "https://github.com/mirage/eqaf/issues"
+dev-repo:     "git+https://github.com/mirage/eqaf.git"
+doc:          "https://mirage.github.io/eqaf/"
+license:      "MIT"
+synopsis:     "Constant-time equal function on string"
+description: """
+This package provides an equal function on string in constant-time to avoid timing-attack with crypto stuff.
+"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" "1" "--no-buffer" "--verbose" ] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"
+  "alcotest"       {with-test}
+  "crowbar"        {with-test}
+]
+
+depopts: [
+  "cstruct" {>= "4.0.0"}
+  "bigarray-compat"
+]
+url {
+  src: "https://github.com/mirage/eqaf/releases/download/v0.6/eqaf-v0.6.tbz"
+  checksum: [
+    "sha256=09ebddd1789828354eb84253b679c6ca1be9a44e0b7fac2ebef52015c3101919"
+    "sha512=8c3dd3dbd53eb7ebd4b42e67b9798c407408a93e20b40d92a590b87674b095f70cef5b273cd0d8c7371dc946f0fbf47043b62eb51186648912bc499a162c6417"
+  ]
+}

--- a/packages/eqaf/eqaf.0.6/opam
+++ b/packages/eqaf/eqaf.0.6/opam
@@ -26,9 +26,14 @@ depends: [
 ]
 
 depopts: [
-  "cstruct" {>= "4.0.0"}
+  "cstruct"
   "bigarray-compat"
 ]
+
+conflicts: [
+  "cstruct" {< "4.0.0"}
+]
+
 url {
   src: "https://github.com/mirage/eqaf/releases/download/v0.6/eqaf-v0.6.tbz"
   checksum: [


### PR DESCRIPTION
Constant-time equal function on string

- Project page: <a href="https://github.com/mirage/eqaf">https://github.com/mirage/eqaf</a>
- Documentation: <a href="https://mirage.github.io/eqaf/">https://mirage.github.io/eqaf/</a>

##### CHANGES:

- remove build dependency on dune (@CraigFe, mirage/eqaf#16)
- add bigarray-compat and optional dependencies (@hannesm, mirage/eqaf#17)
- add `select_int`, `one_if_not_zero`, `zero_if_not_zero` (@cfcs, @dinosaure, mirage/eqaf#19, mirage/eqaf#18)
