### PR TITLE
Fix bisect_ppx revdeps

### DIFF
--- a/packages/bisect-summary/bisect-summary.0.3/opam
+++ b/packages/bisect-summary/bisect-summary.0.3/opam
@@ -17,7 +17,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "bisect_ppx"
+  "bisect_ppx" {< "2.0.0"}
   "oasis" {build}
   "ocamlfind" {build}
 ]

--- a/packages/minicaml/minicaml.0.3.3/opam
+++ b/packages/minicaml/minicaml.0.3.3/opam
@@ -21,7 +21,7 @@ depends: [
     "ppx_deriving"
     "cmdliner"
     "alcotest" {with-test & >= "0.8.5" & < "1.0.0"}
-    "bisect_ppx" {with-test >= "1.4.1"}
+    "bisect_ppx" {with-test >= "1.4.1" & < "2.0.0"}
 ]
 url {
   src:

--- a/packages/minicaml/minicaml.0.4/opam
+++ b/packages/minicaml/minicaml.0.4/opam
@@ -22,7 +22,7 @@ depends: [
     "ppx_deriving"
     "cmdliner"
     "alcotest" {with-test & >= "0.8.5"}
-    "bisect_ppx" {with-test >= "1.4.1"}
+    "bisect_ppx" {with-test & >= "1.4.1" & < "2.0.0"}
 ]
 url {
   src:

--- a/packages/rfc6287/rfc6287.1.0.2/opam
+++ b/packages/rfc6287/rfc6287.1.0.2/opam
@@ -36,7 +36,7 @@ depends: [
   "hex"
   "rresult"
   "ounit" {with-test}
-  "bisect_ppx" {with-test}
+  "bisect_ppx" {with-test & < "2.0.0"}
 ]
 synopsis: "RFC6287 OCRA (OATH Challenge-Response Algorithm)"
 authors: "Stefan Grundmann <sg2342@googlemail.com>"

--- a/packages/rfc6287/rfc6287.1.0.3/opam
+++ b/packages/rfc6287/rfc6287.1.0.3/opam
@@ -36,7 +36,7 @@ depends: [
   "hex"
   "rresult"
   "ounit" {with-test}
-  "bisect_ppx" {with-test}
+  "bisect_ppx" {with-test & < "2.0.0"}
 ]
 synopsis: "RFC6287 OCRA (OATH Challenge-Response Algorithm)"
 authors: "Stefan Grundmann <sg2342@googlemail.com>"


### PR DESCRIPTION
Fixes constraints for packages that fail to build with the newest `bisect_ppx` release.
See https://github.com/ocaml/opam-repository/pull/16033 for more details

cc @0x0f0f0f for `minicaml`
cc @sg2342 for `rfc6287`