### PR TITLE
Package orpie.1.6.1

### DIFF
--- a/packages/orpie/orpie.1.6.1/opam
+++ b/packages/orpie/orpie.1.6.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Paul Pelzl <pelzlpj@gmail.com>"
+authors: "Paul Pelzl <pelzlpj@gmail.com>"
+homepage: "https://github.com/pelzlpj/orpie"
+bug-reports: "https://github.com/pelzlpj/orpie/issues"
+license: "GPL-3.0-only"
+dev-repo: "git+https://github.com/pelzlpj/orpie.git"
+build: ["dune" "build" "-p" "orpie"]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "camlp5" {build}
+  "dune" {>= "1.1"}
+  "curses" {>= "1.0.3"}
+  "gsl" {>= "1.22.0"}
+  "num"
+]
+synopsis: "Curses-based RPN calculator"
+description: """
+Orpie is a curses-based RPN calculator for the terminal.  It supports a
+large chunk of the features supported by classic HP RPN calculators, but
+the user interface is optimized for a keyboard."""
+url {
+  src: "https://github.com/pelzlpj/orpie/archive/release-1.6.1.tar.gz"
+  checksum: [
+    "md5=a5a1ef54c70bc58c1e91af2a8139bd19"
+    "sha512=df998e96cef53ef595178dfb9b51a17d5b22a8ccd894a543fa3130e5ab2204ea367706a79b1f53307f97c22ec7ce866be2097a4588ffeb0479d804f56706f248"
+  ]
+}


### PR DESCRIPTION
### `orpie.1.6.1`
Curses-based RPN calculator
Orpie is a curses-based RPN calculator for the terminal.  It supports a
large chunk of the features supported by classic HP RPN calculators, but
the user interface is optimized for a keyboard.



---
* Homepage: https://github.com/pelzlpj/orpie
* Source repo: git+https://github.com/pelzlpj/orpie.git
* Bug tracker: https://github.com/pelzlpj/orpie/issues

---
:camel: Pull-request generated by opam-publish v2.0.2