### PR TITLE
Package pprint.20200410

### DIFF
--- a/packages/pprint/pprint.20200410/opam
+++ b/packages/pprint/pprint.20200410/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "A pretty-printing combinator library and rendering engine"
+description: """
+This library offers a set of combinators for building so-called documents as
+well as an efficient engine for converting documents to a textual, fixed-width
+format. The engine takes care of indentation and line breaks, while respecting
+the constraints imposed by the structure of the document and by the text width."""
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+  "Nicolas Pouillard <np@nicolaspouillard.fr>"
+]
+homepage: "https://github.com/fpottier/pprint"
+bug-reports: "francois.pottier@inria.fr"
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "1.3"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+ssh://git@github.com/fpottier/pprint.git"
+url {
+  src: "https://github.com/fpottier/pprint/archive/20200410.tar.gz"
+  checksum: [
+    "md5=d6b20d1db73cf15f79b2884a9e38bf06"
+    "sha512=f9a4ea908248cc14df1ef93418ce80598e88666b9347f683d5cc6f67a8c28290f0a4e40ae6f1842efa1d9c38d4802e7e3c77bbcf2e6f986c45ba12907e9580c9"
+  ]
+}


### PR DESCRIPTION
### `pprint.20200410`
A pretty-printing combinator library and rendering engine
This library offers a set of combinators for building so-called documents as
well as an efficient engine for converting documents to a textual, fixed-width
format. The engine takes care of indentation and line breaks, while respecting
the constraints imposed by the structure of the document and by the text width.



---
* Homepage: https://github.com/fpottier/pprint
* Source repo: git+ssh://git@github.com/fpottier/pprint.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.2