### PR TITLE
Sync up versions of bimage subpackages

### DIFF
--- a/packages/bimage-gtk/bimage-gtk.0.1.1/opam
+++ b/packages/bimage-gtk/bimage-gtk.0.1.1/opam
@@ -12,7 +12,7 @@ depends:
 [
     "ocaml" {>= "4.03.0"}
     "dune" {>= "1.1"}
-    "bimage" {>= "0.1"}
+    "bimage" {= version}
     "lablgtk3" {>= "3.0.beta6"}
     "cairo2" {>= "0.6"}
 ]

--- a/packages/bimage-gtk/bimage-gtk.0.1.2/opam
+++ b/packages/bimage-gtk/bimage-gtk.0.1.2/opam
@@ -12,7 +12,7 @@ depends:
 [
     "ocaml" {>= "4.03.0"}
     "dune" {>= "1.1"}
-    "bimage" {>= "0.1"}
+    "bimage" {= version}
     "lablgtk3" {>= "3.0.beta6"}
     "cairo2" {>= "0.6"}
 ]

--- a/packages/bimage-gtk/bimage-gtk.0.1/opam
+++ b/packages/bimage-gtk/bimage-gtk.0.1/opam
@@ -12,7 +12,7 @@ depends:
 [
     "ocaml" {>= "4.03.0"}
     "dune"
-    "bimage" {>= "0.1"}
+    "bimage" {= version}
     "lablgtk" {>= "2.18"}
     "cairo2" {>= "0.6"}
 ]

--- a/packages/bimage-sdl/bimage-sdl.0.1.1/opam
+++ b/packages/bimage-sdl/bimage-sdl.0.1.1/opam
@@ -12,7 +12,7 @@ depends:
 [
     "ocaml" {>= "4.03.0"}
     "dune" {>= "1.1"}
-    "bimage" {>= "0.1"}
+    "bimage" {= version}
     "tsdl" {>= "0.9"}
 ]
 

--- a/packages/bimage-sdl/bimage-sdl.0.1.2/opam
+++ b/packages/bimage-sdl/bimage-sdl.0.1.2/opam
@@ -12,7 +12,7 @@ depends:
 [
     "ocaml" {>= "4.03.0"}
     "dune" {>= "1.1"}
-    "bimage" {>= "0.1"}
+    "bimage" {= version}
     "tsdl" {>= "0.9"}
 ]
 

--- a/packages/bimage-unix/bimage-unix.0.1.1/opam
+++ b/packages/bimage-unix/bimage-unix.0.1.1/opam
@@ -12,7 +12,7 @@ depends:
 [
     "ocaml" {>= "4.06.0"}
     "dune" {>= "1.1"}
-    "bimage" {>= "0.1"}
+    "bimage" {= version}
     "ctypes" {>= "0.14"}
     "ctypes-foreign" {>= "0.4"}
 ]

--- a/packages/bimage-unix/bimage-unix.0.1.2/opam
+++ b/packages/bimage-unix/bimage-unix.0.1.2/opam
@@ -12,7 +12,7 @@ depends:
 [
     "ocaml" {>= "4.06.0"}
     "dune" {>= "1.1"}
-    "bimage" {>= "0.1"}
+    "bimage" {= version}
     "ctypes" {>= "0.14"}
     "ctypes-foreign" {>= "0.4"}
 ]

--- a/packages/bimage-unix/bimage-unix.0.1/opam
+++ b/packages/bimage-unix/bimage-unix.0.1/opam
@@ -12,7 +12,7 @@ depends:
 [
     "ocaml" {>= "4.06.0"}
     "dune"
-    "bimage" {>= "0.1"}
+    "bimage" {= version}
     "ctypes" {>= "0.14"}
     "ctypes-foreign" {>= "0.4"}
 ]


### PR DESCRIPTION
Fixes revdep failures encountered in https://github.com/ocaml/opam-repository/pull/16181 as well as potential future breakage.

@zshipko is that ok?