### PR TITLE
Package bastet.1.1.0

### DIFF
--- a/packages/bastet/bastet.1.1.0/opam
+++ b/packages/bastet/bastet.1.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A ReasonML/Ocaml library for category theory and abstract algebra"
+maintainer: ["me@risto.codes"]
+authors: ["Risto Stevcev"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/Risto-Stevcev/bastet"
+bug-reports: "https://github.com/Risto-Stevcev/bastet/issues"
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "reason" {>= "3.6.0"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "qcheck" {>= "0.13" & with-test}
+  "qcheck-alcotest" {>= "0.13" & with-test}
+  "ocamlformat" {>= "0.13.0" & with-test}
+  "mdx" {>= "1.6.0" & with-test}
+  "odoc" {>= "1.5.0" & with-doc}
+  "mustache" {>= "3.1.0" & with-doc}
+  "dune" {>= "2.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Risto-Stevcev/bastet.git"
+url {
+  src: "https://github.com/Risto-Stevcev/bastet/archive/1.1.0.tar.gz"
+  checksum: [
+    "md5=22dabc44a034fcacb895e4b6a38f1e92"
+    "sha512=9c46e605c2f86da8e8a5ee4bb3bc0751d29385130dd821f427d87d272e81e66fec1f31392c84d57d98a51c91a398e87873fc05b5c71850c0d899aa1eb5534d47"
+  ]
+}

--- a/packages/bastet/bastet.1.1.0/opam
+++ b/packages/bastet/bastet.1.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "A ReasonML/Ocaml library for category theory and abstract algebra"
+synopsis: "A ReasonML/OCaml library for category theory and abstract algebra"
 maintainer: ["me@risto.codes"]
 authors: ["Risto Stevcev"]
 license: "BSD-3-Clause"


### PR DESCRIPTION
### `bastet.1.1.0`
A ReasonML/Ocaml library for category theory and abstract algebra



---
* Homepage: https://github.com/Risto-Stevcev/bastet
* Source repo: git+https://github.com/Risto-Stevcev/bastet.git
* Bug tracker: https://github.com/Risto-Stevcev/bastet/issues

---
:camel: Pull-request generated by opam-publish v2.0.2