### PR TITLE
Package qtest.2.11

### DIFF
--- a/packages/qtest/qtest.2.11/opam
+++ b/packages/qtest/qtest.2.11/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes <simon.cruanes.2007@m4x.org"
+authors: [
+  "Vincent Hugot <vincent.hugot@gmail.com>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org"
+]
+synopsis: "Lightweight inline test extraction from comments"
+homepage: "https://github.com/vincent-hugot/qtest"
+bug-reports: "https://github.com/vincent-hugot/qtest/issues"
+doc:
+  "https://github.com/vincent-hugot/qtest/blob/master/README.adoc#introduction"
+dev-repo: "git+https://github.com/vincent-hugot/qtest.git"
+build: [
+  [ "dune" "build" "@install" "-j" jobs "-p" name ]
+]
+depends: [
+  "base-bytes"
+  "ounit2"
+  "dune" { >= "1.1" }
+  "qcheck" { >= "0.5" }
+  "ocaml" { >= "4.03.0" }
+]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+url {
+  src: "https://github.com/vincent-hugot/qtest/archive/v2.11.tar.gz"
+  checksum: [
+    "md5=adf68ea2dd8a10ec400c6a6b415e7c2c"
+    "sha512=ea0d08aa927bfea71f04ed9d6bc66512b95432cbba5a8f3d77d0ebf5bbd5969f33c68ee95c03dd94b19c6a54b92c08d3b69b5ab35414650b3581d946b75b1698"
+  ]
+}


### PR DESCRIPTION
### `qtest.2.11`
Lightweight inline test extraction from comments



---
* Homepage: https://github.com/vincent-hugot/qtest
* Source repo: git+https://github.com/vincent-hugot/qtest.git
* Bug tracker: https://github.com/vincent-hugot/qtest/issues

---
:camel: Pull-request generated by opam-publish v2.0.0