### PR TITLE
Release dune-deps 1.1.0. Adds dependency on cmdliner.

### DIFF
--- a/packages/dune-deps/dune-deps.1.1.0/opam
+++ b/packages/dune-deps/dune-deps.1.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "https://github.com/mjambon/dune-deps"
+bug-reports: "https://github.com/mjambon/dune-deps/issues"
+dev-repo: "git+https://github.com/mjambon/dune-deps.git"
+license: "BSD-3-Clause"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "cmdliner"
+  "dune" {>= "2.1"}
+  "ocaml"
+  "sexplib"
+]
+
+synopsis: "Show dependency graph of a multi-component dune project"
+
+description: """
+Dune-deps scans a dune project and produces a dependency graph
+which can be rendered with 'dot'. It is useful for projects that define
+multiple libraries or executables. It allows the developer to visualize
+the dependencies between the various components of a project.
+"""
+
+url {
+  src: "https://github.com/mjambon/dune-deps/archive/v1.1.0.tar.gz"
+  checksum: "md5=53700d2e414490a15266c68b9a4fa5a3"
+}


### PR DESCRIPTION
`make test` also depends on alcotest but I didn't specify it in the opam file since it's not required for the build.