### PR TITLE
[new release] sentry (v0.10.0)

### DIFF
--- a/packages/sentry/sentry.v0.10.0/opam
+++ b/packages/sentry/sentry.v0.10.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Unofficial Async Sentry error monitoring client"
+description:
+  "Sentry is an unofficial Async OCaml client for the Sentry error reporting."
+maintainer: ["Brendan Long <self@brendanlong.com>"]
+authors: ["Brendan Long <self@brendanlong.com>"]
+license: "Unlicense"
+homepage: "https://github.com/brendanlong/sentry-ocaml"
+doc: "https://brendanlong.github.io/sentry-ocaml"
+bug-reports: "https://github.com/brendanlong/sentry-ocaml/issues"
+depends: [
+  "async_unix" {>= "v0.13.0"}
+  "atdgen"
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-async" {>= "2.0.0"}
+  "dune" {>= "1.11.0"}
+  "hex" {>= "1.2.0"}
+  "json-derivers"
+  "ppx_jane"
+  "ocaml" {>= "4.08.0"}
+  "re2"
+  "sexplib" {>= "v0.13.0"}
+  "uuidm"
+  "uri"
+  "yojson"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/brendanlong/sentry-ocaml.git"
+url {
+  src:
+    "https://github.com/brendanlong/sentry-ocaml/releases/download/v0.10.0/sentry-v0.10.0.tbz"
+  checksum: [
+    "sha256=3e07b7194e190d4c879f333991c1cdf192268229c741dfe73306c996e1766bec"
+    "sha512=a3d970a9c012313d376be8f497ec1953d960e05f0921067a2e7fb3ccb977a857b49dedca6d525daa261f805caa5d345e332f350a2490b49d7dcb4e511b854622"
+  ]
+}


### PR DESCRIPTION
Unofficial Async Sentry error monitoring client

- Project page: <a href="https://github.com/brendanlong/sentry-ocaml">https://github.com/brendanlong/sentry-ocaml</a>
- Documentation: <a href="https://brendanlong.github.io/sentry-ocaml">https://brendanlong.github.io/sentry-ocaml</a>

##### CHANGES:

- Removed unused dependencies like async_extended and ounit
- Better handing of 429 errors
