### PR TITLE
soupault: Specify dependency on tsort < 2.0 to prevent breaking builds.

### DIFF
--- a/packages/soupault/soupault.1.10.0/opam
+++ b/packages/soupault/soupault.1.10.0/opam
@@ -33,7 +33,7 @@ depends: [
   "calendar"
   "spelll"
   "mustache"
-  "tsort"
+  "tsort" {< "2.0.0"}
   "lua-ml" {>= "0.9.1"}
 ]
 build: [

--- a/packages/soupault/soupault.1.11.0/opam
+++ b/packages/soupault/soupault.1.11.0/opam
@@ -33,7 +33,7 @@ depends: [
   "calendar"
   "spelll"
   "mustache"
-  "tsort"
+  "tsort" {< "2.0.0"}
   "lua-ml" {>= "0.9.1"}
 ]
 build: [

--- a/packages/soupault/soupault.1.6/opam
+++ b/packages/soupault/soupault.1.6/opam
@@ -33,7 +33,7 @@ depends: [
   "calendar"
   "spelll"
   "mustache"
-  "tsort"
+  "tsort" {< "2.0.0"}
   "lua-ml"
 ]
 build: [

--- a/packages/soupault/soupault.1.7.0/opam
+++ b/packages/soupault/soupault.1.7.0/opam
@@ -33,7 +33,7 @@ depends: [
   "calendar"
   "spelll"
   "mustache"
-  "tsort"
+  "tsort" {< "2.0.0"}
   "lua-ml"
 ]
 build: [

--- a/packages/soupault/soupault.1.8.0/opam
+++ b/packages/soupault/soupault.1.8.0/opam
@@ -39,7 +39,7 @@ depends: [
   "calendar"
   "spelll"
   "mustache"
-  "tsort"
+  "tsort" {< "2.0.0"}
   "lua-ml" {>= "0.9.1"}
 ]
 url {

--- a/packages/soupault/soupault.1.9.0/opam
+++ b/packages/soupault/soupault.1.9.0/opam
@@ -39,7 +39,7 @@ depends: [
   "calendar"
   "spelll"
   "mustache"
-  "tsort"
+  "tsort" {< "2.0.0"}
   "lua-ml" {>= "0.9.1"}
 ]
 


### PR DESCRIPTION
[tsort](https://opam.ocaml.org/packages/tsort/) is about to make a about to make a [breaking change](https://github.com/dmbaturin/ocaml-tsort/pull/1).

This will prevent buiilds of older soupault versions from breaking due to that change.