### PR TITLE
Package linenoise.1.3.1

### DIFF
--- a/packages/linenoise/linenoise.1.3.1/opam
+++ b/packages/linenoise/linenoise.1.3.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Lightweight readline alternative"
+maintainer: "Simon Cruanes"
+authors: [ "Edgar Aroutiounian <edgar.factorial@gmail.com>" "Simon Cruanes" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/ocaml-community/ocaml-linenoise"
+dev-repo: "git+https://github.com/ocaml-community/ocaml-linenoise.git"
+bug-reports: "https://github.com/ocaml-community/ocaml-linenoise/issues"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+depends: [
+  "dune"
+  "result"
+  "ocaml" { >= "4.02.0" }
+  "odoc" {with-doc}
+]
+url {
+  src:
+    "https://github.com/ocaml-community/ocaml-linenoise/archive/v1.3.1.tar.gz"
+  checksum: [
+    "md5=56b9354fd2a1b5ff0c4b7bccd82ad60b"
+    "sha512=02d5c002a37b41254d6f9d1645117b99209129ba8b808871e6bd48ab2c8c4486fa12aca98db9a8cd44fafccca4c88b517fe0311afbcb9791f270a7329176f793"
+  ]
+}

--- a/packages/linenoise/linenoise.1.3.1/opam
+++ b/packages/linenoise/linenoise.1.3.1/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "build" "@doc" "-p" name] {with-doc}
 ]
 depends: [
-  "dune"
+  "dune" {>= "1.1"}
   "result"
   "ocaml" { >= "4.02.0" }
   "odoc" {with-doc}


### PR DESCRIPTION
### `linenoise.1.3.1`
Lightweight readline alternative



---
* Homepage: https://github.com/ocaml-community/ocaml-linenoise
* Source repo: git+https://github.com/ocaml-community/ocaml-linenoise.git
* Bug tracker: https://github.com/ocaml-community/ocaml-linenoise/issues

---
:camel: Pull-request generated by opam-publish v2.0.0