### PR TITLE
[new release] dotenv (0.0.2)

### DIFF
--- a/packages/dotenv/dotenv.0.0.2/opam
+++ b/packages/dotenv/dotenv.0.0.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Jose Nogueira <ze@thatportugueseguy.com>"
+authors: [ "Jose Nogueira <ze@thatportugueseguy.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/thatportugueseguy/ocaml-dotenv"
+dev-repo: "git+https://github.com/thatportugueseguy/ocaml-dotenv.git"
+bug-reports: "https://github.com/thatportugueseguy/ocaml-dotenv/issues"
+doc: "https://thatportugueseguy.github.io/ocaml-dotenv"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05"}
+  "base"
+  "stdio"
+  "uutf"
+  "dune"
+]
+synopsis: "Javascript's dotenv port to ocaml"
+description: """
+Small lib to allow storing config separate from code.
+
+Dotenv loads variables from a file (named by default `.env`, hence the name) into the application environment. They can be read in `Sys.env`.
+
+This allows for the user to reproduce the deployed environments locally, as if the application was deployed in said environments.
+
+This is a port of JavaScript's Dotenv (https://github.com/motdotla/dotenv).
+"""
+url {
+  src:
+    "https://github.com/thatportugueseguy/ocaml-dotenv/releases/download/v0.0.2/dotenv-v0.0.2.tbz"
+  checksum: [
+    "sha256=bd215250c3645bfe79abfd7db3b476207c22c18b9dd1b40093be1470fd8a83ae"
+    "sha512=6a91bbd909223e67fd6dd3d577fc6814c7e0ab3fbbeb1a06b7f32c73b08ffc04f8c74e2d36c4a9c133e0f9647dd6a7399579284d5556d7952c96381e554d625a"
+  ]
+}


### PR DESCRIPTION
Javascript's dotenv port to ocaml

- Project page: <a href="https://github.com/thatportugueseguy/ocaml-dotenv">https://github.com/thatportugueseguy/ocaml-dotenv</a>
- Documentation: <a href="https://thatportugueseguy.github.io/ocaml-dotenv">https://thatportugueseguy.github.io/ocaml-dotenv</a>

##### CHANGES:

- Add tests, use PCRE for regex.
