### PR TITLE
[new release] capnp-rpc-net, capnp-rpc-lwt, capnp-rpc-mirage, capnp-rpc and capnp-rpc-unix (0.6.0)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.6.0/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "lwt"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.6.0/capnp-rpc-v0.6.0.tbz"
+  checksum: [
+    "sha256=ca0c454813ca28a6787e0bbb8bdc938d0dbf241a4896721019c827e4ea6ecd2d"
+    "sha512=7c7c3b3e8a2b40faf9cffaef880f48b8bcfd2056bc5c42ad918b8ff504e57a6152ddf3ebca118a2475458ba8ee72b22c08dc32ec04ed51fefb910ca8f775692c"
+  ]
+}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.6.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.6.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp" {>= "3.1.0"}
+  "capnp-rpc-net" {= version}
+  "astring"
+  "fmt"
+  "logs"
+  "dns-client"
+  "tls-mirage"
+  "mirage-stack" {>="2.0.0"}
+  "arp-mirage" {with-test}
+  "alcotest-lwt" {>= "1.0.1" & with-test}
+  "io-page-unix" {with-test}
+  "tcpip" {with-test}
+  "mirage-vnetif" {with-test}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.6.0/capnp-rpc-v0.6.0.tbz"
+  checksum: [
+    "sha256=ca0c454813ca28a6787e0bbb8bdc938d0dbf241a4896721019c827e4ea6ecd2d"
+    "sha512=7c7c3b3e8a2b40faf9cffaef880f48b8bcfd2056bc5c42ad918b8ff504e57a6152ddf3ebca118a2475458ba8ee72b22c08dc32ec04ed51fefb910ca8f775692c"
+  ]
+}

--- a/packages/capnp-rpc-net/capnp-rpc-net.0.6.0/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.0.6.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "capnp-rpc-lwt" {= version}
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "mirage-flow" {>="2.0.0"}
+  "tls" {>= "0.8.0"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "0.10.0"}
+  "tls-mirage"
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.6.0/capnp-rpc-v0.6.0.tbz"
+  checksum: [
+    "sha256=ca0c454813ca28a6787e0bbb8bdc938d0dbf241a4896721019c827e4ea6ecd2d"
+    "sha512=7c7c3b3e8a2b40faf9cffaef880f48b8bcfd2056bc5c42ad918b8ff504e57a6152ddf3ebca118a2475458ba8ee72b22c08dc32ec04ed51fefb910ca8f775692c"
+  ]
+}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.6.0/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.6.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp-rpc-net" {= version}
+  "cmdliner"
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.4"}
+  "logs"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "1.0"}
+  "alcotest-lwt" {with-test & >= "1.0.1"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.6.0/capnp-rpc-v0.6.0.tbz"
+  checksum: [
+    "sha256=ca0c454813ca28a6787e0bbb8bdc938d0dbf241a4896721019c827e4ea6ecd2d"
+    "sha512=7c7c3b3e8a2b40faf9cffaef880f48b8bcfd2056bc5c42ad918b8ff504e57a6152ddf3ebca118a2475458ba8ee72b22c08dc32ec04ed51fefb910ca8f775692c"
+  ]
+}

--- a/packages/capnp-rpc/capnp-rpc.0.6.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "stdint"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "1.0.1"}
+  "afl-persistent" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.6.0/capnp-rpc-v0.6.0.tbz"
+  checksum: [
+    "sha256=ca0c454813ca28a6787e0bbb8bdc938d0dbf241a4896721019c827e4ea6ecd2d"
+    "sha512=7c7c3b3e8a2b40faf9cffaef880f48b8bcfd2056bc5c42ad918b8ff504e57a6152ddf3ebca118a2475458ba8ee72b22c08dc32ec04ed51fefb910ca8f775692c"
+  ]
+}


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

- Port to latest interfaces for x509 (0.10+), mirage-crypto,
  alcotest (1.0+), and mirage-types post the `-lwt` package
  merge (@avsm mirage/capnp-rpc#190, review by @talex5 @hannesm)

- Convert many info-level log messages to debug level (@talex5 mirage/capnp-rpc#193)
