### PR TITLE
obandit: Fixing tarball URLs for old versions.

### DIFF
--- a/packages/obandit/obandit.0.1.38/opam
+++ b/packages/obandit/obandit.0.1.38/opam
@@ -26,6 +26,6 @@ EXP3, UCB1 and Epsilon-greedy algorithms.
 
 Obandit is distributed under the ISC license."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/76/76cd434c6106f5fec5714c6dc80d2cb0"
-  checksum: "md5=76cd434c6106f5fec5714c6dc80d2cb0"
+  src: "https://github.com/freuk/obandit/archive/v0.1.38.tar.gz"
+  checksum: "md5=4196359be2872c1de87eac8b8de46cf8"
 }

--- a/packages/obandit/obandit.0.1.41/opam
+++ b/packages/obandit/obandit.0.1.41/opam
@@ -26,6 +26,6 @@ EXP3, UCB1 and Epsilon-greedy algorithms.
 
 Obandit is distributed under the ISC license."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/89/89fd9ab631c27702392c0bda1e97e418"
-  checksum: "md5=89fd9ab631c27702392c0bda1e97e418"
+  src: "https://github.com/freuk/obandit/archive/v0.1.41.tar.gz"
+  checksum: "md5=637f206e05562062bab45305b346672b"
 }

--- a/packages/obandit/obandit.0.1.42/opam
+++ b/packages/obandit/obandit.0.1.42/opam
@@ -26,6 +26,6 @@ EXP3, UCB1 and Epsilon-greedy algorithms.
 
 Obandit is distributed under the ISC license."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/42/4231d2caa746931050a49f9b93c74b07"
-  checksum: "md5=4231d2caa746931050a49f9b93c74b07"
+  src: "https://github.com/freuk/obandit/archive/v0.1.42.tar.gz"
+  checksum: "md5=aa6b32c5706d6d71c30fdc7e9316405f"
 }

--- a/packages/obandit/obandit.0.2.1/opam
+++ b/packages/obandit/obandit.0.2.1/opam
@@ -26,7 +26,7 @@ EXP3, UCB1 and Epsilon-greedy algorithms.
 
 Obandit is distributed under the ISC license."""
 url {
-  src: "http://freux.fr/obandit/releases/obandit-0.2.1.tbz"
-  checksum: "md5=0b987104754720a203abd5dd86a0b63d"
+  src: "https://github.com/freuk/obandit/archive/v0.2.1.tar.gz"
+  checksum: "md5=755a7e0a25da631ab5d4b486506f9cfa"
 }
 available: false

--- a/packages/obandit/obandit.0.2/opam
+++ b/packages/obandit/obandit.0.2/opam
@@ -26,6 +26,6 @@ EXP3, UCB1 and Epsilon-greedy algorithms.
 
 Obandit is distributed under the ISC license."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/ab/ab6d991193a637c188cc421effcd1889"
-  checksum: "md5=ab6d991193a637c188cc421effcd1889"
+  src: "https://github.com/freuk/obandit/archive/v0.2.2.tar.gz"
+  checksum: "md5=1c0cf1677d232515f1a8f014cc24ea7c"
 }


### PR DESCRIPTION
This commit fixes the release tarball URLs for older
versions of the "obandit" package. Github tarballs are used in
place of self-hosted ones, which should be more reliable.
