### PR TITLE
zmq.5.1.0: Fix dependency

### DIFF
--- a/packages/zmq/zmq.5.1.0/opam
+++ b/packages/zmq/zmq.5.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "conf-zmq"
   "dune"
-  "configurator" {build & < "v0.14"}
+  "dune-configurator"
   "ounit" {with-test & < "2.1.0"}
   "base-unix"
   "stdint" {>= "0.4.2"}


### PR DESCRIPTION
Build failure detected in https://github.com/ocaml/opam-repository/pull/16135
```
#=== ERROR while compiling zmq.5.1.0 ==========================================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.05.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.05/.opam-switch/build/zmq.5.1.0
# command              ~/.opam/4.05/bin/dune build -p zmq -j 72
# exit-code            1
# env-file             ~/.opam/log/zmq-23-a6325a.env
# output-file          ~/.opam/log/zmq-23-a6325a.out
### output ###
# File "zmq/src/config/dune", line 3, characters 13-30:
# 3 |   (libraries dune.configurator))
#                  ^^^^^^^^^^^^^^^^^
# Error: Library "dune.configurator" not found.
# Hint: try: dune external-lib-deps --missing -p zmq -j 72 @install
```