### PR TITLE
ocaml-migrate-parsetree < 1.7.3: Restrict to OCaml < 4.11

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.5.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.5.0/opam
@@ -17,7 +17,7 @@ depends: [
   "result"
   "ppx_derivers"
   "dune" {>= "1.9.0"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.11"}
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.6.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.6.0/opam
@@ -17,7 +17,7 @@ depends: [
   "result"
   "ppx_derivers"
   "dune" {>= "1.9.0"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.11"}
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.1/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.1/opam
@@ -17,7 +17,7 @@ depends: [
   "result"
   "ppx_derivers"
   "dune" {>= "1.9.0"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.11"}
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.2/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.2/opam
@@ -17,7 +17,7 @@ depends: [
   "result"
   "ppx_derivers"
   "dune" {>= "1.9.0"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.11"}
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """


### PR DESCRIPTION
cc @jeremiedimino 