### PR TITLE
Fix issues with older opam packages

### DIFF
--- a/packages/bindlib/bindlib.4.0.2/opam
+++ b/packages/bindlib/bindlib.4.0.2/opam
@@ -26,6 +26,6 @@ Authors
 	* Rodolphe Lepigre"""
 flags: light-uninstall
 url {
-  src: "https://lama.univ-savoie.fr/~raffalli/bindlib/bindlib-4.0.2.tar.gz"
+  src: "https://opam.ocaml.org/cache/md5/6b/6b37b02a6d1c7e5bb51ba96adbf84afc"
   checksum: "md5=6b37b02a6d1c7e5bb51ba96adbf84afc"
 }

--- a/packages/bindlib/bindlib.4.0.3/opam
+++ b/packages/bindlib/bindlib.4.0.3/opam
@@ -26,6 +26,6 @@ Authors
 	* Rodolphe Lepigre"""
 flags: light-uninstall
 url {
-  src: "https://lama.univ-savoie.fr/~raffalli/bindlib/bindlib-4.0.3.tar.gz"
+  src: "https://opam.ocaml.org/cache/md5/49/49f7dcb45ebe49765dc850db7b842e32"
   checksum: "md5=49f7dcb45ebe49765dc850db7b842e32"
 }

--- a/packages/bindlib/bindlib.4.0/opam
+++ b/packages/bindlib/bindlib.4.0/opam
@@ -28,6 +28,6 @@ Authors
 	* Rodolphe Lepigre"""
 flags: light-uninstall
 url {
-  src: "https://lama.univ-savoie.fr/~raffalli/bindlib/bindlib-4.0.tar.gz"
+  src: "https://opam.ocaml.org/cache/md5/ce/ce1ca69a76ba5ecf1735a64ab1c175c9"
   checksum: "md5=ce1ca69a76ba5ecf1735a64ab1c175c9"
 }

--- a/packages/cubicle/cubicle.1.0.2/opam
+++ b/packages/cubicle/cubicle.1.0.2/opam
@@ -29,6 +29,6 @@ extra-files: [
   ["cubicle.install" "md5=ba6d18615d00544948c96638b6c8d900"]
 ]
 url {
-  src: "http://cubicle.lri.fr/cubicle-1.0.2.tar.gz"
+  src: "https://opam.ocaml.org/cache/md5/08/08a6f19c157037c162bb4a764f2c3747"
   checksum: "md5=08a6f19c157037c162bb4a764f2c3747"
 }

--- a/packages/cubicle/cubicle.1.0.2/opam
+++ b/packages/cubicle/cubicle.1.0.2/opam
@@ -15,7 +15,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "4.06"}
   "ocamlfind"
   "num"
 ]

--- a/packages/gles3/gles3.20160307.alpha/opam
+++ b/packages/gles3/gles3.20160307.alpha/opam
@@ -22,6 +22,7 @@ depexts: [
   ["mesa-libGLES" "mesa-libGLES-devel"] {os-distribution = "centos"}
   ["mesa-libGLES-devel"] {os-distribution = "fedora"}
 ]
+x-ci-accept-failures: ["debian-unstable"]
 post-messages: [
   "gles3 requires libgles2-mesa (>= 10.1) which is only available on ubuntu trusty (12.10) or more recent"     {failure & (os = "ubuntu")}
   "gles3 requires gles, egl and X11" { failure & (os != "ubuntu") }

--- a/packages/gles3/gles3.20160307.alpha/opam
+++ b/packages/gles3/gles3.20160307.alpha/opam
@@ -54,6 +54,6 @@ Authors
 flags: light-uninstall
 url {
   src:
-    "https://lama.univ-savoie.fr/~raffalli/gles3/gles3-20160307.alpha.tar.gz"
+    "https://opam.ocaml.org/cache/md5/86/86b0d72e42fd3e7eed18f3ced34de66a"
   checksum: "md5=86b0d72e42fd3e7eed18f3ced34de66a"
 }

--- a/packages/gles3/gles3.20160505.alpha/opam
+++ b/packages/gles3/gles3.20160505.alpha/opam
@@ -55,6 +55,6 @@ Authors
 flags: light-uninstall
 url {
   src:
-    "https://lama.univ-savoie.fr/~raffalli/gles3/gles3-20160505.alpha.tar.gz"
+    "https://opam.ocaml.org/cache/md5/f6/f69ee4f6933304ead70b09e5ae5192e9"
   checksum: "md5=f69ee4f6933304ead70b09e5ae5192e9"
 }

--- a/packages/gles3/gles3.20160505.alpha/opam
+++ b/packages/gles3/gles3.20160505.alpha/opam
@@ -14,7 +14,7 @@ build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "gles3"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.08"}
   "ocamlfind" {build}
 ]
 depexts: [

--- a/packages/imagelib/imagelib.20160413/opam
+++ b/packages/imagelib/imagelib.20160413/opam
@@ -9,7 +9,7 @@ build: [make]
 install: [make "install"]
 remove: [make "uninstall"]
 depends: [
-  "ocaml" {>= "3.12.1"}
+  "ocaml" {>= "3.12.1" & < "4.06"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "camlzip"

--- a/packages/imagelib/imagelib.20160413/opam
+++ b/packages/imagelib/imagelib.20160413/opam
@@ -35,6 +35,6 @@ As imagelib only requires camlzip, it is suitable for compilation to
 javascript using js_of_ocaml (only for operations not requireing the
 convert binary)."""
 url {
-  src: "http://patoline.org/archive/imagelib/imagelib_20160413.tar.gz"
+  src: "https://opam.ocaml.org/cache/md5/b2/b24402c12c50c8d891735ae3c03ceae9"
   checksum: "md5=b24402c12c50c8d891735ae3c03ceae9"
 }

