### PR TITLE
zenon: conflict with Coq >= 8.9

### DIFF
--- a/packages/zenon/zenon.0.7.1/opam
+++ b/packages/zenon/zenon.0.7.1/opam
@@ -6,7 +6,7 @@ authors: [ "R. Bonichon" "D. Delahaye" "D. Doligez" ]
 bug-reports: "zenon.prover at gmail.com"
 depends: [
   "ocaml" {< "4.06.0"}
-  "coq"
+  "coq" {< "8.9"}
 ]
 build: [
   ["mkdir" "-p" "%{zenon:lib}%" ] # Needed otherwise configure fails

--- a/packages/zenon/zenon.0.8.0/opam
+++ b/packages/zenon/zenon.0.8.0/opam
@@ -6,7 +6,7 @@ authors: [ "R. Bonichon" "D. Delahaye" "D. Doligez" ]
 bug-reports: "zenon.prover at gmail.com"
 depends: [
   "ocaml" {< "4.06.0"}
-  "coq"
+  "coq" {< "8.9"}
 ]
 build: [
   ["./configure" "--prefix" "%{prefix}%" "--libdir" "%{zenon:lib}%"]

--- a/packages/zenon/zenon.0.8.4/opam
+++ b/packages/zenon/zenon.0.8.4/opam
@@ -10,6 +10,9 @@ depends: [
 depopts: [
   "coq" {< "8.9"}
 ]
+conflicts: [
+  "coq" {>= "8.9"}
+]
 build: [
   ["./configure" "--prefix" "%{prefix}%" "--libdir" "%{zenon:lib}%"]
   [make]

--- a/packages/zenon/zenon.0.8.4/opam
+++ b/packages/zenon/zenon.0.8.4/opam
@@ -8,7 +8,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
 ]
 depopts: [
-  "coq" {< "8.9"}
+  "coq"
 ]
 conflicts: [
   "coq" {>= "8.9"}


### PR DESCRIPTION
At installation time, the zenon package runs Coq on a few files that rely on the `Implicit Arguments` syntax that has been deprecated in Coq 8.9. The following issue is about updating the files to support a more recent version of Coq: https://github.com/zenon-prover/zenon/issues/1.