### PR TITLE
Remove {build} flags from all ppx_* dependencies.

### DIFF
--- a/packages/alba/alba.0.4.1/opam
+++ b/packages/alba/alba.0.4.1/opam
@@ -20,8 +20,8 @@ depends: [
   "odoc" {with-doc}
   "js_of_ocaml" {build}
   "js_of_ocaml-ppx"
-  "ppx_inline_test" {build} (* is needed for building the libraries
-                               otherwise it does not compile *)
+  "ppx_inline_test" (* is needed for building the libraries
+                       otherwise it does not compile *)
 ]
 url {
     src: "https://github.com/hbr/albatross/archive/0.4.1.tar.gz"

--- a/packages/alba/alba.0.4.2/opam
+++ b/packages/alba/alba.0.4.2/opam
@@ -20,8 +20,8 @@ depends: [
   "js_of_ocaml-ppx"
   "menhir"           {build}
   "js_of_ocaml"      {build}
-  "ppx_inline_test"  {build} (* is needed for building the libraries,
-                                otherwise it does not compile *)
+  "ppx_inline_test" (* is needed for building the libraries,
+                       otherwise it does not compile *)
   "odoc"             {with-doc}
 ]
 url {

--- a/packages/amf/amf.0.1.2/opam
+++ b/packages/amf/amf.0.1.2/opam
@@ -14,7 +14,7 @@ depends: [
   "core" {>= "v0.9.1" & < "v0.13"}
   "stdint"
   "sexplib" {< "v0.13"}
-  "bisect_ppx" {build}
+  "bisect_ppx"
   "ounit" {with-test}
 ]
 build: [

--- a/packages/bitstring/bitstring.3.1.0/opam
+++ b/packages/bitstring/bitstring.3.1.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder"
-  "ppx_tools_versioned" {build}
+  "ppx_tools_versioned"
   "ocaml-migrate-parsetree" {>= "1.0.5"}
   "ounit" {with-test}
 ]

--- a/packages/bitstring/bitstring.3.1.1/opam
+++ b/packages/bitstring/bitstring.3.1.1/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune"
-  "ppx_tools_versioned" {build}
+  "ppx_tools_versioned"
   "ocaml-migrate-parsetree" {>= "1.0.5"}
   "stdlib-shims"
   "ounit" {with-test}

--- a/packages/cconv-ppx/cconv-ppx.0.5/opam
+++ b/packages/cconv-ppx/cconv-ppx.0.5/opam
@@ -13,7 +13,7 @@ depends: [
   "ppx_deriving" {>= "2.0"}
   "ppxlib" {< "0.9.0"}
   "cppo" {build}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ppxfind" {build}
   "ocaml" {>= "4.02"}
   "mdx" {with-test}

--- a/packages/charrua-core/charrua-core.0.10/opam
+++ b/packages/charrua-core/charrua-core.0.10/opam
@@ -17,8 +17,8 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "jbuilder" {>= "1.0+beta7"}
-  "ppx_sexp_conv" {build & < "v0.14"}
-  "ppx_cstruct" {build}
+  "ppx_sexp_conv" {< "v0.14"}
+  "ppx_cstruct"
   "menhir" {build}
   "cstruct" {>= "3.0.1" & < "4.0.0"}
   "sexplib" {< "v0.14"}

--- a/packages/charrua-core/charrua-core.0.11.0/opam
+++ b/packages/charrua-core/charrua-core.0.11.0/opam
@@ -15,8 +15,8 @@ build: [
 
 depends: [
   "jbuilder" {>= "1.0+beta7"}
-  "ppx_sexp_conv" {build & < "v0.14"}
-  "ppx_cstruct" {build}
+  "ppx_sexp_conv" {< "v0.14"}
+  "ppx_cstruct"
   "menhir" {build}
   "ocaml" {>= "4.0.3"}
   "cstruct" {>= "3.0.1" & < "4.0.0"}

--- a/packages/charrua-core/charrua-core.0.11.1/opam
+++ b/packages/charrua-core/charrua-core.0.11.1/opam
@@ -15,8 +15,8 @@ build: [
 
 depends: [
   "jbuilder" {>= "1.0+beta7"}
-  "ppx_sexp_conv" {build & < "v0.14"}
-  "ppx_cstruct" {build}
+  "ppx_sexp_conv" {< "v0.14"}
+  "ppx_cstruct"
   "menhir" {build}
   "ocaml" {>= "4.0.3"}
   "cstruct" {>= "3.0.1" & < "4.0.0"}

--- a/packages/charrua-core/charrua-core.0.3/opam
+++ b/packages/charrua-core/charrua-core.0.3/opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_deriving"
   "ppx_cstruct"
   "ppx_sexp_conv" {< "v0.14"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "cstruct" {>= "1.9.0" & < "3.0.0"}
   "cstruct-unix"
   "sexplib" {< "v0.14"}

--- a/packages/charrua-core/charrua-core.0.4/opam
+++ b/packages/charrua-core/charrua-core.0.4/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_deriving"
   "ppx_cstruct"
   "ppx_sexp_conv" {< "v0.14"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "cstruct" {>= "1.9.0" & < "3.0.0"}
   "sexplib" {< "v0.14"}
   "menhir"

--- a/packages/cohttp/cohttp.1.0.2/opam
+++ b/packages/cohttp/cohttp.1.0.2/opam
@@ -27,7 +27,7 @@ depends: [
   "uri" {>= "1.9.0" & < "2.0.0"}
   "fieldslib" {< "v0.14"}
   "sexplib" {< "v0.14"}
-  "ppx_type_conv" {build & >= "v0.9.1"}
+  "ppx_type_conv" {>= "v0.9.1"}
   "ppx_fields_conv" {>= "v0.9.0" & < "v0.14"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
   "stringext"

--- a/packages/cohttp/cohttp.1.1.0/opam
+++ b/packages/cohttp/cohttp.1.1.0/opam
@@ -26,7 +26,7 @@ depends: [
   "uri" {>= "1.9.0" & < "2.0.0"}
   "fieldslib" {< "v0.14"}
   "sexplib" {< "v0.14"}
-  "ppx_type_conv" {build & >= "v0.9.1"}
+  "ppx_type_conv" {>= "v0.9.1"}
   "ppx_fields_conv" {>= "v0.9.0" & < "v0.14"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
   "stringext"

--- a/packages/conduit/conduit.0.12.0/opam
+++ b/packages/conduit/conduit.0.12.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & <= "113.33.04"}
+  "ppx_driver" {<= "113.33.04"}
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
   "sexplib" {< "v0.14"}

--- a/packages/conduit/conduit.0.13.0/opam
+++ b/packages/conduit/conduit.0.13.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & <= "113.33.04"}
+  "ppx_driver" {<= "113.33.04"}
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
   "sexplib" {< "v0.14"}

--- a/packages/conduit/conduit.0.14.0/opam
+++ b/packages/conduit/conduit.0.14.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & <= "113.33.04"}
+  "ppx_driver" {<= "113.33.04"}
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
   "sexplib" {< "v0.14"}

--- a/packages/conduit/conduit.0.14.1/opam
+++ b/packages/conduit/conduit.0.14.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & <= "113.33.04"}
+  "ppx_driver" {<= "113.33.04"}
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
   "sexplib" {< "v0.14"}

--- a/packages/conduit/conduit.0.14.2/opam
+++ b/packages/conduit/conduit.0.14.2/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & <= "113.33.04"}
+  "ppx_driver" {<= "113.33.04"}
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
   "sexplib" {< "v0.14"}

--- a/packages/conduit/conduit.0.14.3/opam
+++ b/packages/conduit/conduit.0.14.3/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & < "v0.10.0"}
+  "ppx_driver" {< "v0.10.0"}
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
   "sexplib" {< "v0.14"}

--- a/packages/conduit/conduit.0.14.4/opam
+++ b/packages/conduit/conduit.0.14.4/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & < "v0.10.0"}
+  "ppx_driver" {< "v0.10.0"}
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
   "sexplib" {< "v0.14"}

--- a/packages/conduit/conduit.0.14.5/opam
+++ b/packages/conduit/conduit.0.14.5/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & < "v0.10.0"}
+  "ppx_driver" {< "v0.10.0"}
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
   "sexplib" {< "v0.14"}

--- a/packages/conduit/conduit.0.15.0/opam
+++ b/packages/conduit/conduit.0.15.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & < "v0.10.0"}
+  "ppx_driver" {< "v0.10.0"}
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
   "sexplib" {< "v0.14"}

--- a/packages/conduit/conduit.0.15.1/opam
+++ b/packages/conduit/conduit.0.15.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & < "v0.10.0"}
+  "ppx_driver" {< "v0.10.0"}
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
   "sexplib" {< "v0.14"}

--- a/packages/conduit/conduit.0.15.2/opam
+++ b/packages/conduit/conduit.0.15.2/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & < "v0.10.0"}
+  "ppx_driver" {< "v0.10.0"}
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
   "sexplib" {< "v0.14"}

--- a/packages/conduit/conduit.0.15.3/opam
+++ b/packages/conduit/conduit.0.15.3/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & < "v0.10.0"}
+  "ppx_driver" {< "v0.10.0"}
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
   "sexplib" {< "v0.14"}

--- a/packages/conduit/conduit.0.15.4/opam
+++ b/packages/conduit/conduit.0.15.4/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_driver" {build & >= "v0.9.1" & < "v0.10.0"}
+  "ppx_driver" {>= "v0.9.1" & < "v0.10.0"}
   "ppx_deriving"
   "ppx_optcomp" {>= "113.24.00" & < "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}

--- a/packages/coq-serapi/coq-serapi.8.10.0+0.7.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.10.0+0.7.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"             }
   "sexplib"             {           >= "v0.11.0" & < "v0.14" }
   "dune"                {           >= "1.2.0"             }
-  "ppx_import"          { build   & >= "1.5-3"             }
+  "ppx_import"          {           >= "1.5-3"             }
   "ppx_deriving"        {           >= "4.2.1"             }
   "ppx_sexp_conv"       {           >= "v0.11.0" & < "v0.14" }
   "yojson"              {           >= "1.7.0"             }

--- a/packages/coq-serapi/coq-serapi.8.11.0+0.11.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.11.0+0.11.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"             }
   "sexplib"             {           >= "v0.11.0"           }
   "dune"                {           >= "1.2.0"             }
-  "ppx_import"          { build   & >= "1.5-3"             }
+  "ppx_import"          {           >= "1.5-3"             }
   "ppx_deriving"        {           >= "4.2.1"             }
   "ppx_sexp_conv"       {           >= "v0.11.0"           }
   "yojson"              {           >= "1.7.0"             }

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_deriving" {>= "4.2.1"}
   "cmdliner"
   "sexplib" {< "v0.14"}
-  "ppx_driver" {build & >= "v0.10.1"}
+  "ppx_driver" {>= "v0.10.1"}
   "ppx_sexp_conv" {< "v0.11.0"}
 ]
 build:   [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.12/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.12/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_import" {>= "1.4"}
   "ppx_deriving" {>= "4.2.1"}
-  "ppx_driver" {build & >= "v0.10.1"}
+  "ppx_driver" {>= "v0.10.1"}
   "ppx_sexp_conv" {< "v0.11.0"}
 ]
 build:    [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_import" {>= "1.4"}
   "ppx_deriving" {>= "4.2.1"}
-  "ppx_driver" {build & >= "v0.10.1"}
+  "ppx_driver" {>= "v0.10.1"}
   "ppx_sexp_conv" {< "v0.11.0"}
 ]
 build:   [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.8/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.8/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_import" {>= "1.4"}
   "ppx_deriving" {>= "4.2.1"}
-  "ppx_driver" {build & >= "v0.10.1"}
+  "ppx_driver" {>= "v0.10.1"}
   "ppx_sexp_conv" {< "v0.11.0"}
 ]
 build:    [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4/opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_deriving" {>= "4.2.1"}
   "cmdliner"
   "sexplib" {< "v0.14"}
-  "ppx_driver" {build & >= "v0.10.1"}
+  "ppx_driver" {>= "v0.10.1"}
   "ppx_sexp_conv" {< "v0.11.0"}
 ]
 build:   [ make "-j%{jobs}%" "TARGET=native" ]

--- a/packages/coq-serapi/coq-serapi.8.9.0+0.6.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.9.0+0.6.0/opam
@@ -17,9 +17,9 @@ depends: [
   "ocamlfind"     { >= "1.8.0"            }
   "sexplib"       { >= "v0.11.0" & < "v0.14" }
   "dune"          { >= "1.2.0"    }
-  "ppx_import"    { build & >= "1.5-3"    }
-  "ppx_deriving"  { build & >= "4.2.1"    }
-  "ppx_sexp_conv" { build & >= "v0.11.0" & < "v0.14" }
+  "ppx_import"    { >= "1.5-3"            }
+  "ppx_deriving"  { >= "4.2.1"            }
+  "ppx_sexp_conv" { >= "v0.11.0" & < "v0.14" }
 ]
 
 build: [ "dune" "build" "-p" name "-j" jobs ]

--- a/packages/coq-serapi/coq-serapi.8.9.0+0.6.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.9.0+0.6.1/opam
@@ -17,9 +17,9 @@ depends: [
   "ocamlfind"     { >= "1.8.0"            }
   "sexplib"       { >= "v0.11.0" & < "v0.14" }
   "dune"          { >= "1.2.0"    }
-  "ppx_import"    { build & >= "1.5-3"    }
-  "ppx_deriving"  { build & >= "4.2.1"    }
-  "ppx_sexp_conv" { build & >= "v0.11.0" & < "v0.14" }
+  "ppx_import"    { >= "1.5-3"    }
+  "ppx_deriving"  { >= "4.2.1"    }
+  "ppx_sexp_conv" { >= "v0.11.0" & < "v0.14" }
 ]
 
 build: [ "dune" "build" "-p" name "-j" jobs ]

--- a/packages/datakit-ci/datakit-ci.0.12.2/opam
+++ b/packages/datakit-ci/datakit-ci.0.12.2/opam
@@ -36,7 +36,7 @@ depends: [
   "github-hooks-unix" {with-test}
   "prometheus-app"
   "lwt" {>= "3.0.0"}
-  "ppx_sexp_conv" {build & < "v0.14"}
+  "ppx_sexp_conv" {< "v0.14"}
   "crunch" {build & < "3.0.0"}
   "datakit" {with-test & >= "0.12.0"}
   "irmin-unix" {with-test & >= "1.2.0" & < "2.0.0"}

--- a/packages/datakit-ci/datakit-ci.1.0.0/opam
+++ b/packages/datakit-ci/datakit-ci.1.0.0/opam
@@ -35,7 +35,7 @@ depends: [
   "github-unix" {>= "3.0.0"}
   "prometheus-app"
   "lwt" {>= "3.0.0"}
-  "ppx_sexp_conv" {build & >= "v0.9.0" & < "v0.14"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
   "crunch" {build}
   "datakit" {with-test & >= "0.12.0"}
   "irmin-unix" {with-test & >= "1.2.0" & < "2.0.0"}

--- a/packages/diet/diet.0.1/opam
+++ b/packages/diet/diet.0.1/opam
@@ -17,9 +17,9 @@ depends: [
   "result"
   "sexplib" {< "v0.14"}
   "jbuilder" {>= "1.0+beta10"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build & >= "v0.9.0" & < "v0.14"}
-  "ppx_type_conv" {build}
+  "ppx_tools"
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
+  "ppx_type_conv"
   "ounit" {with-test}
 ]
 synopsis: "Discrete Interval Encoding Trees"

--- a/packages/easy_xlsx/easy_xlsx.1.0/opam
+++ b/packages/easy_xlsx/easy_xlsx.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_jane" {< "v0.14"}
   "ptime"
   "spreadsheetml"
-  "bisect_ppx" {build & >= "1.3.0"}
+  "bisect_ppx" {>= "1.3.0"}
   "jbuilder" {>= "1.0+beta18"}
   "csv" {with-test}
   "ounit" {with-test}

--- a/packages/flow_parser/flow_parser.0.80.0/opam
+++ b/packages/flow_parser/flow_parser.0.80.0/opam
@@ -14,8 +14,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "dtoa"
-  "ppx_deriving" {build}
-  "ppx_gen_rec" {build}
+  "ppx_deriving"
+  "ppx_gen_rec"
   "sedlex" {< "2.0"}
   "ppx_tools_versioned" {= "5.2"}
   "wtf8"

--- a/packages/flowtype/flowtype.0.78.0/opam
+++ b/packages/flowtype/flowtype.0.78.0/opam
@@ -19,8 +19,8 @@ depends: [
   "lwt" {>= "3.3.0"}
   "lwt_log" {= "1.0.0"}
   "lwt_ppx" {>= "1.1.0"}
-  "ppx_deriving" {build}
-  "ppx_gen_rec" {build}
+  "ppx_deriving"
+  "ppx_gen_rec"
   "wtf8"
 ]
 build: [ [ "env" "FLOW_RELEASE=1" make ] ]

--- a/packages/flowtype/flowtype.0.79.0/opam
+++ b/packages/flowtype/flowtype.0.79.0/opam
@@ -19,8 +19,8 @@ depends: [
   "lwt" {>= "3.3.0"}
   "lwt_log" {= "1.0.0"}
   "lwt_ppx" {>= "1.1.0"}
-  "ppx_deriving" {build}
-  "ppx_gen_rec" {build}
+  "ppx_deriving"
+  "ppx_gen_rec"
   "wtf8"
 ]
 build: [ [ "env" "FLOW_RELEASE=1" make ] ]

--- a/packages/flowtype/flowtype.0.79.1/opam
+++ b/packages/flowtype/flowtype.0.79.1/opam
@@ -19,8 +19,8 @@ depends: [
   "lwt" {>= "3.3.0"}
   "lwt_log" {= "1.0.0"}
   "lwt_ppx" {>= "1.1.0"}
-  "ppx_deriving" {build}
-  "ppx_gen_rec" {build}
+  "ppx_deriving"
+  "ppx_gen_rec"
   "wtf8"
 ]
 build: [ [ "env" "FLOW_RELEASE=1" make ] ]

--- a/packages/flowtype/flowtype.0.80.0/opam
+++ b/packages/flowtype/flowtype.0.80.0/opam
@@ -19,8 +19,8 @@ depends: [
   "lwt" {>= "3.3.0"}
   "lwt_log" {= "1.0.0"}
   "lwt_ppx" {>= "1.1.0"}
-  "ppx_deriving" {build}
-  "ppx_gen_rec" {build}
+  "ppx_deriving"
+  "ppx_gen_rec"
   "ppx_tools_versioned" {= "5.2"}
   "wtf8"
 ]

--- a/packages/lens/lens.1.2.1/opam
+++ b/packages/lens/lens.1.2.1/opam
@@ -14,8 +14,8 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.10"}
-  "ppx_deriving" {build}
-  "ppx_tools" {build}
+  "ppx_deriving"
+  "ppx_tools"
   "ppxfind" {build}
   "jbuilder"
   "ounit" {with-test}

--- a/packages/lens/lens.1.2.2/opam
+++ b/packages/lens/lens.1.2.2/opam
@@ -12,8 +12,8 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.10"}
-  "ppx_deriving" {build}
-  "ppx_tools" {build}
+  "ppx_deriving"
+  "ppx_tools"
   "ppxfind" {build}
   "jbuilder"
   "ounit" {with-test}

--- a/packages/lens/lens.1.2.3/opam
+++ b/packages/lens/lens.1.2.3/opam
@@ -13,8 +13,8 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.10"}
-  "ppx_deriving" {build}
-  "ppx_tools" {build}
+  "ppx_deriving"
+  "ppx_tools"
   "ppxfind" {build}
   "dune"         { >= "1.0"}
   "ounit" {with-test}

--- a/packages/lwt/lwt.2.7.0/opam
+++ b/packages/lwt/lwt.2.7.0/opam
@@ -39,7 +39,7 @@ depends: [
   "ocamlfind" {build & >= "1.5.0"}
   "ocamlbuild" {build}
   "result"
-  ("base-no-ppx" | "ppx_tools" {build})
+  ("base-no-ppx" | "ppx_tools")
 ]
 depopts: [
   "base-threads"

--- a/packages/lwt/lwt.2.7.1/opam
+++ b/packages/lwt/lwt.2.7.1/opam
@@ -45,7 +45,7 @@ depends: [
   "result"
   "cppo" {build & >= "1.1.0"}
   "cppo_ocamlbuild" {build}
-  "base-no-ppx" | "ppx_tools" {build}
+  "base-no-ppx" | "ppx_tools"
 ]
 depopts: [
   "base-threads"

--- a/packages/lwt/lwt.3.0.0/opam
+++ b/packages/lwt/lwt.3.0.0/opam
@@ -42,7 +42,7 @@ depends: [
   "result"
   "cppo" {build & >= "1.1.0"}
   "cppo_ocamlbuild" {build}
-  ("base-no-ppx" | "ppx_tools" {build})
+  ("base-no-ppx" | "ppx_tools")
 ]
 depopts: [
   "base-threads"

--- a/packages/mirage-block-xen/mirage-block-xen.1.6.1/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.6.1/opam
@@ -14,7 +14,7 @@ depends: [
   "stringext"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
-  "ppx_cstruct" {build & >= "3.6.0"}
+  "ppx_cstruct" {>= "3.6.0"}
   "shared-memory-ring-lwt"
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"

--- a/packages/mirage-block-xen/mirage-block-xen.1.6.2/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.6.2/opam
@@ -14,7 +14,7 @@ depends: [
   "stringext"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
-  "ppx_cstruct" {build & >= "3.6.0"}
+  "ppx_cstruct" {>= "3.6.0"}
   "shared-memory-ring-lwt"
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"

--- a/packages/mirage-block-xen/mirage-block-xen.1.7.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.7.0/opam
@@ -14,7 +14,7 @@ depends: [
   "stringext"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
-  "ppx_cstruct" {build & >= "3.6.0"}
+  "ppx_cstruct" {>= "3.6.0"}
   "shared-memory-ring-lwt"
   "mirage-block" {>= "2.0.0"}
   "ipaddr"

--- a/packages/mirage-nat/mirage-nat.1.1.0/opam
+++ b/packages/mirage-nat/mirage-nat.1.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "rresult"
   "logs"
   "lru" {< "0.3.0"}
-  "ppx_deriving" {build & >= "4.2" }
+  "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
   "tcpip" { >= "3.7.0" }
   "ethernet" { >= "2.0.0" }

--- a/packages/mirage-nat/mirage-nat.1.2.0/opam
+++ b/packages/mirage-nat/mirage-nat.1.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "rresult"
   "logs"
   "lru" {>= "0.3.0"}
-  "ppx_deriving" {build & >= "4.2" }
+  "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
   "tcpip" { >= "3.7.2" }
   "ethernet" { >= "2.0.0" }

--- a/packages/mirage-profile/mirage-profile.0.9.0/opam
+++ b/packages/mirage-profile/mirage-profile.0.9.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.0"}
   "cstruct" {>= "3.0.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ocplib-endian"
   "lwt"
 ]

--- a/packages/mirage-profile/mirage-profile.0.9.1/opam
+++ b/packages/mirage-profile/mirage-profile.0.9.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.0"}
   "cstruct" {>= "3.0.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ocplib-endian"
   "lwt"
 ]

--- a/packages/mmdb/mmdb.0.1.0/opam
+++ b/packages/mmdb/mmdb.0.1.0/opam
@@ -15,8 +15,8 @@ depends: [
   "ctypes-foreign" {>= "0.4"}
   "dune" {>= "1.6"}
   "ocaml" {>= "4.04.1"}
-  "ppx_deriving" {build & >= "4.2"}
-  "ppx_let" {build & >= "v0.10" & < "v0.14"}
+  "ppx_deriving" {>= "4.2"}
+  "ppx_let" {>= "v0.10" & < "v0.14"}
 ]
 synopsis: "Binding to the MaxMind DB library for GeoIP lookups"
 description: """

--- a/packages/mpris/mpris.0.2.0/opam
+++ b/packages/mpris/mpris.0.2.0/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/johnelse/ocaml-mpris/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
-  "lwt_ppx" {build}
+  "lwt_ppx"
   "obus"
   "odoc" {with-doc}
 ]

--- a/packages/mrt-format/mrt-format.0.3.1/opam
+++ b/packages/mrt-format/mrt-format.0.3.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ipaddr"      {>= "2.0.0"}
   "logs"
   "ocamlfind"   {build}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "result"
 ]
 

--- a/packages/mssql/mssql.1.1/opam
+++ b/packages/mssql/mssql.1.1/opam
@@ -23,7 +23,7 @@ depends: [
   "logs"
   "text" {>= "0.8.0"}
 
-  "bisect_ppx" {build & >= "1.3.1"}
+  "bisect_ppx" {>= "1.3.1"}
   "dune" {>= "1.4"}
   "dune-configurator"
 ]

--- a/packages/netchannel/netchannel.1.8.1/opam
+++ b/packages/netchannel/netchannel.1.8.1/opam
@@ -14,9 +14,9 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder" {>= "1.0+beta9"}
   "cstruct" {>= "3.0.0"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build & < "v0.14"}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_sexp_conv" {< "v0.14"}
+  "ppx_cstruct"
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
   "io-page" {>= "1.5.0"}

--- a/packages/obeam/obeam.0.0.3/opam
+++ b/packages/obeam/obeam.0.0.3/opam
@@ -16,7 +16,7 @@ depends: [
   "zarith"        {>= "1.7"}
   "dune"
   "ounit"         {build}
-  "bisect_ppx"    {build}
+  "bisect_ppx"
 ]
 synopsis: "A utility library for parsing BEAM format"
 url {

--- a/packages/obeam/obeam.0.0.4/opam
+++ b/packages/obeam/obeam.0.0.4/opam
@@ -13,7 +13,7 @@ depends: [
   "zarith" {>= "1.7"}
   "dune"
   "ounit" {build}
-  "bisect_ppx" {build}
+  "bisect_ppx"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/yutopp/obeam.git"

--- a/packages/obeam/obeam.0.1.0/opam
+++ b/packages/obeam/obeam.0.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ppx_here"      {< "v0.14"}
   "ppx_let"       {< "v0.14"}
   "ppx_sexp_conv" {< "v0.14"}
-  "bisect_ppx"    {build}
+  "bisect_ppx"
   "ounit"         {with-test}
 ]
 synopsis: "A utility library for parsing BEAM format"

--- a/packages/obeam/obeam.0.1.1/opam
+++ b/packages/obeam/obeam.0.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_let" {>= "v0.11.0" & < "v0.14"}
   "ppx_sexp_conv" {>= "v0.11.2" & < "v0.14"}
   "dune"
-  "bisect_ppx" {build}
+  "bisect_ppx"
   "expect_test_helpers_kernel" {with-test & < "v0.14"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/obeam/obeam.0.1.2/opam
+++ b/packages/obeam/obeam.0.1.2/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_let" {>= "v0.11.0" & < "v0.14"}
   "ppx_sexp_conv" {>= "v0.11.2" & < "v0.14"}
   "dune"
-  "bisect_ppx" {build}
+  "bisect_ppx"
   "expect_test_helpers_kernel" {with-test & < "v0.14"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/obeam/obeam.0.1.3/opam
+++ b/packages/obeam/obeam.0.1.3/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_let" {>= "v0.11.0" & < "v0.14"}
   "ppx_sexp_conv" {>= "v0.11.2" & < "v0.14"}
   "dune"
-  "bisect_ppx" {build}
+  "bisect_ppx"
   "expect_test_helpers_kernel" {with-test & < "v0.14"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/obeam/obeam.0.1.4/opam
+++ b/packages/obeam/obeam.0.1.4/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_let" {>= "v0.11.0" & < "v0.14"}
   "ppx_sexp_conv" {>= "v0.11.2" & < "v0.14"}
   "dune"
-  "bisect_ppx" {build}
+  "bisect_ppx"
   "expect_test_helpers_kernel" {with-test & < "v0.14"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/obeam/obeam.0.1.5/opam
+++ b/packages/obeam/obeam.0.1.5/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_let" {>= "v0.11.0" & < "v0.14"}
   "ppx_sexp_conv" {>= "v0.11.2" & < "v0.14"}
   "dune"
-  "bisect_ppx" {build}
+  "bisect_ppx"
   "expect_test_helpers_kernel" {with-test & < "v0.14"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ocveralls/ocveralls.0.3.2/opam
+++ b/packages/ocveralls/ocveralls.0.3.2/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "ezjsonm" {build & >= "0.4.0"}
-  ("bisect" | "bisect_ppx" {build & < "1.5.0"})
+  ("bisect" | "bisect_ppx" {< "1.5.0"})
 ]
 synopsis:
   "Generate JSON for http://coveralls.io from bisect code coverage data."

--- a/packages/ocveralls/ocveralls.0.3.3/opam
+++ b/packages/ocveralls/ocveralls.0.3.3/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "ezjsonm" {build & >= "0.4.0"}
-  ("bisect" | "bisect_ppx" {build & < "1.5.0"})
+  ("bisect" | "bisect_ppx" {< "1.5.0"})
 ]
 synopsis:
   "Generate JSON for http://coveralls.io from bisect code coverage data."

--- a/packages/ocveralls/ocveralls.0.3.4/opam
+++ b/packages/ocveralls/ocveralls.0.3.4/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "ezjsonm" {build & >= "0.4.0"}
-  ("bisect" | "bisect_ppx" {build & < "1.5.0"})
+  ("bisect" | "bisect_ppx" {< "1.5.0"})
 ]
 synopsis:
   "Generate JSON for http://coveralls.io from bisect code coverage data (deprecated)."

--- a/packages/open_packaging/open_packaging.1.0/opam
+++ b/packages/open_packaging/open_packaging.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "sexplib" {< "v0.14"}
   "stdint"
   "xml-light"
-  "bisect_ppx" {build & >= "1.3.0"}
+  "bisect_ppx" {>= "1.3.0"}
   "jbuilder" {>= "1.0+beta18"}
   "ounit" {with-test}
 ]

--- a/packages/orewa/orewa.0.1.0/opam
+++ b/packages/orewa/orewa.0.1.0/opam
@@ -10,7 +10,7 @@ depends: [
   "async" {>= "v0.11" & < "v0.14"}
   "core" {>= "v0.11" & < "v0.14"}
   "dune" {>= "1.4"}
-  "ppx_let" {build & >= "v0.11" & < "v0.14"}
+  "ppx_let" {>= "v0.11" & < "v0.14"}
   "alcotest" {with-test & >= "0.8.4"}
   "alcotest-async" {with-test & >= "0.8.2"}
   "ppx_deriving" {>= "4.2"}

--- a/packages/orewa/orewa.0.1.1/opam
+++ b/packages/orewa/orewa.0.1.1/opam
@@ -10,7 +10,7 @@ depends: [
   "async" {>= "v0.11" & < "v0.14"}
   "core" {>= "v0.11" & < "v0.14"}
   "dune" {>= "1.4"}
-  "ppx_let" {build & >= "v0.11" & < "v0.14"}
+  "ppx_let" {>= "v0.11" & < "v0.14"}
   "alcotest" {with-test & >= "0.8.4"}
   "alcotest-async" {with-test & >= "0.8.2"}
   "ppx_deriving" {>= "4.2"}

--- a/packages/orewa/orewa.0.2.0/opam
+++ b/packages/orewa/orewa.0.2.0/opam
@@ -10,7 +10,7 @@ depends: [
   "async" {>= "v0.11" & < "v0.14"}
   "core" {>= "v0.11" & < "v0.14"}
   "dune" {>= "1.4"}
-  "ppx_let" {build & >= "v0.11" & < "v0.14"}
+  "ppx_let" {>= "v0.11" & < "v0.14"}
   "alcotest" {with-test & >= "0.8.4"}
   "alcotest-async" {with-test & >= "0.8.2"}
   "ppx_deriving" {>= "4.2"}

--- a/packages/pcap-format/pcap-format.0.5.1/opam
+++ b/packages/pcap-format/pcap-format.0.5.1/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml" {< "4.08.0"}
   "jbuilder" {>= "1.0+beta10"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "cstruct" {>= "1.9.0" & <"5.0.0"}
   "ppx_cstruct" {> "0"}
   "ounit" {with-test}

--- a/packages/pgocaml/pgocaml.3.1/opam
+++ b/packages/pgocaml/pgocaml.3.1/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ounit" {with-test}
-  "ppx_tools" {build}
+  "ppx_tools"
   "re"
   "rresult" {build}
   "ocaml-migrate-parsetree"

--- a/packages/pgocaml/pgocaml.3.2/opam
+++ b/packages/pgocaml/pgocaml.3.2/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ounit" {with-test}
-  "ppx_tools" {build}
+  "ppx_tools"
   "re"
   "rresult" {build}
   "ocaml-migrate-parsetree"

--- a/packages/pgx/pgx.0.1/opam
+++ b/packages/pgx/pgx.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "uuidm"
   "re"
   "sexplib" {>= "v0.10" & < "v0.13"}
-  "bisect_ppx" {build & >= "1.3.1"}
+  "bisect_ppx" {>= "1.3.1"}
   "jbuilder" {>= "1.0+beta14"}
   "base64" {with-test & < "3.0.0"}
   "ounit" {with-test}

--- a/packages/plotkicadsch/plotkicadsch.0.2.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "kicadsch" {= "0.2.0"}
   "tyxml" {>= "4.0.0"}
   "lwt" {>= "3.1.0" & < "4.0.0"}
-  "lwt_ppx" {build}
+  "lwt_ppx"
   "sha"
   "git" {< "1.12.0"}
   "git-unix" {< "2.0.0"}

--- a/packages/plotkicadsch/plotkicadsch.0.3.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.3.0/opam
@@ -14,7 +14,7 @@ depends: [
   "kicadsch" {= "0.3.0"}
   "tyxml" {>= "4.0.0"}
   "lwt" {>= "3.1.0" & < "4.0.0"}
-  "lwt_ppx" {build}
+  "lwt_ppx"
   "sha"
   "git" {< "2.0.0"}
   "git-unix" {< "2.0.0"}

--- a/packages/plotkicadsch/plotkicadsch.0.4.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.4.0/opam
@@ -21,7 +21,7 @@ depends: [
   "kicadsch" {= "0.4.0"}
   "tyxml" {>= "4.0.0"}
   "lwt"
-  "lwt_ppx" {build}
+  "lwt_ppx"
   "sha"
   "git" {< "2.0.0"}
   "git-unix"

--- a/packages/plotkicadsch/plotkicadsch.0.5.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.5.0/opam
@@ -21,7 +21,7 @@ depends: [
   "kicadsch" {= "0.4.0"}
   "tyxml" {>= "4.0.0"}
   "lwt"
-  "lwt_ppx" {build}
+  "lwt_ppx"
   "sha"
   "git" {>= "2.0.0"}
   "git-unix"

--- a/packages/plotkicadsch/plotkicadsch.0.5.1/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.5.1/opam
@@ -20,7 +20,7 @@ depends: [
   "kicadsch" {= "0.5.0"}
   "tyxml" {>= "4.0.0"}
   "lwt"
-  "lwt_ppx" {build}
+  "lwt_ppx"
   "sha"
   "git" {>= "2.0.0"}
   "git-unix"

--- a/packages/plotkicadsch/plotkicadsch.0.5.2/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.5.2/opam
@@ -21,7 +21,7 @@ depends: [
   "kicadsch" {= version}
   "tyxml" {>= "4.0.0"}
   "lwt"
-  "lwt_ppx" {build}
+  "lwt_ppx"
   "sha"
   "git" {>= "2.0.0"}
   "git-unix"

--- a/packages/ppx_bitstring/ppx_bitstring.1.3.0/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.1.3.0/opam
@@ -28,8 +28,8 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ppx_tools"
-  "ppx_driver" {build & < "v0.9.0"}
-  "ppx_core" {build}
+  "ppx_driver" {< "v0.9.0"}
+  "ppx_core"
   "ounit" {build}
   "js-build-tools" {build}
 ]

--- a/packages/ppx_bitstring/ppx_bitstring.1.3.1/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.1.3.1/opam
@@ -19,8 +19,8 @@ depends: [
   "js-build-tools" {build}
   "bitstring" {build & >= "2.1.0" & < "3.0.0"}
   "ppx_tools"
-  "ppx_driver" {build & < "v0.9.0"}
-  "ppx_core" {build}
+  "ppx_driver" {< "v0.9.0"}
+  "ppx_core"
   "ounit" {build}
 ]
 conflicts: [ "oasis" {= "0.4.7"} ]

--- a/packages/ppx_bitstring/ppx_bitstring.1.3.2/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.1.3.2/opam
@@ -19,8 +19,8 @@ depends: [
   "js-build-tools" {build}
   "bitstring" {build & >= "2.1.0" & < "3.0.0"}
   "ppx_tools"
-  "ppx_driver" {build & < "v0.9.0"}
-  "ppx_core" {build}
+  "ppx_driver" {< "v0.9.0"}
+  "ppx_core"
   "ounit" {build}
 ]
 synopsis: "PPX extension for the bitstring library."

--- a/packages/ppx_bitstring/ppx_bitstring.1.3.3/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.1.3.3/opam
@@ -19,8 +19,8 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.2"}
   "ounit" {build}
-  "ppx_core" {build}
-  "ppx_driver" {build & < "v0.9.0"}
+  "ppx_core"
+  "ppx_driver" {< "v0.9.0"}
   "ppx_tools"
 ]
 synopsis: "PPX extension for the bitstring library."

--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.7/opam
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.2.7/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"        {>= "4.3"}
   "dune"         {>= "1.0"}
   "ppxfind"      {build}
-  "ppx_tools"    {build}
+  "ppx_tools"
   "cppo"         {build}
   "ppx_deriving" {>= "4.0" & < "5.0"}
   "ounit"        {with-test}

--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
@@ -13,11 +13,11 @@ depends: [
   "yojson"
   "xml-light"
   "base" {< "v0.14"}
-  "ppx_core" {build}
-  "ppx_type_conv" {build}
-  "ppx_driver" {build}
+  "ppx_core"
+  "ppx_type_conv"
+  "ppx_driver"
   "jbuilder"
-  "ppx_metaquot" {build}
+  "ppx_metaquot"
 ]
 synopsis:
   "Ppx for deriving protocol serialisation and de-serialisation of types"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.3/opam
@@ -17,7 +17,7 @@ depends: [
   "yojson" {< "1.6.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}
-  "ppx_tools"    {build}
+  "ppx_tools"
   "ppxfind"      {build}
   "dune"         {>= "1.2"}
   "cppo"         {build}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.4/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.4/opam
@@ -17,7 +17,7 @@ depends: [
   "yojson" {>= "1.6.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}
-  "ppx_tools"    {build}
+  "ppx_tools"
   "ppxfind"      {build}
   "dune"         {>= "1.2"}
   "cppo"         {build}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5.1/opam
@@ -16,7 +16,7 @@ depends: [
   "yojson" {>= "1.6.0" & < "2.0.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}
-  "ppx_tools"    {build}
+  "ppx_tools"
   "ppxfind"      {build}
   "dune"         {>= "1.2"}
   "cppo"         {build}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5.2/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5.2/opam
@@ -16,7 +16,7 @@ depends: [
   "yojson" {>= "1.6.0" & < "2.0.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}
-  "ppx_tools"    {build}
+  "ppx_tools"
   "ppxfind"      {build}
   "dune"         {>= "1.2"}
   "cppo"         {build}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5/opam
@@ -16,7 +16,7 @@ depends: [
   "yojson" {>= "1.6.0" & < "2.0.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}
-  "ppx_tools"    {build}
+  "ppx_tools"
   "ppxfind"      {build}
   "dune"         {>= "1.2"}
   "cppo"         {build}

--- a/packages/ppx_hardcaml/ppx_hardcaml.1.0.0/opam
+++ b/packages/ppx_hardcaml/ppx_hardcaml.1.0.0/opam
@@ -18,8 +18,8 @@ depends: [
   "ocamlfind" {build & >= "1.3.2"}
   "js-build-tools" {build}
   "ppx_tools"
-  "ppx_driver" {build & < "v0.10.0"}
-  "ppx_core" {build}
+  "ppx_driver" {< "v0.10.0"}
+  "ppx_core"
   "ounit" {build}
   "hardcaml" {>= "1.1.0" & < "2.0.0"}
 ]

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_driver"
   "ppx_core"
   "jbuilder"
-  "ppx_metaquot" {build}
+  "ppx_metaquot"
 ]
 synopsis:
   "Serialization and de-serialization of ocaml types to/from json, msgpack and xml_light."

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.1.0.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.1.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_driver" {>= "v0.10.1"}
   "ppx_core"
   "jbuilder"
-  "ppx_metaquot" {build}
+  "ppx_metaquot"
 ]
 synopsis:
   "Serialization and de-serialization of ocaml types to/from json, msgpack and xml_light."

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.2.0.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.2.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_driver"
   "ppx_core"
   "jbuilder"
-  "ppx_metaquot" {build}
+  "ppx_metaquot"
   "msgpck" {with-test}
   "yojson" {with-test}
   "yaml" {with-test}

--- a/packages/ppx_regexp/ppx_regexp.0.3.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.3.0/opam
@@ -11,7 +11,7 @@ depends: [
   "jbuilder"
   "ocaml-migrate-parsetree"
   "re" {< "1.7.2~"}
-  "ppx_metaquot" {build}
+  "ppx_metaquot"
   "topkg-jbuilder" {build}
 ]
 synopsis: "Matching Regular Expressions with OCaml Patterns"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.12.1/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.12.1/opam
@@ -32,8 +32,8 @@ depends: [
   "logs" {>= "0.5.0"}
   "win-error"
   "io-page-unix" {>= "2.0.0"}
-  "ppx_sexp_conv" {build & < "v0.14"}
-  "ppx_tools" {build}
+  "ppx_sexp_conv" {< "v0.14"}
+  "ppx_tools"
   "ocaml-migrate-parsetree"
   "alcotest" {with-test & >= "0.4.0"}
 ]

--- a/packages/protocol-9p/protocol-9p.0.12.1/opam
+++ b/packages/protocol-9p/protocol-9p.0.12.1/opam
@@ -27,8 +27,8 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_sexp_conv" {build & < "v0.14"}
-  "ppx_tools" {build}
+  "ppx_sexp_conv" {< "v0.14"}
+  "ppx_tools"
   "alcotest" {with-test & >= "0.4.0"}
   "ocaml-migrate-parsetree"
 ]

--- a/packages/qcow-format/qcow-format.0.4.1/opam
+++ b/packages/qcow-format/qcow-format.0.4.1/opam
@@ -38,7 +38,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.14"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow-format/qcow-format.0.4.2/opam
+++ b/packages/qcow-format/qcow-format.0.4.2/opam
@@ -38,7 +38,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.14"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow-format/qcow-format.0.4/opam
+++ b/packages/qcow-format/qcow-format.0.4/opam
@@ -38,7 +38,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.14"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow-format/qcow-format.0.5.0/opam
+++ b/packages/qcow-format/qcow-format.0.5.0/opam
@@ -38,7 +38,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.14"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow/qcow.0.10.0/opam
+++ b/packages/qcow/qcow.0.10.0/opam
@@ -31,7 +31,7 @@ depends: [
   "jbuilder"
   "ppx_tools"
   "ppx_sexp_conv" {< "v0.14"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
 ]
 build: [
   ["jbuilder" "build" "--only-packages=qcow"]

--- a/packages/qcow/qcow.0.10.2/opam
+++ b/packages/qcow/qcow.0.10.2/opam
@@ -34,7 +34,7 @@ depends: [
   "jbuilder"
   "ppx_tools"
   "ppx_sexp_conv" {< "v0.14"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow/qcow.0.10.3/opam
+++ b/packages/qcow/qcow.0.10.3/opam
@@ -34,7 +34,7 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "ppx_tools"
   "ppx_sexp_conv" {< "v0.14"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow/qcow.0.10.4/opam
+++ b/packages/qcow/qcow.0.10.4/opam
@@ -34,7 +34,7 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "ppx_tools"
   "ppx_sexp_conv" {< "v0.14"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow/qcow.0.6.0/opam
+++ b/packages/qcow/qcow.0.6.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.11.0"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow/qcow.0.7.0/opam
+++ b/packages/qcow/qcow.0.7.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.11.0"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow/qcow.0.8.1/opam
+++ b/packages/qcow/qcow.0.8.1/opam
@@ -31,7 +31,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.11.0"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow/qcow.0.9.0/opam
+++ b/packages/qcow/qcow.0.9.0/opam
@@ -34,7 +34,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.11.0"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow/qcow.0.9.4/opam
+++ b/packages/qcow/qcow.0.9.4/opam
@@ -32,7 +32,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.11.0"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow/qcow.0.9.5/opam
+++ b/packages/qcow/qcow.0.9.5/opam
@@ -34,7 +34,7 @@ depends: [
   "ppx_tools"
   "ppx_deriving"
   "ppx_sexp_conv" {< "v0.11.0"}
-  "ppx_type_conv" {build}
+  "ppx_type_conv"
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.1/opam
+++ b/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "jbuilder"
   "cppo" {build}
-  "bisect_ppx" {build}
+  "bisect_ppx"
   "core_kernel" {< "v0.14"}
   "ctypes"
   "ctypes-foreign"

--- a/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.2/opam
+++ b/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.2/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "dune"
   "cppo" {build}
-  "bisect_ppx" {build}
+  "bisect_ppx"
   "core_kernel" {< "v0.14"}
   "ctypes"
   "ctypes-foreign"

--- a/packages/satyrographos/satyrographos.0.0.1.4/opam
+++ b/packages/satyrographos/satyrographos.0.0.1.4/opam
@@ -19,9 +19,9 @@ depends: [
   "dune"
   "fileutils"
   "json-derivers"
-  "ppx_deriving" {build}
-  "ppx_inline_test" {build & < "v0.12"}
-  "ppx_jane" {build & < "v0.12"}
+  "ppx_deriving"
+  "ppx_inline_test" {< "v0.12"}
+  "ppx_jane" {< "v0.12"}
   "uri" {>= "2.0.0" & < "3.0.0"}
   "yojson"
 ]

--- a/packages/spreadsheetml/spreadsheetml.1.0/opam
+++ b/packages/spreadsheetml/spreadsheetml.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "open_packaging"
   "ppx_jane" {< "v0.14"}
-  "bisect_ppx" {build & >= "1.3.0"}
+  "bisect_ppx" {>= "1.3.0"}
   "jbuilder" {>= "1.0+beta18"}
   "ounit" {with-test}
 ]

--- a/packages/ssh-agent/ssh-agent.0.1.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.1.0/opam
@@ -8,7 +8,7 @@ build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder"
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ppx_sexp_conv" {< "v0.14"}
   "angstrom" {>= "0.10" & < "0.11"}
   "faraday" {>= "0.6" & < "0.7"}

--- a/packages/ssh-agent/ssh-agent.0.2.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.2.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ppx_sexp_conv" {< "v0.14"}
   "angstrom" {>= "0.10" & < "0.13"}
   "faraday" {>= "0.6" & < "0.8"}

--- a/packages/ssh-agent/ssh-agent.0.3.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.3.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
   "ppx_sexp_conv"
   "angstrom" {>= "0.10" & < "0.13"}
   "faraday" {>= "0.6" & < "0.8"}

--- a/packages/tar/tar.1.0.0/opam
+++ b/packages/tar/tar.1.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ppx_cstruct" {>= "3.1.0"}
   "cstruct" {>= "1.9.0"}
   "re"

--- a/packages/tar/tar.1.0.1/opam
+++ b/packages/tar/tar.1.0.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ppx_cstruct" {>= "3.1.0"}
   "cstruct" {>= "1.9.0"}
   "re"

--- a/packages/tar/tar.1.1.0/opam
+++ b/packages/tar/tar.1.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.0"}
-  "ppx_tools" {build}
+  "ppx_tools"
   "ppx_cstruct" {>= "3.6.0"}
   "cstruct" {>= "1.9.0"}
   "re"

--- a/packages/teash/teash.0.1.0/opam
+++ b/packages/teash/teash.0.1.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.08.0"}
   "dune"
   "lwt" {>= "3.2.1"}
-  "lwt_ppx" {build & >= "1.2.1"}
+  "lwt_ppx" {>= "1.2.1"}
   "notty" {>= "0.2.1"}
   "odoc" {build}
 ]

--- a/packages/travesty/travesty.0.1.2/opam
+++ b/packages/travesty/travesty.0.1.2/opam
@@ -13,10 +13,10 @@ bug-reports: "https://github.com/MattWindsor91/travesty/issues"
 depends: [
   "ocaml" {>= "4.06"}
   "dune"
-  "ppx_deriving" {build}
-  "ppx_expect" {build & < "v0.12"}
-  "ppx_jane" {build & < "v0.12"}
-  "ppx_sexp_message" {build & < "v0.12"}
+  "ppx_deriving"
+  "ppx_expect" {< "v0.12"}
+  "ppx_jane" {< "v0.12"}
+  "ppx_sexp_message" {< "v0.12"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/uri/uri.2.1.0/opam
+++ b/packages/uri/uri.2.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.2.0" & < "2.0"}
   "ounit" {with-test & >= "1.0.2"}
-  "ppx_sexp_conv" {build & >= "v0.9.0" & < "v0.14"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
   "re" {>= "1.7.2"}
   "sexplib0" {< "v0.14"}
   "stringext" {>= "1.4.0"}

--- a/packages/uri/uri.2.2.0/opam
+++ b/packages/uri/uri.2.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.2.0"}
   "ounit" {with-test & >= "1.0.2"}
-  "ppx_sexp_conv" {build & >= "v0.9.0" & < "v0.14"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
   "re" {>= "1.7.2"}
   "sexplib0" {< "v0.14"}
   "stringext" {>= "1.4.0"}

--- a/packages/uri/uri.2.2.1/opam
+++ b/packages/uri/uri.2.2.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.2.0"}
   "ounit" {with-test & >= "1.0.2"}
-  "ppx_sexp_conv" {build & >= "v0.9.0" & < "v0.14"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
   "re" {>= "1.9.0"}
   "sexplib0" {< "v0.14"}
   "stringext" {>= "1.4.0"}

--- a/packages/vchan-xen/vchan-xen.4.0.0/opam
+++ b/packages/vchan-xen/vchan-xen.4.0.0/opam
@@ -13,9 +13,9 @@ depends: [
   "vchan" {= "4.0.0"}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build & < "v0.14"}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_sexp_conv" {< "v0.14"}
+  "ppx_cstruct"
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan-xen/vchan-xen.4.0.1/opam
+++ b/packages/vchan-xen/vchan-xen.4.0.1/opam
@@ -13,9 +13,9 @@ depends: [
   "vchan" {>= "4.0.0" & < "4.0.2"}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build & < "v0.14"}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_sexp_conv" {< "v0.14"}
+  "ppx_cstruct"
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vchan-xen/vchan-xen.4.0.2/opam
+++ b/packages/vchan-xen/vchan-xen.4.0.2/opam
@@ -13,9 +13,9 @@ depends: [
   "vchan" {>= "4.0.2"}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
-  "ppx_tools" {build}
-  "ppx_sexp_conv" {build & < "v0.14"}
-  "ppx_cstruct" {build}
+  "ppx_tools"
+  "ppx_sexp_conv" {< "v0.14"}
+  "ppx_cstruct"
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}

--- a/packages/vhd-format/vhd-format.0.12.0/opam
+++ b/packages/vhd-format/vhd-format.0.12.0/opam
@@ -12,7 +12,7 @@ depends: [
   "rresult"
   "uuidm"
   "dune" {>= "1.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct"
 ]
 available: os = "linux" | os = "macos"
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
This was suggested by @avsm in #11852, which had a more narrow scope addressing the specific issue with having `ppx_sexp_conv` as a build dependency. I agree with extending the scope, though we may want to discuss the approach before merging.  I am not familiar with most of the packages involved, so what I have done here is to remove the `{build}` flag on every dependency on a package starting with `ppx_*`, as well as `bisect_ppx` and `lwt_ppx`, and hoping that the CI will catch any errors.
