### PR TITLE
Package nmea.0.1.5

### DIFF
--- a/packages/nmea/nmea.0.1.5/opam
+++ b/packages/nmea/nmea.0.1.5/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Nmea parser"
+description: "NMEA sentence parser library for OCaml"
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: "Davide Gessa <gessadavide@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dakk/nmea"
+bug-reports: "https://github.com/dakk/nmea/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "2.5.0"}
+  "menhir" {>= "20200211"}
+  "ounit" {with-test & >= "2.0.8"}
+  "odoc" {with-test & >= "1.3.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dakk/nmea.git"
+url {
+  src: "https://github.com/dakk/nmea/archive/v0.1.5.tar.gz"
+  checksum: [
+    "md5=a84ecb52034f5b2f7989d5bec78d3d90"
+    "sha512=663f942c49ede25f6e8f0433e5d85d7b9450a21313de1a2fbd12b482ca21228337434fb13c7b145f690d5af986ef6ea2ae0ce06cc4f4666bd1985bdca9ec2de7"
+  ]
+}


### PR DESCRIPTION
### `nmea.0.1.5`
Nmea parser
NMEA sentence parser library for OCaml

- Compass sentences
- ZDA sentence
- Extended test suite
- Fixing parsing error with real old GPS devices

Sorry for the new release so near to the first, but I tested the library with other real instruments, fixing parsing errors (there is no fixed standard for empty fields, so every instrument adopt a different approach that have to be handled via software)




---
* Homepage: https://github.com/dakk/nmea
* Source repo: git+https://github.com/dakk/nmea.git
* Bug tracker: https://github.com/dakk/nmea/issues

---
:camel: Pull-request generated by opam-publish v2.0.2