### PR TITLE
[new release] rosetta (0.3.0)

### DIFF
--- a/packages/rosetta/rosetta.0.3.0/opam
+++ b/packages/rosetta/rosetta.0.3.0/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "1.4"}
   "coin" {>= "0.1.2"}
   "uuuu" {>= "0.2.0"}
   "yuscii" {>= "0.3.0"}

--- a/packages/rosetta/rosetta.0.3.0/opam
+++ b/packages/rosetta/rosetta.0.3.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/rosetta"
+bug-reports:  "https://github.com/mirage/rosetta/issues"
+dev-repo:     "git+https://github.com/mirage/rosetta.git"
+doc:          "https://mirage.github.io/rosetta/"
+license:      "MIT"
+synopsis:     "Universal mapper to Unicode"
+description:  "Universal mapper to Unicode (ISO-8859, KOI8, UTF-7)"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "coin" {>= "0.1.2"}
+  "uuuu" {>= "0.2.0"}
+  "yuscii" {>= "0.3.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/rosetta/releases/download/v0.3.0/rosetta-v0.3.0.tbz"
+  checksum: [
+    "sha256=dffb638f78af6b03f23b285137538bb2575f67ecddbecab3ee7248b4de284564"
+    "sha512=c48851ccc623a24b7c2c6e6db959382933a5b4caa8e19abf07b2fdb787d9e3736edd572f8b5a479fdec943c1df3e96ec6a163e28c98fdfb144d15a181e76a15a"
+  ]
+}


### PR DESCRIPTION
Universal mapper to Unicode

- Project page: <a href="https://github.com/mirage/rosetta">https://github.com/mirage/rosetta</a>
- Documentation: <a href="https://mirage.github.io/rosetta/">https://mirage.github.io/rosetta/</a>

##### CHANGES:

* Clean the distribution to have fewer dependencies
* `dune` is not a build dependency anymore
* Update OPAM file with lastest versions of `yuscii`, `coin` and `uuuu`
