### PR TITLE
conf-mpfr: fix macports build

### DIFF
--- a/packages/conf-mpfr/conf-mpfr.2/files/test.c
+++ b/packages/conf-mpfr/conf-mpfr.2/files/test.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <mpfr.h>
+
+// compile with: gcc test.c -lmpfr -lgmp
+
+int main (void) {
+  printf ("MPFR library: %-12s\nMPFR header:  %s (based on %d.%d.%d)\n",
+          mpfr_get_version (), MPFR_VERSION_STRING, MPFR_VERSION_MAJOR,
+          MPFR_VERSION_MINOR, MPFR_VERSION_PATCHLEVEL);
+  return 0;
+}

--- a/packages/conf-mpfr/conf-mpfr.2/opam
+++ b/packages/conf-mpfr/conf-mpfr.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "http://www.mpfr.org/"
+authors: "http://www.mpfr.org/credit.html"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "LGPL-2.0-or-later"
+build: [
+  ["cc" "test.c" "-I/usr/local/include" "-L/usr/local/lib" "-lgmp" "-lmpfr"] {os-distribution != "macports"}
+  ["cc" "test.c" "-I/opt/local/include" "-L/opt/local/lib" "-lgmp" "-lmpfr"] {os = "macos" & os-distribution = "macports"}
+]
+depexts: [
+  ["libmpfr-dev"] {os-family = "debian"}
+  ["mpfr-devel"] {os-distribution = "fedora"}
+  ["mpfr"] {os = "macos" & os-distribution = "homebrew"}
+  ["mpfr"] {os = "macos" & os-distribution = "macports"}
+  ["mpfr"] {os = "freebsd"}
+  ["mpfr"] {os = "openbsd"}
+  ["mpfr-dev"] {os-distribution = "alpine"}
+  ["mpfr-devel"] {os-distribution = "centos"}
+  ["mpfr-devel"] {os-family = "suse"}
+]
+depends: ["conf-gmp"]
+synopsis: "Virtual package relying on library MPFR installation"
+description:
+  "This package can only install if the MPFR library is installed on the system."
+extra-files: ["test.c" "md5=ac7e04b5e22a41cb3c028180d1b811d6"]
+flags: conf


### PR DESCRIPTION
This should fix https://github.com/ocaml/opam-repository/issues/12681
Tested locally. I think for the future it would be a good idea to make
these conf packages use pkgconfig instead.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>