### PR TITLE
[new release] elpi (1.11.0)

### DIFF
--- a/packages/elpi/elpi.1.11.0/opam
+++ b/packages/elpi/elpi.1.11.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/LPCIC/elpi/issues"
 build: [
   ["dune" "subst"] {pinned}
   [make "build" "DUNE_OPTS=-p %{name}% -j %{jobs}%"]
-  [make "tests" "DUNE_OPTS=-p %{name}%" "TIMEOUT=120"] {with-test & os != "macos"}
+  [make "tests" "DUNE_OPTS=-p %{name}%" "TIMEOUT=120"] {with-test & os != "macos" & os-distribution != "alpine"}
   [make "fix-elpi.install"]
 ]
 

--- a/packages/elpi/elpi.1.11.0/opam
+++ b/packages/elpi/elpi.1.11.0/opam
@@ -1,0 +1,84 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Claudio Sacerdoti Coen" "Enrico Tassi" ]
+license: "LGPL 2.1+"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+build: [
+  ["dune" "subst"] {pinned}
+  [make "build" "DUNE_OPTS=-p %{name}% -j %{jobs}%"]
+  [make "tests" "DUNE_OPTS=-p %{name}%" "TIMEOUT=120"] {with-test & os != "macos"}
+  [make "fix-elpi.install"]
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "camlp5"
+  "ppxlib"
+  "ppx_deriving"
+  "re" {>= "1.7.2"}
+  "ANSITerminal" {with-test}
+  "cmdliner" {with-test}
+  "dune" {>= "2.0.0"}
+  "conf-time" {with-test}
+]
+synopsis: "ELPI - Embeddable λProlog Interpreter"
+description: """
+ELPI implements a variant of λProlog enriched with Constraint Handling Rules,
+a programming language well suited to manipulate syntax trees with binders.
+
+ELPI is designed to be embedded into larger applications written in OCaml as
+an extension language. It comes with an API to drive the interpreter and 
+with an FFI for defining built-in predicates and data types, as well as
+quotations and similar goodies that are handy to adapt the language to the host
+application.
+
+This package provides both a command line interpreter (elpi) and a library to
+be linked in other applications (eg by passing -package elpi to ocamlfind).
+
+The ELPI programming language has the following features:
+
+- Native support for variable binding and substitution, via an Higher Order
+  Abstract Syntax (HOAS) embedding of the object language. The programmer needs
+  not to care about De Bruijn indexes.
+
+- Native support for hypothetical context. When moving under a binder one can
+  attach to the bound variable extra information that is collected when the
+  variable gets out of scope. For example when writing a type-checker the
+  programmer needs not to care about managing the typing context.
+
+- Native support for higher order unification variables, again via HOAS.
+  Unification variables of the meta-language (λProlog) can be reused to
+  represent the unification variables of the object language. The programmer
+  does not need to care about the unification-variable assignment map and
+  cannot assign to a unification variable a term containing variables out of
+  scope, or build a circular assignment.
+
+- Native support for syntactic constraints and their meta-level handling rules.
+  The generative semantics of Prolog can be disabled by turning a goal into a
+  syntactic constraint (suspended goal). A syntactic constraint is resumed as
+  soon as relevant variables gets assigned. Syntactic constraints can be
+  manipulated by constraint handling rules (CHR).
+
+- Native support for backtracking. To ease implementation of search.
+
+- The constraint store is extensible.  The host application can declare
+  non-syntactic constraints and use custom constraint solvers to check their
+  consistency.
+
+- Clauses are graftable. The user is free to extend an existing program by
+  inserting/removing clauses, both at runtime (using implication) and at
+  "compilation" time by accumulating files.
+
+ELPI is free software released under the terms of LGPL 2.1 or above."""
+url {
+  src:
+    "https://github.com/LPCIC/elpi/releases/download/v1.11.0/elpi-v1.11.0.tbz"
+  checksum: [
+    "sha256=f7ed0f01e021c9a582ff01c33b64df56a5ed312544b5ca2517c6d867b7764ade"
+    "sha512=a101f602b97057fe95fd755cef613bdb1074f496f3744ddf4947e957ff671e3dce96d6abb84d65967182fc01bfca444d5545ecb8a70bc2823e78a50c9052bcab"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- Builtin:
  - `var` now accepts 3 arguments, as `constant` and `name`.

- Trace:
  - output facilities: json and tty on both files and network sockets
  - trace messages to link goals to their subgoals
  - spy points categorized into `user` and `dev`
  - all trace points were revised and improved
  - port to ppxlib

- Build system:
  - minimal build dependencies are now: camlp5 ocamlfind dune re
  - cache ppx output in .ml format in `src/.ppcache` that Elpi can be buildt
    without `ppx_deriving.std` and `elpi.trace.ppx` using a new tool in
    `ppxfindcache/`
  - vendor a copy of `ppx_deriving_runtime` (suffix `_proxy`) to be used when
    `ppx_deriving` is not installed
  - generate custom `merlinppx.exe` for `src/` and and patch `.merlin` file so
    that one can have decent merlin support
  - make target `test-noppx` to compile on an alternative opam switch