### PR TITLE
Package ringo.0.3

### DIFF
--- a/packages/ringo/ringo.0.3/opam
+++ b/packages/ringo/ringo.0.3/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Caches (bounded-size key-value stores) and other bounded-size stores"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.3/ringo-v0.3.tar.gz"
+  checksum: [
+    "md5=535a39a13a69228976cc1bb5d21c897c"
+    "sha512=3076faac3e721014b58b08c2afc8b7d23461db37b68f7542743dbfc5721544071c9f66391a070a0c9372675616d57b6fe9cb76650e4223620f110da3ccf7c84b"
+  ]
+}


### PR DESCRIPTION
### `ringo.0.3`
Caches (bounded-size key-value stores) and other bounded-size stores



---
* Homepage: https://gitlab.com/nomadic-labs/ringo
* Source repo: git+https://gitlab.com/nomadic-labs/ringo.git
* Bug tracker: https://gitlab.com/nomadic-labs/ringo/issues

---
:camel: Pull-request generated by opam-publish v2.0.0