### PR TITLE
Add upper bound constraints to all reverse dependencies of Jane Street packages

### DIFF
--- a/packages/alba/alba.0.4.1/opam
+++ b/packages/alba/alba.0.4.1/opam
@@ -20,8 +20,8 @@ depends: [
   "odoc" {with-doc}
   "js_of_ocaml" {build}
   "js_of_ocaml-ppx"
-  "ppx_inline_test" {build} (* is needed for building the libraries
-                               otherwise it does not compile *)
+  "ppx_inline_test" {build & < "v0.14"} (* is needed for building the libraries
+                                           otherwise it does not compile *)
 ]
 url {
     src: "https://github.com/hbr/albatross/archive/0.4.1.tar.gz"

--- a/packages/alba/alba.0.4.2/opam
+++ b/packages/alba/alba.0.4.2/opam
@@ -20,8 +20,8 @@ depends: [
   "js_of_ocaml-ppx"
   "menhir"           {build}
   "js_of_ocaml"      {build}
-  "ppx_inline_test"  {build} (* is needed for building the libraries,
-                                otherwise it does not compile *)
+  "ppx_inline_test"  {build & < "v0.14"} (* is needed for building the libraries,
+                                            otherwise it does not compile *)
   "odoc"             {with-doc}
 ]
 url {

--- a/packages/alcotest-async/alcotest-async.1.0.0/opam
+++ b/packages/alcotest-async/alcotest-async.1.0.0/opam
@@ -17,8 +17,8 @@ depends: [
   "dune" {>= "1.11"}
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}
-  "async_unix" {>= "v0.9.0"}
-  "core_kernel" {>= "v0.9.0"}
+  "async_unix" {>= "v0.9.0" & < "v0.14"}
+  "core_kernel" {>= "v0.9.0" & < "v0.14"}
 ]
 
 synopsis: "Async-based helpers for Alcotest"

--- a/packages/alcotest-async/alcotest-async.1.0.1/opam
+++ b/packages/alcotest-async/alcotest-async.1.0.1/opam
@@ -17,8 +17,8 @@ depends: [
   "dune" {>= "1.11"}
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}
-  "async_unix" {>= "v0.9.0"}
-  "core_kernel" {>= "v0.9.0"}
+  "async_unix" {>= "v0.9.0" & < "v0.14"}
+  "core_kernel" {>= "v0.9.0" & < "v0.14"}
 ]
 
 synopsis: "Async-based helpers for Alcotest"

--- a/packages/alcotest-async/alcotest-async.1.1.0/opam
+++ b/packages/alcotest-async/alcotest-async.1.1.0/opam
@@ -11,8 +11,8 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}
-  "async_unix" {>= "v0.9.0"}
-  "core_kernel" {>= "v0.9.0"}
+  "async_unix" {>= "v0.9.0" & < "v0.14"}
+  "core_kernel" {>= "v0.9.0" & < "v0.14"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/amqp-client-async/amqp-client-async.2.2.2/opam
+++ b/packages/amqp-client-async/amqp-client-async.2.2.2/opam
@@ -16,7 +16,7 @@ depends: [
   "xml-light" {build}
   "amqp-client" {= "2.2.2"}
   "ocplib-endian" {>= "0.6"}
-  "async" {>= "v0.10.0"}
+  "async" {>= "v0.10.0" & < "v0.14"}
   "uri"
 ]
 synopsis: "Amqp client library, async version"

--- a/packages/amqp-client/amqp-client.2.2.2/opam
+++ b/packages/amqp-client/amqp-client.2.2.2/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "1.1"}
   "ezxmlm" {build}
   "ocplib-endian" {>= "0.6"}
-  "async" {with-test}
+  "async" {with-test & < "v0.14"}
   "lwt" {with-test}
 ]
 synopsis: "Amqp client base library"

