### PR TITLE
Add a GitHub Action to close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "20 * * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove the stale label, or comment, or this will be closed in 15 days.'
+        days-before-stale: 90
+        days-before-close: 15


### PR DESCRIPTION
At the OCaml core developers meeting in April 2020, we decided
to experiment with closing stale issues that have no activity for
a long period of time. This is simply to keep the working set of
issues at mangeable levels.

This PR experiments with adding this to opam-repository, where
stale issues are particularly prone to being closable as many
have been fixed by subsequent metadata improvements. Feedback
welcome on the timeouts, and the message itself.