### PR TITLE
Fix musl+static switches for Alpine

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.01.0+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+musl+static/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "4.01.0 release compiled with musl-gcc -static"
 description:
-  "Requires musl-gcc to be installed (apt-get install musl-tools on Debian)"
+  "Requires musl-gcc to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
 maintainer: "platform@lists.ocaml.org"
 depends: [
   "ocaml" {= "4.01.0" & post}
@@ -9,6 +9,11 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "base-ocamlbuild" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
@@ -20,9 +25,11 @@ build: [
     prefix
     "-with-debug-runtime"
     "-cc"
-    "musl-gcc -Os"
+    "musl-gcc -Os" {os-distribution != "alpine"}
+    "gcc -Os" {os-distribution = "alpine"}
     "-aspp"
-    "musl-gcc -c"
+    "musl-gcc -c" {os-distribution != "alpine"}
+    "gcc -c" {os-distribution = "alpine"}
     "-libs"
     "-static"
     "-no-tk"

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+musl+static/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "4.02.1 release compiled with musl-gcc -static"
 description:
-  "Requires musl-gcc to be installed (apt-get install musl-tools on Debian)"
+  "Requires musl-gcc to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
 maintainer: "platform@lists.ocaml.org"
 depends: [
   "ocaml" {= "4.02.1" & post}
@@ -9,6 +9,11 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "base-ocamlbuild" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
@@ -20,9 +25,11 @@ build: [
     prefix
     "-with-debug-runtime"
     "-cc"
-    "musl-gcc -Os"
+    "musl-gcc -Os" {os-distribution != "alpine"}
+    "gcc -Os" {os-distribution = "alpine"}
     "-aspp"
-    "musl-gcc -c"
+    "musl-gcc -c" {os-distribution != "alpine"}
+    "gcc -c" {os-distribution = "alpine"}
     "-libs"
     "-static"
     "-no-curses"

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+musl+static/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "OCaml 4.02.3 compiled with musl-gcc -static"
 description:
-  "Requires musl-gcc to be installed (apt-get install musl-tools on Debian)"
+  "Requires musl-gcc to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
 maintainer: "platform@lists.ocaml.org"
 depends: [
   "ocaml" {= "4.02.3" & post}
@@ -9,6 +9,11 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "base-ocamlbuild" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
@@ -20,9 +25,11 @@ build: [
     prefix
     "-with-debug-runtime"
     "-cc"
-    "musl-gcc -Os"
+    "musl-gcc -Os" {os-distribution != "alpine"}
+    "gcc -Os" {os-distribution = "alpine"}
     "-aspp"
-    "musl-gcc -c"
+    "musl-gcc -c" {os-distribution != "alpine"}
+    "gcc -c" {os-distribution = "alpine"}
     "-libs"
     "-static"
     "-no-curses"

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+musl+static+flambda/opam
@@ -2,13 +2,18 @@ opam-version: "2.0"
 synopsis:
   "Official 4.05.0 release compiled with musl-clang -static and with flambda activated"
 description:
-  "Requires musl-clang to be installed (package musl on Arch Linux or musl-tools on Debian)"
+  "Requires musl-clang to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
 maintainer: "platform@lists.ocaml.org"
 depends: [
   "ocaml" {= "4.05.0" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
@@ -21,9 +26,11 @@ build: [
     "-with-debug-runtime"
     "-flambda"
     "-cc"
-    "musl-clang -Os"
+    "musl-clang -Os" {os-distribution != "alpine"}
+    "clang -Os" {os-distribution = "alpine"}
     "-aspp"
-    "musl-clang -c"
+    "musl-clang -c" {os-distribution != "alpine"}
+    "clang -c" {os-distribution = "alpine"}
     "-libs"
     "-static"
     "-no-curses"

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+musl+static+flambda/opam
@@ -2,13 +2,18 @@ opam-version: "2.0"
 synopsis:
   "Official 4.06.0 release compiled with musl-clang -static and with flambda activated"
 description:
-  "Requires musl-clang to be installed (package musl on Arch Linux or musl-tools on Debian)"
+  "Requires musl-clang to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
 maintainer: "platform@lists.ocaml.org"
 depends: [
   "ocaml" {= "4.06.0" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
@@ -21,9 +26,11 @@ build: [
     "-with-debug-runtime"
     "-flambda"
     "-cc"
-    "musl-clang -Os"
+    "musl-clang -Os" {os-distribution != "alpine"}
+    "clang -Os" {os-distribution = "alpine"}
     "-aspp"
-    "musl-clang -c"
+    "musl-clang -c" {os-distribution != "alpine"}
+    "clang -c" {os-distribution = "alpine"}
     "-libs"
     "-static"
     "-no-curses"

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
@@ -2,13 +2,18 @@ opam-version: "2.0"
 synopsis:
   "Official 4.06.1 release compiled with musl-clang -static and with flambda activated"
 description:
-  "Requires musl-clang to be installed (package musl on Arch Linux or musl-tools on Debian)"
+  "Requires musl-clang to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
 maintainer: "platform@lists.ocaml.org"
 depends: [
   "ocaml" {= "4.06.1" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
@@ -26,9 +26,11 @@ build: [
     "-with-debug-runtime"
     "-flambda"
     "-cc"
-    "musl-clang -Os"
+    "musl-clang -Os" {os-distribution != "alpine"}
+    "clang -Os" {os-distribution = "alpine"}
     "-aspp"
-    "musl-clang -c"
+    "musl-clang -c" {os-distribution != "alpine"}
+    "clang -c" {os-distribution = "alpine"}
     "-libs"
     "-static"
     "-no-curses"

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
@@ -2,13 +2,18 @@ opam-version: "2.0"
 synopsis:
   "Official 4.07.1 release compiled with musl-gcc -static and with flambda activated"
 description:
-  "Requires musl-gcc to be installed (package musl on Arch Linux or musl-tools on Debian)"
+  "Requires musl-gcc to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
 maintainer: "platform@lists.ocaml.org"
 depends: [
   "ocaml" {= "4.07.1" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
@@ -23,9 +28,11 @@ build: [
     "-with-debug-runtime"
     "-flambda"
     "-cc"
-    "musl-gcc -Os"
+    "musl-gcc -Os" {os-distribution != "alpine"}
+    "gcc -Os" {os-distribution = "alpine"}
     "-aspp"
-    "musl-gcc -c"
+    "musl-gcc -c" {os-distribution != "alpine"}
+    "gcc -c" {os-distribution = "alpine"}
     "-libs"
     "-static"
     "-no-curses"

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis:
   "Official release 4.08.0, compiled with musl-gcc -static and with flambda activated"
 description:
-  "Requires musl-gcc to be installed (package musl on Arch Linux or musl-tools on Debian)"
+  "Requires musl-gcc to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
@@ -14,6 +14,11 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
 ]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
+]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
@@ -23,9 +28,9 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "CC=musl-gcc"
+    "CC=musl-gcc" {os-distribution != "alpine"}
     "CFLAGS=-Os"
-    "ASPP=musl-gcc -c"
+    "ASPP=musl-gcc -c" {os-distribution != "alpine"}
     "--enable-flambda"
     "LIBS=-static"
     "--disable-graph-lib"

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis:
   "Official release 4.08.1, compiled with musl-gcc -static and with flambda activated"
 description:
-  "Requires musl-gcc to be installed (package musl on Arch Linux or musl-tools on Debian)"
+  "Requires musl-gcc to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
@@ -17,6 +17,7 @@ depends: [
 depexts: [
   ["musl-tools"] {os-family = "debian"}
   ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
@@ -27,8 +28,9 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "CC=musl-gcc -Os"
-    "ASPP=musl-gcc -c"
+    "CC=musl-gcc" {os-distribution != "alpine"}
+    "CFLAGS=-Os"
+    "ASPP=musl-gcc -c" {os-distribution != "alpine"}
     "--enable-flambda"
     "LIBS=-static"
     "--disable-graph-lib"

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis:
   "Official release 4.09.0, compiled with musl-gcc -static and with flambda activated"
 description:
-  "Requires musl-gcc to be installed (package musl on Arch Linux or musl-tools on Debian)"
+  "Requires musl-gcc to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
@@ -17,6 +17,7 @@ depends: [
 depexts: [
   ["musl-tools"] {os-family = "debian"}
   ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
@@ -27,9 +28,9 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "CC=musl-gcc"
+    "CC=musl-gcc" {os-distribution != "alpine"}
     "CFLAGS=-Os"
-    "ASPP=musl-gcc -c"
+    "ASPP=musl-gcc -c" {os-distribution != "alpine"}
     "--enable-flambda"
     "LIBS=-static"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+musl+static+flambda/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis:
   "Official release 4.09.1, compiled with musl-gcc -static and with flambda activated"
 description:
-  "Requires musl-gcc to be installed (package musl on Arch Linux or musl-tools on Debian)"
+  "Requires musl-gcc to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
@@ -17,6 +17,7 @@ depends: [
 depexts: [
   ["musl-tools"] {os-family = "debian"}
   ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
@@ -27,9 +28,9 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "CC=musl-gcc"
+    "CC=musl-gcc" {os-distribution != "alpine"}
     "CFLAGS=-Os"
-    "ASPP=musl-gcc -c"
+    "ASPP=musl-gcc -c" {os-distribution != "alpine"}
     "--enable-flambda"
     "LIBS=-static"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}


### PR DESCRIPTION
Continuation of https://github.com/ocaml/opam-repository/pull/16064

See also https://github.com/ocaml/ocaml/issues/9390

Used the following script to automate the patching:
```sh
#!/bin/sh

replace_musl() {
	sed -i 's/package musl on Arch Linux or musl-tools on Debian/package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine/g' "$1"
	sed -i '/^  \["musl"\] {os-distribution = "arch"}/a\
  \["musl-dev"\] {os-distribution = "alpine"}' "$1"
	sed -i 's/"CC=musl-gcc"$/"CC=musl-gcc" {os-distribution != "alpine"}/g' "$1"
	sed -i 's/"ASPP=musl-gcc -c"$/"ASPP=musl-gcc -c" {os-distribution != "alpine"}/g' "$1"
}

for f in packages/ocaml-variants/ocaml-variants*musl+static*/opam; do
	if [ -f "$f" ]; then
		echo "Patching $f..."
		replace_musl "$f"
	fi
done

```