### PR TITLE
mdx: add bound on cmdliner

### DIFF
--- a/packages/mdx/mdx.1.5.0/opam
+++ b/packages/mdx/mdx.1.5.0/opam
@@ -21,7 +21,7 @@ depends: [
   "cppo" {build}
   "astring"
   "logs"
-  "cmdliner"
+  "cmdliner" {>= "1.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-migrate-parsetree" {>= "1.0.6"}

--- a/packages/mdx/mdx.1.6.0/opam
+++ b/packages/mdx/mdx.1.6.0/opam
@@ -21,7 +21,7 @@ depends: [
   "cppo" {build}
   "astring"
   "logs"
-  "cmdliner"
+  "cmdliner" {>= "1.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-migrate-parsetree" {>= "1.0.6"}


### PR DESCRIPTION
Versions 1.5.0 and 1.6.0 use `Arg.conv` which has been added in 1.0.0.

See realworldocaml/mdx#268.