--- a/packages/libtorch/libtorch.1.3.0/opam
+++ b/packages/libtorch/libtorch.1.3.0/opam
@@ -30,7 +30,7 @@ extra-source "libtorch-linux.zip" {
 }
 extra-source "libtorch-macos.zip" {
   src: "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.3.0.zip"
-  checksum: "md5=f79f4797e77b11da6a77c1b7a88214a4"
+  checksum: "md5=180651185e3e10c1d386dfeeb099e25f"
 }
 extra-source "mklml-macos.tgz" {
   src: "https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_mac_2019.0.1.20181227.tgz"

--- a/packages/minimal/minimal.1.0.0/opam
+++ b/packages/minimal/minimal.1.0.0/opam
@@ -20,6 +20,6 @@ depends: [
 synopsis: "Minima.l, a minimal Lisp"
 description: "Minimalist Lisp interpreter."
 url {
-  src: "https://bitbucket.org/thanatonauts/minima.l/get/v1.0.0.tar.gz"
+  src: "https://opam.ocaml.org/cache/md5/eb/eb390419022c23fbf3d0818478b53028"
   checksum: "md5=eb390419022c23fbf3d0818478b53028"
 }

--- a/packages/morbig/morbig.0.9.1/opam
+++ b/packages/morbig/morbig.0.9.1/opam
@@ -22,6 +22,7 @@ bug-reports: "https://github.com/colis-anr/morbig/issues"
 dev-repo: "git://github.com/colis-anr/morbig.git"
 
 available: [os != "macos"]
+x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "menhir"
   "ocaml"                {build & >= "4.03"}

--- a/packages/obandit/obandit.0.1.38/opam
+++ b/packages/obandit/obandit.0.1.38/opam
@@ -26,6 +26,6 @@ EXP3, UCB1 and Epsilon-greedy algorithms.
 
 Obandit is distributed under the ISC license."""
 url {
-  src: "http://freux.fr/obandit/releases/obandit-0.1.38.tbz"
+  src: "https://opam.ocaml.org/cache/md5/76/76cd434c6106f5fec5714c6dc80d2cb0"
   checksum: "md5=76cd434c6106f5fec5714c6dc80d2cb0"
 }

--- a/packages/obandit/obandit.0.1.41/opam
+++ b/packages/obandit/obandit.0.1.41/opam
@@ -26,6 +26,6 @@ EXP3, UCB1 and Epsilon-greedy algorithms.
 
 Obandit is distributed under the ISC license."""
 url {
-  src: "http://freux.fr/obandit/releases/obandit-0.1.41.tbz"
+  src: "https://opam.ocaml.org/cache/md5/89/89fd9ab631c27702392c0bda1e97e418"
   checksum: "md5=89fd9ab631c27702392c0bda1e97e418"
 }

--- a/packages/obandit/obandit.0.1.42/opam
+++ b/packages/obandit/obandit.0.1.42/opam
@@ -26,6 +26,6 @@ EXP3, UCB1 and Epsilon-greedy algorithms.
 
 Obandit is distributed under the ISC license."""
 url {
-  src: "http://freux.fr/obandit/releases/obandit-0.1.42.tbz"
+  src: "https://opam.ocaml.org/cache/md5/42/4231d2caa746931050a49f9b93c74b07"
   checksum: "md5=4231d2caa746931050a49f9b93c74b07"
 }

--- a/packages/obandit/obandit.0.2.1/opam
+++ b/packages/obandit/obandit.0.2.1/opam
@@ -26,6 +26,6 @@ EXP3, UCB1 and Epsilon-greedy algorithms.
 
 Obandit is distributed under the ISC license."""
 url {
-  src: "http://freux.fr/obandit/releases/obandit-0.2.1.tbz"
+  src: "https://opam.ocaml.org/cache/md5/0b/0b987104754720a203abd5dd86a0b63d"
   checksum: "md5=0b987104754720a203abd5dd86a0b63d"
 }

--- a/packages/obandit/obandit.0.2.1/opam
+++ b/packages/obandit/obandit.0.2.1/opam
@@ -26,6 +26,7 @@ EXP3, UCB1 and Epsilon-greedy algorithms.
 
 Obandit is distributed under the ISC license."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/0b/0b987104754720a203abd5dd86a0b63d"
+  src: "http://freux.fr/obandit/releases/obandit-0.2.1.tbz"
   checksum: "md5=0b987104754720a203abd5dd86a0b63d"
 }
+available: false

--- a/packages/obandit/obandit.0.2/opam
+++ b/packages/obandit/obandit.0.2/opam
@@ -26,6 +26,6 @@ EXP3, UCB1 and Epsilon-greedy algorithms.
 
 Obandit is distributed under the ISC license."""
 url {
-  src: "http://freux.fr/obandit/releases/obandit-0.2.tbz"
+  src: "https://opam.ocaml.org/cache/md5/ab/ab6d991193a637c188cc421effcd1889"
   checksum: "md5=ab6d991193a637c188cc421effcd1889"
 }

--- a/packages/ocamlfind-lint/ocamlfind-lint.0.1.0/opam
+++ b/packages/ocamlfind-lint/ocamlfind-lint.0.1.0/opam
@@ -27,6 +27,6 @@ extra-files: [
   "ocamlfind-lint.install" "md5=b0a7863158805e2f08baa791fa4e61ef"
 ]
 url {
-  src: "http://github.com/zoggy/findlib-lint/archive/v0.1.0.tar.gz"
+  src: "https://opam.ocaml.org/cache/md5/74/74b3f70eac0cabcd51b317fc73dbfc69"
   checksum: "md5=74b3f70eac0cabcd51b317fc73dbfc69"
 }

--- a/packages/orsetto/orsetto.1.0.2/opam
+++ b/packages/orsetto/orsetto.1.0.2/opam
@@ -23,7 +23,7 @@ install: [
 ]
 url {
     src: "https://bitbucket.org/jhw/orsetto-hg/get/r1.0.2.tar.gz"
-    checksum: "md5=658a468c734f2825773e810177cd9020"
+    checksum: "md5=8b8142e51b134e27900f6e07e41597a4"
 }
 extra-source "ucd.all.grouped.zip" {
     src: "http://www.unicode.org/Public/12.0.0/ucdxml/ucd.all.grouped.zip"

--- a/packages/r2pipe/r2pipe.0.0.1/opam
+++ b/packages/r2pipe/r2pipe.0.0.1/opam
@@ -18,6 +18,6 @@ messages: ["DEPRECATED. r2pipe is outdated, you should consider using radare2 in
 post-messages: ["DEPRECATED. r2pipe is outdated, you should consider using radare2 instead"]
 synopsis: "Deprecated: use radare2 instead"
 url {
-  src: "https://github.com/binoopang/r2pipe-ocaml/archive/v0.0.2.zip"
+  src: "https://opam.ocaml.org/cache/md5/3c/3c9ccfdf81a10d3e865b50bf5e9cf97a"
   checksum: "md5=3c9ccfdf81a10d3e865b50bf5e9cf97a"
 }

--- a/packages/statverif/statverif.1.97pl1/opam
+++ b/packages/statverif/statverif.1.97pl1/opam
@@ -20,6 +20,6 @@ synopsis:
   "StatVerif: automated verifier for cryptographic protocols with state, based on ProVerif."
 flags: light-uninstall
 url {
-  src: "https://github.com/rittere/statverif/archive/1.97pl1.tar.gz"
+  src: "https://opam.ocaml.org/cache/md5/6e/6e4ab2c56c4af4cb001c8e6353ad00d5"
   checksum: "md5=6e4ab2c56c4af4cb001c8e6353ad00d5"
 }

--- a/packages/statverif/statverif.1.97pl1/opam
+++ b/packages/statverif/statverif.1.97pl1/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "prefix=%{prefix}%" "install"]
 remove: [["ocamlfind" "remove" "statverif"] ["rm" "-f" "%{bin}%/statverif"] ["rm" "-f" "%{bin}%/statveriftotex"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/torch/torch.0.1/opam
+++ b/packages/torch/torch.0.1/opam
@@ -25,6 +25,7 @@ depends: [
   "stdio" {< "v0.14"}
 ]
 available: [ os = "linux" ]
+x-ci-accept-failures: ["debian-unstable"]
 
 synopsis: "PyTorch bindings for OCaml"
 description: """

--- a/packages/torch/torch.0.2/opam
+++ b/packages/torch/torch.0.2/opam
@@ -28,6 +28,7 @@ depends: [
 ]
 
 available: [ os = "linux" ]
+x-ci-accept-failures: ["debian-unstable"]
 
 synopsis: "PyTorch bindings for OCaml"
 description: """

--- a/packages/torch/torch.0.3/opam
+++ b/packages/torch/torch.0.3/opam
@@ -27,6 +27,7 @@ depends: [
 ]
 
 available: os = "linux" | os = "macos"
+x-ci-accept-failures: ["debian-unstable"]
 
 synopsis: "PyTorch bindings for OCaml"
 description: """


### PR DESCRIPTION
cc @craff. The patoline website is dead, your page on the lama website too
cc @mebsout. The previous releases of cubicle have been deleted on the official website.
cc @LaurentMazare. Mh, I wasn't aware libtorch was a binary package.. This is rather opposite to opam's spirit, is there any way of compile from source instead?
cc @freuk. The archive on your website for obandit have been deleted.
cc @zoggy. findlib-lint has been deleted.
cc @rittere. The archive/git-tag for 1.97pl1 has been significantly altered.