### PR TITLE
[new release] scrypt-kdf (1.1.0)

### DIFF
--- a/packages/scrypt-kdf/scrypt-kdf.1.1.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.1.1.0/opam
@@ -15,7 +15,7 @@ dev-repo: "git+https://github.com/abeaumont/ocaml-scrypt-kdf.git"
 doc: "https://abeaumont.github.io/ocaml-scrypt-kdf/"
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune"
+  "dune" {>= "1.8.0"}
   "cstruct" {>= "3.2.0"}
   "mirage-crypto"
   "pbkdf" {>= "0.1.0"}

--- a/packages/scrypt-kdf/scrypt-kdf.1.1.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "scrypt-kdf"
+synopsis: "The scrypt Password-Based Key Derivation Function"
+description: """
+A pure OCaml implementation of [scrypt](https://en.wikipedia.org/wiki/Scrypt) password based key derivation function,
+as defined in [The scrypt Password-Based Key Derivation Function internet draft](https://tools.ietf.org/html/draft-josefsson-scrypt-kdf-04),
+including test cases from the RFC.
+"""
+maintainer: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>"]
+authors: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Sonia Meruelo <smeruelo@gmail.com>"]
+license: "BSD2"
+homepage: "https://github.com/abeaumont/ocaml-scrypt-kdf"
+bug-reports: "https://github.com/abeaumont/ocaml-scrypt-kdf/issues"
+dev-repo: "git+https://github.com/abeaumont/ocaml-scrypt-kdf.git"
+doc: "https://abeaumont.github.io/ocaml-scrypt-kdf/"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "cstruct" {>= "3.2.0"}
+  "mirage-crypto"
+  "pbkdf" {>= "0.1.0"}
+  "salsa20-core" {>= "0.1.0"}
+  "alcotest" {with-test}
+]
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-j" jobs "-p" name "@install" ]
+  [ "dune" "runtest" "-j" jobs "-p" name ] {with-test}
+]
+url {
+  src:
+    "https://github.com/abeaumont/ocaml-scrypt-kdf/releases/download/1.1.0/scrypt-kdf-1.1.0.tbz"
+  checksum: [
+    "sha256=335f0aa395a449b1d4b3f6cc5123ad92af13cc402bcb3baabc3d7a01ff6cd86b"
+    "sha512=026e763589cacc884fbe8e715708965491bbdca0461a4cb3c8d7aedf48312808e9424b3ee9f5f61ac0b165048ce7b3465f05ad683b146e12ca7be679ef36c4ab"
+  ]
+}


### PR DESCRIPTION
The scrypt Password-Based Key Derivation Function

- Project page: <a href="https://github.com/abeaumont/ocaml-scrypt-kdf">https://github.com/abeaumont/ocaml-scrypt-kdf</a>
- Documentation: <a href="https://abeaumont.github.io/ocaml-scrypt-kdf/">https://abeaumont.github.io/ocaml-scrypt-kdf/</a>

##### CHANGES:

* Port to mirage-crypto (thanks to @hannesm)
