### PR TITLE
[new release] nacc (1.0)

### DIFF
--- a/packages/nacc/nacc.1.0/opam
+++ b/packages/nacc/nacc.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+version: "0.1"
+synopsis: "Not Another Compiler Compiler"
+description: """
+
+    nacc, short for "Not a Compiler Compiler" or alternatively "Not Another Compiler Compiler" is a homemade parser combinator, as inspired from Computerphile's video on Functional Parsing (https://www.youtube.com/watch?v=dDtZLm7HIJs).
+
+    nacc strives to be simple yet monadic, allowing any context-free grammar to be safely parsed with this library. The library provides utility functions and operators to ease the writing of combinator parsers."""
+maintainer: ["Nathan Graule <solarliner@gmail.com>"]
+authors: [
+  "Nathan Graule <solarliner@gmail.com>"
+  "Arthur Correnson <arthur.correnson@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/codeanonorg/nacc"
+doc: "https://codeanonorg.github.io/nacc"
+bug-reports: "https://github.com/codeanonorg/nacc/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "ppx_deriving" {>= "4.4"}
+  "ppx_variants_conv" {>= "0.13"}
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/codeanonorg/nacc.git"
+url {
+  src:
+    "https://github.com/codeanonorg/nacc/releases/download/1.0/nacc-1.0.tbz"
+  checksum: [
+    "sha256=bf68a6a56150e3425b53dace30472552a01503ae5a1c5b274a864d442165d69f"
+    "sha512=88e034277e6f548478cd65f2e209a83dbb72c050cdab0e0bd27f5da98a87d46753c02167782d93d8c738d3db95978ea8077bd656b9b23ddff7860b3a84947d37"
+  ]
+}


### PR DESCRIPTION
Not Another Compiler Compiler

- Project page: <a href="https://github.com/codeanonorg/nacc">https://github.com/codeanonorg/nacc</a>
- Documentation: <a href="https://codeanonorg.github.io/nacc">https://codeanonorg.github.io/nacc</a>

##### CHANGES:

Changes in the public API ! Nacc now supports chainl and chainr combinators to eliminate left recursion in patterns with associative operators. A new minimal error handling API is also available.

- Chainl and Chainr combinators
- Let syntax to chain parsers
- Parse_from_file function
- New documentation
- Rework of the error handling API
