### PR TITLE
[new release] postgresql (4.6.0)

### DIFF
--- a/packages/postgresql/postgresql.4.6.0/opam
+++ b/packages/postgresql/postgresql.4.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "dune-configurator"
+  "base" {build}
+  "stdio" {build}
+  "conf-postgresql" {build}
+  "base-bytes"
+]
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/4.6.0/postgresql-4.6.0.tbz"
+  checksum: [
+    "sha256=9e9b6ce75c9e93c77dd906eccf88555d7fc88fd6b1f02345c367b254a26265b1"
+    "sha512=6dca72ef03afbe631db0822e057961ef7e68d4294c2631ed12c2438a919d608adb241c7f9666883c14da631b505e32db52b87acd01b06c033694fcaa15c9b20e"
+  ]
+}


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

* Fixed missing runtime release during calls to PQisBusy.

  * Added a temporary workaround for dealing with notice processing and
    asynchronous operations.

    Thanks to Petter A. Urkedal for the patch!
