### PR TITLE
fix container's result contraint

### DIFF
--- a/packages/containers/containers.2.7/opam
+++ b/packages/containers/containers.2.7/opam
@@ -12,7 +12,7 @@ depends: [
   "result" { < "1.5" }
   "uchar"
   "qtest" { with-test }
-  "qcheck" { with-test }
+  "qcheck" { with-test & >= "0.9" }
   "ounit" { with-test }
   "iter" { with-test }
   "gen" { with-test }

--- a/packages/containers/containers.2.7/opam
+++ b/packages/containers/containers.2.7/opam
@@ -9,8 +9,7 @@ build: [
 depends: [
   "dune"
   "dune-configurator"
-  "result"
-  "result" { with-test & < "1.5" }
+  "result" { < "1.5" }
   "uchar"
   "qtest" { with-test }
   "qcheck" { with-test }


### PR DESCRIPTION
See: https://ci.ocaml.org/log/saved/docker-build-05d4d46ebd4828e7b4715fb56cfd84a0/3c34be550534e9f83be41b48205c0a305b136d3b
```
#=== ERROR while compiling containers.2.7 =====================================#
# context              2.0.7 | linux/x86_64 | ocaml-base-compiler.4.02.3 | file:///home/opam/opam-repository
...
# (cd _build/default && /home/opam/.opam/4.02/bin/ocamlc.opt -w -40 -warn-error -3 -w +a-4-42-44-48-50-58-32-60@8 -safe-string -nolabels -open CCMonomorphic -g -bin-annot -I src/core/.containers.objs/byte -I /home/opam/.opam/4.02/lib/result -I /home/opam/.opam/4.02/lib/uchar -I src/monomorphic/.containers_monomorphic.objs/byte -I src/monomorphic/.containers_monomorphic.objs/native -no-alias-deps -o src/core/.containers.objs/byte/CCResult.cmi -c -intf src/core/CCResult.mli)
# File "src/core/CCResult.mli", line 19, characters 21-22:
# Error: Multiple definition of the type name t.
#        Names must be unique in a given structure or signature.
#       ocamlc src/core/.containers.objs/byte/CCShimsFormat_.{cmi,cmo,cmt}
```
It probably always requires an old version of result, not just for the tests.

CC: @c-cube