### PR TITLE
[fix] conf-python-2-7's CentOS package name

### DIFF
--- a/packages/conf-python-2-7/conf-python-2-7.1.1/files/test.py
+++ b/packages/conf-python-2-7/conf-python-2-7.1.1/files/test.py
@@ -1,0 +1,1 @@
+print 'python-2.7 OK'

--- a/packages/conf-python-2-7/conf-python-2-7.1.1/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://www.python.org/download/releases/2.7/"
+authors: "Python Software Foundation"
+license: "PSF"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+build: ["python2.7" "test.py"]
+depexts: [
+  ["python2.7"] {os-family = "debian"}
+  ["python27"] {os-distribution = "nixos"}
+  ["python"] {os-distribution = "alpine"}
+  ["python2"] {os-distribution = "centos"}
+  ["python2"] {os-distribution = "fedora"}
+  ["python2"] {os-distribution = "arch"}
+  ["python"] {os-family = "suse"}
+  ["dev-lang/python:2.7"] {os-distribution = "gentoo"}
+  ["python/2.7"] {os = "openbsd"}
+  ["lang/python27"] {os = "netbsd"}
+  ["lang/python27"] {os = "freebsd"}
+  ["python27"] {os-distribution = "macports" & os = "macos"}
+  ["python"] {os-distribution = "homebrew" & os = "macos"}
+]
+synopsis: "Virtual package relying on Python-2.7 installation"
+description: """
+This package can only install if the Python-2.7 interpreter is available
+on the system."""
+extra-files: ["test.py" "md5=b2b11a2f587814ed4c08b109d9ed949f"]
+flags: conf


### PR DESCRIPTION
The CentOS build job for PR #16474 failed with 

```
The following command needs to be run through "sudo":
    yum install -y gmp-devel python
Last metadata expiration check: 0:00:01 ago on Tue May 19 08:47:46 2020.
No match for argument: python
There are following alternatives for "python": python2, python36
Error: Unable to find a match: python
OS package installation failed
```

Hopefully this PR fixes that.