### PR TITLE
Tezos release 7.0~rc1

### DIFF
--- a/packages/tezos-accuser-006-PsCARTHA/tezos-accuser-006-PsCARTHA.7.0~rc1/opam
+++ b/packages/tezos-accuser-006-PsCARTHA/tezos-accuser-006-PsCARTHA.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-baking-006-PsCARTHA-commands" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/bin_accuser/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 006_PsCARTHA accuser binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-baker-006-PsCARTHA/tezos-baker-006-PsCARTHA.7.0~rc1/opam
+++ b/packages/tezos-baker-006-PsCARTHA/tezos-baker-006-PsCARTHA.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-baking-006-PsCARTHA-commands" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/bin_baker/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 006_PsCARTHA baker binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-baking-006-PsCARTHA-commands/tezos-baking-006-PsCARTHA-commands.7.0~rc1/opam
+++ b/packages/tezos-baking-006-PsCARTHA-commands/tezos-baking-006-PsCARTHA-commands.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-baking-006-PsCARTHA" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_delegate/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for baking"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-baking-006-PsCARTHA/tezos-baking-006-PsCARTHA.7.0~rc1/opam
+++ b/packages/tezos-baking-006-PsCARTHA/tezos-baking-006-PsCARTHA.7.0~rc1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-version" { = version }
+  "tezos-shell-context" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-client-006-PsCARTHA" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_delegate/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: base library for `tezos-baker/endorser/accuser`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-baking-alpha-commands/tezos-baking-alpha-commands.7.0~rc1/opam
+++ b/packages/tezos-baking-alpha-commands/tezos-baking-alpha-commands.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-baking-alpha" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_delegate/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for baking"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-baking-alpha/tezos-baking-alpha.7.0~rc1/opam
+++ b/packages/tezos-baking-alpha/tezos-baking-alpha.7.0~rc1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-version" { = version }
+  "tezos-shell-context" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-client-alpha" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_delegate/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: base library for `tezos-baker/endorser/accuser`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-base/tezos-base.7.0~rc1/opam
+++ b/packages/tezos-base/tezos-base.7.0~rc1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-clic" { = version }
+  "tezos-crypto" { = version }
+  "tezos-micheline" { = version }
+  "ptime" { >= "0.8.4" }
+  "ezjsonm" { >= "0.5.0" }
+  "ipaddr" { >= "4.0.0" }
+  "re" { >= "1.7.2" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_base/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: meta-package and pervasive type definitions for Tezos"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-clic/tezos-clic.7.0~rc1/opam
+++ b/packages/tezos-clic/tezos-clic.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-stdlib-unix" { = version }
+  "re" { >= "1.7.2" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_clic/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented command-line-parsing combinators"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-000-Ps9mPmXa/tezos-client-000-Ps9mPmXa.7.0~rc1/opam
+++ b/packages/tezos-client-000-Ps9mPmXa/tezos-client-000-Ps9mPmXa.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-commands" { = version }
+  "tezos-protocol-000-Ps9mPmXa" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_000_Ps9mPmXa/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 000-Ps9mPmXa (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-001-PtCJ7pwo-commands/tezos-client-001-PtCJ7pwo-commands.7.0~rc1/opam
+++ b/packages/tezos-client-001-PtCJ7pwo-commands/tezos-client-001-PtCJ7pwo-commands.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-001-PtCJ7pwo" { = version }
+  "tezos-client-commands" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_001_PtCJ7pwo/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 001_PtCJ7pwo (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-001-PtCJ7pwo/tezos-client-001-PtCJ7pwo.7.0~rc1/opam
+++ b/packages/tezos-client-001-PtCJ7pwo/tezos-client-001-PtCJ7pwo.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-001-PtCJ7pwo" { = version }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_001_PtCJ7pwo/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-002-PsYLVpVv-commands/tezos-client-002-PsYLVpVv-commands.7.0~rc1/opam
+++ b/packages/tezos-client-002-PsYLVpVv-commands/tezos-client-002-PsYLVpVv-commands.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-002-PsYLVpVv" { = version }
+  "tezos-client-commands" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_002_PsYLVpVv/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 002_PsYLVpVv (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-002-PsYLVpVv/tezos-client-002-PsYLVpVv.7.0~rc1/opam
+++ b/packages/tezos-client-002-PsYLVpVv/tezos-client-002-PsYLVpVv.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-002-PsYLVpVv" { = version }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_002_PsYLVpVv/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-003-PsddFKi3-commands/tezos-client-003-PsddFKi3-commands.7.0~rc1/opam
+++ b/packages/tezos-client-003-PsddFKi3-commands/tezos-client-003-PsddFKi3-commands.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-003-PsddFKi3" { = version }
+  "tezos-client-commands" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_003_PsddFKi3/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 003_PsddFKi3 (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-003-PsddFKi3/tezos-client-003-PsddFKi3.7.0~rc1/opam
+++ b/packages/tezos-client-003-PsddFKi3/tezos-client-003-PsddFKi3.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-003-PsddFKi3" { = version }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_003_PsddFKi3/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-004-Pt24m4xi-commands/tezos-client-004-Pt24m4xi-commands.7.0~rc1/opam
+++ b/packages/tezos-client-004-Pt24m4xi-commands/tezos-client-004-Pt24m4xi-commands.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-004-Pt24m4xi" { = version }
+  "tezos-client-commands" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_004_Pt24m4xi/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 004_Pt24m4xi (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-004-Pt24m4xi/tezos-client-004-Pt24m4xi.7.0~rc1/opam
+++ b/packages/tezos-client-004-Pt24m4xi/tezos-client-004-Pt24m4xi.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-004-Pt24m4xi" { = version }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_004_Pt24m4xi/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-005-PsBabyM1-commands/tezos-client-005-PsBabyM1-commands.7.0~rc1/opam
+++ b/packages/tezos-client-005-PsBabyM1-commands/tezos-client-005-PsBabyM1-commands.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-005-PsBabyM1" { = version }
+  "tezos-client-commands" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBabyM1/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 005_PsBabyM1 (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-005-PsBabyM1/tezos-client-005-PsBabyM1.7.0~rc1/opam
+++ b/packages/tezos-client-005-PsBabyM1/tezos-client-005-PsBabyM1.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-005-PsBabyM1" { = version }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBabyM1/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-006-PsCARTHA-commands/tezos-client-006-PsCARTHA-commands.7.0~rc1/opam
+++ b/packages/tezos-client-006-PsCARTHA-commands/tezos-client-006-PsCARTHA-commands.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-006-PsCARTHA" { = version }
+  "tezos-mockup-commands" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 006_PsCARTHA (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-006-PsCARTHA/tezos-client-006-PsCARTHA.7.0~rc1/opam
+++ b/packages/tezos-client-006-PsCARTHA/tezos-client-006-PsCARTHA.7.0~rc1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-mockup-registration" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-protocol-006-PsCARTHA-parameters" { = version }
+  "alcotest-lwt" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-alpha-commands/tezos-client-alpha-commands.7.0~rc1/opam
+++ b/packages/tezos-client-alpha-commands/tezos-client-alpha-commands.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-alpha" { = version }
+  "tezos-mockup-commands" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-alpha/tezos-client-alpha.7.0~rc1/opam
+++ b/packages/tezos-client-alpha/tezos-client-alpha.7.0~rc1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-mockup-registration" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-protocol-alpha-parameters" { = version }
+  "alcotest-lwt" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-base-unix/tezos-client-base-unix.7.0~rc1/opam
+++ b/packages/tezos-client-base-unix/tezos-client-base-unix.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-mockup-commands" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_client_base_unix/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: common helpers for `tezos-client` (unix-specific fragment)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-base/tezos-client-base.7.0~rc1/opam
+++ b/packages/tezos-client-base/tezos-client-base.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-shell-services" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_client_base/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: common helpers for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-commands/tezos-client-commands.7.0~rc1/opam
+++ b/packages/tezos-client-commands/tezos-client-commands.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: protocol agnostic commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-demo-counter/tezos-client-demo-counter.7.0~rc1/opam
+++ b/packages/tezos-client-demo-counter/tezos-client-demo-counter.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-commands" { = version }
+  "tezos-protocol-demo-counter" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_demo_counter/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-genesis-carthagenet/tezos-client-genesis-carthagenet.7.0~rc1/opam
+++ b/packages/tezos-client-genesis-carthagenet/tezos-client-genesis-carthagenet.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-commands" { = version }
+  "tezos-protocol-genesis-carthagenet" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis_carthagenet/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client-genesis/tezos-client-genesis.7.0~rc1/opam
+++ b/packages/tezos-client-genesis/tezos-client-genesis.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-commands" { = version }
+  "tezos-protocol-genesis" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-client/tezos-client.7.0~rc1/opam
+++ b/packages/tezos-client/tezos-client.7.0~rc1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-base-unix" { = version }
+
+  "tezos-client-genesis-carthagenet" { = version }
+
+  "tezos-client-000-Ps9mPmXa" { = version }
+  "tezos-client-001-PtCJ7pwo-commands" { = version }
+  "tezos-client-002-PsYLVpVv-commands" { = version }
+  "tezos-client-003-PsddFKi3-commands" { = version }
+  "tezos-client-004-Pt24m4xi-commands" { = version }
+  "tezos-client-005-PsBabyM1-commands" { = version }
+  "tezos-client-006-PsCARTHA-commands" { = version }
+
+  "tezos-baking-006-PsCARTHA-commands" { = version }
+]
+depopts: [
+  "tezos-client-genesis" { = version }
+  "tezos-client-alpha-commands" { = version }
+  "tezos-client-demo-counter" { = version }
+
+  "tezos-baking-alpha-commands" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/bin_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `tezos-client` binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-codec/tezos-codec.7.0~rc1/opam
+++ b/packages/tezos-codec/tezos-codec.7.0~rc1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "data-encoding" { = "0.2" }
+  "tezos-client-base-unix" { = version }
+  "tezos-signer-services" { = version }
+  "tezos-client-alpha" { = version }
+  "tezos-client-005-PsBabyM1" { = version }
+  "tezos-client-006-PsCARTHA" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/bin_codec/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `tezos-codec` binary to encode and decode values"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-crypto/tezos-crypto.7.0~rc1/opam
+++ b/packages/tezos-crypto/tezos-crypto.7.0~rc1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-rpc" { = version }
+  "blake2"
+  "hacl"
+  "zarith"
+  "secp256k1-internal"
+  "uecc"
+  "alcotest" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_crypto/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library with all the cryptographic primitives used by Tezos"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-000-Ps9mPmXa/tezos-embedded-protocol-000-Ps9mPmXa.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-000-Ps9mPmXa/tezos-embedded-protocol-000-Ps9mPmXa.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.11" }
+  "tezos-protocol-000-Ps9mPmXa" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_000_Ps9mPmXa/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 000-Ps9mPmXa (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-001-PtCJ7pwo/tezos-embedded-protocol-001-PtCJ7pwo.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-001-PtCJ7pwo/tezos-embedded-protocol-001-PtCJ7pwo.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.11" }
+  "tezos-protocol-001-PtCJ7pwo" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_001_PtCJ7pwo/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 001_PtCJ7pwo (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-002-PsYLVpVv/tezos-embedded-protocol-002-PsYLVpVv.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-002-PsYLVpVv/tezos-embedded-protocol-002-PsYLVpVv.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.11" }
+  "tezos-protocol-002-PsYLVpVv" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_002_PsYLVpVv/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 002_PsYLVpVv (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-003-PsddFKi3/tezos-embedded-protocol-003-PsddFKi3.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-003-PsddFKi3/tezos-embedded-protocol-003-PsddFKi3.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.11" }
+  "tezos-protocol-003-PsddFKi3" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_003_PsddFKi3/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 003_PsddFKi3 (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-004-Pt24m4xi/tezos-embedded-protocol-004-Pt24m4xi.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-004-Pt24m4xi/tezos-embedded-protocol-004-Pt24m4xi.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-004-Pt24m4xi" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_004_Pt24m4xi/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-005-PsBABY5H/tezos-embedded-protocol-005-PsBABY5H.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-005-PsBABY5H/tezos-embedded-protocol-005-PsBABY5H.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-005-PsBABY5H" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBABY5H/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-005-PsBabyM1/tezos-embedded-protocol-005-PsBabyM1.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-005-PsBabyM1/tezos-embedded-protocol-005-PsBabyM1.7.0~rc1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-005-PsBabyM1" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  [ "rm" "src/proto_005_PsBabyM1/lib_protocol/dune" ]
+  [
+    "%{tezos-protocol-compiler:lib}%/replace"
+    "%{tezos-protocol-compiler:lib}%/dune_protocol.template"
+    "%{build}%/src/proto_005_PsBabyM1/lib_protocol/dune"
+    "%{tezos-protocol-compiler:lib}%/final_protocol_versions"
+    "005_PsBabyM1"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBabyM1/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-006-PsCARTHA/tezos-embedded-protocol-006-PsCARTHA.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-006-PsCARTHA/tezos-embedded-protocol-006-PsCARTHA.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-006-PsCARTHA" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-alpha/tezos-embedded-protocol-alpha.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-alpha/tezos-embedded-protocol-alpha.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-alpha" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-demo-counter/tezos-embedded-protocol-demo-counter.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-demo-counter/tezos-embedded-protocol-demo-counter.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-demo-counter" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_demo_counter/lib_protocol/%{name}%.install" "./"]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_counter (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-demo-noops/tezos-embedded-protocol-demo-noops.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-demo-noops/tezos-embedded-protocol-demo-noops.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-demo-noops" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_demo_noops/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_noops (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-genesis-carthagenet/tezos-embedded-protocol-genesis-carthagenet.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-genesis-carthagenet/tezos-embedded-protocol-genesis-carthagenet.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-genesis-carthagenet" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis_carthagenet/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis_carthagenet (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-embedded-protocol-genesis/tezos-embedded-protocol-genesis.7.0~rc1/opam
+++ b/packages/tezos-embedded-protocol-genesis/tezos-embedded-protocol-genesis.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-genesis" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-endorser-006-PsCARTHA/tezos-endorser-006-PsCARTHA.7.0~rc1/opam
+++ b/packages/tezos-endorser-006-PsCARTHA/tezos-endorser-006-PsCARTHA.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-baking-006-PsCARTHA-commands" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/bin_endorser/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 006_PsCARTHA endorser binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-error-monad/tezos-error-monad.7.0~rc1/opam
+++ b/packages/tezos-error-monad/tezos-error-monad.7.0~rc1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-stdlib" { = version }
+  "data-encoding" { = "0.2" }
+  "lwt-canceler" { = "0.2" }
+  "alcotest-lwt" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_error_monad/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: error monad"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-event-logging/tezos-event-logging.7.0~rc1/opam
+++ b/packages/tezos-event-logging/tezos-event-logging.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-error-monad" { = version }
+  "lwt_log"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_event_logging/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos event logging library"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-lmdb/tezos-lmdb.7.0~rc1/files/tests_use_temp_dir.patch
+++ b/packages/tezos-lmdb/tezos-lmdb.7.0~rc1/files/tests_use_temp_dir.patch
@@ -1,0 +1,81 @@
+diff --git a/vendors/ocaml-lmdb/test/test.ml b/vendors/ocaml-lmdb/test/test.ml
+index db68600f69..a50b6c6f4b 100644
+--- a/vendors/ocaml-lmdb/test/test.ml
++++ b/vendors/ocaml-lmdb/test/test.ml
+@@ -21,15 +21,20 @@ let test_string_of_error () =
+   let errmsg = string_of_error KeyExist in
+   assert (String.length errmsg > 0)
+ 
++let tmpdir = Filename.get_temp_dir_name ()
++
+ let cleanup () =
+-  let files = [ "/tmp/data.mdb" ; "/tmp/lock.mdb" ] in
++  let files = [
++      Filename.concat tmpdir "data.mdb" ;
++      Filename.concat tmpdir "lock.mdb"
++    ] in
+   ListLabels.iter files ~f:begin fun fn ->
+     Sys.(if file_exists fn then remove fn)
+   end
+ 
+ let env () =
+   cleanup () ;
+-  opendir ~maxreaders:34 ~maxdbs:1 "/tmp" 0o644 >>= fun env ->
++  opendir ~maxreaders:34 ~maxdbs:1 tmpdir 0o644 >>= fun env ->
+   let _stat = stat env in
+   let _envinfo = envinfo env in
+   let _flags = get_flags env in
+@@ -42,7 +47,7 @@ let env () =
+ 
+ let txn () =
+   cleanup () ;
+-  opendir ~maxdbs:1 "/tmp" 0o644 >>= fun env ->
++  opendir ~maxdbs:1 tmpdir 0o644 >>= fun env ->
+   create_ro_txn env >>= fun rotxn ->
+   reset_ro_txn rotxn ;
+   create_rw_txn env >>= fun rwtxn ->
+@@ -64,7 +69,7 @@ let txn () =
+ 
+ let cursors () =
+   cleanup () ;
+-  opendir "/tmp" 0o644 >>= fun env ->
++  opendir tmpdir 0o644 >>= fun env ->
+   create_rw_txn env >>= fun txn ->
+   opendb txn >>= fun db ->
+   opencursor txn db >>= fun cursor ->
+@@ -89,7 +94,7 @@ let cursors () =
+ 
+ let cursors_del () =
+   cleanup () ;
+-  opendir "/tmp" 0o644 >>= fun env ->
++  opendir tmpdir 0o644 >>= fun env ->
+   with_rw_db env ~f:begin fun txn db ->
+     with_cursor txn db ~f:begin fun cursor ->
+       cursor_put_string cursor "k1" "v1" >>= fun () ->
+@@ -104,7 +109,7 @@ let cursors_del () =
+ 
+ let cursors_del4 () =
+   cleanup () ;
+-  opendir "/tmp" 0o644 >>= fun env ->
++  opendir tmpdir 0o644 >>= fun env ->
+   with_rw_db env ~f:begin fun txn db ->
+     with_cursor txn db ~f:begin fun cursor ->
+       cursor_put_string cursor "k1" "v1" >>= fun () ->
+@@ -122,7 +127,7 @@ let cursors_del4 () =
+ 
+ let fold () =
+   cleanup () ;
+-  opendir "/tmp" 0o644 >>= fun env ->
++  opendir tmpdir 0o644 >>= fun env ->
+   with_rw_db env ~f:begin fun txn db ->
+     opencursor txn db >>= fun cursor ->
+     cursor_put_string cursor "k1" "v1" >>= fun () ->
+@@ -142,7 +147,7 @@ let fold () =
+ 
+ let consistency () =
+   cleanup () ;
+-  opendir "/tmp" 0o644 >>= fun env ->
++  opendir tmpdir 0o644 >>= fun env ->
+   let v = Cstruct.(to_bigarray (of_string "bleh")) in
+   with_rw_db env ~f:begin fun txn db ->
+     put txn db "bleh" v

--- a/packages/tezos-lmdb/tezos-lmdb.7.0~rc1/opam
+++ b/packages/tezos-lmdb/tezos-lmdb.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "contact@tezos.com"
+license: "ISC"
+synopsis: "Legacy Tezos OCaml binding to LMDB (Consider ocaml-lmdb instead)"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+build: [
+  ["dune" "build" "-j" jobs "-p" name "@install"]
+  ["mv" "vendors/ocaml-lmdb/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" {>= "1.11"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {with-test & >= "3.2.1"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-lmdb/tezos-lmdb.7.0~rc1/opam
+++ b/packages/tezos-lmdb/tezos-lmdb.7.0~rc1/opam
@@ -5,6 +5,7 @@ license: "ISC"
 synopsis: "Legacy Tezos OCaml binding to LMDB (Consider ocaml-lmdb instead)"
 bug-reports: "https://gitlab.com/tezos/tezos/issues"
 dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+patches: [ "tests_use_temp_dir.patch" ]
 build: [
   ["dune" "build" "-j" jobs "-p" name "@install"]
   ["mv" "vendors/ocaml-lmdb/%{name}%.install" "./"]
@@ -17,6 +18,8 @@ depends: [
   "cstruct" {with-test & >= "3.2.1"}
   "alcotest" {with-test & >= "0.8.1"}
 ]
+
+extra-files: [ [ "tests_use_temp_dir.patch" "sha256=853f158673ac72150cca36c9766fd55386325012987d5e17f1cbbca6a91e6202" ] ]
 
 url {
   src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"

--- a/packages/tezos-mempool-006-PsCARTHA/tezos-mempool-006-PsCARTHA.7.0~rc1/opam
+++ b/packages/tezos-mempool-006-PsCARTHA/tezos-mempool-006-PsCARTHA.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-embedded-protocol-006-PsCARTHA" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_mempool/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: mempool-filters for protocol 006-PsCARTHA"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-micheline/tezos-micheline.7.0~rc1/opam
+++ b/packages/tezos-micheline/tezos-micheline.7.0~rc1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-error-monad" { = version }
+  "uutf"
+  "alcotest-lwt" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_micheline/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: internal AST and parser for the Michelson language"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-mockup-commands/tezos-mockup-commands.7.0~rc1/opam
+++ b/packages/tezos-mockup-commands/tezos-mockup-commands.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.7" }
+  "tezos-client-commands" { = version }
+  "tezos-mockup" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_mockup/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (commands)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-mockup-registration/tezos-mockup-registration.7.0~rc1/opam
+++ b/packages/tezos-mockup-registration/tezos-mockup-registration.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.7" }
+  "tezos-shell-services" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_mockup/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: protocol registration for the mockup mode"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-mockup/tezos-mockup.7.0~rc1/opam
+++ b/packages/tezos-mockup/tezos-mockup.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.7" }
+  "tezos-p2p" { = version }
+  "tezos-client-base" { = version }
+  "tezos-mockup-registration" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_mockup/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (mockup mode)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-node/tezos-node.7.0~rc1/opam
+++ b/packages/tezos-node/tezos-node.7.0~rc1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-rpc-http-server" { = version }
+  "tezos-validator" { = version }
+  "tezos-embedded-protocol-genesis-carthagenet" { = version }
+  "tezos-embedded-protocol-000-Ps9mPmXa" { = version }
+  "tezos-embedded-protocol-001-PtCJ7pwo" { = version }
+  "tezos-embedded-protocol-002-PsYLVpVv" { = version }
+  "tezos-embedded-protocol-003-PsddFKi3" { = version }
+  "tezos-embedded-protocol-004-Pt24m4xi" { = version }
+  "tezos-embedded-protocol-005-PsBABY5H" { = version }
+  "tezos-embedded-protocol-005-PsBabyM1" { = version }
+  "tezos-embedded-protocol-006-PsCARTHA" { = version }
+  "tezos-mempool-006-PsCARTHA" { = version }
+  "tls"
+]
+depopts: [
+  "tezos-embedded-protocol-genesis" { = version }
+  "tezos-embedded-protocol-demo-noops" { = version }
+  "tezos-embedded-protocol-demo-counter" { = version }
+  "tezos-embedded-protocol-alpha" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/bin_node/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `tezos-node` binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-p2p-services/tezos-p2p-services.7.0~rc1/opam
+++ b/packages/tezos-p2p-services/tezos-p2p-services.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-workers" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_p2p_services/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: descriptions of RPCs exported by `tezos-p2p`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-p2p/tezos-p2p.7.0~rc1/opam
+++ b/packages/tezos-p2p/tezos-p2p.7.0~rc1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-p2p-services" { = version }
+  "alcotest-lwt" { with-test & = "0.8.5" }
+  "lwt" { < "4.3" }
+  "lwt-watcher" { = "0.1" }
+  "lwt-canceler" { = "0.2" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_p2p/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library for a pool of P2P connections"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-000-Ps9mPmXa/tezos-protocol-000-Ps9mPmXa.7.0~rc1/opam
+++ b/packages/tezos-protocol-000-Ps9mPmXa/tezos-protocol-000-Ps9mPmXa.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_000_Ps9mPmXa/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 000_Ps9mPmXa (economic-protocol definition, functor version)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-001-PtCJ7pwo/tezos-protocol-001-PtCJ7pwo.7.0~rc1/opam
+++ b/packages/tezos-protocol-001-PtCJ7pwo/tezos-protocol-001-PtCJ7pwo.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_001_PtCJ7pwo/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 001_PtCJ7pwo (economic-protocol definition, functor version)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-002-PsYLVpVv/tezos-protocol-002-PsYLVpVv.7.0~rc1/opam
+++ b/packages/tezos-protocol-002-PsYLVpVv/tezos-protocol-002-PsYLVpVv.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_002_PsYLVpVv/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 002_PsYLVpVv (economic-protocol definition, functor version)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-003-PsddFKi3/tezos-protocol-003-PsddFKi3.7.0~rc1/opam
+++ b/packages/tezos-protocol-003-PsddFKi3/tezos-protocol-003-PsddFKi3.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_003_PsddFKi3/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 003_PsddFKi3 (economic-protocol definition, functor version)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-004-Pt24m4xi/tezos-protocol-004-Pt24m4xi.7.0~rc1/opam
+++ b/packages/tezos-protocol-004-Pt24m4xi/tezos-protocol-004-Pt24m4xi.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_004_Pt24m4xi/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-005-PsBABY5H/tezos-protocol-005-PsBABY5H.7.0~rc1/opam
+++ b/packages/tezos-protocol-005-PsBABY5H/tezos-protocol-005-PsBABY5H.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBABY5H/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-005-PsBabyM1/tezos-protocol-005-PsBabyM1.7.0~rc1/opam
+++ b/packages/tezos-protocol-005-PsBabyM1/tezos-protocol-005-PsBabyM1.7.0~rc1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  [ "rm" "src/proto_005_PsBabyM1/lib_protocol/dune" ]
+  [
+    "%{tezos-protocol-compiler:lib}%/replace"
+    "%{tezos-protocol-compiler:lib}%/dune_protocol.template"
+    "%{build}%/src/proto_005_PsBabyM1/lib_protocol/dune"
+    "%{tezos-protocol-compiler:lib}%/final_protocol_versions"
+    "005_PsBabyM1"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBabyM1/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-006-PsCARTHA-parameters/tezos-protocol-006-PsCARTHA-parameters.7.0~rc1/opam
+++ b/packages/tezos-protocol-006-PsCARTHA-parameters/tezos-protocol-006-PsCARTHA-parameters.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-006-PsCARTHA" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_parameters/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: parameters for protocol 006-PsCARTHA"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-006-PsCARTHA/tezos-protocol-006-PsCARTHA.7.0~rc1/opam
+++ b/packages/tezos-protocol-006-PsCARTHA/tezos-protocol-006-PsCARTHA.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-alpha-parameters/tezos-protocol-alpha-parameters.7.0~rc1/opam
+++ b/packages/tezos-protocol-alpha-parameters/tezos-protocol-alpha-parameters.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-alpha" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_parameters/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: parameters"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-alpha/tezos-protocol-alpha.7.0~rc1/opam
+++ b/packages/tezos-protocol-alpha/tezos-protocol-alpha.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-compiler/tezos-protocol-compiler.7.0~rc1/opam
+++ b/packages/tezos-protocol-compiler/tezos-protocol-compiler.7.0~rc1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "ocaml" { = "4.09.1" }
+  "dune" { >= "1.11" }
+  "base-unix"
+  "tezos-base" { = version }
+  "tezos-protocol-environment" { = version }
+  "ocp-ocamlres" { >= "0.4" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_compiler/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: economic-protocol compiler"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-demo-counter/tezos-protocol-demo-counter.7.0~rc1/opam
+++ b/packages/tezos-protocol-demo-counter/tezos-protocol-demo-counter.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_demo_counter/lib_protocol/%{name}%.install" "./"]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_counter economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-demo-noops/tezos-protocol-demo-noops.7.0~rc1/opam
+++ b/packages/tezos-protocol-demo-noops/tezos-protocol-demo-noops.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_demo_noops/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_noops economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-environment-sigs/tezos-protocol-environment-sigs.7.0~rc1/opam
+++ b/packages/tezos-protocol-environment-sigs/tezos-protocol-environment-sigs.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "ocaml" { >= "4.08.0" }
+  "tezos-stdlib" { with-test & = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_environment/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: restricted typing environment for the economic protocols"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-environment/tezos-protocol-environment.7.0~rc1/opam
+++ b/packages/tezos-protocol-environment/tezos-protocol-environment.7.0~rc1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-base" { = version }
+  "tezos-protocol-environment-sigs" { = version }
+  "alcotest-lwt" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_environment/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: custom economic-protocols environment implementation for `tezos-client` and testing"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-genesis-carthagenet/tezos-protocol-genesis-carthagenet.7.0~rc1/opam
+++ b/packages/tezos-protocol-genesis-carthagenet/tezos-protocol-genesis-carthagenet.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis_carthagenet/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis_carthagenet economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-genesis/tezos-protocol-genesis.7.0~rc1/opam
+++ b/packages/tezos-protocol-genesis/tezos-protocol-genesis.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-protocol-updater/tezos-protocol-updater.7.0~rc1/opam
+++ b/packages/tezos-protocol-updater/tezos-protocol-updater.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+  "tezos-shell-context" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_updater/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: economic-protocol dynamic loading for `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-requester/tezos-requester.7.0~rc1/opam
+++ b/packages/tezos-requester/tezos-requester.7.0~rc1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-base" { = version }
+  "lwt-watcher"
+  "alcotest-lwt" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_requester/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: generic resource fetching service"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.7.0~rc1/opam
+++ b/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.7.0~rc1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-stdlib-unix" { = version }
+  "cohttp-lwt-unix" { >= "1.0.0" }
+  "tezos-rpc-http-client" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc_http/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: unix implementation of the RPC client"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-rpc-http-client/tezos-rpc-http-client.7.0~rc1/opam
+++ b/packages/tezos-rpc-http-client/tezos-rpc-http-client.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-rpc-http" { = version }
+  "resto-cohttp-client" { = "0.4" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc_http/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (http client)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.0~rc1/opam
+++ b/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.11" }
+  "tezos-rpc-http" { = version }
+  "resto-cohttp-server" { = "0.4" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc_http/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (http server)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-rpc-http/tezos-rpc-http.7.0~rc1/opam
+++ b/packages/tezos-rpc-http/tezos-rpc-http.7.0~rc1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-base" { = version }
+  "resto-directory" { = "0.4" }
+  "resto-cohttp" { = "0.4" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc_http/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (http server and client)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-rpc/tezos-rpc.7.0~rc1/opam
+++ b/packages/tezos-rpc/tezos-rpc.7.0~rc1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-error-monad" { = version }
+  "resto"
+  "resto-directory"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (service and hierarchy descriptions)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-shell-context/tezos-shell-context.7.0~rc1/opam
+++ b/packages/tezos-shell-context/tezos-shell-context.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-environment" { = version }
+  "tezos-storage" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_environment/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: economic-protocols environment implementation for `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-shell-services/tezos-shell-services.7.0~rc1/opam
+++ b/packages/tezos-shell-services/tezos-shell-services.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-p2p-services" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_shell_services/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: descriptions of RPCs exported by `tezos-shell`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-shell/tezos-shell.7.0~rc1/opam
+++ b/packages/tezos-shell/tezos-shell.7.0~rc1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-version" { = version }
+  "tezos-p2p" { = version }
+  "tezos-validation" { = version }
+  "tezos-requester" { = version }
+  "lwt-watcher" { = "0.1" }
+  "lwt-canceler" { = "0.2" }
+  "alcotest-lwt" { with-test & = "0.8.5" }
+  "tezos-embedded-protocol-demo-noops" { with-test & = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_shell/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: core of `tezos-node` (gossip, validation scheduling, mempool, ...)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-signer-backends/tezos-signer-backends.7.0~rc1/opam
+++ b/packages/tezos-signer-backends/tezos-signer-backends.7.0~rc1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-rpc-http-client-unix" { = version }
+  "tezos-signer-services" { = version }
+  "alcotest" {with-test & = "0.8.5"}
+  "alcotest-lwt" {with-test & = "0.8.5"}
+]
+depopts: [
+  "ledgerwallet-tezos"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_signer_backends/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: remote-signature backends for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-signer-services/tezos-signer-services.7.0~rc1/opam
+++ b/packages/tezos-signer-services/tezos-signer-services.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-base" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_signer_services/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: descriptions of RPCs exported by `tezos-signer`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-signer/tezos-signer.7.0~rc1/opam
+++ b/packages/tezos-signer/tezos-signer.7.0~rc1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-client-base-unix" { = version }
+  "tezos-rpc-http-server" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/bin_signer/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `tezos-signer` binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.0~rc1/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.0~rc1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "base-unix"
+  "dune" { >= "1.11" }
+  "tezos-event-logging" { = version }
+  "tezos-rpc" { = version }
+  "lwt" { >= "3.0.0" }
+  "ptime" { >= "0.8.4" }
+  "mtime" { >= "1.0.0" }
+  "conf-libev"
+  "ipaddr" { >= "4.0.0" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_stdlib_unix/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: yet-another local-extension of the OCaml standard library (unix-specific fragment)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-stdlib/tezos-stdlib.7.0~rc1/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.7.0~rc1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "ocaml" { >= "4.08.0" }
+  "hex"
+  "lwt"
+  "zarith"
+  "bigstring" { with-test }
+  "lwt_log" { with-test }
+  "alcotest" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_stdlib/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: yet-another local-extension of the OCaml standard library"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-storage/tezos-storage.7.0~rc1/opam
+++ b/packages/tezos-storage/tezos-storage.7.0~rc1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-lmdb" { = version }
+  "irmin-pack" { >= "2.1" }
+  "digestif" {>= "0.7.3"}
+  "tezos-shell-services" { = version }
+  "alcotest-lwt" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_storage/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: low-level key-value store for `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-tooling/tezos-tooling.7.0~rc1/opam
+++ b/packages/tezos-tooling/tezos-tooling.7.0~rc1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.11" }
+  "ocamlformat" { = "0.10" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/tooling/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: tooling for the project"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-validation/tezos-validation.7.0~rc1/opam
+++ b/packages/tezos-validation/tezos-validation.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_validation/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library for blocks validation"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-validator/tezos-validator.7.0~rc1/opam
+++ b/packages/tezos-validator/tezos-validator.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-shell" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/bin_validation/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `tezos-validator` binary for external validation of blocks"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-version/tezos-version.7.0~rc1/opam
+++ b/packages/tezos-version/tezos-version.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "ocaml" { >= "4.03.0" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_version/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: version information generated from Git"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos-workers/tezos-workers.7.0~rc1/opam
+++ b/packages/tezos-workers/tezos-workers.7.0~rc1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-base" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_workers/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: worker library"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.0-rc1/tezos-v7.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=89385ff254582d64b909bcd33f10068f1ba5fe8a47802bb0bcf983f30f7eb49b"
+    "sha512=413bb72b556de80fadfdf3278a6c674a471a614af6adf19c9b383cbc2ee0d081f0421156c92fa917808d47eccaed4a369fc9613a267d5f77a6c3b8e928e5f244"
+  ]
+}

--- a/packages/tezos/tezos.7.0~rc1/opam
+++ b/packages/tezos/tezos.7.0~rc1/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "ledgerwallet-tezos"
+  "tezos-node" { = version }
+  "tezos-client" { = version }
+  "tezos-signer" { = version }
+  "tezos-accuser-006-PsCARTHA" { = version }
+  "tezos-baker-006-PsCARTHA" { = version }
+  "tezos-endorser-006-PsCARTHA" { = version }
+  "tezos-codec" { = version }
+]
+synopsis: "Tezos meta package installing all active binaries"


### PR DESCRIPTION
We can finally release software to participate to the Tezos blockchain in opam "central" repository (up to now, binaries were specific to a specific "chain"). :tada: 

For now, we follow the policy to add the constraint `{ = version }` in between all the packages part of the same tar.bz2 but we're not sure about that and we welcome feedback...

An other question: is it OK to have "meta-package" in the opam-repository? In that case, we would add a package `tezos` with nothing but dependencies to all the binaries (tezos-node, tezos-client, tezos-{accuser,baker,endorser}-006-PsCARTHA) and optional dependencies. 