### PR TITLE
[new release] 0install-gtk, 0install and 0install-solver (2.17)

### DIFF
--- a/packages/0install-gtk/0install-gtk.2.17/opam
+++ b/packages/0install-gtk/0install-gtk.2.17/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Decentralised installation system - GTK UI"
+maintainer: "talex5@gmail.com"
+authors: "zero-install-devel@lists.sourceforge.net"
+homepage: "https://github.com/0install/0install"
+bug-reports: "https://github.com/0install/0install/issues"
+dev-repo: "git+https://github.com/0install/0install.git"
+doc: "https://0install.github.io/0install/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "0install" {= version}
+  "ounit2" {with-test}
+  "dune" {>= "2.1"}
+  "lablgtk3" {>= "3"}
+  "lwt_glib"
+]
+description: """
+Zero Install is a decentralised cross-distribution software installation system.
+This package provides a GTK-based user interface for it."""
+url {
+  src:
+    "https://github.com/0install/0install/releases/download/v2.17/0install-v2.17.tbz"
+  checksum: [
+    "sha256=1704e5d852bad79ef9f5b5b31146846420270411c5396434f6fe26577f2d0923"
+    "sha512=6ac7f2c8719018414f2b08ab799e641e54c5689a38a85c4014d9f02bc4a14dcdbcd764dec63036fb4b0a0302e26f22d40473aded78b6a08d639849f3e365d42a"
+  ]
+}

--- a/packages/0install-solver/0install-solver.2.17/opam
+++ b/packages/0install-solver/0install-solver.2.17/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Package dependency solver"
+maintainer: "talex5@gmail.com"
+authors: "zero-install-devel@lists.sourceforge.net"
+homepage: "https://github.com/0install/0install"
+bug-reports: "https://github.com/0install/0install/issues"
+dev-repo: "git+https://github.com/0install/0install.git"
+doc: "https://0install.github.io/0install/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.1"}
+  "ounit2" {with-test}
+]
+description: """
+A package dependency resolver based on a SAT solver. This was originally
+written for the 0install package manager, but is now generic and is also used
+as a solver backend for opam.
+The SAT solver is based on MiniSat (http://minisat.se/Papers.html) and
+the application to package management is based on OPIUM (Optimal Package
+Install/Uninstall Manager). 0install-solver uses a (novel?) strategy to find
+the optimal solution extremely quickly (even for a SAT-based solver).
+"""
+url {
+  src:
+    "https://github.com/0install/0install/releases/download/v2.17/0install-v2.17.tbz"
+  checksum: [
+    "sha256=1704e5d852bad79ef9f5b5b31146846420270411c5396434f6fe26577f2d0923"
+    "sha512=6ac7f2c8719018414f2b08ab799e641e54c5689a38a85c4014d9f02bc4a14dcdbcd764dec63036fb4b0a0302e26f22d40473aded78b6a08d639849f3e365d42a"
+  ]
+}

--- a/packages/0install/0install.2.17/opam
+++ b/packages/0install/0install.2.17/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Decentralised installation system"
+maintainer: "talex5@gmail.com"
+authors: "zero-install-devel@lists.sourceforge.net"
+homepage: "https://github.com/0install/0install"
+bug-reports: "https://github.com/0install/0install/issues"
+dev-repo: "git+https://github.com/0install/0install.git"
+doc: "https://0install.github.io/0install/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "0install-solver"
+  "yojson"
+  "xmlm"
+  "ounit2" {with-test}
+  "lwt"
+  "lwt_react"
+  "obus" {os != "macos" & os-family != "windows"}
+  "ocurl" {>= "0.7.9"}
+  "sha" {>= "1.9"}
+  "dune" {>= "2.1"}
+]
+depexts: [
+  ["gnupg" "unzip"] {os-family = "debian"}
+  ["gnupg" "unzip"] {os-distribution = "alpine"}
+  ["gnupg"] {os = "macos" & os-distribution = "homebrew"}
+]
+description: """
+Zero Install is a decentralised cross-distribution software installation system.
+Other features include full support for shared libraries (with a SAT solver for
+dependency resolution), sharing between users, and integration with native platform
+package managers. It supports both binary and source packages, and works on Linux,
+macOS, Unix and Windows systems."""
+url {
+  src:
+    "https://github.com/0install/0install/releases/download/v2.17/0install-v2.17.tbz"
+  checksum: [
+    "sha256=1704e5d852bad79ef9f5b5b31146846420270411c5396434f6fe26577f2d0923"
+    "sha512=6ac7f2c8719018414f2b08ab799e641e54c5689a38a85c4014d9f02bc4a14dcdbcd764dec63036fb4b0a0302e26f22d40473aded78b6a08d639849f3e365d42a"
+  ]
+}


### PR DESCRIPTION
Decentralised installation system - GTK UI

- Project page: <a href="https://github.com/0install/0install">https://github.com/0install/0install</a>
- Documentation: <a href="https://0install.github.io/0install/">https://0install.github.io/0install/</a>

##### CHANGES:

Solver:

- Add 0install-solver.opam. This makes the solver into a separate opam package.

- Improve display of implementations in diagnostics. Instead of `sha1=3ce644dc725f1d21cfcf02562c76f375944b266a (1)`, show: `v1 (sha1=3ce644dc725f...)`.

- Only report restrictions that affected the result. If a restriction didn't remove any candidates (either because it matched all of them or because another restriction already removed them) then don't bother reporting it. Also, don't bother reporting a restriction that only removed candidates worse than the selected one (if any). For user-provided restrictions, filter the rejects to show only the version the user asked for (unless that would remove all of them). Since we only show the first 5 rejects, this would often mean that the interesting candidates weren't even shown.

- Expose more of the solver diagnostics API. This allows users to format the results in other ways (for example, as a list in a GUI). Also, use formatting boxes instead of manual indentation.

- Add `conflict_class`. This isn't used by 0install, but the new opam backend that uses the 0install solver needs it.

Build:

- Update minimum OCaml version to 4.08. Remove our custom `Option` module and use the new stdlib one instead. Use the new `List.filter_map` from the stdlib instead of our one. Also, rename our `first_match` to `find_map`, to match the name in 4.10.

- Depend on ounit2 for unit-tests. The old `oUnit` is just a transition package that depends on `ounit2` now.
