### PR TITLE
Package sklearn.0.22-0.1.3

### DIFF
--- a/packages/sklearn/sklearn.0.22-0.1.3/opam
+++ b/packages/sklearn/sklearn.0.22-0.1.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Scikit-learn machine learning library for OCaml"
+description: """
+Scikit-learn machine learning library for OCaml
+These are bindings to Python's scikit-learn machine learning library:
+- Simple and efficient tools for predictive data analysis
+- Accessible to everybody, and reusable in various contexts
+- Built on NumPy, SciPy, and matplotlib
+- Open source, commercially usable - BSD license
+"""
+maintainer: ["Ronan Le Hy <ronan.lehy@gmail.com>"]
+authors: ["Ronan Le Hy"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/lehy/ocaml-sklearn"
+bug-reports: "https://github.com/lehy/ocaml-sklearn/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.07.1"}
+  "pyml" {>= "20200222"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lehy/ocaml-sklearn.git"
+url {
+  src: "https://github.com/lehy/ocaml-sklearn/archive/0.22-0.1.3.tar.gz"
+  checksum: [
+    "md5=9069738571ec0c95f5a4b805b5e4f528"
+    "sha512=fbd3f6cc249bbb8e7620f3731471f794f1eae0b1b34152c3b7f3a9a3245e34cdcf15501f09c799c98b085472eb0d7a24151b3178940295fd9a2f7063ee8b5499"
+  ]
+}


### PR DESCRIPTION
### `sklearn.0.22-0.1.3`
Scikit-learn machine learning library for OCaml
Scikit-learn machine learning library for OCaml
These are bindings to Python's scikit-learn machine learning library:
- Simple and efficient tools for predictive data analysis
- Accessible to everybody, and reusable in various contexts
- Built on NumPy, SciPy, and matplotlib
- Open source, commercially usable - BSD license



---
* Homepage: https://github.com/lehy/ocaml-sklearn
* Source repo: git+https://github.com/lehy/ocaml-sklearn.git
* Bug tracker: https://github.com/lehy/ocaml-sklearn/issues

---
:camel: Pull-request generated by opam-publish v2.0.2