### PR TITLE
9 packages from savonet/ocaml-posix at 2.0.0

### DIFF
--- a/packages/posix-base/posix-base.2.0.0/opam
+++ b/packages/posix-base/posix-base.2.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Base module for the posix bindings"
+description: "posix-base provides base tools for the posix binding modules."
+maintainer: ["romain.beauxis@gmail.com"]
+authors: ["Romain Beauxis"]
+license: "MIT"
+homepage: "https://github.com/savonet/ocaml-posix"
+bug-reports: "https://github.com/savonet/ocaml-posix/issues"
+depends: [
+  "dune" {> "2.5"}
+  "integers"
+  "ctypes"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
+url {
+  src: "https://github.com/savonet/ocaml-posix/archive/v2.0.0.tar.gz"
+  checksum: [
+    "md5=2c186aa5161b72208a870d5710fb6208"
+    "sha512=d583c3d386865eab7575fc4f1976c17294bad2ee5037327cb5c3075965788170e652b7b9b9f660ef25f71558553fbcc47734b971e3c9f41627cc573d75d2fb54"
+  ]
+}

--- a/packages/posix-bindings/posix-bindings.2.0.0/opam
+++ b/packages/posix-bindings/posix-bindings.2.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "POSIX bindings"
+description: "install all available posix bindings"
+maintainer: ["romain.beauxis@gmail.com"]
+authors: ["Romain Beauxis"]
+license: "MIT"
+homepage: "https://github.com/savonet/ocaml-posix"
+bug-reports: "https://github.com/savonet/ocaml-posix/issues"
+depends: [
+  "dune" {> "2.5"}
+  "ctypes"
+  "posix-base" {= version}
+  "posix-types" {= version}
+  "posix-socket" {= version}
+  "posix-socket-unix" {= version}
+  "posix-uname" {= version}
+  "posix-getopt" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
+url {
+  src: "https://github.com/savonet/ocaml-posix/archive/v2.0.0.tar.gz"
+  checksum: [
+    "md5=2c186aa5161b72208a870d5710fb6208"
+    "sha512=d583c3d386865eab7575fc4f1976c17294bad2ee5037327cb5c3075965788170e652b7b9b9f660ef25f71558553fbcc47734b971e3c9f41627cc573d75d2fb54"
+  ]
+}

--- a/packages/posix-getopt/posix-getopt.2.0.0/opam
+++ b/packages/posix-getopt/posix-getopt.2.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Bindings for posix getopt/getopt_long"
+description:
+  "posix-getopt provides a simple interface for the POSIX getopt and its extensions, getopt_long and getopt_long_only."
+maintainer: ["romain.beauxis@gmail.com"]
+authors: ["Romain Beauxis"]
+license: "MIT"
+homepage: "https://github.com/savonet/ocaml-posix"
+bug-reports: "https://github.com/savonet/ocaml-posix/issues"
+depends: [
+  "dune" {> "2.5"}
+  "dune-configurator"
+  "ounit2" {with-test}
+  "posix-uname" {with-test & = version}
+  "ctypes"
+  "posix-base" {= version}
+  "unix-errno"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
+available: os != "win32" & os != "bsd"
+url {
+  src: "https://github.com/savonet/ocaml-posix/archive/v2.0.0.tar.gz"
+  checksum: [
+    "md5=2c186aa5161b72208a870d5710fb6208"
+    "sha512=d583c3d386865eab7575fc4f1976c17294bad2ee5037327cb5c3075965788170e652b7b9b9f660ef25f71558553fbcc47734b971e3c9f41627cc573d75d2fb54"
+  ]
+}

--- a/packages/posix-signal/posix-signal.2.0.0/opam
+++ b/packages/posix-signal/posix-signal.2.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Bindings for the types defined in <signal.h>"
+description:
+  "posix-signal provides an API to the types and bindings defined in <signal.h>"
+maintainer: ["romain.beauxis@gmail.com"]
+authors: ["Romain Beauxis"]
+license: "MIT"
+homepage: "https://github.com/savonet/ocaml-posix"
+bug-reports: "https://github.com/savonet/ocaml-posix/issues"
+depends: [
+  "dune" {> "2.5"}
+  "posix-base" {= version}
+  "ctypes"
+  "unix-errno"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
+available: os != "win32"
+url {
+  src: "https://github.com/savonet/ocaml-posix/archive/v2.0.0.tar.gz"
+  checksum: [
+    "md5=2c186aa5161b72208a870d5710fb6208"
+    "sha512=d583c3d386865eab7575fc4f1976c17294bad2ee5037327cb5c3075965788170e652b7b9b9f660ef25f71558553fbcc47734b971e3c9f41627cc573d75d2fb54"
+  ]
+}

--- a/packages/posix-socket-unix/posix-socket-unix.2.0.0/opam
+++ b/packages/posix-socket-unix/posix-socket-unix.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Bindings for posix sockets"
+description:
+  "posix-socket-unix provides unix-specific types and bindings for posix sockets."
+maintainer: ["romain.beauxis@gmail.com"]
+authors: ["Romain Beauxis"]
+license: "MIT"
+homepage: "https://github.com/savonet/ocaml-posix"
+bug-reports: "https://github.com/savonet/ocaml-posix/issues"
+depends: [
+  "dune" {> "2.5"}
+  "ctypes"
+  "posix-base" {= version}
+  "posix-socket" {= version}
+  "unix-errno"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
+available: os != "win32"
+url {
+  src: "https://github.com/savonet/ocaml-posix/archive/v2.0.0.tar.gz"
+  checksum: [
+    "md5=2c186aa5161b72208a870d5710fb6208"
+    "sha512=d583c3d386865eab7575fc4f1976c17294bad2ee5037327cb5c3075965788170e652b7b9b9f660ef25f71558553fbcc47734b971e3c9f41627cc573d75d2fb54"
+  ]
+}

--- a/packages/posix-socket/posix-socket.2.0.0/opam
+++ b/packages/posix-socket/posix-socket.2.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Bindings for posix sockets"
+description:
+  "posix-socket provides the types and bindings of posix sockets APIs available on both unix and windows."
+maintainer: ["romain.beauxis@gmail.com"]
+authors: ["Romain Beauxis"]
+license: "MIT"
+homepage: "https://github.com/savonet/ocaml-posix"
+bug-reports: "https://github.com/savonet/ocaml-posix/issues"
+depends: [
+  "dune" {> "2.5"}
+  "posix-base" {= version}
+  "ctypes"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
+url {
+  src: "https://github.com/savonet/ocaml-posix/archive/v2.0.0.tar.gz"
+  checksum: [
+    "md5=2c186aa5161b72208a870d5710fb6208"
+    "sha512=d583c3d386865eab7575fc4f1976c17294bad2ee5037327cb5c3075965788170e652b7b9b9f660ef25f71558553fbcc47734b971e3c9f41627cc573d75d2fb54"
+  ]
+}

--- a/packages/posix-time2/posix-time2.2.0.0/opam
+++ b/packages/posix-time2/posix-time2.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Bindings for posix time functions"
+description:
+  "posix-time2 provides the types and bindings for posix time APIs."
+maintainer: ["romain.beauxis@gmail.com"]
+authors: ["Romain Beauxis"]
+license: "MIT"
+homepage: "https://github.com/savonet/ocaml-posix"
+bug-reports: "https://github.com/savonet/ocaml-posix/issues"
+depends: [
+  "dune" {> "2.5"}
+  "ctypes"
+  "posix-base" {= version}
+  "posix-types" {= version}
+  "unix-errno"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
+available: os != "win32"
+url {
+  src: "https://github.com/savonet/ocaml-posix/archive/v2.0.0.tar.gz"
+  checksum: [
+    "md5=2c186aa5161b72208a870d5710fb6208"
+    "sha512=d583c3d386865eab7575fc4f1976c17294bad2ee5037327cb5c3075965788170e652b7b9b9f660ef25f71558553fbcc47734b971e3c9f41627cc573d75d2fb54"
+  ]
+}

--- a/packages/posix-types/posix-types.2.0.0/opam
+++ b/packages/posix-types/posix-types.2.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Bindings for the types defined in <sys/types.h>"
+description:
+  "posix-types provides an API to the types defined in <sys/types.h>"
+maintainer: ["romain.beauxis@gmail.com"]
+authors: ["Romain Beauxis"]
+license: "MIT"
+homepage: "https://github.com/savonet/ocaml-posix"
+bug-reports: "https://github.com/savonet/ocaml-posix/issues"
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune" {> "2.5"}
+  "posix-base" {= version}
+  "ctypes"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
+available: os != "win32"
+url {
+  src: "https://github.com/savonet/ocaml-posix/archive/v2.0.0.tar.gz"
+  checksum: [
+    "md5=2c186aa5161b72208a870d5710fb6208"
+    "sha512=d583c3d386865eab7575fc4f1976c17294bad2ee5037327cb5c3075965788170e652b7b9b9f660ef25f71558553fbcc47734b971e3c9f41627cc573d75d2fb54"
+  ]
+}

--- a/packages/posix-uname/posix-uname.2.0.0/opam
+++ b/packages/posix-uname/posix-uname.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Bindings for posix uname"
+description: "posix-uname provides a simple interface for POSIX uname."
+maintainer: ["romain.beauxis@gmail.com"]
+authors: ["Romain Beauxis"]
+license: "MIT"
+homepage: "https://github.com/savonet/ocaml-posix"
+bug-reports: "https://github.com/savonet/ocaml-posix/issues"
+depends: [
+  "dune" {> "2.5"}
+  "ctypes"
+  "posix-base" {= version}
+  "unix-errno"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
+available: os != "win32"
+url {
+  src: "https://github.com/savonet/ocaml-posix/archive/v2.0.0.tar.gz"
+  checksum: [
+    "md5=2c186aa5161b72208a870d5710fb6208"
+    "sha512=d583c3d386865eab7575fc4f1976c17294bad2ee5037327cb5c3075965788170e652b7b9b9f660ef25f71558553fbcc47734b971e3c9f41627cc573d75d2fb54"
+  ]
+}


### PR DESCRIPTION
This pull-request introduces external posix bindings based on `ocaml-ctypes`. The plan is to remove/deprecate `ocaml-ctypes`'s internal `PosixTypes` in favor of this module's `posix-types`. See: https://github.com/ocamllabs/ocaml-ctypes/issues/624 and https://github.com/ocamllabs/ocaml-ctypes/pull/648

The bindings for these modules are light-weight and follow the pattern detailed here: https://medium.com/@romain.beauxis/advanced-c-binding-using-ocaml-ctypes-and-dune-cc3f4cbab302

In particular, they allow proper export of both low-level ctypes API (struct, etc) and high-level bindings suitable for general consumption.

This pull-request contains the following packages:
-`posix-base.2.0.0`: Base module for the posix bindings
-`posix-bindings.2.0.0`: POSIX bindings
-`posix-getopt.2.0.0`: Bindings for posix getopt/getopt_long
-`posix-signal.2.0.0`: Bindings for the types defined in <signal.h>
-`posix-socket.2.0.0`: Bindings for posix sockets
-`posix-socket-unix.2.0.0`: Bindings for posix sockets
-`posix-time2.2.0.0`: Bindings for posix time functions
-`posix-types.2.0.0`: Bindings for the types defined in <sys/types.h>
-`posix-uname.2.0.0`: Bindings for posix uname

---
* Homepage: https://github.com/savonet/ocaml-posix
* Source repo: git+https://github.com/savonet/ocaml-posix.git
* Bug tracker: https://github.com/savonet/ocaml-posix/issues

---
:camel: Pull-request generated by opam-publish v2.0.2