### PR TITLE
Package ctypes-zarith.0.1.0

### DIFF
--- a/packages/ctypes-zarith/ctypes-zarith.0.1.0/opam
+++ b/packages/ctypes-zarith/ctypes-zarith.0.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/fdopen/ctypes-zarith.git"
+homepage: "https://github.com/fdopen/ctypes-zarith"
+bug-reports: "https://github.com/fdopen/ctypes-zarith/issues"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {>= "1.2"}
+  "zarith"
+  "ctypes"
+  "dune-configurator"
+  "ppx_cstubs" {>= "0.4.1"}
+  "conf-pkg-config" {build}
+  "ctypes-foreign" {with-test}
+  "alcotest" {with-test}
+]
+
+synopsis: """
+Ctypes wrapper for zarith
+"""
+url {
+  src: "https://github.com/fdopen/ctypes-zarith/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=cec08d81edd4d1c434e94ad4fef013ff"
+    "sha512=84975a307bf6679ba50f129703eda896fb580a6e825e83d88e377383b0696c2d211c84e5fbb48591bd22ca8b50b5ca8dfccded746b091c823d4dbaf44caa33f4"
+  ]
+}


### PR DESCRIPTION
### `ctypes-zarith.0.1.0`
Ctypes wrapper for zarith



---
* Homepage: https://github.com/fdopen/ctypes-zarith
* Source repo: git+https://github.com/fdopen/ctypes-zarith.git
* Bug tracker: https://github.com/fdopen/ctypes-zarith/issues

---
:camel: Pull-request generated by opam-publish v2.0.2