### PR TITLE
Packages camelot.0.2, camelot-canonical.0.2, camelot-report.0.2, camelot-style.0.2, camelot-traverse.0.2 and camelot-utils.0.2

### DIFF
--- a/packages/camelot-canonical/camelot-canonical.0.2/opam
+++ b/packages/camelot-canonical/camelot-canonical.0.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis:
+  "Core types for the camelot linter internals. Used by the Camelot package"
+maintainer: ["cis120@seas.upenn.edu"]
+authors: ["Vighnesh Vijay" "Daniel Like" "William Goeller"]
+license: "Apache License 2.0"
+homepage: "https://github.com/upenn-cis1xx/camelot"
+bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
+depends: [
+  "dune" {>= "2.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/upenn-cis1xx/camelot.git"

--- a/packages/camelot-report/camelot-report.0.2/opam
+++ b/packages/camelot-report/camelot-report.0.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis:
+  "Output modules for reporting and grading linted code. Used by the Camelot package"
+maintainer: ["cis120@seas.upenn.edu"]
+authors: ["Vighnesh Vijay" "Daniel Like" "William Goeller"]
+license: "Apache License 2.0"
+homepage: "https://github.com/upenn-cis1xx/camelot"
+bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
+depends: [
+  "dune" {>= "2.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/upenn-cis1xx/camelot.git"

--- a/packages/camelot-style/camelot-style.0.2/opam
+++ b/packages/camelot-style/camelot-style.0.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis:
+  "Style Checking Modules implemented here. Used by the Camelot package"
+maintainer: ["cis120@seas.upenn.edu"]
+authors: ["Vighnesh Vijay" "Daniel Like" "William Goeller"]
+license: "Apache License 2.0"
+homepage: "https://github.com/upenn-cis1xx/camelot"
+bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
+depends: [
+  "dune" {>= "2.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/upenn-cis1xx/camelot.git"

--- a/packages/camelot-traverse/camelot-traverse.0.2/opam
+++ b/packages/camelot-traverse/camelot-traverse.0.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis:
+  "Core modules for traversing the OCaml AST and calculating the style hints. Used by the Camelot package"
+maintainer: ["cis120@seas.upenn.edu"]
+authors: ["Vighnesh Vijay" "Daniel Like" "William Goeller"]
+license: "Apache License 2.0"
+homepage: "https://github.com/upenn-cis1xx/camelot"
+bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
+depends: [
+  "dune" {>= "2.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/upenn-cis1xx/camelot.git"

--- a/packages/camelot-utils/camelot-utils.0.2/opam
+++ b/packages/camelot-utils/camelot-utils.0.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis:
+  "Utility modules for extracting information from the AST and the raw ml file for that AST. Used by the Camelot package"
+maintainer: ["cis120@seas.upenn.edu"]
+authors: ["Vighnesh Vijay" "Daniel Like" "William Goeller"]
+license: "Apache License 2.0"
+homepage: "https://github.com/upenn-cis1xx/camelot"
+bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
+depends: [
+  "dune" {>= "2.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/upenn-cis1xx/camelot.git"

--- a/packages/camelot/camelot.0.2/opam
+++ b/packages/camelot/camelot.0.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "An OCaml Linter / Style Checker"
+maintainer: ["cis120@seas.upenn.edu"]
+authors: ["Vighnesh Vijay" "Daniel Like" "William Goeller"]
+license: "Apache License 2.0"
+homepage: "https://github.com/upenn-cis1xx/camelot"
+bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "ocamlc" {>= "4.09.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "camelot-canonical" {>= "0.2"}
+  "camelot-report" {>= "0.2"}
+  "camelot-style" {>= "0.2"}
+  "camelot-traverse" {>= "0.2"}
+  "camelot-utils" {>= "0.2"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/upenn-cis1xx/camelot.git"


### PR DESCRIPTION
This pull-request concerns:
-`camelot.0.2`: An OCaml Linter / Style Checker
-`camelot-canonical.0.2`: Core types for the camelot linter internals. Used by the Camelot package
-`camelot-report.0.2`: Output modules for reporting and grading linted code. Used by the Camelot package
-`camelot-style.0.2`: Style Checking Modules implemented here. Used by the Camelot package
-`camelot-traverse.0.2`: Core modules for traversing the OCaml AST and calculating the style hints. Used by the Camelot package
-`camelot-utils.0.2`: Utility modules for extracting information from the AST and the raw ml file for that AST. Used by the Camelot package



---
* Homepage: https://github.com/upenn-cis1xx/camelot
* Source repo: git+https://github.com/upenn-cis1xx/camelot.git
* Bug tracker: https://github.com/upenn-cis1xx/camelot/issues

---
:camel: Pull-request generated by opam-publish v2.0.2