### PR TITLE
[new release] emile (0.9)

### DIFF
--- a/packages/emile/emile.0.9/opam
+++ b/packages/emile/emile.0.9/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/emile"
+bug-reports:  "https://github.com/dinosaure/emile/issues"
+dev-repo:     "git+https://github.com/dinosaure/emile.git"
+doc:          "https://dinosaure.github.io/emile/"
+license:      "MIT"
+synopsis:     "Parser of email address according RFC822"
+description: """A parser of email address according RFC822, RFC2822, RFC5321 and RFC6532.
+It handles UTF-8 email addresses and encoded-word according RFC2047."""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {>= "1.0"}
+  "angstrom" {>= "0.14.0"}
+  "ipaddr"   {>= "2.7.0"}
+  "base64"   {>= "3.0.0"}
+  "pecu"
+  "uutf"
+  "alcotest" {with-test}
+]
+depopts: [ "cmdliner" ]
+url {
+  src:
+    "https://github.com/dinosaure/emile/releases/download/v0.9/emile-v0.9.tbz"
+  checksum: [
+    "sha256=a3416d5ad183ba7cd009aad7681bddcd9cba15fcc4c59c1ebd603179ed28e215"
+    "sha512=d3202d69a39e0719a10a2672d212da74f25bdc577cbbc2969fc9d82178a070aa7aead8381afb92355e2bf681b69967347bc303e242966fc8cb9758df6d446ed5"
+  ]
+}


### PR DESCRIPTION
Parser of email address according RFC822

- Project page: <a href="https://github.com/dinosaure/emile">https://github.com/dinosaure/emile</a>
- Documentation: <a href="https://dinosaure.github.io/emile/">https://dinosaure.github.io/emile/</a>

##### CHANGES:

- Update to `angstrom.0.14.0`
