### PR TITLE
base.v0.13.2+ppx_expect.v0.13.1

### DIFF
--- a/packages/base/base.v0.13.2/opam
+++ b/packages/base/base.v0.13.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"    {>= "4.04.2"}
+  "sexplib0" {>= "v0.13" & < "v0.14"}
+  "dune"     {>= "1.5.1"}
+  "dune-configurator"
+]
+synopsis: "Full standard library replacement for OCaml"
+description: "
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio
+"
+url {
+  src: "https://github.com/janestreet/base/archive/v0.13.2.tar.gz"
+  checksum: "md5=f43ce18d98fd0879e77ff671e077e607"
+}

--- a/packages/ppx_expect/ppx_expect.v0.13.1/opam
+++ b/packages/ppx_expect/ppx_expect.v0.13.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "4.04.2"}
+  "base"              {>= "v0.13" & < "v0.14"}
+  "ppx_assert"        {>= "v0.13" & < "v0.14"}
+  "ppx_compare"       {>= "v0.13" & < "v0.14"}
+  "ppx_custom_printf" {>= "v0.13" & < "v0.14"}
+  "ppx_fields_conv"   {>= "v0.13" & < "v0.14"}
+  "ppx_here"          {>= "v0.13" & < "v0.14"}
+  "ppx_inline_test"   {>= "v0.13" & < "v0.14"}
+  "ppx_sexp_conv"     {>= "v0.13" & < "v0.14"}
+  "ppx_variants_conv" {>= "v0.13" & < "v0.14"}
+  "stdio"             {>= "v0.13" & < "v0.14"}
+  "dune"              {>= "1.5.1"}
+  "ppxlib"            {>= "0.9.0"}
+  "re"                {>= "1.8.0"}
+]
+synopsis: "Cram like framework for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src: "https://github.com/janestreet/ppx_expect/archive/v0.13.1.tar.gz"
+  checksum: "md5=8f6fd9c0c3c93f9e5a25038f1c26b0aa"
+}


### PR DESCRIPTION
This pull requests publishes:

- `base.v0.13.2` (fixing https://github.com/janestreet/base/issues/88);
- `ppx_expect.v0.13.1` (fixing https://github.com/janestreet/ppx_expect/pull/17 and https://github.com/janestreet/ppx_expect/pull/21).