### PR TITLE
4 packages from zshipko/ocaml-bimage at 0.1.2

### DIFF
--- a/packages/bimage-gtk/bimage-gtk.0.1.2/opam
+++ b/packages/bimage-gtk/bimage-gtk.0.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing" "gtk"]
+
+depends:
+[
+    "ocaml" {>= "4.03.0"}
+    "dune" {>= "1.1"}
+    "bimage" {>= "0.1"}
+    "lablgtk3" {>= "3.0.beta6"}
+    "cairo2" {>= "0.6"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+
+synopsis: """
+Bimage_gtk allows images to be displayed in GTK windows
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src: "https://github.com/zshipko/ocaml-bimage/archive/v0.1.2.tar.gz"
+  checksum: [
+    "md5=6ccee1b75d2adf84330e886e7ac2c04b"
+    "sha512=1cca1e5110f729b5d443dee84198bad10eb834e5feb67558ddbd7be281fb8622d5fd05c0f81f53115e268eafb9d3f64178048c4c85c0ff0038f2b2412338ae7a"
+  ]
+}

--- a/packages/bimage-sdl/bimage-sdl.0.1.2/opam
+++ b/packages/bimage-sdl/bimage-sdl.0.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing" "sdl"]
+
+depends:
+[
+    "ocaml" {>= "4.03.0"}
+    "dune" {>= "1.1"}
+    "bimage" {>= "0.1"}
+    "tsdl" {>= "0.9"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+
+synopsis: """
+Bimage_gtk allows images to be displayed using SDL
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src: "https://github.com/zshipko/ocaml-bimage/archive/v0.1.2.tar.gz"
+  checksum: [
+    "md5=6ccee1b75d2adf84330e886e7ac2c04b"
+    "sha512=1cca1e5110f729b5d443dee84198bad10eb834e5feb67558ddbd7be281fb8622d5fd05c0f81f53115e268eafb9d3f64178048c4c85c0ff0038f2b2412338ae7a"
+  ]
+}

--- a/packages/bimage-unix/bimage-unix.0.1.2/opam
+++ b/packages/bimage-unix/bimage-unix.0.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.06.0"}
+    "dune" {>= "1.1"}
+    "bimage" {>= "0.1"}
+    "ctypes" {>= "0.14"}
+    "ctypes-foreign" {>= "0.4"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/Ffmpeg/stb_image
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src: "https://github.com/zshipko/ocaml-bimage/archive/v0.1.2.tar.gz"
+  checksum: [
+    "md5=6ccee1b75d2adf84330e886e7ac2c04b"
+    "sha512=1cca1e5110f729b5d443dee84198bad10eb834e5feb67558ddbd7be281fb8622d5fd05c0f81f53115e268eafb9d3f64178048c4c85c0ff0038f2b2412338ae7a"
+  ]
+}

--- a/packages/bimage/bimage.0.1.2/opam
+++ b/packages/bimage/bimage.0.1.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.03.0"}
+    "dune" {>= "1.1"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src: "https://github.com/zshipko/ocaml-bimage/archive/v0.1.2.tar.gz"
+  checksum: [
+    "md5=6ccee1b75d2adf84330e886e7ac2c04b"
+    "sha512=1cca1e5110f729b5d443dee84198bad10eb834e5feb67558ddbd7be281fb8622d5fd05c0f81f53115e268eafb9d3f64178048c4c85c0ff0038f2b2412338ae7a"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`bimage.0.1.2`: A simple, efficient image-processing library
-`bimage-gtk.0.1.2`: Bimage_gtk allows images to be displayed in GTK windows
-`bimage-sdl.0.1.2`: Bimage_gtk allows images to be displayed using SDL
-`bimage-unix.0.1.2`: Bimage_unix provides methods for encoding/decoding
 images in many formats using ImageMagick/Ffmpeg/stb_image



---
* Homepage: https://github.com/zshipko/ocaml-bimage
* Source repo: git://github.com/zshipko/ocaml-bimage.git
* Bug tracker: https://github.com/zshipko/ocaml-bimage/issues

---
:camel: Pull-request generated by opam-publish v2.0.2