### PR TITLE
Package ocaml-vdom.0.2

### DIFF
--- a/packages/ocaml-vdom/ocaml-vdom.0.2/opam
+++ b/packages/ocaml-vdom/ocaml-vdom.0.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Alain Frisch <alain.frisch@lexifi.com>"
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+]
+homepage: "https://github.com/LexiFi/ocaml-vdom"
+bug-reports: "https://github.com/LexiFi/ocaml-vdom/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/LexiFi/ocaml-vdom.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {build & >= "2.0"}
+  "js_of_ocaml-compiler"
+  "gen_js_api" {>= "1.0.6"}
+]
+synopsis: "DOM and VDOM for OCaml"
+description: """
+This package contains:
+- OCaml bindings to DOM and other client-side Javascript APIs (using gen_js_api).
+- An implementation of the Elm architecture, where the UI is specified as a functional "view" on the current state.
+"""
+url {
+  src: "https://github.com/LexiFi/ocaml-vdom/archive/v0.2.tar.gz"
+  checksum: [
+    "md5=9d23abfd7165df20c802a2c66f1a2120"
+    "sha512=7545af02cf586a454999e0b3a2e94432ff3794ccead1612e78b779c14b7b9ed1a65b7d6e256e3d37fc007876af889e6825d94ba7fc110b325d358aa5ec7a7ef8"
+  ]
+}

--- a/packages/ocaml-vdom/ocaml-vdom.0.2/opam
+++ b/packages/ocaml-vdom/ocaml-vdom.0.2/opam
@@ -10,7 +10,7 @@ dev-repo: "git+https://github.com/LexiFi/ocaml-vdom.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {build & >= "2.0"}
+  "dune" {>= "2.0"}
   "js_of_ocaml-compiler"
   "gen_js_api" {>= "1.0.6"}
 ]


### PR DESCRIPTION
### `ocaml-vdom.0.2`
DOM and VDOM for OCaml
This package contains:
- OCaml bindings to DOM and other client-side Javascript APIs (using gen_js_api).
- An implementation of the Elm architecture, where the UI is specified as a functional "view" on the current state.



---
* Homepage: https://github.com/LexiFi/ocaml-vdom
* Source repo: git+https://github.com/LexiFi/ocaml-vdom.git
* Bug tracker: https://github.com/LexiFi/ocaml-vdom/issues

---
:camel: Pull-request generated by opam-publish v2.0.2