### PR TITLE
minios-xen: drop ocaml depedency

### DIFF
--- a/packages/minios-xen/minios-xen.0.7/opam
+++ b/packages/minios-xen/minios-xen.0.7/opam
@@ -20,7 +20,6 @@ remove: [
   ]
 ]
 depends: [
-  "ocaml"
   "conf-perl" {build}
   "conf-findutils" {build}
 ]

--- a/packages/minios-xen/minios-xen.0.8/opam
+++ b/packages/minios-xen/minios-xen.0.8/opam
@@ -20,7 +20,6 @@ remove: [
   ]
 ]
 depends: [
-  "ocaml"
   "conf-perl" {build}
   "conf-findutils" {build}
 ]

--- a/packages/minios-xen/minios-xen.0.9/opam
+++ b/packages/minios-xen/minios-xen.0.9/opam
@@ -20,7 +20,6 @@ remove: [
   ]
 ]
 depends: [
-  "ocaml"
   "conf-perl" {build}
   "conf-findutils" {build}
 ]


### PR DESCRIPTION
it does not depend on ocaml, the dependency got introduced in the big https://github.com/ocaml/opam-repository/commit/1bab4537a2f3b2328d771e1bb50b0d0268b0798a "restart 2.0 with a clean repo" commit for unknown reasons.