### PR TITLE
[new release] ppx_defer (0.4.0)

### DIFF
--- a/packages/ppx_defer/ppx_defer.0.4.0/opam
+++ b/packages/ppx_defer/ppx_defer.0.4.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Go-like [%defer later]; now syntax"
+maintainer: ["Hezekiah M. Carty <hez@0ok.org>"]
+authors: ["Hezekiah M. Carty <hez@0ok.org>"]
+license: "MIT"
+homepage: "https://github.com/hcarty/ppx_defer"
+bug-reports: "https://github.com/hcarty/ppx_defer/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "2.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ppx_tools_versioned"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hcarty/ppx_defer.git"
+url {
+  src:
+    "https://github.com/hcarty/ppx_defer/releases/download/v0.4.0/ppx_defer-v0.4.0.tbz"
+  checksum: [
+    "sha256=c505b537074c98b0e33101ec8862fb3cf4538f16f94b89e67f51b810131ddde5"
+    "sha512=f8093c92c4033cdc97816dd0cd75fd0415db53aadce5be079a90e5ce91e2a30310024eb58f185bda4c2819fd7a2fe8c4426a2a0e2d79da5d7f9e2d16535e8e8e"
+  ]
+}

--- a/packages/ppx_defer/ppx_defer.0.4.0/opam
+++ b/packages/ppx_defer/ppx_defer.0.4.0/opam
@@ -8,6 +8,8 @@ bug-reports: "https://github.com/hcarty/ppx_defer/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "2.0"}
+  "lwt" {with-test}
+  "lwt_ppx" {with-test}
   "ocaml-migrate-parsetree" {>= "1.5.0"}
   "ppx_tools_versioned"
 ]


### PR DESCRIPTION
Go-like [%defer later]; now syntax

- Project page: <a href="https://github.com/hcarty/ppx_defer">https://github.com/hcarty/ppx_defer</a>

##### CHANGES:

* Upgrade to dune
* Use dune to generate opam metadata
* Use 4.10 AST from ocaml-migrate-parsetree and ppx\_tools\_versioned
