### PR TITLE
[new release] ocaml-print-intf (1.1.0)

### DIFF
--- a/packages/ocaml-print-intf/ocaml-print-intf.1.1.0/opam
+++ b/packages/ocaml-print-intf/ocaml-print-intf.1.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Display human-readable OCaml interface from a compiled .cmi"
+description: """
+This tool parses a compiled .cmi interface file and outputs
+the corresponding textual .mli file.  This can be useful to quickly generate
+a skeleton interface file to then annotate with comments or add abstraction."""
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Nathan Rebours"]
+license: "ISC"
+homepage: "https://github.com/avsm/ocaml-print-intf"
+doc: "https://avsm.github.io/ocaml-print-intf/"
+bug-reports: "https://github.com/avsm/ocaml-print-intf/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03"}
+  "dune-build-info"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-print-intf.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-print-intf/releases/download/v1.1.0/ocaml-print-intf-v1.1.0.tbz"
+  checksum: [
+    "sha256=636e16fce81fb843fb6ca7b26033f62b55c451d93078671e921a52f8b0d1f9f8"
+    "sha512=e6c38852e689cfadd9dbc107ec462b70579c356bfcc6ea36d40642fbd805348ea4ffe23d905bf171f80996171f937b62010b764f2659cb6376da591bde6a8575"
+  ]
+}


### PR DESCRIPTION
Display human-readable OCaml interface from a compiled .cmi

- Project page: <a href="https://github.com/avsm/ocaml-print-intf">https://github.com/avsm/ocaml-print-intf</a>
- Documentation: <a href="https://avsm.github.io/ocaml-print-intf/">https://avsm.github.io/ocaml-print-intf/</a>

##### CHANGES:

- Add support for passing `.ml` input files as a shortcut for building the `.cmi`
  (using dune) and calling `ocaml-print-intf` on the resulting file. (avsm/ocaml-print-intf#1, @NathanReb)
