### PR TITLE
[new release] routes (0.7.3)

### DIFF
--- a/packages/routes/routes.0.7.3/opam
+++ b/packages/routes/routes.0.7.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni <anurag@sonianurag.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anuragsoni/routes"
+bug-reports: "https://github.com/anuragsoni/routes/issues"
+dev-repo: "git+https://github.com/anuragsoni/routes.git"
+doc: "https://anuragsoni.github.io/routes/"
+tags: ["router" "http"]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune"
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "alcotest" {with-test}
+  "mdx" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Typed routing for OCaml applications"
+description: """
+routes provides combinators for adding typed routing
+to OCaml applications. The core library will be independent
+of any particular web framework or runtime. It does
+path based dispatch from a target url to a user
+provided handler.
+"""
+url {
+  src:
+    "https://github.com/anuragsoni/routes/releases/download/0.7.3/routes-0.7.3.tbz"
+  checksum: [
+    "sha256=e08028974b626f85c395d8196aef7b0052ba9a1d534b896b83015641b5dfc32e"
+    "sha512=0e10de2031b828e1eeeafbee07e42c903d18e0e6bbe90ff58ef1d28d0be10fd7d086bc771dc1ed6744cd2c42fc17e4200193942d40add52cfa048eb188479781"
+  ]
+}


### PR DESCRIPTION
Typed routing for OCaml applications

- Project page: <a href="https://github.com/anuragsoni/routes">https://github.com/anuragsoni/routes</a>
- Documentation: <a href="https://anuragsoni.github.io/routes/">https://anuragsoni.github.io/routes/</a>

##### CHANGES:

* Allow adding new routes to existing router. (anuragsoni/routes#108, @tatchi)
* Fix library name in bsconfig.json. (anuragsoni/routes#109, @tsnobip)
* Specify -O3 flag for ocamlopt when using dune's release profile. (anuragsoni/routes#110)
