### PR TITLE
[new release] Package tldr.0.3.0

### DIFF
--- a/packages/tldr/tldr.0.3.0/opam
+++ b/packages/tldr/tldr.0.3.0/opam
@@ -6,7 +6,7 @@ license: "MIT"
 homepage: "https://github.com/RosalesJ/tldr-ocaml/"
 bug-reports: "https://github.com/RosalesJ/tldr-ocaml/issues"
 depends: [
-  "dune" {build}
+  "dune" {>= "1.2"}
   "cohttp-lwt-unix"
   "lwt_ssl"
   "ANSITerminal"

--- a/packages/tldr/tldr.0.3.0/opam
+++ b/packages/tldr/tldr.0.3.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "An ocaml tldr client"
+maintainer: "coby@case.edu"
+authors: "Jacob Rosales Chase <coby@case.edu>"
+license: "MIT"
+homepage: "https://github.com/RosalesJ/tldr-ocaml/"
+bug-reports: "https://github.com/RosalesJ/tldr-ocaml/issues"
+depends: [
+  "dune" {build}
+  "cohttp-lwt-unix"
+  "lwt_ssl"
+  "ANSITerminal"
+  "angstrom"
+]
+conflicts: [
+  "ssl" {= "0.5.6"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/RosalesJ/tldr-ocaml.git"
+url {
+  src: "https://github.com/RosalesJ/tldr-ocaml/archive/v0.3.0.tar.gz"
+  checksum: [
+    "md5=4bdb2a3847b23e226a3fe6213fffa4fe"
+    "sha512=865d2528d814587d2a8ab8326fe1547905a6256a60f817ac448138c177a8460292ec704e81a2639d85f4f0c326721f97e168f08b0b3d5652e8bdef6923c26024"
+  ]
+}

--- a/packages/tldr/tldr.0.3.0/opam
+++ b/packages/tldr/tldr.0.3.0/opam
@@ -10,7 +10,7 @@ depends: [
   "cohttp-lwt-unix"
   "lwt_ssl"
   "ANSITerminal"
-  "angstrom"
+  "angstrom" {>= "0.14.0"}
 ]
 conflicts: [
   "ssl" {= "0.5.6"}


### PR DESCRIPTION
### `tldr.0.3.0`
An ocaml tldr client.

#### v0.3.0 - 5/24/2020
--------------------
- Change version numbers to be semantic versioning compliant
- Changed to using `cmdliner` for command line parsing
- Cut down on some large dependencies
- Generate manpage on install

---
* Homepage: https://github.com/RosalesJ/tldr-ocaml/
* Source repo: git+https://github.com/RosalesJ/tldr-ocaml.git
* Bug tracker: https://github.com/RosalesJ/tldr-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2