### PR TITLE
tls-mirage: fix name in opam file

### DIFF
--- a/packages/tls-mirage/tls-mirage.0.11.0/opam
+++ b/packages/tls-mirage/tls-mirage.0.11.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "tls"
 homepage:     "https://github.com/mirleft/ocaml-tls"
 dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
 bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"


### PR DESCRIPTION
upstream at https://github.com/mirleft/ocaml-tls/pull/408