### PR TITLE
[new release] metrics, metrics-unix, metrics-lwt, metrics-mirage and metrics-influx (0.2.0)

### DIFF
--- a/packages/metrics-influx/metrics-influx.0.2.0/opam
+++ b/packages/metrics-influx/metrics-influx.0.2.0/opam
@@ -15,6 +15,7 @@ build: [
 
 depends: [
   "dune"
+  "ocaml" {>= "4.05.0"}
   "metrics" {= version}
   "astring"
   "fmt"

--- a/packages/metrics-influx/metrics-influx.0.2.0/opam
+++ b/packages/metrics-influx/metrics-influx.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Hannes Mehnert"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "dune"
+  "metrics" {= version}
+  "astring"
+  "fmt"
+  "duration"
+  "lwt"
+]
+synopsis: "Influx reporter for the Metrics library"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/0.2.0/metrics-0.2.0.tbz"
+  checksum: [
+    "sha256=0f4ff94e0b632dffd8b1d6c180cc0e49873cf29ba6a6f8e1a3e8d811252b4148"
+    "sha512=3f1a6cfbcc674409a7382446084c11c3646e6b380e4972306334e7fa0e558d256dadfd39f7f3acd32afffe78757f66ecefc1b7960ae366afe09397ba0bbdaf68"
+  ]
+}

--- a/packages/metrics-influx/metrics-influx.0.2.0/opam
+++ b/packages/metrics-influx/metrics-influx.0.2.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.4"}
   "ocaml" {>= "4.05.0"}
   "metrics" {= version}
   "astring"

--- a/packages/metrics-lwt/metrics-lwt.0.2.0/opam
+++ b/packages/metrics-lwt/metrics-lwt.0.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "dune"
+  "metrics" {= version}
+  "lwt"
+  "logs"
+]
+synopsis: "Lwt backend for the Metrics library"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/0.2.0/metrics-0.2.0.tbz"
+  checksum: [
+    "sha256=0f4ff94e0b632dffd8b1d6c180cc0e49873cf29ba6a6f8e1a3e8d811252b4148"
+    "sha512=3f1a6cfbcc674409a7382446084c11c3646e6b380e4972306334e7fa0e558d256dadfd39f7f3acd32afffe78757f66ecefc1b7960ae366afe09397ba0bbdaf68"
+  ]
+}

--- a/packages/metrics-lwt/metrics-lwt.0.2.0/opam
+++ b/packages/metrics-lwt/metrics-lwt.0.2.0/opam
@@ -10,11 +10,11 @@ doc:          "https://mirage.github.io/metrics/"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.4"}
   "metrics" {= version}
   "lwt"
   "logs"

--- a/packages/metrics-mirage/metrics-mirage.0.2.0/opam
+++ b/packages/metrics-mirage/metrics-mirage.0.2.0/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "dune"
-  "metrics"
+  "metrics" {=version}
   "lwt"
   "metrics-influx"
   "ipaddr"

--- a/packages/metrics-mirage/metrics-mirage.0.2.0/opam
+++ b/packages/metrics-mirage/metrics-mirage.0.2.0/opam
@@ -14,10 +14,9 @@ build: [
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.4"}
   "metrics" {=version}
-  "lwt"
-  "metrics-influx"
+  "metrics-influx" {= version}
   "ipaddr"
   "lwt"
   "mirage-clock" {>= "3.0.0"}

--- a/packages/metrics-mirage/metrics-mirage.0.2.0/opam
+++ b/packages/metrics-mirage/metrics-mirage.0.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Hannes Mehnert"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "dune"
+  "metrics"
+  "lwt"
+  "metrics-influx"
+  "ipaddr"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "cstruct"
+  "logs"
+]
+synopsis: "Mirage backend for the Metrics library"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/0.2.0/metrics-0.2.0.tbz"
+  checksum: [
+    "sha256=0f4ff94e0b632dffd8b1d6c180cc0e49873cf29ba6a6f8e1a3e8d811252b4148"
+    "sha512=3f1a6cfbcc674409a7382446084c11c3646e6b380e4972306334e7fa0e558d256dadfd39f7f3acd32afffe78757f66ecefc1b7960ae366afe09397ba0bbdaf68"
+  ]
+}

--- a/packages/metrics-unix/metrics-unix.0.2.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "metrics" {= version}
   "mtime"
   "lwt"
