### PR TITLE
+ mikmatch 1.0.9

### DIFF
--- a/packages/mikmatch/mikmatch.1.0.9/opam
+++ b/packages/mikmatch/mikmatch.1.0.9/opam
@@ -7,11 +7,11 @@ dev-repo: "git://github.com/mjambon/mikmatch.git"
 authors: [ "Martin Jambon" ]
 build: [
   [make "str"]
-  [make] {"%{pcre:installed}%"}
+  [make] {pcre:installed}
 ]
 install: [
   [make "install-str"]
-  [make "install"] {"%{pcre:installed}%"}
+  [make "install"] {pcre:installed}
 ]
 depends: [
   "ocaml" {>= "4.07"}

--- a/packages/mikmatch/mikmatch.1.0.9/opam
+++ b/packages/mikmatch/mikmatch.1.0.9/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "ygrek@autistici.org"
+homepage: "https://mjambon.github.io/mjambon2016/micmatch.html"
+doc: ["https://mjambon.github.io/mjambon2016/mikmatch-manual.html"]
+bug-reports: "https://github.com/mjambon/mikmatch/issues"
+dev-repo: "git://github.com/mjambon/mikmatch.git"
+authors: [ "Martin Jambon" ]
+build: [
+  [make "str"]
+  [make] {"%{pcre:installed}%"}
+]
+install: [
+  [make "install-str"]
+  [make "install"] {"%{pcre:installed}%"}
+]
+remove: [
+  [make "uninstall-str"]
+  [make "uninstall"] {"%{pcre:installed}%"}
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "ocamlfind" {build}
+  "camlp4" {build}
+  "tophide" {>= "1.0.2"}
+]
+depopts: [
+  "pcre"
+]
+conflicts: [
+  "pcre" {< "7.2.3"}
+]
+synopsis: "OCaml syntax extension for regexps"
+url {
+  src: "https://github.com/mjambon/mikmatch/releases/download/v1.0.9/mikmatch-1.0.9.tar.gz"
+  checksum: [
+    "md5=d975558ba0707df415d814308a3e92d6"
+    "sha256=96431fce84a519f53a8c15931701fe3a6bed410bbe169f82d35d30e977b3acff"
+    "sha512=dcf62f67b01f039e0510446267f3d4b965daa6507631da71c8562f7eeedebf9859403d0be7a2e217365af95bb818d05de38ab4987d900a4050a1c5403a66fa5c"
+  ]
+}

--- a/packages/mikmatch/mikmatch.1.0.9/opam
+++ b/packages/mikmatch/mikmatch.1.0.9/opam
@@ -13,14 +13,10 @@ install: [
   [make "install-str"]
   [make "install"] {"%{pcre:installed}%"}
 ]
-remove: [
-  [make "uninstall-str"]
-  [make "uninstall"] {"%{pcre:installed}%"}
-]
 depends: [
   "ocaml" {>= "4.07"}
   "ocamlfind" {build}
-  "camlp4" {build}
+  "camlp4"
   "tophide" {>= "1.0.2"}
 ]
 depopts: [


### PR DESCRIPTION
https://github.com/mjambon/mikmatch/releases/tag/v1.0.9

Build fixes, including (but not limited to) :
* add separate ocamlfind subpackages for syntax and library
* fix build with ocaml-pcre 7.2.0 and later (api breakage)
* fix build with OCaml 4.10 (safe-string)