### PR TITLE
[new release] csexp (1.2.0)

### DIFF
--- a/packages/csexp/csexp.1.2.0/opam
+++ b/packages/csexp/csexp.1.2.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Parsing and printing of S-expressions in Canonical form"
+description: """
+
+This library provides minimal support for Canonical S-expressions
+[1]. Canonical S-expressions are a binary encoding of S-expressions
+that is super simple and well suited for communication between
+programs.
+
+This library only provides a few helpers for simple applications. If
+you need more advanced support, such as parsing from more fancy input
+sources, you should consider copying the code of this library given
+how simple parsing S-expressions in canonical form is.
+
+To avoid a dependency on a particular S-expression library, the only
+module of this library is parameterised by the type of S-expressions.
+
+[1] https://en.wikipedia.org/wiki/Canonical_S-expressions
+"""
+maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
+authors: [
+  "Quentin Hocquet <mefyl@gruntech.org>"
+  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jeremie Dimino <jeremie@dimino.org>"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-dune/csexp"
+doc: "https://ocaml-dune.github.io/csexp/"
+bug-reports: "https://github.com/ocaml-dune/csexp/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "ocaml" {>= "4.02.3"}
+  "ppx_expect" {with-test}
+  "result" {>= "1.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-dune/csexp.git"
+url {
+  src:
+    "https://github.com/ocaml-dune/csexp/releases/download/1.2.0/csexp-1.2.0.tbz"
+  checksum: [
+    "sha256=04afa50ca96ce07b395e58b7b7f574fa4f6f21c98f3c19fc386305a29b167c28"
+    "sha512=5bf09f4bea1503c5893fb1728a3a7db55d90c1f1871623579738946523e9f3e0d6080d214f519d88a8df549424e21468fe6550f302c2a9e3f3a2e1a7cd641c15"
+  ]
+}


### PR DESCRIPTION
Parsing and printing of S-expressions in Canonical form

- Project page: <a href="https://github.com/ocaml-dune/csexp">https://github.com/ocaml-dune/csexp</a>
- Documentation: <a href="https://ocaml-dune.github.io/csexp/">https://ocaml-dune.github.io/csexp/</a>

##### CHANGES:

- Expose low level, monad agnostic parser. (ocaml-dune/csexp#2, @mefyl)
