### PR TITLE
[new release] ocaml-migrate-parsetree (1.7.0)

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "result"
+  "ppx_derivers"
+  "dune" {>= "1.9.0"}
+  "ocaml" {>= "4.02.3"}
+]
+synopsis: "Convert OCaml parsetrees between different versions"
+description: """
+Convert OCaml parsetrees between different versions
+
+This library converts parsetrees, outcometree and ast mappers between
+different OCaml versions.  High-level functions help making PPX
+rewriters independent of a compiler version.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.7.0/ocaml-migrate-parsetree-v1.7.0.tbz"
+  checksum: [
+    "sha256=c0ae0a35ce0752735c8bd5d65b3a54dbb6d243eec553a64f4eeb98fdcf7029af"
+    "sha512=30fe8768c9bf81a204b278d64ae44a8326531de65f1b54f84120fa7ff8ba204c9d4733c2fe7313c3b2b6751ca997c525e43e026f8ef18f794e6f79c4aeee717c"
+  ]
+}


### PR DESCRIPTION
Convert OCaml parsetrees between different versions

- Project page: <a href="https://github.com/ocaml-ppx/ocaml-migrate-parsetree">https://github.com/ocaml-ppx/ocaml-migrate-parsetree</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ocaml-migrate-parsetree/">https://ocaml-ppx.github.io/ocaml-migrate-parsetree/</a>

##### CHANGES:

- Add support for 4.11 (ocaml-ppx/ocaml-migrate-parsetree#92, @diml)
