### PR TITLE
Release x509 0.11.0

### DIFF
--- a/packages/letsencrypt/letsencrypt.0.2.1/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.1/opam
@@ -25,7 +25,7 @@ depends: [
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-rng"
-  "x509" {>= "0.10.0"}
+  "x509" {>= "0.10.0" & < "0.11.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}
   "dns"

--- a/packages/tls/tls.0.11.0/opam
+++ b/packages/tls/tls.0.11.0/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-rng"
-  "x509" {>= "0.10.0"}
+  "x509" {>= "0.10.0" & < "0.11.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/x509/x509.0.11.0/opam
+++ b/packages/x509/x509.0.11.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD2"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.2"}
+  "cstruct" {>= "4.0.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "ptime"
+  "base64" {>= "3.0.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "rresult"
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "mirage-crypto-rng" {with-test}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 7, PKCS 8, PKCS 9 and PKCS 10.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v0.11.0/x509-v0.11.0.tbz"
+  checksum: [
+    "sha256=1508993f7ccce9ba7ab8e04e1e94774e06dec382378a45b0e8bdf758ef1e9a3d"
+    "sha512=4ddeb6e991faae1e93a8061dfba88506cea6bc8b1fd5e0dbcd89bbbda52ac8be7f92b79c29ea2736a938615eadf1b0cf61e3268e2e5260a681ed39a467cd14d7"
+  ]
+}


### PR DESCRIPTION
[new release] x509 (0.11.0)

CHANGES:

* BREAKING Validation.validate_raw_signature results in a
  `(unit, signature_error) result` and logs (Logs.warn) if a weak (non-SHA2)
  hash algorithm was used. This function is used for verifying signatures
  on certificates, signing requests, and certificate revocation lists.
* The `` `CAInvalidSelfSignature `` constructor (Validation.ca_error) and
  `` `ChainInvalidSignature `` constructor (Validation.chain_validation_error)
  have been removed.
* BREAKING The polymorphic variant `Validation.chain_error` is now flat (the
  tags `` `Chain `` and `` `Leaf `` have been removed)
* BREAKING Adapted return type of CRL.validate and CRL.verify
* The pretty-printer Public_key.pp is now provided
* All implemented by @hannesm in mirleft/ocaml-x509#132 based on private conversation with @cfcs
  (who kindly reviewed the changes)