### PR TITLE
[new release] decoders, decoders-bencode, decoders-cbor, decoders-ezjsonm, decoders-jsonm, decoders-sexplib and decoders-yojson (0.4.0)

### DIFF
--- a/packages/decoders-bencode/decoders-bencode.0.4.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Matt Bray <mattjbray@gmail.com>"
+authors: ["Simon Cruanes"]
+synopsis: "Bencode interface for decoders"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders-bencode"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "containers" {with-test}
+  "decoders"
+  "bencode"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz"
+  checksum: [
+    "sha256=18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
+    "sha512=a6221b40cc1c3d9ea46c5e7cec6c5992b923e390ce004c23d7f36e99974c10f6d4a690113255b85d3895f357e0dd44562e9bc03ba8708223cb1e56ba182c10d3"
+  ]
+}

--- a/packages/decoders-cbor/decoders-cbor.0.4.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.0.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Matt Bray <mattjbray@gmail.com>"
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+synopsis: "CBOR interface for decoders"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders-cbor"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "containers" {with-test}
+  "decoders"
+  "cbor"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz"
+  checksum: [
+    "sha256=18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
+    "sha512=a6221b40cc1c3d9ea46c5e7cec6c5992b923e390ce004c23d7f36e99974c10f6d4a690113255b85d3895f357e0dd44562e9bc03ba8708223cb1e56ba182c10d3"
+  ]
+}

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.4.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Matt Bray <matt@aestheticintegration.com>"
+authors: ["Matt Bray <matt@aestheticintegration.com>"]
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+synopsis: "Interface to ezjsonm for decoders"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders-ezjsonm"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "containers" {with-test}
+  "decoders"
+  "ezjsonm" {>= "0.4.0"}
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz"
+  checksum: [
+    "sha256=18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
+    "sha512=a6221b40cc1c3d9ea46c5e7cec6c5992b923e390ce004c23d7f36e99974c10f6d4a690113255b85d3895f357e0dd44562e9bc03ba8708223cb1e56ba182c10d3"
+  ]
+}

--- a/packages/decoders-jsonm/decoders-jsonm.0.4.0/opam
+++ b/packages/decoders-jsonm/decoders-jsonm.0.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Matt Bray <matt@aestheticintegration.com>"
+authors: ["Matt Bray <matt@aestheticintegration.com>"]
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+synopsis: "Interface to jsonm for decoders"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders-jsonm"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "containers" {with-test}
+  "decoders"
+  "jsonm"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz"
+  checksum: [
+    "sha256=18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
+    "sha512=a6221b40cc1c3d9ea46c5e7cec6c5992b923e390ce004c23d7f36e99974c10f6d4a690113255b85d3895f357e0dd44562e9bc03ba8708223cb1e56ba182c10d3"
+  ]
+}

--- a/packages/decoders-sexplib/decoders-sexplib.0.4.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.0.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Matt Bray <mattjbray@gmail.com>"
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+synopsis: "Sexplib interface for decoders"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders-sexplib"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "containers" {with-test}
+  "decoders"
+  "sexplib0"
+  "sexplib"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz"
+  checksum: [
+    "sha256=18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
+    "sha512=a6221b40cc1c3d9ea46c5e7cec6c5992b923e390ce004c23d7f36e99974c10f6d4a690113255b85d3895f357e0dd44562e9bc03ba8708223cb1e56ba182c10d3"
+  ]
+}

--- a/packages/decoders-yojson/decoders-yojson.0.4.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Matt Bray <matt@aestheticintegration.com>"
+authors: ["Matt Bray <matt@aestheticintegration.com>"]
+synopsis: "Interface to yojson for decoders"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders-yojson"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "decoders"
+  "yojson"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz"
+  checksum: [
+    "sha256=18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
+    "sha512=a6221b40cc1c3d9ea46c5e7cec6c5992b923e390ce004c23d7f36e99974c10f6d4a690113255b85d3895f357e0dd44562e9bc03ba8708223cb1e56ba182c10d3"
+  ]
+}

--- a/packages/decoders/decoders.0.4.0/opam
+++ b/packages/decoders/decoders.0.4.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Elm-inspired decoders for Ocaml"
+description: """
+A combinator library for "decoding" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`.
+
+> Eh?
+
+An Ocaml program having a JSON (or YAML) data source usually goes something like this:
+
+1. Get your data from somewhere. Now you have a `string`.
+2. *Parse* the `string` as JSON (or YAML). Now you have a `Yojson.Basic.json`, or maybe an `Ezjsonm.value`, or perhaps a `Ocyaml.yaml`.
+3. *Decode* the JSON value to an Ocaml type that's actually useful for your program's domain.
+
+This library helps with step 3.
+"""
+maintainer: "Matt Bray <matt@aestheticintegration.com>"
+authors: ["Matt Bray <matt@aestheticintegration.com>"]
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "containers" {with-test}
+  "ocaml" { >= "4.03.0" }
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.4.0/decoders-v0.4.0.tbz"
+  checksum: [
+    "sha256=18ebbd98901dff67c9944d465ed508df018c8ee8e13bfe037d5ad780584eebf7"
+    "sha512=a6221b40cc1c3d9ea46c5e7cec6c5992b923e390ce004c23d7f36e99974c10f6d4a690113255b85d3895f357e0dd44562e9bc03ba8708223cb1e56ba182c10d3"
+  ]
+}


### PR DESCRIPTION
Elm-inspired decoders for Ocaml

- Project page: <a href="https://github.com/mattjbray/ocaml-decoders">https://github.com/mattjbray/ocaml-decoders</a>
- Documentation: <a href="https://mattjbray.github.io/ocaml-decoders/decoders">https://mattjbray.github.io/ocaml-decoders/decoders</a>

##### CHANGES:

* Expose `null` decoder (mattjbray/ocaml-decoders#18, @mattjbray)
* Rename `Encode.option` to `Encode.nullable` (mattjbray/ocaml-decoders#19, @mattjbray)
* Add `Decoders_jsonm` (mattjbray/ocaml-decoders#20, @mattjbray)
