### PR TITLE
Package yuujinchou.0.9

### DIFF
--- a/packages/yuujinchou/yuujinchou.0.9/opam
+++ b/packages/yuujinchou/yuujinchou.0.9/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Generic name manipulation combinators"
+description: """
+This library implements a generic library for selecting names. It intends to facilitate the implementation of the "import" statement or any feature that allows users to select a group of names by patterns.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: "favonia <favonia@gmail.com>"
+license: "Apache 2.0"
+homepage: "https://github.com/favonia/yuujinchou"
+bug-reports: "https://github.com/favonia/yuujinchou/issues"
+dev-repo: "git+https://github.com/favonia/yuujinchou.git"
+depends: [
+  "dune"
+  "ocaml" {>= "4.08.0"}
+  "ppx_deriving" {>= "4.5" & < "4.6"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest"] {with-test}
+]
+url {
+  src: "https://github.com/favonia/yuujinchou/archive/0.9.tar.gz"
+  checksum: [
+    "md5=bf224fea578558dc6fb3088efd2a4657"
+    "sha512=7cbafa504a64017ceabe2f40601ab4042b85cf91abc582f71ae298c48c056e4c9b2eebd3062efbf0719e307d27aae9fd6c015f0372d7570072720abfb902e0d4"
+  ]
+}

--- a/packages/yuujinchou/yuujinchou.0.9/opam
+++ b/packages/yuujinchou/yuujinchou.0.9/opam
@@ -10,13 +10,13 @@ homepage: "https://github.com/favonia/yuujinchou"
 bug-reports: "https://github.com/favonia/yuujinchou/issues"
 dev-repo: "git+https://github.com/favonia/yuujinchou.git"
 depends: [
-  "dune"
+  "dune" {>= "2.5"}
   "ocaml" {>= "4.08.0"}
-  "ppx_deriving" {>= "4.5" & < "4.6"}
+  "ppx_deriving" {>= "4.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest"] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 url {
   src: "https://github.com/favonia/yuujinchou/archive/0.9.tar.gz"


### PR DESCRIPTION
### `yuujinchou.0.9`
Generic name manipulation combinators
This library implements a generic library for selecting names. It intends to facilitate the implementation of the "import" statement or any feature that allows users to select a group of names by patterns.



---
* Homepage: https://github.com/favonia/yuujinchou
* Source repo: git+https://github.com/favonia/yuujinchou.git
* Bug tracker: https://github.com/favonia/yuujinchou/issues

---
:camel: Pull-request generated by opam-publish v2.0.2