### PR TITLE
[new release] salsa20 (1.1.0)

### DIFF
--- a/packages/salsa20/salsa20.1.1.0/opam
+++ b/packages/salsa20/salsa20.1.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+name: "salsa20"
+synopsis: "Salsa20 family of encryption functions, in pure OCaml"
+description: """
+```ocaml
+utop[0]> #require "mirage-crypto";;
+utop[1]> #require "mirage-crypto-rng.unix";;
+utop[2]> Mirage_crypto_rng_unix.initialize ();;
+- : unit = ()
+utop[3]> let key = Mirage_crypto_rng.generate 32;;
+val key : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 32}
+utop[4]> let nonce = Cstruct.create 8;;
+val nonce : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 8}
+utop[5]> #require "salsa20";;
+utop[6]> let state = Salsa20.create key nonce;;
+val state : Salsa20.t = <abstr>
+utop[7]> Salsa20.encrypt (Cstruct.of_string "My secret text") state |> Cstruct.to_string;;
+- : string = " 2\\193\\020`\\142\\182\\234\\188H[R\\241V"
+```
+"""
+maintainer: "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+authors: "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+license: "BSD2"
+homepage: "https://github.com/abeaumont/ocaml-salsa20"
+dev-repo: "git+https://github.com/abeaumont/ocaml-salsa20.git"
+bug-reports: "https://github.com/abeaumont/ocaml-salsa20/issues"
+doc: "https://abeaumont.github.io/ocaml-salsa20/"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {build}
+  "cstruct" {>= "3.2.0"}
+  "mirage-crypto"
+  "salsa20-core" {>= "0.1.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst" ] {pinned}
+  [ "dune" "build" "-j" jobs "-p" name "@install" ]
+  [ "dune" "runtest" "-j" jobs "-p" name ] {with-test}
+]
+url {
+  src:
+    "https://github.com/abeaumont/ocaml-salsa20/releases/download/1.1.0/salsa20-1.1.0.tbz"
+  checksum: [
+    "sha256=60b5c1a6ab4e8a7f0a03b194230c2fcb4783aacf9b149f73802767c2334f4f95"
+    "sha512=89f5d9a0b68d9d7158d5e3868aa35074800a619932194a14ccc848a58696a1d9a583bb14de966d68720c6d22f3f0b51430a4ade1fa0051cff75fcb99c26450e8"
+  ]
+}

--- a/packages/salsa20/salsa20.1.1.0/opam
+++ b/packages/salsa20/salsa20.1.1.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "salsa20"
 synopsis: "Salsa20 family of encryption functions, in pure OCaml"
 description: """
 ```ocaml
@@ -27,7 +26,7 @@ bug-reports: "https://github.com/abeaumont/ocaml-salsa20/issues"
 doc: "https://abeaumont.github.io/ocaml-salsa20/"
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune" {build}
+  "dune" {>= "1.8"}
   "cstruct" {>= "3.2.0"}
   "mirage-crypto"
   "salsa20-core" {>= "0.1.0"}


### PR DESCRIPTION
Salsa20 family of encryption functions, in pure OCaml

- Project page: <a href="https://github.com/abeaumont/ocaml-salsa20">https://github.com/abeaumont/ocaml-salsa20</a>
- Documentation: <a href="https://abeaumont.github.io/ocaml-salsa20/">https://abeaumont.github.io/ocaml-salsa20/</a>

##### CHANGES:

* Use mirage-crypto instead of nocrypto (by @hannesm)
* Stop using Salsa20_core.Utils (by @hannesm)
