### PR TITLE
[new release] bech32 (0.1)

### DIFF
--- a/packages/bech32/bech32.0.1/opam
+++ b/packages/bech32/bech32.0.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bech32"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+authors: ["Vincent Bernardoff <vb@luminar.eu.org>"]
+homepage: "https://github.com/vbmithr/ocaml-bech32"
+license: "ISC"
+dev-repo: "git+https://github.com/vbmithr/ocaml-bech32.git"
+doc: "https://vbmithr.github.io/ocaml-bech32/doc"
+bug-reports: "https://github.com/vbmithr/ocaml-bech32/issues"
+tags: ["bitcoin"]
+build:    [ "dune" "build" "-j" jobs "-p" name ]
+run-test: [ "dune" "runtest" "-j" jobs "-p" name ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.3.1"}
+  "rresult" {>= "0.6.0"}
+  "astring" {>= "0.8.3"}
+  "hex" {with-test & >= "1.4.0"}
+  "alcotest" {with-test & >= "1.1.0"}
+]
+synopsis: "Bech32 addresses for OCaml (see
+https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)"
+description:"""This package implements parsing and pretty-printing of
+Bech32 addresses, used in Bitcoin as well as other blockchains
+projects, i.e. Zilliqa."""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-bech32/releases/download/0.1/bech32-0.1.tbz"
+  checksum: [
+    "sha256=1c858f8e155c57b8f98d40f02e93076db3fcebbc41ee8f2236a8c4abf9ab1ce5"
+    "sha512=6241e4b60b2ab6dea685833c55905ae90d5df5392097e97af184574228248d4837b60a107aafa24fc31e0c968d59de129e45d73cc26b949574e559c9eeefd236"
+  ]
+}


### PR DESCRIPTION
Bech32 addresses for OCaml (see
https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)

- Project page: <a href="https://github.com/vbmithr/ocaml-bech32">https://github.com/vbmithr/ocaml-bech32</a>
- Documentation: <a href="https://vbmithr.github.io/ocaml-bech32/doc">https://vbmithr.github.io/ocaml-bech32/doc</a>

##### CHANGES:

- First public release
