### PR TITLE
Back-port OCaml PR #9383

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/files/12ef11225a5242f41bac8b47e5e1f6b578fd6f33.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/files/12ef11225a5242f41bac8b47e5e1f6b578fd6f33.patch
@@ -1,0 +1,62 @@
+From 12ef11225a5242f41bac8b47e5e1f6b578fd6f33 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Fri, 20 Mar 2020 13:05:44 +0000
+Subject: [PATCH] Merge pull request #9383 from dra27/explicit-awk
+
+Don't assume . in AWKPATH
+
+(cherry picked from commit d4ace8c347a9a4f8baa8f0b1738a5b4436fcd027)
+---
+ stdlib/Compflags   | 2 +-
+ stdlib/Makefile    | 2 +-
+ testsuite/Makefile | 4 ++--
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/stdlib/Compflags b/stdlib/Compflags
+index 0bffcebefa4..b62e552aa6c 100755
+--- a/stdlib/Compflags
++++ b/stdlib/Compflags
+@@ -17,7 +17,7 @@
+ case $1 in
+   stdlib.cm[iox]|stdlib.p.cmx)
+       echo ' -nopervasives -no-alias-deps -w -49' \
+-           ' -pp "$AWK -f expand_module_aliases.awk"';;
++           ' -pp "$AWK -f ./expand_module_aliases.awk"';;
+   stdlib__pervasives.cm[iox]|stdlib__pervasives.p.cmx) echo ' -nopervasives';;
+   camlinternalOO.cmx|camlinternalOO.p.cmx) echo ' -inline 0';;
+   stdlib__buffer.cmx|stdlib__buffer.p.cmx) echo ' -inline 3';;
+diff --git a/stdlib/Makefile b/stdlib/Makefile
+index 4b044914da2..47618f4d45a 100644
+--- a/stdlib/Makefile
++++ b/stdlib/Makefile
+@@ -292,7 +292,7 @@ SPACE := $(EMPTY) $(EMPTY)
+ depend:
+ 	$(CAMLDEP) -slash $(filter-out stdlib.%,$(wildcard *.mli *.ml)) \
+ 	  > .depend.tmp
+-	$(CAMLDEP) -slash -pp "$(AWK) -f remove_module_aliases.awk" \
++	$(CAMLDEP) -slash -pp "$(AWK) -f ./remove_module_aliases.awk" \
+ 	  stdlib.ml stdlib.mli >> .depend.tmp
+ 	$(CAMLDEP) -slash $(filter-out stdlib.%,$(wildcard *.ml)) \
+ 	  | sed -e 's/\.cmx : /.p.cmx : /g' >>.depend.tmp
+diff --git a/testsuite/Makefile b/testsuite/Makefile
+index 7375c4676cd..d343601495a 100644
+--- a/testsuite/Makefile
++++ b/testsuite/Makefile
+@@ -269,7 +269,7 @@ clean:
+ .PHONY: report
+ report:
+ 	@if [ ! -f $(TESTLOG) ]; then echo "No $(TESTLOG) file."; exit 1; fi
+-	@awk -f makefiles/summarize.awk < $(TESTLOG)
++	@$(AWK) -f makefiles/summarize.awk < $(TESTLOG)
+ 
+ .PHONY: retry-list
+ retry-list:
+@@ -284,7 +284,7 @@ retry-list:
+ 
+ .PHONY: retries
+ retries:
+-	@awk -v retries=1 -v max_retries=$(MAX_TESTSUITE_DIR_RETRIES) \
++	@$(AWK) -v retries=1 -v max_retries=$(MAX_TESTSUITE_DIR_RETRIES) \
+ 	     -f makefiles/summarize.awk < $(TESTLOG) > _retries
+ 	@test `cat _retries | wc -l` -eq 0 || $(MAKE) $(NO_PRINT) retry-list
+ 	@rm -f _retries

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
@@ -40,3 +40,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: "12ef11225a5242f41bac8b47e5e1f6b578fd6f33.patch"
+extra-files: ["12ef11225a5242f41bac8b47e5e1f6b578fd6f33.patch" "md5=233e31d7408a860053fc09b49f0ed930"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -40,3 +40,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: "12ef11225a5242f41bac8b47e5e1f6b578fd6f33.patch"
+extra-source "12ef11225a5242f41bac8b47e5e1f6b578fd6f33.patch" {
+  src:
+    "https://github.com/ocaml/ocaml/commit/12ef11225a5242f41bac8b47e5e1f6b578fd6f33.patch"
+  checksum: "md5=34809e9ba33eba49c4a328deaffc6b40"
+}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/files/a8271945129217f3cdfca269a9a024536c008714.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/files/a8271945129217f3cdfca269a9a024536c008714.patch
@@ -1,0 +1,62 @@
+From a8271945129217f3cdfca269a9a024536c008714 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Fri, 20 Mar 2020 13:05:44 +0000
+Subject: [PATCH] Merge pull request #9383 from dra27/explicit-awk
+
+Don't assume . in AWKPATH
+
+(cherry picked from commit d4ace8c347a9a4f8baa8f0b1738a5b4436fcd027)
+---
+ stdlib/Compflags   | 2 +-
+ stdlib/Makefile    | 2 +-
+ testsuite/Makefile | 4 ++--
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/stdlib/Compflags b/stdlib/Compflags
+index 0f3138cd8f7..ad75da16795 100755
+--- a/stdlib/Compflags
++++ b/stdlib/Compflags
+@@ -17,7 +17,7 @@
+ case $1 in
+   stdlib.cm[iox]|stdlib.p.cmx)
+       echo ' -nopervasives -no-alias-deps -w -49' \
+-           ' -pp "$AWK -f expand_module_aliases.awk"';;
++           ' -pp "$AWK -f ./expand_module_aliases.awk"';;
+   camlinternalOO.cmx|camlinternalOO.p.cmx) echo ' -inline 0 -afl-inst-ratio 0';;
+   camlinternalLazy.cmx|camlinternalLazy.p.cmx) echo ' -afl-inst-ratio 0';;
+     # never instrument camlinternalOO or camlinternalLazy (PR#7725)
+diff --git a/stdlib/Makefile b/stdlib/Makefile
+index 67dc8bc4788..f158592f9f9 100644
+--- a/stdlib/Makefile
++++ b/stdlib/Makefile
+@@ -307,7 +307,7 @@ SPACE := $(EMPTY) $(EMPTY)
+ depend:
+ 	$(CAMLDEP) $(DEPFLAGS) $(filter-out stdlib.%,$(wildcard *.mli *.ml)) \
+ 	  > .depend.tmp
+-	$(CAMLDEP) $(DEPFLAGS) -pp "$(AWK) -f remove_module_aliases.awk" \
++	$(CAMLDEP) $(DEPFLAGS) -pp "$(AWK) -f ./remove_module_aliases.awk" \
+ 	  stdlib.ml stdlib.mli >> .depend.tmp
+ 	$(CAMLDEP) $(DEPFLAGS) $(filter-out stdlib.%,$(wildcard *.ml)) \
+ 	  | sed -e 's/\.cmx : /.p.cmx : /g' >>.depend.tmp
+diff --git a/testsuite/Makefile b/testsuite/Makefile
+index b383ec2308e..8263232e99f 100644
+--- a/testsuite/Makefile
++++ b/testsuite/Makefile
+@@ -287,7 +287,7 @@ clean:
+ .PHONY: report
+ report:
+ 	@if [ ! -f $(TESTLOG) ]; then echo "No $(TESTLOG) file."; exit 1; fi
+-	@awk -f makefiles/summarize.awk < $(TESTLOG)
++	@$(AWK) -f makefiles/summarize.awk < $(TESTLOG)
+ 
+ .PHONY: retry-list
+ retry-list:
+@@ -302,7 +302,7 @@ retry-list:
+ 
+ .PHONY: retries
+ retries:
+-	@awk -v retries=1 -v max_retries=$(MAX_TESTSUITE_DIR_RETRIES) \
++	@$(AWK) -v retries=1 -v max_retries=$(MAX_TESTSUITE_DIR_RETRIES) \
+ 	     -f makefiles/summarize.awk < $(TESTLOG) > _retries
+ 	@test `cat _retries | wc -l` -eq 0 || $(MAKE) $(NO_PRINT) retry-list
+ 	@rm -f _retries

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
@@ -30,7 +30,10 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"
   checksum: "md5=42ed24e9a7c0e3998cab7d5e7c9f7618"
 }
-extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+extra-files: [
+  ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+  ["a8271945129217f3cdfca269a9a024536c008714.patch" "md5=02bac10c5c44da38bc91d7744e35cedc"]
+]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
@@ -40,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: "a8271945129217f3cdfca269a9a024536c008714.patch"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/files/a8271945129217f3cdfca269a9a024536c008714.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/files/a8271945129217f3cdfca269a9a024536c008714.patch
@@ -1,0 +1,62 @@
+From a8271945129217f3cdfca269a9a024536c008714 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Fri, 20 Mar 2020 13:05:44 +0000
+Subject: [PATCH] Merge pull request #9383 from dra27/explicit-awk
+
+Don't assume . in AWKPATH
+
+(cherry picked from commit d4ace8c347a9a4f8baa8f0b1738a5b4436fcd027)
+---
+ stdlib/Compflags   | 2 +-
+ stdlib/Makefile    | 2 +-
+ testsuite/Makefile | 4 ++--
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/stdlib/Compflags b/stdlib/Compflags
+index 0f3138cd8f7..ad75da16795 100755
+--- a/stdlib/Compflags
++++ b/stdlib/Compflags
+@@ -17,7 +17,7 @@
+ case $1 in
+   stdlib.cm[iox]|stdlib.p.cmx)
+       echo ' -nopervasives -no-alias-deps -w -49' \
+-           ' -pp "$AWK -f expand_module_aliases.awk"';;
++           ' -pp "$AWK -f ./expand_module_aliases.awk"';;
+   camlinternalOO.cmx|camlinternalOO.p.cmx) echo ' -inline 0 -afl-inst-ratio 0';;
+   camlinternalLazy.cmx|camlinternalLazy.p.cmx) echo ' -afl-inst-ratio 0';;
+     # never instrument camlinternalOO or camlinternalLazy (PR#7725)
+diff --git a/stdlib/Makefile b/stdlib/Makefile
+index 67dc8bc4788..f158592f9f9 100644
+--- a/stdlib/Makefile
++++ b/stdlib/Makefile
+@@ -307,7 +307,7 @@ SPACE := $(EMPTY) $(EMPTY)
+ depend:
+ 	$(CAMLDEP) $(DEPFLAGS) $(filter-out stdlib.%,$(wildcard *.mli *.ml)) \
+ 	  > .depend.tmp
+-	$(CAMLDEP) $(DEPFLAGS) -pp "$(AWK) -f remove_module_aliases.awk" \
++	$(CAMLDEP) $(DEPFLAGS) -pp "$(AWK) -f ./remove_module_aliases.awk" \
+ 	  stdlib.ml stdlib.mli >> .depend.tmp
+ 	$(CAMLDEP) $(DEPFLAGS) $(filter-out stdlib.%,$(wildcard *.ml)) \
+ 	  | sed -e 's/\.cmx : /.p.cmx : /g' >>.depend.tmp
+diff --git a/testsuite/Makefile b/testsuite/Makefile
+index b383ec2308e..8263232e99f 100644
+--- a/testsuite/Makefile
++++ b/testsuite/Makefile
+@@ -287,7 +287,7 @@ clean:
+ .PHONY: report
+ report:
+ 	@if [ ! -f $(TESTLOG) ]; then echo "No $(TESTLOG) file."; exit 1; fi
+-	@awk -f makefiles/summarize.awk < $(TESTLOG)
++	@$(AWK) -f makefiles/summarize.awk < $(TESTLOG)
+ 
+ .PHONY: retry-list
+ retry-list:
+@@ -302,7 +302,7 @@ retry-list:
+ 
+ .PHONY: retries
+ retries:
+-	@awk -v retries=1 -v max_retries=$(MAX_TESTSUITE_DIR_RETRIES) \
++	@$(AWK) -v retries=1 -v max_retries=$(MAX_TESTSUITE_DIR_RETRIES) \
+ 	     -f makefiles/summarize.awk < $(TESTLOG) > _retries
+ 	@test `cat _retries | wc -l` -eq 0 || $(MAKE) $(NO_PRINT) retry-list
+ 	@rm -f _retries

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
@@ -30,7 +30,10 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.1.tar.gz"
   checksum: "md5=723b6bfe8cf5abcbccc6911143f71055"
 }
-extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+extra-files: [
+  ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+  ["a8271945129217f3cdfca269a9a024536c008714.patch" "md5=02bac10c5c44da38bc91d7744e35cedc"]
+]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
@@ -40,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: "a8271945129217f3cdfca269a9a024536c008714.patch"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/files/f01dbfc9cc9a489d3a5a459f082d0bb768330585.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/files/f01dbfc9cc9a489d3a5a459f082d0bb768330585.patch
@@ -1,0 +1,62 @@
+From f01dbfc9cc9a489d3a5a459f082d0bb768330585 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Fri, 20 Mar 2020 13:05:44 +0000
+Subject: [PATCH] Merge pull request #9383 from dra27/explicit-awk
+
+Don't assume . in AWKPATH
+
+(cherry picked from commit d4ace8c347a9a4f8baa8f0b1738a5b4436fcd027)
+---
+ stdlib/Compflags   | 2 +-
+ stdlib/Makefile    | 2 +-
+ testsuite/Makefile | 4 ++--
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/stdlib/Compflags b/stdlib/Compflags
+index 8aa24398214..e2262d3cb6b 100755
+--- a/stdlib/Compflags
++++ b/stdlib/Compflags
+@@ -17,7 +17,7 @@
+ case $1 in
+   stdlib.cm[iox])
+       echo ' -nopervasives -no-alias-deps -w -49' \
+-           ' -pp "$AWK -f expand_module_aliases.awk"';;
++           ' -pp "$AWK -f ./expand_module_aliases.awk"';;
+   camlinternalOO.cmx) echo ' -inline 0 -afl-inst-ratio 0';;
+   camlinternalLazy.cmx) echo ' -afl-inst-ratio 0';;
+     # never instrument camlinternalOO or camlinternalLazy (PR#7725)
+diff --git a/stdlib/Makefile b/stdlib/Makefile
+index 97135b5ac60..260ffd42ee4 100644
+--- a/stdlib/Makefile
++++ b/stdlib/Makefile
+@@ -259,7 +259,7 @@ SPACE := $(EMPTY) $(EMPTY)
+ depend:
+ 	$(CAMLDEP) $(DEPFLAGS) $(filter-out stdlib.%,$(wildcard *.mli *.ml)) \
+ 	  > .depend.tmp
+-	$(CAMLDEP) $(DEPFLAGS) -pp "$(AWK) -f remove_module_aliases.awk" \
++	$(CAMLDEP) $(DEPFLAGS) -pp "$(AWK) -f ./remove_module_aliases.awk" \
+ 	  stdlib.ml stdlib.mli >> .depend.tmp
+ 	sed -Ee \
+ 	  's#(^| )(${subst ${SPACE},|,${UNPREFIXED_OBJS}})[.]#\1stdlib__\2.#g' \
+diff --git a/testsuite/Makefile b/testsuite/Makefile
+index b383ec2308e..8263232e99f 100644
+--- a/testsuite/Makefile
++++ b/testsuite/Makefile
+@@ -287,7 +287,7 @@ clean:
+ .PHONY: report
+ report:
+ 	@if [ ! -f $(TESTLOG) ]; then echo "No $(TESTLOG) file."; exit 1; fi
+-	@awk -f makefiles/summarize.awk < $(TESTLOG)
++	@$(AWK) -f makefiles/summarize.awk < $(TESTLOG)
+ 
+ .PHONY: retry-list
+ retry-list:
+@@ -302,7 +302,7 @@ retry-list:
+ 
+ .PHONY: retries
+ retries:
+-	@awk -v retries=1 -v max_retries=$(MAX_TESTSUITE_DIR_RETRIES) \
++	@$(AWK) -v retries=1 -v max_retries=$(MAX_TESTSUITE_DIR_RETRIES) \
+ 	     -f makefiles/summarize.awk < $(TESTLOG) > _retries
+ 	@test `cat _retries | wc -l` -eq 0 || $(MAKE) $(NO_PRINT) retry-list
+ 	@rm -f _retries

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
@@ -30,7 +30,10 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.0.tar.gz"
   checksum: "md5=76ac39570fc88b16fda2a94db7cd5cf3"
 }
-extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+extra-files: [
+  ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+  ["f01dbfc9cc9a489d3a5a459f082d0bb768330585.patch" "md5=715b58d136b51e925533c0e21cc64792"]
+]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
@@ -40,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: "f01dbfc9cc9a489d3a5a459f082d0bb768330585.patch"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.1/opam
@@ -40,3 +40,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: "f01dbfc9cc9a489d3a5a459f082d0bb768330585.patch"
+extra-source "f01dbfc9cc9a489d3a5a459f082d0bb768330585.patch" {
+  src:
+    "https://github.com/ocaml/ocaml/commit/f01dbfc9cc9a489d3a5a459f082d0bb768330585.patch"
+  checksum: "md5=5ee72e0729f72cb7b38109e5cd5b85b6"
+}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.0/opam
@@ -40,3 +40,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: "0756052841d0d3e6266c8c1ca4a608dc16c11441.patch"
+extra-source "0756052841d0d3e6266c8c1ca4a608dc16c11441.patch" {
+  src:
+    "https://github.com/ocaml/ocaml/commit/0756052841d0d3e6266c8c1ca4a608dc16c11441.patch"
+  checksum: "md5=17950de108b125572684999f0ff8f57b"
+}


### PR DESCRIPTION
This back-ports https://github.com/ocaml/ocaml/pull/9383 to `ocaml-base-compiler` 4.07.0-4.10.0 inclusive. I haven't done anything with `ocaml-variants`, but of course anyone else would be welcome to apply the same pattern to packages there, if needed.

This patch hardens the use of awk in OCaml's build system so that it is no longer affected by the user's  `AWKPATH`

I have tested each of the packages which are updated here, so it may be wise to terminate the CI run!

cc @nobrowser