### PR TITLE
[new release] emile (0.8)

### DIFF
--- a/packages/emile/emile.0.8/opam
+++ b/packages/emile/emile.0.8/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/emile"
+bug-reports:  "https://github.com/dinosaure/emile/issues"
+dev-repo:     "git+https://github.com/dinosaure/emile.git"
+doc:          "https://dinosaure.github.io/emile/"
+license:      "MIT"
+synopsis:     "Parser of email address according RFC822"
+description: """A parser of email address according RFC822, RFC2822, RFC5321 and RFC6532.
+It handles UTF-8 email addresses and encoded-word according RFC2047."""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {>= "1.0"}
+  "angstrom" {>= "0.9.0"}
+  "ipaddr"   {>= "2.7.0"}
+  "base64"   {>= "3.0.0"}
+  "pecu"
+  "uutf"
+  "alcotest" {with-test}
+]
+depopts: [ "cmdliner" ]
+url {
+  src:
+    "https://github.com/dinosaure/emile/releases/download/v0.8/emile-v0.8.tbz"
+  checksum: [
+    "sha256=607ce669b838d351c64295f17cba64ddd9c4e756b3a3a8facf4ff6d067d7307f"
+    "sha512=2c6b35dcd98bd8c040360a05317131c66277cbd41e1cd1af17c6dd806fe72b8e66f3f4cbbee3a1262b6d5308d9016783d01751cc81f764611a47b9f5a01d433c"
+  ]
+}


### PR DESCRIPTION
Parser of email address according RFC822

- Project page: <a href="https://github.com/dinosaure/emile">https://github.com/dinosaure/emile</a>
- Documentation: <a href="https://dinosaure.github.io/emile/">https://dinosaure.github.io/emile/</a>

##### CHANGES:

- `dune` is no longer a _build_ dependency
- fix pretty-printers
- fix comparison functions
- add tests about comparison functions
- delete useless internal functions
- clean the distribution (and delete `fmt` dependency)
