### PR TITLE
restrict salsa20 to salsa20-core < 1.0.0, which removed some bindings

### DIFF
--- a/packages/salsa20/salsa20.0.1.0/opam
+++ b/packages/salsa20/salsa20.0.1.0/opam
@@ -8,9 +8,6 @@ license:      "BSD-2-Clause"
 
 build: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
-  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
-    {with-test}
-  ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.0"}

--- a/packages/salsa20/salsa20.0.1.0/opam
+++ b/packages/salsa20/salsa20.0.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "topkg" {build}
   "cstruct" {>= "1.7.0"}
   "nocrypto" {>= "0.5.3"}
-  "salsa20-core" {>= "0.1.0"}
+  "salsa20-core" {>= "0.1.0" & < "1.0.0"}
   "alcotest" {with-test}
 ]
 synopsis: "Family of encryption functions, in pure OCaml"

--- a/packages/salsa20/salsa20.1.0.0/opam
+++ b/packages/salsa20/salsa20.1.0.0/opam
@@ -30,7 +30,7 @@ depends: [
   "dune"
   "cstruct" {>= "1.7.0"}
   "nocrypto" {>= "0.5.3"}
-  "salsa20-core" {>= "0.1.0"}
+  "salsa20-core" {>= "0.1.0" & < "1.0.0"}
   "alcotest" {with-test}
 ]
 build: [


### PR DESCRIPTION
//cc @abeaumont in order to unblock #16102