### PR TITLE
[new release] travesty (0.6.2)

### DIFF
--- a/packages/travesty/travesty.0.6.2/opam
+++ b/packages/travesty/travesty.0.6.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Monadically traversable containers"
+description: """
+'Travesty' is a library for defining containers with monadic traversals,
+inspired by Haskell's Traversable typeclass.  It sits on top of Jane Street's
+Base library and ecosystem."""
+maintainer: ["Matt Windsor <m.windsor@imperial.ac.uk>"]
+authors: ["Matt Windsor <m.windsor@imperial.ac.uk>"]
+license: "MIT"
+homepage: "https://MattWindsor91.github.io/travesty/"
+doc: "https://MattWindsor91.github.io/travesty/"
+bug-reports: "https://github.com/MattWindsor91/travesty/issues"
+depends: [
+  "ocaml" {>= "4.07" & < "4.11"}
+  "dune" {>= "2.0" & < "3.0"}
+  "ppx_jane" {>= "v0.12.0" & < "v0.14.0"}
+  "base" {>= "v0.12.0" & < "v0.14.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/MattWindsor91/travesty.git"
+url {
+  src:
+    "https://github.com/MattWindsor91/travesty/releases/download/v0.6.2/travesty-v0.6.2.tbz"
+  checksum: [
+    "sha256=be89ec1c96fedcc47362568b359aa6b8d3fefb8b86f70133dd1a75ca72476807"
+    "sha512=19616b0a5fddd5725fdf7ab160e9f89d243f0dbaaaf53ba455bfbac2790cb07811862ecc5ada81be35a06869a987dcc149f24a7e84f461222216d45fe0036ca2"
+  ]
+}


### PR DESCRIPTION
Monadically traversable containers

- Project page: <a href="https://MattWindsor91.github.io/travesty/">https://MattWindsor91.github.io/travesty/</a>
- Documentation: <a href="https://MattWindsor91.github.io/travesty/">https://MattWindsor91.github.io/travesty/</a>

##### CHANGES:

Minor release with one new feature.

- Can now build with OCaml v4.10
- New feature: Traversable.Const, an implementation of a traversal that
  type-checks, but does nothing.
