### PR TITLE
Fix why3's revdeps

### DIFF
--- a/packages/archetype/archetype.0.1.3/opam
+++ b/packages/archetype/archetype.0.1.3/opam
@@ -25,7 +25,7 @@ depends: [
   "menhir"
   "uri"
   "digestif"
-  "why3"                { >= "1.2.0" }
+  "why3"                { >= "1.2.0" & < "1.3.0" }
   "yojson"
   "ppx_deriving"
   "ppx_deriving_yojson"

--- a/packages/frama-c/frama-c.20.0/opam
+++ b/packages/frama-c/frama-c.20.0/opam
@@ -98,7 +98,7 @@ depends: [
   ( "alt-ergo-free" | "alt-ergo" )
   "conf-graphviz" { post }
   "yojson"
-  "why3" { >= "1.2.0" }
+  "why3" { >= "1.2.0" & < "1.3.0" }
   "conf-time" {with-test}
 ]
 


### PR DESCRIPTION
This PR mark a number of packages incompatible with the new release of why3 (1.3.0)
Revdeps failure discovered in https://github.com/ocaml/opam-repository/pull/16027

cc @bobot for `frama-c`:
```
# File "src/plugins/wp/ProverWhy3.ml", line 131, characters 29-45:
# 131 |   Why3.(Term.t_const Number.(const_of_big_int (BigInt.of_string (Z.to_string z)))) Why3.Ty.ty_int
#                                    ^^^^^^^^^^^^^^^^
# Error: Unbound value const_of_big_int
# make: *** [share/Makefile.generic:77: src/plugins/wp/ProverWhy3.cmo] Error 2
# make: *** Waiting for unfinished jobs....
```