### PR TITLE
Package: lambda-term.3.0.0

### DIFF
--- a/packages/lambda-term/lambda-term.3.0.0/opam
+++ b/packages/lambda-term/lambda-term.3.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml-community/lambda-term"
+bug-reports: "https://github.com/ocaml-community/lambda-term/issues"
+dev-repo: "git://github.com/ocaml-community/lambda-term.git"
+license: "BSD-3-Clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "lwt"   {>= "4.0.0"}
+  "lwt_log"
+  "react"
+  "zed"   {>= "3.0.0" & < "4.0"}
+  "camomile" {>= "1.0.1"}
+  "lwt_react"
+  "mew_vi"  {>= "0.3.0" & < "1.0.0"}
+  "dune" {>= "1.1.0"}
+]
+synopsis: "Terminal manipulation library for OCaml"
+description: """
+Lambda-term is a cross-platform library for manipulating the terminal. It
+provides an abstraction for keys, mouse events, colors, as well as a set of
+widgets to write curses-like applications. The main objective of lambda-term is
+to provide a higher level functional interface to terminal manipulation than,
+for example, ncurses, by providing a native OCaml interface instead of bindings
+to a C library. Lambda-term integrates with zed to provide text edition
+facilities in console applications."""
+url {
+  src: "https://github.com/ocaml-community/lambda-term/archive/3.0.0.tar.gz"
+  checksum: "md5=3ee0d8b6cb31f20a07fcbf34990f8a4b"
+}

--- a/packages/lambda-term/lambda-term.3.0.0/opam
+++ b/packages/lambda-term/lambda-term.3.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "zed"   {>= "3.0.0" & < "4.0"}
   "camomile" {>= "1.0.1"}
   "lwt_react"
-  "mew_vi"  {>= "0.3.0" & < "1.0.0"}
+  "mew_vi"  {>= "0.3.0" & < "0.4.0"}
   "dune" {>= "1.1.0"}
 ]
 synopsis: "Terminal manipulation library for OCaml"


### PR DESCRIPTION
This PR depends on #16287 and #16290

3.0.0 (2020-04-25)
------------------

### Additions

* `LTerm_editor`: two editor modes: default and vi

* `LTerm_read_line: class virtual ['a] term`:
  * `method editor_mode : LTerm_editor.mode signal`: the current editor mode
  * `method set_editor_mode : LTerm_editor.mode -> unit`: set the current editor mode

Add initial support for vi editing mode to `LTerm_read_line`:
  * motions:
    * h l 0 ^ $
    * j k gg G
    * w W e E b B ge gE
    * f F t T
    * aw iw aW iW
    * include or inner ( ), [ ], { }, < >, ' and "
    * generic quote: aq? iq? where ? could be any character
    * bracket matching: jump back and forth between matched brakcets
  * delete, change, yank with motions
  * paste: p P
  * line joining: J

Many thanks to @nilsbecker for his feature-request on vi edit mode and the helps during the development on this topic!

### Breaking

  * `LTerm_read_line`
    * `class virtual ['a] term`: the type signature of `method private exec` is changed
      from
      `method private exec : action list -> 'a Lwt.t`
      to
      `?keys : LTerm_key.t list -> action list -> 'a loop_result Lwt.t`

Since this is a private method and is intended to be used internally, the backward-compatibility will not be affected in most cases.

### General

* Load inputrc file from ~/.config/.lambda-term-inputrc as per XDG conventions (@copy)