### PR TITLE
[new release] received, sendmail-lwt, colombe and sendmail (0.2.0)

### DIFF
--- a/packages/bigarray-overlap/bigarray-overlap.0.1.0/opam
+++ b/packages/bigarray-overlap/bigarray-overlap.0.1.0/opam
@@ -25,6 +25,7 @@ install: [
 depends: [
   "ocaml"       {>= "4.07.0"}
   "dune" {>= "2.3"}
+  "conf-pkg-config"
   "bigarray-compat"
   "alcotest" {with-test}
   "astring" {with-test}

--- a/packages/colombe/colombe.0.2.0/opam
+++ b/packages/colombe/colombe.0.2.0/opam
@@ -23,7 +23,12 @@ depends: [
   "ocaml-syntax-shims"
   "alcotest" {with-test}
 ]
-depopts: [ "emile" {>= "0.8"} ]
+depopts: [
+  "emile"
+]
+conflicts: [
+  "emile" {< "0.8"}
+]
 url {
   src:
     "https://github.com/mirage/colombe/releases/download/v0.2.0/colombe-v0.2.0.tbz"

--- a/packages/colombe/colombe.0.2.0/opam
+++ b/packages/colombe/colombe.0.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "SMTP protocol in OCaml"
+doc:          "https://mirage.github.io/colombe/"
+description: """SMTP protocol according RFC5321 without extension."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.8.0"}
+  "fmt"
+  "ipaddr" {>= "2.9.0"}
+  "angstrom"
+  "ocaml-syntax-shims"
+  "alcotest" {with-test}
+]
+depopts: [ "emile" {>= "0.8"} ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.2.0/colombe-v0.2.0.tbz"
+  checksum: [
+    "sha256=12c2736f0e1a6e001a47e2b39907bc1f6ddb18718f2c341dcd10b19554706ead"
+    "sha512=09e19eff4a016f7735b35f2298f0557be38ee00b24b5bbf102b3c66c3b783ea5190e55ed2da3300fb8c05f445a832f1482fdea84ec35b78b238e771e5e377fd7"
+  ]
+}

--- a/packages/colombe/colombe.0.2.0/opam
+++ b/packages/colombe/colombe.0.2.0/opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.07.0"}
   "dune" {>= "1.8.0"}
   "fmt"
   "ipaddr" {>= "2.9.0"}

--- a/packages/received/received.0.2.0/opam
+++ b/packages/received/received.0.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "Received field according RFC5321"
+doc:          "https://mirage.github.io/colombe/"
+description: """A little library to parse or emit a Received field according
+RFC5321. It is able to notify which SMTP server serves the email (and track, by this way,
+on which way - TLS or not - the email was transmitted)."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {>= "1.8.0"}
+  "colombe"  {= version}
+  "mrmime"   {>= "0.2.0"}
+  "emile"    {>= "0.8"}
+  "angstrom" {>= "0.11.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.2.0/colombe-v0.2.0.tbz"
+  checksum: [
+    "sha256=12c2736f0e1a6e001a47e2b39907bc1f6ddb18718f2c341dcd10b19554706ead"
+    "sha512=09e19eff4a016f7735b35f2298f0557be38ee00b24b5bbf102b3c66c3b783ea5190e55ed2da3300fb8c05f445a832f1482fdea84ec35b78b238e771e5e377fd7"
+  ]
+}

--- a/packages/sendmail-lwt/sendmail-lwt.0.2.0/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.2.0/opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "1.8"}
   "sendmail" {= version}
   "domain-name"
   "lwt"

--- a/packages/sendmail-lwt/sendmail-lwt.0.2.0/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "sendmail" {= version}
+  "domain-name"
+  "lwt"
+  "tls"
+  "x509" {>= "0.7.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.2.0/colombe-v0.2.0.tbz"
+  checksum: [
+    "sha256=12c2736f0e1a6e001a47e2b39907bc1f6ddb18718f2c341dcd10b19554706ead"
+    "sha512=09e19eff4a016f7735b35f2298f0557be38ee00b24b5bbf102b3c66c3b783ea5190e55ed2da3300fb8c05f445a832f1482fdea84ec35b78b238e771e5e377fd7"
+  ]
+}

--- a/packages/sendmail/sendmail.0.2.0/opam
+++ b/packages/sendmail/sendmail.0.2.0/opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "1.8"}
   "colombe" {= version}
   "tls"
   "base64"

--- a/packages/sendmail/sendmail.0.2.0/opam
+++ b/packages/sendmail/sendmail.0.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command"
+description: """A library to be able to send an email."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "colombe" {= version}
+  "tls"
+  "base64"
+  "logs"
+  "emile" {>= "0.8" & with-test}
+  "mrmime" {>= "0.2.0" & with-test}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.2.0/colombe-v0.2.0.tbz"
+  checksum: [
+    "sha256=12c2736f0e1a6e001a47e2b39907bc1f6ddb18718f2c341dcd10b19554706ead"
+    "sha512=09e19eff4a016f7735b35f2298f0557be38ee00b24b5bbf102b3c66c3b783ea5190e55ed2da3300fb8c05f445a832f1482fdea84ec35b78b238e771e5e377fd7"
+  ]
+}


### PR DESCRIPTION
Received field according RFC5321

- Project page: <a href="https://github.com/mirage/colombe">https://github.com/mirage/colombe</a>
- Documentation: <a href="https://mirage.github.io/colombe/">https://mirage.github.io/colombe/</a>

##### CHANGES:

- Fix warnings from OCaml 4.08.1
- Monadic view about implementation of the state machine 
- Handle `let*` syntax and add dependency with `future_syntax`
- Use at least `dune.1.8.0`
- Use `emile` instead `mrmime` about email address
- Support `8BITMIME`
- Add some logs
- Rename `Parser` to `Decoder`
- Add `Domain.compare`
- Externalize some parsers/decoders
- Add Received encoder/decoder
- Functorize `STARTTLS` implementation
- Close properly a TLS connection
- Relax SMTP parser about End-Of-Line character (be compatible with `gnutls-cli`)
- Add tests
- Clean the distribution
