### PR TITLE
[new release] archi-lwt, archi-async and archi (0.1.0)

### DIFF
--- a/packages/archi-async/archi-async.0.1.0/opam
+++ b/packages/archi-async/archi-async.0.1.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06"}
   "dune" {>= "1.0"}
-  "archi"
+  "archi" {= version}
   "async"
 ]
 synopsis:

--- a/packages/archi-async/archi-async.0.1.0/opam
+++ b/packages/archi-async/archi-async.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/archi"
+bug-reports: "https://github.com/anmonteiro/archi/issues"
+dev-repo: "git+https://github.com/anmonteiro/archi.git"
+doc: "https://anmonteiro.github.io/archi/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.0"}
+  "archi"
+  "async"
+]
+synopsis:
+  "Async runtime for Archi, a library for managing the lifecycle of stateful components in OCaml"
+url {
+  src:
+    "https://github.com/anmonteiro/archi/releases/download/0.1.0/archi-0.1.0.tbz"
+  checksum: [
+    "sha256=b485cd300d87c5d0c7448c70f2ad85b508bb5d0e377900b3d6fb70c71c5ac5db"
+    "sha512=2c3239c570750b02f078382f7ca1a87a2de55c817c17611abc0e58c32012a390174aa2b4fb3e89f646b8053ed443e46d98b176477bc2ba94152f38cf5253e8e2"
+  ]
+}

--- a/packages/archi-lwt/archi-lwt.0.1.0/opam
+++ b/packages/archi-lwt/archi-lwt.0.1.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06"}
   "dune" {>= "1.0"}
-  "archi"
+  "archi" {= version}
   "lwt"
 ]
 synopsis:

--- a/packages/archi-lwt/archi-lwt.0.1.0/opam
+++ b/packages/archi-lwt/archi-lwt.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/archi"
+bug-reports: "https://github.com/anmonteiro/archi/issues"
+dev-repo: "git+https://github.com/anmonteiro/archi.git"
+doc: "https://anmonteiro.github.io/archi/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.0"}
+  "archi"
+  "lwt"
+]
+synopsis:
+  "Lwt runtime for Archi, a library for managing the lifecycle of stateful components in OCaml"
+url {
+  src:
+    "https://github.com/anmonteiro/archi/releases/download/0.1.0/archi-0.1.0.tbz"
+  checksum: [
+    "sha256=b485cd300d87c5d0c7448c70f2ad85b508bb5d0e377900b3d6fb70c71c5ac5db"
+    "sha512=2c3239c570750b02f078382f7ca1a87a2de55c817c17611abc0e58c32012a390174aa2b4fb3e89f646b8053ed443e46d98b176477bc2ba94152f38cf5253e8e2"
+  ]
+}

--- a/packages/archi/archi.0.1.0/opam
+++ b/packages/archi/archi.0.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/archi"
+bug-reports: "https://github.com/anmonteiro/archi/issues"
+dev-repo: "git+https://github.com/anmonteiro/archi.git"
+doc: "https://anmonteiro.github.io/archi/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.0"}
+  "hmap"
+  "alcotest" {with-test}
+]
+synopsis:
+  "A library for managing the lifecycle of stateful components in OCaml"
+description:
+"""
+Archi is an OCaml library for managing the lifecycle of stateful components and
+their dependencies.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/archi/releases/download/0.1.0/archi-0.1.0.tbz"
+  checksum: [
+    "sha256=b485cd300d87c5d0c7448c70f2ad85b508bb5d0e377900b3d6fb70c71c5ac5db"
+    "sha512=2c3239c570750b02f078382f7ca1a87a2de55c817c17611abc0e58c32012a390174aa2b4fb3e89f646b8053ed443e46d98b176477bc2ba94152f38cf5253e8e2"
+  ]
+}


### PR DESCRIPTION
Lwt runtime for Archi, a library for managing the lifecycle of stateful components in OCaml

- Project page: <a href="https://github.com/anmonteiro/archi">https://github.com/anmonteiro/archi</a>
- Documentation: <a href="https://anmonteiro.github.io/archi/">https://anmonteiro.github.io/archi/</a>

##### CHANGES:

- Initial public release
