### PR TITLE
Package ringo.0.2

### DIFF
--- a/packages/ringo/ringo.0.2/opam
+++ b/packages/ringo/ringo.0.2/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Caches (bounded-size key-value stores) and other bounded-size stores"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.2/ringo-v0.2.tar.gz"
+  checksum: [
+    "md5=d506032acd287702d0d098ddd7ead15e"
+    "sha512=eb602c6ec7b7b8fb88d254ad5b781709b891a6d09db3a167ca5ffb52a8cdf8d91769c2de75cd501c7d5be80678aa5c269df0b69270c2d383c7f6454dd97143c0"
+  ]
+}


### PR DESCRIPTION
### `ringo.0.2`
Caches (bounded-size key-value stores) and other bounded-size stores



---
* Homepage: https://gitlab.com/nomadic-labs/ringo
* Source repo: git+https://gitlab.com/nomadic-labs/ringo.git
* Bug tracker: https://gitlab.com/nomadic-labs/ringo/issues

---
:camel: Pull-request generated by opam-publish v2.0.0