### PR TITLE
Package not-ocamlfind.0.04

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.04/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.04/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.8.0"}
+  "fmt" {>= "0.8.8"}
+  "sexplib" {>= "v0.13.0"}
+  "rresult" {>= "0.6.0"}
+]
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/0.04.tar.gz"
+  checksum: [
+    "md5=1e1defa1b30be843db85ad5bc28f7554"
+    "sha512=dd89e0ad7c27952b6b22f5e060753782e415dbe6cae61a19356abac84083d34670b4486cdd4d6930de2131b3dacc2ebbc639da39fe37c5c8ed74f9653065ef9e"
+  ]
+}


### PR DESCRIPTION
### `not-ocamlfind.0.04`
A small frontend for ocamlfind that adds a few useful commands



---
* Homepage: https://github.com/chetmurthy/not-ocamlfind
* Source repo: git+https://github.com/chetmurthy/not-ocamlfind
* Bug tracker: Chet Murthy <chetsky@gmail.com>

---
:camel: Pull-request generated by opam-publish v2.0.2