### PR TITLE
[new release] pyml.20200518

### DIFF
--- a/packages/pyml/pyml.20200518/opam
+++ b/packages/pyml/pyml.20200518/opam
@@ -14,10 +14,11 @@ depends: [
   "ocaml" {>= "3.12.1" & < "4.12.0"}
   "ocamlfind" {build}
   "stdcompat" {>= "13"}
+  "conf-python-3-dev" {with-test}
 ]
 depopts: ["utop"]
 version: "20200518"
 url {
   src: "https://github.com/thierry-martinez/pyml/archive/20200518.tar.gz"
-  checksum: "sha512=b9b99013eed16b3ba94a7d481fd40f0c0f3d159abbe3ea99b8141537442a24794b1bea3cbabd62c2f4c13145bb36d075e69ea594b553ada7e6cc25b3d88f2727"
+  checksum: "sha512=e3dec173e6e0134f89137686291aa706db0f151ef1075f6661ccf8bdbed3a70eb8ed3e3c56a98836fc1456e32cedb6a7cd94ebf75dcb3414d0193158496317c4"
 }

--- a/packages/pyml/pyml.20200518/opam
+++ b/packages/pyml/pyml.20200518/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "http://github.com/thierry-martinez/pyml"
+bug-reports: "http://github.com/thierry-martinez/pyml/issues"
+license: "BSD"
+dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
+build: [make "all" "pymltop" "pymlutop" {utop:installed} "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%"]
+run-test: [make "tests"]
+synopsis: "OCaml bindings for Python"
+description: "OCaml bindings for Python 2 and Python 3"
+depends: [
+  "ocaml" {>= "3.12.1" & < "4.12.0"}
+  "ocamlfind" {build}
+  "stdcompat" {>= "13"}
+]
+depopts: ["utop"]
+version: "20200518"
+url {
+  src: "https://github.com/thierry-martinez/pyml/archive/20200518.tar.gz"
+  checksum: "sha512=4b93d61889ca354b9e71f1fdab466084ae5e3954e93f93a7ef421e5f6ee0509dec210e843d3c1331018f0f625f7a91803066434a19f829137d75a94edb85a628"
+}

--- a/packages/pyml/pyml.20200518/opam
+++ b/packages/pyml/pyml.20200518/opam
@@ -19,5 +19,5 @@ depopts: ["utop"]
 version: "20200518"
 url {
   src: "https://github.com/thierry-martinez/pyml/archive/20200518.tar.gz"
-  checksum: "sha512=f3781cbb4e9e190df38c3fe7fa80ba69bf6f9dbafb158e0426dd4604f2f1ba794450679005a38d0f9f1dad0696e2f22b8b086b2d7d08a0f99bb4fd3b0f7ed5d8"
+  checksum: "sha512=b9b99013eed16b3ba94a7d481fd40f0c0f3d159abbe3ea99b8141537442a24794b1bea3cbabd62c2f4c13145bb36d075e69ea594b553ada7e6cc25b3d88f2727"
 }

--- a/packages/pyml/pyml.20200518/opam
+++ b/packages/pyml/pyml.20200518/opam
@@ -7,7 +7,7 @@ license: "BSD"
 dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
 build: [make "all" "pymltop" "pymlutop" {utop:installed} "PREFIX=%{prefix}%"]
 install: [make "install" "PREFIX=%{prefix}%"]
-run-test: [make "tests"]
+run-test: [make "test"]
 synopsis: "OCaml bindings for Python"
 description: "OCaml bindings for Python 2 and Python 3"
 depends: [
@@ -19,5 +19,5 @@ depopts: ["utop"]
 version: "20200518"
 url {
   src: "https://github.com/thierry-martinez/pyml/archive/20200518.tar.gz"
-  checksum: "sha512=4b93d61889ca354b9e71f1fdab466084ae5e3954e93f93a7ef421e5f6ee0509dec210e843d3c1331018f0f625f7a91803066434a19f829137d75a94edb85a628"
+  checksum: "sha512=f3781cbb4e9e190df38c3fe7fa80ba69bf6f9dbafb158e0426dd4604f2f1ba794450679005a38d0f9f1dad0696e2f22b8b086b2d7d08a0f99bb4fd3b0f7ed5d8"
 }


### PR DESCRIPTION
- Fix: Add an `__iter__` method to python iterators.
  (Fixed by Laurent Mazare, https://github.com/thierry-martinez/pyml/pull/47)

- Add `Py.Seq.{of_seq_map, to_seq_map, unsafe_to_seq_map, of_list, of_list_map}` functions.

- Remove `Py.Import.cleanup`, which has been removed from Python 3.9, and was marked "for internal use only" before.
  (Reported by Victor Stinner, https://github.com/thierry-martinez/pyml/issues/49)

- Fix: memory leak in pyml_wrap_closure
  (Fixed by Laurent Mazare, https://github.com/thierry-martinez/pyml/pull/53)

- Add `Py.Module.set_docstring`, for Python >=3.5.
  (Added by Laurent Mazare, https://github.com/thierry-martinez/pyml/pull/54)

- Fix: install .cmx files
  (Reported by Jonathan Laurent, https://github.com/thierry-martinez/pyml/issues/55)