### PR TITLE
conf-packages to detect embedded compilation toolchains

### DIFF
--- a/packages/conf-avr-gcc/conf-avr-gcc.1/opam
+++ b/packages/conf-avr-gcc/conf-avr-gcc.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "tim@gfxmonk.net"
+homepage: "https://nongnu.org/avr-libc/"
+bug-reports: "https://nongnu.org/avr-libc/bugs.html"
+authors: "Joerg Wunsch"
+license: "Modified BSD"
+build: [["sh" "-exc" "avr-g++ --version && avr-objcopy --version"]]
+depexts: [
+  ["gcc-avr"] {os-family = "debian"}
+  ["avr-gcc"] {os-distribution = "fedora"}
+  ["avr-gcc"] {os-distribution = "centos"}
+  ["gcc-avr"] {os-distribution = "alpine"}
+  ["avr-gcc"] {os-distribution = "arch"}
+  ["avr-gcc"] {os-distribution = "arch"}
+  ["avr-gcc"] {os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on avr-gcc"
+description:
+  "This package can only install if the avr-g++ and avr-objcopy binaries are installed on the system."
+flags: conf

--- a/packages/conf-avrdude/conf-avrdude.1/opam
+++ b/packages/conf-avrdude/conf-avrdude.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "tim@gfxmonk.net"
+homepage: "https://nongnu.org/avrdude/"
+bug-reports: "https://savannah.nongnu.org/bugs/?group=avrdude"
+authors: "Joerg Wunsch"
+license: "GPL2 or ulterior"
+build: [["sh" "-exc" "avrdude --version"]]
+depexts: [
+  ["avrdude"] {os-family = "debian"}
+  ["avrdude"] {os-distribution = "fedora"}
+  ["avrdude"] {os-distribution = "centos"}
+  ["avrdude"] {os-distribution = "alpine"}
+  ["avrdude"] {os-distribution = "arch"}
+  ["avrdude"] {os-distribution = "suse"}
+  ["avrdude"] {os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on avrdude"
+description:
+  "This package can only install if the avrdude binary is installed on the system."
+flags: conf

--- a/packages/conf-xc32-toolchain/conf-xc32-toolchain.1/opam
+++ b/packages/conf-xc32-toolchain/conf-xc32-toolchain.1/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+maintainer: "ClientSuccess@microchip.com"
+authors: "Microchip Technology, Inc."
+homepage: "https://www.microchip.com"
+bug-reports: "https://www.microchip.com/support"
+license: "Proprietary"
+build: [["sh" "-exc" "command -v xc32-g++ && command -v xc32-bin2hex && command -v pic32prog"]]
+
+synopsis: "Virtual package relying on the XC32 Toolchain"
+description:
+  "This package can only install if the xc32-g++, xc32-bin2hex  and pic32prog binaries are installed on the system."
+flags: conf


### PR DESCRIPTION
These three pseudo-packages detect existing compilation tools for
use with future opam packages:
- `conf-avr-gcc` for the Gnu toolchain for AVR
- `conf-avrdude` for the associated firmware uploader
- `conf-xc32-toolchain` for the proprietary XC32 platform