### PR TITLE
Bisect_ppx 2.2.0 - code coverage for OCaml

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.2.2.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.2.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+
+synopsis: "Code coverage for OCaml"
+version: "2.2.0"
+license: "MIT"
+homepage: "https://github.com/aantron/bisect_ppx"
+doc: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+
+dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+
+depends: [
+  "base-unix"
+  "cmdliner" {>= "1.0.0"}
+  "dune"
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ppx_tools_versioned" {>= "5.3.0"}
+
+  "ocamlfind" {with-test}
+  "ounit2" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+post-messages: [
+  "Bisect_ppx 2.0.0 has deprecated some command-line options. See
+  https://github.com/aantron/bisect_ppx/releases/tag/2.0.0"
+]
+
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+url {
+  src: "https://github.com/aantron/bisect_ppx/archive/2.2.0.tar.gz"
+  checksum: "md5=b95bf21859fba40079eddce8cd910cca"
+}


### PR DESCRIPTION
[Changelog](https://github.com/aantron/bisect_ppx/releases/tag/2.2.0):

Additions

- Support for exception pattern extensions added in OCaml 4.08 (aantron/bisect_ppx#297).

Bugs fixed

- HTML: generate `<!DOCTYPE html>` and `<html lang="en">` (aantron/bisect_ppx#288, @zapashcanon).
- Invalid doc comment section heading levels (aantron/bisect_ppx#291, reported Risto Stevcev).
- Hide generated code from odoc (aantron/bisect_ppx#293, reported Risto Stevcev).