### PR TITLE
Package sklearn.0.22-0.2.0

### DIFF
--- a/packages/sklearn/sklearn.0.22-0.2.0/opam
+++ b/packages/sklearn/sklearn.0.22-0.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Scikit-learn machine learning library for OCaml"
+description: """
+Scikit-learn machine learning library for OCaml
+These are bindings to Python's scikit-learn machine learning library:
+- Simple and efficient tools for predictive data analysis
+- Accessible to everybody, and reusable in various contexts
+- Built on NumPy, SciPy, and matplotlib
+- Open source, commercially usable - BSD license
+"""
+maintainer: ["Ronan Le Hy <ronan.lehy@gmail.com>"]
+authors: ["Ronan Le Hy"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/lehy/ocaml-sklearn"
+bug-reports: "https://github.com/lehy/ocaml-sklearn/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.07.1"}
+  "pyml" {>= "20200222"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lehy/ocaml-sklearn.git"
+url {
+  src: "https://github.com/lehy/ocaml-sklearn/archive/0.22-0.2.0.tar.gz"
+  checksum: [
+    "md5=5219c6159701b598f4df2656f48f7dc3"
+    "sha512=2ab4806b05c01ce429fbac6b64cba038f29d3f06553a3bafe64679589bea9e6096ca2a3c1b65b13c4a527645edb367d310475c4d310a50d8415b972cb7cb4b86"
+  ]
+}


### PR DESCRIPTION
### `sklearn.0.22-0.2.0`
Scikit-learn machine learning library for OCaml
Scikit-learn machine learning library for OCaml
These are bindings to Python's scikit-learn machine learning library:
- Simple and efficient tools for predictive data analysis
- Accessible to everybody, and reusable in various contexts
- Built on NumPy, SciPy, and matplotlib
- Open source, commercially usable - BSD license



---
* Homepage: https://github.com/lehy/ocaml-sklearn
* Source repo: git+https://github.com/lehy/ocaml-sklearn.git
* Bug tracker: https://github.com/lehy/ocaml-sklearn/issues

---
:camel: Pull-request generated by opam-publish v2.0.2