### PR TITLE
Make old versions of irc-client unavailable

### DIFF
--- a/packages/irc-client/irc-client.0.1.1/opam
+++ b/packages/irc-client/irc-client.0.1.1/opam
@@ -22,3 +22,4 @@ url {
   src: "https://github.com/johnelse/ocaml-irc-client/archive/0.1.1.tar.gz"
   checksum: "md5=90ac5b939c3d1e473afc6a9b9cb0e33a"
 }
+available: false

--- a/packages/irc-client/irc-client.0.1.2/opam
+++ b/packages/irc-client/irc-client.0.1.2/opam
@@ -20,3 +20,4 @@ url {
   src: "https://github.com/johnelse/ocaml-irc-client/archive/0.1.2.tar.gz"
   checksum: "md5=9728eaa5e16db384354aff45f795f421"
 }
+available: false

--- a/packages/irc-client/irc-client.0.2.0/opam
+++ b/packages/irc-client/irc-client.0.2.0/opam
@@ -20,3 +20,4 @@ url {
   src: "https://github.com/johnelse/ocaml-irc-client/archive/0.2.0.tar.gz"
   checksum: "md5=62fb92777d42fc5a2d1d2316c96aedd3"
 }
+available: false

--- a/packages/irc-client/irc-client.0.2.1/opam
+++ b/packages/irc-client/irc-client.0.2.1/opam
@@ -20,3 +20,4 @@ url {
   src: "https://github.com/johnelse/ocaml-irc-client/archive/0.2.1.tar.gz"
   checksum: "md5=97d280ad8230a880ff78b9b04532326d"
 }
+available: false

--- a/packages/irc-client/irc-client.0.3.0/opam
+++ b/packages/irc-client/irc-client.0.3.0/opam
@@ -24,3 +24,4 @@ url {
   src: "https://github.com/johnelse/ocaml-irc-client/archive/0.3.0.tar.gz"
   checksum: "md5=178f3aeb93402716df031ba284993b8f"
 }
+available: false

--- a/packages/irc-client/irc-client.0.3.1/opam
+++ b/packages/irc-client/irc-client.0.3.1/opam
@@ -27,3 +27,4 @@ url {
   src: "https://github.com/johnelse/ocaml-irc-client/archive/0.3.1.tar.gz"
   checksum: "md5=24497187cbb0b6d347f0a7ede00bbcba"
 }
+available: false

--- a/packages/irc-client/irc-client.0.3.2/opam
+++ b/packages/irc-client/irc-client.0.3.2/opam
@@ -27,3 +27,4 @@ url {
   src: "https://github.com/johnelse/ocaml-irc-client/archive/0.3.2.tar.gz"
   checksum: "md5=a0655a261b020551ecf2e8d04356906f"
 }
+available: false

--- a/packages/irc-client/irc-client.0.4.0/opam
+++ b/packages/irc-client/irc-client.0.4.0/opam
@@ -49,3 +49,4 @@ url {
   src: "https://github.com/johnelse/ocaml-irc-client/archive/0.4.0.tar.gz"
   checksum: "md5=4424648730b87edfcf96ffae4072550a"
 }
+available: false

--- a/packages/irc-client/irc-client.0.5.0/opam
+++ b/packages/irc-client/irc-client.0.5.0/opam
@@ -50,3 +50,4 @@ url {
     "https://github.com/johnelse/ocaml-irc-client/archive/irc-client.0.5.0.tar.gz"
   checksum: "md5=fb82142695a6719fe11d50f53e611ef7"
 }
+available: false

--- a/packages/irc-client/irc-client.0.5.1/opam
+++ b/packages/irc-client/irc-client.0.5.1/opam
@@ -50,3 +50,4 @@ url {
     "https://github.com/johnelse/ocaml-irc-client/archive/irc-client.0.5.1.tar.gz"
   checksum: "md5=5047a422402f36af4a59261db7d0c287"
 }
+available: false

--- a/packages/irc-client/irc-client.0.5.2/opam
+++ b/packages/irc-client/irc-client.0.5.2/opam
@@ -50,3 +50,4 @@ url {
     "https://github.com/johnelse/ocaml-irc-client/archive/irc-client.0.5.2.tar.gz"
   checksum: "md5=9357f6465a5629e27e2df3bb4ce7b812"
 }
+available: false

--- a/packages/irc-client/irc-client.0.5.4/opam
+++ b/packages/irc-client/irc-client.0.5.4/opam
@@ -50,3 +50,4 @@ url {
     "https://github.com/johnelse/ocaml-irc-client/archive/irc-client.0.5.4.tar.gz"
   checksum: "md5=776adba9e35b83b93848f2be8866c09d"
 }
+available: false


### PR DESCRIPTION
These are all from before the switch to jbuilder/dune, and before this
package was split up into lwt/tls/unix variants. They shouldn't be used
by anyone at this point.

Signed-off-by: John Else <john.else@gmail.com>