### PR TITLE
Fix release version constraint on irmin-git

### DIFF
--- a/packages/irmin-git/irmin-git.2.0.0/opam
+++ b/packages/irmin-git/irmin-git.2.0.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"      {>= "4.02.3"}
   "dune"       {>= "1.1.0"}
-  "irmin"      {= version}
+  "irmin"      {>= "2.0.0"}
   "git"        {>= "2.1.1"}
   "digestif"   {>= "0.7.3"}
   "irmin-test" {with-test & >= "2.0.0"}


### PR DESCRIPTION
`irmin-git.2.0.0` is also compatible with `irmin.2.1.0`