### PR TITLE
[new release] spin (0.6.0)

### DIFF
--- a/packages/spin/spin.0.6.0/opam
+++ b/packages/spin/spin.0.6.0/opam
@@ -17,6 +17,7 @@ depends: [
   "odoc" {with-doc}
   "crunch" {build}
   "base"
+  "stdio"
   "fmt"
   "fpath"
   "cmdliner"

--- a/packages/spin/spin.0.6.0/opam
+++ b/packages/spin/spin.0.6.0/opam
@@ -37,7 +37,8 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@test/runtest" {with-test}
+    "@test_bin/runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/spin/spin.0.6.0/opam
+++ b/packages/spin/spin.0.6.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "A project generator for Reason and OCaml"
+description: """
+A project generator for Reason and OCaml
+"""
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/tmattio/spin"
+doc: "https://tmattio.github.io/spin/"
+bug-reports: "https://github.com/tmattio/spin/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.4"}
+  "mdx" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "crunch" {build}
+  "base"
+  "fmt"
+  "fpath"
+  "cmdliner"
+  "logs"
+  "sexplib"
+  "lwt" {>= "5.3.0"}
+  "jingoo"
+  "reason"
+  "inquire" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmattio/spin.git"
+url {
+  src:
+    "https://github.com/tmattio/spin/releases/download/0.6.0/spin-0.6.0.tbz"
+  checksum: [
+    "sha256=2fea29779b8751651e101064affbfc482c62c68fc6672f28a314ae60f30c75c2"
+    "sha512=df00a63f6f12fe8ebd1626356741256f00c2c51878f227bca4243c83ff8dbbe1734fe7ce70d22ecb134968795e166ea5770fc038551f48fb6d510e52c3234c2e"
+  ]
+}


### PR DESCRIPTION
A project generator for Reason and OCaml

- Project page: <a href="https://github.com/tmattio/spin">https://github.com/tmattio/spin</a>
- Documentation: <a href="https://tmattio.github.io/spin/">https://tmattio.github.io/spin/</a>

##### CHANGES:

This release is a complete rewrite of Spin.

Since the beginning of the project, a lot of learnings have been made and this new version incorporates these learning to build a solid foundation for the future of Spin.

## Added

- New template DSL
- Template inheritance with the `(inherit ...)` stanza
- Documentation of the CLI and template DSL.
- The CLI now provides a verbose flag to increase the verbosity
- The git templates are now cached

## Changed

- Calling `spin` without a subcommand now displays a simpler usage documentation. The `man` page is available with `spin --help`
- Better man page documentation
- Better error messages
- Improvements of the configuration prompts using Inquire
- Update native templates to follow best practices (e.g. name of libraries)
- The official templates are now embedded. No need to download a git repository, and the project generation works offline.

## Fixed

- Bucklescript templates now fallback to using `npm` when `yarn` is absent
