### PR TITLE
[new release] capnp-rpc-net, capnp-rpc-lwt, capnp-rpc-mirage, capnp-rpc and capnp-rpc-unix (0.7.0)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.7.0/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.7.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "lwt"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.7.0/capnp-rpc-v0.7.0.tbz"
+  checksum: [
+    "sha256=ff44c96a1de0bd47b4ebbf8d94712ee0ef0eb1c6dcdeaf6d7194a7b6429a397b"
+    "sha512=36389156f0b629a7a671231e666527c80779cc5ceb63ba1bd8c4a6f074b499bd7dd5e93534a9b95053c2cc6b2166fadf77a71c45797edbf683421dbdc4e2f805"
+  ]
+}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.7.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.7.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp" {>= "3.1.0"}
+  "capnp-rpc-net" {= version}
+  "astring"
+  "fmt"
+  "logs"
+  "dns-client" {>= "4.5.0"}
+  "tls-mirage"
+  "mirage-stack" {>="2.0.0"}
+  "arp-mirage" {with-test}
+  "alcotest-lwt" {>= "1.0.1" & with-test}
+  "io-page-unix" {with-test}
+  "tcpip" {with-test}
+  "mirage-vnetif" {with-test}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.7.0/capnp-rpc-v0.7.0.tbz"
+  checksum: [
+    "sha256=ff44c96a1de0bd47b4ebbf8d94712ee0ef0eb1c6dcdeaf6d7194a7b6429a397b"
+    "sha512=36389156f0b629a7a671231e666527c80779cc5ceb63ba1bd8c4a6f074b499bd7dd5e93534a9b95053c2cc6b2166fadf77a71c45797edbf683421dbdc4e2f805"
+  ]
+}

--- a/packages/capnp-rpc-net/capnp-rpc-net.0.7.0/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.0.7.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "capnp-rpc-lwt" {= version}
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "mirage-flow" {>="2.0.0"}
+  "tls" {>= "0.8.0"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "0.11.0"}
+  "tls-mirage"
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.7.0/capnp-rpc-v0.7.0.tbz"
+  checksum: [
+    "sha256=ff44c96a1de0bd47b4ebbf8d94712ee0ef0eb1c6dcdeaf6d7194a7b6429a397b"
+    "sha512=36389156f0b629a7a671231e666527c80779cc5ceb63ba1bd8c4a6f074b499bd7dd5e93534a9b95053c2cc6b2166fadf77a71c45797edbf683421dbdc4e2f805"
+  ]
+}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.7.0/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.7.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp-rpc-net" {= version}
+  "cmdliner"
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.4"}
+  "logs"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "1.0"}
+  "alcotest-lwt" {with-test & >= "1.0.1"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.7.0/capnp-rpc-v0.7.0.tbz"
+  checksum: [
+    "sha256=ff44c96a1de0bd47b4ebbf8d94712ee0ef0eb1c6dcdeaf6d7194a7b6429a397b"
+    "sha512=36389156f0b629a7a671231e666527c80779cc5ceb63ba1bd8c4a6f074b499bd7dd5e93534a9b95053c2cc6b2166fadf77a71c45797edbf683421dbdc4e2f805"
+  ]
+}

--- a/packages/capnp-rpc/capnp-rpc.0.7.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.7.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "stdint"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "1.0.1"}
+  "afl-persistent" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.7.0/capnp-rpc-v0.7.0.tbz"
+  checksum: [
+    "sha256=ff44c96a1de0bd47b4ebbf8d94712ee0ef0eb1c6dcdeaf6d7194a7b6429a397b"
+    "sha512=36389156f0b629a7a671231e666527c80779cc5ceb63ba1bd8c4a6f074b499bd7dd5e93534a9b95053c2cc6b2166fadf77a71c45797edbf683421dbdc4e2f805"
+  ]
+}


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

- Update for x509 0.11.0 API changes (@talex5, mirage/capnp-rpc#196).

- Update to new mirage network API (@Cjen1, mirage/capnp-rpc#198).

- Add echo benchmark test (@Cjen1, mirage/capnp-rpc#197).

- Estimate message sizes to improve performance (@talex5, mirage/capnp-rpc#200).
  By default, capnproto allocates 8k buffers, but most capnp-rpc messages are
  much smaller than this.

Logging:

- Fix application logging, to use library's log (@Cjen1, mirage/capnp-rpc#195).

- Expose the endpoint logger (@Cjen1, mirage/capnp-rpc#195).

- Only enable debug logging for capnp libraries in the calc example.
  TLS now generates a lot of messages at debug level (@talex5, mirage/capnp-rpc#200).
