### PR TITLE
Package ocsigen-toolkit.2.7.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.7.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.7.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.10.1"}
+  "calendar"
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.7.0.tar.gz"
+  checksum: [
+    "md5=69e9cd7685a90cc5c9cebf32362d1f1c"
+    "sha512=b473954fd7e6df074c1c76dfc91970acdaa66e00bed826043afd17e1623c61ea4521be64244a8f8fc982f1237e3069d86f8f2dbe5937c597e3c118d96b37160b"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.7.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.2