### PR TITLE
merlin.3.3.5: Fix dune constraint

### DIFF
--- a/packages/merlin/merlin.3.3.5/opam
+++ b/packages/merlin/merlin.3.3.5/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.11"}
-  "dune" {>= "1.8.0"}
+  "dune" {>= "2.5.0"}
   "ocamlfind" {>= "1.5.2"}
   "yojson" {>= "1.6.0"}
   "mdx" {with-test & >= "1.3.0"}


### PR DESCRIPTION
reported by @jonludlam this unnecessary dune-project file in the tests makes merlin require dune 2.5.0: https://github.com/ocaml/merlin/commit/9bedb9bf3e70961b3ee60296e0110753a82b0d50

cc @voodoos could this file be removed and a new version released? (maybe some people out-there need merlin and dune 1.x)