### PR TITLE
crowbar.0.2: Untag dune as a build dependency

### DIFF
--- a/packages/crowbar/crowbar.0.2/opam
+++ b/packages/crowbar/crowbar.0.2/opam
@@ -17,7 +17,7 @@ run-test: [
   ]
 ]
 depends: [
-  "dune" {build & >= "1.1"}
+  "dune" {>= "1.1"}
   "ocaml" {>= "4.08"}
   "ocplib-endian"
   "cmdliner"


### PR DESCRIPTION
cc @stedolan could you return the fix upstream?