### PR TITLE
[new release] cookie, session-cookie, session-cookie-async and session-cookie-lwt (0.1.8)

### DIFF
--- a/packages/cookie/cookie.0.1.8/opam
+++ b/packages/cookie/cookie.0.1.8/opam
@@ -14,6 +14,7 @@ depends: [
   "uri"
   "ptime"
   "astring"
+  "base" {with-test}
   "alcotest" {with-test}
   "junit" {with-test}
   "junit_alcotest" {with-test}

--- a/packages/cookie/cookie.0.1.8/opam
+++ b/packages/cookie/cookie.0.1.8/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+version: "0.1.8"
+synopsis: "Cookie handling for OCaml and ReasonML"
+description: "Parsing and printing cookies in OCaml and Reason"
+maintainer: ["ulrik.strid@outlook.com"]
+authors: ["Ulrik Strid"]
+license: "BSD3-clause"
+homepage: "https://ulrikstrid.github.io/ocaml-cookie"
+doc: "https://ulrikstrid.github.io/ocaml-cookie"
+bug-reports: "https://github.com/ulrikstrid/ocaml-cookie/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.07.0"}
+  "uri"
+  "ptime"
+  "astring"
+  "alcotest" {with-test}
+  "junit" {with-test}
+  "junit_alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/ocaml-cookie.git"
+url {
+  src:
+    "https://github.com/ulrikstrid/ocaml-cookie/releases/download/0.1.8/cookie-0.1.8.tbz"
+  checksum: [
+    "sha256=bc405a88a6f94453fbaee19b98469818c09b567646a46e1f4ac1a9d5d9fee2db"
+    "sha512=fd66a50db8ca8431e7e0ec847c828f448a61b7fbfea9581a75b2b93c205ec4728b072fa2bdc6c70e7afe41f6e6254756fb176ce9c3f71a0cb6da0086479644ed"
+  ]
+}

--- a/packages/session-cookie-async/session-cookie-async.0.1.8/opam
+++ b/packages/session-cookie-async/session-cookie-async.0.1.8/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+version: "0.1.8"
+synopsis: "Session handling for OCaml and ReasonML"
+description:
+  "Session implementation using the cookie library with async support"
+maintainer: ["ulrik.strid@outlook.com"]
+authors: ["Ulrik Strid"]
+license: "BSD3-clause"
+homepage: "https://ulrikstrid.github.io/ocaml-cookie"
+doc: "https://ulrikstrid.github.io/ocaml-cookie"
+bug-reports: "https://github.com/ulrikstrid/ocaml-cookie/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.07.0"}
+  "session-cookie" {= version}
+  "async"
+  "alcotest" {with-test}
+  "junit" {with-test}
+  "junit_alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/ocaml-cookie.git"
+url {
+  src:
+    "https://github.com/ulrikstrid/ocaml-cookie/releases/download/0.1.8/cookie-0.1.8.tbz"
+  checksum: [
+    "sha256=bc405a88a6f94453fbaee19b98469818c09b567646a46e1f4ac1a9d5d9fee2db"
+    "sha512=fd66a50db8ca8431e7e0ec847c828f448a61b7fbfea9581a75b2b93c205ec4728b072fa2bdc6c70e7afe41f6e6254756fb176ce9c3f71a0cb6da0086479644ed"
+  ]
+}

--- a/packages/session-cookie-lwt/session-cookie-lwt.0.1.8/opam
+++ b/packages/session-cookie-lwt/session-cookie-lwt.0.1.8/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+version: "0.1.8"
+synopsis: "Session handling for OCaml and ReasonML"
+description:
+  "Session implementation using the cookie library with lwt support"
+maintainer: ["ulrik.strid@outlook.com"]
+authors: ["Ulrik Strid"]
+license: "BSD3-clause"
+homepage: "https://ulrikstrid.github.io/ocaml-cookie"
+doc: "https://ulrikstrid.github.io/ocaml-cookie"
+bug-reports: "https://github.com/ulrikstrid/ocaml-cookie/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.07.0"}
+  "session-cookie" {= version}
+  "lwt"
+  "alcotest" {with-test}
+  "junit" {with-test}
+  "junit_alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/ocaml-cookie.git"
+url {
+  src:
+    "https://github.com/ulrikstrid/ocaml-cookie/releases/download/0.1.8/session-cookie-lwt-0.1.8.tbz"
+  checksum: [
+    "sha256=bc405a88a6f94453fbaee19b98469818c09b567646a46e1f4ac1a9d5d9fee2db"
+    "sha512=fd66a50db8ca8431e7e0ec847c828f448a61b7fbfea9581a75b2b93c205ec4728b072fa2bdc6c70e7afe41f6e6254756fb176ce9c3f71a0cb6da0086479644ed"
+  ]
+}

--- a/packages/session-cookie/session-cookie.0.1.8/opam
+++ b/packages/session-cookie/session-cookie.0.1.8/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+version: "0.1.8"
+synopsis: "Session handling for OCaml and ReasonML"
+description: "Session implementation using the cookie library"
+maintainer: ["ulrik.strid@outlook.com"]
+authors: ["Ulrik Strid"]
+license: "BSD3-clause"
+homepage: "https://ulrikstrid.github.io/ocaml-cookie"
+doc: "https://ulrikstrid.github.io/ocaml-cookie"
+bug-reports: "https://github.com/ulrikstrid/ocaml-cookie/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.07.0"}
+  "cookie" {= version}
+  "session"
+  "base" {with-test}
+  "alcotest" {with-test}
+  "junit" {with-test}
+  "junit_alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/ocaml-cookie.git"
+url {
+  src:
+    "https://github.com/ulrikstrid/ocaml-cookie/releases/download/0.1.8/cookie-0.1.8.tbz"
+  checksum: [
+    "sha256=bc405a88a6f94453fbaee19b98469818c09b567646a46e1f4ac1a9d5d9fee2db"
+    "sha512=fd66a50db8ca8431e7e0ec847c828f448a61b7fbfea9581a75b2b93c205ec4728b072fa2bdc6c70e7afe41f6e6254756fb176ce9c3f71a0cb6da0086479644ed"
+  ]
+}


### PR DESCRIPTION
Cookie handling for OCaml and ReasonML

- Project page: <a href="https://github.com/ulrikstrid/ocaml-cookie">https://github.com/ulrikstrid/ocaml-cookie</a>
- Documentation: <a href="https://ulrikstrid.github.io/ocaml-cookie">https://ulrikstrid.github.io/ocaml-cookie</a>

##### CHANGES:

- Fix bug where spaces were kept when parsing cookie headers
- Add session libraries
- Support for OCaml 4.07.1
