### PR TITLE
+secp256k1-internal.0.1.0

### DIFF
--- a/packages/secp256k1-internal/secp256k1-internal.0.1.0/opam
+++ b/packages/secp256k1-internal/secp256k1-internal.0.1.0/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "conf-gmp" {build}
-  "dune" {build & >= "1.0.1"}
+  "dune" {>= "1.0.1"}
   "cstruct" {>= "3.2.1"}
   "bigstring" {>= "0.1.1"}
   "hex" {with-test & >= "1.4.0"}

--- a/packages/secp256k1-internal/secp256k1-internal.0.1.0/opam
+++ b/packages/secp256k1-internal/secp256k1-internal.0.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "secp256k1-internal"
+maintainer: "contact@nomadic-labs.com"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal"
+synopsis: "Bindings to secp256k1 internal functions (generic operations on the curve)"
+
+license: "MIT"
+bug-reports: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name "@install"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "conf-gmp" {build}
+  "dune" {build & >= "1.0.1"}
+  "cstruct" {>= "3.2.1"}
+  "bigstring" {>= "0.1.1"}
+  "hex" {with-test & >= "1.4.0"}
+  "alcotest" {with-test}
+]
+
+url {
+  src: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/-/archive/v0.1/ocaml-secp256k1-internal-v0.1.tar.bz2"
+  checksum: [
+    "md5=16cfea99a40a430240d9f6cce52d5301"
+    "sha256=5425342359c72e019bc0d0fff3ca66a0e80acf17f68f1a39c436f6791b0faed5"
+    "sha512=4fe1227dc0e19bd09c376c2990ad003fc83003fb92b9e30420a85ddd5e521adf1946f7092dee1501c68078062e0e47a7a1f1eb3faaf5ec2be25e695506927391"
+  ]
+}


### PR DESCRIPTION
There is already a binding of secp256k1 in the opam repository but
this one is different and providing both is useful.

secp256k1 binds the public functions of libsecp256k1 (the one
exposed in secp256k1.h) and uses the dynamic library installed
system wise. This is very clean and allows an easy integration
in distribution that are piky with code duplication.

secp256k1-internal exposes the internal functions of libsecp256k1.
To do so, it copies the C code and build ocaml wrappers for low
level components. It is used by tezos codebase.