### PR TITLE
[new release] h2, h2-lwt and h2-lwt-unix (0.6.0)

### DIFF
--- a/packages/h2-lwt-unix/h2-lwt-unix.0.6.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "faraday-lwt-unix"
+  "h2-lwt" {= version}
+  "dune" {>= "1.7"}
+  "lwt"
+  "gluten-lwt-unix" {>= "0.2.0"}
+]
+depopts: [
+  "tls"
+  "lwt_ssl"
+]
+synopsis: "Lwt + UNIX support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-lwt-unix provides an Lwt runtime implementation for h2 that targets UNIX
+binaries.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.6.0/h2-0.6.0.tbz"
+  checksum: [
+    "sha256=6929ab97c7c53ba993f0681b638ea11179862122592efd81efd85591c7c47915"
+    "sha512=9be738856c25f1ca22e55d47cb8f14da46adfc168839bff945aaf32f71d86ad50069dc14ca3bb6b525aeae0fa01c3529b2fc91fff33dd087bdd5e9558e26143e"
+  ]
+}

--- a/packages/h2-lwt/h2-lwt.0.6.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.6.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "h2" {= version}
+  "dune" {>= "1.7"}
+  "lwt"
+  "gluten-lwt" {>= "0.2.0"}
+]
+synopsis: "Lwt support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-lwt
+provides an Lwt runtime implementation for h2.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.6.0/h2-0.6.0.tbz"
+  checksum: [
+    "sha256=6929ab97c7c53ba993f0681b638ea11179862122592efd81efd85591c7c47915"
+    "sha512=9be738856c25f1ca22e55d47cb8f14da46adfc168839bff945aaf32f71d86ad50069dc14ca3bb6b525aeae0fa01c3529b2fc91fff33dd087bdd5e9558e26143e"
+  ]
+}

--- a/packages/h2/h2.0.6.0/opam
+++ b/packages/h2/h2.0.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.7"}
+  "alcotest" {with-test}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "base64"
+  "bigstringaf" {>= "0.5.0"}
+  "angstrom" {>= "0.14.0"}
+  "faraday" {>= "0.5.0"}
+  "psq"
+  "hpack"
+  "httpaf"
+]
+synopsis:
+  "A high-performance, memory-efficient, and scalable HTTP/2 library for for OCaml"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. It
+is based on the concepts in http/af, and therefore uses the Angstrom and
+Faraday libraries to implement the parsing and serialization layers of the
+HTTP/2 standard as a state machine that is agnostic to the underlying I/O
+specifics. It also preserves the same API as http/af wherever possible.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.6.0/h2-0.6.0.tbz"
+  checksum: [
+    "sha256=6929ab97c7c53ba993f0681b638ea11179862122592efd81efd85591c7c47915"
+    "sha512=9be738856c25f1ca22e55d47cb8f14da46adfc168839bff945aaf32f71d86ad50069dc14ca3bb6b525aeae0fa01c3529b2fc91fff33dd087bdd5e9558e26143e"
+  ]
+}


### PR DESCRIPTION
A high-performance HTTP/2 library for OCaml

- Project page: <a href="https://github.com/anmonteiro/ocaml-h2">https://github.com/anmonteiro/ocaml-h2</a>
- Documentation: <a href="https://anmonteiro.github.io/ocaml-h2/">https://anmonteiro.github.io/ocaml-h2/</a>

##### CHANGES:

- h2-async: add Async adapter
  ([anmonteiro/ocaml-h2#94](https://github.com/anmonteiro/ocaml-h2/pull/94))
- h2-lwt: Close the communication channel after shutting down the client
  ([anmonteiro/ocaml-h2#108](https://github.com/anmonteiro/ocaml-h2/pull/108))
- h2-lwt-unix: fix premature SSL termination in the SSL / TLS runtimes
  ([anmonteiro/ocaml-h2#109](https://github.com/anmonteiro/ocaml-h2/pull/109))
- h2-lwt-unix: TLS runtime: adapt to TLS v0.11.0
  ([anmonteiro/ocaml-h2#109](https://github.com/anmonteiro/ocaml-h2/pull/109))
- h2-lwt-unix: feed EOF to the state machine if the socket has been closed --
  this is especially important on the client because it allows connections to
  terminate cleanly. ([anmonteiro/ocaml-h2#112](https://github.com/anmonteiro/ocaml-h2/pull/112))
- h2: Refactor the `Settings` module API
  ([anmonteiro/ocaml-h2#113](https://github.com/anmonteiro/ocaml-h2/pull/113))
- h2-lwt, h2-lwt-unix: Use [gluten](https://github.com/anmonteiro/gluten) to
  implement the Lwt-based runtimes
  ([anmonteiro/ocaml-h2#114](https://github.com/anmonteiro/ocaml-h2/pull/114))
- h2: set a lower bound on Angstrom 0.14.0
  ([anmonteiro/ocaml-h2#118](https://github.com/anmonteiro/ocaml-h2/pull/118))
- h2: in the client implementation, don't report an error if the server has
  sent an `RST_STREAM` frame after sending a complete response
  ([anmonteiro/ocaml-h2#119](https://github.com/anmonteiro/ocaml-h2/pull/119)).
- h2-mirage: Use [gluten](https://github.com/anmonteiro/gluten) to implement
  h2-mirage ([anmonteiro/ocaml-h2#120](https://github.com/anmonteiro/ocaml-h2/pull/120))
