### PR TITLE
Package ppx_cstubs.0.4.0

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.4.0/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://fdopen.github.io/ppx_cstubs/"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+doc: "https://fdopen.github.io/ppx_cstubs/"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ctypes" {>= "0.13.0" & < "0.18"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.02.3" & < "4.11.0"}
+  "ocaml-migrate-parsetree" {>= "1.6.0"}
+  "ocamlfind" # not only a build dependency, it depends on findlib.top
+  "dune-configurator"
+  "dune" {>= "1.6"}
+  "ppx_tools_versioned" {>= "5.3.0"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: """
+Preprocessor for easier stub generation with ctypes
+"""
+
+description: """
+ppx_cstubs is a ppx-based preprocessor for stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file
+with c stub code and an OCaml file with all additional boilerplate
+code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.4.0.tar.gz"
+  checksum: [
+    "md5=6c607a2a1d91f341453a91ced43bc3c2"
+    "sha512=29594742ef3895af5524cdaa92d35ebfc7b33cb7a204ad2da0ab285b87d3b13920d05f80a3fc9c67974d5781b6df7d8f9a1a0dbe502ec433772bf4162ea85ad6"
+  ]
+}


### PR DESCRIPTION
### `ppx_cstubs.0.4.0`
Preprocessor for easier stub generation with ctypes
ppx_cstubs is a ppx-based preprocessor for stub generation with
ctypes. ppx_cstubs creates two files from a single ml file: a file
with c stub code and an OCaml file with all additional boilerplate
code.



---
* Homepage: https://fdopen.github.io/ppx_cstubs/
* Source repo: git+https://github.com/fdopen/ppx_cstubs.git
* Bug tracker: https://github.com/fdopen/ppx_cstubs/issues

---
:camel: Pull-request generated by opam-publish v2.0.2