### PR TITLE
[new release] tls-mirage and tls (0.12.0)

### DIFF
--- a/packages/irc-client-tls/irc-client-tls.0.6.0/opam
+++ b/packages/irc-client-tls/irc-client-tls.0.6.0/opam
@@ -15,6 +15,7 @@ depends: [
   "irc-client"
   "lwt"
   "tls"
+  "x509" {< "0.10.0"}
   "ounit" {with-test}
 ]
 synopsis: "IRC client library - TLS implementation"

--- a/packages/irc-client-tls/irc-client-tls.0.6.1/opam
+++ b/packages/irc-client-tls/irc-client-tls.0.6.1/opam
@@ -15,6 +15,7 @@ depends: [
   "irc-client"
   "lwt"
   "tls"
+  "x509" {< "0.10.0"}
   "ounit" {with-test}
 ]
 synopsis: "IRC client library - TLS implementation"

--- a/packages/irc-client-tls/irc-client-tls.0.6.2/opam
+++ b/packages/irc-client-tls/irc-client-tls.0.6.2/opam
@@ -14,6 +14,7 @@ depends: [
   "irc-client"
   "lwt"
   "tls"
+  "x509" {< "0.10.0"}
   "odoc" {with-doc}
   "ocaml" {>= "4.02.0"}
 ]

--- a/packages/tls-mirage/tls-mirage.0.12.0/opam
+++ b/packages/tls-mirage/tls-mirage.0.12.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.0"}
+  "tls" {= version}
+  "x509" {>= "0.10.0"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "hacl_x25519" {>= "0.1.1"}
+  "fiat-p256" {>= "0.2.1"}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"
+description: """
+Tls-mirage provides an effectful FLOW module to be used in the MirageOS
+ecosystem.
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.12.0/tls-v0.12.0.tbz"
+  checksum: [
+    "sha256=a7586790a7d0b44b8b0844347c140f1b641728f3e47f4c566894e5e32b46c33b"
+    "sha512=37c4c97cafad6b51f1b8cbfc9b437680a643ea71c340b86a1930e89282d893f266886ffbedb8e239a66754328bc2575e96ffb4dae46ae9df018494f12a94f228"
+  ]
+}

--- a/packages/tls/tls.0.12.0/opam
+++ b/packages/tls/tls.0.12.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_cstruct" {>= "3.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "cstruct-sexp"
+  "sexplib"
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-rng"
+  "x509" {>= "0.11.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt"
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "ounit" {with-test & >= "2.2.0"}
+  "lwt" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "hacl_x25519"
+  "fiat-p256"
+  "hkdf"
+  "logs"
+  "alcotest" {with-test}
+]
+
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.12.0/tls-v0.12.0.tbz"
+  checksum: [
+    "sha256=a7586790a7d0b44b8b0844347c140f1b641728f3e47f4c566894e5e32b46c33b"
+    "sha512=37c4c97cafad6b51f1b8cbfc9b437680a643ea71c340b86a1930e89282d893f266886ffbedb8e239a66754328bc2575e96ffb4dae46ae9df018494f12a94f228"
+  ]
+}


### PR DESCRIPTION
CHANGES:

in mirleft/ocaml-tls#405 by @hannesm
* TLS 1.3 support
* Tracing now uses the logs library (log source tls.tracing on debug level)
* bugfix for padding in ClientHello, which computed wrong length
* bugfix hs_fragments to be set before executing the protocol handling logic
* bugfix guard RSA signature with an Insufficient_key handler, which may occur
  when using an RSA key which size is too small for the used digest algorithm