### PR TITLE
ocp-browser.1.2 is incompatible with lambda-term.3.0.0

### DIFF
--- a/packages/ocp-browser/ocp-browser.1.2/opam
+++ b/packages/ocp-browser/ocp-browser.1.2/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-index" {= version}
   "cmdliner"
-  "lambda-term"
+  "lambda-term" {< "3.0.0"}
   "zed" { >= "2.0.0" }
 ]
 url {


### PR DESCRIPTION
cc @AltGr @Drup.
See https://github.com/ocaml/opam-repository/pull/16292#issuecomment-620566858