### PR TITLE
Package lambda.0.1.7

### DIFF
--- a/packages/lambda/lambda.0.1.7/opam
+++ b/packages/lambda/lambda.0.1.7/opam
@@ -18,7 +18,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.05.0"}
   
-  "dune" {build & >= "1.6.0"}
+  "dune" {>= "2.5.0"}
   "menhir" {>= "20200211"}
 
   "ounit" {with-test & >= "2.0.8"}

--- a/packages/lambda/lambda.0.1.7/opam
+++ b/packages/lambda/lambda.0.1.7/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "λ-calculus ocaml library"
+description: """
+λ-calculus ocaml library. Modules documentation is 
+available at https://dakk.github.io/lambda/
+"""
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: [
+  "Davide Gessa <gessadavide@gmail.com>"
+]
+
+homepage: "https://github.com/dakk/lambda"
+bug-reports: "https://github.com/dakk/lambda/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/dakk/lambda.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  
+  "dune" {build & >= "1.6.0"}
+  "menhir" {>= "20200211"}
+
+  "ounit" {with-test & >= "2.0.8"}
+  "odoc" {with-test & >= "1.3.0"}
+]
+
+url {
+  src: "https://github.com/dakk/lambda/archive/v0.1.7.tar.gz"
+  checksum: [
+    "md5=6331108c312dc036ae08691621549bb1"
+    "sha512=1f8a2a77310dea6c5162cfc8b9c4ac0104f62ec948037d61a5c000b5863c2dc49e450c08b7e811d3037d890542708df509f516df721a3e15cef9fb574bc4f9f6"
+  ]
+}


### PR DESCRIPTION
### `lambda.0.1.7`
λ-calculus ocaml library
λ-calculus ocaml library. Modules documentation is 
available at https://dakk.github.io/lambda/



---
* Homepage: https://github.com/dakk/lambda
* Source repo: git+https://github.com/dakk/lambda.git
* Bug tracker: https://github.com/dakk/lambda/issues

---
:camel: Pull-request generated by opam-publish v2.0.2