### PR TITLE
[new release] fileutils (0.6.2)

### DIFF
--- a/packages/fileutils/fileutils.0.6.2/opam
+++ b/packages/fileutils/fileutils.0.6.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ocaml-fileutils"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/gildor478/ocaml-fileutils.git"
+bug-reports: "https://github.com/gildor478/ocaml-fileutils/issues"
+doc: "https://gildor478.github.io/ocaml-fileutils/"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "base-unix"
+  "base-bytes"
+  "stdlib-shims"
+  "dune" {>= "1.11.0"}
+  "ounit" {with-test & >= "2.0.0"}
+]
+synopsis: "API to manipulate files (POSIX like) and filenames"
+description: """
+This library provides an API to perform POSIX like operations on files like:
+
+- mv
+- cp
+- rm
+- mkdir
+- touch
+- which...
+
+It also providesa module to manipulate abstract filenames:
+
+- classification
+- make_relative: made a filename relative to another
+- make_absolute
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-fileutils/releases/download/v0.6.2/fileutils-v0.6.2.tbz"
+  checksum: [
+    "sha256=c73d94247b6aef1450853ed14677ae58e9701376475d3f29ca730472a0171e1d"
+    "sha512=104c7389832f22ec189ce6f1596144b28dcaeea7d23d5b19d369c44e54326e97fcb7b4f4c4a8d2965523e63b35b594a1351b7e630dde590871efe512fe38853c"
+  ]
+}


### PR DESCRIPTION
API to manipulate files (POSIX like) and filenames

- Project page: <a href="https://github.com/gildor478/ocaml-fileutils">https://github.com/gildor478/ocaml-fileutils</a>
- Documentation: <a href="https://gildor478.github.io/ocaml-fileutils/">https://gildor478.github.io/ocaml-fileutils/</a>

##### CHANGES:

### Fixed

- Improve documentation:
  - hide modules for the implementation.
  - clarify usage of chop_extension/add_extension.
- Move fileutils and fileutils.str in their own directories.
