### PR TITLE
[soupault] Pin lambdasoup dependency to 0.7.0 due to backwards-incompatile changes in 0.7.1

### DIFF
--- a/packages/soupault/soupault.1.10.0/opam
+++ b/packages/soupault/soupault.1.10.0/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/dmbaturin/soupault/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.0.0"}
-  "lambdasoup" {>= "0.7.0"}
+  "lambdasoup" {= "0.7.0"}
   "markup" {>= "0.8.2"}
   "toml"
   "fileutils"

--- a/packages/soupault/soupault.1.11.0/opam
+++ b/packages/soupault/soupault.1.11.0/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/dmbaturin/soupault/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.0.0"}
-  "lambdasoup" {>= "0.7.0"}
+  "lambdasoup" {= "0.7.0"}
   "markup" {>= "0.8.2"}
   "toml"
   "fileutils"

--- a/packages/soupault/soupault.1.12.0/opam
+++ b/packages/soupault/soupault.1.12.0/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/dmbaturin/soupault/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.0.0"}
-  "lambdasoup" {>= "0.7.0"}
+  "lambdasoup" {= "0.7.0"}
   "markup" {>= "0.8.2"}
   "toml"
   "fileutils"

--- a/packages/soupault/soupault.1.9.0/opam
+++ b/packages/soupault/soupault.1.9.0/opam
@@ -26,7 +26,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.0.0"}
-  "lambdasoup" {>= "0.7.0"}
+  "lambdasoup" {= "0.7.0"}
   "markup" {>= "0.8.2"}
   "toml"
   "fileutils"


### PR DESCRIPTION
lambdasoup, unfortunately, made a stealthy backwards-incompatible behaviour change (it now automatically adds an HTML5 doctype, while older versions never produced a doctype so code that used the formatting function had to compensate for it—now that will produce a duplicate doctype).

I will work with @aantron to work out something.

This issue also affects minima-theme.