### PR TITLE
+ extlib 1.7.7

### DIFF
--- a/packages/extlib/extlib.1.7.7/opam
+++ b/packages/extlib/extlib.1.7.7/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "ygrek@autistici.org"
+homepage: "https://github.com/ygrek/ocaml-extlib"
+dev-repo: "git://github.com/ygrek/ocaml-extlib.git"
+bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
+doc: ["https://ygrek.org/p/extlib/doc/"]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+authors: [
+  "Nicolas Cannasse"
+  "Brian Hurt"
+  "Yamagata Yoriyuki"
+  "Markus Mottl"
+  "Jesse Guardiani"
+  "John Skaller"
+  "Bardur Arantsson"
+  "Janne Hellsten"
+  "Richard W.M. Jones"
+  "ygrek"
+  "Gabriel Scherer"
+  "Pietro Abate"
+]
+build: [
+  [make "minimal=1" "build"]
+  [make "minimal=1" "test"] {with-test}
+  [make "minimal=1" "doc"] {with-doc}
+]
+install: [ [make "minimal=1" "install"] ]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+  "cppo" {build}
+  "base-bytes" {build}
+]
+synopsis:
+  "A complete yet small extension for OCaml standard library (reduced, recommended)"
+description: """
+The purpose of this library is to add new functions to OCaml standard library
+modules, to modify some functions in order to get better performances or
+safety (tail-recursive) and also to provide new modules which should be useful
+for day to day programming.
+
+Current goal is to maintain compatibility, new software is encouraged to not use extlib since stdlib
+is now seeing many additions and improvements which make many parts of extlib obsolete.
+For tail-recursion safety consider using other libraries e.g. containers.
+"""
+url {
+  src: "https://ygrek.org/p/release/ocaml-extlib/extlib-1.7.7.tar.gz"
+  checksum: [
+    "md5=2c620993aecd4b31b3a362b21b55dd94"
+    "sha256=4183abeca72efefc2513a440706c0e6e56d4676f60ae89a4306f8e5e03fbb5eb"
+    "sha512=4f3d6f5bc29c43254ad9f927213fca4afb8a74afbfbaca01ae7e540ea4509f2583aeedd91da8d5252843dd0998093e6e02801a4e95a70a04c6f7229b2b817bf3"
+  ]
+  mirrors: "https://github.com/ygrek/ocaml-extlib/releases/download/1.7.7/extlib-1.7.7.tar.gz"
+}


### PR DESCRIPTION
* sync with OCaml 4.10
* mark ExtList.find_map deprecated in anticipation of type breakage in next release to match OCaml 4.10 function with same name
* String: fold_left and fold_right without allocations

