### PR TITLE
[new release] routes (0.7.0)

### DIFF
--- a/packages/routes/routes.0.7.0/opam
+++ b/packages/routes/routes.0.7.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Typed routing for OCaml applications"
+description: """
+routes provides combinators for adding typed routing
+to OCaml applications. The core library will be independent
+of any particular web framework or runtime. It does
+path based dispatch from a target url to a user
+provided handler.
+"""
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni <anurag@sonianurag.com>"]
+license: "BSD-3-clause"
+tags: ["router" "http"]
+homepage: "https://github.com/anuragsoni/routes"
+doc: "https://anuragsoni.github.io/routes/"
+bug-reports: "https://github.com/anuragsoni/routes/issues"
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "dune" {>= "2.1"}
+  "alcotest" {with-test}
+  "mdx" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/routes.git"
+url {
+  src:
+    "https://github.com/anuragsoni/routes/releases/download/0.7.0/routes-0.7.0.tbz"
+  checksum: [
+    "sha256=0b67b3837302ccea4c0d42e463f2edbde6408d651b5e65e74cd694656d44f0be"
+    "sha512=775b7037cda4f784b31942df2c96787f64c56ab95d9399ac6a59426958abb19b830e974daeae6a4e53c6d04f5f6673006af5e7cefd4db5a27b2bf66ce2ac17d6"
+  ]
+}


### PR DESCRIPTION
Typed routing for OCaml applications

- Project page: <a href="https://github.com/anuragsoni/routes">https://github.com/anuragsoni/routes</a>
- Documentation: <a href="https://anuragsoni.github.io/routes/">https://anuragsoni.github.io/routes/</a>

##### CHANGES:

This is a breaking release:

* Reduce the number of combinators to two. '/' and '/?' (anuragsoni/routes#80)
* Routes are now bi-directional. They can be used for matching, and for printing via a sprintf style function (anuragsoni/routes#80)
* Its now possible to configure trailing slash on individual routes (anuragsoni/routes#89)
* Remove HTTP method handling (anuragsoni/routes#92)
* dune version needs to be >= 2.1
