### PR TITLE
[new release] pecu (0.4)

### DIFF
--- a/packages/pecu/pecu.0.4/opam
+++ b/packages/pecu/pecu.0.4/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "pecu"
 maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
 authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
 homepage:     "https://github.com/mirage/pecu"

--- a/packages/pecu/pecu.0.4/opam
+++ b/packages/pecu/pecu.0.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name:         "pecu"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/pecu"
+bug-reports:  "https://github.com/mirage/pecu/issues"
+dev-repo:     "git+https://github.com/mirage/pecu.git"
+doc:          "https://mirage.github.io/pecu/"
+license:      "MIT"
+synopsis:     "Encoder/Decoder of Quoted-Printable (RFC2045 & RFC2047)"
+description:  """A non-blocking encoder/decoder of Quoted-Printable according to
+RFC2045 and RFC2047 (about encoded-word). Useful to translate contents of emails."""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "fmt" {with-test}
+  "alcotest" {with-test}
+]
+url {
+  src: "https://github.com/mirage/pecu/releases/download/v0.4/pecu-v0.4.tbz"
+  checksum: [
+    "sha256=77d3ce3b785257acce0b62d75db647707ad70b622f48f3c7b6109911d03cbc1e"
+    "sha512=0216d7bd533489dd800f48418931832b0d96d277a9424a6fe08ff87eb55cf78c0ad55c26459603a138715d1bcc90768e944cff24f5497d2e3390387aa93a1c14"
+  ]
+}


### PR DESCRIPTION
Encoder/Decoder of Quoted-Printable (RFC2045 & RFC2047)

- Project page: <a href="https://github.com/mirage/pecu">https://github.com/mirage/pecu</a>
- Documentation: <a href="https://mirage.github.io/pecu/">https://mirage.github.io/pecu/</a>

##### CHANGES:

* Clean the distribution
* Delete the useless binary
* Better documentation
