### PR TITLE
new file:   packages/parany/parany.11.0.2/opam

### DIFF
--- a/packages/hts_shrink/hts_shrink.2.1.1/opam
+++ b/packages/hts_shrink/hts_shrink.2.1.1/opam
@@ -11,7 +11,7 @@ depends: [
   "batteries"
   "dolog" {>= "4.0.0"}
   "parmap"
-  "parany" {>= "5.0.0"}
+  "parany" {>= "5.0.0" & < "11.0.0"}
   "minicli" {>= "5.0.0"}
   "bitv"
   "bst"

--- a/packages/molenc/molenc.7.0.1/opam
+++ b/packages/molenc/molenc.7.0.1/opam
@@ -25,7 +25,7 @@ depends: [
   "dune" {>= "1.11"}
   "minicli"
   "ocaml"
-  "parany" {>= "9.0.0"} # for the Parmap compatibility module
+  "parany" {>= "9.0.0" & < "11.0.0"}
 ]
 synopsis: "Molecular encoder/featurizer using rdkit and OCaml"
 description: """Chemical fingerprints are lossy encodings of molecules.

--- a/packages/molenc/molenc.8.0.2/opam
+++ b/packages/molenc/molenc.8.0.2/opam
@@ -25,7 +25,7 @@ depends: [
   "dune" {>= "1.11"}
   "minicli"
   "ocaml"
-  "parany" {>= "9.0.0"} # for the Parmap compatibility module
+  "parany" {>= "9.0.0" & < "11.0.0"}
 ]
 synopsis: "Molecular encoder/featurizer using rdkit and OCaml"
 description: """Chemical fingerprints are lossy encodings of molecules.

--- a/packages/oplsr/oplsr.5.0.1/opam
+++ b/packages/oplsr/oplsr.5.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "batteries"
   "minicli" {>= "5.0.0"}
   "cpm"
-  "parany" {>= "5.0.0"}
+  "parany" {>= "5.0.0" & < "11.0.0"}
 ]
 synopsis: "OCaml wrapper for the R 'pls' package"
 description: """

--- a/packages/parany/parany.11.0.1/opam
+++ b/packages/parany/parany.11.0.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: "Francois Berenger"
+license: "LGPL-2.0-or-later"
+homepage: "https://github.com/UnixJunkie/parany"
+bug-reports: "https://github.com/UnixJunkie/parany/issues"
+dev-repo: "git+https://github.com/UnixJunkie/parany.git"
+depends: [
+  "base-unix"
+  "cpu"
+  "dune" {>= "1.6.0"}
+  "ocaml"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+# the test exe doesn't run in the CI env. of the opam-repository
+# probably because processes are limited to one core, I guess
+# ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Parallelize any computation"
+description: """
+Generalized map reduce for parallel computers (not distributed computing).
+Can process in parallel an infinite stream of elements.
+
+Can process a very large file in parallel on a multicore computer;
+provided there is a way to cut your file into independent blocks
+(the 'demux' function).
+The processing function is called 'work'.
+The function gathering the results is called 'mux'.
+The number of processors running your computation in parallel is called
+'nprocs'.
+The chunk size (number of items) processed by one call to the 'work' function
+is called 'csize'.
+
+There is a minimalist Parmap module, if you want to switch
+to/from Parmap easily.
+
+Read the corresponding ocamldoc before using.
+
+USING THIS LIBRARY IN A MISSION CRITICAL, LONG-RUNNING SOFTWARE
+THAT IS NEVER SUPPOSED TO CRASH IS NOT ADVIZED.
+WHILE THIS LIBRARY IS HIGH PERFORMANCE, IT IS ALSO DANGEROUS.
+USE AT YOUR OWN RISKS.
+"""
+url {
+  src: "https://github.com/UnixJunkie/parany/archive/v11.0.1.tar.gz"
+  checksum: "md5=242ea55067f387f5051b725593005de2"
+}

--- a/packages/parany/parany.11.0.2/opam
+++ b/packages/parany/parany.11.0.2/opam
@@ -43,6 +43,6 @@ WHILE THIS LIBRARY IS HIGH PERFORMANCE, IT IS ALSO DANGEROUS.
 USE AT YOUR OWN RISKS.
 """
 url {
-  src: "https://github.com/UnixJunkie/parany/archive/v11.0.1.tar.gz"
-  checksum: "md5=242ea55067f387f5051b725593005de2"
+  src: "https://github.com/UnixJunkie/parany/archive/v11.0.2.tar.gz"
+  checksum: "md5=052b131c99bdf3f67c51175f5e3bccfe"
 }

--- a/packages/pardi/pardi.2.0.4/opam
+++ b/packages/pardi/pardi.2.0.4/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "1.11"}
   "batteries"
   "dolog" {>= "4.0.0"}
-  "parany" {>= "6.0.0"}
+  "parany" {>= "6.0.0" & < "11.0.0"}
   "minicli" {>= "5.0.0"}
   "lz4"
   "cryptokit"


### PR DESCRIPTION
Major release; existing client software that is not yet updated should use parany < 11.0.0.

```
val Parany.run ?preserve:bool -> ?core_pin:bool -> ?csize:int -> int ->
  demux:(unit -> 'a) -> work:('a -> 'b) -> mux:('b -> unit) -> unit                                                                                                                                   
```
ncores is no more a labeled paramete. Rather, it is the only anonymous parameter now.
New optional parameters with default values:
~preserve (default = false); to reflect input order in output. Off by default for performance reasons.
Also note that while the output will be in the same order as the input. Computations might still
happen out of order for performance reasons.
~csize (default=1); to tweak the granularity of a computation.
~core_pin (default=false); pin processes to core (off by default because powerful computers are usually shared by several users; also, you could run several parany computations on one computer
and you don't want that they all stay pinned to the same cores).

Thanks to @darrenldl for some non trivial code factorization.
