### PR TITLE
[new release] dockerfile-opam, dockerfile and dockerfile-cmd (6.4.0)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.6.4.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.6.4.0/opam
@@ -16,7 +16,7 @@ doc: "https://avsm.github.io/ocaml-dockerfile/doc"
 bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build}
+  "dune" {>= "1.0"}
   "dockerfile-opam" {>= "3.0.0"}
   "cmdliner"
   "fmt"

--- a/packages/dockerfile-cmd/dockerfile-cmd.6.4.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.6.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL - generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "dockerfile-opam" {>= "3.0.0"}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "ppx_sexp_conv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.4.0/dockerfile-v6.4.0.tbz"
+  checksum: [
+    "sha256=554c9df81a79bbf0e6099cdd437b0c2e89969c48d9697c6f115267d3f183c61a"
+    "sha512=3d4a82c348c4666e3ae4215e859cbd250270b3ca1d80dc17d8168f5fbc20d2637d78bc35e5320a79b044105d7b4b78cdff2897596ebaf8dcda3774156616f3dc"
+  ]
+}

--- a/packages/dockerfile-opam/dockerfile-opam.6.4.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.6.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution
+support for generating dockerfiles."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "dockerfile" {= version}
+  "ocaml-version" {>= "1.0.0"}
+  "cmdliner"
+  "astring"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.4.0/dockerfile-v6.4.0.tbz"
+  checksum: [
+    "sha256=554c9df81a79bbf0e6099cdd437b0c2e89969c48d9697c6f115267d3f183c61a"
+    "sha512=3d4a82c348c4666e3ae4215e859cbd250270b3ca1d80dc17d8168f5fbc20d2637d78bc35e5320a79b044105d7b4b78cdff2897596ebaf8dcda3774156616f3dc"
+  ]
+}

--- a/packages/dockerfile-opam/dockerfile-opam.6.4.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.6.4.0/opam
@@ -16,7 +16,7 @@ doc: "https://avsm.github.io/ocaml-dockerfile/"
 bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build}
+  "dune" {>= "1.0"}
   "dockerfile" {= version}
   "ocaml-version" {>= "1.0.0"}
   "cmdliner"

--- a/packages/dockerfile/dockerfile.6.4.0/opam
+++ b/packages/dockerfile/dockerfile.6.4.0/opam
@@ -13,7 +13,7 @@ doc: "https://avsm.github.io/ocaml-dockerfile/doc"
 bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build}
+  "dune" {>= "1.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
   "fmt"

--- a/packages/dockerfile/dockerfile.6.4.0/opam
+++ b/packages/dockerfile/dockerfile.6.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.4.0/dockerfile-v6.4.0.tbz"
+  checksum: [
+    "sha256=554c9df81a79bbf0e6099cdd437b0c2e89969c48d9697c6f115267d3f183c61a"
+    "sha512=3d4a82c348c4666e3ae4215e859cbd250270b3ca1d80dc17d8168f5fbc20d2637d78bc35e5320a79b044105d7b4b78cdff2897596ebaf8dcda3774156616f3dc"
+  ]
+}


### PR DESCRIPTION
Dockerfile eDSL -- opam support

- Project page: <a href="https://github.com/avsm/ocaml-dockerfile">https://github.com/avsm/ocaml-dockerfile</a>
- Documentation: <a href="https://avsm.github.io/ocaml-dockerfile/">https://avsm.github.io/ocaml-dockerfile/</a>

##### CHANGES:

- Permute the order of Yum groupinstall/install to workaround
  a build issue in CentOS 8 under OverlayFS/Docker. (@avsm)
- Do not install `yum-ovl-plugin` workaround on CentOS 8. (@avsm)
- Add Fedora 31 and Ubuntu 19.10 (@XVilka @talex5)
- Add Alpine 3.11 and Ubuntu 20.04 (@avsm)
- Remove Ubuntu 19.04 from the supported distro list (@avsm).
- Add a `clone_opam_repo` optional argument to `gen_opam2_distro`
  to let the caller decide whether or not to have the git clone
  present in the container (@avsm @talex5).
