### PR TITLE
[new release] ppx_show.0.2.0

### DIFF
--- a/packages/ppx_show/ppx_show.0.2.0/opam
+++ b/packages/ppx_show/ppx_show.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "OCaml PPX deriver for deriving show based on ppxlib"
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/ppx_show"
+doc: "https://github.com/thierry-martinez/ppx_show"
+bug-reports: "https://github.com/thierry-martinez/ppx_show"
+depends: [
+  "dune" {>= "1.11.0"}
+  "ppxlib" {>= "0.9.0"}
+  "stdcompat" {>= "9"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry-martinez/ppx_show.git"
+url {
+  src: "https://github.com/thierry-martinez/ppx_show/archive/v0.2.0.tar.gz"
+  checksum: "sha512=0e46da5ff86fb9ac765e9d611665e8668199d1930a5ec95c4cdd509aeda2e8b3577b0a6185215ee5ee75a284a19a5626e2c73dfbeafcd67184b21b86e35a2df1"
+}


### PR DESCRIPTION
- Migrate to GitHub

- Reverse the parenthesis and the constructor name for single argument, to make more outputs parsable by OCaml (e.g. `Constructor (ref (42))`) (Suggested by Sebastien Mondet).

- Update to ppxlib 0.9.0.