### PR TITLE
Package monolith.20200609

### DIFF
--- a/packages/monolith/monolith.20200609/opam
+++ b/packages/monolith/monolith.20200609/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/monolith"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/monolith.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "2.0" }
+  "afl-persistent" { >= "1.3" }
+  "pprint" { >= "20200410" }
+]
+synopsis: "A framework for testing a library using afl-fuzz"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/monolith/repository/20200609/archive.tar.gz"
+  checksum: [
+    "md5=23616fea1b28fb5309ced2e52e8b2c19"
+    "sha512=c0f8235ef4e0a6093f21233d154d6018cf87072639f2f7e069da494aea6bc1eb2a282a14090f4fc9fc1924ed7884a71cbd0a8b862c8a991feb6279c05f387c04"
+  ]
+}


### PR DESCRIPTION
### `monolith.20200609`
A framework for testing a library using afl-fuzz



---
* Homepage: https://gitlab.inria.fr/fpottier/monolith
* Source repo: git+https://gitlab.inria.fr/fpottier/monolith.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.2