### PR TITLE
Package bastet_lwt.0.1.0

### DIFF
--- a/packages/bastet_lwt/bastet_lwt.0.1.0/opam
+++ b/packages/bastet_lwt/bastet_lwt.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Lwt implementations for bastet"
+maintainer: ["me@risto.codes"]
+authors: ["Risto Stevcev"]
+license: "BSD-3-Clause"
+tags: ["category theory" "abstract algebra" "algebra" "cats" "lwt"]
+homepage: "https://github.com/Risto-Stevcev/bastet-lwt"
+doc: "https://risto-stevcev.github.io/bastet-lwt"
+bug-reports: "https://github.com/Risto-Stevcev/bastet-lwt/issues"
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "bastet" {>= "1.2.5"}
+  "lwt" {>= "5.2.0"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "alcotest-lwt" {= "1.0.1" & with-test}
+  "mdx" {>= "1.6.0" & with-test}
+  "odoc" {>= "1.5.0" & with-doc}
+  "dune" {>= "2.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Risto-Stevcev/bastet-lwt.git"
+url {
+  src: "https://github.com/Risto-Stevcev/bastet-lwt/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=4aef3007a0050ca5ec7de2a5cd91f9ee"
+    "sha512=f749201895759847acae88ae215668a704b91babe28555763ae6003725b730ba5031639348527eccf31610ee9e214b2270e72aeca1ce4987bd2a629b497296f4"
+  ]
+}


### PR DESCRIPTION
### `bastet_lwt.0.1.0`
Lwt implementations for bastet



---
* Homepage: https://github.com/Risto-Stevcev/bastet-lwt
* Source repo: git+https://github.com/Risto-Stevcev/bastet-lwt.git
* Bug tracker: https://github.com/Risto-Stevcev/bastet-lwt/issues

---
:camel: Pull-request generated by opam-publish v2.0.2