### PR TITLE
[new release] h2, h2-lwt, h2-lwt-unix, h2-mirage and h2-async (0.6.1)

### DIFF
--- a/packages/h2-async/h2-async.0.6.1/opam
+++ b/packages/h2-async/h2-async.0.6.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.7"}
+  "faraday-async"
+  "async"
+  "gluten-async"
+  "h2" {= version}
+]
+depopts: ["async_ssl"]
+synopsis: "Async support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-async provides an Async runtime implementation for h2.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.6.1/h2-0.6.1.tbz"
+  checksum: [
+    "sha256=585fb8f4f1bef0a9f93dbbd24a7a9d2d048e725bab0c2fbdbef9eb301e7a677d"
+    "sha512=ee6d4f554593187b8ac21fa73c98e5be82b5a99828f4d5dfb082623a57e2eccbd0eb252a5d970481ad6892580e9fffeaa819ab729708f6dd11072165ebceca01"
+  ]
+}

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.6.1/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.6.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "faraday-lwt-unix"
+  "h2-lwt" {= version}
+  "dune" {>= "1.7"}
+  "lwt"
+  "gluten-lwt-unix" {>= "0.2.1"}
+]
+depopts: [
+  "tls"
+  "lwt_ssl"
+]
+synopsis: "Lwt + UNIX support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-lwt-unix provides an Lwt runtime implementation for h2 that targets UNIX
+binaries.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.6.1/h2-0.6.1.tbz"
+  checksum: [
+    "sha256=585fb8f4f1bef0a9f93dbbd24a7a9d2d048e725bab0c2fbdbef9eb301e7a677d"
+    "sha512=ee6d4f554593187b8ac21fa73c98e5be82b5a99828f4d5dfb082623a57e2eccbd0eb252a5d970481ad6892580e9fffeaa819ab729708f6dd11072165ebceca01"
+  ]
+}

--- a/packages/h2-lwt/h2-lwt.0.6.1/opam
+++ b/packages/h2-lwt/h2-lwt.0.6.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "h2" {= version}
+  "dune" {>= "1.7"}
+  "lwt"
+  "gluten-lwt" {>= "0.2.1"}
+]
+synopsis: "Lwt support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-lwt
+provides an Lwt runtime implementation for h2.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.6.1/h2-0.6.1.tbz"
+  checksum: [
+    "sha256=585fb8f4f1bef0a9f93dbbd24a7a9d2d048e725bab0c2fbdbef9eb301e7a677d"
+    "sha512=ee6d4f554593187b8ac21fa73c98e5be82b5a99828f4d5dfb082623a57e2eccbd0eb252a5d970481ad6892580e9fffeaa819ab729708f6dd11072165ebceca01"
+  ]
+}

--- a/packages/h2-mirage/h2-mirage.0.6.1/opam
+++ b/packages/h2-mirage/h2-mirage.0.6.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "faraday-lwt"
+  "h2-lwt" {= version}
+  "gluten-lwt" {>= "0.2.0"}
+  "dune" {>= "1.7"}
+  "lwt"
+  "conduit-mirage" {>= "2.0.2"}
+  "mirage-flow" {>= "2.0.0"}
+  "cstruct"
+]
+synopsis: "Mirage support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-mirage provides an Lwt runtime implementation for h2 that targets MirageOS
+unikernels.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.6.1/h2-0.6.1.tbz"
+  checksum: [
+    "sha256=585fb8f4f1bef0a9f93dbbd24a7a9d2d048e725bab0c2fbdbef9eb301e7a677d"
+    "sha512=ee6d4f554593187b8ac21fa73c98e5be82b5a99828f4d5dfb082623a57e2eccbd0eb252a5d970481ad6892580e9fffeaa819ab729708f6dd11072165ebceca01"
+  ]
+}

--- a/packages/h2-mirage/h2-mirage.0.6.1/opam
+++ b/packages/h2-mirage/h2-mirage.0.6.1/opam
@@ -16,6 +16,7 @@ depends: [
   "gluten-lwt" {>= "0.2.0"}
   "dune" {>= "1.7"}
   "lwt"
+  "gluten-mirage"
   "conduit-mirage" {>= "2.0.2"}
   "mirage-flow" {>= "2.0.0"}
   "cstruct"

--- a/packages/h2/h2.0.6.1/opam
+++ b/packages/h2/h2.0.6.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.7"}
+  "alcotest" {with-test}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "base64"
+  "bigstringaf" {>= "0.5.0"}
+  "angstrom" {>= "0.14.0"}
+  "faraday" {>= "0.5.0"}
+  "psq"
+  "hpack"
+  "httpaf"
+]
+synopsis:
+  "A high-performance, memory-efficient, and scalable HTTP/2 library for OCaml"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. It
+is based on the concepts in http/af, and therefore uses the Angstrom and
+Faraday libraries to implement the parsing and serialization layers of the
+HTTP/2 standard as a state machine that is agnostic to the underlying I/O
+specifics. It also preserves the same API as http/af wherever possible.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.6.1/h2-0.6.1.tbz"
+  checksum: [
+    "sha256=585fb8f4f1bef0a9f93dbbd24a7a9d2d048e725bab0c2fbdbef9eb301e7a677d"
+    "sha512=ee6d4f554593187b8ac21fa73c98e5be82b5a99828f4d5dfb082623a57e2eccbd0eb252a5d970481ad6892580e9fffeaa819ab729708f6dd11072165ebceca01"
+  ]
+}


### PR DESCRIPTION
A high-performance, memory-efficient, and scalable HTTP/2 library for OCaml

- Project page: <a href="https://github.com/anmonteiro/ocaml-h2">https://github.com/anmonteiro/ocaml-h2</a>
- Documentation: <a href="https://anmonteiro.github.io/ocaml-h2/">https://anmonteiro.github.io/ocaml-h2/</a>

##### CHANGES:


