### PR TITLE
Changes required to publish tezos-node

### DIFF
--- a/packages/conf-hidapi/conf-hidapi.0/opam
+++ b/packages/conf-hidapi/conf-hidapi.0/opam
@@ -11,7 +11,9 @@ build: [
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libhidapi-dev"] {os-family = "debian"}
+  ["libhidapi-devel"] {os-family = "suse"}
   ["hidapi"] {os-distribution = "arch"}
+  ["hidapi-devel"] {os-distribution = "fedora"}
   ["hidapi"] {os = "macos" & os-distribution = "homebrew"}
   ["hidapi"] {os = "freebsd"}
   ["hidapi-dev"] {os-distribution = "alpine"}

--- a/packages/ledgerwallet-tezos/ledgerwallet-tezos.0.1.0/opam
+++ b/packages/ledgerwallet-tezos/ledgerwallet-tezos.0.1.0/opam
@@ -11,7 +11,7 @@ build:    [ "dune" "build"   "-p" name "-j" jobs ]
 # run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.4.0"}
+  "dune" {>= "1.11.0"}
   "ledgerwallet" {= version}
 ]
 synopsis: "Ledger wallet library for OCaml: Tezos app"

--- a/packages/ledgerwallet/ledgerwallet.0.1.0/opam
+++ b/packages/ledgerwallet/ledgerwallet.0.1.0/opam
@@ -11,7 +11,7 @@ build:    [ "dune" "build"   "-p" name "-j" jobs ]
 # run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.4.0"}
+  "dune" {>= "1.11.0"}
   "rresult" {>= "0.6.0"}
   "cstruct" {>= "5.1.1"}
   "hidapi" {>= "1.1.1"}

--- a/packages/resto-cohttp-client/resto-cohttp-client.0.4/opam
+++ b/packages/resto-cohttp-client/resto-cohttp-client.0.4/opam
@@ -17,7 +17,7 @@ depends: [
   "uri" {>= "1.9.0" }
   "resto-cohttp" {= version }
   "cohttp-lwt" { >= "1.0.0" }
-  "lwt" { >= "3.0.0" & <= "5.0.0" }
+  "lwt" { >= "3.0.0" }
 ]
 url {
   src:

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.4/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.4/opam
@@ -17,7 +17,7 @@ depends: [
   "resto-directory" {= version }
   "resto-cohttp" {= version }
   "cohttp-lwt-unix" { >= "1.0.0" }
-  "lwt" { >= "3.0.0" & <= "5.0.0" }
+  "lwt" { >= "3.0.0" }
 ]
 url {
   src:

--- a/packages/resto-directory/resto-directory.0.4/opam
+++ b/packages/resto-directory/resto-directory.0.4/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" { >= "1.7" }
   "resto" {= version }
   "resto-json" {= version & with-test }
-  "lwt" { >= "3.0.0" & <= "5.0.0" }
+  "lwt" { >= "3.0.0" }
 ]
 url {
   src:


### PR DESCRIPTION
- conf-hidapi may still fail on alpine as hidapi is only available in the most recent alpine 3.11
- the compatibility of ledgerwallet with dune 1.11 won't be test by the CI I guess but I checked it and you can see it in CI logs of !16215 (meta packages `tezos` installs at the same time ledgerwallet-tezos and tezos-node which transitively imposes dune < 2)