### PR TITLE
[new release] letsencrypt (0.2.1)

### DIFF
--- a/packages/letsencrypt/letsencrypt.0.2.1/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.2.0"}
+  "astring"
+  "rresult"
+  "base64" {>= "3.1.0"}
+  "cmdliner"
+  "cohttp"
+  "cohttp-lwt" {>= "2.5.1"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "zarith"
+  "logs"
+  "fmt"
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-rng"
+  "x509" {>= "0.10.0"}
+  "yojson" {>= "1.6.0"}
+  "ounit" {with-test}
+  "dns"
+  "dns-tsig"
+  "ptime"
+  "bos"
+  "fpath"
+  "randomconv"
+  "domain-name" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.2.1/letsencrypt-v0.2.1.tbz"
+  checksum: [
+    "sha256=1d143813663c019c03bb98221f766050f9c040660756648c1bb058cdd7a2cd16"
+    "sha512=687aff0da30c2e8e041545422c78ed0768c8f94a7a244d9fcde3f9bd770f3e704eb00a62a6f19cee5f511816d15934c24178cab2f22ec2cb27795d999631950e"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* use mirage-crypto instead of nocrypto mmaker/ocaml-letsencrypt#20
* reorder arguments for nsupdate to avoid a labelled one at the end mmaker/ocaml-letsencrypt#20