### PR TITLE
Add conf-libssl.2: Early failure and helpful error messages

### DIFF
--- a/packages/conf-libssl/conf-libssl.2/opam
+++ b/packages/conf-libssl/conf-libssl.2/opam
@@ -4,7 +4,10 @@ authors: ["The OpenSSL Project"]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.openssl.org/"
 license: "Apache-1.0"
-build: ["pkg-config" "openssl"]
+build: [
+  ["pkg-config" "openssl"]
+    {os != "freebsd" & os != "openbsd" & os != "netbsd"} # libssl is provided by base system on BSDs
+]
 depends: [
   "conf-pkg-config" {build}
 ]
@@ -19,7 +22,6 @@ depexts: [
   ["openssl"] {os-distribution = "nixos"}
   ["openssl"] {os-distribution = "arch"}
   ["libopenssl-devel"] {os-family = "suse"}
-  ["openssl"] {os = "freebsd"}
 ]
 post-messages: [
   "Make sure libssl/openssl is installed and accessible using pkg-config." {failure}

--- a/packages/conf-libssl/conf-libssl.2/opam
+++ b/packages/conf-libssl/conf-libssl.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "David Sheets <sheets@alum.mit.edu>"
+authors: ["The OpenSSL Project"]
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://www.openssl.org/"
+license: "Apache-1.0"
+build: ["pkg-config" "openssl"]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["libssl-dev"] {os-family = "debian"}
+  ["openssl-devel"] {os-distribution = "centos"}
+  ["openssl-devel"] {os-distribution = "ol"}
+  ["openssl-devel"] {os-distribution = "fedora"}
+  ["openssl"] {os = "macos" & os-distribution = "homebrew"}
+  ["openssl"] {os = "macos" & os-distribution = "macports"}
+  ["libressl-dev"] {os-distribution = "alpine"}
+  ["openssl"] {os-distribution = "nixos"}
+  ["openssl"] {os-distribution = "arch"}
+  ["libopenssl-devel"] {os-family = "suse"}
+  ["openssl"] {os = "freebsd"}
+]
+post-messages: [
+  "Make sure libssl/openssl is installed and accessible using pkg-config." {failure}
+  "Set the PKG_CONFIG_PATH environment variable if necessary." {failure}
+  "For example: export PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig" {failure & os-distribution = "homebrew"}
+  "For example: export PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig" {failure & os-distribution = "nixos"}
+  "For example: export PKG_CONFIG_PATH=/opt/local/lib/pkgconfig" {failure & os-distribution = "macports"}
+]
+synopsis: "Virtual package relying on an OpenSSL library system installation"
+description:
+  "This package can only install if the OpenSSL library is installed on the system."
+flags: conf


### PR DESCRIPTION
Here is the difference between the two versions:
```
--- conf-libssl.1/opam	2020-04-03 15:22:16.796495179 +0100
+++ conf-libssl.2/opam	2020-05-02 13:41:51.890023963 +0100
@@ -4,12 +4,10 @@
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.openssl.org/"
 license: "Apache-1.0"
-build: [
-  ["pkg-config" "openssl"]
-    {os != "macos" & os != "freebsd" & os != "openbsd" & os != "netbsd"}
-  ["sh" "./osx-build.sh"] {os = "macos"}
+build: ["pkg-config" "openssl"]
+depends: [
+  "conf-pkg-config" {build}
 ]
-depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libssl-dev"] {os-family = "debian"}
   ["openssl-devel"] {os-distribution = "centos"}
@@ -21,9 +19,16 @@
   ["openssl"] {os-distribution = "nixos"}
   ["openssl"] {os-distribution = "arch"}
   ["libopenssl-devel"] {os-family = "suse"}
+  ["openssl"] {os = "freebsd"}
+]
+post-messages: [
+  "Make sure libssl/openssl is installed and accessible using pkg-config." {failure}
+  "Set the PKG_CONFIG_PATH environment variable if necessary." {failure}
+  "For example: export PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig" {failure & os-distribution = "homebrew"}
+  "For example: export PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig" {failure & os-distribution = "nixos"}
+  "For example: export PKG_CONFIG_PATH=/opt/local/lib/pkgconfig" {failure & os-distribution = "macports"}
 ]
 synopsis: "Virtual package relying on an OpenSSL library system installation"
 description:
   "This package can only install if the OpenSSL library is installed on the system."
-extra-files: ["osx-build.sh" "md5=faf81a6bf30e346abe94610f136c6193"]
 flags: conf
```
With this change, the package should not succeed and let users try to install `ssl` for example without having a reachable libssl library (see https://github.com/ocaml/opam-repository/issues/15295#issuecomment-606789054). cc @reykjalin does that help?

The `osx-build.sh` script didn't seem to make much sense, I'm not too sure why it was added in the first place. I didn't understand it myself and seemed to have made things worst. It seems to me that instead of looking for the right library, we should display helpful error messages instead of ignoring a potential future error, as if people don't set their `PKG_CONFIG_PATH` environment variable, nothing will tell them something is missing until they run into issues later like:
```
discover.c:2:10: fatal error: 'openssl/ssl.h' file not found
#include <openssl/ssl.h>
```
cc @toots it seems that the original special case for macOS was added in https://github.com/ocaml/opam-repository/pull/10453 and https://github.com/ocaml/opam-repository/pull/10503. Is this distinction still relevant? How can we help users and not run into issues later if it is the case?

The Nix special case was added in https://github.com/ocaml/opam-repository/pull/13135 and fixed in https://github.com/ocaml/opam-repository/pull/13284. cc @anmonteiro does my change make sense?

cc @hannesm @rneswold I was looking at old commits (https://github.com/ocaml/opam-repository/commit/b96dc1f095593c9089ee3edf52cda44658fbd169) to understand why there was restrictions on BSDs. Should those restrictions still exists? I was able to get openssl installed and working with pkg-config first try with FreeBSD 12.1. (let's see if the experimental freebsd travis check confirms it)

This PR is just a draft for the moment, a place for discussion.