### PR TITLE
Package not-ocamlfind.0.01-alpha01

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.01-alpha01/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.01-alpha01/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.8.0"}
+]
+build: [
+  [make]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/0.001.tar.gz"
+  checksum: [
+    "md5=54997e25b256b46632c121258e4423fc"
+    "sha512=9f0857437d88133c31b2f81013f4c9db5dce5749fd747d4bedebfc520cab3611fc643a497719d518889cc4f597cb96dc13d527ac530ca1eeee78cb269836c29b"
+  ]
+}


### PR DESCRIPTION
### `not-ocamlfind.0.01-alpha01`
A small frontend for ocamlfind that adds a few useful commands



---
* Homepage: https://github.com/chetmurthy/not-ocamlfind
* Source repo: git+https://github.com/chetmurthy/not-ocamlfind
* Bug tracker: Chet Murthy <chetsky@gmail.com>

---
:camel: Pull-request generated by opam-publish v2.0.2