### PR TITLE
Package bastet_async.0.1.0

### DIFF
--- a/packages/bastet_async/bastet_async.0.1.0/opam
+++ b/packages/bastet_async/bastet_async.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Async implementations for bastet"
+maintainer: ["me@risto.codes"]
+authors: ["Risto Stevcev"]
+license: "BSD-3-Clause"
+tags: ["category theory" "abstract algebra" "algebra" "cats" "async"]
+homepage: "https://github.com/Risto-Stevcev/bastet-async"
+doc: "https://risto-stevcev.github.io/bastet-async"
+bug-reports: "https://github.com/Risto-Stevcev/bastet-async/issues"
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "bastet" {>= "1.2.5"}
+  "async_kernel" {>= "v0.12.0"}
+  "async_unix" {>= "v0.12.0" & with-test}
+  "core" {>= "v0.12.0" & with-test}
+  "alcotest" {>= "1.0.1" & with-test}
+  "alcotest-async" {>= "1.0.1" & with-test}
+  "mdx" {>= "1.6.0" & with-test}
+  "odoc" {>= "1.5.0" & with-doc}
+  "dune" {>= "2.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Risto-Stevcev/bastet-async.git"
+url {
+  src: "https://github.com/Risto-Stevcev/bastet-async/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=e15663969dac6d7013205e2c5750fd21"
+    "sha512=4dd0476f5285fed7dc570625b3fddf9546866f488ab4cd6933e9f9cc3c9947d84dba9d18bab71fd65aed0dc8826e01fa2e04291c53ece6a31c0e887e0e18439e"
+  ]
+}


### PR DESCRIPTION
### `bastet_async.0.1.0`
Async implementations for bastet



---
* Homepage: https://github.com/Risto-Stevcev/bastet-async
* Source repo: git+https://github.com/Risto-Stevcev/bastet-async.git
* Bug tracker: https://github.com/Risto-Stevcev/bastet-async/issues

---
:camel: Pull-request generated by opam-publish v2.0.2