### PR TITLE
loosen-coin-deps: no upper bound on angstrom necessary

### DIFF
--- a/packages/coin/coin.0.1.2/opam
+++ b/packages/coin/coin.0.1.2/opam
@@ -21,7 +21,7 @@ depends: [
   "dune"
   "re"
   "menhir"
-  "angstrom" {>= "0.11.0" & < "0.14.0"}
+  "angstrom" {>= "0.11.0"}
 ]
 url {
   src:


### PR DESCRIPTION
It looks like the upper bound on angstrom wasn't necessary after all.