### PR TITLE
Second alpha for OCaml 4.11.0

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+afl/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Second alpha for 4.11.0, with afl-fuzz instrumentation"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--with-afl"
+    "--disable-debug-runtime"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+alpha2.tar.gz"
+  checksum: "sha256=bec26791c60870ddf8ceecf0acb9111867de227b4110f8702854e6fb167cfd0e"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+flambda/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Second alpha for 4.11.0, with flambda activated"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+alpha2.tar.gz"
+  checksum: "sha256=bec26791c60870ddf8ceecf0acb9111867de227b4110f8702854e6fb167cfd0e"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp+flambda/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Second alpha for 4.11.0, with frame-pointers and flambda activated"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+alpha2.tar.gz"
+  checksum: "sha256=bec26791c60870ddf8ceecf0acb9111867de227b4110f8702854e6fb167cfd0e"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Second alpha for 4.11.0, with frame pointers"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+alpha2.tar.gz"
+  checksum: "sha256=bec26791c60870ddf8ceecf0acb9111867de227b4110f8702854e6fb167cfd0e"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Second alpha for 4.11.0"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+alpha2.tar.gz"
+  checksum: "sha256=bec26791c60870ddf8ceecf0acb9111867de227b4110f8702854e6fb167cfd0e"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]


### PR DESCRIPTION
This is the new opam package for the second alpha of OCaml 4.11.0
The change compared to the first alpha are:
* [*additional fixes*] [6673](https://github.com/ocaml/ocaml/issues/6673), [1132](https://github.com/ocaml/ocaml/issues/1132), [9617](https://github.com/ocaml/ocaml/issues/9617): Relax the handling of explicit polymorphic types
   (Leo White, review by Jacques Garrigue and Gabriel Scherer)

* [*additional fixes*] [7364](https://github.com/ocaml/ocaml/issues/7364), [2188](https://github.com/ocaml/ocaml/issues/2188), [9592](https://github.com/ocaml/ocaml/issues/9592), [9609](https://github.com/ocaml/ocaml/issues/9609): improvement of the unboxability check for types
   with a single constructor. Mutually-recursive type declarations can
   now contain unboxed types. This is based on the paper
     https://arxiv.org/abs/1811.02300

- [9549](https://github.com/ocaml/ocaml/issues/9549), [9557](https://github.com/ocaml/ocaml/issues/9557): Make -flarge-toc the default for PowerPC and introduce
  -fsmall-toc to enable the previous behaviour.
  (David Allsopp, report by Nathaniel Wesley Filardo, review by Xavier Leroy)

- [9320](https://github.com/ocaml/ocaml/issues/9320), [9550](https://github.com/ocaml/ocaml/issues/9550): under Windows, make sure that the Unix.exec* functions
  properly quote their argument lists.
  (Xavier Leroy, report by André Maroneze, review by Nicolás Ojeda Bär
   and David Allsopp)

- [9490](https://github.com/ocaml/ocaml/issues/9490), [9505](https://github.com/ocaml/ocaml/issues/9505): ensure proper rounding of file times returned by
  Unix.stat, Unix.lstat, Unix.fstat.
  (Xavier Leroy and Guillaume Melquiond, report by David Brown,
   review by Gabriel Scherer and David Allsopp)

- [8676](https://github.com/ocaml/ocaml/issues/8676), [9594](https://github.com/ocaml/ocaml/issues/9594): turn debugger off in programs launched by the program
  being debugged
  (Xavier Leroy, report by Michael Soegtrop, review by Gabriel Scherer)

- [9552](https://github.com/ocaml/ocaml/issues/9552): restore ocamloptp build and installation
  (Florian Angeletti, review by David Allsopp and Xavier Leroy)

- [7708](https://github.com/ocaml/ocaml/issues/7708), [9580](https://github.com/ocaml/ocaml/issues/9580): Ensure Stdlib documentation index refers to Stdlib.
  (Stephen Dolan, review by Florian Angeletti, report by Hannes Mehnert)

- [7817](https://github.com/ocaml/ocaml/issues/7817), [9546](https://github.com/ocaml/ocaml/issues/9546): Unsound inclusion check for polymorphic variant
  (Jacques Garrigue, report by Mikhail Mandrykin, review by Gabriel Scherer)

- [9189](https://github.com/ocaml/ocaml/issues/9189), [9281](https://github.com/ocaml/ocaml/issues/9281): fix a conflict with Gentoo build system
  by removing an one-letter Makefile variable.
  (Florian Angeletti, report by Ralph Seichter, review by David Allsopp
   and Damien Doligez)
