### PR TITLE
Package naboris.0.1.2

### DIFF
--- a/packages/naboris/naboris.0.1.2/opam
+++ b/packages/naboris/naboris.0.1.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built on httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "1.6"}
+  "reason" {>= "3.4.0"}
+  "httpaf" {>= "0.6.0"}
+  "httpaf-lwt-unix" {>= "0.6.0"}
+  "lwt" {>= "5.1.1"}
+  "uri" {>= "2.2.0"}
+]
+depopts: [
+  "conf-libev"
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/0.1.2.tar.gz"
+  checksum: [
+    "md5=ca1ecbc038f43cd52a03f1a0c0ee5964"
+    "sha512=ead6418f5f49d377a1a82154251f6ea2e3034db921def2625ce08d619dfa1088b51eceae29d7b976a22d570ea3d6a7855320ea57bec01c4adf1565cecb22a5e6"
+  ]
+}


### PR DESCRIPTION
### `naboris.0.1.2`
Simple http server
Simple http server built on httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.0