### PR TITLE
3 packages from ryanslade/influxdb-ocaml at 0.3.0

### DIFF
--- a/packages/influxdb-async/influxdb-async.0.3.0/opam
+++ b/packages/influxdb-async/influxdb-async.0.3.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "InfluxDB client library using async for concurrency"
+description: "A client library for writing time series data to InfluxDB"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/influxdb-ocaml"
+bug-reports: "https://github.com/ryanslade/influxdb-ocaml/issues"
+dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {>= "2.0"}
+  "base"
+  "alcotest" {with-test}
+  "influxdb" {= "0.3.0"}
+  "async"
+  "cohttp"
+  "cohttp-async"
+  "ocaml" {>= "4.04.0"}
+]
+url {
+  src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=c5d2d4dddcd8498ace3dd44870efa201"
+    "sha512=e9d4e2938ec22dd7df8c4f9b82a76892c146bc2d682cb9dd99fe7ca9d813d26c5268658fa16e8eb75b2256449e22086711a6e01229a542e785c4ab1b0ff065d3"
+  ]
+}

--- a/packages/influxdb-lwt/influxdb-lwt.0.3.0/opam
+++ b/packages/influxdb-lwt/influxdb-lwt.0.3.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "InfluxDB client library using lwt for concurrency"
+description: "A client library for writing time series data to InfluxDB"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/influxdb-ocaml"
+bug-reports: "https://github.com/ryanslade/influxdb-ocaml/issues"
+dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {>= "2.0"}
+  "base"
+  "alcotest" {with-test}
+  "influxdb" {= "0.3.0"}
+  "lwt"
+  "cohttp"
+  "cohttp-lwt-unix"
+  "ocaml" {>= "4.04.0"}
+]
+url {
+  src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=c5d2d4dddcd8498ace3dd44870efa201"
+    "sha512=e9d4e2938ec22dd7df8c4f9b82a76892c146bc2d682cb9dd99fe7ca9d813d26c5268658fa16e8eb75b2256449e22086711a6e01229a542e785c4ab1b0ff065d3"
+  ]
+}

--- a/packages/influxdb/influxdb.0.3.0/opam
+++ b/packages/influxdb/influxdb.0.3.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "InfluxDB client library"
+description: "A client library for writing time series data to InfluxDB"
+maintainer: "Ryan Slade <ryanslade@gmail.com>"
+authors: "Ryan Slade <ryanslade@gmail.com>"
+homepage: "https://github.com/ryanslade/influxdb-ocaml"
+bug-reports: "https://github.com/ryanslade/influxdb-ocaml/issues"
+dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {>= "2.0"}
+  "base"
+  "stdio"
+  "ppx_expect"
+  "ocaml" {>= "4.04.0"}
+]
+url {
+  src: "https://github.com/ryanslade/influxdb-ocaml/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=c5d2d4dddcd8498ace3dd44870efa201"
+    "sha512=e9d4e2938ec22dd7df8c4f9b82a76892c146bc2d682cb9dd99fe7ca9d813d26c5268658fa16e8eb75b2256449e22086711a6e01229a542e785c4ab1b0ff065d3"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`influxdb.0.3.0`: InfluxDB client library
-`influxdb-async.0.3.0`: InfluxDB client library using async for concurrency
-`influxdb-lwt.0.3.0`: InfluxDB client library using lwt for concurrency



---
* Homepage: https://github.com/ryanslade/influxdb-ocaml
* Source repo: git://github.com/ryanslade/influxdb-ocaml.git
* Bug tracker: https://github.com/ryanslade/influxdb-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2