### PR TITLE
session-upper-bound: add upper bound to session-related libraries

### DIFF
--- a/packages/session-cohttp/session-cohttp.0.4.0/opam
+++ b/packages/session-cohttp/session-cohttp.0.4.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {>= "1.0+beta9"}
-  "session" {>= "0.4.0"}
+  "session" {>= "0.4.0" & <= "0.4.1"}
   "cohttp" {>= "0.99.0"}
 ]
 synopsis:

--- a/packages/session-cohttp/session-cohttp.0.4.1/opam
+++ b/packages/session-cohttp/session-cohttp.0.4.1/opam
@@ -9,7 +9,7 @@ doc: "https://inhabitedtype.github.io/ocaml-session/"
 depends: [
   "ocaml"
   "dune" {>= "1.0"}
-  "session" {>= "0.4.0"}
+  "session" {>= "0.4.0" & <= "0.4.1"}
   "cohttp" {>= "0.99.0"}
 ]
 build: [

--- a/packages/session-postgresql/session-postgresql.0.4.0/opam
+++ b/packages/session-postgresql/session-postgresql.0.4.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {>= "1.0+beta9"}
-  "session" {>= "0.4.0"}
+  "session" {>= "0.4.0" & <= "0.4.1"}
   "postgresql"
 ]
 synopsis:

--- a/packages/session-postgresql/session-postgresql.0.4.1/opam
+++ b/packages/session-postgresql/session-postgresql.0.4.1/opam
@@ -9,7 +9,7 @@ doc: "https://inhabitedtype.github.io/ocaml-session/"
 depends: [
   "ocaml"
   "dune" {>= "1.0"}
-  "session" {>= "0.4.0"}
+  "session" {>= "0.4.0" & <= "0.4.1"}
   "postgresql"
 ]
 build: [

--- a/packages/session-redis-lwt/session-redis-lwt.0.4.0/opam
+++ b/packages/session-redis-lwt/session-redis-lwt.0.4.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {>= "1.0+beta9"}
-  "session" {>= "0.4.0"}
+  "session" {>= "0.4.0" & <= "0.4.1"}
   "redis-lwt"
 ]
 synopsis:

--- a/packages/session-redis-lwt/session-redis-lwt.0.4.1/opam
+++ b/packages/session-redis-lwt/session-redis-lwt.0.4.1/opam
@@ -9,7 +9,7 @@ doc: "https://inhabitedtype.github.io/ocaml-session/"
 depends: [
   "ocaml"
   "dune" {>= "1.0"}
-  "session" {>= "0.4.0"}
+  "session" {>= "0.4.0" & <= "0.4.1"}
   "redis-lwt"
 ]
 build: [


### PR DESCRIPTION
This is in preparation for an upcoming release that will cause these libraries to break (or at least to behave in non-obvious ways) if they depend on the new session library.