### PR TITLE
[new release] plotkicadsch and kicadsch (0.6.1)

### DIFF
--- a/packages/kicadsch/kicadsch.0.6.1/opam
+++ b/packages/kicadsch/kicadsch.0.6.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+authors: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+doc: "https://jnavila.github.io/plotkicadsch/index"
+synopsis: "Library to read and convert Kicad Sch files"
+description: """
+Library able to read Kicad libraries and sch file and
+drive a painter to paint the schematics.
+"""
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "ocaml" {>="4.07"}
+]
+url {
+  src:
+    "https://github.com/jnavila/plotkicadsch/releases/download/v0.6.1/plotkicadsch-v0.6.1.tbz"
+  checksum: [
+    "sha256=1efcfc94ac666717c8a4cb1a4eadb2b9f0ef60692620426e98aedfcd027a09ed"
+    "sha512=5194e64985d64544d894cc99e470510aae9eb03c1260e6fbf0a37a9dcc1911bda92c8f939132c4ff14e37481dcf6668ae7bdd75d4efda58f8f7d7fc4a6292580"
+  ]
+}

--- a/packages/plotkicadsch/plotkicadsch.0.6.1/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.6.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+authors: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+doc: "https://jnavila.github.io/plotkicadsch/index"
+synopsis: "Utilities to print and compare version of Kicad schematics"
+description: """
+Two utilities:
+ * plotkicadsch is able to plot schematic sheets to SVG files
+ * plotgitsch is able to compare git revisions of schematics
+"""
+license: "ISC"
+dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="4.09"}
+  "dune" {>= "1.0"}
+  "kicadsch" {= version}
+  "tyxml" {>= "4.0.0"}
+  "lwt"
+  "lwt_ppx" {build}
+  "sha"
+  "git" {>= "2.0.0"}
+  "git-unix"
+  "base64" {>= "3.0.0"}
+  "patience_diff" { = "v0.13.0" }
+  "core_kernel"
+  "cmdliner"
+]
+url {
+  src:
+    "https://github.com/jnavila/plotkicadsch/releases/download/v0.6.1/plotkicadsch-v0.6.1.tbz"
+  checksum: [
+    "sha256=1efcfc94ac666717c8a4cb1a4eadb2b9f0ef60692620426e98aedfcd027a09ed"
+    "sha512=5194e64985d64544d894cc99e470510aae9eb03c1260e6fbf0a37a9dcc1911bda92c8f939132c4ff14e37481dcf6668ae7bdd75d4efda58f8f7d7fc4a6292580"
+  ]
+}


### PR DESCRIPTION
Utilities to print and compare version of Kicad schematics

- Project page: <a href="https://jnavila.github.io/plotkicadsch/">https://jnavila.github.io/plotkicadsch/</a>
- Documentation: <a href="https://jnavila.github.io/plotkicadsch/index">https://jnavila.github.io/plotkicadsch/index</a>

##### CHANGES:

- Switch to ocaml 4.09.0 and JaneStreet libs 0.13.x
