### PR TITLE
[new release] coq-serapi (8.10.0+0.7.1)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.10.0+0.7.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.10.0+0.7.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.07.0"            }
+  "coq"                 {           >= "8.10.0" & < "8.11" }
+  "cmdliner"            {           >= "1.0.0"             }
+  "ocamlfind"           {           >= "1.8.0"             }
+  "sexplib"             {           >= "v0.11.0"           }
+  "dune"                {           >= "1.4.0"             }
+  "ppx_import"          { build   & >= "1.5-3"             }
+  "ppx_deriving"        {           >= "4.2.1"             }
+  "ppx_sexp_conv"       {           >= "v0.11.0"           }
+  "yojson"              {           >= "1.7.0"             }
+  "ppx_deriving_yojson" {           >= "3.4"               }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.10.0%2B0.7.1/coq-serapi-8.10.0.0.7.1.tbz"
+  checksum: [
+    "sha256=207b091d8d9d9e1a649759f0acfd15cbfda54a2627a01fc74aa74ec0ffaa3400"
+    "sha512=af85d00c5896e78a6edea7794070795ca14c8e47a0e9a28f2ac003364b0f99eb72f19f57e755a3967d255b1aaf62cae0d09bbab02d2d35ef6ee02b84823a0929"
+  ]
+}


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

* [sertop ] Add `sername` program for batch serialization elaborated terms
             Note that this utility will be deprecated in future versions,
             to be subsumed by `Query`.
             (ejgallego/coq-serapi#207, @palmskog, with help from @ejgallego)
 * [serlib ] Expose `QueryUtil.info_of_id` and `gen_pp_obj` in `serapi_protocol.mli` to enable
             using them in `sername` to retrieve serialized body-type pairs (@palmskog)
 * [general] Improved compat with Jane Street v0.13 toolchain
 * [serlib ] Only use `ssreflect` from Coq in tests (@ejgallego)
