### PR TITLE
[new release] argon2 (1.0.0)

### DIFF
--- a/packages/argon2/argon2.1.0.0/opam
+++ b/packages/argon2/argon2.1.0.0/opam
@@ -8,7 +8,7 @@ doc: "https://khady.github.io/ocaml-argon2/"
 license: "MIT"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune"
+  "dune" {>= "2.0"}
   "ctypes" {>= "0.4.1"}
   "ctypes-foreign"
   "result"

--- a/packages/argon2/argon2.1.0.0/opam
+++ b/packages/argon2/argon2.1.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Louis Roché <louis@louisroche.net>"
+authors: "Louis Roché <louis@louisroche.net>"
+homepage: "https://github.com/Khady/ocaml-argon2"
+dev-repo: "git+https://github.com/Khady/ocaml-argon2.git"
+bug-reports: "https://github.com/Khady/ocaml-argon2/issues"
+doc: "https://khady.github.io/ocaml-argon2/"
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune"
+  "ctypes" {>= "0.4.1"}
+  "ctypes-foreign"
+  "result"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+synopsis: "OCaml bindings to Argon2"
+description: """
+Based on argon2 library as described in https://github.com/P-H-C/phc-winner-argon2.
+
+libargon2 must be installed on your system for this library to work.
+"""
+url {
+  src:
+    "https://github.com/Khady/ocaml-argon2/releases/download/1.0.0/argon2-1.0.0.tbz"
+  checksum: [
+    "sha256=2faf327a25b4d3df1557ed8c0b05431a6ccdf056ab2a977d7d944445a62f020f"
+    "sha512=cb74864d9f5c4929ef108019a199f911545b130e25983fbcc765967467e409742994e605b0c9e8c81f8da94abaa7380888ee80dba726a834162656c7795bc4bf"
+  ]
+}


### PR DESCRIPTION
OCaml bindings to Argon2

- Project page: <a href="https://github.com/Khady/ocaml-argon2">https://github.com/Khady/ocaml-argon2</a>
- Documentation: <a href="https://khady.github.io/ocaml-argon2/">https://khady.github.io/ocaml-argon2/</a>

##### CHANGES:

- compatibility with libargon2 20171227 (Khady/ocaml-argon2#3)
- change build system to dune (Khady/ocaml-argon2#3)
- ocamlformat sources
- support argon2id
- add tests
