### PR TITLE
Package soupault.1.11.0

### DIFF
--- a/packages/soupault/soupault.1.11.0/opam
+++ b/packages/soupault/soupault.1.11.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Static website generator based on HTML rewriting"
+description: """
+A website generator that works with page element tree rather than text
+and allows you to manipulate pages and retrieve metadata from
+existing HTML using arbitrary CSS selectors.
+
+Built-in functionality includes setting page title, generating ToC and footnotes,
+inserting files/HTML snippets or output of external programs into pages etc.
+
+Metadata extracted from pages can be rendered using Mustache templates or exported to JSON
+and processed with an external script.
+
+Extensible with Lua (2.5) plugins. Can also be used as an HTML processor for existing pages."""
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: "Daniil Baturin <daniil+soupault@baturin.org>"
+license: "MIT"
+homepage: "https://soupault.neocities.org"
+bug-reports: "https://github.com/dmbaturin/soupault/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0.0"}
+  "lambdasoup" {>= "0.7.0"}
+  "markup" {>= "0.8.2"}
+  "toml"
+  "fileutils"
+  "logs"
+  "fmt"
+  "re"
+  "ezjsonm"
+  "containers"
+  "stringext"
+  "calendar"
+  "spelll"
+  "mustache"
+  "tsort"
+  "lua-ml" {>= "0.9.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/dmbaturin/soupault"
+url {
+  src: "https://github.com/dmbaturin/soupault/archive/1.11.0.zip"
+  checksum: [
+    "md5=ba68610d90e02fd895e9b100c2011888"
+    "sha512=bc820d181eb4579eba259986499a12abdf8cdaa8fbafc2af37b33f001a82f3ebbb1b2679dbd280f5fcdd36a999f62ee932b13019089dae82f5ef29f9f1ac6575"
+  ]
+}


### PR DESCRIPTION
### `soupault.1.11.0`
Static website generator based on HTML rewriting
A website generator that works with page element tree rather than text
and allows you to manipulate pages and retrieve metadata from
existing HTML using arbitrary CSS selectors.

Built-in functionality includes setting page title, generating ToC and footnotes,
inserting files/HTML snippets or output of external programs into pages etc.

Metadata extracted from pages can be rendered using Mustache templates or exported to JSON
and processed with an external script.

Extensible with Lua (2.5) plugins. Can also be used as an HTML processor for existing pages.



---
* Homepage: https://soupault.neocities.org
* Source repo: git+https://github.com/dmbaturin/soupault
* Bug tracker: https://github.com/dmbaturin/soupault/issues

---
:camel: Pull-request generated by opam-publish v2.0.0