### PR TITLE
new release: mirage-xen-ocaml 3.3.2

### DIFF
--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.2/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: "The MirageOS team"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-platform"
+bug-reports: "https://github.com/mirage/mirage-platform/issues/"
+depends: [
+  "ocaml" {>= "4.04.2" & < "4.11.0"}
+  "mirage-xen-posix" {>="3.3.1"}
+  "conf-pkg-config"
+  "ocamlfind" {build}
+  "ocaml-src"
+]
+substs: [
+  "xen-ocaml/flags/cflags.tmp"
+  "xen-ocaml/flags/libs.tmp"
+  ]
+conflicts: ["ocaml-system"]
+available: os = "linux"
+build: [make "xen-ocaml-build"]
+install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]
+remove: [make "xen-ocaml-uninstall" "PREFIX=%{prefix}%"]
+dev-repo: "git+https://github.com/mirage/mirage-platform.git"
+synopsis: "MirageOS headers for the OCaml runtime"
+description:
+  "The package contains the OCaml runtime patches and build system."
+url {
+  src: "https://github.com/mirage/mirage-platform/archive/v3.3.2.tar.gz"
+  checksum: "md5=7e7f95542bcb07605c2b99ff8f8965c4"
+}


### PR DESCRIPTION
CHANGES:
- add support for OCaml 4.09 and 4.10 (@linse @hannesm)