### PR TITLE
fdkaac.0.3.2

### DIFF
--- a/packages/fdkaac/fdkaac.0.3.2/opam
+++ b/packages/fdkaac/fdkaac.0.3.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Fraunhofer FDK AAC Codec Library"
+description:
+  "The FDK AAC Codec Library For Android contains an encoder implementation of the Advanced Audio Coding (AAC) audio codec."
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-fdkaac"
+bug-reports: "https://github.com/savonet/ocaml-fdkaac/issues"
+depends: [
+  "dune" {> "2.0"}
+  "dune-configurator"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-fdkaac.git"
+depexts: [
+  ["fdk-aac-dev"] {os-distribution = "alpine"}
+  ["libfdk-aac"] {os-distribution = "arch"}
+  ["fdk-aac-devel"] {os-distribution = "centos"}
+  ["fdk-aac-devel"] {os-distribution = "fedora"}
+  ["fdk-aac-devel"] {os-family = "suse"}
+  ["libfdk-aac-dev"] {os-family = "debian"}
+  ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}
+]
+url {
+  src: "https://github.com/savonet/ocaml-fdkaac/archive/0.3.2.tar.gz"
+  checksum: [
+    "md5=34800a5a6f7e055699df5d8244679e40"
+    "sha512=fd66e54587b9d3162408ea923a45ca444885668ae56cd42a8ead378ed4579d86edd24e71ff0f6cf2bffb5a14d4cafb4b6c1a9577b16d13c3a8d47fa531cd1144"
+  ]
+}


### PR DESCRIPTION
This PR adds the recently-release `fdkaac.0.3.2`, with support for version `2.0.x` of the upstream library.