### PR TITLE
Package sedlex.2.2

### DIFF
--- a/packages/sedlex/sedlex.2.2/opam
+++ b/packages/sedlex/sedlex.2.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "An OCaml lexer generator for Unicode"
+description: "
+sedlex is a lexer generator for OCaml. It is similar to ocamllex, but supports
+Unicode. Unlike ocamllex, sedlex allows lexer specifications within regular
+OCaml source files. Lexing specific constructs are provided via a ppx syntax
+extension.
+"
+license: "MIT"
+doc: "https://ocaml-community.github.io/sedlex/index.html"
+maintainer: "Alain Frisch <alain.frisch@lexifi.com>"
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "https://github.com/ocaml-community/sedlex/graphs/contributors"
+]
+homepage: "https://github.com/ocaml-community/sedlex"
+dev-repo: "git+https://github.com/ocaml-community/sedlex.git"
+bug-reports: "https://github.com/ocaml-community/sedlex/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.8"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "ocaml-migrate-parsetree"
+  "gen"
+  "uchar"
+]
+conflicts: [
+  "wcs-lib" {= "2017-05-26.03" | = "2017-05-26.04"}
+]
+url {
+  src: "https://github.com/ocaml-community/sedlex/archive/v2.2.tar.gz"
+  checksum: [
+    "md5=5bb2b819ac42959b8d7583abd2a2e610"
+    "sha512=c38940654d8d2a4b8f627bc9109b0fd983c520d8db05bf4b514ddc05cf50946c086d3558dfced64cc8f2b4eaabc6155426eb44ee6d903e3520ebb65daadf990a"
+  ]
+}


### PR DESCRIPTION
### `sedlex.2.2`
An OCaml lexer generator for Unicode
sedlex is a lexer generator for OCaml. It is similar to ocamllex, but supports
Unicode. Unlike ocamllex, sedlex allows lexer specifications within regular
OCaml source files. Lexing specific constructs are provided via a ppx syntax
extension.



---
* Homepage: https://github.com/ocaml-community/sedlex
* Source repo: git+https://github.com/ocaml-community/sedlex.git
* Bug tracker: https://github.com/ocaml-community/sedlex/issues

---
:camel: Pull-request generated by opam-publish v2.0.2