### PR TITLE
Package not-ocamlfind.0.02

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.02/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.02/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.8.0"}
+]
+build: [
+  [make]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/0.02.tar.gz"
+  checksum: [
+    "md5=25e1d045f7ab3aa0ce0a5a76c1582335"
+    "sha512=1a394c3b3e56b0653c853e68cc8ef1016ce800b511ac5cc96835e15653141d1583240cf5cc74095e84795c66213d384def55e00859c01cf897295a700f37a0e3"
+  ]
+}


### PR DESCRIPTION
### `not-ocamlfind.0.02`
A small frontend for ocamlfind that adds a few useful commands



---
* Homepage: https://github.com/chetmurthy/not-ocamlfind
* Source repo: git+https://github.com/chetmurthy/not-ocamlfind
* Bug tracker: Chet Murthy <chetsky@gmail.com>

---
:camel: Pull-request generated by opam-publish v2.0.2