### PR TITLE
[ocamlformat] Fix dependency on dune

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.14.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.14.0/opam
@@ -24,7 +24,7 @@ depends: [
   "base" {>= "v0.11.0"}
   "base-unix"
   "cmdliner"
-  "dune" {>= "1.11.1"}
+  "dune" {>= "2.2.0"}
   "fix"
   "fpath"
   "menhir"


### PR DESCRIPTION
`ocamlformat` depends on `(using menhir 2.1)` which in turn requires
Dune >= 2.2.0