### PR TITLE
Package bastet.1.2.4

### DIFF
--- a/packages/bastet/bastet.1.2.4/opam
+++ b/packages/bastet/bastet.1.2.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A ReasonML/OCaml library for category theory and abstract algebra"
+maintainer: ["me@risto.codes"]
+authors: ["Risto Stevcev"]
+license: "BSD-3-Clause"
+tags: ["category theory" "abstract algebra" "algebra" "cats"]
+homepage: "https://github.com/Risto-Stevcev/bastet"
+doc: "https://risto-stevcev.github.io/bastet"
+bug-reports: "https://github.com/Risto-Stevcev/bastet/issues"
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "reason" {>= "3.6.0"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "qcheck" {>= "0.13" & with-test}
+  "qcheck-alcotest" {>= "0.13" & with-test}
+  "merlin" {>= "3.3.3" & with-test}
+  "ocamlformat" {>= "0.13.0" & with-test}
+  "mdx" {>= "1.6.0" & with-test}
+  "bisect_ppx" {>= "2.1.0" & with-test}
+  "odoc" {>= "1.5.0" & with-doc}
+  "mustache" {>= "3.1.0" & with-doc}
+  "dune" {>= "2.0.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Risto-Stevcev/bastet.git"
+url {
+  src: "https://github.com/Risto-Stevcev/bastet/archive/1.2.4.tar.gz"
+  checksum: [
+    "md5=a17bd129257d522a4ea8161d9a5e4268"
+    "sha512=40b9f31bc272c7fd273c7aa20152caeaff055f96b7f09a7f6c65d042c9426c56267f711ed3c0276b3728f6154ae4713c32f49827bc05479202db76ae8ba8d9dc"
+  ]
+}


### PR DESCRIPTION
### `bastet.1.2.4`
A ReasonML/OCaml library for category theory and abstract algebra



---
* Homepage: https://github.com/Risto-Stevcev/bastet
* Source repo: git+https://github.com/Risto-Stevcev/bastet.git
* Bug tracker: https://github.com/Risto-Stevcev/bastet/issues

---
:camel: Pull-request generated by opam-publish v2.0.2