### PR TITLE
Package not-ocamlfind.0.05

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.05/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.05/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.8.0"}
+  "fmt" {>= "0.8.8"}
+  "sexplib" {>= "v0.13.0"}
+  "rresult" {>= "0.6.0"}
+]
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/0.05.tar.gz"
+  checksum: [
+    "md5=7ede86ece0850fe90766063fb3fa10ed"
+    "sha512=e732e2acffcc67af9533bba7489a35b6c6a4f0137463427b39a9774616e1a877ac69deabaacb69c8481ce2b2153bfbed50ffdb17fe253a6a884464f342d5380d"
+  ]
+}


### PR DESCRIPTION
### `not-ocamlfind.0.05`
A small frontend for ocamlfind that adds a few useful commands



---
* Homepage: https://github.com/chetmurthy/not-ocamlfind
* Source repo: git+https://github.com/chetmurthy/not-ocamlfind
* Bug tracker: Chet Murthy <chetsky@gmail.com>

---
:camel: Pull-request generated by opam-publish v2.0.2