### PR TITLE
Package nmea.0.1.2

### DIFF
--- a/packages/nmea/nmea.0.1.2/opam
+++ b/packages/nmea/nmea.0.1.2/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Nmea parser"
+description: "NMEA sentence parser library for OCaml"
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: "Davide Gessa <gessadavide@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dakk/nmea"
+bug-reports: "https://github.com/dakk/nmea/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "2.5.0"}
+  "menhir" {>= "20200211"}
+  "ounit" {with-test & >= "2.0.8"}
+  "odoc" {with-test & >= "1.3.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dakk/nmea.git"
+url {
+  src: "https://github.com/dakk/nmea/archive/v0.1.2.tar.gz"
+  checksum: [
+    "md5=3cd6910f8f088825f470584891ebf78b"
+    "sha512=92466f7294f4e26eca36effc4b39020432785f09bb79b1bc1b838a43b91dfa7c838834344966630002e70144412a516aaf97aff431641a537087ec87103e7c3e"
+  ]
+}


### PR DESCRIPTION
### `nmea.0.1.2`
Nmea parser
NMEA sentence parser library for OCaml



---
* Homepage: https://github.com/dakk/nmea
* Source repo: git+https://github.com/dakk/nmea.git
* Bug tracker: https://github.com/dakk/nmea/issues

---
:camel: Pull-request generated by opam-publish v2.0.2