### PR TITLE
Package bastet.1.2.5

### DIFF
--- a/packages/bastet/bastet.1.2.5/opam
+++ b/packages/bastet/bastet.1.2.5/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A ReasonML/OCaml library for category theory and abstract algebra"
+maintainer: ["me@risto.codes"]
+authors: ["Risto Stevcev"]
+license: "BSD-3-Clause"
+tags: ["category theory" "abstract algebra" "algebra" "cats"]
+homepage: "https://github.com/Risto-Stevcev/bastet"
+doc: "https://risto-stevcev.github.io/bastet"
+bug-reports: "https://github.com/Risto-Stevcev/bastet/issues"
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "reason" {>= "3.6.0"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "qcheck" {>= "0.13" & with-test}
+  "qcheck-alcotest" {>= "0.13" & with-test}
+  "merlin" {>= "3.3.3" & with-test}
+  "ocamlformat" {>= "0.13.0" & with-test}
+  "mdx" {>= "1.6.0" & with-test}
+  "bisect_ppx" {>= "2.1.0" & with-test}
+  "odoc" {>= "1.5.0" & with-doc}
+  "mustache" {>= "3.1.0" & with-doc}
+  "dune" {>= "2.0.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Risto-Stevcev/bastet.git"
+url {
+  src: "https://github.com/Risto-Stevcev/bastet/archive/1.2.5.tar.gz"
+  checksum: [
+    "md5=0f5f123f9405e3fa9e64a1726d6d739b"
+    "sha512=f26be7f98ed94b3a224dffc3970bdd0a1efb6e66ac2627eae2c1bba765da2e9a730df042fa8b30d9ff827db52cb9c9dc6f561af3f0e5d7ce93b624fd2bada6de"
+  ]
+}


### PR DESCRIPTION
### `bastet.1.2.5`
A ReasonML/OCaml library for category theory and abstract algebra



---
* Homepage: https://github.com/Risto-Stevcev/bastet
* Source repo: git+https://github.com/Risto-Stevcev/bastet.git
* Bug tracker: https://github.com/Risto-Stevcev/bastet/issues

---
:camel: Pull-request generated by opam-publish v2.0.2