### PR TITLE
Bisect_ppx 2.0.0: code coverage for OCaml

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.2.0.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+
+synopsis: "Code coverage for OCaml"
+version: "2.0.0"
+license: "MIT"
+homepage: "https://github.com/aantron/bisect_ppx"
+doc: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+
+dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+
+depends: [
+  "base-unix"
+  "cmdliner" {>= "1.0.0"}
+  "dune"
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ppx_tools_versioned" {>= "5.3.0"}
+
+  "ocamlfind" {with-test}
+  "ounit2" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+url {
+  src: "https://github.com/aantron/bisect_ppx/archive/2.0.0.tar.gz"
+  checksum: "md5=7eb3e98f1a082ea3b688451de24dfa64"
+}


### PR DESCRIPTION
[**Bisect_ppx**](https://github.com/aantron/bisect_ppx) is a code coverage tool for OCaml. [2.0.0](https://github.com/aantron/bisect_ppx/releases/tag/2.0.0) is a major release with many improvements, and some scheduled breaking changes:

Additions

- BuckleScript support and NPM packaging (aantron/bisect_ppx#206, aantron/bisect_ppx#249).
- Js_of_ocaml support (aantron/bisect_ppx#212).
- Automated sending of reports from Travis and CircleCI to Coveralls and Codecov (aantron/bisect_ppx#241).
- Better integration with Dune (aantron/bisect_ppx#235).
- Better integration with esy (aantron/bisect_ppx#263, aantron/bisect_ppx#270).
- [`[@coverage off]`](https://github.com/aantron/bisect_ppx#Exclusion) attribute and its variants for excluding expressions and module items from coverage (aantron/bisect_ppx#198).
- `[@@@coverage exclude file]` for excluding entire files (aantron/bisect_ppx#130, aantron/bisect_ppx#219).
- Cmdliner-based command line (aantron/bisect_ppx#145).
- Reporter automatically searches for `.coverage` files (aantron/bisect_ppx#236).
- New, more disciplined instrumentation strategy (aantron/bisect_ppx#82, aantron/bisect_ppx#128, aantron/bisect_ppx#205).
- Syntax highlighting in the generated reports (aantron/bisect_ppx#135).
- Sanity-checking the set of source files included in the coverage report (aantron/bisect_ppx@a7a4ca0).
- Use 4.10 ASTs internally for the transformation (aantron/bisect_ppx#274).
- MIT license (aantron/bisect_ppx#199).
- New documentation.

Deprecations

*These features will be removed in 2.1.0.*

- PPX `-mode` option (aantron/bisect_ppx#200).
- PPX `-no-comment-parsing` option (aantron/bisect_ppx#202).
- PPX `-exclude` option (aantron/bisect_ppx#244).
- PPX `-exclude-file` in favor of `--exclusions` (aantron/bisect_ppx#245).
- Reporter `--html`, `--text`, `--coveralls` are deprecated in favor of the `html`, `summary`, `coveralls` sub-commands, respectively (aantron/bisect_ppx#145).
- All other reporter multi-character options with a single dash (`-`) prefix are deprecated in favor of double-dashed (`--`) versions (aantron/bisect_ppx#145).
- `.out` files are now `.coverage` files (aantron/bisect_ppx#110).

Removed

- `BISECT-IGNORE` comments, in favor of `[@coverage off]` (aantron/bisect_ppx#202).

Bugs fixed

- Randomize intermediate filenames to avoid collisions upon their creation (aantron/bisect_ppx#194, Mindy Preston).
- Left margin indicators in the HTML report could be invisible, if they were located at the bottom of the margin (aantron/bisect_ppx#254).