### PR TITLE
[new release] routes (0.7.1)

### DIFF
--- a/packages/routes/routes.0.7.1/opam
+++ b/packages/routes/routes.0.7.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni <anurag@sonianurag.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anuragsoni/routes"
+bug-reports: "https://github.com/anuragsoni/routes/issues"
+dev-repo: "git+https://github.com/anuragsoni/routes.git"
+doc: "https://anuragsoni.github.io/routes/"
+tags: ["router" "http"]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune"
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Typed routing for OCaml applications"
+description: """
+routes provides combinators for adding typed routing
+to OCaml applications. The core library will be independent
+of any particular web framework or runtime. It does
+path based dispatch from a target url to a user
+provided handler.
+"""
+url {
+  src:
+    "https://github.com/anuragsoni/routes/releases/download/0.7.1/routes-0.7.1.tbz"
+  checksum: [
+    "sha256=96c738fe243a23c2ed5a5dd079a477a25ae515c225dd78b804200acb3795ae05"
+    "sha512=22030f4cc85c0306b4eb412f9f973e85c6985685d800107ce5013b134c95ee6f85f832b142510242e3324fccb63da51d5a6b411a78ee3f0d828001a7230bd9bb"
+  ]
+}


### PR DESCRIPTION
Typed routing for OCaml applications

- Project page: <a href="https://github.com/anuragsoni/routes">https://github.com/anuragsoni/routes</a>
- Documentation: <a href="https://anuragsoni.github.io/routes/">https://anuragsoni.github.io/routes/</a>

##### CHANGES:

* Use bisect_ppx to generate coverage reports (anuragsoni/routes#95)
* Lower version constraint for dune and ocaml. Minimum versions needed are now dune 1.0 and OCaml 4.05.0 (anuragsoni/routes#99, anuragsoni/routes#100)
