### PR TITLE
[new release] mirage-qubes and mirage-qubes-ipv4 (0.8.2)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.2/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "4.0.0" }
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-protocols" { >= "4.0.0" }
+  "cstruct" { >= "1.9.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.8.2/mirage-qubes-v0.8.2.tbz"
+  checksum: [
+    "sha256=6eb8e3457f6cfd046aa64182dd0ad8e8c39048478bc0fc87ca8fe72cf0c1e233"
+    "sha512=71b0b6c06424d325bc2f27e7bad9f97a942e4d1c5b4581926fe5a747eea12c1fe94bb325fe02216faf53f9ec66b07909dfef1505d0205c992eb9b87940c537b9"
+  ]
+}

--- a/packages/mirage-qubes/mirage-qubes.0.8.2/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.8.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "2.2.0" }
+  "ppx_cstruct"
+  "vchan-xen" { >= "5.0.0" }
+  "xen-evtchn"
+  "xen-gnt"
+  "mirage-xen" { >= "5.0.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.8.2/mirage-qubes-v0.8.2.tbz"
+  checksum: [
+    "sha256=6eb8e3457f6cfd046aa64182dd0ad8e8c39048478bc0fc87ca8fe72cf0c1e233"
+    "sha512=71b0b6c06424d325bc2f27e7bad9f97a942e4d1c5b4581926fe5a747eea12c1fe94bb325fe02216faf53f9ec66b07909dfef1505d0205c992eb9b87940c537b9"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- provide Qubes.DB.got_new_commit to wait for specific commit writes in QubesDB
  (mirage/mirage-qubes#52 @linse @hannesm)