### PR TITLE
[new release] gluten-lwt-unix, gluten and gluten-lwt (0.2.0)

### DIFF
--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.2.0/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+doc: "https://anmonteiro.github.io/gluten/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "faraday-lwt-unix" {>= "0.5.0"}
+  "gluten" {= version}
+  "gluten-lwt" {= version}
+  "lwt"
+]
+depopts: [
+  "tls"
+  "lwt_ssl"
+]
+synopsis: "Lwt + Unix support for gluten"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.2.0/gluten-0.2.0.tbz"
+  checksum: [
+    "sha256=45d195db6dd6e9495c4e855283aef2d620cd153e0eca5da7c7d5dd1f4e51d39c"
+    "sha512=82af8768266e2fe1da2f8646fb12d54b63042c78937fa6184449626acfa0e24c120a66df6bb02a42f0bb18fa8aea528c0a7f503f541b740dfdcb99933f292959"
+  ]
+}

--- a/packages/gluten-lwt/gluten-lwt.0.2.0/opam
+++ b/packages/gluten-lwt/gluten-lwt.0.2.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+doc: "https://anmonteiro.github.io/gluten/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "gluten" {= version}
+  "dune" {>= "1.0"}
+  "lwt"
+]
+synopsis: "Lwt-specific runtime for gluten"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.2.0/gluten-0.2.0.tbz"
+  checksum: [
+    "sha256=45d195db6dd6e9495c4e855283aef2d620cd153e0eca5da7c7d5dd1f4e51d39c"
+    "sha512=82af8768266e2fe1da2f8646fb12d54b63042c78937fa6184449626acfa0e24c120a66df6bb02a42f0bb18fa8aea528c0a7f503f541b740dfdcb99933f292959"
+  ]
+}

--- a/packages/gluten/gluten.0.2.0/opam
+++ b/packages/gluten/gluten.0.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+doc: "https://anmonteiro.github.io/gluten/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.0"}
+  "bigstringaf" {>= "0.4.0"}
+  "httpaf" {>= "0.6.5"}
+]
+synopsis:
+  "A reusable runtime library for network protocols"
+description: """
+gluten implements platform specific runtime code for driving network libraries
+based on state machines, such as http/af, h2 and websocketaf.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.2.0/gluten-0.2.0.tbz"
+  checksum: [
+    "sha256=45d195db6dd6e9495c4e855283aef2d620cd153e0eca5da7c7d5dd1f4e51d39c"
+    "sha512=82af8768266e2fe1da2f8646fb12d54b63042c78937fa6184449626acfa0e24c120a66df6bb02a42f0bb18fa8aea528c0a7f503f541b740dfdcb99933f292959"
+  ]
+}


### PR DESCRIPTION
Lwt + Unix support for gluten

- Project page: <a href="https://github.com/anmonteiro/gluten">https://github.com/anmonteiro/gluten</a>
- Documentation: <a href="https://anmonteiro.github.io/gluten/">https://anmonteiro.github.io/gluten/</a>

##### CHANGES:

- gluten-lwt: Refactor the runtime to reuse more code
  ([anmonteiro/gluten#3](https://github.com/anmonteiro/gluten/pull/3))
- gluten, gluten-lwt: Change the API, support runtimes that aren't upgradable
  ([anmonteiro/gluten#4](https://github.com/anmonteiro/gluten/pull/4))
