### PR TITLE
Package memprof-limits.0.1

### DIFF
--- a/packages/memprof-limits/memprof-limits.0.1/opam
+++ b/packages/memprof-limits/memprof-limits.0.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Guillaume Munch-Maccagnoni <Guillaume.Munch-Maccagnoni@inria.fr>"
+authors: [
+  "Guillaume Munch-Maccagnoni <Guillaume.Munch-Maccagnoni@inria.fr>"
+]
+license: "LGPL-3.0-only"
+homepage: "https://gitlab.com/gadmm/memprof-limits"
+bug-reports: "https://gitlab.com/gadmm/memprof-limits/issues"
+depends: [
+  "ocaml"
+  "ocaml-variants" {>="4.11.0"}
+  "dune" {build & >= "1.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/gadmm/memprof-limits.git"
+synopsis: "Memory limits based on memprof"
+description: """
+Memprof-limits provides per-thread global memory limits, and
+per-thread allocation limits à la Haskell, compatible with systhreads.
+
+Per-thread global memory limits let you bound the memory consumption
+of specific parts of your program, in terms of memory used by the
+whole program.
+
+Per-thread allocation limits let you bound the execution of parts of
+the program measured in number of allocation, analogous to the same
+feature in Haskell. Allocation limits count allocations but not
+deallocations, and is therefore a measure of the work done which can
+be more suitable than execution time.
+
+The implementation uses memprof with a low sampling rate that does not
+affect performance. A reimplementation of the memprof interface
+compatible with memprof-limits running at the same time is provided
+for profiling needs.
+
+THIS PACKAGE IS EXPERIMENTAL
+"""
+url {
+  src:
+    "https://gitlab.com/gadmm/memprof-limits/-/archive/0.1/memprof-limits-0.1.tar.bz2"
+  checksum: [
+    "md5=60f493b72979390032a8682ac5b1d0d3"
+    "sha512=aa7cf9047f0aa45bf8f49cad4326c1a3374dc8053969681d0c88ade396c299fa4371f51daa8f0239b2a3ce1b1848e77be4cbff776731bc7a4d52ecec500b5177"
+  ]
+}

--- a/packages/memprof-limits/memprof-limits.0.1/opam
+++ b/packages/memprof-limits/memprof-limits.0.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://gitlab.com/gadmm/memprof-limits/issues"
 depends: [
   "ocaml"
   "ocaml-variants" {>="4.11.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/gadmm/memprof-limits.git"


### PR DESCRIPTION
### `memprof-limits.0.1`
Memory limits based on memprof
Memprof-limits provides per-thread global memory limits, and
per-thread allocation limits à la Haskell, compatible with systhreads.

Per-thread global memory limits let you bound the memory consumption
of specific parts of your program, in terms of memory used by the
whole program.

Per-thread allocation limits let you bound the execution of parts of
the program measured in number of allocation, analogous to the same
feature in Haskell. Allocation limits count allocations but not
deallocations, and is therefore a measure of the work done which can
be more suitable than execution time.

The implementation uses memprof with a low sampling rate that does not
affect performance. A reimplementation of the memprof interface
compatible with memprof-limits running at the same time is provided
for profiling needs.

THIS PACKAGE IS EXPERIMENTAL



---
* Homepage: https://gitlab.com/gadmm/memprof-limits
* Source repo: git+https://gitlab.com/gadmm/memprof-limits.git
* Bug tracker: https://gitlab.com/gadmm/memprof-limits/issues

---
:camel: Pull-request generated by opam-publish v2.0.2