### PR TITLE
Fix integers.0.4.0's revdeps

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.1.0/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ctypes" {>= "0.13.0" & <= "0.15.0"}
-  "integers"
+  "integers" {< "0.4.0"}
   "num"
   "result"
   "containers" {>= "2.2"}

--- a/packages/ppx_cstubs/ppx_cstubs.0.2.0/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.2.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ctypes" {>= "0.13.0" & < "0.15.0"}
-  "integers"
+  "integers" {< "0.4.0"}
   "num"
   "result"
   "containers" {>= "2.2"}

--- a/packages/ppx_cstubs/ppx_cstubs.0.2.1/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.2.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ctypes" {>= "0.13.0" & < "0.17.0"}
-  "integers"
+  "integers" {< "0.4.0"}
   "num"
   "result"
   "containers" {>= "2.2"}

--- a/packages/ppx_cstubs/ppx_cstubs.0.3.0/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.3.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ctypes" {>= "0.13.0" & < "0.18.0"}
-  "integers"
+  "integers" {< "0.4.0"}
   "num"
   "result"
   "containers" {>= "2.2"}


### PR DESCRIPTION
Fix revdeps failures from https://github.com/ocaml/opam-repository/pull/16329