### PR TITLE
[new release] conduit-mirage, conduit-lwt, conduit, conduit-lwt-unix and conduit-async (2.1.0)

### DIFF
--- a/packages/conduit-async/conduit-async.2.1.0/opam
+++ b/packages/conduit-async/conduit-async.2.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "core"
+  "ppx_sexp_conv" {>="v0.9.0"}
+  "sexplib"
+  "conduit" {=version}
+  "async" {>= "v0.10.0"}
+  "ipaddr" {>= "3.0.0"}
+]
+depopts: ["async_ssl"]
+conflicts: [
+  "async_ssl" {< "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Async"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.1.0/conduit-v2.1.0.tbz"
+  checksum: [
+    "sha256=7b4dd1faca7ed4dc77c1b5d765fca9053209dcfcb2c379d666a19314d8f77e72"
+    "sha512=2f0baaa0b1d99874c12b2382ba2f95989a782c3b37ccc06fa69c61efb068100c0bf904f6e04d6ec64fd2346d696f0c97870f9f5a740ff278d51820af28ed0ac1"
+  ]
+}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.1.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.12.0"}
+  "conduit-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+depopts: ["tls" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls" {< "0.11.0"}
+  "ssl" {< "0.5.9"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.1.0/conduit-v2.1.0.tbz"
+  checksum: [
+    "sha256=7b4dd1faca7ed4dc77c1b5d765fca9053209dcfcb2c379d666a19314d8f77e72"
+    "sha512=2f0baaa0b1d99874c12b2382ba2f95989a782c3b37ccc06fa69c61efb068100c0bf904f6e04d6ec64fd2346d696f0c97870f9f5a740ff278d51820af28ed0ac1"
+  ]
+}

--- a/packages/conduit-lwt/conduit-lwt.2.1.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.2.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.12.0"}
+  "sexplib"
+  "conduit" {=version}
+  "lwt" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.1.0/conduit-v2.1.0.tbz"
+  checksum: [
+    "sha256=7b4dd1faca7ed4dc77c1b5d765fca9053209dcfcb2c379d666a19314d8f77e72"
+    "sha512=2f0baaa0b1d99874c12b2382ba2f95989a782c3b37ccc06fa69c61efb068100c0bf904f6e04d6ec64fd2346d696f0c97870f9f5a740ff278d51820af28ed0ac1"
+  ]
+}

--- a/packages/conduit-mirage/conduit-mirage.2.1.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.12.0"}
+  "sexplib"
+  "cstruct" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "dns-client" {>= "4.1.0"}
+  "conduit-lwt"
+  "vchan" {>= "5.0.0"}
+  "xenstore"
+  "tls" {>= "0.11.0"}
+  "tls-mirage" {>= "0.11.0"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+]
+conflicts: [
+  "mirage-conduit"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.1.0/conduit-v2.1.0.tbz"
+  checksum: [
+    "sha256=7b4dd1faca7ed4dc77c1b5d765fca9053209dcfcb2c379d666a19314d8f77e72"
+    "sha512=2f0baaa0b1d99874c12b2382ba2f95989a782c3b37ccc06fa69c61efb068100c0bf904f6e04d6ec64fd2346d696f0c97870f9f5a740ff278d51820af28ed0ac1"
+  ]
+}

--- a/packages/conduit/conduit.2.1.0/opam
+++ b/packages/conduit/conduit.2.1.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.12.0"}
+  "sexplib"
+  "astring"
+  "uri"
+  "logs" {>= "0.5.0"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for 
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.1.0/conduit-v2.1.0.tbz"
+  checksum: [
+    "sha256=7b4dd1faca7ed4dc77c1b5d765fca9053209dcfcb2c379d666a19314d8f77e72"
+    "sha512=2f0baaa0b1d99874c12b2382ba2f95989a782c3b37ccc06fa69c61efb068100c0bf904f6e04d6ec64fd2346d696f0c97870f9f5a740ff278d51820af28ed0ac1"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.6.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.6.0/opam
@@ -13,7 +13,7 @@ build: [ ["dune" "subst"] {pinned}
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {build}
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.7"}
   "dune-configurator" {>= "2.0.0"}

--- a/packages/mirage-crypto/mirage-crypto.0.6.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.6.0/opam
@@ -13,7 +13,7 @@ build: [ ["dune" "subst"] {pinned}
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config"
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.7"}
   "dune-configurator" {>= "2.0.0"}


### PR DESCRIPTION
CHANGES:

* port to tls.0.11.0 interfaces which also uses mirage-crypto (mirage/ocaml-conduit#309 @hannesm)
* do not use deprecated ppx sexplib declarations (mirage/ocaml-conduit#309 @avsm)
* replace Appveyor CI with GitHub Actions (mirage/ocaml-conduit#309 @avsm)