### PR TITLE
Release conduit mirage 2.2.1

### DIFF
--- a/packages/conduit-mirage/conduit-mirage.2.2.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.2.0/opam
@@ -45,3 +45,4 @@ url {
     "sha512=a8342fc4dbc1191f04994d89c9c0d12d24a91737eb5ae549588d2ddc5e663ac267e6934aa5ec44de9f5d8b34c6148504be67857d5b96dc6b4fb4b4058eef18ac"
   ]
 }
+available: false

--- a/packages/conduit-mirage/conduit-mirage.2.2.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.2.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.12.0"}
+  "sexplib"
+  "cstruct" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "dns-client" {>= "4.5.0"}
+  "conduit-lwt"
+  "vchan" {>= "5.0.0"}
+  "xenstore"
+  "tls" {>= "0.11.0"}
+  "tls-mirage" {>= "0.11.0"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+]
+conflicts: [
+  "mirage-conduit"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.2.1/conduit-v2.2.1.tbz"
+  checksum: [
+    "sha256=daac02c9955b5b1ec0e3ce29588bb20c4869ab956bd92e992bf3b0c0d98e26ff"
+    "sha512=8a2606590d560a7dac844e84cd342804505ae910a8d6df9d58f4948b5a517b6788a2551573c84930b96bdf3b20fc74d18ee3c90b00e0cc02b29234562a45eafe"
+  ]
+}


### PR DESCRIPTION
which only change is that it has its dependencies in both opam and dune corrected (this is the reason for marking 2.2.0 as unavailable)