### PR TITLE
Package yuujinchou.0.9

### DIFF
--- a/packages/yuujinchou/yuujinchou.0.9/opam
+++ b/packages/yuujinchou/yuujinchou.0.9/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Generic name manipulation combinators"
+description: """
+This library implements a generic library for selecting names. It intends to facilitate the implementation of the "import" statement or any feature that allows users to select a group of names by patterns.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: "favonia <favonia@gmail.com>"
+license: "Apache 2.0"
+homepage: "https://github.com/favonia/yuujinchou"
+bug-reports: "https://github.com/favonia/yuujinchou/issues"
+dev-repo: "git+https://github.com/favonia/yuujinchou.git"
+depends: [
+  "dune" {build}
+  "ppx_deriving" {>= "4.5" & < "4.6"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest"]
+]
+url {
+  src: "https://github.com/favonia/yuujinchou/archive/0.9.tar.gz"
+  checksum: [
+    "md5=42af632d57c728994c2820acdb74e3e3"
+    "sha512=bc41ccc7c077549e03418f2b42ada00b44b59e837b473482a9830967fa95010f74d63d1e1bc747bf402ef9c9706dd620813cbb9cf2925b5a808a8d02d7b145e2"
+  ]
+}


### PR DESCRIPTION
### `yuujinchou.0.9`
Generic name manipulation combinators
This library implements a generic library for selecting names. It intends to facilitate the implementation of the "import" statement or any feature that allows users to select a group of names by patterns.



---
* Homepage: https://github.com/favonia/yuujinchou
* Source repo: git+https://github.com/favonia/yuujinchou.git
* Bug tracker: https://github.com/favonia/yuujinchou/issues

---
:camel: Pull-request generated by opam-publish v2.0.2