-  "metrics-lwt" {with-test}
+  "metrics-lwt" {=version & with-test}
   "conf-gnuplot"
 ]
 synopsis: "Unix backend for the Metrics library"

--- a/packages/metrics-unix/metrics-unix.0.2.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.2.0/opam
@@ -10,11 +10,11 @@ doc:          "https://mirage.github.io/metrics/"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.4"}
   "uuidm"
   "metrics" {= version}
   "mtime"

--- a/packages/metrics-unix/metrics-unix.0.2.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "dune"
+  "uuidm"
+  "metrics"
+  "mtime"
+  "lwt"
+  "metrics-lwt" {with-test}
+  "conf-gnuplot"
+]
+synopsis: "Unix backend for the Metrics library"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/0.2.0/metrics-0.2.0.tbz"
+  checksum: [
+    "sha256=0f4ff94e0b632dffd8b1d6c180cc0e49873cf29ba6a6f8e1a3e8d811252b4148"
+    "sha512=3f1a6cfbcc674409a7382446084c11c3646e6b380e4972306334e7fa0e558d256dadfd39f7f3acd32afffe78757f66ecefc1b7960ae366afe09397ba0bbdaf68"
+  ]
+}

--- a/packages/metrics-unix/metrics-unix.0.2.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.2.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "dune"
   "uuidm"
-  "metrics"
+  "metrics" {= version}
   "mtime"
   "lwt"
   "metrics-lwt" {with-test}

--- a/packages/metrics/metrics.0.2.0/opam
+++ b/packages/metrics/metrics.0.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"
+  "fmt"
+  "alcotest" {with-test}
+]
+synopsis: "Metrics infrastructure for OCaml"
+description: """
+Metrics provides a basic infrastructure to monitor and gather runtime
+metrics for OCaml program. Monitoring is performed on sources, indexed
+by tags, allowing users to enable or disable at runtime the gathering
+of data-points. As disabled metric sources have a low runtime cost
+(only a closure allocation), the library is designed to instrument
+production systems.
+
+Metric reporting is decoupled from monitoring and is handled by a
+custom reporter. A few reporters are (will be) provided by default.
+
+Metrics is heavily inspired by
+[Logs](http://erratique.ch/software/logs).
+"""
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/0.2.0/metrics-0.2.0.tbz"
+  checksum: [
+    "sha256=0f4ff94e0b632dffd8b1d6c180cc0e49873cf29ba6a6f8e1a3e8d811252b4148"
+    "sha512=3f1a6cfbcc674409a7382446084c11c3646e6b380e4972306334e7fa0e558d256dadfd39f7f3acd32afffe78757f66ecefc1b7960ae366afe09397ba0bbdaf68"
+  ]
+}

--- a/packages/metrics/metrics.0.2.0/opam
+++ b/packages/metrics/metrics.0.2.0/opam
@@ -10,12 +10,12 @@ doc:          "https://mirage.github.io/metrics/"
 build: [
  ["dune" "subst"] {pinned}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"
+  "dune" {>= "1.4"}
   "fmt"
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
Metrics infrastructure for OCaml

- Project page: <a href="https://github.com/mirage/metrics">https://github.com/mirage/metrics</a>
- Documentation: <a href="https://mirage.github.io/metrics/">https://mirage.github.io/metrics/</a>

##### CHANGES:

- Add mirage layer and influxdb reporter (mirage/metrics#28, @hannesm)
- Gnuplot: namespacing improvements (mirage/metrics#34, @CraigFe)
- Gnuplot: optional graph generation (mirage/metrics#35, @CraigFe)
- Support OCaml 4.08 (mirage/metrics#37, @CraigFe)
- Use OCamlFormat 0.14.1 (mirage/metrics#38, mirage/metrics#45, @CraigFe and @samoht)
- opam: remove the 'build' directive on dune dependency (mirage/metrics#43, @CraigFe)
- introduce Metrics.cache_reporter -- a reporter holding the most recent
  measurement from each reporting sources (mirage/metrics#42, @hannesm)
- Influx: expose the "encode_line_protocol" function (mirage/metrics#42, @hannesm)
- Metrics_lwt: provide a source based on Logs.warn_count and
  Logs.error_count (mirage/metrics#42, @hannesm)
- Metrics_lwt: provide a function to periodically poll a source
  (used e.g. for GC stats etc.) (mirage/metrics#42, @hannesm)
- Mirage: fix the mirage subpackage for newer mirage APIs (mirage/metrics#42, @hannesm)
