### PR TITLE
ocaml-secondary-compiler: --disable-graph-lib (disable Graphics)

### DIFF
--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/files/0001-Don-t-build-manpages-for-stdlib-docs.patch
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/files/0001-Don-t-build-manpages-for-stdlib-docs.patch
@@ -1,0 +1,24 @@
+From 0cf3c6ad7ce2a2b2806faceccfb0a9321da5e22a Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Fri, 26 Jul 2019 12:12:19 +0100
+Subject: [PATCH] Don't build manpages for stdlib docs
+---
+ ocamldoc/Makefile            | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ocamldoc/Makefile b/ocamldoc/Makefile
+index b109815071..e31e441f61 100644
+--- a/ocamldoc/Makefile
++++ b/ocamldoc/Makefile
+@@ -170,7 +170,7 @@ LIBCMIFILES = $(LIBCMOFILES:.cmo=.cmi)
+ 
+ 
+ .PHONY: all
+-all: lib exe generators manpages
++all: lib exe generators
+ 
+ manpages: generators
+ 
+-- 
+2.20.1
+

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/files/0001-Fix-failure-to-install-tools-links.patch
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/files/0001-Fix-failure-to-install-tools-links.patch
@@ -1,0 +1,26 @@
+From 705739fa54260b7a0e6cbba0b5a99e52c79f9c09 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Tue, 6 Aug 2019 09:23:06 +0100
+Subject: [PATCH] Fix failure to install tools links
+
+In --disable-installing-bytecode-programs mode, the .opt version of the
+tools is installed, but the symlink for the tool itself is not created.
+---
+ tools/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tools/Makefile b/tools/Makefile
+index 530dd37f34..1b3014a3ab 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -197,6 +197,7 @@ else
+ 	do \
+ 	  if test -f "$$i".opt; then \
+ 	    $(INSTALL_PROG) "$$i.opt" "$(INSTALL_BINDIR)/$$i.opt$(EXE)"; \
++	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
+ 	  fi; \
+ 	done
+ endif
+-- 
+2.20.1
+

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/opam
@@ -15,6 +15,7 @@ build: [
       "--disable-installing-bytecode-programs"
       "--disable-debug-runtime"
       "--disable-instrumented-runtime"
+      "--disable-graph-lib"
       "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
       "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
   ]

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/opam
@@ -5,7 +5,7 @@ authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/ocaml/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
-conflicts: "ocaml" {>= "4.08.0" & < "4.09~"}
+depends: "ocaml" {< "4.08.0" | >= "4.09~"}
 build: [
   [
     "./configure"

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
@@ -15,6 +15,7 @@ build: [
       "--disable-installing-bytecode-programs"
       "--disable-debug-runtime"
       "--disable-instrumented-runtime"
+      "--disable-graph-lib"
       "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
       "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
   ]

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
@@ -5,7 +5,7 @@ authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/ocaml/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
-conflicts: "ocaml" {>= "4.08.0" & < "4.09~"}
+depends: "ocaml" {< "4.08.0" | >= "4.09~"}
 build: [
   [
     "./configure"


### PR DESCRIPTION
Continuation of #16236 in a bid to fix #16226.

@AltGr / @rjbou - https://github.com/ocaml/opam-repository/commit/33e22b6f3dc30101bd35f0003c86716cd248e47f expresses the same requirement using `depends` instead of `conflicts` but that's not ideal, since that would attempt to change the installed compiler, rather than reporting the conflict (I think)? What the best way to express the conflict with all 4.08 versions of `ocaml`?