### PR TITLE
ocaml-variants.4.10.0+default-unsafe-string: disable force-safe-string

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.10.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+default-unsafe-string/opam
@@ -16,11 +16,16 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "DEFAULT_STRING=unsafe"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "DEFAULT_STRING=unsafe"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
     "CC=cc"
     "ASPP=cc -c"
     "DEFAULT_STRING=unsafe"


### PR DESCRIPTION
Before:
```
$ opam sw show
4.10.0+default-unsafe-string

$ ocamlc -v
The OCaml compiler, version 4.10.0
Standard library directory: /home/ygrek/.opam/4.10.0+default-unsafe-string/lib/ocaml

$ ocaml
        OCaml version 4.10.0

# String.set "dsasd";;
Alert deprecated: Stdlib.String.set
Use Bytes.set instead.
Error: This expression has type string but an expression was expected of type
         bytes
```

After:
string type is equal to bytes as expected
