### PR TITLE
[new release] ocamlformat (0.14.1)

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.14.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.14.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "alcotest" {with-test}
+  "base" {>= "v0.11.0"}
+  "base-unix"
+  "cmdliner"
+  "dune" {>= "2.2.0"}
+  "fix"
+  "fpath"
+  "menhir"
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "re"
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.14.1/ocamlformat-0.14.1.tbz"
+  checksum: [
+    "sha256=4a7d4575c202bd0413b2864be60000854feade9190f5530222679815bb21960f"
+    "sha512=95dd81fd05716d422c5b8873d0ef6665d2dcabc3e43a9cf4c8af5c4e060445d40af3910a558f5aceee63db7132296b201f241d02d920669e8be1e6a81b7a7baa"
+  ]
+}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### Changes

  + The default for `doc-comments` is changed to `after` (ocaml-ppx/ocamlformat#1335) (Jules Aguillon)
    This reverts a change introduced in 0.14.0 (ocaml-ppx/ocamlformat#1012).

  + Revert deprecation of the `doc-comments` option (ocaml-ppx/ocamlformat#1331) (Jules Aguillon)
    This reverts a change introduced in 0.14.0 (ocaml-ppx/ocamlformat#1293).
