### PR TITLE
Redirect Wasm packages to new tag names

### DIFF
--- a/packages/wasm/wasm.0.13/opam
+++ b/packages/wasm/wasm.0.13/opam
@@ -18,6 +18,6 @@ depends: [
 synopsis:
   "An OCaml library to read and write Web Assembly (wasm) files and manipulate their AST."
 url {
-  src: "https://github.com/WebAssembly/spec/archive/v0.13.tar.gz"
-  checksum: "md5=e0d55d6ecd93d0f750145512599c536d"
+  src: "https://github.com/WebAssembly/spec/archive/opam-0.13.zip"
+  checksum: "md5=96755299361df7b89111b5810528352b"
 }

--- a/packages/wasm/wasm.0.13/opam
+++ b/packages/wasm/wasm.0.13/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 synopsis:
-  "An OCaml library to read and write Web Assembly (wasm) files and manipulate their AST."
+  "Library to read and write WebAssembly (Wasm) files and manipulate their AST"
 url {
   src: "https://github.com/WebAssembly/spec/archive/opam-0.13.zip"
   checksum: "md5=96755299361df7b89111b5810528352b"

--- a/packages/wasm/wasm.1.0.1/opam
+++ b/packages/wasm/wasm.1.0.1/opam
@@ -17,6 +17,6 @@ depends: [
 synopsis:
   "An OCaml library for reading and writing WebAssembly (Wasm) files and manipulate their AST"
 url {
-  src: "https://github.com/WebAssembly/spec/archive/v1.0.1.zip"
-  checksum: "md5=d15e756a45458c7f7818a257f2e5b02f"
+  src: "https://github.com/WebAssembly/spec/archive/opam-1.0.1.zip"
+  checksum: "md5=1620a741ed65a1be380136d62e282e9f"
 }

--- a/packages/wasm/wasm.1.0.1/opam
+++ b/packages/wasm/wasm.1.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 synopsis:
-  "An OCaml library for reading and writing WebAssembly (Wasm) files and manipulate their AST"
+  "Library to read and write WebAssembly (Wasm) files and manipulate their AST"
 url {
   src: "https://github.com/WebAssembly/spec/archive/opam-1.0.1.zip"
   checksum: "md5=1620a741ed65a1be380136d62e282e9f"

--- a/packages/wasm/wasm.1.0/opam
+++ b/packages/wasm/wasm.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 synopsis:
-  "An OCaml library to read and write Web Assembly (wasm) files and manipulate their AST."
+  "Library to read and write WebAssembly (Wasm) files and manipulate their AST"
 url {
   src: "https://github.com/WebAssembly/spec/archive/opam-1.0.zip"
   checksum: "md5=20aa180dfe8d8028c020f9854efabf8a"

--- a/packages/wasm/wasm.1.0/opam
+++ b/packages/wasm/wasm.1.0/opam
@@ -18,6 +18,6 @@ depends: [
 synopsis:
   "An OCaml library to read and write Web Assembly (wasm) files and manipulate their AST."
 url {
-  src: "https://github.com/WebAssembly/spec/archive/v1.0.zip"
-  checksum: "md5=82d4cc7c67ae32a6785268a1cdddd973"
+  src: "https://github.com/WebAssembly/spec/archive/opam-1.0.zip"
+  checksum: "md5=20aa180dfe8d8028c020f9854efabf8a"
 }

--- a/packages/wasm/wasm.1.1.1/opam
+++ b/packages/wasm/wasm.1.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 synopsis:
-  "An OCaml library to read and write Web Assembly (wasm) files and manipulate their AST."
+  "Library to read and write WebAssembly (Wasm) files and manipulate their AST"
 url {
   src: "https://github.com/WebAssembly/spec/archive/opam-1.1.1.zip"
   checksum: "md5=331c984a40d2f37524a10d70f427abf7"

--- a/packages/wasm/wasm.1.1/opam
+++ b/packages/wasm/wasm.1.1/opam
@@ -17,6 +17,6 @@ depends: [
 synopsis:
   "An OCaml library to read and write Web Assembly (wasm) files and manipulate their AST."
 url {
-  src: "https://github.com/WebAssembly/spec/archive/v1.1.zip"
-  checksum: "md5=b3589f0015fd1996b5674baba519a787"
+  src: "https://github.com/WebAssembly/spec/archive/opam-1.1.zip"
+  checksum: "md5=ca8653ea9b27e8995e3d268dd7a772fd"
 }

--- a/packages/wasm/wasm.1.1/opam
+++ b/packages/wasm/wasm.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 synopsis:
-  "An OCaml library to read and write Web Assembly (wasm) files and manipulate their AST."
+  "Library to read and write WebAssembly (Wasm) files and manipulate their AST"
 url {
   src: "https://github.com/WebAssembly/spec/archive/opam-1.1.zip"
   checksum: "md5=ca8653ea9b27e8995e3d268dd7a772fd"


### PR DESCRIPTION
In order to complete a clean-up of the tagging scheme in the Wasm spec repo, this PR changes the existing Wasm packages to point to the new tag names.

Note: Since GH's zip file generator mangles the tag name into the toplevel dir name inside the zip, this also changes the MD5's, even though the actual source contents aren't changed.