### PR TITLE
[new release] hxd (0.2.0)

### DIFF
--- a/packages/hxd/hxd.0.2.0/opam
+++ b/packages/hxd/hxd.0.2.0/opam
@@ -20,6 +20,7 @@ build: [
 depends: [
   "ocaml"      {>= "4.06.0"}
   "dune"       {>= "2.0"}
+  "dune-configurator"
   "base-bytes"
   "base-bigarray"
   "base-unix"

--- a/packages/hxd/hxd.0.2.0/opam
+++ b/packages/hxd/hxd.0.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name:         "hxd"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/hxd"
+bug-reports:  "https://github.com/dinosaure/hxd/issues"
+dev-repo:     "git+https://github.com/dinosaure/hxd.git"
+doc:          "https://dinosaure.github.io/hxd/"
+license:      "MIT"
+synopsis:     "Hexdump in OCaml"
+description: """Please, help me to debug ocaml-git
+"""
+
+build: [
+  [ "dune" "subst" ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.06.0"}
+  "dune"       {>= "2.0"}
+  "base-bytes"
+  "base-bigarray"
+  "base-unix"
+  "angstrom" {>= "0.14.0"}
+  "stdlib-shims"
+  "rresult"
+  "fmt"
+  "cmdliner"
+  "fpath"
+]
+url {
+  src:
+    "https://github.com/dinosaure/hxd/releases/download/v0.2.0/hxd-v0.2.0.tbz"
+  checksum: [
+    "sha256=3438fc2308d2d2161ba5c9463e7b4510683f361c4e7f0818e889315400ceced3"
+    "sha512=6df3e07c202792f0c029eabf4f48b1036feb61bcd26262741d2b1a8f22d457d60d0c05782b7fcf4ec39acc8fe077c6f4661a77a7497758dd6944691ad468e37a"
+  ]
+}

--- a/packages/mrmime/mrmime.0.2.0/opam
+++ b/packages/mrmime/mrmime.0.2.0/opam
@@ -32,7 +32,7 @@ depends: [
   "bigarray-compat"
   "bigarray-overlap"
   "angstrom"        {>= "0.11.0"}
-  "hxd"             {with-testi & = "v0.1.0"}
+  "hxd"             {with-test & = "v0.1.0"}
   "alcotest"        {with-test}
   "jsonm"           {with-test}
 ]

--- a/packages/mrmime/mrmime.0.2.0/opam
+++ b/packages/mrmime/mrmime.0.2.0/opam
@@ -31,7 +31,7 @@ depends: [
   "bigstringaf"
   "bigarray-compat"
   "bigarray-overlap"
-  "angstrom"        {>= "0.11.0"}
+  "angstrom"        {>= "0.11.0" & < "0.14.0"}
   "hxd"             {with-test & = "0.1.0"}
   "alcotest"        {with-test}
   "jsonm"           {with-test}

--- a/packages/mrmime/mrmime.0.2.0/opam
+++ b/packages/mrmime/mrmime.0.2.0/opam
@@ -32,7 +32,7 @@ depends: [
   "bigarray-compat"
   "bigarray-overlap"
   "angstrom"        {>= "0.11.0"}
-  "hxd"             {with-test}
+  "hxd"             {with-testi & = "v0.1.0"}
   "alcotest"        {with-test}
   "jsonm"           {with-test}
 ]

--- a/packages/mrmime/mrmime.0.2.0/opam
+++ b/packages/mrmime/mrmime.0.2.0/opam
@@ -32,7 +32,7 @@ depends: [
   "bigarray-compat"
   "bigarray-overlap"
   "angstrom"        {>= "0.11.0"}
-  "hxd"             {with-test & = "v0.1.0"}
+  "hxd"             {with-test & = "0.1.0"}
   "alcotest"        {with-test}
   "jsonm"           {with-test}
 ]

--- a/packages/unstrctrd/unstrctrd.0.1/opam
+++ b/packages/unstrctrd/unstrctrd.0.1/opam
@@ -24,7 +24,7 @@ depends: [
   "alcotest"    {with-test}
   "ke"          {with-test}
   "bigstringaf" {with-test}
-  "hxd"         {with-test}
+  "hxd"         {with-test & = "v0.1.0"}
 ]
 url {
   src:

--- a/packages/unstrctrd/unstrctrd.0.1/opam
+++ b/packages/unstrctrd/unstrctrd.0.1/opam
@@ -24,7 +24,7 @@ depends: [
   "alcotest"    {with-test}
   "ke"          {with-test}
   "bigstringaf" {with-test}
-  "hxd"         {with-test & = "v0.1.0"}
+  "hxd"         {with-test & = "0.1.0"}
 ]
 url {
   src:


### PR DESCRIPTION
Hexdump in OCaml

- Project page: <a href="https://github.com/dinosaure/hxd">https://github.com/dinosaure/hxd</a>
- Documentation: <a href="https://dinosaure.github.io/hxd/">https://dinosaure.github.io/hxd/</a>

##### CHANGES:

- Update to use `angstrom.0.14.0`
- Use `stdlib-shims` and remove deprecated functions about formatter
