### PR TITLE
Package pprint.20200316

### DIFF
--- a/packages/pprint/pprint.20200316/opam
+++ b/packages/pprint/pprint.20200316/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "A pretty-printing combinator library and rendering engine"
+description: """
+This library offers a set of combinators for building so-called documents as
+well as an efficient engine for converting documents to a textual, fixed-width
+format. The engine takes care of indentation and line breaks, while respecting
+the constraints imposed by the structure of the document and by the text width."""
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+  "Nicolas Pouillard <np@nicolaspouillard.fr>"
+]
+homepage: "https://github.com/fpottier/pprint"
+bug-reports: "francois.pottier@inria.fr"
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "1.3"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+ssh://git@github.com/fpottier/pprint.git"
+url {
+  src: "https://github.com/fpottier/pprint/archive/20200316.tar.gz"
+  checksum: [
+    "md5=db30436804a95f4106757f3da3b9cd18"
+    "sha512=cdc822e546b83a5db4782adcd45301530c659088b74b9134483d97bbcfe6c8f0a9f7cac320189f0417502cf3697f2bcf75b5d35dbb7dfb6d4bb6b5ab7dd61fdd"
+  ]
+}


### PR DESCRIPTION
### `pprint.20200316`
A pretty-printing combinator library and rendering engine
This library offers a set of combinators for building so-called documents as
well as an efficient engine for converting documents to a textual, fixed-width
format. The engine takes care of indentation and line breaks, while respecting
the constraints imposed by the structure of the document and by the text width.



---
* Homepage: https://github.com/fpottier/pprint
* Source repo: git+ssh://git@github.com/fpottier/pprint.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.2