### PR TITLE
hacl v0.2

### DIFF
--- a/packages/hacl/hacl.0.2/opam
+++ b/packages/hacl/hacl.0.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+authors: [ "Vincent Bernardoff <vb@luminar.eu.org>" "Marco Stronati <marco@stronati.org>" ]
+maintainer: "contact@tezos.com"
+synopsis: "Tezos binding for Hacl*"
+homepage: "https://gitlab.com/nomadic-labs/ocaml-hacl"
+bug-reports: "https://gitlab.com/nomadic-labs/ocaml-hacl/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ocaml-hacl.git"
+license: "MIT"
+depends: [
+  "dune" {>= "1.7" & < "2.0"}
+  "bigstring" {>= "0.1.1"}
+  "ocplib-endian" {>= "1.0"}
+  "zarith" {>= "1.7"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "hex" {with-test & >= "1.4.0"}
+  "base" {< "v0.14"}
+  "stdio" {< "v0.14"}
+]
+build: [
+  ["dune" "build" "-j" jobs "-p" name "@install"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ocaml-hacl/-/archive/v0.2/ocaml-hacl-v0.2.tar.gz"
+  checksum: [
+    "sha256=84c4f6c4c54c8386d8b44d5a48840d8fec25568fbe64b3c6414d21d4d8cb4afc"
+    "sha512=f565673faf6587ad786bd747e25664a9e1c22b549ed801c444ee40840d8fb6b49b248fae9205743e1b47c7244a182758380eeaa5b802f5a0f3b7eb4bbe8667f6"
+  ]
+}


### PR DESCRIPTION
This release fixes a segfault! in tezos-node. Tezos release will immediatly follow the merge of this.