### PR TITLE
[new release] dotenv (0.0.3)

### DIFF
--- a/packages/dotenv/dotenv.0.0.3/opam
+++ b/packages/dotenv/dotenv.0.0.3/opam
@@ -15,9 +15,9 @@ depends: [
   "stdio"
   "uutf"
   "pcre"
-  "dune"
+  "dune" {>= "1.7"}
 ]
-synopsis: "Javascript's dotenv port to ocaml"
+synopsis: "Javascript's dotenv port to OCaml"
 description: """
 Small lib to allow storing config separate from code.
 

--- a/packages/dotenv/dotenv.0.0.3/opam
+++ b/packages/dotenv/dotenv.0.0.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Jose Nogueira <ze@thatportugueseguy.com>"
+authors: [ "Jose Nogueira <ze@thatportugueseguy.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/thatportugueseguy/ocaml-dotenv"
+dev-repo: "git+https://github.com/thatportugueseguy/ocaml-dotenv.git"
+bug-reports: "https://github.com/thatportugueseguy/ocaml-dotenv/issues"
+doc: "https://thatportugueseguy.github.io/ocaml-dotenv"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05"}
+  "base"
+  "stdio"
+  "uutf"
+  "pcre"
+  "dune"
+]
+synopsis: "Javascript's dotenv port to ocaml"
+description: """
+Small lib to allow storing config separate from code.
+
+Dotenv loads variables from a file (named by default `.env`, hence the name) into the application environment. They can be read in `Sys.env`.
+
+This allows for the user to reproduce the deployed environments locally, as if the application was deployed in said environments.
+
+This is a port of JavaScript's Dotenv (https://github.com/motdotla/dotenv).
+"""
+url {
+  src:
+    "https://github.com/thatportugueseguy/ocaml-dotenv/releases/download/v0.0.3/dotenv-v0.0.3.tbz"
+  checksum: [
+    "sha256=b8b0745746db0b8c6dd6bff9de8b89512c657cc5e0d09f9ba29aa5561a07c517"
+    "sha512=de509d75d633ae992bca34bca6a2cf5e49368ba6b4a2ce58c377cd3661cd796ad3b9c3cc341ac827f76b3915495943019e79a90454d8da97f166e25c861da81c"
+  ]
+}


### PR DESCRIPTION
Javascript's dotenv port to ocaml

- Project page: <a href="https://github.com/thatportugueseguy/ocaml-dotenv">https://github.com/thatportugueseguy/ocaml-dotenv</a>
- Documentation: <a href="https://thatportugueseguy.github.io/ocaml-dotenv">https://thatportugueseguy.github.io/ocaml-dotenv</a>

##### CHANGES:

- Fix missing PCRE dependency in opam file.
