### PR TITLE
Package linksem.0.7

### DIFF
--- a/packages/linksem/linksem.0.7/opam
+++ b/packages/linksem/linksem.0.7/opam
@@ -7,7 +7,6 @@ license: "BSD-2"
 dev-repo: "git+https://github.com/rems-project/linksem.git"
 build: [make]
 install: [make "install"]
-remove: [make "uninstall"]
 depends: [
   "ocaml" {>= "4.06.1"}
   "ocamlfind" {build}

--- a/packages/linksem/linksem.0.7/opam
+++ b/packages/linksem/linksem.0.7/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Linksem Devs <cl-linksem-dev@lists.cam.ac.uk>"
+authors: ["Stephen Kell" "Dominic Mulligan" "Peter Sewell"]
+homepage: "https://github.com/rems-project/linksem"
+bug-reports: "https://github.com/rems-project/linksem/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/rems-project/linksem.git"
+build: [make]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "lem" {>= "2018-05-11"}
+]
+synopsis:
+  "A formalisation of the core ELF file format written in Lem"
+description: """
+A formalisation of the core ELF file format written in Lem.
+ELF is the de facto standard executable and linkable file format
+on Linux and related systems.
+This formalisation has been tested against approximately 5,000 ELF binaries
+found \"in the wild\" on various different platforms.
+"""
+url {
+  src: "https://github.com/rems-project/linksem/archive/0.7.tar.gz"
+  checksum: [
+    "md5=277cd1864b4f65683b58918f92ef25cd"
+    "sha512=780b1acb62ea658658ccd6b3f6fd16acb15fa54c48e76a52eb9578159bf187a8723db8c63111b58b7afb769920eb8db1130b75eabb5058bf770e6a6b839bcd9c"
+  ]
+}


### PR DESCRIPTION
### `linksem.0.7`
A formalisation of the core ELF file format written in Lem
A formalisation of the core ELF file format written in Lem.
ELF is the de facto standard executable and linkable file format
on Linux and related systems.
This formalisation has been tested against approximately 5,000 ELF binaries
found "in the wild" on various different platforms.



---
* Homepage: https://github.com/rems-project/linksem
* Source repo: git+https://github.com/rems-project/linksem.git
* Bug tracker: https://github.com/rems-project/linksem/issues

---
:camel: Pull-request generated by opam-publish v2.0.2