### PR TITLE
Package bastet_lwt.0.1.0

### DIFF
--- a/packages/bastet_lwt/bastet_lwt.0.1.0/opam
+++ b/packages/bastet_lwt/bastet_lwt.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Lwt implementations for bastet"
+maintainer: ["me@risto.codes"]
+authors: ["Risto Stevcev"]
+license: "BSD-3-Clause"
+tags: ["category theory" "abstract algebra" "algebra" "cats" "lwt"]
+homepage: "https://github.com/Risto-Stevcev/bastet-lwt"
+doc: "https://risto-stevcev.github.io/bastet-lwt"
+bug-reports: "https://github.com/Risto-Stevcev/bastet-lwt/issues"
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "bastet" {>= "1.2.4"}
+  "lwt" {>= "5.2.0"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "alcotest-lwt" {= "1.0.1" & with-test}
+  "merlin" {>= "3.3.3" & with-test}
+  "ocamlformat" {>= "0.13.0" & with-test}
+  "mdx" {>= "1.6.0" & with-test}
+  "odoc" {>= "1.5.0" & with-doc}
+  "dune" {>= "2.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Risto-Stevcev/bastet-lwt.git"
+url {
+  src: "https://github.com/Risto-Stevcev/bastet-lwt/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=3310f6adf0d2e47dcf850e1809d7356a"
+    "sha512=3f349a6fcd50d74ccdcc18efc2c226b81e6cd4ebdc097b8b511cc782ab03017ab93f633a4e3b20da8a1389487247ac6daa97c53cc9699e4e710df839391923dd"
+  ]
+}


### PR DESCRIPTION
### `bastet_lwt.0.1.0`
Lwt implementations for bastet



---
* Homepage: https://github.com/Risto-Stevcev/bastet-lwt
* Source repo: git+https://github.com/Risto-Stevcev/bastet-lwt.git
* Bug tracker: https://github.com/Risto-Stevcev/bastet-lwt/issues

---
:camel: Pull-request generated by opam-publish v2.0.2