### PR TITLE
[new release] mirage (3.7.7)

### DIFF
--- a/packages/mirage/mirage.3.7.7/opam
+++ b/packages/mirage/mirage.3.7.7/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "3.0.0"}
+  "functoria"          {>= "3.1.0"}
+  "bos"
+  "astring"
+  "logs"
+  "stdlib-shims"
+  "mirage-runtime"     {>= "3.7.0" & < "3.8.0"}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.7.7/mirage-v3.7.7.tbz"
+  checksum: [
+    "sha256=3bb6aa19267bd67fb7e735d036f591b6084bb8f74a6adad604643cb0b8fb45b7"
+    "sha512=926a15482f8d6b0200a942e5ebf86475020f4018a7fd454c8211e8cff85d8e4c3ec45a11d4a6c4f55488e4c7ecc1d33748cf5a89a76253f4171eb01279788644"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* handle errors from Bos.OS.Cmd.run_out
* use PREFIX if defined (no need to call "opam config var prefix")
* adapt to conduit 2.2.0, tls 0.12, mirage-crypto 0.7.0 changes