### PR TITLE
[Travis] Update XCode from 10.1 to 11.3 (MacOS 10.13 to 10.14)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 matrix:
   include:
   - os: osx
-    osx_image: xcode10.1
+    osx_image: xcode11.3
     env: OCAML_VERSION=4.09
   - os: linux
     env: OCAML_VERSION=4.09 INSTALL_LOCAL=1


### PR DESCRIPTION
Some people seem to hit an issue with our current version of XCode in https://github.com/ocaml/opam-repository/pull/16243

According to the Travis documentation [1], XCode 10.1 was the last version on Travis to come with MacOS 10.13 so upgrading XCode also upgrades MacOS. Does that seem ok for everyone?

cc @msprotz @avsm @mseri 

I'll merge this by the end of the day if nobody has any strong counter-indications. If we notice issues we can still revert this PR.

[1]: https://docs.travis-ci.com/user/reference/osx