### PR TITLE
[new release] eqaf (0.7)

### DIFF
--- a/packages/eqaf/eqaf.0.7/opam
+++ b/packages/eqaf/eqaf.0.7/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+name:         "eqaf"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/eqaf"
+bug-reports:  "https://github.com/mirage/eqaf/issues"
+dev-repo:     "git+https://github.com/mirage/eqaf.git"
+doc:          "https://mirage.github.io/eqaf/"
+license:      "MIT"
+synopsis:     "Constant-time equal function on string"
+description: """
+This package provides an equal function on string in constant-time to avoid timing-attack with crypto stuff.
+"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" "1" "--no-buffer" "--verbose" ] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"
+  "base64"         {with-test}
+  "alcotest"       {with-test}
+  "crowbar"        {with-test}
+]
+
+depopts: [
+  "cstruct"
+  "bigarray-compat"
+]
+
+conflicts: [
+  "cstruct" {< "4.0.0"}
+]
+url {
+  src: "https://github.com/mirage/eqaf/releases/download/v0.7/eqaf-v0.7.tbz"
+  checksum: [
+    "sha256=10e666aea9a413e63c5e9dd1c0566aed78a2bf0f4e09caa2bb3b88a021bf09e0"
+    "sha512=38a2687bafb5cd1d1deb51ceceba94fcff9ce88515fd2c61ec1182808c50c0e3373a4d71fe51a17a23c74616c5ab350a4cf7914de656886981538abf2b57ff61"
+  ]
+}


### PR DESCRIPTION
Constant-time equal function on string

- Project page: <a href="https://github.com/mirage/eqaf">https://github.com/mirage/eqaf</a>
- Documentation: <a href="https://mirage.github.io/eqaf/">https://mirage.github.io/eqaf/</a>

##### CHANGES:

- Add `find_uint8` (@dinosaure, @cfcs, mirage/eqaf#20)
- Add `exists_uint8` (@dinosaure, @cfcs, mirage/eqaf#20)
