### PR TITLE
Package otfm.0.4.0

### DIFF
--- a/packages/otfm/otfm.0.4.0/opam
+++ b/packages/otfm/otfm.0.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "https://erratique.ch/software/otfm"
+authors: ["The otfm programmers"]
+doc: "https://erratique.ch/software/otfm/doc"
+dev-repo: "git+https://erratique.ch/repos/otfm.git"
+bug-reports: "https://github.com/dbuenzli/otfm/issues"
+tags: [ "OpenType" "ttf" "font" "decoder" "graphics" "org:erratique" ]
+license: "ISC"
+depends: [
+ "ocaml" {>= "4.05.0"}
+ "ocamlfind" {build}
+ "ocamlbuild" {build}
+ "topkg" {build}
+ "uutf" {>= "1.0.0"}
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]]
+synopsis: """OpenType font decoder for OCaml"""
+description: """\
+
+Otfm is an in-memory decoder for the OpenType font data format. It
+provides low-level access to font tables and functions to decode some
+of them.
+
+Otfm is made of a single module and depends on [Uutf][uutf]. It is distributed 
+under the ISC license.
+
+[uutf]: http://erratique.ch/software/uutf
+     """
+url {
+archive: "https://erratique.ch/software/otfm/releases/otfm-0.4.0.tbz"
+checksum: "6b3a04945a4c536191c479ea51652152"
+}


### PR DESCRIPTION
### `otfm.0.4.0`
OpenType font decoder for OCaml
Otfm is an in-memory decoder for the OpenType font data format. It
provides low-level access to font tables and functions to decode some
of them.

Otfm is made of a single module and depends on [Uutf][uutf]. It is distributed 
under the ISC license.

[uutf]: http://erratique.ch/software/uutf



---
* Homepage: https://erratique.ch/software/otfm
* Source repo: git+https://erratique.ch/repos/otfm.git
* Bug tracker: https://github.com/dbuenzli/otfm/issues

---
v0.4.0 2020-03-23 Concise
-------------------------

- Fix decoding of `kern` table. Thanks to Philippe Veber for the patch (#4).
- Fix decoding of language tag records in `name` tables with
  format 1. Thanks to Philippe Veber for the report. (#3).
- Require OCaml >= 4.05.0

---
:camel: Pull-request generated by opam-publish v2.0.2