### PR TITLE
fixes a typo in bap-constant-tracker

### DIFF
--- a/packages/bap-constant-tracker/bap-constant-tracker.1.5.0/opam
+++ b/packages/bap-constant-tracker/bap-constant-tracker.1.5.0/opam
@@ -14,7 +14,7 @@ build: [
 
 install: [[make "install"]]
 
-remove: [["ocamlfind" "remove" "bap-plugin-costant_tracker"]
+remove: [["ocamlfind" "remove" "bap-plugin-constant_tracker"]
          ["bapbundle" "remove" "constant_tracker.plugin"]]
 
 depends: [

--- a/packages/bap-constant-tracker/bap-constant-tracker.1.6.0/opam
+++ b/packages/bap-constant-tracker/bap-constant-tracker.1.6.0/opam
@@ -14,7 +14,7 @@ build: [
 
 install: [[make "install"]]
 
-remove: [["ocamlfind" "remove" "bap-plugin-costant_tracker"]
+remove: [["ocamlfind" "remove" "bap-plugin-constant_tracker"]
          ["bapbundle" "remove" "constant_tracker.plugin"]]
 
 depends: [

--- a/packages/bap-constant-tracker/bap-constant-tracker.2.0.0/opam
+++ b/packages/bap-constant-tracker/bap-constant-tracker.2.0.0/opam
@@ -14,7 +14,7 @@ build: [
 
 install: [[make "install"]]
 
-remove: [["ocamlfind" "remove" "bap-plugin-costant_tracker"]
+remove: [["ocamlfind" "remove" "bap-plugin-constant_tracker"]
          ["bapbundle" "remove" "constant_tracker.plugin"]]
 
 depends: [


### PR DESCRIPTION
This PR fixes a typo that causes a failure during the reinstalling `bap-constant-tracker` package.