### PR TITLE
[new release] mirage-nat (2.2.1)

### DIFF
--- a/packages/mirage-nat/mirage-nat.2.2.1/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+name: "mirage-nat"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+homepage: "https://github.com/mirage/mirage-nat"
+bug-reports: "https://github.com/mirage/mirage-nat/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-nat.git"
+doc: "https://mirage.github.io/mirage-nat/"
+license: "ISC"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "ipaddr"
+  "cstruct"
+  "lwt"
+  "rresult"
+  "logs"
+  "lru" {>= "0.3.0"}
+  "ppx_deriving" {>= "4.2" }
+  "dune" {>= "1.0"}
+  "tcpip" { >= "4.1.0" }
+  "ethernet" { >= "2.0.0" }
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+]
+synopsis: "Mirage-nat is a library for network address translation to be used with MirageOS"
+description: """
+Mirage-nat is a library for [network address
+translation](https://tools.ietf.org/html/rfc2663).  It is intended for use in
+[MirageOS](https://mirage.io) and makes extensive use of
+[tcpip](https://github.com/mirage/mirage-tcpip), the network stack used by
+default in MirageOS unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-nat/releases/download/v2.2.1/mirage-nat-v2.2.1.tbz"
+  checksum: [
+    "sha256=95d446e00b89c0c094eba0dcc7685f3677daf4ac70ae969b1e3510e6716d140a"
+    "sha512=e2edce1d51e50aff261d38a3c18677819355484eacbe8ad4f42335ba4943109d959607ff03218f03af57379608810bbf5eadf14c5f591e107c4757a567a640a8"
+  ]
+}


### PR DESCRIPTION
Mirage-nat is a library for network address translation to be used with MirageOS

- Project page: <a href="https://github.com/mirage/mirage-nat">https://github.com/mirage/mirage-nat</a>
- Documentation: <a href="https://mirage.github.io/mirage-nat/">https://mirage.github.io/mirage-nat/</a>

##### CHANGES:

- Also report freed ICMP ports in remove_connections (mirage/mirage-nat#40 by @linse @hannesm)
