### PR TITLE
[new release] pbkdf (1.1.0)

### DIFF
--- a/packages/pbkdf/pbkdf.1.1.0/opam
+++ b/packages/pbkdf/pbkdf.1.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "pbkdf"
+synopsis: "Password based key derivation functions (PBKDF) from PKCS#5"
+description: """
+An implementation of PBKDF 1 and 2 as defined by [PKCS#5](https://tools.ietf.org/html/rfc2898) using
+ [mirage-crypto](https://github.com/mirage/mirage-crypto)
+"""
+maintainer: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>"]
+authors: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Sonia Meruelo <smeruelo@gmail.com>"]
+license: "BSD2"
+homepage: "https://github.com/abeaumont/ocaml-pbkdf"
+bug-reports: "https://github.com/abeaumont/ocaml-pbkdf/issues"
+dev-repo: "git+https://github.com/abeaumont/ocaml-pbkdf.git"
+doc: "https://abeaumont.github.io/ocaml-pbkdf/"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "mirage-crypto"
+  "alcotest" {with-test & >= "0.8.1"}
+]
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-j" jobs "-p" name "@install" ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+url {
+  src:
+    "https://github.com/abeaumont/ocaml-pbkdf/releases/download/1.1.0/pbkdf-1.1.0.tbz"
+  checksum: [
+    "sha256=e53ed1bd9abf490c858a341c10fb548bc9ad50d4479acdf95a9358a73d042264"
+    "sha512=7c31f5470b9028a5f0b3baf670494f26c632af0449e59911efbe126d71e69fe8ebd73522f4fc96761cd71b67125579a5bbd75762f8753f9fb8c746f98bbb0aa5"
+  ]
+}

--- a/packages/pbkdf/pbkdf.1.1.0/opam
+++ b/packages/pbkdf/pbkdf.1.1.0/opam
@@ -14,7 +14,7 @@ dev-repo: "git+https://github.com/abeaumont/ocaml-pbkdf.git"
 doc: "https://abeaumont.github.io/ocaml-pbkdf/"
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune"
+  "dune" {>= "1.8.0"}
   "mirage-crypto"
   "alcotest" {with-test & >= "0.8.1"}
 ]


### PR DESCRIPTION
Password based key derivation functions (PBKDF) from PKCS#5

- Project page: <a href="https://github.com/abeaumont/ocaml-pbkdf">https://github.com/abeaumont/ocaml-pbkdf</a>
- Documentation: <a href="https://abeaumont.github.io/ocaml-pbkdf/">https://abeaumont.github.io/ocaml-pbkdf/</a>

##### CHANGES:

* Port to mirage-crypto (thanks to @hannesm)
