### PR TITLE
[new release] conex-mirage-crypto and conex (0.11.1)

### DIFF
--- a/packages/conex-mirage-crypto/conex-mirage-crypto.0.11.1/opam
+++ b/packages/conex-mirage-crypto/conex-mirage-crypto.0.11.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD2"
+homepage: "https://github.com/hannesm/conex"
+doc: "https://hannesm.github.io/conex/doc"
+bug-reports: "https://github.com/hannesm/conex/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "alcotest" {with-test}
+  "cmdliner"
+  "conex" {= version}
+  "cstruct" {>= "1.6.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-rng"
+  "x509" {>= "0.7.0"}
+  "logs"
+  "fmt"
+  "rresult"
+  "base64" {>= "3.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/conex.git"
+synopsis: "Establishing trust in community repositories: crypto provided via mirage-crypto"
+description: """
+Conex is a system based on [TUF](https://theupdateframework.github.io/) to
+establish trust in community repositories. Since opam2, the required hooks
+are present.
+
+This package uses the crypto primitives provided by mirage-crypto.
+"""
+url {
+  src:
+    "https://github.com/hannesm/conex/releases/download/v0.11.1/conex-v0.11.1.tbz"
+  checksum: [
+    "sha256=997966693236d1ab2930ff8bb24cce175e88279b99aaacd39fa022d5e45dd3b1"
+    "sha512=af207a3e6f35c81745d36fa8759846ed7ac357e9d8dfe0a7f3e0918e2a7f709d48d21ff15d6ee7b399a72c52d9c920cea478b1c7d7ad0d693637983f6dcb8033"
+  ]
+}

--- a/packages/conex/conex.0.11.1/opam
+++ b/packages/conex/conex.0.11.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD2"
+homepage: "https://github.com/hannesm/conex"
+doc: "https://hannesm.github.io/conex/doc"
+bug-reports: "https://github.com/hannesm/conex/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune"
+  "cmdliner"
+  "opam-file-format" {>= "2.0.0~rc2"}
+  "stdlib-shims"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/hannesm/conex.git"
+synopsis: "Establishing trust in community repositories"
+description: """
+Conex is a system based on [TUF](https://theupdateframework.github.io/) to
+establish trust in community repositories. Since opam2, the required hooks
+are present.
+
+This package uses openssl for the required crypto primitives (>=1.0.0u for RSA-PSS).
+"""
+url {
+  src:
+    "https://github.com/hannesm/conex/releases/download/v0.11.1/conex-v0.11.1.tbz"
+  checksum: [
+    "sha256=997966693236d1ab2930ff8bb24cce175e88279b99aaacd39fa022d5e45dd3b1"
+    "sha512=af207a3e6f35c81745d36fa8759846ed7ac357e9d8dfe0a7f3e0918e2a7f709d48d21ff15d6ee7b399a72c52d9c920cea478b1c7d7ad0d693637983f6dcb8033"
+  ]
+}


### PR DESCRIPTION
Establishing trust in community repositories: crypto provided via mirage-crypto

- Project page: <a href="https://github.com/hannesm/conex">https://github.com/hannesm/conex</a>
- Documentation: <a href="https://hannesm.github.io/conex/doc">https://hannesm.github.io/conex/doc</a>

##### CHANGES:

* Use mirage-crypto instead of nocrypto
