### PR TITLE
8 packages from gitlab.com/nomadic-labs/resto/-/archive/v0.4/resto-v0.4.tar.gz

### DIFF
--- a/packages/ezresto-directory/ezresto-directory.0.4/opam
+++ b/packages/ezresto-directory/ezresto-directory.0.4/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.07" }
+  "dune" { >= "1.7" }
+  "ezresto" {= version }
+  "resto-directory" {= version }
+  "resto" {= version }
+  "lwt" { >= "3.0.0" & < "5.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.4/resto-v0.4.tar.gz"
+  checksum: [
+    "md5=441e7916b7f5e2952ede014e283a5dee"
+    "sha512=35dc4be2ae98947a82059b112678d44b1c97a69c16ed1b923b5775f6c49cda31642f292fcf7d317a9e654c74f084fa54e80845739521fec8e1987febc67036ad"
+  ]
+}

--- a/packages/ezresto/ezresto.0.4/opam
+++ b/packages/ezresto/ezresto.0.4/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.07" }
+  "dune" { >= "1.7" }
+  "uri" {>= "1.9.0" }
+  "resto" {= version }
+  "resto-json" {= version }
+  "lwt" {with-test}
+  "base-unix" {with-test}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.4/resto-v0.4.tar.gz"
+  checksum: [
+    "md5=441e7916b7f5e2952ede014e283a5dee"
+    "sha512=35dc4be2ae98947a82059b112678d44b1c97a69c16ed1b923b5775f6c49cda31642f292fcf7d317a9e654c74f084fa54e80845739521fec8e1987febc67036ad"
+  ]
+}

--- a/packages/resto-cohttp-client/resto-cohttp-client.0.4/opam
+++ b/packages/resto-cohttp-client/resto-cohttp-client.0.4/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.07" }
+  "dune" { >= "1.7" }
+  "uri" {>= "1.9.0" }
+  "resto-cohttp" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+  "lwt" { >= "3.0.0" & <= "5.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.4/resto-v0.4.tar.gz"
+  checksum: [
+    "md5=441e7916b7f5e2952ede014e283a5dee"
+    "sha512=35dc4be2ae98947a82059b112678d44b1c97a69c16ed1b923b5775f6c49cda31642f292fcf7d317a9e654c74f084fa54e80845739521fec8e1987febc67036ad"
+  ]
+}

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.4/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.4/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs - server library"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.07" }
+  "dune" { >= "1.7" }
+  "resto-directory" {= version }
+  "resto-cohttp" {= version }
+  "cohttp-lwt-unix" { >= "1.0.0" }
+  "lwt" { >= "3.0.0" & <= "5.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.4/resto-v0.4.tar.gz"
+  checksum: [
+    "md5=441e7916b7f5e2952ede014e283a5dee"
+    "sha512=35dc4be2ae98947a82059b112678d44b1c97a69c16ed1b923b5775f6c49cda31642f292fcf7d317a9e654c74f084fa54e80845739521fec8e1987febc67036ad"
+  ]
+}

--- a/packages/resto-cohttp/resto-cohttp.0.4/opam
+++ b/packages/resto-cohttp/resto-cohttp.0.4/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.07" }
+  "dune" { >= "1.7" }
+  "resto-directory" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.4/resto-v0.4.tar.gz"
+  checksum: [
+    "md5=441e7916b7f5e2952ede014e283a5dee"
+    "sha512=35dc4be2ae98947a82059b112678d44b1c97a69c16ed1b923b5775f6c49cda31642f292fcf7d317a9e654c74f084fa54e80845739521fec8e1987febc67036ad"
+  ]
+}

--- a/packages/resto-directory/resto-directory.0.4/opam
+++ b/packages/resto-directory/resto-directory.0.4/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.07" }
+  "dune" { >= "1.7" }
+  "resto" {= version }
+  "resto-json" {= version & with-test }
+  "lwt" { >= "3.0.0" & <= "5.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.4/resto-v0.4.tar.gz"
+  checksum: [
+    "md5=441e7916b7f5e2952ede014e283a5dee"
+    "sha512=35dc4be2ae98947a82059b112678d44b1c97a69c16ed1b923b5775f6c49cda31642f292fcf7d317a9e654c74f084fa54e80845739521fec8e1987febc67036ad"
+  ]
+}

--- a/packages/resto-json/resto-json.0.4/opam
+++ b/packages/resto-json/resto-json.0.4/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.07" }
+  "dune" { >= "1.7" }
+  "resto" {= version }
+  "json-data-encoding" {= "0.8" }
+  "json-data-encoding-bson" {= "0.8" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.4/resto-v0.4.tar.gz"
+  checksum: [
+    "md5=441e7916b7f5e2952ede014e283a5dee"
+    "sha512=35dc4be2ae98947a82059b112678d44b1c97a69c16ed1b923b5775f6c49cda31642f292fcf7d317a9e654c74f084fa54e80845739521fec8e1987febc67036ad"
+  ]
+}

--- a/packages/resto/resto.0.4/opam
+++ b/packages/resto/resto.0.4/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.07" }
+  "dune" { >= "1.7" }
+  "uri" {>= "1.9.0" }
+  "json-data-encoding" {= "0.8" & with-test }
+  "json-data-encoding-bson" {= "0.8" & with-test }
+  "lwt" {with-test}
+  "base-unix"{with-test}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.4/resto-v0.4.tar.gz"
+  checksum: [
+    "md5=441e7916b7f5e2952ede014e283a5dee"
+    "sha512=35dc4be2ae98947a82059b112678d44b1c97a69c16ed1b923b5775f6c49cda31642f292fcf7d317a9e654c74f084fa54e80845739521fec8e1987febc67036ad"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ezresto.0.4`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`ezresto-directory.0.4`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto.0.4`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp.0.4`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-client.0.4`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-server.0.4`: A minimal OCaml library for type-safe HTTP/JSON RPCs - server library
-`resto-directory.0.4`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-json.0.4`: A minimal OCaml library for type-safe HTTP/JSON RPCs



---
* Homepage: https://gitlab.com/nomadic-labs/resto
* Source repo: git+https://gitlab.com/nomadic-labs/resto
* Bug tracker: https://gitlab.com/nomadic-labs/resto/issues

---
:camel: Pull-request generated by opam-publish v2.0.0