### PR TITLE
[new release] spin (0.5.1)

### DIFF
--- a/packages/spin/spin.0.5.1/opam
+++ b/packages/spin/spin.0.5.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Project scaffolding tool and set of templates for Reason and OCaml"
+description: """
+Project scaffolding tool and set of templates for Reason and OCaml
+"""
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/tmattio/spin"
+doc: "https://tmattio.github.io/spin"
+bug-reports: "https://github.com/tmattio/spin/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+  "reason" {build}
+  "base"
+  "stdio"
+  "cmdliner"
+  "fileutils"
+  "jingoo"
+  "lwt"
+  "ppx_sexp_conv"
+  "sexplib"
+]
+dev-repo: "git+https://github.com/tmattio/spin.git"
+# We need to avoid "@runtest", since it depends on rely
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/tmattio/spin/releases/download/0.5.1/spin-0.5.1.tbz"
+  checksum: [
+    "sha256=63f80ce6baa89438f3b5b5f0a07fe8ec3648a0af2116f64d1ced0a55e1db1452"
+    "sha512=15df032c37f5bebab26e36b732c8c4fd5e63ade258a4c045e601f61fe142c01757e83a3903e76114e606ef7aea0bb46f998f98bf94dde40c07168cf5e009be22"
+  ]
+}


### PR DESCRIPTION
CHANGES:

## Added

- Add versionning for the official templates to ensure updates on the templates don't break old version of Spin.
- Sort `spin ls` result by name.

### Templates

- Rename react to bs-react. All the upcoming Bucklescript templates will be prefixed by bs-.
- Add a lib template that is releasable on Opam.
- Make the cli and ppx templates releasable on Opam.
- Add support for Alcotest as an alternative to Rely in the native templates.
- Add support for Opam as an alternative to Esy in the native templates.
- Stop using Pesy and the dune files manually in each sub-directories.
- Move the test_runner to a subdirectory support in test.
- Extract the Contributing section of the README to a CONTRIBUTING.md file.
- Add a CHANGES.md file that complies with dune-release requirements.
- Use dune-release in the release scripts.
- Remove homebrew Formula from the cli template that was a bad practice and didn’t allow users to update the generated projects.
- Enable Windows in CI/CD of generated projects