### PR TITLE
Relocate distributions for Conjury and Orsetto.

### DIFF
--- a/packages/conjury/conjury.2.0/opam
+++ b/packages/conjury/conjury.2.0/opam
@@ -3,9 +3,9 @@ name: "conjury" version: "2.0"
 synopsis: "Conjury library for OMake"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
-homepage: "https://bitbucket.org/jhw/conjury-hg/"
-bug-reports: "https://bitbucket.org/jhw/conjury-hg/issues"
-dev-repo: "hg+https://bitbucket.org/jhw/conjury-hg"
+homepage: "https://bitbucket.org/jhw/conjury/"
+bug-reports: "https://bitbucket.org/jhw/conjury/issues"
+dev-repo: "git+https://bitbucket.org/jhw/conjury"
 tags: [ "org:conjury.org" ]
 depends: [
     "ocaml" { with-test & >= "4.04" }
@@ -18,6 +18,6 @@ build: [
 ]
 install: [ "omake" "install" ]
 url {
-    src: "https://bitbucket.org/jhw/conjury-hg/get/r2.0.tar.gz"
-    checksum: "md5=5485ea44e4a11b0203ec07c08d56c7c0"
+    src: "https://bitbucket.org/jhw/conjury/get/r2.0.tar.gz"
+    checksum: "md5=515624798f90fe6ec07a03e7cd5aa726"
 }

--- a/packages/orsetto/orsetto.1.0.1/opam
+++ b/packages/orsetto/orsetto.1.0.1/opam
@@ -2,9 +2,9 @@ opam-version: "2.0"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
-homepage: "https://bitbucket.org/jhw/orsetto-hg/"
-bug-reports: "https://bitbucket.org/jhw/orsetto-hg/issues"
-dev-repo: "hg+https://bitbucket.org/jhw/orsetto-hg"
+homepage: "https://bitbucket.org/jhw/orsetto/"
+bug-reports: "https://bitbucket.org/jhw/orsetto/issues"
+dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
 depends: [
     ("ocaml" { >= "4.07" & < "4.09" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
@@ -22,12 +22,12 @@ install: [
     [ "omake" "--verbose" "install" "MODE=develop" ] { dev }
 ]
 url {
-    src: "https://bitbucket.org/jhw/orsetto-hg/get/r1.0.1.tar.gz"
+    src: "https://bitbucket.org/jhw/orsetto/get/r1.0.1.tar.gz"
     checksum: "md5=81e0f8a5f2c0cf364e3c8e9acbadef93"
 }
 extra-source "ucd.all.grouped.zip" {
     src: "http://www.unicode.org/Public/12.0.0/ucdxml/ucd.all.grouped.zip"
-    checksum: "md5=31c0d979d71f0aba02bb3fc74fd8a96b"
+    checksum: "md5=3a15a377800cf988a310b4082406c685"
 }
 extra-source "NormalizationTest.txt" {
     src: "http://www.unicode.org/Public/12.0.0/ucd/NormalizationTest.txt"

--- a/packages/orsetto/orsetto.1.0.2/opam
+++ b/packages/orsetto/orsetto.1.0.2/opam
@@ -2,9 +2,9 @@ opam-version: "2.0"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
-homepage: "https://bitbucket.org/jhw/orsetto-hg/"
-bug-reports: "https://bitbucket.org/jhw/orsetto-hg/issues"
-dev-repo: "hg+https://bitbucket.org/jhw/orsetto-hg"
+homepage: "https://bitbucket.org/jhw/orsetto/"
+bug-reports: "https://bitbucket.org/jhw/orsetto/issues"
+dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
 depends: [
     ("ocaml" { >= "4.07" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
@@ -22,8 +22,8 @@ install: [
     [ "omake" "--verbose" "install" "MODE=develop" ] { dev }
 ]
 url {
-    src: "https://bitbucket.org/jhw/orsetto-hg/get/r1.0.2.tar.gz"
-    checksum: "md5=658a468c734f2825773e810177cd9020"
+    src: "https://bitbucket.org/jhw/orsetto/get/r1.0.2.tar.gz"
+    checksum: "md5=f7bfa83013801b42fcdba607af2f012b"
 }
 extra-source "ucd.all.grouped.zip" {
     src: "http://www.unicode.org/Public/12.0.0/ucdxml/ucd.all.grouped.zip"

--- a/packages/orsetto/orsetto.1.0/opam
+++ b/packages/orsetto/orsetto.1.0/opam
@@ -3,9 +3,9 @@ name: "orsetto" version: "1.0"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
-homepage: "https://bitbucket.org/jhw/orsetto-hg/"
-bug-reports: "https://bitbucket.org/jhw/orsetto-hg/issues"
-dev-repo: "hg+https://bitbucket.org/jhw/orsetto-hg"
+homepage: "https://bitbucket.org/jhw/orsetto/"
+bug-reports: "https://bitbucket.org/jhw/orsetto/issues"
+dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
 depends: [
     ("ocaml" { >= "4.07" & < "4.09" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
@@ -23,8 +23,8 @@ install: [
     [ "omake" "--verbose" "install" "MODE=develop" ] { dev }
 ]
 url {
-    src: "https://bitbucket.org/jhw/orsetto-hg/get/r1.0.tar.gz"
-    checksum: "md5=af03ca5123daf40860d6a0e16f5fb565"
+    src: "https://bitbucket.org/jhw/orsetto/get/r1.0.tar.gz"
+    checksum: "md5=6bb6a7ba88bf2c7595a0b332921e60b4"
 }
 extra-source "ucd.all.grouped.zip" {
     src: "http://www.unicode.org/Public/12.0.0/ucdxml/ucd.all.grouped.zip"


### PR DESCRIPTION
- Atlassian has announced end of life for their Mercurial services.
- Moved the repositories to their Git services. All history preserved.