### PR TITLE
[new release] mirage-crypto-pk, mirage-crypto, mirage-crypto-rng and mirage-crypto-entropy (0.6.2)

### DIFF
--- a/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.2/opam
+++ b/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "BSD2"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "1.7.0"}
+  "ocaml" {>= "4.07.0"}
+  "cstruct" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.7.0"}
+  "lwt" {>= "4.0.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "mirage-unix" {with-test & >= "3.0.0"}
+]
+tags: [ "org:mirage"]
+available: [
+  arch = "arm" | arch = "x86_32" | arch = "x86_64" | arch = "arm64"
+]
+synopsis: "Entropy source for MirageOS unikernels"
+description: """
+Mirage-crypto-entropy implements various entropy sources for MirageOS unikernels:
+- timer based ones (see [whirlwind RNG paper](https://www.ieee-security.org/TC/SP2014/papers/Not-So-RandomNumbersinVirtualizedLinuxandtheWhirlwindRNG.pdf))
+- rdseed and rdrand (x86/x86-64 only)
+"""
+authors: ["Hannes Mehnert" "David Kaloper" "Anil Madhavapeddy" "Dave Scott"]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.6.2/mirage-crypto-v0.6.2.tbz"
+  checksum: [
+    "sha256=e2284dc0f8d37110f4713b87145a26a2bbce3e43f14be51e88de18db5922b823"
+    "sha512=2c9808261aec8498921e4dce2d66214e10dfe65e2c3729c081731d6c44abc0e990233e5398c9c2d31a97d1a40bdd38920c54817f572d3b592f4257ce85b331da"
+  ]
+}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.2/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.7"}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.5"}
+  "rresult" {>= "0.6.0"}
+  ("mirage-no-xen" | "zarith-xen")
+  ("mirage-no-solo5" | "zarith-freestanding")
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.6.2/mirage-crypto-v0.6.2.tbz"
+  checksum: [
+    "sha256=e2284dc0f8d37110f4713b87145a26a2bbce3e43f14be51e88de18db5922b823"
+    "sha512=2c9808261aec8498921e4dce2d66214e10dfe65e2c3729c081731d6c44abc0e990233e5398c9c2d31a97d1a40bdd38920c54817f572d3b592f4257ce85b331da"
+  ]
+}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.6.2/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.6.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator"
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "randomconv" {with-test & >= "0.1.3"}
+  "ounit" {with-test}
+]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.6.2/mirage-crypto-v0.6.2.tbz"
+  checksum: [
+    "sha256=e2284dc0f8d37110f4713b87145a26a2bbce3e43f14be51e88de18db5922b823"
+    "sha512=2c9808261aec8498921e4dce2d66214e10dfe65e2c3729c081731d6c44abc0e990233e5398c9c2d31a97d1a40bdd38920c54817f572d3b592f4257ce85b331da"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.6.2/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.6.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "cpuid" {build}
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "ocplib-endian"
+]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4), and hashes (MD5,
+SHA-1, SHA-2).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.6.2/mirage-crypto-v0.6.2.tbz"
+  checksum: [
+    "sha256=e2284dc0f8d37110f4713b87145a26a2bbce3e43f14be51e88de18db5922b823"
+    "sha512=2c9808261aec8498921e4dce2d66214e10dfe65e2c3729c081731d6c44abc0e990233e5398c9c2d31a97d1a40bdd38920c54817f572d3b592f4257ce85b331da"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Do not validate hardcoded DH groups to speedup initializatio time
  (reported in mirage/mirage-crypto#43 by @rbardou, fixed in mirage/mirage-crypto#42 by @hannesm)