### PR TITLE
Package graphql_ppx.0.7.1

### DIFF
--- a/packages/graphql_ppx/graphql_ppx.0.7.1/opam
+++ b/packages/graphql_ppx/graphql_ppx.0.7.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "alcotest" {with-test}
   "cppo"
-  "dune"
+  "dune" {>= "1.6"}
   "ocaml" {>= "4.06.0"}
   "ocaml-migrate-parsetree" {>= "1.6.0"}
   "ppx_tools_versioned" {>= "5.2.3"}

--- a/packages/graphql_ppx/graphql_ppx.0.7.1/opam
+++ b/packages/graphql_ppx/graphql_ppx.0.7.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "GraphQL PPX rewriter for Bucklescript/ReasonML"
+maintainer: "Tomasz Cichocinski <tomaszcichocinski@gmail.com>"
+authors: "Tomasz Cichocinski <tomaszcichocinski@gmail.com>"
+homepage: "https://github.com/reasonml-community/graphql_ppx"
+bug-reports: "https://github.com/reasonml-community/graphql_ppx/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "alcotest" {with-test}
+  "cppo"
+  "dune"
+  "ocaml" {>= "4.06.0"}
+  "ocaml-migrate-parsetree" {>= "1.6.0"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "reason"
+  "result"
+  "yojson"
+]
+dev-repo: "git+https://github.com/reasonml-community/graphql_ppx.git"
+url {
+  src:
+    "https://github.com/reasonml-community/graphql_ppx/archive/v0.7.1.tar.gz"
+  checksum: [
+    "md5=313f81e579f7bbe4c72d9b6208ce124e"
+    "sha512=06fc18b4de770bca7e4f07d63d2526d7f9ab70247c7ab9c6aa940c1d6070b9bab056b63ce1e4cc49a4ac3cbc139220ae5bfac4e11818e48fcb581b0ea165af76"
+  ]
+} 


### PR DESCRIPTION
### `graphql_ppx.0.7.1`
GraphQL PPX rewriter for Bucklescript/ReasonML

Package `graphql_ppx` is now maintained at [https://github.com/reasonml-community/graphql_ppx](https://github.com/reasonml-community/graphql_ppx).
Its latest stable release is 0.7.1.

Relevant issue: [https://github.com/reasonml-community/graphql_ppx/issues/130](https://github.com/reasonml-community/graphql_ppx/issues/130).


---
* Homepage: https://github.com/reasonml-community/graphql_ppx
* Bug tracker: https://github.com/reasonml-community/graphql_ppx/issues

---
:camel: Pull-request generated by opam-publish v2.0.2