### PR TITLE
dynload-sys 0.4.7

### DIFF
--- a/packages/dynload-sys/dynload-sys.0.4.7/opam
+++ b/packages/dynload-sys/dynload-sys.0.4.7/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   ["contact@adlink-labs.tech"]
+authors:      ["Angelo Corsaro" "Julien Enoch" "Oliver Hecart" "Gabriele Baldoni"]
+homepage:     "https://github.com/atolab"
+bug-reports:  "https://github.com/atolab/apero-core/issues/"
+dev-repo:     "git+https://github.com/atolab/apero-core.git"
+
+license: "Apache-2.0"
+
+
+build: [
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {= "2.3.0" }
+  "apero-core" {= "0.4.7" }
+]
+
+synopsis : "Sys.argv override for dynamically loaded libraries"
+description: """
+Dynload-sys is a library that allows, when linked with an ocaml library,
+to dynamically load the ocaml library with a new set of Sys.arv arguments."""
+
+url {
+  src:
+    "https://github.com/atolab/apero-core/archive/0.4.7.tar.gz"
+  checksum: [
+    "sha256=f4ec7ce1174f0401955cb551548fcdc0efeecaf701de38573a94092b54e69648"
+    "sha512=6673419024e5f36a0ff08f38234b8af214b713e5d702c04dd860026b76f3d29babe83dc8a49d371eb088231d2864ed01ef1166706c5df5332e0717eb71b29e44"
+  ]
+}


### PR DESCRIPTION
Hi,
this PR adds dynload-sys (which codebase is in [apero-core](https://github.com/atolab/apero-core) repo).