### PR TITLE
[new release] 0install-gtk and 0install (2.15.2)

### DIFF
--- a/packages/0install-gtk/0install-gtk.2.15.2/opam
+++ b/packages/0install-gtk/0install-gtk.2.15.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Decentralised installation system - GTK UI"
+maintainer: "talex5@gmail.com"
+authors: "zero-install-devel@lists.sourceforge.net"
+homepage: "https://0install.net/"
+bug-reports: "https://github.com/0install/0install/issues"
+dev-repo: "git+https://github.com/0install/0install.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "0install" {= version}
+  "ounit" {with-test}
+  "dune" {>= "1.11"}
+  "lablgtk" {>= "2.18.2"}
+  "lwt_glib"
+]
+description: """
+Zero Install is a decentralised cross-distribution software installation system.
+This package provides a GTK-based user interface for it."""
+url {
+  src:
+    "https://github.com/0install/0install/releases/download/v2.15.2/0install-v2.15.2.tbz"
+  checksum: [
+    "sha256=00b4e66db11196a589703c45ec84c50ef5e099685ce20f8d146eed9803fe49fd"
+    "sha512=0b6b1cdd39a7ef522f189496728feef9f234f0b89745f3ec78de3720317eedf8cb6ea97844cc325e2ca0982f70b73015e8138bde85330fdc0ac5350192ced7b9"
+  ]
+}

--- a/packages/0install/0install.2.15.2/opam
+++ b/packages/0install/0install.2.15.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Decentralised installation system"
+maintainer: "talex5@gmail.com"
+authors: "zero-install-devel@lists.sourceforge.net"
+homepage: "https://0install.net/"
+bug-reports: "https://github.com/0install/0install/issues"
+dev-repo: "git+https://github.com/0install/0install.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "yojson"
+  "xmlm"
+  "ounit" {with-test}
+  "lwt"
+  "lwt_react"
+  "obus" {os != "macos" & os-family != "windows"}
+  "ocurl" {>= "0.7.9"}
+  "sha" {>= "1.9"}
+  "dune" {>= "1.11"}
+]
+depexts: [
+  ["gnupg" "unzip"] {os-family = "debian"}
+  ["gnupg" "unzip"] {os-distribution = "alpine"}
+  ["gnupg"] {os = "macos" & os-distribution = "homebrew"}
+]
+description: """
+Zero Install is a decentralised cross-distribution software installation system.
+Other features include full support for shared libraries (with a SAT solver for
+dependency resolution), sharing between users, and integration with native platform
+package managers. It supports both binary and source packages, and works on Linux,
+macOS, Unix and Windows systems."""
+url {
+  src:
+    "https://github.com/0install/0install/releases/download/v2.15.2/0install-v2.15.2.tbz"
+  checksum: [
+    "sha256=00b4e66db11196a589703c45ec84c50ef5e099685ce20f8d146eed9803fe49fd"
+    "sha512=0b6b1cdd39a7ef522f189496728feef9f234f0b89745f3ec78de3720317eedf8cb6ea97844cc325e2ca0982f70b73015e8138bde85330fdc0ac5350192ced7b9"
+  ]
+}


### PR DESCRIPTION
Decentralised installation system - GTK UI

- Project page: <a href="https://0install.net/">https://0install.net/</a>

##### CHANGES:

### Bug fixes

- Don't try to update distribution caches in `--dry-run` mode.
  If we needed to update a cache, the operation would fail with e.g.
  `Bug: 'with_open_out' called in --dry-run mode`.

### Opam package

- Mark obus as required (except on Windows and macOS).
  This is more explicit than just asking users to install it where it makes sense, and also means that the CI will test it.

- Split GTK UI into a separate opam package.
  This makes it easy to install it (using `opam install 0install-gtk`), and means that the CI will test it.

- Update opam metadata to match opam-repository.

### Code cleanups

- Rename "ocaml" directory to "src". There are no other languages here now.

- Make the solver return a `SOLVER_RESULT`.
  The old API was a bit confusing. The user of the solver had to wrap the solver's return to provide a `SOLVER_RESULT` for the diagnostics.
  Now, the user-required bits are in `SOLVER_INPUT` and the solver itself provides the rest.

- Split the solver into its own library. Since the refactoring in 2014
  (see [Simplifying the Solver With Functors](https://roscidus.com/blog/blog/2014/09/17/simplifying-the-solver-with-functors/)),
  the solver isn't really tied to 0install at all, and could be useful for other package managers.

- Generalise the solver's machine groups system.
  This removes the one remaining dependency from the solver to the rest of 0install.

- Rename option functions in solver to match OCaml 4.08.

- Split `Feed_metadata` and `Feed_import` out into their own modules.

- Rename `Feed.feed` to `Feed.t` and make the type abstract.

- Skip rpm2cpio unit test if cpio isn't available. It seems that recent Fedora images provide rpm2cpio, but not cpio.
