### PR TITLE
[new release] jose (0.3.1)

### DIFF
--- a/packages/jose/jose.0.3.1/opam
+++ b/packages/jose/jose.0.3.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "JOSE implementation for OCaml and ReasonML"
+description:
+  "JavaScript Object Signing and Encryption built ontop of pure OCaml libs"
+maintainer: ["ulrik.strid@outlook.com"]
+authors: ["Ulrik Strid"]
+license: "MIT"
+homepage: "https://ulrikstrid.github.io/reason-jose"
+doc: "https://ulrikstrid.github.io/reason-jose"
+bug-reports: "https://github.com/ulrikstrid/reason-jose/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "base64" {>= "3.0.0"}
+  "dune" {>= "1.11"}
+  "mirage-crypto" {>= "0.6.0" & < "0.8.0"}
+  "x509" {>= "0.10.0"}
+  "cstruct" {>= "4.0.0"}
+  "astring"
+  "yojson"
+  "result"
+  "zarith"
+  "containers" {with-test}
+  "bisect_ppx" {with-test}
+  "alcotest" {with-test}
+  "junit" {with-test}
+  "junit_alcotest" {with-test}
+  "lwt" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
+url {
+  src:
+    "https://github.com/ulrikstrid/reason-jose/releases/download/v0.3.1/jose-v0.3.1.tbz"
+  checksum: [
+    "sha256=e1352a308ccb6ba3cf1df16fbcd527491c1dea34af4b4d509e409670a4b5a47d"
+    "sha512=497d6bb39aa41741310b73e284dbffd4eb9762cc7f66f7700ae94d4228acb7a29c13e1e480241ae9599e0fdbccbd8fad3842e29552909e7c0219f4b16e62c980"
+  ]
+}


### PR DESCRIPTION
JOSE implementation for OCaml and ReasonML

- Project page: <a href="https://ulrikstrid.github.io/reason-jose">https://ulrikstrid.github.io/reason-jose</a>
- Documentation: <a href="https://ulrikstrid.github.io/reason-jose">https://ulrikstrid.github.io/reason-jose</a>

##### CHANGES:

- Add result compatability package (by @anmonteiro)
- Add `kid` to JWK representation to keep it when parsing JSON input
- Fix upper constraint on mirage-crypto
