### PR TITLE
Solo5 0.6.5

### DIFF
--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.5/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.5/opam
@@ -14,20 +14,15 @@ build: [
   [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE="]
 ]
 install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-hvt" "PREFIX=%{prefix}%"]
-remove: [
-  ["touch" "./Makeconf"]
-  [make "V=1" "uninstall-opam-hvt" "PREFIX=%{prefix}%"]
-]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+  ["linux-libc-dev"] {os-family = "debian"}
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.5/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.5/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE="]
+]
+install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-hvt" "PREFIX=%{prefix}%"]
+remove: [
+  ["touch" "./Makeconf"]
+  [make "V=1" "uninstall-opam-hvt" "PREFIX=%{prefix}%"]
+]
+depends: [
+  "conf-pkg-config"
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment (hvt target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the "hvt" target, including the
+"solo5-hvt" tender source code, and "solo5-hvt-configure" script
+used to specialize the tender at MirageOS unikernel build time.
+
+The "hvt" target is supported on 64-bit Linux, FreeBSD and
+OpenBSD systems with hardware virtualization."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.5/solo5-v0.6.5.tar.gz"
+  checksum: "sha512=58ed9b1d934547b13a3ee4b098b0935842c54bdf78e22043bac50bbf27a832b2ee0a747e7f002b3026b6130a73a8452c78a930a170728f251b7fde85d0bf034a"
+}

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.5/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.5/opam
@@ -14,10 +14,6 @@ build: [
   [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE="]
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE=" "install-opam-muen" "PREFIX=%{prefix}%"]
-remove: [
-  ["touch" "./Makeconf"]
-  [make "V=1" "uninstall-opam-muen" "PREFIX=%{prefix}%"]
-]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.5/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.5/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE="]
+]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE=" "install-opam-muen" "PREFIX=%{prefix}%"]
+remove: [
+  ["touch" "./Makeconf"]
+  [make "V=1" "uninstall-opam-muen" "PREFIX=%{prefix}%"]
+]
+depends: [
+  "conf-pkg-config"
+  "conf-libseccomp" {build & os = "linux"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
+  "solo5-bindings-genode"
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+]
+available: [
+  arch = "x86_64" &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment (muen target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels on the "muen" target. The resulting
+unikernels can then be deployed directly on a host running the
+Muen Separation Kernel.
+
+Building the "muen" target is supported on 64-bit Linux, FreeBSD
+and OpenBSD systems."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.5/solo5-v0.6.5.tar.gz"
+  checksum: "sha512=58ed9b1d934547b13a3ee4b098b0935842c54bdf78e22043bac50bbf27a832b2ee0a747e7f002b3026b6130a73a8452c78a930a170728f251b7fde85d0bf034a"
+}

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.5/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.5/opam
@@ -14,20 +14,15 @@ build: [
   [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE="]
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-spt" "PREFIX=%{prefix}%"]
-remove: [
-  ["touch" "./Makeconf"]
-  [make "V=1" "uninstall-opam-spt" "PREFIX=%{prefix}%"]
-]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {os = "linux"}
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+  ["linux-libc-dev"] {os-family = "debian"}
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.5/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.5/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE="]
+]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-spt" "PREFIX=%{prefix}%"]
+remove: [
+  ["touch" "./Makeconf"]
+  [make "V=1" "uninstall-opam-spt" "PREFIX=%{prefix}%"]
+]
+depends: [
+  "conf-pkg-config"
+  "conf-libseccomp" {os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["linux-libc-dev"] {os-distribution = "debian"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64") & os = "linux"
+]
+synopsis: "Solo5 sandboxed execution environment (spt target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels on the "spt" target and the "solo5-spt" tender
+binary used to run such unikernels.
+
+The "spt" target is supported on 64-bit Linux systems only."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.5/solo5-v0.6.5.tar.gz"
+  checksum: "sha512=58ed9b1d934547b13a3ee4b098b0935842c54bdf78e22043bac50bbf27a832b2ee0a747e7f002b3026b6130a73a8452c78a930a170728f251b7fde85d0bf034a"
+}

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.5/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.5/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE="]
+]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-virtio" "PREFIX=%{prefix}%"]
+remove: [
+  ["touch" "./Makeconf"]
+  [make "V=1" "uninstall-opam-virtio" "PREFIX=%{prefix}%"]
+]
+depends: [
+  "conf-pkg-config"
+  "conf-libseccomp" {build & os = "linux"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+]
+available: [
+  arch = "x86_64" &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment (virtio target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels using the "virtio" target.
+
+The "virtio" target is supported on 64-bit Linux and FreeBSD
+systems with hardware virtualization, and produces unikernels
+suitable for running on any virtio-compliant hypervisor (e.g.
+QEMU/KVM).
+
+Note that the "virtio" target provides limited support for
+current and future Solo5 features and abstractions. We recommend
+that you use the "hvt" target instead."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.5/solo5-v0.6.5.tar.gz"
+  checksum: "sha512=58ed9b1d934547b13a3ee4b098b0935842c54bdf78e22043bac50bbf27a832b2ee0a747e7f002b3026b6130a73a8452c78a930a170728f251b7fde85d0bf034a"
+}

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.5/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.5/opam
@@ -14,10 +14,6 @@ build: [
   [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE="]
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-virtio" "PREFIX=%{prefix}%"]
-remove: [
-  ["touch" "./Makeconf"]
-  [make "V=1" "uninstall-opam-virtio" "PREFIX=%{prefix}%"]
-]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}


### PR DESCRIPTION
New features:

* Stop host kernels from attempting to execute Solo5 binaries. This improves
  both the user experience on some hosts (e.g. "No such file or directory" vs.
  "Segmentation fault" on Linux) and overall security posture by forcing the
  host kernel ELF loader to bail out earlier rather than actually jumping to
  the unikernel code. (#442)
* hvt: Full support for W^X and correct guest-side page protections on OpenBSD
  6.7+ systems with EPT. (#447)
* hvt: capsicum(4) sandbox for the hvt tender on FreeBSD 12+. (#366)

Bug fixes:

* hvt: Fix hang in `HVT_HYPERCALL_POLL`. On Linux hosts, if `solo5_yield()` was
  called with a deadline that has already passed and the unikernel was not using
  any network devices then the underlying hypercall would hang forever. Not
  known to affect any existing code in production. (#460)

Other notable changes:

* muen: Muen ABI updates, now uses ABI version 2 on the Solo5 side. Muen
  commit f10bd6b or later is required. (#454, #448)
* genode: Support for Genode is limited by toolchain issues and Genode bindings
  are no longer built by default. (#446, see also ocaml/opam-repository#16368)
* Improvements to the build system on BSD/clang hosts. System headers
  (sys/endian.h, osreldate.h) that were mistakenly being installed into the
  Solo5-provided include paths have been removed. For OCaml/MirageOS users,
  ocaml-freestanding 0.6.0 or later is now required. (#453, #455, #457, #461,
  see also mirage/ocaml-freestanding#77)
* Improvements to built-in self tests. (#451)
* Fix build failures with GCC >= 10. (#459)

Known issues:

* Full W^X support / correct guest-side page protections are currently only
  available on the "spt" target on Linux, and the "hvt" target on OpenBSD 6.7
  or later. (#303)
* On OpenBSD, "hvt" operation with multiple network devices results in packet
  loss. This appears to be a bug in kqueue(2) but we have no confirmation from
  upstream. (#374)
* virtio-net is not functional on at least QEMU 5.0 and possibly earlier
  versions. QEMU versions up to and including 3.1.0 are known to work. (#463)

Acknowledgements:

* Thanks to Adam Steen (@adamsteen) for pushing for OpenBSD kernel support for
  manipulating guest EPT mappings, bringing full W^X to hvt on OpenBSD 6.7 or
  later.
* Thanks to Adrian-Ken Rueegsegger (@kensan) for the Muen updates.
* Thanks to Anurag Soni (@anuragsoni) for diagnosing and fixing the build on
  systems with GCC >= 10.
* Thanks to Hannes Mehnert (@hannesm) for diagnosing #460 and for help with
  testing BSD/clang build system changes and generally helping out.
* Thanks to Stefan Grundmann (@sg2342) for the capsicum(4) hvt tender sandbox
  on FreeBSD.