### PR TITLE
[new release] coin (0.1.3)

### DIFF
--- a/packages/coin/coin.0.1.3/opam
+++ b/packages/coin/coin.0.1.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/coin"
+bug-reports:  "https://github.com/mirage/coin/issues"
+dev-repo:     "git+https://github.com/mirage/coin.git"
+doc:          "https://mirage.github.io/coin/"
+license:      "MIT"
+synopsis:     "Mapper of KOI8-{U,R} to Unicode"
+description: """A simple mapper between KOI8-{U,R} to Unicode. Useful for
+a translation between KOI8-{U,R} and Unicode"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "dune"
+  "re"
+  "menhir"
+]
+url {
+  src:
+    "https://github.com/mirage/coin/releases/download/v0.1.3/coin-v0.1.3.tbz"
+  checksum: [
+    "sha256=7b2d781664f7b99f5bf047ba5522007352422552daa017a4bb1ce16b059f253f"
+    "sha512=148e3b4302154800aee892464eea095938d5194e6fb4a74a92940ab467b2fc2a98d99795a4feffc3f69a0fa8f05b7aae2caa98a91298d80bc7220941caf01fe5"
+  ]
+}


### PR DESCRIPTION
Mapper of KOI8-{U,R} to Unicode

- Project page: <a href="https://github.com/mirage/coin">https://github.com/mirage/coin</a>
- Documentation: <a href="https://mirage.github.io/coin/">https://mirage.github.io/coin/</a>

##### CHANGES:

* Remove `angstrom` as a dependency of `coin`
