### PR TITLE
Bisect_ppx 2.3.0 - now with dark theme

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.2.3.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.3.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+
+synopsis: "Code coverage for OCaml"
+version: "2.3.0"
+license: "MIT"
+homepage: "https://github.com/aantron/bisect_ppx"
+doc: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+
+dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+
+depends: [
+  "base-unix"
+  "cmdliner" {>= "1.0.0"}
+  "dune"
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ppx_tools_versioned" {>= "5.3.0"}
+
+  "ocamlfind" {with-test}
+  "ounit2" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+post-messages: [
+  "Bisect_ppx 2.0.0 has deprecated some command-line options. See
+  https://github.com/aantron/bisect_ppx/releases/tag/2.0.0"
+]
+
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+url {
+  src: "https://github.com/aantron/bisect_ppx/archive/2.3.0.tar.gz"
+  checksum: "md5=7dcdd959ef3a164dce84dd2889ca6802"
+}


### PR DESCRIPTION
[Bisect_ppx](https://github.com/aantron/bisect_ppx) is a coverage tool for OCaml.

[Changelog](https://github.com/aantron/bisect_ppx/releases/tag/2.3.0):

> Additions
>
> - Dark theme support (aantron/bisect_ppx#301, Ulrik Strid).
> - Dark theme based on [GitHub-Dark](https://github.com/StylishThemes/Github-Dark) (aantron/bisect_ppx#260).
> - PPX options `--bisect-file` and `--bisect-silent` as alternatives to `BISECT_FILE` and `BISECT_SILENT` environment variables (aantron/bisect_ppx#303, Mehdi Bouaziz).
>
> Bugs fixed
>
> - HTML: coverage meters displayed incorrectly (aantron/bisect_ppx@b61f46a, reported Ulrik Strid).
> - HTML: Firefox would use the default font in `pre > code` (aantron/bisect_ppx#300, Ulrik Strid).
> - HTML: don't show tooltip over unvisited points (aantron/bisect_ppx#304).