### PR TITLE
Package gen_js_api.1.0.6

### DIFF
--- a/packages/gen_js_api/gen_js_api.1.0.6/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.6/opam
@@ -11,7 +11,7 @@ dev-repo: "git+https://github.com/LexiFi/gen_js_api.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {build & >= "1.11"}
+  "dune" {>= "1.11"}
   "js_of_ocaml"  {>= "3.1.0"}
   "ocaml-migrate-parsetree" {>= "1.6.0"}
   "ppxlib" {>= "0.9"}

--- a/packages/gen_js_api/gen_js_api.1.0.6/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.6/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Alain Frisch <alain.frisch@lexifi.com>"
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Sebastien Briais <sebastien.briais@lexifi.com>"
+]
+homepage: "https://github.com/LexiFi/gen_js_api"
+bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/LexiFi/gen_js_api.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {build & >= "1.11"}
+  "js_of_ocaml"  {>= "3.1.0"}
+  "ocaml-migrate-parsetree" {>= "1.6.0"}
+  "ppxlib" {>= "0.9"}
+]
+synopsis: "Easy OCaml bindings for Javascript libraries"
+description: """
+gen_js_api aims at simplifying the creation of OCaml bindings for
+Javascript libraries.  Authors of bindings write OCaml signatures for
+Javascript libraries and the tool generates the actual binding code
+with a combination of implicit conventions and explicit annotations.
+
+gen_js_api is to be used with the js_of_ocaml compiler."""
+url {
+  src: "https://github.com/LexiFi/gen_js_api/archive/v1.0.6.tar.gz"
+  checksum: [
+    "md5=efe14f394576c5bb60ae0d53fb402ca8"
+    "sha512=cda932339a16c85888b4d410fa18d1e179cd66eb0e39a611e545aac5583f9bb76c0325977dd7d9cf0ac40ad10ec0e5879a8a748ac6e045b469cddd9d8097a176"
+  ]
+}


### PR DESCRIPTION
### `gen_js_api.1.0.6`
Easy OCaml bindings for Javascript libraries
gen_js_api aims at simplifying the creation of OCaml bindings for
Javascript libraries.  Authors of bindings write OCaml signatures for
Javascript libraries and the tool generates the actual binding code
with a combination of implicit conventions and explicit annotations.

gen_js_api is to be used with the js_of_ocaml compiler.



---
* Homepage: https://github.com/LexiFi/gen_js_api
* Source repo: git+https://github.com/LexiFi/gen_js_api.git
* Bug tracker: https://github.com/LexiFi/gen_js_api/issues

---
:camel: Pull-request generated by opam-publish v2.0.2