### PR TITLE
[new release] plotkicadsch and kicadsch (0.6.0)

### DIFF
--- a/packages/kicadsch/kicadsch.0.6.0/opam
+++ b/packages/kicadsch/kicadsch.0.6.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+authors: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+doc: "https://jnavila.github.io/plotkicadsch/index"
+synopsis: "Library to read and convert Kicad Sch files"
+description: """
+Library able to read Kicad libraries and sch file and
+drive a painter to paint the schematics.
+"""
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "ocaml" {>="4.07"}
+]
+url {
+  src:
+    "https://github.com/jnavila/plotkicadsch/releases/download/v0.6.0/plotkicadsch-v0.6.0.tbz"
+  checksum: [
+    "sha256=d8cad9a1cdc1dff028ad57faf32d3515c7fd059fe1ad5e8b48bebad70be6048a"
+    "sha512=bc4604a6c651492d8d6e9f4e8862542c7163a5fe2af56d3fba414ac588320cd492efa3bcc3596dd33564ec598726c83146e6df5774f9beefd8accc8163ad35b6"
+  ]
+}

--- a/packages/plotkicadsch/plotkicadsch.0.6.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.6.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+authors: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+doc: "https://jnavila.github.io/plotkicadsch/index"
+synopsis: "Utilities to print and compare version of Kicad schematics"
+description: """
+Two utilities:
+ * plotkicadsch is able to plot schematic sheets to SVG files
+ * plotgitsch is able to compare git revisions of schematics
+"""
+license: "ISC"
+dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="4.07"}
+  "dune" {>= "1.0"}
+  "kicadsch" {= version}
+  "tyxml" {>= "4.0.0"}
+  "lwt"
+  "lwt_ppx" {build}
+  "sha"
+  "git" {>= "2.0.0"}
+  "git-unix"
+  "base64" {= "2.3.0"}
+  "patience_diff" { < "v0.12.0" }
+  "core_kernel"
+  "cmdliner"
+]
+url {
+  src:
+    "https://github.com/jnavila/plotkicadsch/releases/download/v0.6.0/plotkicadsch-v0.6.0.tbz"
+  checksum: [
+    "sha256=d8cad9a1cdc1dff028ad57faf32d3515c7fd059fe1ad5e8b48bebad70be6048a"
+    "sha512=bc4604a6c651492d8d6e9f4e8862542c7163a5fe2af56d3fba414ac588320cd492efa3bcc3596dd33564ec598726c83146e6df5774f9beefd8accc8163ad35b6"
+  ]
+}


### PR DESCRIPTION
Utilities to print and compare version of Kicad schematics

- Project page: <a href="https://jnavila.github.io/plotkicadsch/">https://jnavila.github.io/plotkicadsch/</a>
- Documentation: <a href="https://jnavila.github.io/plotkicadsch/index">https://jnavila.github.io/plotkicadsch/index</a>

##### CHANGES:

- Search libs and schs recursively from working directory (fixes jnavila/plotkicadsch#33)
