### PR TITLE
[new release] Add CoqIDE 8.11.1

### DIFF
--- a/packages/coqide/coqide.8.11.1/files/coqide.install
+++ b/packages/coqide/coqide.8.11.1/files/coqide.install
@@ -1,0 +1,9 @@
+bin: [
+  "bin/coqide"
+]
+share_root: [
+  "ide/coq.lang" {"coq/coq.lang"}
+  "ide/coq-ssreflect.lang" {"coq/coq-ssreflect.lang"}
+  "ide/coq.png" {"coq/coq.png"}
+  "ide/coq_style.xml" {"coq/coq_style.xml"}
+]

--- a/packages/coqide/coqide.8.11.1/opam
+++ b/packages/coqide/coqide.8.11.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, and contributors."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "git+https://github.com/coq/coq.git"
+license: "LGPL-2.1-only"
+synopsis: "IDE of the Coq formal proof management system"
+description: """
+CoqIDE is a graphical user interface for interactive development
+of mathematical definitions, executable algorithms, and proofs of theorems
+using the Coq proof assistant.
+"""
+
+depends: [
+  "coq" {= version}
+  "lablgtk3-sourceview3" {!= "3.0.beta7"}
+  "conf-findutils" {build}
+  "conf-gnome-icon-theme3"
+]
+build: [
+  [
+    "./configure"
+    "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
+    "-mandir" man
+    "-docdir" doc
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
+  ]
+  [make "-j%{jobs}%" "coqide-files"]
+  [make "-j%{jobs}%" "coqide-opt"]
+]
+install: [
+  make
+  "install-ide-bin"
+  "install-ide-files"
+  "install-ide-info"
+  "install-ide-devfiles"
+]
+
+extra-files: [
+  ["coqide.install" "sha512=0c59f0c3cf3453e92c02b29aceb31090020410d2b0dd2856172cd19b1b2b58b2a1d46047fb08a9c1d4767d87934c73ae6adfcb4204b1ea6a55a85ba75b2b812d"]
+]
+
+url {
+  src: "https://github.com/coq/coq/archive/V8.11.1.tar.gz"
+  checksum: "sha512=974f09268ca729b525884e02e3179837e31f8001a2c244f138a36a7984329324083e66d07526bba89acaed656eb7711e2c5b257517309d0479839c5d1ac96aa5"
+}

--- a/packages/coqide/coqide.8.11.1/opam
+++ b/packages/coqide/coqide.8.11.1/opam
@@ -27,7 +27,7 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
-    ("-native-compiler" "no") {os = "macos"}
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]

--- a/packages/coqide/coqide.8.11.1/opam
+++ b/packages/coqide/coqide.8.11.1/opam
@@ -27,7 +27,7 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
-    "-native-compiler" {os = "macos"} "no" {os = "macos"}
+    "-native-compiler" "no" {os = "macos"}
   ]
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]

--- a/packages/coqide/coqide.8.11.1/opam
+++ b/packages/coqide/coqide.8.11.1/opam
@@ -27,7 +27,7 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
-    "-native-compiler" "no" {os = "macos"}
+    ("-native-compiler" "no") {os = "macos"}
   ]
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]


### PR DESCRIPTION
A follow-up on #16146. Builds upon #15766 with minor tweaks + disables `-native_compiler` on macOS.