### PR TITLE
odig.0.0.5: fix b0 constraint.

### DIFF
--- a/packages/odig/odig.0.0.5/opam
+++ b/packages/odig/odig.0.0.5/opam
@@ -14,7 +14,7 @@ depends: [
   "topkg" {build & >= "0.9.1"}
   "cmdliner" {>= "1.0.0"}
   "odoc" {>= "1.5.0"}
-  "b0" {= "0.0.2"}
+  "b0" {= "0.0.1"}
 ]
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
 


### PR DESCRIPTION
It seems I put the wrong constraint on `b0`. Where is my friend @camelus ? 