### PR TITLE
[new release] sentry (v0.10.1)

### DIFF
--- a/packages/sentry/sentry.v0.10.1/opam
+++ b/packages/sentry/sentry.v0.10.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Unofficial Async Sentry error monitoring client"
+description:
+  "Sentry is an unofficial Async OCaml client for the Sentry error reporting."
+maintainer: ["Brendan Long <self@brendanlong.com>"]
+authors: ["Brendan Long <self@brendanlong.com>"]
+license: "Unlicense"
+homepage: "https://github.com/brendanlong/sentry-ocaml"
+doc: "https://brendanlong.github.io/sentry-ocaml"
+bug-reports: "https://github.com/brendanlong/sentry-ocaml/issues"
+depends: [
+  "async_unix" {>= "v0.13.0"}
+  "atdgen"
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-async" {>= "2.0.0"}
+  "dune" {>= "1.11.0"}
+  "hex" {>= "1.2.0"}
+  "json-derivers"
+  "ppx_jane"
+  "ocaml" {>= "4.08.0"}
+  "re2"
+  "sexplib" {>= "v0.13.0"}
+  "uuidm"
+  "uri"
+  "yojson"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/brendanlong/sentry-ocaml.git"
+url {
+  src:
+    "https://github.com/brendanlong/sentry-ocaml/releases/download/v0.10.1/sentry-v0.10.1.tbz"
+  checksum: [
+    "sha256=bf6356599923dfd043d933f0fe9f876dd88c6c0c9ba05dcaf9fed74e9621fec2"
+    "sha512=43d81f211cea1e411eb969c371b2181969c0357931fdadecc05432c6d61c28e72af5af8c22c72abd27cf4508845915148c84a805057313c526c70ae3d17e439d"
+  ]
+}


### PR DESCRIPTION
Unofficial Async Sentry error monitoring client

- Project page: <a href="https://github.com/brendanlong/sentry-ocaml">https://github.com/brendanlong/sentry-ocaml</a>
- Documentation: <a href="https://brendanlong.github.io/sentry-ocaml">https://brendanlong.github.io/sentry-ocaml</a>

##### CHANGES:

- Don't require bisect_ppx for builds
