### PR TITLE
[new release] merlin (3.3.4)

### DIFF
--- a/packages/merlin/merlin.3.3.4/opam
+++ b/packages/merlin/merlin.3.3.4/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos" & ocaml:version >= "4.03"}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/merlin/merlin.3.3.4/opam
+++ b/packages/merlin/merlin.3.3.4/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.8.0"}
+  "ocamlfind" {>= "1.5.2"}
+  "yojson" {>= "1.6.0"}
+  "mdx" {with-test & >= "1.3.0"}
+  "conf-jq" {with-test}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam config var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v3.3.4/merlin-v3.3.4.tbz"
+  checksum: [
+    "sha256=adcde0ebe3dce183bae0df1cc988e0aa5cd4e446b59bc081d5350f6b58cc9d8b"
+    "sha512=5f4fb73b852f431e1fee7def63a1150de1b9ae931a74078c870ab7c420607ae0654195baf9e09bee5304aeefa92108e42fe963684e8e8511006a562ba15c4a83"
+  ]
+}


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Tue Apr 14 15:25:05 CEST 2020

  + ocaml support
    - full support from OCaml 4.02 to OCaml 4.10 (ocaml/merlin#1117, ocaml/merlin#1127)
    - fix desynchronized cache (ocaml/merlin#1120)
    - short path for OCaml 4.09 and OCaml 4.10 (ocaml/merlin#1082, ocaml/merlin#1117)
    - catch and test environment initialization errors (ocaml/merlin#1083, ocaml/merlin#1130)
    - restore type levels after recovery (ocaml/merlin#1092)
  + merlin binary
    - fix syntax errors in 4.08 and 4.09 (ocaml/merlin#1081)
    - complete-prefix command accepts -kind option to filter results (ocaml/merlin#1071)
    - code cleanup (ocaml/merlin#1093, ocaml/merlin#1079, ocaml/merlin#1112)
    - better handling of expression and pattern extra nodes during browse tree
      traversal (ocaml/merlin#1091, ocaml/merlin#1121)
    - improve context detection (e.g. appropriate namespace for lookup) for
      various queries (ocaml/merlin#1104, ocaml/merlin#1110)
    - add stdlib to locate source path (ocaml/merlin#1085)
  + editor modes
    - vim: tweak heuristic to select python version (ocaml/merlin#1111)
    - emacs: marlin/call
    - lsp: move server to its own repository (ocaml/merlin#1069),
      https://github.com/ocaml/ocaml-lsp
  + test suite
    - dune rules for the test suite are now generated, deterministic and
      can be run individually (ocaml/merlin#1068, ocaml/merlin#1070, ocaml/merlin#1072)
    - fix incorrect command-line arguments in tests (ocaml/merlin#1073)
    - better coverage of frontend features (ocaml/merlin#1075, ocaml/merlin#1078, ocaml/merlin#1088, ocaml/merlin#1089, ocaml/merlin#1126)

Build no longer relies on implicit transitive_deps (ocaml/merlin#1065).