### PR TITLE
2 packages from oxidizing/sihl at 0.0.20

### DIFF
--- a/packages/sihl_core/sihl_core.0.0.20/opam
+++ b/packages/sihl_core/sihl_core.0.0.20/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "A web framework for Reason and OCaml"
+description:
+  "A web framework for Reason and OCaml to build web apps rapidly."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.3.0"}
+  "base" {>= "v0.13.1"}
+  "opium" {>= "0.17.1"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.5.2"}
+  "caqti" {>= "1.2.1"}
+  "caqti-lwt" {>= "1.2.0"}
+  "caqti-driver-postgresql" {>= "1.2.1"}
+  "caqti-driver-mariadb" {>= "1.2.1"}
+  "ppx_rapper" {>= "0.9.2"}
+  "tyxml" {>= "4.3.0"}
+  "tyxml-ppx" {>= "4.3.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.8"}
+  "pcre" {>= "7.4.3"}
+  "safepass" {>= "3.0"}
+  "uuidm" {>= "0.9.7"}
+  "sexplib" {>= "0.13.0"}
+  "ppx_fields_conv" {>= "0.13.0"}
+  "ppx_sexp_conv" {>= "0.13.0"}
+  "ppx_string_interpolation" {>= "1.0.0"}
+  "utop" {dev}
+  "merlin" {dev}
+  "ocamlformat" {dev}
+  "ocp-indent" {dev}
+  "tuareg" {dev}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.20.tar.gz"
+  checksum: [
+    "md5=66471a4b65d459f62cb7c57cf2999466"
+    "sha512=5beaf10dc0ff115dffd8c687d2329e83a02d9fec2405c327cb0ff3c7d561d4ad2ab6dc43c3b2099b19ef6fbcc69b8ede68f96cc247efe01146c828f0f9427c35"
+  ]
+}

--- a/packages/sihl_users/sihl_users.0.0.20/opam
+++ b/packages/sihl_users/sihl_users.0.0.20/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A user management app for Sihl"
+description:
+  "This app provides an Admin UI, Email confirmation & Password reset workflows, an HTTP API and a Service API supporting MariaDB and Postgres."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.3.0"}
+  "sihl_core" {>= "0.0.20"}
+  "base" {>= "v0.13.1"}
+  "ppx_rapper" {>= "0.9.2"}
+  "utop" {dev}
+  "merlin" {dev}
+  "ocamlformat" {dev}
+  "ocp-indent" {dev}
+  "tuareg" {dev}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.20.tar.gz"
+  checksum: [
+    "md5=66471a4b65d459f62cb7c57cf2999466"
+    "sha512=5beaf10dc0ff115dffd8c687d2329e83a02d9fec2405c327cb0ff3c7d561d4ad2ab6dc43c3b2099b19ef6fbcc69b8ede68f96cc247efe01146c828f0f9427c35"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`sihl_core.0.0.20`: A web framework for Reason and OCaml
-`sihl_users.0.0.20`: A user management app for Sihl



---
* Homepage: https://github.com/oxidizing/sihl
* Bug tracker: https://github.com/oxidizing/sihl/issues

---
:camel: Pull-request generated by opam-publish v2.0.2