### PR TITLE
Package sklearn.0.22-0.1.2

### DIFF
--- a/packages/sklearn/sklearn.0.22-0.1.2/opam
+++ b/packages/sklearn/sklearn.0.22-0.1.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Scikit-learn machine learning library for OCaml"
+description: """
+Scikit-learn machine learning library for OCaml
+These are bindings to Python's scikit-learn machine learning library:
+- Simple and efficient tools for predictive data analysis
+- Accessible to everybody, and reusable in various contexts
+- Built on NumPy, SciPy, and matplotlib
+- Open source, commercially usable - BSD license
+"""
+maintainer: ["Ronan Le Hy <ronan.lehy@gmail.com>"]
+authors: ["Ronan Le Hy"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/lehy/ocaml-sklearn"
+bug-reports: "https://github.com/lehy/ocaml-sklearn/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.07.1"}
+  "ppx_expect" {with-test}
+  "owl" {with-test}
+  "re" {with-test}
+  "pyml" {>= "20200222"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lehy/ocaml-sklearn.git"
+url {
+  src: "https://github.com/lehy/ocaml-sklearn/archive/0.22-0.1.2.tar.gz"
+  checksum: [
+    "md5=98e2460a1cba350baaacd5cfc75f11b2"
+    "sha512=4637e9b36d3910a3dbe1b278a773dcb69b248acccfb8693e0346ae65094d1c5f10cc3f072ee2342c242fdcb53ebf213ad74a0cdf0df696fa45432707fa1643ad"
+  ]
+}


### PR DESCRIPTION
### `sklearn.0.22-0.1.2`
Scikit-learn machine learning library for OCaml
Scikit-learn machine learning library for OCaml
These are bindings to Python's scikit-learn machine learning library:
- Simple and efficient tools for predictive data analysis
- Accessible to everybody, and reusable in various contexts
- Built on NumPy, SciPy, and matplotlib
- Open source, commercially usable - BSD license



---
* Homepage: https://github.com/lehy/ocaml-sklearn
* Source repo: git+https://github.com/lehy/ocaml-sklearn.git
* Bug tracker: https://github.com/lehy/ocaml-sklearn/issues

---
:camel: Pull-request generated by opam-publish v2.0.2