--- a/packages/angstrom-async/angstrom-async.0.10.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.10.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom" {>= "0.7.0" & < "0.11.0"}
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.9.0" & < "v0.14"}
 ]
 synopsis: "Angstrom - Async-specific support"
 url {

--- a/packages/angstrom-async/angstrom-async.0.11.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.11.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom" {>= "0.7.0"}
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.9.0" & < "v0.14"}
 ]
 synopsis: "Async support for Angstrom"
 url {

--- a/packages/angstrom-async/angstrom-async.0.11.1/opam
+++ b/packages/angstrom-async/angstrom-async.0.11.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.0"}
   "angstrom" {>= "0.7.0"}
-  "async" {>= "v0.10.0"}
+  "async" {>= "v0.10.0" & < "v0.14"}
 ]
 synopsis: "Async support for Angstrom"
 url {

--- a/packages/angstrom-async/angstrom-async.0.11.2/opam
+++ b/packages/angstrom-async/angstrom-async.0.11.2/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.0"}
   "angstrom" {>= "0.7.0"}
-  "async" {>= "v0.10.0"}
+  "async" {>= "v0.10.0" & < "v0.14"}
 ]
 synopsis: "Async support for Angstrom"
 url {

--- a/packages/angstrom-async/angstrom-async.0.12.1/opam
+++ b/packages/angstrom-async/angstrom-async.0.12.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.0"}
   "angstrom" {>= "0.7.0"}
-  "async" {>= "v0.10.0"}
+  "async" {>= "v0.10.0" & < "v0.14"}
 ]
 synopsis: "Async support for Angstrom"
 url {

--- a/packages/angstrom-async/angstrom-async.0.13.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.13.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.0"}
   "angstrom" {>= "0.7.0"}
-  "async" {>= "v0.10.0"}
+  "async" {>= "v0.10.0" & < "v0.14"}
 ]
 synopsis: "Async support for Angstrom"
 url {

--- a/packages/angstrom-async/angstrom-async.0.14.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.14.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.0"}
   "angstrom" {>= "0.7.0"}
-  "async" {>= "v0.10.0"}
+  "async" {>= "v0.10.0" & < "v0.14"}
 ]
 synopsis: "Async support for Angstrom"
 url {

--- a/packages/angstrom-async/angstrom-async.0.14.1/opam
+++ b/packages/angstrom-async/angstrom-async.0.14.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.0"}
   "angstrom" {>= "0.7.0"}
-  "async" {>= "v0.10.0"}
+  "async" {>= "v0.10.0" & < "v0.14"}
 ]
 synopsis: "Async support for Angstrom"
 url {

--- a/packages/angstrom-async/angstrom-async.0.7.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.7.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom" {>= "0.7.0" & < "0.9.0"}
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.9.0" & < "v0.14"}
 ]
 synopsis: "Angstrom - Async-specific support"
 url {

--- a/packages/angstrom-async/angstrom-async.0.8.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.8.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom" {>= "0.7.0" & < "0.9.0"}
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.9.0" & < "v0.14"}
 ]
 synopsis: "Angstrom - Async-specific support"
 url {

--- a/packages/angstrom-async/angstrom-async.0.8.1/opam
+++ b/packages/angstrom-async/angstrom-async.0.8.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom" {>= "0.7.0" & < "0.9.0"}
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.9.0" & < "v0.14"}
 ]
 synopsis: "Angstrom - Async-specific support"
 url {

--- a/packages/angstrom-async/angstrom-async.0.9.0/opam
+++ b/packages/angstrom-async/angstrom-async.0.9.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom" {>= "0.9.0" & < "0.11.0"}
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.9.0" & < "v0.14"}
 ]
 synopsis: "Angstrom - Async-specific support"
 url {

--- a/packages/anthill/anthill.0.1/opam
+++ b/packages/anthill/anthill.0.1/opam
@@ -5,7 +5,7 @@ build: [
 depends: [
   "ocaml" {>= "4.07"}
   "dune" {>= "1.0"}
-  "core"
+  "core" {< "v0.14"}
   "pcre"
   "mparser"
   "lwt"

--- a/packages/archi-async/archi-async.0.1.0/opam
+++ b/packages/archi-async/archi-async.0.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "dune" {>= "1.0"}
   "archi" {= version}
-  "async"
+  "async" {< "v0.14"}
 ]
 synopsis:
   "Async runtime for Archi, a library for managing the lifecycle of stateful components in OCaml"

--- a/packages/async-uri/async-uri.0.1/opam
+++ b/packages/async-uri/async-uri.0.1/opam
@@ -10,9 +10,9 @@ run-test: [ "dune" "runtest" "-j" jobs "-p" name ]
 depends: [
   "dune" {>= "1.11.4"}
   "uri" {>= "3.1.0"}
-  "core" {>= "v0.12.0"}
-  "async" {>= "v0.12.0"}
-  "async_ssl" {>= "v0.12.0"}
+  "core" {>= "v0.12.0" & < "v0.14"}
+  "async" {>= "v0.12.0" & < "v0.14"}
+  "async_ssl" {>= "v0.12.0" & < "v0.14"}
 ]
 synopsis: "Open Async (TLS) TCP connections with Uri.t"
 description: """Simple wrapper to the Async's Tcp module to

--- a/packages/async-uri/async-uri.0.2/opam
+++ b/packages/async-uri/async-uri.0.2/opam
@@ -11,9 +11,9 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.11.4"}
   "uri-sexp" {>= "3.1.0"}
-  "core" {>= "v0.13.0"}
-  "async" {>= "v0.13.0"}
-  "async_ssl" {>= "v0.13.0"}
+  "core" {>= "v0.13.0" & < "v0.14"}
+  "async" {>= "v0.13.0" & < "v0.14"}
+  "async_ssl" {>= "v0.13.0" & < "v0.14"}
 ]
 synopsis: "Open Async (TLS) TCP connections with Uri.t"
 description: """Simple wrapper to the Async's Tcp module to open

--- a/packages/aws-s3-async/aws-s3-async.4.5.1/opam
+++ b/packages/aws-s3-async/aws-s3-async.4.5.1/opam
@@ -14,9 +14,9 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune"
   "aws-s3" {= version}
-  "async_kernel" {>= "v0.9.0" }
-  "async_unix" {>= "v0.9.0" }
-  "conduit-async" {>= "1.5.0" }
+  "async_kernel" {>= "v0.9.0" & < "v0.14"}
+  "async_unix" {>= "v0.9.0" & < "v0.14"}
+  "conduit-async" {>= "1.5.0"}
 ]
 synopsis: "Ocaml library for accessing Amazon S3 - Async version"
 description: """

--- a/packages/aws-s3/aws-s3.4.5.1/opam
+++ b/packages/aws-s3/aws-s3.4.5.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_protocol_conv_xml_light" {>= "5.0.0" & < "6.0.0"}
   "ppx_protocol_conv_json" {>= "5.0.0" & < "6.0.0"}
   "cmdliner"
-  "ppx_inline_test"
+  "ppx_inline_test" {< "v0.14"}
   "base64" {>= "3.1.0"}
 ]
 synopsis: "Ocaml library for accessing Amazon S3"

--- a/packages/azblob-async/azblob-async.0.1.0/opam
+++ b/packages/azblob-async/azblob-async.0.1.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/kkazuo/azblob"
 bug-reports: "https://github.com/kkazuo/azblob/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
-  "core"
+  "core" {< "v0.14"}
   "cohttp"
   "cohttp-async" {>= "2.4.0"}
   "azblob" {= version}

--- a/packages/azblob/azblob.0.1.0/opam
+++ b/packages/azblob/azblob.0.1.0/opam
@@ -7,9 +7,9 @@ homepage: "https://github.com/kkazuo/azblob"
 bug-reports: "https://github.com/kkazuo/azblob/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
-  "base" {>= "v0.11.0"}
-  "ppx_sexp_conv"
-  "sexplib0"
+  "base" {>= "v0.11.0" & < "v0.14"}
+  "ppx_sexp_conv" {< "v0.14"}
+  "sexplib0" {< "v0.14"}
   "base64"
   "cohttp" {>= "2.4.0"}
   "uri"

--- a/packages/bap-build/bap-build.2.0.0/opam
+++ b/packages/bap-build/bap-build.2.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "oasis" {build & >= "0.4.7"}
   "ocamlbuild"
   "core_kernel" {>= "v0.11" & < "v0.12"}
-  "ppx_jane"
+  "ppx_jane" {< "v0.14"}
 ]
 
 synopsis: "BAP build automation tools"

--- a/packages/bap-bundle/bap-bundle.2.0.0/opam
+++ b/packages/bap-bundle/bap-bundle.2.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "uri"
   "camlzip"
   "core_kernel" {>= "v0.11" & < "v0.12"}
-  "ppx_jane"
+  "ppx_jane" {< "v0.14"}
   "fileutils"
 ]
 synopsis: "BAP bundler"

--- a/packages/bap-main/bap-main.2.0.0/opam
+++ b/packages/bap-main/bap-main.2.0.0/opam
@@ -15,8 +15,8 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-main"] ]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "base"
-  "stdio"
+  "base" {< "v0.14"}
+  "stdio" {< "v0.14"}
   "cmdliner"
   "bap-build"   {= "2.0.0"}
   "bap-future"  {= "2.0.0"}

--- a/packages/bap-raw/bap-raw.2.0.0/opam
+++ b/packages/bap-raw/bap-raw.2.0.0/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-raw"]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
-  "ppx_jane"
+  "ppx_jane" {< "v0.14"}
   "bap-std" {= "2.0.0"}
   "bap-main" {= "2.0.0"}
 ]

--- a/packages/bap-recipe-command/bap-recipe-command.2.0.0/opam
+++ b/packages/bap-recipe-command/bap-recipe-command.2.0.0/opam
@@ -17,9 +17,9 @@ remove: [["ocamlfind" "remove" "bap-plugin-recipe_command"]
          ]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "base"
-  "stdio"
-  "parsexp"
+  "base" {< "v0.14"}
+  "stdio" {< "v0.14"}
+  "parsexp" {< "v0.14"}
   "fileutils"
   "camlzip"
   "uuidm"

--- a/packages/bap-recipe/bap-recipe.2.0.0/opam
+++ b/packages/bap-recipe/bap-recipe.2.0.0/opam
@@ -17,9 +17,9 @@ remove: [["ocamlfind" "remove" "bap-recipe"]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
-  "base"
-  "stdio"
-  "parsexp"
+  "base" {< "v0.14"}
+  "stdio" {< "v0.14"}
+  "parsexp" {< "v0.14"}
   "fileutils"
   "camlzip"
   "uuidm"

--- a/packages/bastet_async/bastet_async.0.1.0/opam
+++ b/packages/bastet_async/bastet_async.0.1.0/opam
@@ -10,9 +10,9 @@ bug-reports: "https://github.com/Risto-Stevcev/bastet-async/issues"
 depends: [
   "ocaml" {>= "4.06.1"}
   "bastet" {>= "1.2.5"}
-  "async_kernel" {>= "v0.12.0"}
-  "async_unix" {>= "v0.12.0" & with-test}
-  "core" {>= "v0.12.0" & with-test}
+  "async_kernel" {>= "v0.12.0" & < "v0.14"}
+  "async_unix" {with-test & >= "v0.12.0" & < "v0.14"}
+  "core" {with-test & >= "v0.12.0" & < "v0.14"}
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-async" {>= "1.0.1" & with-test}
   "mdx" {>= "1.6.0" & with-test}

--- a/packages/biocaml/biocaml.0.10.1/opam
+++ b/packages/biocaml/biocaml.0.10.1/opam
@@ -29,13 +29,13 @@ depends: [
   "ocaml" {< "4.10"}
   "base64"
   "dune" {>= "1.0"}
-  "core_kernel" {>= "v0.12.0"}
-  "sexplib"
+  "core_kernel" {>= "v0.12.0" & < "v0.14"}
+  "sexplib" {< "v0.14"}
   "camlzip" {>= "1.05"}
   "xmlm"
   "cfstream"
-  "ppx_compare"
-  "ppx_sexp_conv"
+  "ppx_compare" {< "v0.14"}
+  "ppx_sexp_conv" {< "v0.14"}
   "re"
   "rresult"
   "uri"

--- a/packages/bitvec-binprot/bitvec-binprot.2.0.0/opam
+++ b/packages/bitvec-binprot/bitvec-binprot.2.0.0/opam
@@ -17,8 +17,8 @@ depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bitvec"
-  "bin_prot"
-  "ppx_jane"
+  "bin_prot" {< "v0.14"}
+  "ppx_jane" {< "v0.14"}
 ]
 synopsis: "Janestreet's Binprot serialization for Bitvec"
 url {

--- a/packages/bitvec-order/bitvec-order.2.0.0/opam
+++ b/packages/bitvec-order/bitvec-order.2.0.0/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "bitvec-order"]]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
-  "base"
+  "base" {< "v0.14"}
   "bitvec"
   "bitvec-sexp"
 ]

--- a/packages/bitvec-sexp/bitvec-sexp.2.0.0/opam
+++ b/packages/bitvec-sexp/bitvec-sexp.2.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bitvec"
-  "sexplib0"
+  "sexplib0" {< "v0.14"}
 ]
 synopsis: "Sexp serializers for Bitvec"
 url {

--- a/packages/cfstream/cfstream.1.3.1/opam
+++ b/packages/cfstream/cfstream.1.3.1/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune"
-  "core_kernel" {>= "v0.11.0"}
+  "core_kernel" {>= "v0.11.0" & < "v0.14"}
   "conf-m4" {build}
   "ounit" {with-test}
 ]

--- a/packages/charrua-server/charrua-server.1.2.1/opam
+++ b/packages/charrua-server/charrua-server.1.2.1/opam
@@ -20,7 +20,7 @@ depends: [
   "menhir"        {build}
   "charrua"       {= version}
   "cstruct"       {>= "3.0.1"}
-  "sexplib"
+  "sexplib"       {< "v0.14"}
   "ipaddr"        {>= "4.0.0"}
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"

--- a/packages/charrua/charrua.1.2.1/opam
+++ b/packages/charrua/charrua.1.2.1/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml"         {>= "4.06.0"}
   "dune"          {>= "1.4.0"}
-  "ppx_sexp_conv" {>="v0.10.0"}
+  "ppx_sexp_conv" {>="v0.10.0" & < "v0.14"}
   "ppx_cstruct"
   "cstruct"       {>= "3.0.1"}
   "sexplib"

--- a/packages/cohttp-async/cohttp-async.2.5.0/opam
+++ b/packages/cohttp-async/cohttp-async.2.5.0/opam
@@ -25,19 +25,19 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.1.0"}
-  "async_kernel" {>= "v0.13.0"}
-  "async_unix" {>= "v0.13.0"}
-  "async" {>= "v0.13.0"}
-  "base" {>= "v0.11.0"}
-  "core" {with-test}
+  "async_kernel" {>= "v0.13.0" & < "v0.14"}
+  "async_unix" {>= "v0.13.0" & < "v0.14"}
+  "async" {>= "v0.13.0" & < "v0.14"}
+  "base" {>= "v0.11.0" & < "v0.14"}
+  "core" {with-test & < "v0.14"}
   "cohttp" {=version}
   "conduit-async" {>="1.2.0"}
   "magic-mime"
   "logs"
   "fmt" {>= "0.8.2"}
-  "sexplib0"
+  "sexplib0" {< "v0.14"}
   "stdlib-shims"
-  "ppx_sexp_conv" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0" & < "v0.14"}
   "ounit" {with-test}
   "uri" {>= "2.0.0"}
   "uri-sexp"

--- a/packages/cohttp-async/cohttp-async.2.5.1/opam
+++ b/packages/cohttp-async/cohttp-async.2.5.1/opam
@@ -25,19 +25,19 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.1.0"}
-  "async_kernel" {>= "v0.13.0"}
-  "async_unix" {>= "v0.13.0"}
-  "async" {>= "v0.13.0"}
-  "base" {>= "v0.11.0"}
-  "core" {with-test}
+  "async_kernel" {>= "v0.13.0" & < "v0.14"}
+  "async_unix" {>= "v0.13.0" & < "v0.14"}
+  "async" {>= "v0.13.0" & < "v0.14"}
+  "base" {>= "v0.11.0" & < "v0.14"}
+  "core" {with-test & < "v0.14"}
   "cohttp" {=version}
   "conduit-async" {>="1.2.0"}
   "magic-mime"
   "logs"
   "fmt" {>= "0.8.2"}
-  "sexplib0"
+  "sexplib0" {< "v0.14"}
   "stdlib-shims"
-  "ppx_sexp_conv" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0" & < "v0.14"}
   "ounit" {with-test}
   "uri" {>= "2.0.0"}
   "uri-sexp"

--- a/packages/cohttp-lwt/cohttp-lwt.2.5.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.2.5.0/opam
@@ -29,8 +29,8 @@ depends: [
   "dune" {>= "1.1.0"}
   "cohttp" {=version}
   "lwt" {>= "2.5.0"}
-  "sexplib0"
-  "ppx_sexp_conv" {>= "v0.13.0"}
+  "sexplib0" {< "v0.14"}
+  "ppx_sexp_conv" {>= "v0.13.0" & < "v0.14"}
   "logs"
 ]
 build: [

--- a/packages/cohttp-lwt/cohttp-lwt.2.5.1/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.2.5.1/opam
@@ -29,8 +29,8 @@ depends: [
   "dune" {>= "1.1.0"}
   "cohttp" {=version}
   "lwt" {>= "2.5.0"}
-  "sexplib0"
-  "ppx_sexp_conv" {>= "v0.13.0"}
+  "sexplib0" {< "v0.14"}
+  "ppx_sexp_conv" {>= "v0.13.0" & < "v0.14"}
   "logs"
 ]
 build: [

--- a/packages/cohttp/cohttp.2.5.0/opam
+++ b/packages/cohttp/cohttp.2.5.0/opam
@@ -37,10 +37,10 @@ depends: [
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}
   "uri-sexp"
-  "fieldslib"
-  "sexplib0"
-  "ppx_fields_conv" {>= "v0.9.0"}
-  "ppx_sexp_conv" {>= "v0.13.0"}
+  "fieldslib" {< "v0.14"}
+  "sexplib0" {< "v0.14"}
+  "ppx_fields_conv" {>= "v0.9.0" & < "v0.14"}
+  "ppx_sexp_conv" {>= "v0.13.0" & < "v0.14"}
   "stringext"
   "base64" {>= "3.1.0"}
   "stdlib-shims"

--- a/packages/cohttp/cohttp.2.5.1/opam
+++ b/packages/cohttp/cohttp.2.5.1/opam
@@ -37,10 +37,10 @@ depends: [
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}
   "uri-sexp"
-  "fieldslib"
-  "sexplib0"
-  "ppx_fields_conv" {>= "v0.9.0"}
-  "ppx_sexp_conv" {>= "v0.13.0"}
+  "fieldslib" {< "v0.14"}
+  "sexplib0" {< "v0.14"}
+  "ppx_fields_conv" {>= "v0.9.0" & < "v0.14"}
+  "ppx_sexp_conv" {>= "v0.13.0" & < "v0.14"}
   "stringext"
   "base64" {>= "3.1.0"}
   "stdlib-shims"

--- a/packages/conduit-async/conduit-async.2.1.0/opam
+++ b/packages/conduit-async/conduit-async.2.1.0/opam
@@ -10,11 +10,11 @@ bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
-  "core"
-  "ppx_sexp_conv" {>="v0.9.0"}
-  "sexplib"
+  "core" {< "v0.14"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
+  "sexplib" {< "v0.14"}
   "conduit" {=version}
-  "async" {>= "v0.10.0"}
+  "async" {>= "v0.10.0" & < "v0.14"}
   "ipaddr" {>= "3.0.0"}
 ]
 depopts: ["async_ssl"]

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.1.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune"
   "base-unix"
-  "ppx_sexp_conv" {>="v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0" & < "v0.14"}
   "conduit-lwt" {=version}
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.9.4"}

--- a/packages/conduit-lwt/conduit-lwt.2.1.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.2.1.0/opam
@@ -11,8 +11,8 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
   "base-unix"
-  "ppx_sexp_conv" {>="v0.13.0"}
-  "sexplib"
+  "ppx_sexp_conv" {>= "v0.13.0" & < "v0.14"}
+  "sexplib" {< "v0.14"}
   "conduit" {=version}
   "lwt" {>= "3.0.0"}
 ]

--- a/packages/conduit-mirage/conduit-mirage.2.1.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.1.0/opam
@@ -8,8 +8,8 @@ bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune"
-  "ppx_sexp_conv" {>="v0.13.0"}
-  "sexplib"
+  "ppx_sexp_conv" {>= "v0.13.0" & < "v0.14"}
+  "sexplib" {< "v0.14"}
   "cstruct" {>= "3.0.0"}
   "mirage-stack" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/conduit-mirage/conduit-mirage.2.2.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.2.0/opam
@@ -8,8 +8,8 @@ bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune"
-  "ppx_sexp_conv" {>="v0.12.0"}
-  "sexplib"
+  "ppx_sexp_conv" {>= "v0.12.0" & < "v0.14"}
+  "sexplib" {< "v0.14"}
   "cstruct" {>= "3.0.0"}
   "mirage-stack" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/conduit/conduit.2.1.0/opam
+++ b/packages/conduit/conduit.2.1.0/opam
@@ -11,8 +11,8 @@ bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
-  "ppx_sexp_conv" {>="v0.13.0"}
-  "sexplib"
+  "ppx_sexp_conv" {>= "v0.13.0" & < "v0.14"}
+  "sexplib" {< "v0.14"}
   "astring"
   "uri"
   "logs" {>= "0.5.0"}

--- a/packages/cookie/cookie.0.1.8/opam
+++ b/packages/cookie/cookie.0.1.8/opam
@@ -14,7 +14,7 @@ depends: [
   "uri"
   "ptime"
   "astring"
-  "base" {with-test}
+  "base" {with-test & < "v0.14"}
   "alcotest" {with-test}
   "junit" {with-test}
   "junit_alcotest" {with-test}

--- a/packages/coq-serapi/coq-serapi.8.11.0+0.11.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.11.0+0.11.0/opam
@@ -23,17 +23,17 @@ authors: [
 ]
 
 depends: [
-  "ocaml"               {           >= "4.07.0"            }
-  "coq"                 {           >= "8.11.0" & < "8.12" }
-  "cmdliner"            {           >= "1.0.0"             }
-  "ocamlfind"           {           >= "1.8.0"             }
-  "sexplib"             {           >= "v0.11.0"           }
-  "dune"                {           >= "1.2.0"             }
-  "ppx_import"          { build   & >= "1.5-3"             }
-  "ppx_deriving"        {           >= "4.2.1"             }
-  "ppx_sexp_conv"       {           >= "v0.11.0"           }
-  "yojson"              {           >= "1.7.0"             }
-  "ppx_deriving_yojson" {           >= "3.4"               }
+  "ocaml"               {           >= "4.07.0"              }
+  "coq"                 {           >= "8.11.0" & < "8.12"   }
+  "cmdliner"            {           >= "1.0.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.11.0"             }
+  "dune"                {           >= "1.2.0"               }
+  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.11.0" & < "v0.14" }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
 ]
 
 build: [ "dune" "build" "-p" name "-j" jobs ]

--- a/packages/csexp/csexp.1.0.0/opam
+++ b/packages/csexp/csexp.1.0.0/opam
@@ -30,7 +30,7 @@ bug-reports: "https://github.com/ocaml-dune/csexp/issues"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.04.0"}
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/csexp/csexp.1.1.0/opam
+++ b/packages/csexp/csexp.1.1.0/opam
@@ -30,7 +30,7 @@ bug-reports: "https://github.com/ocaml-dune/csexp/issues"
 depends: [
   "dune" {>= "2.5"}
   "ocaml" {>= "4.02.3"}
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
   "result" {>= "1.5"}
 ]
 build: [

--- a/packages/cstruct-async/cstruct-async.5.1.1/opam
+++ b/packages/cstruct-async/cstruct-async.5.1.1/opam
@@ -16,9 +16,9 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
-  "async_kernel" {>= "v0.9.0"}
-  "async_unix" {>= "v0.9.0"}
-  "core_kernel" {>= "v0.9.0"}
+  "async_kernel" {>= "v0.9.0" & < "v0.14"}
+  "async_unix" {>= "v0.9.0" & < "v0.14"}
+  "core_kernel" {>= "v0.9.0" & < "v0.14"}
   "cstruct" {=version}
 ]
 synopsis: "Access C-like structures directly from OCaml"

--- a/packages/cstruct-sexp/cstruct-sexp.5.1.1/opam
+++ b/packages/cstruct-sexp/cstruct-sexp.5.1.1/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
-  "sexplib"
+  "sexplib" {< "v0.14"}
   "cstruct" {=version}
   "alcotest" {with-test}
 ]

--- a/packages/decoders-sexplib/decoders-sexplib.0.4.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.0.4.0/opam
@@ -30,8 +30,8 @@ depends: [
   "ounit" {with-test}
   "containers" {with-test}
   "decoders"
-  "sexplib0"
-  "sexplib"
+  "sexplib0" {< "v0.14"}
+  "sexplib" {< "v0.14"}
   "odoc" {with-doc}
   "ocaml" { >= "4.03.0" }
 ]

--- a/packages/dockerfile-cmd/dockerfile-cmd.6.4.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.6.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "fmt"
   "logs"
   "bos"
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.14"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/dockerfile/dockerfile.6.4.0/opam
+++ b/packages/dockerfile/dockerfile.6.4.0/opam
@@ -14,8 +14,8 @@ bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.0"}
-  "ppx_sexp_conv" {>= "v0.9.0"}
-  "sexplib"
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
+  "sexplib" {< "v0.14"}
   "fmt"
 ]
 build: [

--- a/packages/dotenv/dotenv.0.0.3/opam
+++ b/packages/dotenv/dotenv.0.0.3/opam
@@ -11,8 +11,8 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.05"}
-  "base"
-  "stdio"
+  "base" {< "v0.14"}
+  "stdio" {< "v0.14"}
   "uutf"
   "pcre"
   "dune" {>= "1.7"}

--- a/packages/dune-action-plugin/dune-action-plugin.2.0.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.0.0/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.0"}
   "dune-glob"
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-action-plugin/dune-action-plugin.2.0.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.0.1/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.0"}
   "dune-glob"
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-action-plugin/dune-action-plugin.2.1.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.1.1/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.0"}
   "dune-glob"
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-action-plugin/dune-action-plugin.2.1.2/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.1.2/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.0"}
   "dune-glob"
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-action-plugin/dune-action-plugin.2.1.3/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.1.3/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.0"}
   "dune-glob"
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-action-plugin/dune-action-plugin.2.2.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.2.0/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.0"}
   "dune-glob"
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-action-plugin/dune-action-plugin.2.3.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.3.0/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.3"}
   "dune-glob"
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-action-plugin/dune-action-plugin.2.3.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.3.1/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.3"}
   "dune-glob"
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-action-plugin/dune-action-plugin.2.4.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.4.0/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.3"}
   "dune-glob"
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-action-plugin/dune-action-plugin.2.5.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.5.0/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.3"}
   "dune-glob"
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-action-plugin/dune-action-plugin.2.5.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.5.1/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.3"}
   "dune-glob"
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-deps/dune-deps.1.0.1/opam
+++ b/packages/dune-deps/dune-deps.1.0.1/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "dune" {>= "2.1"}
   "ocaml"
-  "sexplib"
+  "sexplib" {< "v0.14"}
 ]
 
 synopsis: "Show dependency graph of a multi-component dune project"

--- a/packages/dune-deps/dune-deps.1.0.2/opam
+++ b/packages/dune-deps/dune-deps.1.0.2/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "dune" {>= "2.1"}
   "ocaml"
-  "sexplib"
+  "sexplib" {< "v0.14"}
 ]
 
 synopsis: "Show dependency graph of a multi-component dune project"

--- a/packages/dune-deps/dune-deps.1.1.0/opam
+++ b/packages/dune-deps/dune-deps.1.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "cmdliner"
   "dune" {>= "2.1"}
   "ocaml"
-  "sexplib"
+  "sexplib" {< "v0.14"}
 ]
 
 synopsis: "Show dependency graph of a multi-component dune project"

--- a/packages/dune-deps/dune-deps.1.2.0/opam
+++ b/packages/dune-deps/dune-deps.1.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "cmdliner"
   "dune" {>= "2.1"}
   "ocaml"
-  "sexplib"
+  "sexplib" {< "v0.14"}
 ]
 
 synopsis: "Show dependency graph of a multi-component dune project"

--- a/packages/dune-deps/dune-deps.1.2.1/opam
+++ b/packages/dune-deps/dune-deps.1.2.1/opam
@@ -14,7 +14,7 @@ depends: [
   "cmdliner"
   "dune" {>= "2.1"}
   "ocaml"
-  "sexplib"
+  "sexplib" {< "v0.14"}
 ]
 
 synopsis: "Show dependency graph of a multi-component dune project"

--- a/packages/electrod/electrod.0.4.1/opam
+++ b/packages/electrod/electrod.0.4.1/opam
@@ -32,7 +32,7 @@ depends: [
   "logs"
   "menhir"
   "mtime"
-  "ppx_inline_test"
+  "ppx_inline_test" {< "v0.14"}
   "printbox"
   "iter"
   "stdcompat"

--- a/packages/faraday-async/faraday-async.0.7.1/opam
+++ b/packages/faraday-async/faraday-async.0.7.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.0"}
   "faraday" {>= "0.5.0"}
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.9.0" & < "v0.14"}
 ]
 synopsis: "Async support for Faraday"
 url {

--- a/packages/gluten-async/gluten-async.0.2.1/opam
+++ b/packages/gluten-async/gluten-async.0.2.1/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "1.0"}
   "gluten" {= version}
   "faraday-async"
-  "async"
+  "async" {< "v0.14"}
 ]
 depopts: ["async_ssl"]
 synopsis: "Async runtime for gluten"

--- a/packages/gobject-introspection/gobject-introspection.0.2/opam
+++ b/packages/gobject-introspection/gobject-introspection.0.2/opam
@@ -17,8 +17,8 @@ depends: [
   "ctypes"
   "ctypes-foreign"
   "ounit"
-  "base"
-  "stdio"
+  "base" {< "v0.14"}
+  "stdio" {< "v0.14"}
   "configurator"
   "conf-pkg-config" {build}
   "conf-gobject-introspection" {build}

--- a/packages/gpr/gpr.1.5.0/opam
+++ b/packages/gpr/gpr.1.5.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "1.10"}
   "base-threads"
-  "core" {>= "v0.13"}
+  "core" {>= "v0.13" & < "v0.14"}
   "lacaml" {>= "11.0.0"}
   "gsl" {>= "1.24.0"}
 ]

--- a/packages/gsl/gsl.1.24.0/opam
+++ b/packages/gsl/gsl.1.24.0/opam
@@ -21,8 +21,8 @@ depends: [
   "dune-configurator"
   "conf-gsl" {build}
   "conf-pkg-config" {build}
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
 ]
 
 synopsis: "GSL - Bindings to the GNU Scientific Library"

--- a/packages/gsl/gsl.1.24.1/opam
+++ b/packages/gsl/gsl.1.24.1/opam
@@ -20,8 +20,8 @@ depends: [
   "dune" {>= "1.7.0"}
   "conf-gsl" {build}
   "conf-pkg-config" {build}
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
 ]
 
 synopsis: "GSL - Bindings to the GNU Scientific Library"

--- a/packages/h2-async/h2-async.0.6.1/opam
+++ b/packages/h2-async/h2-async.0.6.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "dune" {>= "1.7"}
   "faraday-async"
-  "async"
+  "async" {< "v0.14"}
   "gluten-async"
   "h2" {= version}
 ]

--- a/packages/httpaf-async/httpaf-async.0.6.6/opam
+++ b/packages/httpaf-async/httpaf-async.0.6.6/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.5.0"}
   "faraday-async"
-  "async"
+  "async" {< "v0.14"}
   "httpaf" {>= "0.6.0"}
 ]
 synopsis: "Async support for http/af"

--- a/packages/idds/idds.0.2/opam
+++ b/packages/idds/idds.0.2/opam
@@ -18,12 +18,12 @@ description: "BDD and IDD implementation with hash-consing"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.10"}
-  "base" {>= "v0.12.0"}
+  "base" {>= "v0.12.0" & < "v0.14"}
   "odoc" {with-doc}
   "open" {> "0"}
   "ppx_deriving" {>= "4.3"}
-  "ppx_inline_test" {with-test & >= "v0.12.0"}
-  "ppx_jane" {>= "v0.12.0"}
+  "ppx_inline_test" {with-test & >= "v0.12.0" & < "v0.14"}
+  "ppx_jane" {>= "v0.12.0" & < "v0.14"}
 ]
 url {
   src:

--- a/packages/influxdb-async/influxdb-async.0.3.0/opam
+++ b/packages/influxdb-async/influxdb-async.0.3.0/opam
@@ -9,10 +9,10 @@ dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "dune" {>= "2.0"}
-  "base"
+  "base" {< "v0.14"}
   "alcotest" {with-test}
   "influxdb" {= "0.3.0"}
-  "async"
+  "async" {< "v0.14"}
   "cohttp"
   "cohttp-async"
   "ocaml" {>= "4.04.0"}

--- a/packages/influxdb-lwt/influxdb-lwt.0.3.0/opam
+++ b/packages/influxdb-lwt/influxdb-lwt.0.3.0/opam
@@ -9,7 +9,7 @@ dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "dune" {>= "2.0"}
-  "base"
+  "base" {< "v0.14"}
   "alcotest" {with-test}
   "influxdb" {= "0.3.0"}
   "lwt"

--- a/packages/influxdb/influxdb.0.3.0/opam
+++ b/packages/influxdb/influxdb.0.3.0/opam
@@ -9,9 +9,9 @@ dev-repo: "git://github.com/ryanslade/influxdb-ocaml.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "dune" {>= "2.0"}
-  "base"
-  "stdio"
-  "ppx_expect"
+  "base" {< "v0.14"}
+  "stdio" {< "v0.14"}
+  "ppx_expect" {< "v0.14"}
   "ocaml" {>= "4.04.0"}
 ]
 url {

--- a/packages/inquire/inquire.0.1.0/opam
+++ b/packages/inquire/inquire.0.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "2.0"}
   "alcotest" {with-test}
-  "base"
+  "base" {< "v0.14"}
   "lwt"
   "lambda-term"
 ]

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.0/opam
@@ -16,7 +16,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.10"}
   "dune" {>= "1.11.1"}
-  "ppx_expect" {with-test & >= "0.12.0"}
+  "ppx_expect" {with-test & >= "0.12.0" & < "v0.14"}
   "cmdliner"
   "ocaml-migrate-parsetree"
   "yojson" # It's optional, but we want users to be able to use source-map without pain.

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.1/opam
@@ -16,7 +16,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.10"}
   "dune" {>= "1.11.1"}
-  "ppx_expect" {with-test & >= "0.12.0"}
+  "ppx_expect" {with-test & >= "0.12.0" & < "v0.14"}
   "cmdliner"
   "ocaml-migrate-parsetree"
   "yojson" # It's optional, but we want users to be able to use source-map without pain.

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.2/opam
@@ -16,7 +16,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.11"}
   "dune" {>= "1.11.1"}
-  "ppx_expect" {with-test & >= "v0.12.0"}
+  "ppx_expect" {with-test & >= "v0.12.0" & < "v0.14"}
   "cmdliner"
   "ocaml-migrate-parsetree"
   "yojson" # It's optional, but we want users to be able to use source-map without pain.

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.6.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.6.0/opam
@@ -16,7 +16,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "2.5"}
-  "ppx_expect" {with-test & >= "v0.12.0"}
+  "ppx_expect" {with-test & >= "v0.12.0" & < "v0.14"}
   "cmdliner"
   "ocaml-migrate-parsetree"
   "yojson" # It's optional, but we want users to be able to use source-map without pain.

--- a/packages/lacaml/lacaml.11.0.2/opam
+++ b/packages/lacaml/lacaml.11.0.2/opam
@@ -32,8 +32,8 @@ depends: [
   "dune-configurator"
   "conf-blas" {build}
   "conf-lapack" {build}
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
   "base-bytes"
   "base-bigarray"
 ]

--- a/packages/lacaml/lacaml.11.0.3/opam
+++ b/packages/lacaml/lacaml.11.0.3/opam
@@ -32,8 +32,8 @@ depends: [
   "dune-configurator"
   "conf-blas" {build}
   "conf-lapack" {build}
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
   "base-bytes"
   "base-bigarray"
 ]

--- a/packages/lacaml/lacaml.11.0.4/opam
+++ b/packages/lacaml/lacaml.11.0.4/opam
@@ -32,8 +32,8 @@ depends: [
   "dune-configurator"
   "conf-blas" {build}
   "conf-lapack" {build}
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
   "base-bytes"
   "base-bigarray"
 ]

--- a/packages/lacaml/lacaml.11.0.5/opam
+++ b/packages/lacaml/lacaml.11.0.5/opam
@@ -32,8 +32,8 @@ depends: [
   "dune-configurator"
   "conf-blas" {build}
   "conf-lapack" {build}
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
   "base-bytes"
   "base-bigarray"
 ]

--- a/packages/lacaml/lacaml.11.0.6/opam
+++ b/packages/lacaml/lacaml.11.0.6/opam
@@ -36,8 +36,8 @@ depends: [
   "dune-configurator"
   "conf-blas" {build}
   "conf-lapack" {build}
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
   "base-bytes"
   "base-bigarray"
 ]

--- a/packages/lambda_streams_async/lambda_streams_async.0.1.2/opam
+++ b/packages/lambda_streams_async/lambda_streams_async.0.1.2/opam
@@ -11,10 +11,10 @@ depends: [
   "lambda_streams" {= version}
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-async" {>= "1.0.1" & with-test}
-  "async" {>= "v0.12.0"}
-  "async_kernel" {>= "v0.12.0"}
-  "async_unix" {>= "v0.12.0"}
-  "core" {>= "v0.12.0"}
+  "async" {>= "v0.12.0" & < "v0.14"}
+  "async_kernel" {>= "v0.12.0" & < "v0.14"}
+  "async_unix" {>= "v0.12.0" & < "v0.14"}
+  "core" {>= "v0.12.0" & < "v0.14"}
   "dune" {>= "2.2.0"}
 ]
 build: [

--- a/packages/learn-ocaml-client/learn-ocaml-client.0.12/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.0.12/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/ocaml-sf/learn-ocaml"
 bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
 dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
 depends: [
-  "base" {>= "v0.9.4"}
+  "base" {>= "v0.9.4" & < "v0.14"}
   "base64"
   "cmdliner"
   "omd"

--- a/packages/learn-ocaml/learn-ocaml.0.12/opam
+++ b/packages/learn-ocaml/learn-ocaml.0.12/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/ocaml-sf/learn-ocaml"
 bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
 dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
 depends: [
-  "base" {>= "v0.9.4"}
+  "base" {>= "v0.9.4" & < "v0.14"}
   "base64"
   "cmdliner"
   "cohttp" {>= "1.0.0" & < "2.0.0"}

--- a/packages/loga/loga.0.0.5/opam
+++ b/packages/loga/loga.0.0.5/opam
@@ -9,7 +9,7 @@ depends: [
   "dune" {>= "2.5"}
   "ocaml" {>= "4.06.0"}
   "ocaml-migrate-parsetree" {>= "1.7.2"}
-  "ppx_expect" {with-test & >= "v0.11.0"}
+  "ppx_expect" {with-test & >= "v0.11.0" & < "v0.14"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/logical/logical.0.3.0/opam
+++ b/packages/logical/logical.0.3.0/opam
@@ -27,7 +27,7 @@ depends: [
   "dune"
   "alcotest" {with-test}
   "odoc" {with-doc}
-  "base" {>= "0.12.0"}
+  "base" {>= "0.12.0" & < "v0.14"}
   "ocaml" {>= "4.04.2"}
 ]
 url {

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.0/opam
@@ -21,8 +21,8 @@ depends: [
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}
-  "sexplib"
-  "ppx_sexp_conv"
+  "sexplib" {< "v0.14"}
+  "ppx_sexp_conv" {< "v0.14"}
   "zarith" {>= "1.4"}
   "eqaf" {>= "0.5"}
   "rresult" {>= "0.6.0"}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.1/opam
@@ -21,8 +21,8 @@ depends: [
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}
-  "sexplib"
-  "ppx_sexp_conv"
+  "sexplib" {< "v0.14"}
+  "ppx_sexp_conv" {< "v0.14"}
   "zarith" {>= "1.4"}
   "eqaf" {>= "0.5"}
   "rresult" {>= "0.6.0"}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.2/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.2/opam
@@ -21,8 +21,8 @@ depends: [
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}
-  "sexplib"
-  "ppx_sexp_conv"
+  "sexplib" {< "v0.14"}
+  "ppx_sexp_conv" {< "v0.14"}
   "zarith" {>= "1.4"}
   "eqaf" {>= "0.5"}
   "rresult" {>= "0.6.0"}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.7.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.7.0/opam
@@ -21,8 +21,8 @@ depends: [
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}
-  "sexplib"
-  "ppx_sexp_conv"
+  "sexplib" {< "v0.14"}
+  "ppx_sexp_conv" {< "v0.14"}
   "zarith" {>= "1.4"}
   "eqaf" {>= "0.7"}
   "rresult" {>= "0.6.0"}

--- a/packages/mssql/mssql.2.0.3/opam
+++ b/packages/mssql/mssql.2.0.3/opam
@@ -11,9 +11,9 @@ bug-reports: "https://github.com/arenadotio/ocaml-mssql/issues"
 depends: [
   "alcotest" {with-test & >= "1.0.1"}
   "alcotest-async" {with-test & >= "1.0.1"}
-  "async_unix"
-  "bignum"
-  "ppx_jane"
+  "async_unix" {< "v0.14"}
+  "bignum" {< "v0.14"}
+  "ppx_jane" {< "v0.14"}
   "iter" {>= "1.2"}
   "ocaml" {>= "4.06.1"}
   "odoc" {with-doc}

--- a/packages/mssql/mssql.2.1.0/opam
+++ b/packages/mssql/mssql.2.1.0/opam
@@ -11,9 +11,9 @@ bug-reports: "https://github.com/arenadotio/ocaml-mssql/issues"
 depends: [
   "alcotest" {with-test & >= "1.0.1"}
   "alcotest-async" {with-test & >= "1.0.1"}
-  "async_unix"
-  "bignum"
-  "ppx_jane"
+  "async_unix" {< "v0.14"}
+  "bignum" {< "v0.14"}
+  "ppx_jane" {< "v0.14"}
   "iter" {>= "1.2"}
   "ocaml" {>= "4.06.1"}
   "odoc" {with-doc}

--- a/packages/nacc/nacc.0.1/opam
+++ b/packages/nacc/nacc.0.1/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/codeanonorg/nacc/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "ppx_deriving" {>= "4.4"}
-  "ppx_variants_conv" {>= "0.13"}
+  "ppx_variants_conv" {>= "0.13" & < "v0.14"}
   "dune" {>= "2.0"}
 ]
 build: [

--- a/packages/nacc/nacc.1.0/opam
+++ b/packages/nacc/nacc.1.0/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/codeanonorg/nacc/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "ppx_deriving" {>= "4.4"}
-  "ppx_variants_conv" {>= "0.13"}
+  "ppx_variants_conv" {>= "0.13" & < "v0.14"}
   "dune" {>= "2.0"}
 ]
 build: [

--- a/packages/netkat/netkat.0.1/opam
+++ b/packages/netkat/netkat.0.1/opam
@@ -19,20 +19,20 @@ dev-repo: "git+https://github.com/netkat-lang/netkat.git"
 synopsis: "A clean slate implementation of NetKAT"
 description: "A clean slate implementation of NetKAT"
 depends: [
-  "async" {>= "v0.12.0"}
+  "async" {>= "v0.12.0" & < "v0.14"}
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.10"}
   "menhir" {build & >= "20190626"}
-  "base" {>= "v0.12.0"}
-  "core" {>= "v0.12.0"}
-  "stdio" {>= "v0.12.0"}
+  "base" {>= "v0.12.0" & < "v0.14"}
+  "core" {>= "v0.12.0" & < "v0.14"}
+  "stdio" {>= "v0.12.0" & < "v0.14"}
   "odoc" {with-doc}
   "open" {>= "0"}
   "nice_parser" {!= "0"}
   "idds" {!= "0"}
   "ppx_deriving" {>= "4.3"}
-  "ppx_inline_test" {with-test & >= "v0.12.0"}
-  "ppx_jane" {>= "v0.12.0"}
+  "ppx_inline_test" {with-test & >= "v0.12.0" & < "v0.14"}
+  "ppx_jane" {>= "v0.12.0" & < "v0.14"}
   "printbox" {>= "0.2"}
   "tyxml" {>= "4.3.0"}
   "mparser" {>= "1.2.3"}

--- a/packages/nuscr/nuscr.1.0.0/opam
+++ b/packages/nuscr/nuscr.1.0.0/opam
@@ -13,10 +13,10 @@ depends: [
   "menhir" {build & >= "20190924"}
   "ppx_deriving" {>= "4.4"}
   "dune" {>= "1.11.4"}
-  "base" {>= "v0.12.0"}
-  "stdio" {>= "v0.12.0"}
-  "ppx_sexp_conv" {>= "v0.12.0"}
-  "ppx_inline_test" {with-test}
+  "base" {>= "v0.12.0" & < "v0.14"}
+  "stdio" {>= "v0.12.0" & < "v0.14"}
+  "ppx_sexp_conv" {>= "v0.12.0" & < "v0.14"}
+  "ppx_inline_test" {with-test & < "v0.14"}
   "ocamlgraph" {>= "1.8.8"}
   "js_of_ocaml" {>= "3.5.0"}
   "js_of_ocaml-ppx" {>= "3.5.0"}

--- a/packages/nuscr/nuscr.1.1.0/opam
+++ b/packages/nuscr/nuscr.1.1.0/opam
@@ -13,10 +13,10 @@ depends: [
   "menhir" {build & >= "20190924"}
   "ppx_deriving" {>= "4.4"}
   "dune" {>= "1.11.4"}
-  "base" {>= "v0.12.0"}
-  "stdio" {>= "v0.12.0"}
-  "ppx_sexp_conv" {>= "v0.12.0"}
-  "ppx_inline_test" {with-test}
+  "base" {>= "v0.12.0" & < "v0.14"}
+  "stdio" {>= "v0.12.0" & < "v0.14"}
+  "ppx_sexp_conv" {>= "v0.12.0" & < "v0.14"}
+  "ppx_inline_test" {with-test & < "v0.14"}
   "odoc" {with-doc}
   "ocamlgraph" {>= "1.8.8"}
   "ppxlib" {>= "0.9.0"}

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.3.0.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.3.0.0/opam
@@ -14,8 +14,8 @@ depends: [
   "conf-protoc" {>= "1.0.0"}
   "dune" {>= "1.10"}
   "ocaml" {>= "4.06.0"}
-  "ppx_expect" {with-test}
-  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
+  "ppx_inline_test" {with-test & < "v0.14"}
   "ppx_deriving" {with-test}
 ]
 

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.0.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.0.0/opam
@@ -14,8 +14,8 @@ depends: [
   "conf-protoc" {>= "1.0.0"}
   "dune" {>= "1.10"}
   "ocaml" {>= "4.06.0"}
-  "ppx_expect" {with-test}
-  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
+  "ppx_inline_test" {with-test & < "v0.14"}
   "ppx_deriving" {with-test}
 ]
 

--- a/packages/ocamlformat/ocamlformat.0.13.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.13.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "ocaml" {with-test & >= "4.08"}
   "alcotest" {with-test}
-  "base" {>= "v0.11.0"}
+  "base" {>= "v0.11.0" & < "v0.14"}
   "base-unix"
   "cmdliner"
   "dune" {>= "1.11.1"}
@@ -31,7 +31,7 @@ depends: [
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
   "re"
-  "stdio"
+  "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
 ]

--- a/packages/ocamlformat/ocamlformat.0.14.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.14.0/opam
@@ -21,7 +21,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06"}
   "alcotest" {with-test}
-  "base" {>= "v0.11.0"}
+  "base" {>= "v0.11.0" & < "v0.14"}
   "base-unix"
   "cmdliner"
   "dune" {>= "2.2.0"}
@@ -32,7 +32,7 @@ depends: [
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
   "re"
-  "stdio"
+  "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
 ]

--- a/packages/ocamlformat/ocamlformat.0.14.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.14.1/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06"}
   "alcotest" {with-test}
-  "base" {>= "v0.11.0"}
+  "base" {>= "v0.11.0" & < "v0.14"}
   "base-unix"
   "cmdliner"
   "dune" {>= "2.2.0"}
@@ -24,7 +24,7 @@ depends: [
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
   "re"
-  "stdio"
+  "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
 ]

--- a/packages/ocamlformat/ocamlformat.0.14.2/opam
+++ b/packages/ocamlformat/ocamlformat.0.14.2/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06"}
   "alcotest" {with-test}
-  "base" {>= "v0.11.0"}
+  "base" {>= "v0.11.0" & < "v0.14"}
   "base-unix"
   "cmdliner"
   "dune" {>= "2.2.0"}
@@ -24,7 +24,7 @@ depends: [
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
   "re"
-  "stdio"
+  "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
 ]

--- a/packages/odoc/odoc.1.5.0/opam
+++ b/packages/odoc/odoc.1.5.0/opam
@@ -34,7 +34,7 @@ depends: [
   "alcotest" {dev & >= "0.8.3"}
   "markup" {dev & >= "0.8.0"}
   "ocamlfind" {dev}
-  "sexplib" {dev & >= "113.33.00"}
+  "sexplib" {dev & >= "113.33.00" & < "v0.14"}
 
   "bisect_ppx" {with-test & >= "1.3.0"}
 ]

--- a/packages/opium/opium.0.18.0/opam
+++ b/packages/opium/opium.0.18.0/opam
@@ -22,8 +22,8 @@ depends: [
   "lwt"
   "logs"
   "cmdliner"
-  "ppx_fields_conv"
-  "ppx_sexp_conv"
+  "ppx_fields_conv" {< "v0.14"}
+  "ppx_sexp_conv" {< "v0.14"}
   "re"
   "magic-mime"
   "alcotest" {with-test}

--- a/packages/opium_kernel/opium_kernel.0.18.0/opam
+++ b/packages/opium_kernel/opium_kernel.0.18.0/opam
@@ -15,10 +15,10 @@ depends: [
   "cohttp"
   "cohttp-lwt"
   "lwt"
-  "fieldslib"
-  "sexplib"
-  "ppx_fields_conv"
-  "ppx_sexp_conv"
+  "fieldslib" {< "v0.14"}
+  "sexplib" {< "v0.14"}
+  "ppx_fields_conv" {< "v0.14"}
+  "ppx_sexp_conv" {< "v0.14"}
   "re"
   "alcotest" {with-test}
 ]

--- a/packages/oraft/oraft.0.1.0/opam
+++ b/packages/oraft/oraft.0.1.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "2.0"}
-  "core" {>= "v0.9.0"}
+  "core" {>= "v0.9.0" & < "v0.14"}
   "cohttp-lwt-unix"
   "yojson"
   "ppx_deriving"

--- a/packages/otr/otr.0.3.7/opam
+++ b/packages/otr/otr.0.3.7/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune"
   "cstruct" {>= "1.9.0"}
-  "sexplib0"
+  "sexplib0" {< "v0.14"}
   "mirage-crypto"
   "mirage-crypto-pk"
   "astring"

--- a/packages/otr/otr.0.3.8/opam
+++ b/packages/otr/otr.0.3.8/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune"
   "cstruct" {>= "1.9.0"}
-  "sexplib0"
+  "sexplib0" {< "v0.14"}
   "mirage-crypto"
   "mirage-crypto-pk"
   "astring"

--- a/packages/owl/owl.0.7.2/opam
+++ b/packages/owl/owl.0.7.2/opam
@@ -24,7 +24,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "alcotest" {with-test}
-  "base" {build}
+  "base" {build & < "v0.14"}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
   "ctypes" {< "0.17.0"}
@@ -32,7 +32,7 @@ depends: [
   "dune-configurator"
   "eigen" {>= "0.1.0"}
   "owl-base" {= version}
-  "stdio" {build}
+  "stdio" {build & < "v0.14"}
   "stdlib-shims"
 ]
 url {

--- a/packages/owl/owl.0.8.0/opam
+++ b/packages/owl/owl.0.8.0/opam
@@ -24,7 +24,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "alcotest" {with-test}
-  "base" {build}
+  "base" {build & < "v0.14"}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
   "ctypes" {< "0.17.0"}
@@ -32,7 +32,7 @@ depends: [
   "dune-configurator"
   "eigen" {>= "0.1.0"}
   "owl-base" {= version}
-  "stdio" {build}
+  "stdio" {build & < "v0.14"}
   "stdlib-shims"
   "npy"
 ]

--- a/packages/owl/owl.0.9.0/opam
+++ b/packages/owl/owl.0.9.0/opam
@@ -24,7 +24,7 @@ build: [
 depends: [
   "ocaml" {>= "4.10.0"}
   "alcotest" {with-test}
-  "base" {build}
+  "base" {build & < "v0.14"}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
   "ctypes" {>= "0.16.0"}
@@ -32,7 +32,7 @@ depends: [
   "dune-configurator"
   "eigen" {>= "0.1.0"}
   "owl-base" {= version}
-  "stdio" {build}
+  "stdio" {build & < "v0.14"}
   "stdlib-shims"
   "npy"
 ]

--- a/packages/oxylc/oxylc.alpha1.1.2/opam
+++ b/packages/oxylc/oxylc.alpha1.1.2/opam
@@ -12,7 +12,7 @@ bug-reports: "https://gitlab.com/selfReferentialName/oxylc/issues"
 depends: [
   "ocaml"
   "ocamlfind"
-  "core"
+  "core" {< "v0.14"}
   "printbox"
   "omake"
   "llvm" {= "7.0"}

--- a/packages/p4pp/p4pp.0.1.4/opam
+++ b/packages/p4pp/p4pp.0.1.4/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.09.0"}
   "dune" {>= "1.2"}
   "menhir"
-  "core" {>= "v0.13.0" }
+  "core" {>= "v0.13.0" & < "v0.14"}
 ]
 url {
   src: "https://github.com/cornell-netlab/p4pp/archive/0.1.4.tar.gz"

--- a/packages/pcre/pcre.7.3.5/opam
+++ b/packages/pcre/pcre.7.3.5/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.4.0"}
   "dune-configurator"
   "conf-libpcre" {build}
-  "base" {build}
+  "base" {build & < "v0.14"}
   "base-bytes"
 ]
 

--- a/packages/pcre/pcre.7.4.0/opam
+++ b/packages/pcre/pcre.7.4.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.4.0"}
   "dune-configurator"
   "conf-libpcre" {build}
-  "base" {build}
+  "base" {build & < "v0.14"}
   "base-bytes"
 ]
 

--- a/packages/pcre/pcre.7.4.1/opam
+++ b/packages/pcre/pcre.7.4.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.4.0"}
   "dune-configurator"
   "conf-libpcre" {build}
-  "base" {build}
+  "base" {build & < "v0.14"}
   "base-bytes"
 ]
 

--- a/packages/pcre/pcre.7.4.2/opam
+++ b/packages/pcre/pcre.7.4.2/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "1.7.0"}
   "conf-libpcre" {build}
-  "base" {build}
+  "base" {build & < "v0.14"}
   "base-bytes"
 ]
 

--- a/packages/pcre/pcre.7.4.3/opam
+++ b/packages/pcre/pcre.7.4.3/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "1.10"}
   "conf-libpcre" {build}
-  "base" {build}
+  "base" {build & < "v0.14"}
   "base-bytes"
 ]
 url {

--- a/packages/pg_query/pg_query.0.9.3/opam
+++ b/packages/pg_query/pg_query.0.9.3/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/roddyyaga/pg_query-ocaml/issues"
 depends: [
   "ocaml" {>= "4.07"}
   "dune" {>= "2.0"}
-  "core"
+  "core" {< "v0.14"}
   "ctypes"
   "ctypes-foreign"
   "ppx_deriving"

--- a/packages/pg_query/pg_query.0.9.4/opam
+++ b/packages/pg_query/pg_query.0.9.4/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/roddyyaga/pg_query-ocaml/issues"
 depends: [
   "ocaml" {>= "4.07"}
   "dune" {>= "2.0"}
-  "core"
+  "core" {< "v0.14"}
   "ctypes"
   "ctypes-foreign"
   "ppx_deriving"

--- a/packages/pgocaml/pgocaml.4.2/opam
+++ b/packages/pgocaml/pgocaml.4.2/opam
@@ -20,11 +20,11 @@ depends: [
   "dune" {>= "1.10"}
   "hex"
   "ocaml" {>= "4.07"}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.14"}
   "re"
   "ppx_deriving" {>= "4.0"}
   "rresult"
-  "sexplib"
+  "sexplib" {< "v0.14"}
 ]
 url {
   src: "https://github.com/darioteixeira/pgocaml/archive/4.0.tar.gz"

--- a/packages/pgocaml_ppx/pgocaml_ppx.4.2/opam
+++ b/packages/pgocaml_ppx/pgocaml_ppx.4.2/opam
@@ -19,13 +19,13 @@ depends: [
   "ocaml" {>= "4.07"}
   "ocaml-migrate-parsetree"
   "pgocaml" {= version}
-  "ppx_optcomp"
-  "ppx_sexp_conv"
+  "ppx_optcomp" {< "v0.14"}
+  "ppx_sexp_conv" {< "v0.14"}
   "ppx_tools"
   "ppx_tools_versioned"
   "ppx_deriving" {>= "4.0"}
   "rresult"
-  "sexplib"
+  "sexplib" {< "v0.14"}
 ]
 url {
   src: "https://github.com/darioteixeira/pgocaml/archive/4.0.tar.gz"

--- a/packages/pgx/pgx.1.0/opam
+++ b/packages/pgx/pgx.1.0/opam
@@ -16,11 +16,11 @@ depends: [
   "ipaddr"
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
-  "ppx_compare" {>= "v0.13.0"}
-  "ppx_custom_printf" {>= "v0.13.0"}
-  "ppx_sexp_conv" {>= "v0.13.0"}
+  "ppx_compare" {>= "v0.13.0" & < "v0.14"}
+  "ppx_custom_printf" {>= "v0.13.0" & < "v0.14"}
+  "ppx_sexp_conv" {>= "v0.13.0" & < "v0.14"}
   "re"
-  "sexplib0" {>= "v0.13.0"}
+  "sexplib0" {>= "v0.13.0" & < "v0.14"}
   "uuidm"
 ]
 build: [

--- a/packages/pgx_async/pgx_async.1.0/opam
+++ b/packages/pgx_async/pgx_async.1.0/opam
@@ -10,8 +10,8 @@ bug-reports: "https://github.com/arenadotio/pgx/issues"
 depends: [
   "dune" {>= "1.11"}
   "alcotest-async" {with-test & >= "1.0.0"}
-  "async_kernel" {>= "v0.13.0"}
-  "async_unix" {>= "v0.13.0"}
+  "async_kernel" {>= "v0.13.0" & < "v0.14"}
+  "async_unix" {>= "v0.13.0" & < "v0.14"}
   "base64" {with-test & >= "3.0.0"}
   "ocaml" {>= "4.08"}
   "pgx" {= version}

--- a/packages/pgx_value_core/pgx_value_core.1.0/opam
+++ b/packages/pgx_value_core/pgx_value_core.1.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/arenadotio/pgx/issues"
 depends: [
   "dune" {>= "1.11"}
   "alcotest" {with-test & >= "1.0.0"}
-  "core_kernel" {>= "v0.13.0"}
+  "core_kernel" {>= "v0.13.0" & < "v0.14"}
   "ocaml" {>= "4.08"}
   "pgx" {= version}
 ]

--- a/packages/pixel_pusher/pixel_pusher.1.0/opam
+++ b/packages/pixel_pusher/pixel_pusher.1.0/opam
@@ -12,8 +12,8 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
   "dune" {>= "1.11"}
-  "async_udp"   {>= "v0.12.0"}
-  "core"        {>= "v0.12.0"}
+  "async_udp" {>= "v0.12.0" & < "v0.14"}
+  "core" {>= "v0.12.0" & < "v0.14"}
   "bitstring"   {>= "3.1.1"}
 ]
 url {

--- a/packages/pkcs11/pkcs11.1.0.0/opam
+++ b/packages/pkcs11/pkcs11.1.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "integers"
   "ppx_deriving" { >= "4.0" }
   "ppx_deriving_yojson" { >= "3.4" }
-  "ppx_variants_conv"
+  "ppx_variants_conv" {< "v0.14"}
   "zarith"
   "ocaml" {>= "4.04.0"}
   "ounit" {with-test}

--- a/packages/postgresql/postgresql.4.4.1/opam
+++ b/packages/postgresql/postgresql.4.4.1/opam
@@ -20,8 +20,8 @@ depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4.0"}
   "dune-configurator"
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
   "base-bytes"
 ]
 

--- a/packages/postgresql/postgresql.4.4.2/opam
+++ b/packages/postgresql/postgresql.4.4.2/opam
@@ -20,8 +20,8 @@ depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4.0"}
   "dune-configurator"
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
   "base-bytes"
 ]
 

--- a/packages/postgresql/postgresql.4.5.0/opam
+++ b/packages/postgresql/postgresql.4.5.0/opam
@@ -20,8 +20,8 @@ depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4.0"}
   "dune-configurator"
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
   "base-bytes"
   "conf-postgresql" {build}
 ]

--- a/packages/postgresql/postgresql.4.5.1/opam
+++ b/packages/postgresql/postgresql.4.5.1/opam
@@ -19,8 +19,8 @@ build: [
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "1.7.0"}
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
   "base-bytes"
   "conf-postgresql" {build}
 ]

--- a/packages/postgresql/postgresql.4.5.2/opam
+++ b/packages/postgresql/postgresql.4.5.2/opam
@@ -22,8 +22,8 @@ description:
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "1.10"}
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
   "conf-postgresql" {build}
   "base-bytes"
 ]

--- a/packages/pp/pp.1.0.1/opam
+++ b/packages/pp/pp.1.0.1/opam
@@ -30,7 +30,7 @@ bug-reports: "https://github.com/ocaml-dune/pp/issues"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.04.0"}
-  "ppx_expect" {with-test}
+  "ppx_expect" {with-test & < "v0.14"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/ppx_cstruct/ppx_cstruct.5.1.1/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.5.1.1/opam
@@ -22,8 +22,8 @@ depends: [
   "ounit" {with-test}
   "ppx_tools_versioned" {>= "5.0.1"}
   "ocaml-migrate-parsetree"
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {>="v0.9.0"}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {>= "v0.9.0" & < "v0.14"}
   "cstruct-sexp" {with-test}
   "cppo" {with-test}
   "cstruct-unix" {with-test & =version}

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.6.1.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.6.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "rpclib-lwt" {with-test & >= "5.0.0"}
   "rpclib-async" {with-test & >= "5.0.0"}
   "lwt" {with-test & >= "3.0.0"}
-  "async" {with-test}
+  "async" {with-test & < "v0.14"}
   "alcotest" {with-test}
 ]
 build: [

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.7.0.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.7.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "rpclib-lwt" {with-test & >= "5.0.0"}
   "rpclib-async" {with-test & >= "5.0.0"}
   "lwt" {with-test & >= "3.0.0"}
-  "async" {with-test}
+  "async" {with-test & < "v0.14"}
   "alcotest" {with-test}
 ]
 build: [

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.0/opam
@@ -11,11 +11,11 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04"}
-  "base"
+  "base" {< "v0.14"}
   "dune" {>= "1.2"}
   "ppxlib" {>= "0.9.0"}
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis:

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.1/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.1/opam
@@ -11,11 +11,11 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04"}
-  "base"
+  "base" {< "v0.14"}
   "dune" {>= "1.2"}
   "ppxlib" {>= "0.9.0"}
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis:

--- a/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.5.1.0/opam
+++ b/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.5.1.0/opam
@@ -14,10 +14,10 @@ depends: [
   "ppx_protocol_conv" {= version}
   "yojson" {>= "1.5.0" & < "2.0.0"}
   "dune" {>= "1.2"}
-  "ppx_expect"
-  "ppx_inline_test"
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_expect" {< "v0.14"}
+  "ppx_inline_test" {< "v0.14"}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Json driver for Ppx_protocol_conv"

--- a/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.5.1.1/opam
+++ b/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.5.1.1/opam
@@ -14,10 +14,10 @@ depends: [
   "ppx_protocol_conv" {= version}
   "yojson" {>= "1.5.0" & < "2.0.0"}
   "dune" {>= "1.2"}
-  "ppx_expect"
-  "ppx_inline_test"
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_expect" {< "v0.14"}
+  "ppx_inline_test" {< "v0.14"}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Json driver for Ppx_protocol_conv"

--- a/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.5.1.0/opam
+++ b/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.5.1.0/opam
@@ -14,8 +14,8 @@ depends: [
   "ppx_protocol_conv" {= version}
   "ezjsonm"
   "dune" {>= "1.2"}
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Jsonm driver for Ppx_protocol_conv"

--- a/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.5.1.1/opam
+++ b/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.5.1.1/opam
@@ -14,8 +14,8 @@ depends: [
   "ppx_protocol_conv" {= version}
   "ezjsonm"
   "dune" {>= "1.2"}
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Jsonm driver for Ppx_protocol_conv"

--- a/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.5.1.0/opam
+++ b/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.5.1.0/opam
@@ -14,8 +14,8 @@ depends: [
   "ppx_protocol_conv" {= version}
   "msgpck"
   "dune" {>= "1.2"}
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "MessagePack driver for Ppx_protocol_conv"

--- a/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.5.1.1/opam
+++ b/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.5.1.1/opam
@@ -14,8 +14,8 @@ depends: [
   "ppx_protocol_conv" {= version}
   "msgpck"
   "dune" {>= "1.2"}
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "MessagePack driver for Ppx_protocol_conv"

--- a/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.5.1.0/opam
+++ b/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.5.1.0/opam
@@ -14,8 +14,8 @@ depends: [
   "ppx_protocol_conv" {= version}
   "xml-light"
   "dune" {>= "1.2"}
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Xml driver for Ppx_protocol_conv"

--- a/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.5.1.1/opam
+++ b/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.5.1.1/opam
@@ -14,8 +14,8 @@ depends: [
   "ppx_protocol_conv" {= version}
   "xml-light"
   "dune" {>= "1.2"}
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Xml driver for Ppx_protocol_conv"

--- a/packages/ppx_protocol_conv_xmlm/ppx_protocol_conv_xmlm.5.1.1/opam
+++ b/packages/ppx_protocol_conv_xmlm/ppx_protocol_conv_xmlm.5.1.1/opam
@@ -14,8 +14,8 @@ depends: [
   "ppx_protocol_conv" {= version}
   "ezxmlm"
   "dune" {>= "1.2"}
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Xmlm driver for Ppx_protocol_conv"

--- a/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.5.1.0/opam
+++ b/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.5.1.0/opam
@@ -14,8 +14,8 @@ depends: [
   "dune" {>= "1.2"}
   "ppx_protocol_conv" {= version}
   "yaml" { >= "2.0.0"}
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Json driver for Ppx_protocol_conv"

--- a/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.5.1.1/opam
+++ b/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.5.1.1/opam
@@ -14,8 +14,8 @@ depends: [
   "dune" {>= "1.2"}
   "ppx_protocol_conv" {= version}
   "yaml" { >= "2.0.0"}
-  "ppx_sexp_conv" {with-test}
-  "sexplib" {with-test}
+  "ppx_sexp_conv" {with-test & < "v0.14"}
+  "sexplib" {with-test & < "v0.14"}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Json driver for Ppx_protocol_conv"

--- a/packages/ppx_rapper/ppx_rapper.1.0.1/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
-  "base"
+  "base" {< "v0.14"}
   "caqti"
   "caqti-lwt"
 ]

--- a/packages/ppx_rapper/ppx_rapper.1.0.2/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.0.2/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
-  "base"
+  "base" {< "v0.14"}
   "caqti"
   "caqti-lwt"
 ]

--- a/packages/ppx_rapper/ppx_rapper.1.1.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
-  "base"
+  "base" {< "v0.14"}
   "caqti"
   "caqti-lwt"
 ]

--- a/packages/ppx_rapper/ppx_rapper.1.1.1/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.1.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
-  "base"
+  "base" {< "v0.14"}
   "caqti"
   "caqti-lwt"
 ]

--- a/packages/reason-standard/reason-standard.0.1.0~alpha.1/opam
+++ b/packages/reason-standard/reason-standard.0.1.0~alpha.1/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/dean177/reason-standard"
 bug-reports: "https://github.com/dean177/reason-standard/issues"
 depends: [
   "alcotest" {with-test}
-  "base" {>= "0.13.0"}
+  "base" {>= "0.13.0" & < "v0.14"}
   "zarith" {>= "1.9.1"}
   "dune" {>= "2.4"}
   "reason" {>= "3.4.0"}

--- a/packages/rpc/rpc.6.1.0/opam
+++ b/packages/rpc/rpc.6.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "rpclib-async" {=version}
   "rpclib-lwt" {=version}
   "ppx_deriving_rpc" {=version}
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.9.0" & < "v0.14"}
   "lwt"
   "alcotest" {with-test & < "1.0.0"}
   "alcotest-lwt" {with-test & < "1.0.0"}

--- a/packages/rpc/rpc.7.0.0/opam
+++ b/packages/rpc/rpc.7.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "rpclib-async" {=version}
   "rpclib-lwt" {=version}
   "ppx_deriving_rpc" {=version}
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.9.0" & < "v0.14"}
   "lwt"
   "alcotest" {with-test & < "1.0.0"}
   "alcotest-lwt" {with-test & < "1.0.0"}

--- a/packages/rpclib-async/rpclib-async.6.1.0/opam
+++ b/packages/rpclib-async/rpclib-async.6.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "alcotest" {with-test}
   "dune" {>= "1.5.0"}
   "rpclib" {=version}
-  "async"
+  "async" {< "v0.14"}
 ]
 conflicts: [
   "core" {< "v0.9.0"}

--- a/packages/rpclib-async/rpclib-async.7.0.0/opam
+++ b/packages/rpclib-async/rpclib-async.7.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "alcotest" {with-test}
   "dune" {>= "1.5.0"}
   "rpclib" {=version}
-  "async"
+  "async" {< "v0.14"}
 ]
 conflicts: [
   "core" {< "v0.9.0"}

--- a/packages/sentry/sentry.v0.10.1/opam
+++ b/packages/sentry/sentry.v0.10.1/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/brendanlong/sentry-ocaml"
 doc: "https://brendanlong.github.io/sentry-ocaml"
 bug-reports: "https://github.com/brendanlong/sentry-ocaml/issues"
 depends: [
-  "async_unix" {>= "v0.13.0"}
+  "async_unix" {>= "v0.13.0" & < "v0.14"}
   "atdgen"
   "bisect_ppx" {dev & >= "2.0.0"}
   "cohttp" {>= "2.0.0"}
@@ -17,10 +17,10 @@ depends: [
   "dune" {>= "1.11.0"}
   "hex" {>= "1.2.0"}
   "json-derivers"
-  "ppx_jane"
+  "ppx_jane" {< "v0.14"}
   "ocaml" {>= "4.08.0"}
-  "re2"
-  "sexplib" {>= "v0.13.0"}
+  "re2" {< "v0.14"}
+  "sexplib" {>= "v0.13.0" & < "v0.14"}
   "uuidm"
   "uri"
   "yojson"

--- a/packages/session-cookie-async/session-cookie-async.0.1.8/opam
+++ b/packages/session-cookie-async/session-cookie-async.0.1.8/opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "1.11"}
   "ocaml" {>= "4.07.0"}
   "session-cookie" {= version}
-  "async"
+  "async" {< "v0.14"}
   "alcotest" {with-test}
   "junit" {with-test}
   "junit_alcotest" {with-test}

--- a/packages/session-cookie/session-cookie.0.1.8/opam
+++ b/packages/session-cookie/session-cookie.0.1.8/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "cookie" {= version}
   "session"
-  "base" {with-test}
+  "base" {with-test & < "v0.14"}
   "alcotest" {with-test}
   "junit" {with-test}
   "junit_alcotest" {with-test}

--- a/packages/spin/spin.0.5.0/opam
+++ b/packages/spin/spin.0.5.0/opam
@@ -15,14 +15,14 @@ depends: [
   "dune" {>= "2.0"}
   "odoc" {with-doc}
   "reason" {build}
-  "base"
-  "stdio"
+  "base" {< "v0.14"}
+  "stdio" {< "v0.14"}
   "cmdliner"
   "fileutils"
   "jingoo"
   "lwt"
-  "ppx_sexp_conv"
-  "sexplib"
+  "ppx_sexp_conv" {< "v0.14"}
+  "sexplib" {< "v0.14"}
 ]
 dev-repo: "git+https://github.com/tmattio/spin.git"
 # We need to avoid "@runtest", since it depends on rely

--- a/packages/spin/spin.0.5.1/opam
+++ b/packages/spin/spin.0.5.1/opam
@@ -15,14 +15,14 @@ depends: [
   "dune" {>= "2.0"}
   "odoc" {with-doc}
   "reason" {build}
-  "base"
-  "stdio"
+  "base" {< "v0.14"}
+  "stdio" {< "v0.14"}
   "cmdliner"
   "fileutils"
   "jingoo"
   "lwt"
-  "ppx_sexp_conv"
-  "sexplib"
+  "ppx_sexp_conv" {< "v0.14"}
+  "sexplib" {< "v0.14"}
 ]
 dev-repo: "git+https://github.com/tmattio/spin.git"
 # We need to avoid "@runtest", since it depends on rely

--- a/packages/spin/spin.0.6.0/opam
+++ b/packages/spin/spin.0.6.0/opam
@@ -16,13 +16,13 @@ depends: [
   "alcotest" {with-test}
   "odoc" {with-doc}
   "crunch" {build}
-  "base"
-  "stdio"
+  "base" {< "v0.14"}
+  "stdio" {< "v0.14"}
   "fmt"
   "fpath"
   "cmdliner"
   "logs"
-  "sexplib"
+  "sexplib" {< "v0.14"}
   "lwt" {>= "5.3.0"}
   "jingoo"
   "reason"

--- a/packages/sqlite3/sqlite3.4.4.1/opam
+++ b/packages/sqlite3/sqlite3.4.4.1/opam
@@ -20,8 +20,8 @@ depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4.0"}
   "dune-configurator"
-  "base" {build}
-  "stdio" {build}
+  "base" {build & < "v0.14"}
+  "stdio" {build & < "v0.14"}
   "conf-sqlite3" {build}
 ]
 

--- a/packages/sqlite3/sqlite3.5.0.1/opam
+++ b/packages/sqlite3/sqlite3.5.0.1/opam
@@ -25,7 +25,7 @@ depends: [
   "dune" {>= "1.11"}
   "dune-configurator"
   "conf-sqlite3" {build}
-  "ppx_inline_test" {with-test}
+  "ppx_inline_test" {with-test & < "v0.14"}
 ]
 url {
   src:

--- a/packages/ssh-agent/ssh-agent.0.3.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.3.0/opam
@@ -13,13 +13,13 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.0"}
   "ppx_cstruct" {build}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.14"}
   "angstrom" {>= "0.10" & < "0.13"}
   "faraday" {>= "0.6" & < "0.8"}
   "mirage-crypto"
   "mirage-crypto-pk"
   "cstruct"
-  "sexplib"
+  "sexplib" {< "v0.14"}
   "alcotest" {with-test}
 ]
 authors: "Reynir Björnsson <reynir@reynir.dk>"

--- a/packages/tablecloth-native/tablecloth-native.0.0.7/opam
+++ b/packages/tablecloth-native/tablecloth-native.0.0.7/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/darklang/tablecloth/issues"
 depends: [
   "ocaml"
   "dune" {>= "1.6"}
-  "base" {>= "v0.10.0"}
+  "base" {>= "v0.10.0" & < "v0.14"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git://github.com/darklang/tablecloth"

--- a/packages/tls/tls.0.10.6/opam
+++ b/packages/tls/tls.0.10.6/opam
@@ -23,12 +23,12 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.14"}
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
   "cstruct" {>= "4.0.0"}
   "cstruct-sexp"
-  "sexplib"
+  "sexplib" {< "v0.14"}
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.9.0" & < "0.10.0"}
   "domain-name" {>= "0.3.0"}

--- a/packages/tls/tls.0.11.0/opam
+++ b/packages/tls/tls.0.11.0/opam
@@ -16,11 +16,11 @@ build: [
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.0"}
-  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
   "ppx_cstruct" {>= "3.0.0"}
   "cstruct" {>= "4.0.0"}
   "cstruct-sexp"
-  "sexplib"
+  "sexplib" {< "v0.14"}
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-rng"

--- a/packages/tls/tls.0.11.1/opam
+++ b/packages/tls/tls.0.11.1/opam
@@ -15,11 +15,11 @@ build: [
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.0"}
-  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
   "ppx_cstruct" {>= "3.0.0"}
   "cstruct" {>= "4.0.0"}
   "cstruct-sexp"
-  "sexplib"
+  "sexplib" {< "v0.14"}
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-rng"

--- a/packages/tls/tls.0.12.0/opam
+++ b/packages/tls/tls.0.12.0/opam
@@ -15,11 +15,11 @@ build: [
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.0"}
-  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
   "ppx_cstruct" {>= "3.0.0"}
   "cstruct" {>= "4.0.0"}
   "cstruct-sexp"
-  "sexplib"
+  "sexplib" {< "v0.14"}
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-rng"

--- a/packages/tqdm/tqdm.0.1/opam
+++ b/packages/tqdm/tqdm.0.1/opam
@@ -8,11 +8,11 @@ authors:      [ "Laurent Mazare" ]
 build: [["dune" "build" "-j" jobs "-p" name]]
 
 depends: [
-  "base" {>= "v0.12.0"}
+  "base" {>= "v0.12.0" & < "v0.14"}
   "dune" {>= "1.3.0"}
   "ocaml" {>= "4.07"}
   "ocaml-compiler-libs"
-  "stdio"
+  "stdio" {< "v0.14"}
 ]
 
 synopsis: "OCaml library for progress bars"

--- a/packages/uri-sexp/uri-sexp.3.0.0/opam
+++ b/packages/uri-sexp/uri-sexp.3.0.0/opam
@@ -14,7 +14,7 @@ ocaml-uri with sexp support
 depends: [
   "uri" {= version}
   "dune" {>= "1.2.0"}
-  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
   "sexplib0" {< "v0.14"}
   "ounit" {with-test}
 ]

--- a/packages/uri-sexp/uri-sexp.3.1.0/opam
+++ b/packages/uri-sexp/uri-sexp.3.1.0/opam
@@ -14,8 +14,8 @@ ocaml-uri with sexp support
 depends: [
   "uri" {= version}
   "dune" {>= "1.2.0"}
-  "ppx_sexp_conv" {>= "v0.9.0"}
-  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
+  "sexplib0" {< "v0.14"}
   "ounit" {with-test}
 ]
 build: [

--- a/packages/uri/uri.3.1.0/opam
+++ b/packages/uri/uri.3.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.2.0"}
   "ounit" {with-test & >= "1.0.2"}
-  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0" & < "v0.14"}
   "re" {>= "1.9.0"}
   "stringext" {>= "1.4.0"}
 ]

--- a/packages/websocket-async/websocket-async.2.14/opam
+++ b/packages/websocket-async/websocket-async.2.14/opam
@@ -14,8 +14,8 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.3.0"}
   "websocket" {= version}
-  "core" {>= "v0.13.0"}
-  "async" {>= "v0.13.0"}
+  "core" {>= "v0.13.0" & < "v0.14"}
+  "async" {>= "v0.13.0" & < "v0.14"}
   "cohttp-async" {>= "2.5.1"}
   "logs-async" {>= "1.1"}
   "logs-async-reporter" {>= "1.0"}

--- a/packages/wseg/wseg.0.3.0/opam
+++ b/packages/wseg/wseg.0.3.0/opam
@@ -11,8 +11,8 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.4"}
-  "base" {>= "v0.9"}
-  "stdio" {>= "v0.9"}
+  "base" {>= "v0.9" & < "v0.14"}
+  "stdio" {>= "v0.9" & < "v0.14"}
   "trie" {>= "1.0"}
   "camomile" {>= "1.0"}
 ]

--- a/packages/yaml/yaml.2.1.0/opam
+++ b/packages/yaml/yaml.2.1.0/opam
@@ -11,8 +11,8 @@ depends: [
   "dune" {>= "1.3"}
   "dune-configurator"
   "ctypes" {>= "0.12.0"}
-  "ppx_sexp_conv" {>= "v0.9.0"}
-  "sexplib"
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.14"}
+  "sexplib" {< "v0.14"}
   "rresult"
   "fmt"
   "logs"

--- a/packages/zmq-async/zmq-async.5.1.3/opam
+++ b/packages/zmq-async/zmq-async.5.1.3/opam
@@ -15,9 +15,9 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "zmq" {= version}
   "dune"
-  "async_unix" {>= "v0.11.0"}
-  "async_kernel" {>= "v0.11.0"}
-  "base" {>= "v0.11.0"}
+  "async_unix" {>= "v0.11.0" & < "v0.14"}
+  "async_kernel" {>= "v0.11.0" & < "v0.14"}
+  "base" {>= "v0.11.0" & < "v0.14"}
   "ounit2" {with-test}
 ]
 synopsis: "Async aware bindings to zmq"


### PR DESCRIPTION
In preparation of the upcoming v0.14 release of all our packages,
we are adding upper bound constraints to reverse dependencies
so that the release does not break anything.