### PR TITLE
[new release] routes (0.7.2)

### DIFF
--- a/packages/routes/routes.0.7.2/opam
+++ b/packages/routes/routes.0.7.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni <anurag@sonianurag.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anuragsoni/routes"
+bug-reports: "https://github.com/anuragsoni/routes/issues"
+dev-repo: "git+https://github.com/anuragsoni/routes.git"
+doc: "https://anuragsoni.github.io/routes/"
+tags: ["router" "http"]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune"
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Typed routing for OCaml applications"
+description: """
+routes provides combinators for adding typed routing
+to OCaml applications. The core library will be independent
+of any particular web framework or runtime. It does
+path based dispatch from a target url to a user
+provided handler.
+"""
+url {
+  src:
+    "https://github.com/anuragsoni/routes/releases/download/0.7.2/routes-0.7.2.tbz"
+  checksum: [
+    "sha256=ff8f47367ea43879dca1f297944aeea049e31804838b41d5d01cb34b184417a2"
+    "sha512=dfa07568ba424c043a5cf9d9dc30b4e78f8f8f4549bcde082b8d5cf33885d93ab443eaefb9127b50b33e3a521dad37e2f38f5c9663fe58c6115013ca32c22f5c"
+  ]
+}


### PR DESCRIPTION
Typed routing for OCaml applications

- Project page: <a href="https://github.com/anuragsoni/routes">https://github.com/anuragsoni/routes</a>
- Documentation: <a href="https://anuragsoni.github.io/routes/">https://anuragsoni.github.io/routes/</a>

##### CHANGES:

* Use bisect_ppx to generate coverage reports (anuragsoni/routes#95)
* Lower version constraint for dune and ocaml. Minimum versions needed are now dune 1.0 and OCaml 4.05.0 (anuragsoni/routes#99, anuragsoni/routes#100)
