### PR TITLE
Release caqti-driver-postgresql.1.2.4.

### DIFF
--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.4/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "caqti-driver-postgresql"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.2.1" & < "1.3.0~"}
+  "dune" {>= "1.11"}
+  "postgresql" {>= "4.6.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.2.4/caqti-v1.2.4.tbz"
+  checksum: [
+    "sha256=049446600359d9456baa179552b9ebd2d0208ebd1c9d8afad29e97178f302aac"
+    "sha512=1ef4ed94d3206d9f7e0eda88ea40a8c44dd320ccbe6dfe59b7a0aa30eaf6c88c591f56527503a12aa1709ecb8ddb0c7e5169fe0b998202f6a9b9347a5050da51"
+  ]
+}


### PR DESCRIPTION
I forgot to merge a patch promised for the 1.2.3 release last weekend, so this is an update to the affected package:

- Switch to TEXT format for PostgreSQL populate implementation.
