### PR TITLE
dispatch-js.0.4.0-constraint: require dispatch >= 0.4.0

### DIFF
--- a/packages/dispatch-js/dispatch-js.0.4.0/opam
+++ b/packages/dispatch-js/dispatch-js.0.4.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
-  "dispatch"
+  "dispatch" {>= "0.4.0"}
   "js_of_ocaml-lwt" {< "3.4.0"}
   "js_of_ocaml" {< "3.4.0"}
   "result"


### PR DESCRIPTION
This was omitted in error.