### PR TITLE
[new release] dns, dns-stub, dns-certify, dns-mirage, dns-resolver, dns-client, dns-server, dns-tsig and dns-cli (4.4.0)

### DIFF
--- a/packages/dns-certify/dns-certify.4.4.0/opam
+++ b/packages/dns-certify/dns-certify.4.4.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "0.10.0"}
+  "lwt" {>= "4.2.1"}
+  "tls" {>= "0.11.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "logs"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.4.0/dns-v4.4.0.tbz"
+  checksum: [
+    "sha256=1e4d71dc34c2e01f3881f1322c157485f2cb4b8da6c2450017b875810bf9707b"
+    "sha512=f2fc524822dc3f322f9bbb05dd35ada14950b91f37e025d66ad97abb510fa1ddac6c1f8683daaa5b95737ce2abcf24020ffca4650822e79c81683b01d534b825"
+  ]
+}

--- a/packages/dns-cli/dns-cli.4.4.0/opam
+++ b/packages/dns-cli/dns-cli.4.4.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-client" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "rresult" {>= "0.6.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "0.10.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng"
+  "hex" {>= "1.4.0"}
+  "ptime" {>= "0.8.5"}
+  "mtime" {>= "1.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.4.0/dns-v4.4.0.tbz"
+  checksum: [
+    "sha256=1e4d71dc34c2e01f3881f1322c157485f2cb4b8da6c2450017b875810bf9707b"
+    "sha512=f2fc524822dc3f322f9bbb05dd35ada14950b91f37e025d66ad97abb510fa1ddac6c1f8683daaa5b95737ce2abcf24020ffca4650822e79c81683b01d534b825"
+  ]
+}

