### PR TITLE
[new release] ssh-agent-unix and ssh-agent (0.3.0)

### DIFF
--- a/packages/ssh-agent-unix/ssh-agent-unix.0.3.0/opam
+++ b/packages/ssh-agent-unix/ssh-agent-unix.0.3.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Ssh-agent protocol parser and serialization implementation for unix platforms"
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+dev-repo: "git://github.com/reynir/ocaml-ssh-agent.git"
+homepage: "https://github.com/reynir/ocaml-ssh-agent/"
+bug-reports: "https://github.com/reynir/ocaml-ssh-agent/issues/"
+license: "BSD-2-clause"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml"
+  "dune" {>= "1.0"}
+  "ssh-agent" {= version}
+  "angstrom-unix"
+  "faraday"
+]
+authors: "Reynir Björnsson <reynir@reynir.dk>"
+url {
+  src:
+    "https://github.com/reynir/ocaml-ssh-agent/releases/download/V0.3.0/ssh-agent-V0.3.0.tbz"
+  checksum: [
+    "sha256=6cd06ad1432c823e9f614fafd98f3359170e3f7184d370c12890cf1f507fb75c"
+    "sha512=2d198bdbd411b7cd7eaaecaecfb934305301b11f0961c43e508834cb43a16b542d5d6b3cff5d11be26a98a5adf217d88d2952fbd52736107ef4f63b8d8cb368e"
+  ]
+}

--- a/packages/ssh-agent/ssh-agent.0.3.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Ssh-agent protocol parser and serialization implementation"
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+dev-repo: "git+https://github.com/reynir/ocaml-ssh-agent.git"
+homepage: "https://github.com/reynir/ocaml-ssh-agent/"
+bug-reports: "https://github.com/reynir/ocaml-ssh-agent/issues/"
+license: "BSD-2-clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.0"}
+  "ppx_cstruct" {build}
+  "ppx_sexp_conv"
+  "angstrom" {>= "0.10" & < "0.13"}
+  "faraday" {>= "0.6" & < "0.8"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "cstruct"
+  "sexplib"
+  "alcotest" {with-test}
+]
+authors: "Reynir Björnsson <reynir@reynir.dk>"
+url {
+  src:
+    "https://github.com/reynir/ocaml-ssh-agent/releases/download/V0.3.0/ssh-agent-V0.3.0.tbz"
+  checksum: [
+    "sha256=6cd06ad1432c823e9f614fafd98f3359170e3f7184d370c12890cf1f507fb75c"
+    "sha512=2d198bdbd411b7cd7eaaecaecfb934305301b11f0961c43e508834cb43a16b542d5d6b3cff5d11be26a98a5adf217d88d2952fbd52736107ef4f63b8d8cb368e"
+  ]
+}


### PR DESCRIPTION
Ssh-agent protocol parser and serialization implementation for unix platforms

- Project page: <a href="https://github.com/reynir/ocaml-ssh-agent/">https://github.com/reynir/ocaml-ssh-agent/</a>

##### CHANGES:

* Switch fron nocrypto to mirage-crypto
