### PR TITLE
[new release] ppx_blob (0.7.0)

### DIFF
--- a/packages/ppx_blob/ppx_blob.0.7.0/opam
+++ b/packages/ppx_blob/ppx_blob.0.7.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: "John Whitington"
+maintainer: "contact@coherentgraphics.co.uk"
+homepage: "https://github.com/johnwhitington/ppx_blob"
+dev-repo: "git+https://github.com/johnwhitington/ppx_blob.git"
+bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
+doc: "https://johnwhitington.github.io/ppx_blob/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune"
+  "ocaml-migrate-parsetree"
+  "alcotest" {with-test}
+]
+synopsis: "Include a file as a string at compile time"
+description:
+  "ppx_blob allows you to include a binary blob from a file as a string. Writing `[%blob \"filename\"]` will replace the string with the contents of the file at compile time. This allows the inclusion of arbitary, possibly compressed, data, without the need to respect OCaml's lexical conventions."
+url {
+  src:
+    "https://github.com/johnwhitington/ppx_blob/releases/download/0.7.0/ppx_blob-0.7.0.tbz"
+  checksum: [
+    "sha256=ac8a35f7966f7a8b7cf5d2ecde8ca6bfb3e98e420ee55ad066311b2861d31c65"
+    "sha512=6fb3e272540d790cd26d73f531c6dc2118e800f50aa85def5e2e9bf71e06a3b92ea0b0c77210e4d69e2e21acfca5707ccde5d5d5f609819299df54253bef60db"
+  ]
+}


### PR DESCRIPTION
Include a file as a string at compile time

- Project page: <a href="https://github.com/johnwhitington/ppx_blob">https://github.com/johnwhitington/ppx_blob</a>
- Documentation: <a href="https://johnwhitington.github.io/ppx_blob/">https://johnwhitington.github.io/ppx_blob/</a>

##### CHANGES:

Use `Ast_408` from ocaml-migrate-parsetree for compatibility with new OCaml syntax (johnwhitington/ppx_blob#17).
