### PR TITLE
Luv 0.5.1 — libuv binding

### DIFF
--- a/packages/luv/luv.0.5.1/opam
+++ b/packages/luv/luv.0.5.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+
+synopsis: "Binding to libuv: cross-platform asynchronous I/O"
+
+version: "0.5.1"
+license: "MIT"
+homepage: "https://github.com/aantron/luv"
+doc: "https://aantron.github.io/luv"
+bug-reports: "https://github.com/aantron/luv/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/luv.git"
+
+depends: [
+  "base-unix" {build}
+  "ctypes" {>= "0.13.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.02.0"}
+  "result"
+
+  "alcotest" {with-test & >= "0.8.1"}
+  "base-unix" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Luv is a binding to libuv, the cross-platform C library that does
+asynchronous I/O in Node.js and runs its main loop.
+
+Besides asynchronous I/O, libuv also supports multiprocessing and
+multithreading. Multiple event loops can be run in different threads. libuv also
+exposes a lot of other functionality, amounting to a full OS API, and an
+alternative to the standard module Unix."
+
+url {
+  src: "https://github.com/aantron/luv/releases/download/0.5.1/luv-0.5.1.tar.gz"
+  checksum: "md5=1b1665a64412af2a65587a6aa4a42d4a"
+}


### PR DESCRIPTION
[Changelog](https://github.com/aantron/luv/releases/tag/0.5.1):

- Switch from GYP to autotools for building libuv; this drops the dependency on Python and enables cross-compilation (aantron/luv#45).
- Build libuv on Windows (aantron/luv#47, prompted Bryan Phelps).
- Upgrade libuv to [1.35.0](https://github.com/libuv/libuv/releases/tag/v1.35.0) (aantron/luv#53).
