### PR TITLE
Lwt 5.3.0

### DIFF
--- a/packages/lwt/lwt.5.3.0/opam
+++ b/packages/lwt/lwt.5.3.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+
+version: "5.3.0"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.8.0"}
+  "dune-configurator"
+  "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0"}
+  ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
+  "ocplib-endian"
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+build: [
+  ["dune" "exec" "-p" name "src/unix/config/discover.exe" "--" "--save"
+    "--use-libev" "%{conf-libev:installed}%"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.3.0.tar.gz"
+  checksum: "md5=85e9c7e9095b4e14d0698e3ece72f378"
+}


### PR DESCRIPTION
Changelog:

> - Add `let*` and `and*` in `Lwt.Syntax` and `Lwt_result.Syntax` (ocsigen/lwt#775, Rahul Kumar).
> - Also add `let+` and `and+` (ocsigen/lwt#776, Craig Ferguson).
> - Add `Lwt_result.both` (ocsigen/lwt#775, Rahul Kumar).
> - Always use libev if detected (ocsigen/lwt#601).