### PR TITLE
[new release] dns-client, dns-server, dns-certify, dns, dns-resolver, dns-tsig, dns-mirage, dns-stub and dns-cli (4.5.0)

### DIFF
--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.6.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.6.0/opam
@@ -16,7 +16,7 @@ depends: [
   "astring"
   "fmt"
   "logs"
-  "dns-client"
+  "dns-client" {< "4.5.0"}
   "tls-mirage"
   "mirage-stack" {>="2.0.0"}
   "arp-mirage" {with-test}

--- a/packages/conduit-mirage/conduit-mirage.2.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "mirage-time-lwt" {>= "1.1.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-random" {>= "1.2.0" & < "2.0.0"}
-  "dns-client" {>= "4.0.0"}
+  "dns-client" {>= "4.0.0" & < "4.5.0"}
   "conduit-lwt"
   "vchan" {>= "3.0.0"}
   "xenstore"

--- a/packages/conduit-mirage/conduit-mirage.2.0.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "mirage-time-lwt" {>= "1.1.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-random" {>= "1.2.0" & < "2.0.0"}
-  "dns-client" {>= "4.0.0"}
+  "dns-client" {>= "4.0.0" & < "4.5.0"}
   "conduit-lwt"
   "vchan" {>= "3.0.0"}
   "xenstore"

--- a/packages/conduit-mirage/conduit-mirage.2.0.2/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "mirage-flow" {>= "2.0.0"}
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "dns-client" {>= "4.1.0"}
+  "dns-client" {>= "4.1.0" & < "4.5.0"}
   "conduit-lwt"
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/packages/conduit-mirage/conduit-mirage.2.1.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "mirage-flow" {>= "2.0.0"}
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "dns-client" {>= "4.1.0"}
+  "dns-client" {>= "4.1.0" & < "4.5.0"}
   "conduit-lwt"
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/packages/dns-certify/dns-certify.4.5.0/opam
+++ b/packages/dns-certify/dns-certify.4.5.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "0.10.0"}
+  "lwt" {>= "4.2.1"}
+  "tls" {>= "0.11.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "logs"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.5.0/dns-v4.5.0.tbz"
+  checksum: [
+    "sha256=005bfc7f851e51be9ceec94b6c25c4255898a25f911724e6dfd980bbbbb55982"
+    "sha512=ad5de6a6dafb2cf9825e40492bee693c439f51e44bf8f809ec28527841d1b4f23fd4a8e9971885b489548d54a95e5fbd8298ca0f4ce21fecf447a82bba03c5a7"
+  ]
+}

--- a/packages/dns-cli/dns-cli.4.5.0/opam
+++ b/packages/dns-cli/dns-cli.4.5.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-client" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "rresult" {>= "0.6.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "0.10.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng"
+  "hex" {>= "1.4.0"}
+  "ptime" {>= "0.8.5"}
+  "mtime" {>= "1.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.5.0/dns-v4.5.0.tbz"
+  checksum: [
+    "sha256=005bfc7f851e51be9ceec94b6c25c4255898a25f911724e6dfd980bbbbb55982"
+    "sha512=ad5de6a6dafb2cf9825e40492bee693c439f51e44bf8f809ec28527841d1b4f23fd4a8e9971885b489548d54a95e5fbd8298ca0f4ce21fecf447a82bba03c5a7"
+  ]
+}

--- a/packages/dns-client/dns-client.4.5.0/opam
+++ b/packages/dns-client/dns-client.4.5.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD2"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {>="1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt" {>= "0.8.8"}
+  "logs" {>= "0.6.3"}
+  "dns" {= version}
+  "rresult" {>= "0.6.0"}
+  "randomconv" {>= "0.1.2"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng"
+]
+synopsis: "Pure DNS resolver API"
+description: """
+A pure resolver implementation using uDNS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.5.0/dns-v4.5.0.tbz"
+  checksum: [
+    "sha256=005bfc7f851e51be9ceec94b6c25c4255898a25f911724e6dfd980bbbbb55982"
+    "sha512=ad5de6a6dafb2cf9825e40492bee693c439f51e44bf8f809ec28527841d1b4f23fd4a8e9971885b489548d54a95e5fbd8298ca0f4ce21fecf447a82bba03c5a7"
+  ]
+}

--- a/packages/dns-mirage/dns-mirage.4.5.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.5.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack" {>= "2.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  In a similar vein, wildcard records are _not_ supported, and it is
+unlikely they'll ever be in this library.  Truncated hmac in `TSIG` are not
+supported (always the full length of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.5.0/dns-v4.5.0.tbz"
+  checksum: [
+    "sha256=005bfc7f851e51be9ceec94b6c25c4255898a25f911724e6dfd980bbbbb55982"
+    "sha512=ad5de6a6dafb2cf9825e40492bee693c439f51e44bf8f809ec28527841d1b4f23fd4a8e9971885b489548d54a95e5fbd8298ca0f4ce21fecf447a82bba03c5a7"
+  ]
+}

--- a/packages/dns-resolver/dns-resolver.4.5.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.5.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.5.0/dns-v4.5.0.tbz"
+  checksum: [
+    "sha256=005bfc7f851e51be9ceec94b6c25c4255898a25f911724e6dfd980bbbbb55982"
+    "sha512=ad5de6a6dafb2cf9825e40492bee693c439f51e44bf8f809ec28527841d1b4f23fd4a8e9971885b489548d54a95e5fbd8298ca0f4ce21fecf447a82bba03c5a7"
+  ]
+}

--- a/packages/dns-server/dns-server.4.5.0/opam
+++ b/packages/dns-server/dns-server.4.5.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-crypto-rng" {with-test}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.5.0/dns-v4.5.0.tbz"
+  checksum: [
+    "sha256=005bfc7f851e51be9ceec94b6c25c4255898a25f911724e6dfd980bbbbb55982"
+    "sha512=ad5de6a6dafb2cf9825e40492bee693c439f51e44bf8f809ec28527841d1b4f23fd4a8e9971885b489548d54a95e5fbd8298ca0f4ce21fecf447a82bba03c5a7"
+  ]
+}

--- a/packages/dns-stub/dns-stub.4.5.0/opam
+++ b/packages/dns-stub/dns-stub.4.5.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-client" {= version}
+  "dns-mirage" {= version}
+  "dns-resolver" {= version}
+  "dns-tsig" {= version}
+  "dns-server" {= version}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS stub resolver"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.5.0/dns-v4.5.0.tbz"
+  checksum: [
+    "sha256=005bfc7f851e51be9ceec94b6c25c4255898a25f911724e6dfd980bbbbb55982"
+    "sha512=ad5de6a6dafb2cf9825e40492bee693c439f51e44bf8f809ec28527841d1b4f23fd4a8e9971885b489548d54a95e5fbd8298ca0f4ce21fecf447a82bba03c5a7"
+  ]
+}

--- a/packages/dns-tsig/dns-tsig.4.5.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.5.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "mirage-crypto"
+  "base64" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.5.0/dns-v4.5.0.tbz"
+  checksum: [
+    "sha256=005bfc7f851e51be9ceec94b6c25c4255898a25f911724e6dfd980bbbbb55982"
+    "sha512=ad5de6a6dafb2cf9825e40492bee693c439f51e44bf8f809ec28527841d1b4f23fd4a8e9971885b489548d54a95e5fbd8298ca0f4ce21fecf447a82bba03c5a7"
+  ]
+}

--- a/packages/dns/dns.4.5.0/opam
+++ b/packages/dns/dns.4.5.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD2"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "rresult" "astring" "fmt" "logs" "ptime"
+  "domain-name" {>= "0.3.0"}
+  "gmap" {>= "0.3.0"}
+  "cstruct" {>= "3.2.0"}
+  "ipaddr" {>= "3.0.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "metrics"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  In a similar vein, wildcard records are _not_ supported, and it is
+unlikely they'll ever be in this library.  Truncated hmac in `TSIG` are not
+supported (always the full length of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.5.0/dns-v4.5.0.tbz"
+  checksum: [
+    "sha256=005bfc7f851e51be9ceec94b6c25c4255898a25f911724e6dfd980bbbbb55982"
+    "sha512=ad5de6a6dafb2cf9825e40492bee693c439f51e44bf8f809ec28527841d1b4f23fd4a8e9971885b489548d54a95e5fbd8298ca0f4ce21fecf447a82bba03c5a7"
+  ]
+}


### PR DESCRIPTION
Pure DNS resolver API

- Project page: <a href="https://github.com/mirage/ocaml-dns">https://github.com/mirage/ocaml-dns</a>

##### CHANGES:

* client: add timeout for DNS requests (defaults to 5 seconds, as in resolv.h).
* dns-client-mirage functor requires a Mirage_time.S implementation (changes API).
  Update your code as in this commit:
  https://github.com/roburio/unikernels/commit/201e980f458ebb515298392227294e7b508a1009
  mirage/ocaml-dns#223 @linse @hannesm, review by @cfcs
