### PR TITLE
[new release] 0install-gtk and 0install (2.16)

### DIFF
--- a/packages/0install-gtk/0install-gtk.2.16/opam
+++ b/packages/0install-gtk/0install-gtk.2.16/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Decentralised installation system - GTK UI"
+maintainer: "talex5@gmail.com"
+authors: "zero-install-devel@lists.sourceforge.net"
+homepage: "https://0install.net/"
+bug-reports: "https://github.com/0install/0install/issues"
+dev-repo: "git+https://github.com/0install/0install.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "0install" {= version}
+  "ounit" {with-test}
+  "dune" {>= "2.1"}
+  "lablgtk3"
+  "lwt_glib"
+]
+description: """
+Zero Install is a decentralised cross-distribution software installation system.
+This package provides a GTK-based user interface for it."""
+url {
+  src: "https://github.com/0install/0install/releases/download/v2.16/0install-v2.16.tbz"
+  checksum: [
+    "sha256=4a040cd8ab3a55a84f8daec48306b45d9c9662860fe003c927ef8b485cdecef3"
+    "sha512=594184f2cfcba4eb21eb2af9fe9b22045e195f159d9dd6d0839d749e38b0eb2a804b3461ac4351ad8eac40ac0c9333fdabf758aa00c85b796b4fd220f1e176fc"
+  ]
+}

--- a/packages/0install/0install.2.16/opam
+++ b/packages/0install/0install.2.16/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Decentralised installation system"
+maintainer: "talex5@gmail.com"
+authors: "zero-install-devel@lists.sourceforge.net"
+homepage: "https://0install.net/"
+bug-reports: "https://github.com/0install/0install/issues"
+dev-repo: "git+https://github.com/0install/0install.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "yojson"
+  "xmlm"
+  "ounit" {with-test}
+  "lwt"
+  "lwt_react"
+  "obus" {os != "macos" & os-family != "windows"}
+  "ocurl" {>= "0.7.9"}
+  "sha" {>= "1.9"}
+  "dune" {>= "2.1"}
+]
+depexts: [
+  ["gnupg" "unzip"] {os-family = "debian"}
+  ["gnupg" "unzip"] {os-distribution = "alpine"}
+  ["gnupg"] {os = "macos" & os-distribution = "homebrew"}
+]
+description: """
+Zero Install is a decentralised cross-distribution software installation system.
+Other features include full support for shared libraries (with a SAT solver for
+dependency resolution), sharing between users, and integration with native platform
+package managers. It supports both binary and source packages, and works on Linux,
+macOS, Unix and Windows systems."""
+url {
+  src:
+    "https://github.com/0install/0install/releases/download/v2.16/0install-v2.16.tbz"
+  checksum: [
+    "sha256=4a040cd8ab3a55a84f8daec48306b45d9c9662860fe003c927ef8b485cdecef3"
+    "sha512=594184f2cfcba4eb21eb2af9fe9b22045e195f159d9dd6d0839d749e38b0eb2a804b3461ac4351ad8eac40ac0c9333fdabf758aa00c85b796b4fd220f1e176fc"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- Update to GTK 3, because Debian is removing GTK 2 support now. Note that the systray icon no longer blinks to indicate that action is required, as GTK removed this feature.

- Upgrade to dune 2.1.