### PR TITLE
[new release] received, sendmail-lwt, colombe and sendmail (0.3.0)

### DIFF
--- a/packages/colombe/colombe.0.3.0/opam
+++ b/packages/colombe/colombe.0.3.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "SMTP protocol in OCaml"
+doc:          "https://mirage.github.io/colombe/"
+description: """SMTP protocol according RFC5321 without extension."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.8.0"}
+  "fmt"
+  "ipaddr" {>= "2.9.0"}
+  "angstrom" {>= "0.14.0"}
+  "ocaml-syntax-shims"
+  "alcotest" {with-test}
+]
+depopts: [ "emile" ]
+conflicts: [ "emile" {< "0.8"} ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.3.0/colombe-v0.3.0.tbz"
+  checksum: [
+    "sha256=e191073dd4d984cd63e5a78debbc481e4fa1c5a543c756fedef9f82c40962c73"
+    "sha512=6c7279d2df763ec43f09a083feaf8285d4c90df22e9749dc404f8e96d34c5ec7f047b8c54f46c8e9e1d70fda603ab5c3ba3da99333d21c95e16ca9442fd1d573"
+  ]
+}

--- a/packages/received/received.0.3.0/opam
+++ b/packages/received/received.0.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "Received field according RFC5321"
+doc:          "https://mirage.github.io/colombe/"
+description: """A little library to parse or emit a Received field according
+RFC5321. It is able to notify which SMTP server serves the email (and track, by this way,
+on which way - TLS or not - the email was transmitted)."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {>= "1.8.0"}
+  "colombe"  {= version}
+  "mrmime"   {>= "0.2.0"}
+  "emile"    {>= "0.8"}
+  "angstrom" {>= "0.14.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.3.0/colombe-v0.3.0.tbz"
+  checksum: [
+    "sha256=e191073dd4d984cd63e5a78debbc481e4fa1c5a543c756fedef9f82c40962c73"
+    "sha512=6c7279d2df763ec43f09a083feaf8285d4c90df22e9749dc404f8e96d34c5ec7f047b8c54f46c8e9e1d70fda603ab5c3ba3da99333d21c95e16ca9442fd1d573"
+  ]
+}

--- a/packages/sendmail-lwt/sendmail-lwt.0.3.0/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.8"}
+  "sendmail" {= version}
+  "domain-name"
+  "lwt"
+  "tls"
+  "x509" {>= "0.7.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.3.0/colombe-v0.3.0.tbz"
+  checksum: [
+    "sha256=e191073dd4d984cd63e5a78debbc481e4fa1c5a543c756fedef9f82c40962c73"
+    "sha512=6c7279d2df763ec43f09a083feaf8285d4c90df22e9749dc404f8e96d34c5ec7f047b8c54f46c8e9e1d70fda603ab5c3ba3da99333d21c95e16ca9442fd1d573"
+  ]
+}

--- a/packages/sendmail/sendmail.0.3.0/opam
+++ b/packages/sendmail/sendmail.0.3.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command"
+description: """A library to be able to send an email."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.8"}
+  "colombe" {= version}
+  "tls"
+  "base64" {>= "3.0.0"}
+  "logs"
+  "emile" {>= "0.8" & with-test}
+  "mrmime" {>= "0.2.0" & with-test}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.3.0/colombe-v0.3.0.tbz"
+  checksum: [
+    "sha256=e191073dd4d984cd63e5a78debbc481e4fa1c5a543c756fedef9f82c40962c73"
+    "sha512=6c7279d2df763ec43f09a083feaf8285d4c90df22e9749dc404f8e96d34c5ec7f047b8c54f46c8e9e1d70fda603ab5c3ba3da99333d21c95e16ca9442fd1d573"
+  ]
+}


### PR DESCRIPTION
Received field according RFC5321

- Project page: <a href="https://github.com/mirage/colombe">https://github.com/mirage/colombe</a>
- Documentation: <a href="https://mirage.github.io/colombe/">https://mirage.github.io/colombe/</a>

##### CHANGES:

- Fix opam file (mirage/colombe#22, @kit-ty-kate)
- Better documentation (mirage/colombe#23 & mirage/colombe#24, @dinosaure)
- Update to `angstrom.0.14.0` (mirage/colombe#24, @dinosaure)
