### PR TITLE
[new release] ocaml-print-intf (1.0.0)

### DIFF
--- a/packages/ocaml-print-intf/ocaml-print-intf.1.0.0/opam
+++ b/packages/ocaml-print-intf/ocaml-print-intf.1.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Display human-readable OCaml interface from a compiled .cmi"
+description: """
+This tool parses a compiled .cmi interface file and outputs
+the corresponding textual .mli file.  This can be useful to quickly generate
+a skeleton interface file to then annotate with comments or add abstraction."""
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy"]
+license: "ISC"
+homepage: "https://github.com/avsm/ocaml-print-intf"
+doc: "https://avsm.github.io/ocaml-print-intf/"
+bug-reports: "https://github.com/avsm/ocaml-print-intf/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03"}
+  "dune-build-info"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-print-intf.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-print-intf/releases/download/v1.0.0/ocaml-print-intf-v1.0.0.tbz"
+  checksum: [
+    "sha256=e31ed8fd95010addd1a6e4fb6bc638916ba5265ea3b4ebc923e2273290b8a97a"
+    "sha512=961ad780982423e1fe29532cacfd6f012b5dfedb3066ecfff67a1927877978a9452cce63cc113863f9070006f8c0e40d2af7b4a966b27af0929fbd500f6b7b97"
+  ]
+}


### PR DESCRIPTION
Display human-readable OCaml interface from a compiled .cmi

- Project page: <a href="https://github.com/avsm/ocaml-print-intf">https://github.com/avsm/ocaml-print-intf</a>
- Documentation: <a href="https://avsm.github.io/ocaml-print-intf/">https://avsm.github.io/ocaml-print-intf/</a>

##### CHANGES:

Initial public release.
