### PR TITLE
Package ctypes-zarith.0.1.0

### DIFF
--- a/packages/ctypes-zarith/ctypes-zarith.0.1.0/opam
+++ b/packages/ctypes-zarith/ctypes-zarith.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/fdopen/ctypes-zarith.git"
+homepage: "https://github.com/fdopen/ctypes-zarith"
+bug-reports: "https://github.com/fdopen/ctypes-zarith/issues"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {>= "1.2"}
+  "dune-configurator"
+  "zarith"
+  "ctypes"
+  "ppx_cstubs" {>= "0.4.1"}
+  "conf-pkg-config" {build}
+  "ctypes-foreign" {with-test}
+  "alcotest" {with-test}
+]
+
+synopsis: """
+Ctypes wrapper for zarith
+"""
+url {
+  src: "https://github.com/fdopen/ctypes-zarith/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=409aed69b6b1b1ebea9154862ee61093"
+    "sha512=f12e0a9cac137b3d2248c4ec289188a1d6b3dd7dd6fcd6ab9bb813a04abab23bed081e0d5910bd8d60a6cde335307b5c4660234205fe36454db8a5eae47aa718"
+  ]
+}
+
+


### PR DESCRIPTION
### `ctypes-zarith.0.1.0`
Ctypes wrapper for zarith



---
* Homepage: https://github.com/fdopen/ctypes-zarith
* Source repo: git+https://github.com/fdopen/ctypes-zarith.git
* Bug tracker: https://github.com/fdopen/ctypes-zarith/issues

---
:camel: Pull-request generated by opam-publish v2.0.2