### PR TITLE
pkgconf has replaced pkg-config on arch

### DIFF
--- a/packages/conf-pkg-config/conf-pkg-config.1.0/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.0/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depexts: [
   ["pkg-config"] {os-family = "debian"}
-  ["pkg-config"] {os-distribution = "arch"}
+  ["pkgconf"] {os-distribution = "arch"}
   ["pkgconfig"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos"}
   ["pkgconfig"] {os-distribution = "mageia"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -18,7 +18,7 @@ post-messages: [
 ]
 depexts: [
   ["pkg-config"] {os-family = "debian"}
-  ["pkg-config"] {os-distribution = "arch"}
+  ["pkgconf"] {os-distribution = "arch"}
   ["pkgconfig"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos"}
   ["pkgconfig"] {os-distribution = "mageia"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.2/opam
@@ -18,7 +18,7 @@ post-messages: [
 ]
 depexts: [
   ["pkg-config"] {os-family = "debian"}
-  ["pkg-config"] {os-distribution = "arch"}
+  ["pkgconf"] {os-distribution = "arch"}
   ["pkgconfig"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "mageia"}


### PR DESCRIPTION
As far as I can tell has been incorrect for a while, but I've been trying out opam `2.1.0~alpha` and the problem seems to manifest there. I don't think it's a bug in `opam` though - I have pkgconf installed but opam doesn't seem to think it's installed as the name is wrong.

Searching on the arch packages list `pkgconf` seems to be the canonical name, and `pkg-config` is an alias: https://www.archlinux.org/packages/?q=pkg-config

```
$ opam --version
2.1.0~alpha

$ opam install conf-pkg-config.1.1 -vvv
+ /usr/bin/lsb_release "-s" "-r"
- rolling
+ /usr/bin/ocamlc "-vnum"
- 4.09.1
+ /usr/bin/pacman "-Qe"
... <truncated>
- perl 5.30.2-1
- pinta 1.6-4
- pkgconf 1.6.3-4
- plasma-browser-integration 5.18.4.1-1
- plasma-desktop 5.18.4.1-1
... <truncated>
+ /usr/bin/pacman "-Q"
... <truncated>
- pkcs11-helper 1.26.0-1
- pkgconf 1.6.3-4
- plasma-browser-integration 5.18.4.1-1
- plasma-desktop 5.18.4.1-1
... <truncated>
[ERROR] Package conf-pkg-config.1.1 depends on the unavailable system package 'pkg-config'. You
        can use `--no-depexts' to attempt installation anyway.
'opam install conf-pkg-config.1.1 -vvv' failed.
```