### PR TITLE
[new release] mirage-qubes-ipv4 and mirage-qubes (0.8.1)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.1/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "4.0.0" }
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-protocols" { >= "4.0.0" }
+  "cstruct" { >= "1.9.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.8.1/mirage-qubes-v0.8.1.tbz"
+  checksum: [
+    "sha256=1d301f06cfc063f92a89eab3ff6f74d937f89f539fb64927caf6bd32175acf14"
+    "sha512=a7043af8750230a379eace31df868231a7dab24bf51361c0489ddb804e092dc2d291438cc6db845a45a3791beffcb264139b03eec2297103208e6ad8ddd9e9cf"
+  ]
+}

--- a/packages/mirage-qubes/mirage-qubes.0.8.1/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.8.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "2.2.0" }
+  "ppx_cstruct"
+  "vchan-xen" { >= "5.0.0" }
+  "xen-evtchn"
+  "xen-gnt"
+  "mirage-xen" { >= "5.0.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.8.1/mirage-qubes-v0.8.1.tbz"
+  checksum: [
+    "sha256=1d301f06cfc063f92a89eab3ff6f74d937f89f539fb64927caf6bd32175acf14"
+    "sha512=a7043af8750230a379eace31df868231a7dab24bf51361c0489ddb804e092dc2d291438cc6db845a45a3791beffcb264139b03eec2297103208e6ad8ddd9e9cf"
+  ]
+}


### PR DESCRIPTION
Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-qubes">https://github.com/mirage/mirage-qubes</a>
- Documentation: <a href="https://mirage.github.io/mirage-qubes">https://mirage.github.io/mirage-qubes</a>

##### CHANGES:

- fix compile error with cstruct 5.1 (mirage/mirage-qubes#48 @talex5, reported by @hannesm)
- now using dune, no need for `pkg/pkg.ml` anymore (mirage/mirage-qubes#50 @hannesm)
