### PR TITLE
Remove erroneous freebsd constraint

### DIFF
--- a/packages/conf-pkg-config/conf-pkg-config.1.0/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.0/opam
@@ -16,7 +16,6 @@ depexts: [
   ["pkgconfig"] {os-distribution = "rhel"}
   ["pkgconfig"] {os-distribution = "ol"}
   ["pkgconfig"] {os-distribution = "alpine"}
-  ["devel/pkgconf"] {os = "freebsd"}
   ["devel/pkgconf"] {os = "openbsd"}
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconf"] {os = "freebsd"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -26,7 +26,6 @@ depexts: [
   ["pkgconfig"] {os-distribution = "ol"}
   ["pkgconfig"] {os-distribution = "alpine"}
   ["pkgconfig"] {os-distribution = "nixos"}
-  ["devel/pkgconf"] {os = "freebsd"}
   ["devel/pkgconf"] {os = "openbsd"}
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconf"] {os = "freebsd"}


### PR DESCRIPTION
Package name for freebsd must match output of pkg query %n (https://github.com/ocaml/opam-depext/blob/14a9aa6093bfb510b83f2ba07205b899b7e89989/depext.ml#L343) and should not use the category prefix.

The correct constraint already appears in each file.