### PR TITLE
Package onauty.0.5

### DIFF
--- a/packages/onauty/onauty.0.5/opam
+++ b/packages/onauty/onauty.0.5/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings to nauty library"
+description: """
+
+    Library for deternining isomorphis between graphs and digraphs. 
+    It uses nauty library as its backbone."""
+maintainer: ["Piotr Cybulski <pikus3@list.pl>"]
+authors: ["Piotr Cybulski <pikus3@list.pl>"]
+license: "MIT"
+tags: ["nauty" "graphs" "isomorphism"]
+homepage: "https://github.com/zajer/onauty"
+bug-reports: "https://github.com/zajer/onauty/issues"
+depends: [
+  "dune" {build & >= "2.0.0"}
+  "ocaml" {>= "4.06.0"}
+  "conf-nauty"
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/zajer/onauty.git"
+url {
+  src: "https://github.com/zajer/onauty/archive/0.5.tar.gz"
+  checksum: [
+    "md5=ce23bc7d953772b37e3aefa1e7496046"
+    "sha512=9cece420b8039d3cf2a9d4e4ad56ecaeb98e02e4158a879c1a5a7794c2a404d5412cf56ee6385eb78ded3d47f0eabef52ee8bd966b73450bd5a92e590dc7218e"
+  ]
+}


### PR DESCRIPTION
### `onauty.0.5`
OCaml bindings to nauty library
Library for deternining isomorphis between graphs and digraphs. 
    It uses nauty library as its backbone.



---
* Homepage: https://github.com/zajer/onauty
* Source repo: git+https://github.com/zajer/onauty.git
* Bug tracker: https://github.com/zajer/onauty/issues

---
:camel: Pull-request generated by opam-publish v2.0.2