### PR TITLE
capnp-rpc-net: add missing upper-bound on x509

### DIFF
--- a/packages/capnp-rpc-net/capnp-rpc-net.0.6.0/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.0.6.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ptime"
   "prometheus" {>= "0.5"}
   "asn1-combinators" {>= "0.2.0"}
-  "x509" {>= "0.10.0"}
+  "x509" {>= "0.10.0" & < "0.11.0"}
   "tls-mirage"
   "dune" {>= "1.0"}
 ]


### PR DESCRIPTION
Error was:

    File "capnp-rpc-net/auth.ml", line 139, characters 12-22:
    139 |     | Error (`Msg err) -> failwith (Printf.sprintf "x509 signing failed: %s" err)
                  ^^^^^^^^^^
    Error: This pattern matches values of type [? `Msg of 'a ]
           but a pattern was expected which matches values of type
             X509.Validation.signature_error
           The second variant type does not allow tag(s) `Msg

It looks like the CI didn't detect this because it tried to install transitive test dependencies, and that failed because it couldn't solve for `crowbar`!

```
[ERROR] No solution for capnp-rpc-net.0.6.0: The following dependencies couldn't be met:
          - capnp-rpc-net -> tls-mirage -> mirage-crypto-pk -> eqaf >= 0.5 -> crowbar -> xmldiff -> xmlm < 1.3.0 -> ocaml < 4.06.0
              base of this switch (use `--unlock-base' to force)
          - capnp-rpc-net -> tls-mirage -> mirage-crypto-pk -> eqaf >= 0.5 -> crowbar -> xmldiff -> camlp4 -> ocaml < 4.09
              base of this switch (use `--unlock-base' to force)
          - capnp-rpc-net -> tls-mirage -> mirage-crypto-pk -> eqaf >= 0.5 -> crowbar -> xmldiff -> camlp4 -> ocaml-variants (= 4.02.0+modular-implicits & = 4.02.1+modular-implicits-ber)
              no matching version
```

https://ci.ocaml.org/log/saved/docker-run-0c7fcd365ef36aafdddd6759237429ab/9073280bb00f3244812a29acd10a56ce884db53f
