### PR TITLE
Solo5: Disable Genode bindings

### DIFF
--- a/packages/solo5-bindings-genode/solo5-bindings-genode.0.4.1/opam
+++ b/packages/solo5-bindings-genode/solo5-bindings-genode.0.4.1/opam
@@ -16,10 +16,7 @@ conflicts: [
   "solo5-bindings-muen"
   "solo5-bindings-virtio"
 ]
-available: [
-  arch = "x86_64" &
-  (os = "linux" | os = "freebsd" | os = "openbsd")
-]
+available: false
 synopsis: "Solo5 sandboxed execution environment (genode target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended

--- a/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.2/opam
+++ b/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.2/opam
@@ -23,10 +23,7 @@ conflicts: [
   "solo5-bindings-virtio"
   "solo5-bindings-muen"
 ]
-available: [
-  arch = "x86_64" &
-  (os = "linux" | os = "freebsd" | os = "openbsd")
-]
+available: false
 synopsis: "Solo5 sandboxed execution environment (genode target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended

--- a/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.3/opam
+++ b/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.3/opam
@@ -26,10 +26,7 @@ conflicts: [
   "solo5-bindings-virtio"
   "solo5-bindings-muen"
 ]
-available: [
-  arch = "x86_64" &
-  (os = "linux" | os = "freebsd" | os = "openbsd")
-]
+available: false
 synopsis: "Solo5 sandboxed execution environment (genode target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended

--- a/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.4/opam
+++ b/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.4/opam
@@ -26,10 +26,7 @@ conflicts: [
   "solo5-bindings-virtio"
   "solo5-bindings-muen"
 ]
-available: [
-  arch = "x86_64" &
-  (os = "linux" | os = "freebsd" | os = "openbsd")
-]
+available: false
 synopsis: "Solo5 sandboxed execution environment (genode target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended


### PR DESCRIPTION
This is a followup to #16368 where the consensus was to disable the
existing solo5-bindings-genode due to these being unsupported upstream
except on very specific toolchains. See also Solo5/solo5#446.