### PR TITLE
[new release] opium_kernel and opium (0.18.0)

### DIFF
--- a/packages/opium/opium.0.17.0/opam
+++ b/packages/opium/opium.0.17.0/opam
@@ -24,7 +24,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune"
-  "opium_kernel"
+  "opium_kernel" { < "0.18.0" }
   "cohttp-lwt-unix" {>= "0.99.0"}
   "base-unix"
   "lwt"

--- a/packages/opium/opium.0.17.1/opam
+++ b/packages/opium/opium.0.17.1/opam
@@ -25,7 +25,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune"
-  "opium_kernel"
+  "opium_kernel" { < "0.18.0" }
   "cohttp-lwt-unix" {>= "0.99.0"}
   "base-unix"
   "lwt"

--- a/packages/opium/opium.0.18.0/opam
+++ b/packages/opium/opium.0.18.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Sinatra like web toolkit based on Lwt + Cohttp"
+description: """
+Opium is a minimalistic library for quickly binding functions to http routes. Its features include (but not limited to):
+
+    Middleware system for app independent components
+    A simple router for matching urls and parsing parameters
+    Request/Response pretty printing for easier debugging
+  """
+maintainer: ["Rudi Grinberg <rudi.grinberg@gmail>"]
+authors: ["Rudi Grinberg"]
+license: "MIT"
+homepage: "https://github.com/rgrinberg/opium"
+doc: "https://rgrinberg.github.io/opium/"
+bug-reports: "https://github.com/rgrinberg/opium/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.11"}
+  "opium_kernel"
+  "cohttp-lwt-unix"
+  "ezjsonm"
+  "lwt"
+  "logs"
+  "cmdliner"
+  "ppx_fields_conv"
+  "ppx_sexp_conv"
+  "re"
+  "magic-mime"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rgrinberg/opium.git"
+url {
+  src:
+    "https://github.com/rgrinberg/opium/releases/download/0.18.0/opium-0.18.0.tbz"
+  checksum: [
+    "sha256=f80ccf9c36665c2db240482eeb0cc968a9e66ad2b7a811298658df52f84b5e28"
+    "sha512=345585719e58b8a08b45244123f03e094a9c67ad8c2ee903dac4d8b646703cfea74ab87a82f43cf6113ad394c296bddb4bb5fbd910ed8511693b5ec6867baece"
+  ]
+}

--- a/packages/opium_kernel/opium_kernel.0.18.0/opam
+++ b/packages/opium_kernel/opium_kernel.0.18.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Sinatra like web toolkit based on Lwt + Cohttp"
+description:
+  "Opium_kernel is the Unix indpendent core of Opium. Useful for extremely portable environments such as mirage."
+maintainer: ["Rudi Grinberg <rudi.grinberg@gmail>"]
+authors: ["Rudi Grinberg"]
+license: "MIT"
+homepage: "https://github.com/rgrinberg/opium"
+doc: "https://rgrinberg.github.io/opium/"
+bug-reports: "https://github.com/rgrinberg/opium/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.11"}
+  "hmap"
+  "cohttp"
+  "cohttp-lwt"
+  "lwt"
+  "fieldslib"
+  "sexplib"
+  "ppx_fields_conv"
+  "ppx_sexp_conv"
+  "re"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rgrinberg/opium.git"
+url {
+  src:
+    "https://github.com/rgrinberg/opium/releases/download/0.18.0/opium-0.18.0.tbz"
+  checksum: [
+    "sha256=f80ccf9c36665c2db240482eeb0cc968a9e66ad2b7a811298658df52f84b5e28"
+    "sha512=345585719e58b8a08b45244123f03e094a9c67ad8c2ee903dac4d8b646703cfea74ab87a82f43cf6113ad394c296bddb4bb5fbd910ed8511693b5ec6867baece"
+  ]
+}


### PR DESCRIPTION
Sinatra like web toolkit based on Lwt + Cohttp

- Project page: <a href="https://github.com/rgrinberg/opium">https://github.com/rgrinberg/opium</a>
- Documentation: <a href="https://rgrinberg.github.io/opium/">https://rgrinberg.github.io/opium/</a>

##### CHANGES:

* Make examples easier to find and add documentation related to features used in them. (rgrinberg/opium#125, @shonfeder)
* Allow overriding 404 handlers (rgrinberg/opium#127, @anuragsoni)
* Support cohttp streaming response (rgrinberg/opium#135, rgrinberg/opium#137, rgrinberg/opium#139, @anuragsoni)
