### PR TITLE
3 packages from Risto-Stevcev/lambda-streams at 0.1.2

### DIFF
--- a/packages/lambda_streams_async/lambda_streams_async.0.1.2/opam
+++ b/packages/lambda_streams_async/lambda_streams_async.0.1.2/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
-synopsis: "Lambda-based streaming library"
-description: "A simple and principled streaming library based on lambdas"
+synopsis: "Async helpers for lambda_streams"
 maintainer: ["me@risto.codes"]
 authors: ["Risto Stevcev"]
 license: "BSD-3-Clause"
@@ -8,11 +7,14 @@ homepage: "https://github.com/Risto-Stevcev/lambda-streams"
 doc: "https://risto-stevcev.github.io/lambda-streams"
 bug-reports: "https://github.com/Risto-Stevcev/lambda-streams/issues"
 depends: [
-  "ocaml" {>= "4.06.1"}
+  "ocaml" {>= "4.07"}
+  "lambda_streams" {= version}
   "alcotest" {>= "1.0.1" & with-test}
-  "fmt" {>= "0.8.8" & with-test}
-  "mdx" {>= "1.6.0" & with-test}
-  "odoc" {>= "1.5.0" & with-doc}
+  "alcotest-async" {>= "1.0.1" & with-test}
+  "async" {>= "v0.12.0"}
+  "async_kernel" {>= "v0.12.0"}
+  "async_unix" {>= "v0.12.0"}
+  "core" {>= "v0.12.0"}
   "dune" {>= "2.2.0"}
 ]
 build: [

--- a/packages/lambda_streams_lwt/lambda_streams_lwt.0.1.2/opam
+++ b/packages/lambda_streams_lwt/lambda_streams_lwt.0.1.2/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
-synopsis: "Lambda-based streaming library"
-description: "A simple and principled streaming library based on lambdas"
+synopsis: "Lwt helpers for lambda_streams"
 maintainer: ["me@risto.codes"]
 authors: ["Risto Stevcev"]
 license: "BSD-3-Clause"
@@ -9,10 +8,10 @@ doc: "https://risto-stevcev.github.io/lambda-streams"
 bug-reports: "https://github.com/Risto-Stevcev/lambda-streams/issues"
 depends: [
   "ocaml" {>= "4.06.1"}
-  "alcotest" {>= "1.0.1" & with-test}
-  "fmt" {>= "0.8.8" & with-test}
-  "mdx" {>= "1.6.0" & with-test}
-  "odoc" {>= "1.5.0" & with-doc}
+  "lambda_streams" {= version}
+  "alcotest" {= "1.0.1" & with-test}
+  "alcotest-lwt" {= "1.0.1" & with-test}
+  "lwt" {>= "5.2.0"}
   "dune" {>= "2.2.0"}
 ]
 build: [


### PR DESCRIPTION
This pull-request concerns:
-`lambda_streams.0.1.2`: Lambda-based streaming library
-`lambda_streams_async.0.1.2`: Async helpers for lambda_streams
-`lambda_streams_lwt.0.1.2`: Lwt helpers for lambda_streams



---
* Homepage: https://github.com/Risto-Stevcev/lambda-streams
* Source repo: git+https://github.com/Risto-Stevcev/lambda-streams.git
* Bug tracker: https://github.com/Risto-Stevcev/lambda-streams/issues

---
:camel: Pull-request generated by opam-publish v2.0.2