### PR TITLE
[new release] ocaml-migrate-parsetree (1.7.1)

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.1/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "result"
+  "ppx_derivers"
+  "dune" {>= "1.9.0"}
+  "ocaml" {>= "4.02.3"}
+]
+synopsis: "Convert OCaml parsetrees between different versions"
+description: """
+Convert OCaml parsetrees between different versions
+
+This library converts parsetrees, outcometree and ast mappers between
+different OCaml versions.  High-level functions help making PPX
+rewriters independent of a compiler version.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.7.1/ocaml-migrate-parsetree-v1.7.1.tbz"
+  checksum: [
+    "sha256=41a37f1ad93ffa1e40e5c91002e6840cf9b6c37385da1c9db833014e8d6103b8"
+    "sha512=05998114f8caeb0dc1af8bc2b76f80a2b4cba25597088fff01a6643d40c3a49e55b1e2f369fe8959a72c79417ac1438ab06db7bb8cd377a55612b4ab68083576"
+  ]
+}


### PR DESCRIPTION
Convert OCaml parsetrees between different versions

- Project page: <a href="https://github.com/ocaml-ppx/ocaml-migrate-parsetree">https://github.com/ocaml-ppx/ocaml-migrate-parsetree</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ocaml-migrate-parsetree/">https://ocaml-ppx.github.io/ocaml-migrate-parsetree/</a>

##### CHANGES:

- Fix build with OCaml < 4.08
