### PR TITLE
add gufo as opam package

### DIFF
--- a/packages/gufo/gufo.0.1.2/opam
+++ b/packages/gufo/gufo.0.1.2/opam
@@ -17,7 +17,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "ocaml"
+  "ocaml" {>= 4.07}
   "ocamlfind" {build}
   "menhir" {build}
   "zed" {>= "1.6"}

--- a/packages/gufo/gufo.0.1.2/opam
+++ b/packages/gufo/gufo.0.1.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A fonctionnal shell"
+description: """
+Gufo is an experimental replacement to bash. It supports base syntax of bash
+(direct call to external programs, file redirection,...) and nest them into a
+function layer.
+"""
+maintainer: "pierre-vittet@pvittet.com"
+authors: "pierre-vittet@pvittet.com"
+homepage: "https://gufo.pvittet.com"
+bug-reports: "https://github.com/piervit/gufo/issues"
+license: "GPL"
+dev-repo: "git+https://github.com/Piervit/gufo.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+  "menhir" {build}
+  "zed" {>= "1.6"}
+  "camomile"
+  "react"
+  "lwt"
+  "lambda-term" {>= "2.0.2"}
+  "base-unix"
+  "sedlex" {>= "2.0.0"}
+  "oasis" 
+]
+url {
+  src: "https://github.com/Piervit/gufo/archive/0.1.2.tar.gz"
+  checksum: "md5=b3b37549f295b3868559d9d01457170e"
+}


### PR DESCRIPTION
Gufo is a new shell language using functionnal programming. It is still early stage but using opam will help potentially beta-tester to take part.

Last weeks, I have tried a first pull request. It had several issues. I have taken in account the remarks that were given before closing the request. I tested the installation as stated in https://opam.ocaml.org/doc/Packaging.html (opam install . from project directory).

Thanks.
