### PR TITLE
imagelib.20160413: add missing upper bound

### DIFF
--- a/packages/imagelib/imagelib.20160413/opam
+++ b/packages/imagelib/imagelib.20160413/opam
@@ -9,7 +9,7 @@ build: [make]
 install: [make "install"]
 remove: [make "uninstall"]
 depends: [
-  "ocaml" {>= "3.12.1"}
+  "ocaml" {>= "3.12.1" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "camlzip"


### PR DESCRIPTION
Reported in https://github.com/ocaml/opam-repository/issues/15867

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>