### PR TITLE
Package secp256k1.0.4.1

### DIFF
--- a/packages/secp256k1/secp256k1.0.4.1/opam
+++ b/packages/secp256k1/secp256k1.0.4.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Elliptic curve library secp256k1 wrapper for Ocaml"
+description: """
+This library wrap the secp256k1 EC(DSA) library into an OCaml library. At the moment only a subset of functionalities are available:
+- Context: create, clone, destroy, randomize
+- Elliptic curve: public key creation
+- ECDSA: verify, sign, recover
+
+All exchanged data (pubkey, signature, seckey) are represented as hex strings."""
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: [
+  "Davide Gessa <gessadavide@gmail.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Yoichi Hirai <i@yoichihirai.com>"
+  "Anton Trunov"
+]
+license: "MIT"
+homepage: "https://github.com/dakk/secp256k1-ml"
+bug-reports: "https://github.com/dakk/secp256k1-ml/issues"
+depends: [
+  "ocaml"
+  "dune" {build & >= "1.0"}
+  "base" {build & >= "v0.9.2"}
+  "stdio" {build & >= "v0.9.0"}
+  "dune-configurator" {build & >= "1.0"}
+  "hex" {with-test & >= "1.1.1"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "odoc" {with-test & >= "1.3.0"}
+  "base-bigarray"
+  "conf-secp256k1"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dakk/secp256k1-ml"
+url {
+  src: "https://github.com/dakk/secp256k1-ml/archive/0.4.1.zip"
+  checksum: [
+    "md5=64e2484cfb53a2802070eb454358f97a"
+    "sha512=fed5b52773954e4b65d7dd7e05ca0a990efcad22c602e1c79550eb206413c00f4649760c9e5b0e59ef678c8a2f404feccd28216a77acc4fa88fc1e6e99460494"
+  ]
+}

--- a/packages/secp256k1/secp256k1.0.4.1/opam
+++ b/packages/secp256k1/secp256k1.0.4.1/opam
@@ -19,7 +19,7 @@ homepage: "https://github.com/dakk/secp256k1-ml"
 bug-reports: "https://github.com/dakk/secp256k1-ml/issues"
 depends: [
   "ocaml"
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "base" {build & >= "v0.9.2"}
   "stdio" {build & >= "v0.9.0"}
   "dune-configurator" {build & >= "1.0"}


### PR DESCRIPTION
### `secp256k1.0.4.1`
Elliptic curve library secp256k1 wrapper for Ocaml
This library wrap the secp256k1 EC(DSA) library into an OCaml library. At the moment only a subset of functionalities are available:
- Context: create, clone, destroy, randomize
- Elliptic curve: public key creation
- ECDSA: verify, sign, recover

All exchanged data (pubkey, signature, seckey) are represented as hex strings.



---
* Homepage: https://github.com/dakk/secp256k1-ml
* Source repo: git+https://github.com/dakk/secp256k1-ml
* Bug tracker: https://github.com/dakk/secp256k1-ml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2