### PR TITLE
2 packages from gitlab.com/nomadic-labs/ringo/-/archive/v0.4/ringo-v0.4.tar.gz

### DIFF
--- a/packages/ringo-lwt/ringo-lwt.0.4/opam
+++ b/packages/ringo-lwt/ringo-lwt.0.4/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+  "ringo" {= version }
+  "lwt"
+  "unix" { with-test }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Lwt-wrappers for Ringo caches"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.4/ringo-v0.4.tar.gz"
+  checksum: [
+    "md5=f013cdd6813c4301d0af383709c0514e"
+    "sha512=1b37c50c55b487c30b13cae450c586161809298a3db1982bbf46f2e97b36085b36a024731169194093936b02ec58bc2eedb70989c040215d0675dc31f95d8e0b"
+  ]
+}

--- a/packages/ringo/ringo.0.4/opam
+++ b/packages/ringo/ringo.0.4/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Caches (bounded-size key-value stores) and other bounded-size stores"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.4/ringo-v0.4.tar.gz"
+  checksum: [
+    "md5=f013cdd6813c4301d0af383709c0514e"
+    "sha512=1b37c50c55b487c30b13cae450c586161809298a3db1982bbf46f2e97b36085b36a024731169194093936b02ec58bc2eedb70989c040215d0675dc31f95d8e0b"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ringo.0.4`: Caches (bounded-size key-value stores) and other bounded-size stores
-`ringo-lwt.0.4`: Lwt-wrappers for Ringo caches



---
* Homepage: https://gitlab.com/nomadic-labs/ringo
* Source repo: git+https://gitlab.com/nomadic-labs/ringo.git
* Bug tracker: https://gitlab.com/nomadic-labs/ringo/issues

---
:camel: Pull-request generated by opam-publish v2.0.0