### PR TITLE
Tighten the dependencies of irmin-unix.1.3.3

### DIFF
--- a/packages/irmin-unix/irmin-unix.1.3.3/opam
+++ b/packages/irmin-unix/irmin-unix.1.3.3/opam
@@ -14,14 +14,14 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.01.0"}
-  "jbuilder" {>= "1.0+beta10"}
-  "irmin" {>= "1.3.0" & < "2.0.0"}
-  "irmin-mem" {>= "1.3.0" & < "2.0.0"}
-  "irmin-git" {>= "1.3.0" & < "2.0.0"}
-  "irmin-http" {>= "1.3.0" & < "2.0.0"}
-  "irmin-fs" {>= "1.3.0" & < "2.0.0"}
-  "git-unix" {>= "1.11.4" & < "2.0.0"}
-  "irmin-watcher" {>= "0.2.0"}
+  "jbuilder" {= "transition"}
+  "irmin" {= "1.4.0"}
+  "irmin-mem" {= "1.3.0"}
+  "irmin-git" {= "1.3.0"}
+  "irmin-http" {= "1.3.3"}
+  "irmin-fs" {= "1.3.0"}
+  "git-unix" {= "1.11.5"}
+  "irmin-watcher" {= "0.3.0"}
   "alcotest" {with-test}
   "mtime" {with-test & >= "1.0.0"}
 ]

--- a/packages/irmin-unix/irmin-unix.1.3.3/opam
+++ b/packages/irmin-unix/irmin-unix.1.3.3/opam
@@ -22,7 +22,7 @@ depends: [
   "irmin-fs" {= "1.3.0"}
   "git-unix" {= "1.11.5"}
   "irmin-watcher" {= "0.3.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "0.7.0" & < "1.0.0"}
   "mtime" {with-test & >= "1.0.0"}
 ]
 synopsis: "Unix backends for Irmin"


### PR DESCRIPTION
This small PR is a follow-up of a suggestion by @avsm - https://github.com/ocaml/opam/issues/4203#issuecomment-631493823

This patch makes the installation of irmin-unix.1.3.3 tractable (instead of raising a timeout due to a required time of around 10mn with opam's default solver options).
 
I know that `=` dependencies are not recommended, but:

* The constraint on ocaml `>= "4.01.0"` is kept as is
* The chosen dependencies versions correspond to the latest compatible versions
* Version 1.3.3 is not the bleeding-edge version of irmin-unix so "flexibility impact" is limited