### PR TITLE
Package bastet.1.2.0

### DIFF
--- a/packages/bastet/bastet.1.2.0/opam
+++ b/packages/bastet/bastet.1.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A ReasonML/OCaml library for category theory and abstract algebra"
+maintainer: ["me@risto.codes"]
+authors: ["Risto Stevcev"]
+license: "BSD-3-Clause"
+tags: ["category theory" "abstract algebra" "algebra" "cats"]
+homepage: "https://github.com/Risto-Stevcev/bastet"
+doc: "https://risto-stevcev.github.io/bastet"
+bug-reports: "https://github.com/Risto-Stevcev/bastet/issues"
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "reason" {>= "3.6.0"}
+  "stdlib-shims" {>= "0.1.0"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "qcheck" {>= "0.13" & with-test}
+  "qcheck-alcotest" {>= "0.13" & with-test}
+  "ocamlformat" {>= "0.13.0" & with-test}
+  "mdx" {>= "1.6.0" & with-test}
+  "bisect_ppx" {>= "2.1.0" & with-test}
+  "odoc" {>= "1.5.0" & with-doc}
+  "mustache" {>= "3.1.0" & with-doc}
+  "dune" {>= "2.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Risto-Stevcev/bastet.git"
+url {
+  src: "https://github.com/Risto-Stevcev/bastet/archive/1.2.0.tar.gz"
+  checksum: [
+    "md5=be0d938775cfbb86c799b643872bf909"
+    "sha512=02bf2811f37a83e43484eb2394ff17eb44b388c0f2b97cab45a8c61302ee492a56fec0ae125e236bd76315f7fb8364467a12ce5fb9277ce0f9f7d26412f31fdd"
+  ]
+}


### PR DESCRIPTION
### `bastet.1.2.0`
A ReasonML/OCaml library for category theory and abstract algebra



---
* Homepage: https://github.com/Risto-Stevcev/bastet
* Source repo: git+https://github.com/Risto-Stevcev/bastet.git
* Bug tracker: https://github.com/Risto-Stevcev/bastet/issues

---
:camel: Pull-request generated by opam-publish v2.0.2