### PR TITLE
[new release] obelisk (0.5.0)

### DIFF
--- a/packages/obelisk/obelisk.0.5.0/opam
+++ b/packages/obelisk/obelisk.0.5.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune" {>= "2.2.0"}
   "re"
   "menhir"
-  "ocamlfind"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/obelisk/obelisk.0.5.0/opam
+++ b/packages/obelisk/obelisk.0.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+version: "0.5.0"
+synopsis: "Pretty-printing for Menhir files"
+description: """
+Obelisk is a simple tool which produces pretty-printed output from a Menhir parser file (.mly).
+It is inspired from yacc2latex and is also written in OCaml, but is aimed at supporting features from Menhir instead of only those of ocamlyacc."""
+maintainer: ["Lélio Brun <lelio.brun@inria.fr>"]
+authors: ["Lélio Brun"]
+license: "MIT"
+homepage: "https://github.com/Lelio-Brun/Obelisk"
+doc: "https://github.com/Lelio-Brun/Obelisk"
+bug-reports: "https://github.com/Lelio-Brun/obelisk/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.2.0"}
+  "re"
+  "menhir"
+  "ocamlfind"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Lelio-Brun/obelisk.git"
+url {
+  src:
+    "https://github.com/Lelio-Brun/Obelisk/releases/download/v0.5.0/obelisk-v0.5.0.tbz"
+  checksum: [
+    "sha256=9b7a099806d0460bd178262441c7ed7910455563ee35bc387881a8a935320905"
+    "sha512=a6b95053e16a9e7f9c7cf383902284ee2a9f13fe82069a01f6274544fa2b50f6581e9a00eb813eab1c9c74d681ca3b2c8031831c568ddc62727cb1c5b33c11cd"
+  ]
+}


### PR DESCRIPTION
Pretty-printing for Menhir files

- Project page: <a href="https://github.com/Lelio-Brun/Obelisk">https://github.com/Lelio-Brun/Obelisk</a>
- Documentation: <a href="https://github.com/Lelio-Brun/Obelisk">https://github.com/Lelio-Brun/Obelisk</a>

##### CHANGES:

This version implements several important changes:
- drop `ocamlbuild` in favor of `dune`
- drop API-doc style documentation (irrelevant)
- fix break hints after epsilons 
- use `\lit` command for literals in `syntax` mode
- change the name of the grammar environment to `obeliskgrammar` in LaTeX modes
- use `re` library instead of `str`
- add support for token aliases, with a dedicated option `-noaliases`
- add support for the new syntax of Menhir rules (fixes issue [Lelio-Brun/Obelisk#9](https://github.com/Lelio-Brun/Obelisk/issues/9)) 
- fix some lexing and parsing bugs (in particular with Ocaml code and strings in prologue and semantic actions) thanks to the added test benches of Menhir
