### PR TITLE
ocsigen-start is incompatible with js_of_ocaml-ppx 3.6.0

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.1.7.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.7.0/opam
@@ -19,6 +19,7 @@ depends: [
   "ocsigen-toolkit" {>= "2.0.0"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
 ]

--- a/packages/ocsigen-start/ocsigen-start.1.8.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.8.0/opam
@@ -19,6 +19,7 @@ depends: [
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
 ]

--- a/packages/ocsigen-start/ocsigen-start.2.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.0.0/opam
@@ -19,6 +19,7 @@ depends: [
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.0.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.0.1/opam
@@ -19,6 +19,7 @@ depends: [
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.11.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.11.0/opam
@@ -21,6 +21,7 @@ depends: [
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"

--- a/packages/ocsigen-start/ocsigen-start.2.12.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.12.0/opam
@@ -21,6 +21,7 @@ depends: [
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"

--- a/packages/ocsigen-start/ocsigen-start.2.13.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.13.0/opam
@@ -21,6 +21,7 @@ depends: [
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"

--- a/packages/ocsigen-start/ocsigen-start.2.15.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.0/opam
@@ -20,6 +20,7 @@ depends: [
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"

--- a/packages/ocsigen-start/ocsigen-start.2.15.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.1/opam
@@ -22,6 +22,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "js_of_ocaml-ppx" {< "3.6.0"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.2/opam
@@ -20,6 +20,7 @@ depends: [
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"

--- a/packages/ocsigen-start/ocsigen-start.2.16.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.16.0/opam
@@ -22,6 +22,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "js_of_ocaml-ppx" {< "3.6.0"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.16.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.16.1/opam
@@ -22,6 +22,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "js_of_ocaml-ppx" {< "3.6.0"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.2.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.2.2/opam
@@ -19,6 +19,7 @@ depends: [
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
   "cohttp-lwt-unix"

--- a/packages/ocsigen-start/ocsigen-start.2.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.3.0/opam
@@ -19,6 +19,7 @@ depends: [
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
   "cohttp-lwt-unix"

--- a/packages/ocsigen-start/ocsigen-start.2.4.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.4.0/opam
@@ -19,6 +19,7 @@ depends: [
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
   "cohttp-lwt-unix"

--- a/packages/ocsigen-start/ocsigen-start.2.7.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.7.0/opam
@@ -19,6 +19,7 @@ depends: [
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"

--- a/packages/ocsigen-start/ocsigen-start.2.9.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.9.1/opam
@@ -21,6 +21,7 @@ depends: [
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"

--- a/packages/ocsigen-start/ocsigen-start.2.9.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.9.2/opam
@@ -21,6 +21,7 @@ depends: [
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
+  "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"


### PR DESCRIPTION
Failures appear in https://github.com/ocaml/opam-repository/pull/16322
Related to https://github.com/ocsigen/js_of_ocaml/issues/1005