### PR TITLE
An Ocamleditor preview release for OCaml 4.10.

### DIFF
--- a/packages/ocamleditor/ocamleditor.1.13.4~preview.4.10/opam
+++ b/packages/ocamleditor/ocamleditor.1.13.4~preview.4.10/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "ocamleditor"
+version: "1.1.34~preview.4.10"
+
+synopsis:
+  "OCamlEditor is a GTK+ source code editor and build tool for OCaml"
+description:
+  """It provides many features to facilitate editing code, accessing API reference
+directly from the editor and compiling projects."""
+
+authors: "Francesco Tovagliari <ftovagliari@gmail.com>"
+maintainer: "Vasile Rotaru <vrotaru.md@gmail.com>"
+
+homepage: "https://github.com/vrotaru/ocamleditor"
+bug-reports: "https://github.com/vrotaru/ocamleditor/issues"
+
+build: [["ocaml" "build.ml" "ocamleditor"]]
+install: [["ocaml" "tools/install.ml" "-prefix" prefix]]
+remove: [["ocaml" "tools/uninstall.ml" "-prefix" prefix]]
+
+depends: [
+  "ocaml" {= "4.10.0"}
+  "ocamlfind" {>= "1.4.0"}
+  "lablgtk" {>= "2.18.0"}
+  "xml-light" {>= "2.2"}
+]
+depopts: [
+  "ocp-indent"
+  "ocurl"
+  "ocamldiff"
+]
+

--- a/packages/ocamleditor/ocamleditor.1.13.4~preview.4.10/opam
+++ b/packages/ocamleditor/ocamleditor.1.13.4~preview.4.10/opam
@@ -14,7 +14,6 @@ bug-reports: "https://github.com/vrotaru/ocamleditor/issues"
 
 build: [["ocaml" "build.ml" "ocamleditor"]]
 install: [["ocaml" "tools/install.ml" "-prefix" prefix]]
-remove: [["ocaml" "tools/uninstall.ml" "-prefix" prefix]]
 
 depends: [
   "ocaml" {= "4.10.0"}

--- a/packages/ocamleditor/ocamleditor.1.13.4~preview.4.10/opam
+++ b/packages/ocamleditor/ocamleditor.1.13.4~preview.4.10/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 name: "ocamleditor"
-version: "1.1.34~preview.4.10"
 
 synopsis:
   "OCamlEditor is a GTK+ source code editor and build tool for OCaml"
@@ -37,4 +36,3 @@ url {
         "sha512=13167bb307a8b4d4a613a42349db49b688b3175fe1c47b8b2dc831befea8014577d482d8c722cb8e55c606233f73ff1b6bb2751d8289c5e274ef9cdefaeaa031"
     ]
 }
-

--- a/packages/ocamleditor/ocamleditor.1.13.4~preview.4.10/opam
+++ b/packages/ocamleditor/ocamleditor.1.13.4~preview.4.10/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "ocamleditor"
 
 synopsis:
   "OCamlEditor is a GTK+ source code editor and build tool for OCaml"

--- a/packages/ocamleditor/ocamleditor.1.13.4~preview.4.10/opam
+++ b/packages/ocamleditor/ocamleditor.1.13.4~preview.4.10/opam
@@ -29,4 +29,12 @@ depopts: [
   "ocurl"
   "ocamldiff"
 ]
+dev-repo: "git+https://github.com/vrotaru/ocamleditor"
+url {
+    src: "https://github.com/vrotaru/ocamleditor/archive/1.1.34-preview.4.10.tar.gz"
+    checksum: [
+        "sha256=8df5b5847c4f29ff236dd74e44b4f41502495b21564bf0d25a289f5b605a879d"
+        "sha512=13167bb307a8b4d4a613a42349db49b688b3175fe1c47b8b2dc831befea8014577d482d8c722cb8e55c606233f73ff1b6bb2751d8289c5e274ef9cdefaeaa031"
+    ]
+}
 


### PR DESCRIPTION
Ocamleditor is a pure OCaml editor originally written by Francesko Tovagliari, but the last release was for `4.01` version of OCaml

Here is a preview of ocamleditor with compiles and runs (with some issues) under OCaml 4.10.
I have Francesco's permission to go ahead and release a  new version on opam, received in a personal communication