### PR TITLE
Package ppx_cstubs.0.4.1

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.4.1/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.4.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://fdopen.github.io/ppx_cstubs/"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+doc: "https://fdopen.github.io/ppx_cstubs/"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ctypes" {>= "0.13.0" & < "0.18"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.02.3" & < "4.11.0"}
+  "ocaml-migrate-parsetree" {>= "1.7.0"}
+  "ocamlfind" # not only a build dependency, it depends on findlib.top
+  "dune" {>= "1.6"}
+  "ppx_tools_versioned" {>= "5.4.0"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: """
+Preprocessor for easier stub generation with ctypes
+"""
+
+description: """
+ppx_cstubs is a ppx-based preprocessor for stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file
+with c stub code and an OCaml file with all additional boilerplate
+code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.4.1.tar.gz"
+  checksum: [
+    "md5=4ff64403059bc72dea729367dcc255d1"
+    "sha512=2e54f107c82fbae245f639ca31a4000890889fa5065f035c4b9a46605f91c7f96c8a5bd306f6976de9c288b2b3436b8501fc8172ba0cb9b5dd9f5fc5418bd0f6"
+  ]
+}


### PR DESCRIPTION
### `ppx_cstubs.0.4.1`
Preprocessor for easier stub generation with ctypes
ppx_cstubs is a ppx-based preprocessor for stub generation with
ctypes. ppx_cstubs creates two files from a single ml file: a file
with c stub code and an OCaml file with all additional boilerplate
code.



---
* Homepage: https://fdopen.github.io/ppx_cstubs/
* Source repo: git+https://github.com/fdopen/ppx_cstubs.git
* Bug tracker: https://github.com/fdopen/ppx_cstubs/issues

---
:camel: Pull-request generated by opam-publish v2.0.2