### PR TITLE
[new release] mssql (2.0.2)

### DIFF
--- a/packages/mssql/mssql.2.0.2/opam
+++ b/packages/mssql/mssql.2.0.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Async SQL Server client using FreeTDS"
+description:
+  "Mssql wraps FreeTDS in a nicer and safer interface, with support for parameterized queries, thread-based async IO, and a thread pool."
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "Apache-2.0"
+homepage: "https://github.com/arenadotio/ocaml-mssql"
+doc: "https://arenadotio.github.io/ocaml-mssql"
+bug-reports: "https://github.com/arenadotio/ocaml-mssql/issues"
+depends: [
+  "alcotest" {with-test & >= "1.0.1"}
+  "alcotest-async" {with-test & >= "1.0.1"}
+  "async_unix"
+  "bignum"
+  "ppx_jane"
+  "iter" {>= "1.2"}
+  "ocaml" {>= "4.06.1"}
+  "odoc" {with-doc}
+  "logs"
+  "text" {>= "0.8.0"}
+  "freetds" {>= "0.7"}
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "dune" {>= "1.11"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/ocaml-mssql.git"
+url {
+  src:
+    "https://github.com/arenadotio/ocaml-mssql/releases/download/2.0.2/mssql-2.0.2.tbz"
+  checksum: [
+    "sha256=b6aa02b90ec2086b1f93279cd957ec4047d815da97c834051fff4f94cf9a92ee"
+    "sha512=2d0014bb83d89f844b842fd7d8d6ef10f81276c8704987f74f4ca0cfe7e5df43435c042b291f40dab0e8f48d03489f2a7bfdc1d1366b80bbb3d6ca1e4c03dcbd"
+  ]
+}


### PR DESCRIPTION
Async SQL Server client using FreeTDS

- Project page: <a href="https://github.com/arenadotio/ocaml-mssql">https://github.com/arenadotio/ocaml-mssql</a>
- Documentation: <a href="https://arenadotio.github.io/ocaml-mssql">https://arenadotio.github.io/ocaml-mssql</a>

##### CHANGES:

### Added

- Streaming `execute_` helpers: `execute_map`, `execute_iter`, `execute_fold`, and `execute_pipe`.
- `Param.Array` now supports lists, which is useful for `IN ($1)` clauses.

### Changed

- Make `connect`'s `port` argument optional
- Support Core v0.13
- Result sets that don't contain row data aren't returned. For example, `INSERT ...; SELECT ...` now returns one
  result set instead of two.

### Fixed

- Correctly use `port` when provided
- Various [upstream fixes in `ocaml-freetds`](https://github.com/kennknowles/ocaml-freetds/releases/tag/0.7)
  - Exceptions shouldn't break the connection handle
  - Runtime lock released during queries
- Logging always occurs in an Async context
- Logging occurs in the same Async context as the caller and not a random one
- We depend on Async_extra

### Removed

- `Mssql.Test`. This module was for testing and shouldn't have been part of the public API. We recommend adding a
  module like this to your own code if you want it.
- Semi-broken connection pool (`Mssql.Pool`) removed. Doing this safely requires setting the
  [`RESETCONNECTION` bit](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/ce398f9a-7d47-4ede-8f36-9dd6fc21ca43),
  which doesn't seem to be possible in FreeTDS.
