### PR TITLE
[new release] qcow and qcow-tool (0.11.0)

### DIFF
--- a/packages/qcow-tool/qcow-tool.0.11.0/opam
+++ b/packages/qcow-tool/qcow-tool.0.11.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-qcow"
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+tags: [
+  "org:mirage"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "qcow" {= version}
+  "cmdliner"
+  "cstruct"
+  "result"
+  "unix-type-representations"
+  "mirage-types-lwt" {>= "2.6.0" & < "3.7.0"}
+  "lwt"
+  "mirage-block" {>= "2.0.0"}
+  "mirage-block-unix" {>= "2.9.0"}
+  "mirage-time"
+  "sha" {>= "1.10"}
+  "sexplib" {< "v0.14"}
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "astring"
+  "io-page"
+  "ounit" {with-test}
+  "mirage-block-ramdisk" {with-test}
+  "ezjsonm" {with-test}
+]
+synopsis: "A command-line tool for manipulating qcow2-formatted data"
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.11.0/qcow-0.11.0.tbz"
+  checksum: [
+    "sha256=563a2cc10c79055b6d57111592bc6f1445397cf5ef57e74f70f5e1ca6ec23807"
+    "sha512=4ab055332f964dff2c00d04a3f867b7fc86a9a6084f6d58bce59c04a6ed6f23aefe8965eb1c9c1ff4372393235b8920135409fd2f94a253493d8533a39d7d6bd"
+  ]
+}

--- a/packages/qcow/qcow.0.11.0/opam
+++ b/packages/qcow/qcow.0.11.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-qcow"
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+doc: "https://mirage.github.io/ocaml-qcow"
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "base-bytes"
+  "cstruct" {>= "3.4.0"}
+  "result"
+  "io-page-unix" {>= "2.0.0"}
+  "mirage-types-lwt" {>= "2.6.0" & < "3.7.0"}
+  "lwt" {>= "4.0.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-block-unix" {>= "2.5.0"}
+  "mirage-block-combinators"
+  "mirage-time"
+  "cmdliner"
+  "sexplib" {< "v0.14"}
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "astring"
+  "prometheus"
+  "unix-type-representations"
+  "stdlib-shims"
+  "sha"
+  "ppx_tools"
+  "ppx_deriving"
+  "ppx_sexp_conv" {< "v0.14"}
+  "ppxlib" {build}
+  "ounit" {with-test}
+  "mirage-block-ramdisk" {with-test}
+  "ezjsonm" {with-test}
+]
+synopsis: "Support for Qcow2 images"
+description: """
+[![Build Status](https://travis-ci.org/mirage/ocaml-qcow.png?branch=master)](https://travis-ci.org/mirage/ocaml-qcow) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-qcow/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-qcow?branch=master)
+
+Please read [the API documentation](https://mirage.github.io/ocaml-qcow/).
+
+Features
+--------
+
+- supports `resize`
+- exposes sparseness information
+- produces files which can be understood by qemu (although not in
+  reverse since we don't support many features)
+
+Example
+-------
+
+In a top-level like utop:
+```ocaml"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.11.0/qcow-0.11.0.tbz"
+  checksum: [
+    "sha256=563a2cc10c79055b6d57111592bc6f1445397cf5ef57e74f70f5e1ca6ec23807"
+    "sha512=4ab055332f964dff2c00d04a3f867b7fc86a9a6084f6d58bce59c04a6ed6f23aefe8965eb1c9c1ff4372393235b8920135409fd2f94a253493d8533a39d7d6bd"
+  ]
+}


### PR DESCRIPTION
Support for Qcow2 images

- Project page: <a href="https://github.com/mirage/ocaml-qcow">https://github.com/mirage/ocaml-qcow</a>
- Documentation: <a href="https://mirage.github.io/ocaml-qcow">https://mirage.github.io/ocaml-qcow</a>

##### CHANGES:

- Update the build to use `dune` (@emillon, mirage/ocaml-qcow#112)
- Update to Mirage 4.0 interfaces (@djs55, mirage/ocaml-qcow#112)
- LICENSE.md: add title and copyright year range (@waldyrious, mirage/ocaml-qcow#109)
