### PR TITLE
[new release] mirage-block-ramdisk (0.5)

### DIFF
--- a/packages/mirage-block-ramdisk/mirage-block-ramdisk.0.5/opam
+++ b/packages/mirage-block-ramdisk/mirage-block-ramdisk.0.5/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: "David Scott"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block-ramdisk"
+doc: "https://mirage.github.io/mirage-block-ramdisk/"
+bug-reports: "https://github.com/mirage/mirage-block-ramdisk/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "alcotest" {with-test}
+  "cstruct"
+  "io-page"
+  "io-page-unix" {with-test}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-block-combinators" {with-test}
+  "lwt"
+]
+build: [
+ [ "dune" "subst" ] {pinned}
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-block-ramdisk.git"
+synopsis: "In-memory BLOCK device for MirageOS"
+description: """
+- Can be dynamically resized
+- Supports querying sparseness information
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-ramdisk/releases/download/0.5/mirage-block-ramdisk-0.5.tbz"
+  checksum: [
+    "sha256=cc0e814fd54efe7a5b7a8c5eb1c04e2dece751b7d8dee2d95908a0768896e8af"
+    "sha512=2557896713c0d7a833d30b9847e2c545929df40cd04c534fed7a8d0ea25c2cd1075b8ae5ba56e47bdeac5a60a07a222a1780b32cc12ebcb2ce94fdffdcf0657c"
+  ]
+}


### PR DESCRIPTION
In-memory BLOCK device for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-block-ramdisk">https://github.com/mirage/mirage-block-ramdisk</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-ramdisk/">https://mirage.github.io/mirage-block-ramdisk/</a>

##### CHANGES:

- update to mirage-block.2.0.0 API (@hannesm)
