### PR TITLE
[new release] mirage-crypto-rng, mirage-crypto, mirage-crypto-pk and mirage-crypto-entropy (0.6.1)

### DIFF
--- a/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.1/opam
+++ b/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "BSD2"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "1.7.0"}
+  "ocaml" {>= "4.07.0"}
+  "cstruct" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.7.0"}
+  "lwt" {>= "4.0.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "mirage-unix" {with-test & >= "3.0.0"}
+]
+tags: [ "org:mirage"]
+available: [
+  arch = "arm" | arch = "x86_32" | arch = "x86_64" | arch = "arm64"
+]
+synopsis: "Entropy source for MirageOS unikernels"
+description: """
+Mirage-crypto-entropy implements various entropy sources for MirageOS unikernels:
+- timer based ones (see [whirlwind RNG paper](https://www.ieee-security.org/TC/SP2014/papers/Not-So-RandomNumbersinVirtualizedLinuxandtheWhirlwindRNG.pdf))
+- rdseed and rdrand (x86/x86-64 only)
+"""
+authors: ["Hannes Mehnert" "David Kaloper" "Anil Madhavapeddy" "Dave Scott"]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.6.1/mirage-crypto-v0.6.1.tbz"
+  checksum: [
+    "sha256=dd99b67fc30dc0144cb7bfdd4d1c783f42d5a7ba847ce31c132712872f66f7b1"
+    "sha512=351354a044d6c8e24c26389eeb8cb174d2506f8e8bef5795078ca80b6e9a0b56a5c306a0c8279d6d947c3c871b9d9fd8a6311b18fc77a54d031deec29582ffc3"
+  ]
+}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.7"}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.5"}
+  "rresult" {>= "0.6.0"}
+  ("mirage-no-xen" | "zarith-xen")
+  ("mirage-no-solo5" | "zarith-freestanding")
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.6.1/mirage-crypto-v0.6.1.tbz"
+  checksum: [
+    "sha256=dd99b67fc30dc0144cb7bfdd4d1c783f42d5a7ba847ce31c132712872f66f7b1"
+    "sha512=351354a044d6c8e24c26389eeb8cb174d2506f8e8bef5795078ca80b6e9a0b56a5c306a0c8279d6d947c3c871b9d9fd8a6311b18fc77a54d031deec29582ffc3"
+  ]
+}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.6.1/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.6.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator"
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "randomconv" {with-test & >= "0.1.3"}
+  "ounit" {with-test}
+]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.6.1/mirage-crypto-v0.6.1.tbz"
+  checksum: [
+    "sha256=dd99b67fc30dc0144cb7bfdd4d1c783f42d5a7ba847ce31c132712872f66f7b1"
+    "sha512=351354a044d6c8e24c26389eeb8cb174d2506f8e8bef5795078ca80b6e9a0b56a5c306a0c8279d6d947c3c871b9d9fd8a6311b18fc77a54d031deec29582ffc3"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.6.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.6.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "cpuid" {build}
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "ocplib-endian"
+]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4), and hashes (MD5,
+SHA-1, SHA-2).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.6.1/mirage-crypto-v0.6.1.tbz"
+  checksum: [
+    "sha256=dd99b67fc30dc0144cb7bfdd4d1c783f42d5a7ba847ce31c132712872f66f7b1"
+    "sha512=351354a044d6c8e24c26389eeb8cb174d2506f8e8bef5795078ca80b6e9a0b56a5c306a0c8279d6d947c3c871b9d9fd8a6311b18fc77a54d031deec29582ffc3"
+  ]
+}


### PR DESCRIPTION
A cryptographically secure PRNG

- Project page: <a href="https://github.com/mirage/mirage-crypto">https://github.com/mirage/mirage-crypto</a>
- Documentation: <a href="https://mirage.github.io/mirage-crypto/doc">https://mirage.github.io/mirage-crypto/doc</a>

##### CHANGES:

* Add Windows 10+ support (mirage/mirage-crypto#39 @avsm, review by @hannesm @dinosaure)
* Fix unix stubs to be allocating in case of exception (mirage/mirage-crypto#39 @avsm
  review by @hannesm @dinosaure)
* Add GitHub Actions CI (mirage/mirage-crypto#39 @avsm)
* Rebuild source if the `MIRAGE_CRYPTO_ACCELERATE` environment
  variable changes value (mirage/mirage-crypto#40 @avsm)