--- a/packages/dns-client/dns-client.4.4.0/opam
+++ b/packages/dns-client/dns-client.4.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD2"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {>="1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt" {>= "0.8.8"}
+  "logs" {>= "0.6.3"}
+  "dns" {= version}
+  "rresult" {>= "0.6.0"}
+  "randomconv" {>= "0.1.2"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mtime" {>= "1.2.0"}
+]
+synopsis: "Pure DNS resolver API"
+description: """
+A pure resolver implementation using uDNS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.4.0/dns-v4.4.0.tbz"
+  checksum: [
+    "sha256=1e4d71dc34c2e01f3881f1322c157485f2cb4b8da6c2450017b875810bf9707b"
+    "sha512=f2fc524822dc3f322f9bbb05dd35ada14950b91f37e025d66ad97abb510fa1ddac6c1f8683daaa5b95737ce2abcf24020ffca4650822e79c81683b01d534b825"
+  ]
+}

--- a/packages/dns-mirage/dns-mirage.4.4.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack" {>= "2.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  In a similar vein, wildcard records are _not_ supported, and it is
+unlikely they'll ever be in this library.  Truncated hmac in `TSIG` are not
+supported (always the full length of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.4.0/dns-v4.4.0.tbz"
+  checksum: [
+    "sha256=1e4d71dc34c2e01f3881f1322c157485f2cb4b8da6c2450017b875810bf9707b"
+    "sha512=f2fc524822dc3f322f9bbb05dd35ada14950b91f37e025d66ad97abb510fa1ddac6c1f8683daaa5b95737ce2abcf24020ffca4650822e79c81683b01d534b825"
+  ]
+}

--- a/packages/dns-resolver/dns-resolver.4.4.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.4.0/dns-v4.4.0.tbz"
+  checksum: [
+    "sha256=1e4d71dc34c2e01f3881f1322c157485f2cb4b8da6c2450017b875810bf9707b"
+    "sha512=f2fc524822dc3f322f9bbb05dd35ada14950b91f37e025d66ad97abb510fa1ddac6c1f8683daaa5b95737ce2abcf24020ffca4650822e79c81683b01d534b825"
+  ]
+}

--- a/packages/dns-server/dns-server.4.4.0/opam
+++ b/packages/dns-server/dns-server.4.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-crypto-rng" {with-test}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.4.0/dns-v4.4.0.tbz"
+  checksum: [
+    "sha256=1e4d71dc34c2e01f3881f1322c157485f2cb4b8da6c2450017b875810bf9707b"
+    "sha512=f2fc524822dc3f322f9bbb05dd35ada14950b91f37e025d66ad97abb510fa1ddac6c1f8683daaa5b95737ce2abcf24020ffca4650822e79c81683b01d534b825"
+  ]
+}

--- a/packages/dns-stub/dns-stub.4.4.0/opam
+++ b/packages/dns-stub/dns-stub.4.4.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-client" {= version}
+  "dns-mirage" {= version}
+  "dns-resolver" {= version}
+  "dns-tsig" {= version}
+  "dns-server" {= version}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS stub resolver"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.4.0/dns-v4.4.0.tbz"
+  checksum: [
+    "sha256=1e4d71dc34c2e01f3881f1322c157485f2cb4b8da6c2450017b875810bf9707b"
+    "sha512=f2fc524822dc3f322f9bbb05dd35ada14950b91f37e025d66ad97abb510fa1ddac6c1f8683daaa5b95737ce2abcf24020ffca4650822e79c81683b01d534b825"
+  ]
+}

--- a/packages/dns-tsig/dns-tsig.4.4.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.4.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "mirage-crypto"
+  "base64" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.4.0/dns-v4.4.0.tbz"
+  checksum: [
+    "sha256=1e4d71dc34c2e01f3881f1322c157485f2cb4b8da6c2450017b875810bf9707b"
+    "sha512=f2fc524822dc3f322f9bbb05dd35ada14950b91f37e025d66ad97abb510fa1ddac6c1f8683daaa5b95737ce2abcf24020ffca4650822e79c81683b01d534b825"
+  ]
+}

--- a/packages/dns/dns.4.4.0/opam
+++ b/packages/dns/dns.4.4.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "rresult" "astring" "fmt" "logs" "ptime"
+  "domain-name" {>= "0.3.0"}
+  "gmap" {>= "0.3.0"}
+  "cstruct" {>= "3.2.0"}
+  "ipaddr" {>= "3.0.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "metrics"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  In a similar vein, wildcard records are _not_ supported, and it is
+unlikely they'll ever be in this library.  Truncated hmac in `TSIG` are not
+supported (always the full length of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.4.0/dns-v4.4.0.tbz"
+  checksum: [
+    "sha256=1e4d71dc34c2e01f3881f1322c157485f2cb4b8da6c2450017b875810bf9707b"
+    "sha512=f2fc524822dc3f322f9bbb05dd35ada14950b91f37e025d66ad97abb510fa1ddac6c1f8683daaa5b95737ce2abcf24020ffca4650822e79c81683b01d534b825"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* dns-stub, a new opam package, is a stub resolver mirage/ocaml-dns#209 @hannesm, review by
  @cfcs
* embed IP address of recursive resolver only once mirage/ocaml-dns#214 @hannesm, fixes mirage/ocaml-dns#210,
  review by @cfcs
* Dns_trie.lookup returns NotAuthoritative if no SOA is present mirage/ocaml-dns#217 @hannesm,
  review by @cfcs
* Secondary server is looked up in trie properly (may be in another zone, which
  primary is not authoritative for the other zone) mirage/ocaml-dns#217 @hannesm, review by
  @cfcs
* new function Dns.Dnskey.pp_name_key mirage/ocaml-dns#218 @hannesm, review by @cfcs
* dns-certify uses new ACME protocol (where the intermediate certificate is
  part of the issuance process) mirage/ocaml-dns#219 @hannesm, review by @cfcs
* dns-certify/dns-tsig/dns-cli: use mirage-crypto mirage/ocaml-dns#219 @hannesm, review by @cfcs