### PR TITLE
[new release] nacc (0.1)

### DIFF
--- a/packages/nacc/nacc.0.1/opam
+++ b/packages/nacc/nacc.0.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+version: "0.1"
+synopsis: "Not Another Compiler Compiler"
+description: """
+
+    nacc, short for "Not a Compiler Compiler" or alternatively "Not Another Compiler Compiler" is a homemade parser combinator, as inspired from Computerphile's video on Functional Parsing (https://www.youtube.com/watch?v=dDtZLm7HIJs).
+
+    nacc strives to be simple yet monadic, allowing any context-free grammar to be safely parsed with this library. The library provides utility functions and operators to ease the writing of combinator parsers."""
+maintainer: ["Nathan Graule <solarliner@gmail.com>"]
+authors: [
+  "Nathan Graule <solarliner@gmail.com>"
+  "Arthur Correnson <arthur.correnson@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/codeanonorg/nacc"
+doc: "https://codeanonorg.github.io/nacc"
+bug-reports: "https://github.com/codeanonorg/nacc/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "ppx_deriving" {>= "4.4"}
+  "ppx_variants_conv" {>= "0.13"}
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/codeanonorg/nacc.git"
+url {
+  src:
+    "https://github.com/codeanonorg/nacc/releases/download/0.1/nacc-0.1.tbz"
+  checksum: [
+    "sha256=f8e86623aa1014848633778e3c30f2d50719da1025d5ed81983b8d872d6e0633"
+    "sha512=c24ea7155181d4561ac1c1d898ea02097c84dfd2b3fdc14a8a41ad8393a7a64bccd885c04fb45dac6d0664565df086620b7aa5719bf30ff895156e1c7e576093"
+  ]
+}


### PR DESCRIPTION
Not Another Compiler Compiler

- Project page: <a href="https://github.com/codeanonorg/nacc">https://github.com/codeanonorg/nacc</a>
- Documentation: <a href="https://codeanonorg.github.io/nacc">https://codeanonorg.github.io/nacc</a>

##### CHANGES:

- Monadic core parsers and contrib general-usage parsers
- Calculator REPL example
