### PR TITLE
[new release] ocamlformat (0.14.2)

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.14.2/opam
+++ b/packages/ocamlformat/ocamlformat.0.14.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "alcotest" {with-test}
+  "base" {>= "v0.11.0"}
+  "base-unix"
+  "cmdliner"
+  "dune" {>= "2.2.0"}
+  "fix"
+  "fpath"
+  "menhir"
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "re"
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.14.2/ocamlformat-0.14.2.tbz"
+  checksum: [
+    "sha256=5f9f7ac312a8f62315e25536f87601efc7788114a4a1eacc0507acf474f8f09a"
+    "sha512=9f526031c2225b2d3d21c1f241517b9fb87752570645df587bace7afaa5e0e60922f873843343349a2f8f80d1d3e061ce23ee5199fa61a709b877c328a6f7729"
+  ]
+}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### Changes

  + Merge `doc-comments-val` option with `doc-comments`. The placement of documentation comments on `val` and `external` items is now controled by `doc-comments`.

    - `doc-comments=after` becomes `doc-comments=after-when-possible` to take into account the technical limitations of ocamlformat;
    - `doc-comments=before` is unchanged;
    - `doc-comments-val` is now replaced with `doc-comments`
      To reproduce the former behaviors
      * `doc-comments=before` + `doc-comments-val=before`: now use `doc-comments=before`;
      * `doc-comments=before` + `doc-comments-val=after`: now use `doc-comments=before-except-val`;
      * `doc-comments=after` + `doc-comments-val=before`: this behavior did not make much sense and is not available anymore;
      * `doc-comments=after` + `doc-comments-val=after`: now use `doc-comments=after-when-possible`.

   (ocaml-ppx/ocamlformat#1358) (Josh Berdine, Jules Aguillon, Guillaume Petiot)

   This reverts changes introduced in 0.14.1 (ocaml-ppx/ocamlformat#1335) and 0.14.0 (ocaml-ppx/ocamlformat#1012).
