### PR TITLE
[new release] tls-mirage and tls (0.11.0)

### DIFF
--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.2/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.2/opam
@@ -27,7 +27,8 @@ depopts: [
   "launchd"
 ]
 conflicts: [
-  "tls" {<"0.8.0" }
+  "tls" {< "0.8.0"}
+  "tls" {>= "0.11.0"}
 ]
 synopsis: "Network conduit library"
 description: """

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.3/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.0.3/opam
@@ -27,7 +27,8 @@ depopts: [
   "launchd"
 ]
 conflicts: [
-  "tls" {<"0.8.0" }
+  "tls" {< "0.8.0"}
+  "tls" {>= "0.11.0"}
 ]
 synopsis: "An OCaml network connection establishment library"
 description: """

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.1.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.1.0/opam
@@ -27,7 +27,8 @@ depopts: [
   "launchd"
 ]
 conflicts: [
-  "tls" {<"0.8.0" }
+  "tls" {< "0.8.0"}
+  "tls" {>= "0.11.0"}
 ]
 synopsis: "An OCaml network connection establishment library"
 description: """

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.2.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.2.0/opam
@@ -27,7 +27,8 @@ depopts: [
   "launchd"
 ]
 conflicts: [
-  "tls" {<"0.8.0" }
+  "tls" {< "0.8.0"}
+  "tls" {>= "0.11.0"}
 ]
 synopsis: "An OCaml network connection establishment library"
 description: """

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.3.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.3.0/opam
@@ -57,6 +57,7 @@ depends: [
 depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [
   "tls" {< "0.8.0"}
+  "tls" {>= "0.11.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.4.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.4.0/opam
@@ -20,6 +20,7 @@ depends: [
 depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [
   "tls" {< "0.8.0"}
+  "tls" {>= "0.11.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.1.5.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.1.5.0/opam
@@ -21,6 +21,7 @@ depends: [
 depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [
   "tls" {< "0.8.0"}
+  "tls" {>= "0.11.0"}
   "ssl" {< "0.5.9"}
 ]
 build: [

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.0/opam
@@ -21,6 +21,7 @@ depends: [
 depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [
   "tls" {< "0.8.0"}
+  "tls" {>= "0.11.0"}
   "ssl" {< "0.5.9"}
   "lwt_ssl" # due to a build bug fixed in conduit 2.0.1
 ]

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.1/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.1/opam
@@ -21,6 +21,7 @@ depends: [
 depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [
   "tls" {< "0.8.0"}
+  "tls" {>= "0.11.0"}
   "ssl" {< "0.5.9"}
 ]
 build: [

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.2/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.0.2/opam
@@ -21,6 +21,7 @@ depends: [
 depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [
   "tls" {< "0.8.0"}
+  "tls" {>= "0.11.0"}
   "ssl" {< "0.5.9"}
 ]
 build: [

--- a/packages/conduit-mirage/conduit-mirage.2.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "conduit-lwt"
   "vchan" {>= "3.0.0"}
   "xenstore"
-  "tls" {>= "0.8.0"}
+  "tls" {>= "0.8.0" & < "0.11.0"}
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
 

--- a/packages/conduit-mirage/conduit-mirage.2.0.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "conduit-lwt"
   "vchan" {>= "3.0.0"}
   "xenstore"
-  "tls" {>= "0.8.0"}
+  "tls" {>= "0.8.0" & < "0.11.0"}
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
 

--- a/packages/conduit-mirage/conduit-mirage.2.0.2/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "conduit-lwt"
   "vchan" {>= "5.0.0"}
   "xenstore"
-  "tls" {>= "0.8.0"}
+  "tls" {>= "0.8.0" & < "0.11.0"}
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
 

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.1.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.1.0/opam
@@ -19,6 +19,9 @@ depends: [
   "lwt"
 ]
 depopts: ["tls" "lwt_ssl"]
+conflicts: [
+  "tls" {>= "0.11.0"}
+]
 synopsis: "Lwt + UNIX support for h2"
 description: """
 h2 is an implementation of the HTTP/2 specification entirely in OCaml.

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.2.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.2.0/opam
@@ -19,6 +19,9 @@ depends: [
   "lwt"
 ]
 depopts: ["tls" "lwt_ssl"]
+conflicts: [
+  "tls" {>= "0.11.0"}
+]
 synopsis: "Lwt + UNIX support for h2"
 description: """
 h2 is an implementation of the HTTP/2 specification entirely in OCaml.

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.3.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.3.0/opam
@@ -18,6 +18,9 @@ depends: [
   "lwt"
 ]
 depopts: ["tls" "lwt_ssl"]
+conflicts: [
+  "tls" {>= "0.11.0"}
+]
 synopsis: "Lwt + UNIX support for h2"
 description: """
 h2 is an implementation of the HTTP/2 specification entirely in OCaml.

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.4.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.4.0/opam
@@ -17,6 +17,9 @@ depends: [
   "lwt"
 ]
 depopts: ["tls" "lwt_ssl"]
+conflicts: [
+  "tls" {>= "0.11.0"}
+]
 synopsis: "Lwt + UNIX support for h2"
 description: """
 h2 is an implementation of the HTTP/2 specification entirely in OCaml.

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.5.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.5.0/opam
@@ -17,6 +17,9 @@ depends: [
   "lwt"
 ]
 depopts: ["tls" "lwt_ssl"]
+conflicts: [
+  "tls" {>= "0.11.0"}
+]
 synopsis: "Lwt + UNIX support for h2"
 description: """
 h2 is an implementation of the HTTP/2 specification entirely in OCaml.

--- a/packages/irc-client/irc-client.0.4.0/opam
+++ b/packages/irc-client/irc-client.0.4.0/opam
@@ -41,6 +41,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {with-test & >= "5.0.0"}
+  "tls" {>= "0.11.0"}
 ]
 synopsis: "IRC client library"
 flags: light-uninstall

--- a/packages/irc-client/irc-client.0.5.0/opam
+++ b/packages/irc-client/irc-client.0.5.0/opam
@@ -41,6 +41,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {with-test & >= "5.0.0"}
+  "tls" {>= "0.11.0"}
 ]
 synopsis: "IRC client library"
 flags: light-uninstall

--- a/packages/irc-client/irc-client.0.5.1/opam
+++ b/packages/irc-client/irc-client.0.5.1/opam
@@ -41,6 +41,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {with-test & >= "5.0.0"}
+  "tls" {>= "0.11.0"}
 ]
 synopsis: "IRC client library"
 flags: light-uninstall

--- a/packages/irc-client/irc-client.0.5.2/opam
+++ b/packages/irc-client/irc-client.0.5.2/opam
@@ -41,6 +41,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {with-test & >= "5.0.0"}
+  "tls" {>= "0.11.0"}
 ]
 synopsis: "IRC client library"
 flags: light-uninstall

--- a/packages/irc-client/irc-client.0.5.4/opam
+++ b/packages/irc-client/irc-client.0.5.4/opam
@@ -41,6 +41,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {with-test & >= "5.0.0"}
+  "tls" {>= "0.11.0"}
 ]
 synopsis: "IRC client library"
 flags: light-uninstall

--- a/packages/tls-mirage/tls-mirage.0.11.0/opam
+++ b/packages/tls-mirage/tls-mirage.0.11.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+name:         "tls"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD2"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.0"}
+  "tls" {= version}
+  "x509" {>= "0.10.0"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+]
+
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"
+description: """
+Tls-mirage provides an effectful FLOW module to be used in the MirageOS
+ecosystem.
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.11.0/tls-v0.11.0.tbz"
+  checksum: [
+    "sha256=e0e3cda664bbb510afd1f40a3c499326c02e2955785558e2d857e5ab4da445c5"
+    "sha512=1cf424a19a103ac8e0dcbae3673ebc5f774a867500cb12485d06a10f8af28580800e0a61e21da62ce7f695d695a03cad06f954930ef3b86f85b22fdae0c977d0"
+  ]
+}

--- a/packages/tls/tls.0.11.0/opam
+++ b/packages/tls/tls.0.11.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+name:         "tls"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD2"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_cstruct" {>= "3.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "cstruct-sexp"
+  "sexplib"
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-rng"
+  "x509" {>= "0.10.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt"
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "ounit" {with-test & >= "2.2.0"}
+  "lwt" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+]
+
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.11.0/tls-v0.11.0.tbz"
+  checksum: [
+    "sha256=e0e3cda664bbb510afd1f40a3c499326c02e2955785558e2d857e5ab4da445c5"
+    "sha512=1cf424a19a103ac8e0dcbae3673ebc5f774a867500cb12485d06a10f8af28580800e0a61e21da62ce7f695d695a03cad06f954930ef3b86f85b22fdae0c977d0"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* use dune as build system (mirleft/ocaml-tls#407)
* BREAKING split into tls and tls-mirage opam packages (mirleft/ocaml-tls#407)
* BREAKING use mirage-crypto instead of nocrypto (mirleft/ocaml-tls#407)

I'm not sure about revdeps, and will let ocaml-ci figure out which ones need bounds :)