### PR TITLE
Fix dune 2.6 revdeps

### DIFF
--- a/packages/checkseum/checkseum.0.0.9/opam
+++ b/packages/checkseum/checkseum.0.0.9/opam
@@ -20,7 +20,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"         {>= "4.03.0"}
-  "dune"          {>= "1.9.2"}
+  "dune"          {>= "1.9.2" & < "2.6"}
   "optint"
   "base-bytes"
   "bigarray-compat"

--- a/packages/checkseum/checkseum.0.1.0/opam
+++ b/packages/checkseum/checkseum.0.1.0/opam
@@ -23,7 +23,7 @@ build: [
 
 depends: [
   "ocaml"         {>= "4.03.0"}
-  "dune"          {>= "1.9.2"}
+  "dune"          {>= "1.9.2" & < "2.6"}
   "optint"
   "base-bytes"
   "base-bigarray"

--- a/packages/checkseum/checkseum.0.1.1-1/opam
+++ b/packages/checkseum/checkseum.0.1.1-1/opam
@@ -26,7 +26,7 @@ extra-files: [
 
 depends: [
   "ocaml"         {>= "4.07.0"}
-  "dune"          {>= "1.9.2"}
+  "dune"          {>= "1.9.2" & < "2.6"}
   "optint"        {>= "0.0.3"}
   "base-bytes"
   "bigarray-compat"

--- a/packages/checkseum/checkseum.0.1.1/opam
+++ b/packages/checkseum/checkseum.0.1.1/opam
@@ -19,7 +19,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"         {>= "4.07.0"}
-  "dune"          {>= "1.9.2"}
+  "dune"          {>= "1.9.2" & < "2.6"}
   "optint"        {>= "0.0.3"}
   "base-bytes"
   "bigarray-compat"

--- a/packages/checkseum/checkseum.0.2.0/opam
+++ b/packages/checkseum/checkseum.0.2.0/opam
@@ -25,7 +25,7 @@ build: [
 
 depends: [
   "ocaml"         {>= "4.07.0"}
-  "dune"          {>= "2.0.0"}
+  "dune"          {>= "2.0.0" & < "2.6"}
   "dune-configurator"
   "optint"        {>= "0.0.4"}
   "base-bytes"

--- a/packages/digestif/digestif.0.7.2/opam
+++ b/packages/digestif/digestif.0.7.2/opam
@@ -35,7 +35,7 @@ build: [
 
 depends: [
   "ocaml"          {>= "4.03.0"}
-  "dune"           {>= "1.9.2"}
+  "dune"           {>= "1.9.2" & < "2.6"}
   "eqaf"
   "base-bytes"
   "base-bigarray"

--- a/packages/digestif/digestif.0.7.3/opam
+++ b/packages/digestif/digestif.0.7.3/opam
@@ -32,7 +32,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"          {>= "4.03.0"}
-  "dune"           {>= "1.9.2"}
+  "dune"           {>= "1.9.2" & < "2.6"}
   "eqaf"
   "base-bytes"
   "base-bigarray"

--- a/packages/digestif/digestif.0.7.4/opam
+++ b/packages/digestif/digestif.0.7.4/opam
@@ -31,7 +31,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"          {>= "4.03.0"}
-  "dune"           {>= "1.9.2"}
+  "dune"           {>= "1.9.2" & < "2.6"}
   "eqaf"
   "base-bytes"
   "bigarray-compat"

--- a/packages/digestif/digestif.0.8.0-1/opam
+++ b/packages/digestif/digestif.0.8.0-1/opam
@@ -36,7 +36,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"          {>= "4.03.0"}
-  "dune"           {>= "1.9.2"}
+  "dune"           {>= "1.9.2" & < "2.6"}
   "eqaf"
   "base-bytes"
   "bigarray-compat"

--- a/packages/digestif/digestif.0.8.0/opam
+++ b/packages/digestif/digestif.0.8.0/opam
@@ -32,7 +32,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"          {>= "4.03.0"}
-  "dune"           {>= "1.9.2"}
+  "dune"           {>= "1.9.2" & < "2.6"}
   "eqaf"
   "base-bytes"
   "bigarray-compat"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs6/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs6/opam
@@ -15,7 +15,7 @@ depends: [
   "base-unix"
   "camlidl"
   "dune"
-  "dune-configurator"
+  "dune-configurator" {< "2.6"}
 ]
 depexts: [
   ["libfuse-dev"] {os-family = "debian"}


### PR DESCRIPTION
@astrada `ocamlfuse` is not compatible with dune-configure >= 2.6 (see https://github.com/ocaml/opam-repository/pull/16585#issuecomment-640925896 for more details about the error)