### PR TITLE
[new release] subscriptions-transport-ws (0.1.0)

### DIFF
--- a/packages/subscriptions-transport-ws/subscriptions-transport-ws.0.1.0/opam
+++ b/packages/subscriptions-transport-ws/subscriptions-transport-ws.0.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-subscriptions-transport-ws"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-subscriptions-transport-ws.git"
+bug-reports: "https://github.com/anmonteiro/ocaml-subscriptions-transport-ws/issues"
+doc: "https://anmonteiro.github.io/gluten/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "graphql"
+  "graphql_parser"
+  "websocketaf"
+]
+synopsis:
+  "Websocket protocol for exchanging GraphQL requests and responses"
+description: """
+subscriptions-transport-ws implements the Apollo GraphQL protocol
+(https://github.com/apollographql/subscriptions-transport-ws) for exchanging
+GraphQL requests and responses over a websocket connection.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-subscriptions-transport-ws/releases/download/0.1.0/subscriptions-transport-ws-0.1.0.tbz"
+  checksum: [
+    "sha256=03c04ff7ca01ccc8ca7a50d7ca9b5d84d9ad33204ede4f867cc03519d80cd89d"
+    "sha512=74171609de978694920c4284466f086e6b0ea6f00d2b187293c78a3a665a7c3b94943f985f3cc7ebf54293039ee6a402fe60b4c9be65859f158017c888014315"
+  ]
+}


### PR DESCRIPTION
Websocket protocol for exchanging GraphQL requests and responses

- Project page: <a href="https://github.com/anmonteiro/ocaml-subscriptions-transport-ws">https://github.com/anmonteiro/ocaml-subscriptions-transport-ws</a>
- Documentation: <a href="https://anmonteiro.github.io/gluten/">https://anmonteiro.github.io/gluten/</a>

##### CHANGES:

- Initial public release
