### PR TITLE
[new release] dns, dns-stub, dns-certify, dns-mirage, dns-resolver, dns-client, dns-server, dns-tsig and dns-cli (4.6.0)

### DIFF
--- a/packages/dns-certify/dns-certify.4.6.0/opam
+++ b/packages/dns-certify/dns-certify.4.6.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "0.10.0"}
+  "lwt" {>= "4.2.1"}
+  "tls" {>= "0.11.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "logs"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.6.0/dns-v4.6.0.tbz"
+  checksum: [
+    "sha256=9b7a09eb469ddc144c33d7f4441c42af488ec97b4f94bb80d197c890d8e57abe"
+    "sha512=7f56279478de6fcca09b5a680fc13b2879fcec4657029ce6020748ca43ca74e1498da531e11558427e3f52f152cddf2cf47968ce6317e6d67dc65aa979055d05"
+  ]
+}

--- a/packages/dns-cli/dns-cli.4.6.0/opam
+++ b/packages/dns-cli/dns-cli.4.6.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-client" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "rresult" {>= "0.6.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "0.10.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng" {>= "0.7.0"}
+  "hex" {>= "1.4.0"}
+  "ptime" {>= "0.8.5"}
+  "mtime" {>= "1.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.6.0/dns-v4.6.0.tbz"
+  checksum: [
+    "sha256=9b7a09eb469ddc144c33d7f4441c42af488ec97b4f94bb80d197c890d8e57abe"
+    "sha512=7f56279478de6fcca09b5a680fc13b2879fcec4657029ce6020748ca43ca74e1498da531e11558427e3f52f152cddf2cf47968ce6317e6d67dc65aa979055d05"
+  ]
+}

--- a/packages/dns-client/dns-client.4.6.0/opam
+++ b/packages/dns-client/dns-client.4.6.0/opam
@@ -30,6 +30,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng"
+  "alcotest" {with-test}
 ]
 synopsis: "Pure DNS resolver API"
 description: """

--- a/packages/dns-client/dns-client.4.6.0/opam
+++ b/packages/dns-client/dns-client.4.6.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt" {>= "0.8.8"}
+  "logs" {>= "0.6.3"}
+  "dns" {= version}
+  "rresult" {>= "0.6.0"}
+  "randomconv" {>= "0.1.2"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng"
+]
+synopsis: "Pure DNS resolver API"
+description: """
+A pure resolver implementation using uDNS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.6.0/dns-v4.6.0.tbz"
+  checksum: [
+    "sha256=9b7a09eb469ddc144c33d7f4441c42af488ec97b4f94bb80d197c890d8e57abe"
+    "sha512=7f56279478de6fcca09b5a680fc13b2879fcec4657029ce6020748ca43ca74e1498da531e11558427e3f52f152cddf2cf47968ce6317e6d67dc65aa979055d05"
+  ]
+}

--- a/packages/dns-mirage/dns-mirage.4.6.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.6.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack" {>= "2.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  In a similar vein, wildcard records are _not_ supported, and it is
+unlikely they'll ever be in this library.  Truncated hmac in `TSIG` are not
+supported (always the full length of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.6.0/dns-v4.6.0.tbz"
+  checksum: [
+    "sha256=9b7a09eb469ddc144c33d7f4441c42af488ec97b4f94bb80d197c890d8e57abe"
+    "sha512=7f56279478de6fcca09b5a680fc13b2879fcec4657029ce6020748ca43ca74e1498da531e11558427e3f52f152cddf2cf47968ce6317e6d67dc65aa979055d05"
+  ]
+}

--- a/packages/dns-resolver/dns-resolver.4.6.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.6.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.6.0/dns-v4.6.0.tbz"
+  checksum: [
+    "sha256=9b7a09eb469ddc144c33d7f4441c42af488ec97b4f94bb80d197c890d8e57abe"
+    "sha512=7f56279478de6fcca09b5a680fc13b2879fcec4657029ce6020748ca43ca74e1498da531e11558427e3f52f152cddf2cf47968ce6317e6d67dc65aa979055d05"
+  ]
+}

