### PR TITLE
[new release] yuscii (0.3.0)

### DIFF
--- a/packages/yuscii/yuscii.0.3.0/opam
+++ b/packages/yuscii/yuscii.0.3.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "yuscii"
 maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
 authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
 homepage:     "https://github.com/mirage/yuscii"

--- a/packages/yuscii/yuscii.0.3.0/opam
+++ b/packages/yuscii/yuscii.0.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name:         "yuscii"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/yuscii"
+bug-reports:  "https://github.com/mirage/yuscii/issues"
+dev-repo:     "git+https://github.com/mirage/yuscii.git"
+doc:          "https://mirage.github.io/yuscii/"
+license:      "MIT"
+synopsis:     "Mapper of UTF-7 to Unicode"
+description: """A simple mapper between UTF-7 to Unicode according RFC2152.
+Useful for a translation between UTF-7 and Unicode"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "fmt" {with-test}
+  "uutf" {with-test}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/yuscii/releases/download/v0.3.0/yuscii-v0.3.0.tbz"
+  checksum: [
+    "sha256=ef8d87ed575d14547326887930f9d8c0a638d35c40889d5aacec79c45d5074b1"
+    "sha512=d9747ddc01ce0d35be6ec95ff09cf9a0cf67fa53449ce0d700e5c4e31b83e6cf5c8985b0f2e154087bae8ddcce6cb1d4f33819e538570e4308bbba7e21cd669f"
+  ]
+}


### PR DESCRIPTION
Mapper of UTF-7 to Unicode

- Project page: <a href="https://github.com/mirage/yuscii">https://github.com/mirage/yuscii</a>
- Documentation: <a href="https://mirage.github.io/yuscii/">https://mirage.github.io/yuscii/</a>

##### CHANGES:

* Clean the distribution
* Delete the provided binary
