### PR TITLE
ocaml-variants.4.11* and 4.12*: avoid passing CC and ASPP for FreeBSD

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+afl/opam
@@ -17,7 +17,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
@@ -25,7 +25,7 @@ build: [
     "--disable-debug-runtime"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+flambda/opam
@@ -17,14 +17,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "--enable-flambda"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp+flambda/opam
@@ -21,7 +21,7 @@ build: [
     "--prefix=%{prefix}%"
     "--enable-frame-pointers"
     "--enable-flambda"
-  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  ] {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
@@ -29,7 +29,7 @@ build: [
     "--enable-flambda"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp/opam
@@ -20,14 +20,14 @@ build: [
     "./configure"
     "--prefix=%{prefix}%"
     "--enable-frame-pointers"
-  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  ] {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "--enable-frame-pointers"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1/opam
@@ -17,13 +17,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+afl/opam
@@ -17,7 +17,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
@@ -25,7 +25,7 @@ build: [
     "--disable-debug-runtime"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+flambda/opam
@@ -17,14 +17,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "--enable-flambda"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp+flambda/opam
@@ -21,7 +21,7 @@ build: [
     "--prefix=%{prefix}%"
     "--enable-frame-pointers"
     "--enable-flambda"
-  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  ] {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
@@ -29,7 +29,7 @@ build: [
     "--enable-flambda"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp/opam
@@ -20,14 +20,14 @@ build: [
     "./configure"
     "--prefix=%{prefix}%"
     "--enable-frame-pointers"
-  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  ] {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "--enable-frame-pointers"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2/opam
@@ -17,13 +17,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+trunk+afl/opam
@@ -13,14 +13,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" ]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--with-afl"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+trunk+flambda/opam
@@ -13,14 +13,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "--enable-flambda"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+trunk/opam
@@ -13,13 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+trunk+afl/opam
@@ -13,14 +13,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" ]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--with-afl"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+trunk+flambda/opam
@@ -13,14 +13,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "--enable-flambda"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+trunk/opam
@@ -13,13 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]


### PR DESCRIPTION
as mentioned in https://github.com/ocaml/opam-repository/pull/16568#commitcomment-39656969, this is no longer needed (see https://github.com/ocaml/ocaml/pull/9437).

tested locally, and it works (in Makefile.config, `cc -c -Wno-trigraphs` is used as assembler). //cc @Octachron

as mentioned earlier, I suspect this can be done for macos and openbsd as well, but I fail to have such a system for testing at hands (thus this PR only targets FreeBSD).