### PR TITLE
Restrict opam-depext to opam < 2.1

### DIFF
--- a/packages/depext/depext.transition/opam
+++ b/packages/depext/depext.transition/opam
@@ -4,7 +4,7 @@ maintainer: [
   "Anil Madhavapeddy <anil@recoil.org>"
 ]
 depends: ["ocaml" "opam-depext"]
-available: [opam-version >= "2.0.0~beta5"]
+available: [opam-version >= "2.0.0~beta5" & opam-version < "2.1"]
 synopsis: "opam-depext transition package"
 description:
   "This package has been renamed to 'opam-depext' and can safely be removed"

--- a/packages/opam-depext/opam-depext.1.1.0/opam
+++ b/packages/opam-depext/opam-depext.1.1.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
 build: [make]
-available: opam-version >= "2.0.0~beta5"
+available: opam-version >= "2.0.0~beta5" & opam-version < "2.1"
 conflicts: "depext" {!= "transition"}
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """

--- a/packages/opam-depext/opam-depext.1.1.1/opam
+++ b/packages/opam-depext/opam-depext.1.1.1/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
 build: [make]
-available: [opam-version >= "2.0.0~beta5"]
+available: [opam-version >= "2.0.0~beta5" & opam-version < "2.1"]
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between

--- a/packages/opam-depext/opam-depext.1.1.2/opam
+++ b/packages/opam-depext/opam-depext.1.1.2/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
 build: [make]
-available: opam-version >= "2.0.0~beta5"
+available: opam-version >= "2.0.0~beta5" & opam-version < "2.1"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between

--- a/packages/opam-depext/opam-depext.1.1.3/opam
+++ b/packages/opam-depext/opam-depext.1.1.3/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
 build: [make]
-available: opam-version >= "2.0.0~beta5"
+available: opam-version >= "2.0.0~beta5" & opam-version < "2.1"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between


### PR DESCRIPTION
opam-depext is included in the upcoming opam 2.1 and does not work with this release. To prevent any surprises for users this package should not be installable.

cc @rjbou @AltGr 