### PR TITLE
Disable tests of rpclib-lwt

### DIFF
--- a/packages/rpclib-lwt/rpclib-lwt.5.9.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.5.9.0/opam
@@ -15,11 +15,11 @@ build: [
 ]
 depends: [
   "ocaml"
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "jbuilder"
   "rpclib" {= version}
   "lwt" {>= "3.0.0"}
-  "alcotest-lwt" {with-test}
+  "alcotest-lwt" {with-test & < "1.0.0"}
 ]
 synopsis: "Driver for rpclib using lwt"
 url {

--- a/packages/rpclib-lwt/rpclib-lwt.6.0.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.6.0.0/opam
@@ -16,8 +16,8 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0" < "4.10.0"}
   "jbuilder"
-  "alcotest" {with-test}
-  "alcotest-lwt" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
+  "alcotest-lwt" {with-test & < "1.0.0"}
   "rpclib" {= version}
   "lwt" {>= "3.0.0"}
 ]

--- a/packages/rpclib-lwt/rpclib-lwt.6.1.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.6.1.0/opam
@@ -8,11 +8,11 @@ doc: "https://mirage.github.io/ocaml-rpc/rpclib-lwt"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
   "ocaml"
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "dune" {>= "1.5.0"}
   "rpclib" {=version}
   "lwt" {>= "3.0.0"}
-  "alcotest-lwt" {with-test}
+  "alcotest-lwt" {with-test & < "1.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/rpclib-lwt/rpclib-lwt.7.0.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.7.0.0/opam
@@ -8,11 +8,11 @@ doc: "https://mirage.github.io/ocaml-rpc/rpclib-lwt"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
   "ocaml"
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "dune" {>= "1.5.0"}
   "rpclib" {=version}
   "lwt" {>= "3.0.0"}
-  "alcotest-lwt" {with-test}
+  "alcotest-lwt" {with-test & < "1.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
`rpclib-lwt`'s tests produce failures like [this one](https://ci.ocaml.org/log/saved/docker-run-41be14d28eeb8ecf1eb98587cb889cbf/453ebae17e8028b0c921e8b171504b01470310dc):

```
- File "tests/lwt/suite.ml", line 3, characters 28-52:
- 3 |     [("Client_server_test", Client_server_test.tests)]
-                                 ^^^^^^^^^^^^^^^^^^^^^^^^
- Error: This expression has type unit Alcotest_lwt.test_case list
-        but an expression was expected of type unit Alcotest.test_case list
-        Type
-          unit Alcotest_lwt.test_case =
-            string * Alcotest_lwt.speed_level * (unit -> Alcotest_lwt.return)
-        is not compatible with type
-          unit Alcotest.test_case =
-            string * Alcotest.speed_level * (unit -> Alcotest.return) 
-        Type Alcotest_lwt.return = unit Lwt.t is not compatible with type
-          Alcotest.return = unit
```

...so this PR disables them. This applies to all versions of the package.

@samoht, @jonludlam, is there a more intelligent solution to this, perhaps some constraints on Alcotest?