### PR TITLE
Package conf-nauty.1.0

### DIFF
--- a/packages/conf-nauty/conf-nauty.1.0/opam
+++ b/packages/conf-nauty/conf-nauty.1.0/opam
@@ -4,8 +4,10 @@ homepage: "http://pallini.di.uniroma1.it/"
 authors: "http://pallini.di.uniroma1.it/Links.html#contact"
 bug-reports: "https://github.com/zajer/conf-nauty/issues"
 license: "Apache-2.0"
-build: ["pkg-config" "nauty"] {os!="macos"}
-depends: ["conf-pkg-config" {build & os!="macos"}]
+build: ["pkg-config" "nauty"] {os != "macos"}
+depends: [
+  "conf-pkg-config" {build & os != "macos"}
+]
 depexts: [
   ["libnauty2-dev"] {os-family = "debian"}
   ["libnauty-devel"] {os-distribution = "fedora"}
@@ -14,10 +16,3 @@ synopsis: "Virtual package relying on nauty"
 description:
   "This package can only install if the libnauty library is installed on the system."
 flags: conf
-url {
-  src: "https://github.com/zajer/conf-nauty/archive/1.0.tar.gz"
-  checksum: [
-    "md5=a5cd7211717aa159df2e877fa89aba80"
-    "sha512=49f2f3ff503ba10797707d46c18b0b1c66f2786a3c4fda7fc9cd563f5bc9d7bca0e31d65d8eafa9d7902c10f9c6fdd89fbdbe76ea9d223e6383d2afa5beb5261"
-  ]
-}

--- a/packages/conf-nauty/conf-nauty.1.0/opam
+++ b/packages/conf-nauty/conf-nauty.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "pikus3@list.pl"
+homepage: "http://pallini.di.uniroma1.it/"
+authors: "http://pallini.di.uniroma1.it/Links.html#contact"
+bug-reports: "https://github.com/zajer/conf-nauty/issues"
+license: "Apache-2.0"
+build: ["pkg-config" "nauty"] {os!="macos"}
+depends: ["conf-pkg-config" {build & os!="macos"}]
+depexts: [
+  ["libnauty2-dev"] {os-family = "debian"}
+  ["libnauty-devel"] {os-distribution = "fedora"}
+]
+synopsis: "Virtual package relying on nauty"
+description:
+  "This package can only install if the libnauty library is installed on the system."
+flags: conf
+url {
+  src: "https://github.com/zajer/conf-nauty/archive/1.0.tar.gz"
+  checksum: [
+    "md5=a5cd7211717aa159df2e877fa89aba80"
+    "sha512=49f2f3ff503ba10797707d46c18b0b1c66f2786a3c4fda7fc9cd563f5bc9d7bca0e31d65d8eafa9d7902c10f9c6fdd89fbdbe76ea9d223e6383d2afa5beb5261"
+  ]
+}

--- a/packages/conf-nauty/conf-nauty.1.0/opam
+++ b/packages/conf-nauty/conf-nauty.1.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "pikus3@list.pl"
 homepage: "http://pallini.di.uniroma1.it/"
 authors: "http://pallini.di.uniroma1.it/Links.html#contact"
-bug-reports: "https://github.com/zajer/conf-nauty/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Apache-2.0"
 build: ["pkg-config" "nauty"] {os != "macos"}
 depends: [


### PR DESCRIPTION
### `conf-nauty.1.0`
Virtual package relying on nauty
This package can only install if the libnauty library is installed on the system.



---
* Homepage: http://pallini.di.uniroma1.it/
* Bug tracker: https://github.com/zajer/conf-nauty/issues

---
:camel: Pull-request generated by opam-publish v2.0.2