### PR TITLE
containers.1.0 to 2.7: Add missing dependency constraint

### DIFF
--- a/packages/containers/containers.1.0/opam
+++ b/packages/containers/containers.1.0/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "base-bytes"
-  "result"
+  "result" {< "1.5"}
   "cppo" {build}
   "ocamlbuild" {build}
   "qtest" {with-test}

--- a/packages/containers/containers.1.1/opam
+++ b/packages/containers/containers.1.1/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "base-bytes"
-  "result"
+  "result" {< "1.5"}
   "cppo" {build}
   "ocamlbuild" {build}
   "qtest" {with-test}

--- a/packages/containers/containers.1.2/opam
+++ b/packages/containers/containers.1.2/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "base-bytes"
-  "result"
+  "result" {< "1.5"}
   "cppo" {build}
   "ocamlbuild" {build}
   "qtest" {with-test}

--- a/packages/containers/containers.1.3/opam
+++ b/packages/containers/containers.1.3/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "base-bytes"
-  "result"
+  "result" {< "1.5"}
   "cppo" {build}
   "ocamlbuild" {build}
   "qtest" {with-test}

--- a/packages/containers/containers.1.4/opam
+++ b/packages/containers/containers.1.4/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "base-bytes"
-  "result"
+  "result" {< "1.5"}
   "cppo" {build}
   "ocamlbuild" {build}
   "qtest" {with-test}

--- a/packages/containers/containers.1.5.1/opam
+++ b/packages/containers/containers.1.5.1/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "base-bytes"
-  "result"
+  "result" {< "1.5"}
   "ocamlbuild" {build}
   "qtest" {with-test}
 ]

--- a/packages/containers/containers.1.5.2/opam
+++ b/packages/containers/containers.1.5.2/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "base-bytes"
-  "result"
+  "result" {< "1.5"}
   "ocamlbuild" {build}
   "qtest" {with-test}
 ]

--- a/packages/containers/containers.1.5/opam
+++ b/packages/containers/containers.1.5/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.08.0"}
   "ocamlfind" {build}
   "base-bytes"
-  "result"
+  "result" {< "1.5"}
   "ocamlbuild" {build}
   "qtest" {with-test}
 ]

--- a/packages/containers/containers.2.0/opam
+++ b/packages/containers/containers.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "base-bytes"
   "result" {< "1.5"}
   "qtest" {with-test}
-  "qcheck" {with-test}
+  "qcheck" {with-test & >= "0.9"}
   "ounit" {with-test}
   "sequence" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.0/opam
+++ b/packages/containers/containers.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.08.0"}
   "jbuilder" {>= "1.0+beta12"}
   "base-bytes"
-  "result"
+  "result" {< "1.5"}
   "qtest" {with-test}
   "qcheck" {with-test}
   "ounit" {with-test}

--- a/packages/containers/containers.2.1/opam
+++ b/packages/containers/containers.2.1/opam
@@ -17,7 +17,7 @@ depends: [
   "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test}
+  "qcheck" {with-test & >= "0.9"}
   "ounit" {with-test}
   "sequence" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.1/opam
+++ b/packages/containers/containers.2.1/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0" & < "4.07.0"}
   "jbuilder" {>= "1.0+beta12"}
-  "result"
+  "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
   "qcheck" {with-test}

--- a/packages/containers/containers.2.2/opam
+++ b/packages/containers/containers.2.2/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0" & < "4.07.0"}
   "jbuilder" {>= "1.0+beta12"}
-  "result"
+  "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
   "qcheck" {with-test & >= "0.7"}

--- a/packages/containers/containers.2.2/opam
+++ b/packages/containers/containers.2.2/opam
@@ -17,7 +17,7 @@ depends: [
   "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test & >= "0.7"}
+  "qcheck" {with-test & >= "0.9"}
   "ounit" {with-test}
   "sequence" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.3/opam
+++ b/packages/containers/containers.2.3/opam
@@ -17,7 +17,7 @@ depends: [
   "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test & >= "0.7"}
+  "qcheck" {with-test & >= "0.9"}
   "ounit" {with-test}
   "sequence" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.3/opam
+++ b/packages/containers/containers.2.3/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0" & < "4.08.0"}
   "jbuilder" {>= "1.0+beta12"}
-  "result"
+  "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
   "qcheck" {with-test & >= "0.7"}

--- a/packages/containers/containers.2.4.1/opam
+++ b/packages/containers/containers.2.4.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
 depends: [
   "dune"
   "dune-configurator"
-  "result"
+  "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
   "qcheck" {with-test & >= "0.7"}

--- a/packages/containers/containers.2.4.1/opam
+++ b/packages/containers/containers.2.4.1/opam
@@ -13,7 +13,7 @@ depends: [
   "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test & >= "0.7"}
+  "qcheck" {with-test & >= "0.9"}
   "ounit" {with-test}
   "sequence" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.4/opam
+++ b/packages/containers/containers.2.4/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
 depends: [
   "dune"
   "dune-configurator"
-  "result"
+  "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
   "qcheck" {with-test & >= "0.7"}

--- a/packages/containers/containers.2.4/opam
+++ b/packages/containers/containers.2.4/opam
@@ -13,7 +13,7 @@ depends: [
   "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test & >= "0.7"}
+  "qcheck" {with-test & >= "0.9"}
   "ounit" {with-test}
   "sequence" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.5/opam
+++ b/packages/containers/containers.2.5/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
 depends: [
   "dune"
   "dune-configurator"
-  "result"
+  "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
   "qcheck" {with-test & >= "0.7"}

--- a/packages/containers/containers.2.5/opam
+++ b/packages/containers/containers.2.5/opam
@@ -13,7 +13,7 @@ depends: [
   "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test & >= "0.7"}
+  "qcheck" {with-test & >= "0.9"}
   "ounit" {with-test}
   "sequence" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.6.1/opam
+++ b/packages/containers/containers.2.6.1/opam
@@ -13,7 +13,7 @@ depends: [
   "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test}
+  "qcheck" {with-test & >= "0.9"}
   "ounit" {with-test}
   "iter" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.6.1/opam
+++ b/packages/containers/containers.2.6.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
 depends: [
   "dune"
   "dune-configurator"
-  "result"
+  "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
   "qcheck" {with-test}

--- a/packages/containers/containers.2.6/opam
+++ b/packages/containers/containers.2.6/opam
@@ -13,7 +13,7 @@ depends: [
   "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
-  "qcheck" {with-test}
+  "qcheck" {with-test & >= "0.9"}
   "ounit" {with-test}
   "iter" {with-test}
   "gen" {with-test}

--- a/packages/containers/containers.2.6/opam
+++ b/packages/containers/containers.2.6/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
 depends: [
   "dune"
   "dune-configurator"
-  "result"
+  "result" {< "1.5"}
   "uchar"
   "qtest" {with-test}
   "qcheck" {with-test}


### PR DESCRIPTION
Duplicate https://github.com/ocaml/opam-repository/pull/16321 for `containers` `1.0` to `2.7`