### PR TITLE
redis-lwt 0.3.6 requires redis 0.3.6

### DIFF
--- a/packages/redis-lwt/redis-lwt.0.3.6/opam
+++ b/packages/redis-lwt/redis-lwt.0.3.6/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder"
-  "redis" {>= "0.3.5"}
+  "redis" {= version}
   "lwt"
 ]
 synopsis: "Lwt-based client for Redis"


### PR DESCRIPTION
The current constraint, `>= 0.3.5`, allows installation with `redis` 0.4, which [results in](https://ci.ocaml.org/log/saved/docker-run-5ecbb9ce824a2791045cf364eda100f8/c4a1c0c4951f7d4a0fe8761a8b17610c5a568af7)

```
- File "src_lwt/redis_lwt.ml", line 59, characters 34-36:
- 59 | module Client = Redis.Client.Make(IO)
-                                        ^^
- Error: Signature mismatch:
-        ...
-        The value `>|=' is required but not provided
-        File "src/s.ml", line 16, characters 2-40: Expected declaration
```

It's likely that both `redis` 0.3.5 and `redis` 0.3.6 will work with `redis-lwt` 0.3.6, but I went for the narrower constraint to be sure, and I think was the intent. This also is the kind of constraint in `redis-lwt` 0.4.