### PR TITLE
ocaml-secondary-compiler: --disable-graph-lib (disable Graphics)

### DIFF
--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
@@ -15,6 +15,7 @@ build: [
       "--disable-installing-bytecode-programs"
       "--disable-debug-runtime"
       "--disable-instrumented-runtime"
+      "--disable-graph-lib"
       "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
       "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
   ]


### PR DESCRIPTION
Fixes #16226

cc @dra27 @diml: do you need ocamldoc in the secondary compiler, or can it also be disabled? (I sort of assume that you do, given that @dra27 made the effort of backporting the manpages patch?)