### PR TITLE
Package not-ocamlfind.0.03

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.03/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.03/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.8.0"}
+]
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/0.03.tar.gz"
+  checksum: [
+    "md5=137a5a086041067e8027e4113090c378"
+    "sha512=a6021c25ba675e91f173e5ed2d7f3ff1d66636e7bb7627d8151008b4814ed2574ee9cb5888a0da019d58251ed29553822f7d206835300c0e4181761b5cb3114b"
+  ]
+}


### PR DESCRIPTION
### `not-ocamlfind.0.03`
A small frontend for ocamlfind that adds a few useful commands



---
* Homepage: https://github.com/chetmurthy/not-ocamlfind
* Source repo: git+https://github.com/chetmurthy/not-ocamlfind
* Bug tracker: Chet Murthy <chetsky@gmail.com>

---
:camel: Pull-request generated by opam-publish v2.0.2