### PR TITLE
[new release] conduit-mirage (2.2.0)

### DIFF
--- a/packages/conduit-mirage/conduit-mirage.2.2.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.2.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.12.0"}
+  "sexplib"
+  "cstruct" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "dns-client" {>= "4.5.0"}
+  "conduit-lwt"
+  "vchan" {>= "5.0.0"}
+  "xenstore"
+  "tls" {>= "0.11.0"}
+  "tls-mirage" {>= "0.11.0"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+]
+conflicts: [
+  "mirage-conduit"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.2.0/conduit-v2.2.0.tbz"
+  checksum: [
+    "sha256=126538e73f7f8d76644757bf3f879046bd197960f8cf448b8c516bd405547377"
+    "sha512=a8342fc4dbc1191f04994d89c9c0d12d24a91737eb5ae549588d2ddc5e663ac267e6934aa5ec44de9f5d8b34c6148504be67857d5b96dc6b4fb4b4058eef18ac"
+  ]
+}

--- a/packages/conduit-mirage/conduit-mirage.2.2.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.2.0/opam
@@ -27,6 +27,7 @@ depends: [
 ]
 conflicts: [
   "mirage-conduit"
+  "mirage" {< "3.7.7"}
 ]
 
 build: [

--- a/packages/git-mirage/git-mirage.2.1.2/opam
+++ b/packages/git-mirage/git-mirage.2.1.2/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-flow"      {>= "2.0.0"}
   "mirage-channel"   {>= "4.0.0"}
   "conduit-mirage"
+  "conduit-mirage"   {with-test & < "2.2.0"}
   "git-http"         {= version}
   "git"              {= version}
   "alcotest"         {with-test & >= "0.8.1"}

--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.1.0/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "logs"
   "mirage-channel"
-  "conduit-mirage"
+  "conduit-mirage" {>= "2.0.2" & < "2.2.0"}
   "dns-client"
   "mirage-random"
   "mirage-clock"


### PR DESCRIPTION
CHANGES:

* conduit-mirage adapt to dns-client 4.5.0 (mirage/ocaml-conduit#314 @hannesm)