### PR TITLE
[new release] functoria (3.1.1)

### DIFF
--- a/packages/functoria/functoria.3.0.3/opam
+++ b/packages/functoria/functoria.3.0.3/opam
@@ -33,6 +33,8 @@ depends: [
   "alcotest" {with-test}
   "ptime"
 ]
+available: [false]
+
 synopsis: "A DSL to organize functor applications"
 description: """
 Functoria is a DSL to describe a set of modules and functors, their types and

--- a/packages/functoria/functoria.3.1.0/opam
+++ b/packages/functoria/functoria.3.1.0/opam
@@ -33,6 +33,8 @@ depends: [
   "alcotest" {with-test}
   "ptime"
 ]
+available: [false]
+
 synopsis: "A DSL to organize functor applications"
 description: """
 Functoria is a DSL to describe a set of modules and functors, their types and

--- a/packages/functoria/functoria.3.1.1/opam
+++ b/packages/functoria/functoria.3.1.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   "Gabriel Radanne <drupyog@zoho.com>"
+authors:      [ "Thomas Gazagnaire"
+                "Anil Madhavapeddy"
+                "Dave Scott"
+                "Thomas Leonard"
+                "Gabriel Radanne" ]
+homepage:     "https://github.com/mirage/functoria"
+bug-reports:  "https://github.com/mirage/functoria/issues"
+dev-repo:     "git+https://github.com/mirage/functoria.git"
+doc:          "https://mirage.github.io/functoria/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.1.0"}
+  "base-unix"
+  "cmdliner" {>= "0.9.8"}
+  "rresult"
+  "astring"
+  "fmt"
+  "ocamlgraph"
+  "logs"
+  "bos"
+  "fpath"
+  "alcotest" {with-test}
+  "ptime"
+]
+synopsis: "A DSL to organize functor applications"
+description: """
+Functoria is a DSL to describe a set of modules and functors, their types and
+how to apply them in order to produce a complete application.
+
+The main use case is mirage. See the [mirage](https://github.com/mirage/mirage)
+repository for details.
+"""
+url {
+  src:
+    "https://github.com/mirage/functoria/releases/download/v3.1.1/functoria-v3.1.1.tbz"
+  checksum: [
+    "sha256=f538c1ce7ac0820d2542c2d851bdf0bb8e94d0e7689199dd899a7f13f0ea302e"
+    "sha512=335ccc45f87be4c5f3d1f40bace93e15fdabcc612e1868a31dffa7f80b9742e786387648e644fe56085c2c67cede735cf40acc568e789e8fa13597a0a325d210"
+  ]
+}


### PR DESCRIPTION
A DSL to organize functor applications

- Project page: <a href="https://github.com/mirage/functoria">https://github.com/mirage/functoria</a>
- Documentation: <a href="https://mirage.github.io/functoria/">https://mirage.github.io/functoria/</a>

##### CHANGES:

* Ensure that keys with different defaults are distinguished by functoria.
  `Functoria.Key.equal` has been introduced in mirage/functoria#188 but it was not precise
  enough when two keys were sharing the same name (e.g. `interface`)
  but with different default values (e.g. `tap0` or `service`).
  This was causing non-deterministic bugs where some devices were
  not configured properly (mirage/mirage#1157, fixed by mirage/functoria#194 by @samoht)
