### PR TITLE
Package tablecloth-native.0.0.7

### DIFF
--- a/packages/tablecloth-native/tablecloth-native.0.0.7/opam
+++ b/packages/tablecloth-native/tablecloth-native.0.0.7/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis:
+  "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml, Bucklescript and ReasonML"
+description: "Longer description"
+maintainer: "Paul Biggar <paul@darklang.com>"
+authors: "Paul Biggar <paul@darklang.com>"
+license: "MIT with some exceptions"
+homepage: "https://github.com/darklang/tablecloth"
+bug-reports: "https://github.com/darklang/tablecloth/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "base" {>= "v0.10.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/darklang/tablecloth"
+url {
+  src: "https://github.com/darklang/tablecloth/archive/0.0.7.tar.gz"
+  checksum: [
+    "md5=31100157d38f869337360485dae71eb0"
+    "sha512=d19fc65ecea296c6d009e5b3f221d1fc6d035b1aa473f39ea51c8ac99f38ccbf5ecfca01fb41549677e7abc80ccc7d0c5f66b67865959e450a18c89e661feaa9"
+  ]
+}

--- a/packages/tablecloth-native/tablecloth-native.0.0.7/opam
+++ b/packages/tablecloth-native/tablecloth-native.0.0.7/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/darklang/tablecloth"
 bug-reports: "https://github.com/darklang/tablecloth/issues"
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune" {>= "1.6"}
   "base" {>= "v0.10.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
### `tablecloth-native.0.0.7`
Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml, Bucklescript and ReasonML
Longer description



---
* Homepage: https://github.com/darklang/tablecloth
* Source repo: git://github.com/darklang/tablecloth
* Bug tracker: https://github.com/darklang/tablecloth/issues

---
:camel: Pull-request generated by opam-publish v2.0.2