### PR TITLE
Bisect_ppx 2.1.0: code coverage for OCaml

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.2.1.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.1.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+
+synopsis: "Code coverage for OCaml"
+version: "2.1.0"
+license: "MIT"
+homepage: "https://github.com/aantron/bisect_ppx"
+doc: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+
+dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+
+depends: [
+  "base-unix"
+  "cmdliner" {>= "1.0.0"}
+  "dune"
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ppx_tools_versioned" {>= "5.3.0"}
+
+  "ocamlfind" {with-test}
+  "ounit2" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+post-messages: [
+  "Bisect_ppx 2.0.0 has deprecated some command-line options. See
+  https://github.com/aantron/bisect_ppx/releases/tag/2.0.0"
+]
+
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+url {
+  src: "https://github.com/aantron/bisect_ppx/archive/2.1.0.tar.gz"
+  checksum: "md5=c8ed055423d80aeeb5a1bac3d512b307"
+}


### PR DESCRIPTION
[Changelog](https://github.com/aantron/bisect_ppx/releases/tag/2.1.0):

<br/>

> Additions
>
> - [GitHub Actions integration](https://github.com/aantron/bisect_ppx#Coveralls) (aantron/bisect_ppx#280, Ulrik Strid).
> - Reporter `--coverage-path` option to specify search paths for `.coverage` files (aantron/bisect_ppx#269).
> - Reporter `--source-path` option to specify search paths for source files (aantron/bisect_ppx#283).
>
> Deprecations
>
> - `-I` in favor of `--search-path` (aantron/bisect_ppx#283).

<br/>

I also tried to fix the opam-repository Travis build of Bisect releases in https://github.com/aantron/bisect_ppx/issues/281.