### PR TITLE
Relax constraints fo pyml.20200222

### DIFF
--- a/packages/pyml/pyml.20200222/opam
+++ b/packages/pyml/pyml.20200222/opam
@@ -10,7 +10,7 @@ install: [make "install" "PREFIX=%{prefix}%"]
 synopsis: "OCaml bindings for Python"
 description: "OCaml bindings for Python 2 and Python 3"
 depends: [
-  "ocaml" {>= "3.12.1" & < "4.11.0"}
+  "ocaml" {>= "3.12.1" & < "4.12.0"}
   "ocamlfind" {build}
   "stdcompat" {>= "13"}
 ]


### PR DESCRIPTION
This pull request makes `pyml.20200222` compatible with
OCaml 4.11.x (tested locally it is actually the case).