### PR TITLE
[new release] decompress and rfc1951 (1.1.0)

### DIFF
--- a/packages/decompress/decompress.1.1.0/opam
+++ b/packages/decompress/decompress.1.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name:         "decompress"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"
+  "base-bytes"
+  "bigarray-compat"
+  "optint"      {>= "0.0.4"}
+  "checkseum"   {>= "0.2.0"}
+  "bigstringaf" {with-test}
+  "alcotest"    {with-test}
+  "hxd"         {with-test}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.1.0/decompress-v1.1.0.tbz"
+  checksum: [
+    "sha256=881b370fcde8d64764e2635ea3052ecb806f79bd2dc3f6d12984a3fed4943c75"
+    "sha512=a0f69bedb199932bf89698db2beb88fa8032e42d65c5689780a481aad2e57deec44636bde301d8ec45d4886a08f734dba39969e811801fb6f12a7374371e2f11"
+  ]
+}

--- a/packages/rfc1951/rfc1951.1.1.0/opam
+++ b/packages/rfc1951/rfc1951.1.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name:         "rfc1951"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "decompress" {= version}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.1.0/decompress-v1.1.0.tbz"
+  checksum: [
+    "sha256=881b370fcde8d64764e2635ea3052ecb806f79bd2dc3f6d12984a3fed4943c75"
+    "sha512=a0f69bedb199932bf89698db2beb88fa8032e42d65c5689780a481aad2e57deec44636bde301d8ec45d4886a08f734dba39969e811801fb6f12a7374371e2f11"
+  ]
+}


### PR DESCRIPTION
Implementation of Zlib and GZip in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- add GZip support (@dinosaure, @copy, @hcarty, mirage/decompress#79)
- **breaking changes**, `Higher` returns a `result` value instead to raise an exception (@dinosaure, @copy, mirage/decompress#80)
- protect Zlib decoder on multiple _no-op_ calls of `decode`
- test when we generate an empty zlib flow
- fix a bug on the DEFLATE layer when we must flush bits to avoid integer overflow
- really use the internal continuation of the Zlib state
- delete `fmt` depedency
- update fuzzer
- fix default level on `Zl.Higher`
