### PR TITLE
[new release] decompress and rfc1951 (1.1.0)

### DIFF
--- a/packages/decompress/decompress.1.1.0/opam
+++ b/packages/decompress/decompress.1.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name:         "decompress"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"
+  "base-bytes"
+  "bigarray-compat"
+  "optint"      {>= "0.0.4"}
+  "checkseum"   {>= "0.2.0"}
+  "bigstringaf" {with-test}
+  "alcotest"    {with-test}
+  "hxd"         {with-test}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.1.0/decompress-v1.1.0.tbz"
+  checksum: [
+    "sha256=a950f91c33af4d14b25c62dd3edf7067b4020b7f39c2664a2afa925f767be2b9"
+    "sha512=abb4994150ef724b4cbf0612e0215092818139a5eca33c2365b6fdac61e4e33323da490fd8ea1adf8348c136b11a6448b1500173352f7b61f7641d32c02f3874"
+  ]
+}

--- a/packages/rfc1951/rfc1951.1.1.0/opam
+++ b/packages/rfc1951/rfc1951.1.1.0/opam
@@ -18,6 +18,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"      {>= "4.07.0"}
+  "dune"
   "decompress" {= version}
 ]
 url {

--- a/packages/rfc1951/rfc1951.1.1.0/opam
+++ b/packages/rfc1951/rfc1951.1.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name:         "rfc1951"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "decompress" {= version}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.1.0/decompress-v1.1.0.tbz"
+  checksum: [
+    "sha256=a950f91c33af4d14b25c62dd3edf7067b4020b7f39c2664a2afa925f767be2b9"
+    "sha512=abb4994150ef724b4cbf0612e0215092818139a5eca33c2365b6fdac61e4e33323da490fd8ea1adf8348c136b11a6448b1500173352f7b61f7641d32c02f3874"
+  ]
+}


### PR DESCRIPTION
Implementation of Zlib and GZip in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- add GZip support (@dinosaure, @copy, @hcarty, mirage/decompress#79)
- **breaking changes**, `Higher` returns a `result` value instead to raise an exception (@dinosaure, @copy, mirage/decompress#80)
- protect Zlib decoder on multiple _no-op_ calls of `decode`
- test when we generate an empty zlib flow
- fix a bug on the DEFLATE layer when we must flush bits to avoid integer overflow
- really use the internal continuation of the Zlib state
- delete `fmt` depedency
- update fuzzer
- fix default level on `Zl.Higher`
