### PR TITLE
async_unix.v0.13.1

### DIFF
--- a/packages/async_unix/async_unix.v0.10.0/opam
+++ b/packages/async_unix/async_unix.v0.10.0/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.11.0"}
   "async_kernel" {>= "v0.10" & < "v0.11"}
   "core" {>= "v0.10" & < "v0.11"}
   "ppx_driver" {>= "v0.10" & < "v0.11"}

--- a/packages/async_unix/async_unix.v0.11.0/opam
+++ b/packages/async_unix/async_unix.v0.11.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 conflicts: [ "jbuilder" { = "1.0+beta19" } ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.11.0"}
   "async_kernel" {>= "v0.11" & < "v0.12"}
   "core" {>= "v0.11" & < "v0.12"}
   "ppx_jane" {>= "v0.11" & < "v0.12"}

--- a/packages/async_unix/async_unix.v0.13.0/opam
+++ b/packages/async_unix/async_unix.v0.13.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"        {>= "4.08.0"}
+  "ocaml"        {>= "4.08.0" & < "4.11.0"}
   "async_kernel" {>= "v0.13" & < "v0.14"}
   "core"         {>= "v0.13" & < "v0.14"}
   "core_kernel"  {>= "v0.13" & < "v0.14"}

--- a/packages/async_unix/async_unix.v0.13.1/opam
+++ b/packages/async_unix/async_unix.v0.13.1/opam
@@ -10,11 +10,11 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"        {>= "4.07.0" & < "4.11.0"}
-  "async_kernel" {>= "v0.12" & < "v0.13"}
-  "core"         {>= "v0.12" & < "v0.13"}
-  "core_kernel"  {>= "v0.12" & < "v0.13"}
-  "ppx_jane"     {>= "v0.12" & < "v0.13"}
+  "ocaml"        {>= "4.08.0"}
+  "async_kernel" {>= "v0.13" & < "v0.14"}
+  "core"         {>= "v0.13" & < "v0.14"}
+  "core_kernel"  {>= "v0.13" & < "v0.14"}
+  "ppx_jane"     {>= "v0.13" & < "v0.14"}
   "dune"         {>= "1.5.1"}
 ]
 synopsis: "Monadic concurrency library"
@@ -25,6 +25,6 @@ OCaml's standard library that was developed by Jane Street, the
 largest industrial user of OCaml.
 "
 url {
-  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/async_unix-v0.12.0.tar.gz"
-  checksum: "md5=17ad333416b283baf808ff5cc6eaaacd"
+  src: "https://github.com/janestreet/async_unix/archive/v0.13.1.tar.gz"
+  checksum: "md5=0393b0971fa8003bb190223e486dc70e"
 }

--- a/packages/async_unix/async_unix.v0.9.1/opam
+++ b/packages/async_unix/async_unix.v0.9.1/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.11.0"}
   "async_kernel" {>= "v0.9" & < "v0.10"}
   "core" {>= "v0.9.2" & < "v0.10"}
   "jbuilder" {>= "1.0+beta2"}


### PR DESCRIPTION
This pull request makes `async_unix` compatible with OCaml 4.11,
and marks previous versions as not compatible.