### PR TITLE
mirage-crypto-entropy does not support 32 bit

### DIFF
--- a/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.0/opam
+++ b/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.0/opam
@@ -23,7 +23,7 @@ depends: [
 ]
 tags: [ "org:mirage"]
 available: [
-  arch = "arm" | arch = "x86_32" | arch = "x86_64" | arch = "arm64"
+  arch = "x86_64" | arch = "arm64"
 ]
 synopsis: "Entropy source for MirageOS unikernels"
 description: """

--- a/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.1/opam
+++ b/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.1/opam
@@ -23,7 +23,7 @@ depends: [
 ]
 tags: [ "org:mirage"]
 available: [
-  arch = "arm" | arch = "x86_32" | arch = "x86_64" | arch = "arm64"
+  arch = "x86_64" | arch = "arm64"
 ]
 synopsis: "Entropy source for MirageOS unikernels"
 description: """

--- a/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.2/opam
+++ b/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.2/opam
@@ -23,7 +23,7 @@ depends: [
 ]
 tags: [ "org:mirage"]
 available: [
-  arch = "arm" | arch = "x86_32" | arch = "x86_64" | arch = "arm64"
+  arch = "x86_64" | arch = "arm64"
 ]
 synopsis: "Entropy source for MirageOS unikernels"
 description: """


### PR DESCRIPTION
see report in https://github.com/mirage/mirage-crypto/issues/60, and the next release will have 32 bit report.