### PR TITLE
cry.0.6.5

### DIFF
--- a/packages/cry/cry.0.6.5/opam
+++ b/packages/cry/cry.0.6.5/opam
@@ -11,8 +11,11 @@ depends: [
   "dune" {> "2.0"}
 ]
 depopts: [
-  "ssl" {>= "0.5.9"}
+  "ssl"
   "osx-secure-transport"
+]
+conflicts: [
+  "ssl" {< "0.5.9"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/cry/cry.0.6.5/opam
+++ b/packages/cry/cry.0.6.5/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "OCaml client for the various icecast & shoutcast source protocols"
+description:
+  "The cry library is an implementation of the various icecast & shoutcast protocols to connect to streaming servers such as icecast"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["Romain Beauxis <toots@rastageeks.org>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-cry"
+bug-reports: "https://github.com/savonet/ocaml-cry/issues"
+depends: [
+  "dune" {> "2.0"}
+]
+depopts: [
+  "ssl" {>= "0.5.9"}
+  "osx-secure-transport"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-cry.git"
+url {
+  src: "https://github.com/savonet/ocaml-cry/archive/0.6.5.tar.gz"
+  checksum: [
+    "md5=cc8e4ef86401e76960f2447d9bac68ef"
+    "sha512=43de3513ee2a0f5e5ad496f48137519de270f836081870b48768e45146a4aab84ad7a0781eac56f7b69ce8724a7fd49e7f9fd9d2d771f133aeef2db96d7254af"
+  ]
+}


### PR DESCRIPTION
This PR adds newly released `cry` version `0.6.5` with fixed support for `PUT` requests with icecast `2.5` and above.