### PR TITLE
[new release] ocaml-print-intf (1.2.0)

### DIFF
--- a/packages/ocaml-print-intf/ocaml-print-intf.1.2.0/opam
+++ b/packages/ocaml-print-intf/ocaml-print-intf.1.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Display human-readable OCaml interface from a compiled .cmi"
+description: """
+This tool parses a compiled .cmi interface file and outputs
+the corresponding textual .mli file.  This can be useful to quickly generate
+a skeleton interface file to then annotate with comments or add abstraction."""
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Nathan Rebours"]
+license: "ISC"
+homepage: "https://github.com/avsm/ocaml-print-intf"
+doc: "https://avsm.github.io/ocaml-print-intf/"
+bug-reports: "https://github.com/avsm/ocaml-print-intf/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.06"}
+  "bos"
+  "dune-build-info"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-print-intf.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-print-intf/releases/download/v1.2.0/ocaml-print-intf-v1.2.0.tbz"
+  checksum: [
+    "sha256=02aad204b646f67b3d2aa7dae5d74083ce4bd169e5b43b691c1f04c9436d9980"
+    "sha512=35587c33d5d57fb683b3a903930e9cd9bfcd195a0ec171a51b6ab727a84fab8b6b1b16ebdff240addd1a1aa92c7e8ad3d70570da831491368ece6a8a6f36fad7"
+  ]
+}


### PR DESCRIPTION
Display human-readable OCaml interface from a compiled .cmi

- Project page: <a href="https://github.com/avsm/ocaml-print-intf">https://github.com/avsm/ocaml-print-intf</a>
- Documentation: <a href="https://avsm.github.io/ocaml-print-intf/">https://avsm.github.io/ocaml-print-intf/</a>

##### CHANGES:

- Fix a bug with `.ml` input files where `ocaml-print-intf` was unable to figure out
  the dune project root if the path was too long. (avsm/ocaml-print-intf#3, @NathanReb)
