### PR TITLE
atdj.2.0.0 is not compatible with atd >= 2.1.0

### DIFF
--- a/packages/atdj/atdj.2.0.0/opam
+++ b/packages/atdj/atdj.2.0.0/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder"
-  "atd" {>= "2.0.0"}
+  "atd" {>= "2.0.0" & < "2.1.0"}
 ]
 synopsis: "Java code generation for ATD."
 description: """


### PR DESCRIPTION
Fix issue encountered in https://github.com/ocaml/opam-repository/pull/16193