### PR TITLE
Package template_engine.0.1

### DIFF
--- a/packages/template_engine/template_engine.0.1/opam
+++ b/packages/template_engine/template_engine.0.1/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+synopsis: "Simple template engine for OCaml"
+description: """
+Simple template engine for OCaml
+"""
+maintainer: "Emile Trotignon emile.trotignon@gmail.com"
+authors: "Emile Trotignon emile.trotignon@gmail.com"
+license: "MIT"
+homepage: "https://emiletrotignon.github.io/ocaml_template_engine/"
+bug-reports: "https://github.com/EmileTrotignon/ocaml_template_engine/issues"
+dev-repo: "git+https://github.com/EmileTrotignon/ocaml_template_engine.git"
+depends: [ "ocaml" "ocamlfind" "dune" {build} "sedlex" "core" "uutf" "menhir" "ppxlib" "containers" "bwrap"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]


### PR DESCRIPTION
### `template_engine.0.1`
Simple template engine for OCaml
Simple template engine for OCaml



---
* Homepage: https://emiletrotignon.github.io/ocaml_template_engine/
* Source repo: git+https://github.com/EmileTrotignon/ocaml_template_engine.git
* Bug tracker: https://github.com/EmileTrotignon/ocaml_template_engine/issues

---
:camel: Pull-request generated by opam-publish v2.0.2