### PR TITLE
[new release] hkdf (1.0.4)

### DIFF
--- a/packages/hkdf/hkdf.1.0.4/opam
+++ b/packages/hkdf/hkdf.1.0.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "hkdf"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD2"
+homepage: "https://github.com/hannesm/ocaml-hkdf"
+doc: "https://hannesm.github.io/ocaml-hkdf/doc"
+bug-reports: "https://github.com/hannesm/ocaml-hkdf/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "cstruct" {>= "3.2.0"}
+  "mirage-crypto"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/ocaml-hkdf.git"
+synopsis: "HMAC-based Extract-and-Expand Key Derivation Function (RFC 5869)"
+description: """
+An implementation of [HKDF](https://tools.ietf.org/html/rfc5869) using
+[nocrypto](https://github.com/mirleft/ocaml-nocrypto).
+"""
+url {
+  src:
+    "https://github.com/hannesm/ocaml-hkdf/releases/download/v1.0.4/hkdf-v1.0.4.tbz"
+  checksum: [
+    "sha256=b926d6da4ac45aab999735dd2bbfd1f7511316710d791afa361006b6fe36fd5b"
+    "sha512=d08e50857f7761572adc4d382975fde5808898c1d92d9e6e943a496cba8780ffabe1edf67844063b70d9727c0fe10b24391e001a3f65c978a5326ac82199cc88"
+  ]
+}


### PR DESCRIPTION
HMAC-based Extract-and-Expand Key Derivation Function (RFC 5869)

- Project page: <a href="https://github.com/hannesm/ocaml-hkdf">https://github.com/hannesm/ocaml-hkdf</a>
- Documentation: <a href="https://hannesm.github.io/ocaml-hkdf/doc">https://hannesm.github.io/ocaml-hkdf/doc</a>

##### CHANGES:

* use mirage-crypto instead of nocrypto
