### PR TITLE
[new release] ppx_factory (0.1.1)

### DIFF
--- a/packages/ppx_factory/ppx_factory.0.1.1/opam
+++ b/packages/ppx_factory/ppx_factory.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: [
+    "Cryptosense <opensource@cryptosense.com>"
+    "Nathan Rebours <nathan.p.rebours@gmail.com>"
+]
+homepage: "https://github.com/cryptosense/ppx_factory"
+bug-reports: "https://github.com/cryptosense/ppx_factory/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/ppx_factory.git"
+doc: "https://cryptosense.github.io/ppx_factory/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune"
+  "ocaml" {>= "4.07.0" & < "4.11.0"}
+  "ounit" {with-test & >= "2.0.0"}
+  "ppxlib" {>= "0.9.0"}
+  "ppx_deriving" {with-test}
+]
+tags: ["org:cryptosense"]
+synopsis: "PPX to derive factories and default values"
+description: """
+ppx_factory is a ppx deriver that builds factory method from record and variant type
+definitions.
+
+Factory methods allow you to build test values by only supplying the parts that are relevant
+to your tests.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/ppx_factory/releases/download/0.1.1/ppx_factory-0.1.1.tbz"
+  checksum: [
+    "sha256=55a012fbb45cf1694d74781d9257756cc91b5270920877e6b4a5a6b07000e836"
+    "sha512=96909ae01e4ba7a6c766bf35fe94138e4529d8a85974e3efe625c6666c56b1528f28e2d53ba1d663a0908889543b1df9106eaa9a7b813ac43ed5a90f3b64e1ca"
+  ]
+}

--- a/packages/ppx_factory/ppx_factory.0.1.1/opam
+++ b/packages/ppx_factory/ppx_factory.0.1.1/opam
@@ -16,8 +16,8 @@ run-test: [
   [ "dune" "runtest" "-p" name "-j" jobs ]
 ]
 depends: [
-  "dune"
-  "ocaml" {>= "4.07.0" & < "4.11.0"}
+  "dune" {>= "1.1"}
+  "ocaml" {>= "4.07.0"}
   "ounit" {with-test & >= "2.0.0"}
   "ppxlib" {>= "0.9.0"}
   "ppx_deriving" {with-test}


### PR DESCRIPTION
PPX to derive factories and default values

- Project page: <a href="https://github.com/cryptosense/ppx_factory">https://github.com/cryptosense/ppx_factory</a>
- Documentation: <a href="https://cryptosense.github.io/ppx_factory/doc">https://cryptosense.github.io/ppx_factory/doc</a>

##### CHANGES:

All notable changes to this project will be documented in this file.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## Unreleased

_No unreleased changes at the moment_

## 0.1.1 - 2020-05-29

### Added

- Add support for OCaml 4.09 and 4.10

## 0.1.0 - 2019-08-07

### Fixes

- Raise an error when used with an abstract type, except when invoked from `ocamldep`, @NathanReb
  [cryptosense/ppx_factory#20](https://github.com/cryptosense/ppx_factory/pull/20)

## 0.0.0 - 2019-03-07

### Added

- Initial release
