### PR TITLE
[new release] argon2 (1.0.1)

### DIFF
--- a/packages/argon2/argon2.1.0.1/opam
+++ b/packages/argon2/argon2.1.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Louis Roché <louis@louisroche.net>"
+authors: "Louis Roché <louis@louisroche.net>"
+homepage: "https://github.com/Khady/ocaml-argon2"
+dev-repo: "git+https://github.com/Khady/ocaml-argon2.git"
+bug-reports: "https://github.com/Khady/ocaml-argon2/issues"
+doc: "https://khady.github.io/ocaml-argon2/"
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "2.0"}
+  "ctypes" {>= "0.4.1"}
+  "ctypes-foreign"
+  "result"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+synopsis: "OCaml bindings to Argon2"
+description: """
+Based on argon2 library as described in https://github.com/P-H-C/phc-winner-argon2.
+
+libargon2 must be installed on your system for this library to work.
+"""
+url {
+  src:
+    "https://github.com/Khady/ocaml-argon2/releases/download/1.0.1/argon2-1.0.1.tbz"
+  checksum: [
+    "sha256=c71a08bf050ac258700bdcf3a7a4b0a52338769d519ec5ab433c271a1e22b810"
+    "sha512=5f92dc5f4b6e08134340f0130470a0e342626fb74a60f73aa174a0c4b079c0a1bf89aadfc8461ba94d9f6ba21a0e6625b554c09a9511604b663a984a6b38890d"
+  ]
+}


### PR DESCRIPTION
OCaml bindings to Argon2

- Project page: <a href="https://github.com/Khady/ocaml-argon2">https://github.com/Khady/ocaml-argon2</a>
- Documentation: <a href="https://khady.github.io/ocaml-argon2/">https://khady.github.io/ocaml-argon2/</a>

##### CHANGES:

- fix wrong length of hash encoded (Khady/ocaml-argon2#5)
