### PR TITLE
Package curses.1.0.6

### DIFF
--- a/packages/curses/curses.1.0.6/opam
+++ b/packages/curses/curses.1.0.6/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "michael.bacarella@gmail.com"
+authors: ["Nicolas George"]
+homepage: "https://github.com/mbacarella/curses"
+bug-reports: "http://github.com/mbacarella/curses/issues"
+dev-repo: "git+https://github.com/mbacarella/curses"
+build: [
+  ["./configure" "--enable-widec"]
+  [make "OCAMLMAKEFILE=OCamlMakefile" "byte"]
+  [make "OCAMLMAKEFILE=OCamlMakefile" "opt"]
+]
+depends: [
+    "ocaml"
+    "ocamlfind" {build}
+    "conf-ncurses"
+]
+install: [make "OCAMLMAKEFILE=OCamlMakefile" "install"]
+synopsis: "Bindings to curses/ncurses"
+description: "Tools for building terminal-based user interfaces"
+url {
+  src: "https://github.com/mbacarella/curses/archive/1.0.6.tar.gz"
+  checksum: [
+    "md5=330bf85cc529a70c6b3e9a2825e97863"
+    "sha512=b9040ee7a75f6430f5af20b8a7029c18da1d7cc4e39b02e0c2c1848c646f18cae7eed16830be37cd429e228b4fa38b3ce91432ac6d21a7df238cbb1e7cc54f78"
+  ]
+}


### PR DESCRIPTION
### `curses.1.0.6`
Bindings to curses/ncurses
Tools for building terminal-based user interfaces



---
* Homepage: https://github.com/mbacarella/curses
* Source repo: git+https://github.com/mbacarella/curses
* Bug tracker: http://github.com/mbacarella/curses/issues

---
:camel: Pull-request generated by opam-publish v2.0.2