### PR TITLE
Package b0.0.0.1

### DIFF
--- a/packages/b0/b0.0.0.1/opam
+++ b/packages/b0/b0.0.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The b0 programmers"]
+homepage: "https://erratique.ch/software/b0"
+doc: "https://erratique.ch/software/b0/doc"
+license: ["ISC" "BSD2"]
+dev-repo: "git+https://erratique.ch/repos/b0.git#b00"
+bug-reports: "https://github.com/b0-system/b0/issues"
+tags: ["dev" "org:erratique" "org:b0-system" "build" ]
+depends:
+[
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "cmdliner" {build &>= "1.0.2"}
+]
+build:
+[[
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"
+]]
+
+synopsis: """Software construction and deployment kit"""
+description: """\
+
+WARNING this package is unstable and work in progress, do not depend on it. 
+
+B0 describes software construction and deployments using modular and
+customizable definitions written in OCaml.
+
+B0 describes:
+
+* Build environments.
+* Software configuration, build and testing.
+* Source or built artefacts deployments.
+* Development life-cycle procedures and actions.
+
+B0 also provides the B00 build library which provides abitrary build
+abstraction with reliable and efficient incremental rebuilds. The B00
+library can be – and has been – used on its own to devise domain
+specific build systems.
+
+B0 is distributed under the ISC license. It depends on [cmdliner][cmdliner].
+
+[cmdliner]: https://erratique.ch/software/cmdliner"""
+url {
+archive: "https://erratique.ch/software/b0/releases/b0-0.0.1.tbz"
+checksum: "51ee1d66acc4d7f87bdceac1341b7711"
+}


### PR DESCRIPTION
### `b0.0.0.1`
Software construction and deployment kit
WARNING this package is unstable and work in progress, do not depend on it. 

B0 describes software construction and deployments using modular and
customizable definitions written in OCaml.

B0 describes:

* Build environments.
* Software configuration, build and testing.
* Source or built artefacts deployments.
* Development life-cycle procedures and actions.

B0 also provides the B00 build library which provides abitrary build
abstraction with reliable and efficient incremental rebuilds. The B00
library can be – and has been – used on its own to devise domain
specific build systems.

B0 is distributed under the ISC license. It depends on [cmdliner][cmdliner].

[cmdliner]: https://erratique.ch/software/cmdliner



---
* Homepage: https://erratique.ch/software/b0
* Source repo: git+https://erratique.ch/repos/b0.git#b00
* Bug tracker: https://github.com/b0-system/b0/issues

---
v0.0.1 2020-03-11 La Forclaz (VS)
--------------------------------

Second release to support `odig`.

---
:camel: Pull-request generated by opam-publish v2.0.2