### PR TITLE
[new release] x509 (0.11.2)

### DIFF
--- a/packages/x509/x509.0.11.2/opam
+++ b/packages/x509/x509.0.11.2/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.2"}
+  "cstruct" {>= "4.0.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "ptime"
+  "base64" {>= "3.0.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "rresult"
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "mirage-crypto-rng" {with-test}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 7, PKCS 8, PKCS 9 and PKCS 10.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v0.11.2/x509-v0.11.2.tbz"
+  checksum: [
+    "sha256=42ccf807a7b397b8f5411d261f64ae3cb671e59b2a2f10f16b507a5ae16594ac"
+    "sha512=e7f9757f74e2b4caa4f5fb2eb801aa203ba1b77ab7629f01a4bd6e4a02cb82dc67bd97353d45999a5862519b2c704b8285f5e36115efc3e01553379a6f9d1f6c"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Private_key.decode_{pem,der} now has a `~sloppy` option to recover from
  bad keys (where e.g. the private exponent d is wrong).
  (mirleft/ocaml-x509#135 by @hannesm, reported by @mattjbray in mirage/mirage-crypto#62)