### PR TITLE
bap-primus-systems: fix incorrect name in opam file

### DIFF
--- a/packages/bap-primus-systems/bap-primus-systems.2.1.0/opam
+++ b/packages/bap-primus-systems/bap-primus-systems.2.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "bap-primus-dictionary"
+name: "bap-primus-systems"
 version: "2.1.0"
 maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"


### PR DESCRIPTION
it needs to match the name of the directory around it.
cc @ivg