### PR TITLE
Package yuujinchou.0.9

### DIFF
--- a/packages/yuujinchou/yuujinchou.0.9/opam
+++ b/packages/yuujinchou/yuujinchou.0.9/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Generic name manipulation combinators"
+description: """
+This library implements a generic library for selecting names. It intends to facilitate the implementation of the "import" statement or any feature that allows users to select a group of names by patterns.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: "favonia <favonia@gmail.com>"
+license: "Apache 2.0"
+homepage: "https://github.com/favonia/yuujinchou"
+bug-reports: "https://github.com/favonia/yuujinchou/issues"
+dev-repo: "git+https://github.com/favonia/yuujinchou.git"
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.0.8"}
+  "ppx_deriving" {>= "4.5" & < "4.6"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest"]
+]
+url {
+  src: "https://github.com/favonia/yuujinchou/archive/0.9.tar.gz"
+  checksum: [
+    "md5=c3e0ab6e16aaf7b60178f57b4375f9e9"
+    "sha512=31ce4407c62a42a74864b610b2b5d6eae5168e72d895bd979236be2c5f5e2e0bacdda560e36dba4d78f10649c21c999c5dd78fccce1e6ee30b03faf8fc1584e6"
+  ]
+}


### PR DESCRIPTION
### `yuujinchou.0.9`
Generic name manipulation combinators
This library implements a generic library for selecting names. It intends to facilitate the implementation of the "import" statement or any feature that allows users to select a group of names by patterns.



---
* Homepage: https://github.com/favonia/yuujinchou
* Source repo: git+https://github.com/favonia/yuujinchou.git
* Bug tracker: https://github.com/favonia/yuujinchou/issues

---
:camel: Pull-request generated by opam-publish v2.0.2