--- a/packages/dns-server/dns-server.4.6.0/opam
+++ b/packages/dns-server/dns-server.4.6.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-crypto-rng" {with-test}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.6.0/dns-v4.6.0.tbz"
+  checksum: [
+    "sha256=9b7a09eb469ddc144c33d7f4441c42af488ec97b4f94bb80d197c890d8e57abe"
+    "sha512=7f56279478de6fcca09b5a680fc13b2879fcec4657029ce6020748ca43ca74e1498da531e11558427e3f52f152cddf2cf47968ce6317e6d67dc65aa979055d05"
+  ]
+}

--- a/packages/dns-stub/dns-stub.4.6.0/opam
+++ b/packages/dns-stub/dns-stub.4.6.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-client" {= version}
+  "dns-mirage" {= version}
+  "dns-resolver" {= version}
+  "dns-tsig" {= version}
+  "dns-server" {= version}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS stub resolver"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.6.0/dns-v4.6.0.tbz"
+  checksum: [
+    "sha256=9b7a09eb469ddc144c33d7f4441c42af488ec97b4f94bb80d197c890d8e57abe"
+    "sha512=7f56279478de6fcca09b5a680fc13b2879fcec4657029ce6020748ca43ca74e1498da531e11558427e3f52f152cddf2cf47968ce6317e6d67dc65aa979055d05"
+  ]
+}

--- a/packages/dns-tsig/dns-tsig.4.6.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.6.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "mirage-crypto"
+  "base64" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.6.0/dns-v4.6.0.tbz"
+  checksum: [
+    "sha256=9b7a09eb469ddc144c33d7f4441c42af488ec97b4f94bb80d197c890d8e57abe"
+    "sha512=7f56279478de6fcca09b5a680fc13b2879fcec4657029ce6020748ca43ca74e1498da531e11558427e3f52f152cddf2cf47968ce6317e6d67dc65aa979055d05"
+  ]
+}

--- a/packages/dns/dns.4.6.0/opam
+++ b/packages/dns/dns.4.6.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "rresult" "astring" "fmt" "logs" "ptime"
+  "domain-name" {>= "0.3.0"}
+  "gmap" {>= "0.3.0"}
+  "cstruct" {>= "3.2.0"}
+  "ipaddr" {>= "3.0.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "metrics"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  In a similar vein, wildcard records are _not_ supported, and it is
+unlikely they'll ever be in this library.  Truncated hmac in `TSIG` are not
+supported (always the full length of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v4.6.0/dns-v4.6.0.tbz"
+  checksum: [
+    "sha256=9b7a09eb469ddc144c33d7f4441c42af488ec97b4f94bb80d197c890d8e57abe"
+    "sha512=7f56279478de6fcca09b5a680fc13b2879fcec4657029ce6020748ca43ca74e1498da531e11558427e3f52f152cddf2cf47968ce6317e6d67dc65aa979055d05"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* dns: bugfix for name compression when encoding names at offset > (2 ^ 14) - 1
  (mirage/ocaml-dns#225 @hannesm)
* dns: allow unknown DNSKEY algorithm, TLSA certificate usage, selector,
  matching type, SSHFP algorithm and typ. This makes the DNS library
  future-proof for when new values are assigned (mirage/ocaml-dns#228 @hannesm)
* dns: enforce a max_rdata_length for all resource records. This ensures that
  when a resource record is loaded into the server, it can be extracted via a
  DNS query and transferred via IXFR/AXFR
  (mirage/ocaml-dns#230 @hannesm, reported in mirage/ocaml-dns#229 via mirage/ocaml-dns#225)
* AXFR: encode and decode support for AXFR transfers spanning multiple messages
  (mirage/ocaml-dns#225 @hannesm)
* client: do not initialize the Mirage_crypto_rng in the library, initialize
  the RNG in applications (mirage/ocaml-dns#227 @hannesm)
* certify: provide cert_matches_csr function and use it (cleans up partial
  ad-hoc matches which did not verify that all hostnames of the CSR are present
  in the certificate) (mirage/ocaml-dns#226 @hannesm, reported in mirage/ocaml-dns#224)