### PR TITLE
Package monolith.20200606

### DIFF
--- a/packages/monolith/monolith.20200606/opam
+++ b/packages/monolith/monolith.20200606/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/monolith"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/monolith.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "2.0" }
+  "afl-persistent" { >= "1.3" }
+  "pprint" { >= "20200410" }
+]
+synopsis: "A framework for testing a library using afl-fuzz"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/monolith/repository/20200606/archive.tar.gz"
+  checksum: [
+    "md5=535af33a6624d4e2546153c84167dd77"
+    "sha512=ab10598605f15aca95d47358a1704a91f00bc53cc2302a07d67557478c53e6aaf701727d91b479b06435bda878c48134a63e995c2a9d1e0eb748828223a75908"
+  ]
+}


### PR DESCRIPTION
### `monolith.20200606`
A framework for testing a library using afl-fuzz



---
* Homepage: https://gitlab.inria.fr/fpottier/monolith
* Source repo: git+https://gitlab.inria.fr/fpottier/monolith.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.2