### PR TITLE
+secp256k1-internal.0.2.0

### DIFF
--- a/packages/secp256k1-internal/secp256k1-internal.0.2.0/opam
+++ b/packages/secp256k1-internal/secp256k1-internal.0.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "secp256k1-internal"
+maintainer: "contact@nomadic-labs.com"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal"
+synopsis: "Bindings to secp256k1 internal functions (generic operations on the curve)"
+
+license: "MIT"
+bug-reports: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name "@install"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-gmp" {build}
+  "dune" {>= "2"}
+  "dune-configurator"
+  "cstruct" {>= "3.2.1"}
+  "bigstring" {>= "0.1.1"}
+  "hex" {with-test & >= "1.4.0"}
+  "alcotest" {with-test}
+]
+
+url {
+  src: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/-/archive/v0.2/ocaml-secp256k1-internal-v0.2.tar.bz2"
+  checksum: [
+    "sha256=56a12978d13058761ae495068ad683f1da837b2e280c70b2042c4325926a12f1"
+    "sha512=607b8c9d6514421f9fd042a883531d613eb2cb2c2c5bb38d038d930454081dbd707f5b318de6b0c981675ecf6ca56d1eec06b8afbabc293c7600e86b1578cf2d"
+  ]
+}


### PR DESCRIPTION
This version is about compatibility with libgmp being installed by macport under MacOS. Actually, it handles any setting where gmp is not installed in a canonical place but comes with a pkg-config file.