### PR TITLE
0install-solver: require dune 2.5 to fix installation

### DIFF
--- a/packages/0install-solver/0install-solver.2.17/opam
+++ b/packages/0install-solver/0install-solver.2.17/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.1"}
+  "dune" {>= "2.5"}
   "ounit2" {with-test}
 ]
 description: """


### PR DESCRIPTION
https://github.com/ocaml/dune/issues/3252 causes 0install-solver to fail to install, with:

    # File "src/tests/dune", line 3, characters 10-23:
    # 3 |   (deps %{bin:0install})
    #               ^^^^^^^^^^^^^
    # Error: Program 0install not found in the tree or in PATH