### PR TITLE
[new release] stdcompat.14

### DIFF
--- a/packages/stdcompat/stdcompat.14/opam
+++ b/packages/stdcompat/stdcompat.14/opam
@@ -12,7 +12,6 @@ depends: [
 ]
 depopts: [ "result" "seq" "uchar" "ocamlfind" ]
 build: [
-  [make "-f" "Makefile.bootstrap" "-j" jobs]
   ["./configure" "--prefix=%{prefix}%"]
   [make]
 ]

--- a/packages/stdcompat/stdcompat.14/opam
+++ b/packages/stdcompat/stdcompat.14/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Compatibility module for OCaml standard library"
+description:
+  "Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml."
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/stdcompat"
+bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
+depends: [
+  "ocaml" {>= "3.07" & < "4.12.0"}
+]
+depopts: [ "result" "seq" "uchar" "ocamlfind" ]
+build: [
+  [make "-f" "Makefile.bootstrap" "-j" jobs]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
+url {
+  src:
+    "https://github.com/thierry-martinez/stdcompat/releases/download/v14/stdcompat-14.tar.gz"
+  checksum: [
+    "sha512=2ceaf840a81bcda2f02328acf2549a1025bfd408f637dd19359a40f95516af6a44322015ee8f2c32a4945ff5f32d3d5461231b08cc4bcc11c248762eca347168"
+  ]
+}

--- a/packages/stdcompat/stdcompat.14/opam
+++ b/packages/stdcompat/stdcompat.14/opam
@@ -13,8 +13,7 @@ depends: [
 depopts: [ "result" "seq" "uchar" "ocamlfind" ]
 build: [
   ["./configure" "--prefix=%{prefix}%"]
-  [make]
-  [make test] {with-test}
+  [make "all" "test" {with-test}]
 ]
 install: [make "install"]
 dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
@@ -22,6 +21,6 @@ url {
   src:
     "https://github.com/thierry-martinez/stdcompat/releases/download/v14/stdcompat-14.tar.gz"
   checksum: [
-    "sha512=07ebb112f72044d7e01361b54982abe420e1624e2d8ad2587f9068a8b6a7198954f9254909099c730b79bcd56e914b648278f4ff52574237a835f186c26ea995"
+    "sha512=787e2c625a25b25f166047563ae6428e682e2059610bfec3c3c3888d369ba91a80e03b1ab9f847108722d0797dbd9b71634b6ae51cc937aeb7964071c7d6dbe3"
   ]
 }

--- a/packages/stdcompat/stdcompat.14/opam
+++ b/packages/stdcompat/stdcompat.14/opam
@@ -14,6 +14,7 @@ depopts: [ "result" "seq" "uchar" "ocamlfind" ]
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make]
+  [make test] {with-test}
 ]
 install: [make "install"]
 dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
@@ -21,6 +22,6 @@ url {
   src:
     "https://github.com/thierry-martinez/stdcompat/releases/download/v14/stdcompat-14.tar.gz"
   checksum: [
-    "sha512=2ceaf840a81bcda2f02328acf2549a1025bfd408f637dd19359a40f95516af6a44322015ee8f2c32a4945ff5f32d3d5461231b08cc4bcc11c248762eca347168"
+    "sha512=07ebb112f72044d7e01361b54982abe420e1624e2d8ad2587f9068a8b6a7198954f9254909099c730b79bcd56e914b648278f4ff52574237a835f186c26ea995"
   ]
 }


### PR DESCRIPTION
- Support for OCaml 4.11.0 with
  - `Array.{for_all2, exists2}`
  - `Lexing.{set_position, set_filename}`
  - `List.{filteri, fold_left_map}`
  - `Printexc.{default_uncaught_exception_handler, Slot.name}`
  - `Seq.{cons, append, unfold}`
  - `{Set,Map}.filter_map`
  - `Printf.{ibprintf, ikbprintf}`

- More efficient implementation of `Set` functions

- Support for version mismatch between `ocamlc` and `ocamlfind` packages