### PR TITLE
Remove OCaml 4.10.0+rc2 from the travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
     osx_image: xcode10.1
     env: OCAML_VERSION=4.08
   - os: linux
-    env: OCAML_VERSION=4.10.0+rc2 OCAML_BETA=enable
-  - os: linux
     env: OCAML_VERSION=4.09 INSTALL_LOCAL=1
 notifications:
   email:


### PR DESCRIPTION
This is not needed anymore