### PR TITLE
[new release] gettext-stub, gettext-camomile and gettext (0.4.2)

### DIFF
--- a/packages/gettext-camomile/gettext-camomile.0.4.2/opam
+++ b/packages/gettext-camomile/gettext-camomile.0.4.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-gettext"
+dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
+bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
+doc: "https://gildor478.github.io/ocaml-gettext/"
+build: [
+  ["ocaml" "configure.ml"
+    "--with-defaultlocaledir" "%{lib}%/gettext/share/locale"
+    "--version" version]
+  ["dune" "build" "-p" name "-j" jobs
+   "@install"
+   "@doc" {with-doc}
+   "@runtest" {with-test} ]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.11.0"}
+  "camomile"
+  "base-bytes"
+  "gettext" {= version}
+  "ounit" {with-test & > "2.0.8"}
+  "fileutils" {with-test}
+]
+synopsis: "Internationalization library using camomile (i18n)"
+description:"""
+See gettext package description.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-gettext/releases/download/v0.4.2/gettext-v0.4.2.tbz"
+  checksum: [
+    "sha256=8b672c7c521b8ac753c6a90925243cdd367dd5202e7c1e5d1a2507b11ad5d6a7"
+    "sha512=72bad53ce15ccc5113e4cfdc76b56c633926bb3702623964e006a99d21a758e7d47f0b9b67bebffe8b9a0c5f4d018cb7d4ae665568dfab52070ed355d5f9d31b"
+  ]
+}

--- a/packages/gettext-stub/gettext-stub.0.4.2/opam
+++ b/packages/gettext-stub/gettext-stub.0.4.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-gettext"
+dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
+bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
+doc: "https://gildor478.github.io/ocaml-gettext/"
+build: [
+  ["ocaml" "configure.ml"
+    "--with-defaultlocaledir" "%{lib}%/gettext/share/locale"
+    "--version" version]
+  ["dune" "build" "-p" name "-j" jobs
+   "@install"
+   "@doc" {with-doc}
+   "@runtest" {with-test} ]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.11.0"}
+  "dune-configurator"  
+  "base-bytes"
+  "gettext" {= version}
+  "ounit" {with-test & > "2.0.8"}
+  "fileutils" {with-test}
+]
+depexts: [
+  ["gettext"] {os = "macos" & os-distribution = "homebrew"}
+  ["gettext"] {os = "macos" & os-distribution = "macports"}
+  ["gettext"] {os = "win32" & os-distribution = "cygwinports"}
+  ["gettext-dev"] {os-distribution = "alpine"}
+  ["libc6-dev"] {os-family = "debian"}
+]
+synopsis: "Internationalization using C gettext library (i18n)"
+description:"""
+See gettext package description.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-gettext/releases/download/v0.4.2/gettext-v0.4.2.tbz"
+  checksum: [
+    "sha256=8b672c7c521b8ac753c6a90925243cdd367dd5202e7c1e5d1a2507b11ad5d6a7"
+    "sha512=72bad53ce15ccc5113e4cfdc76b56c633926bb3702623964e006a99d21a758e7d47f0b9b67bebffe8b9a0c5f4d018cb7d4ae665568dfab52070ed355d5f9d31b"
+  ]
+}

--- a/packages/gettext/gettext.0.4.2/opam
+++ b/packages/gettext/gettext.0.4.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-gettext"
+dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
+bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
+doc: "https://gildor478.github.io/ocaml-gettext/"
+build: [
+  ["ocaml" "configure.ml"
+    "--with-defaultlocaledir" "%{lib}%/gettext/share/locale"
+    "--version" version]
+  ["dune" "build" "-p" name "-j" jobs
+   "@install"
+   "@doc" {with-doc}
+   "@runtest" {with-test} ]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.11.0"}
+  "cppo" {build}
+  "fileutils"
+  "base-bytes"
+  "ounit" {with-test & > "2.0.8"}
+]
+synopsis: "Internationalization library (i18n)"
+description:"""
+This library enables string translation in OCaml. The API is based on GNU
+gettext. It comes with a tool to extract strings which need to be translated
+from OCaml source files.
+
+This enables OCaml program to output string in the native language of
+the user, if a corresponding translation file of the English strings is
+provided.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-gettext/releases/download/v0.4.2/gettext-v0.4.2.tbz"
+  checksum: [
+    "sha256=8b672c7c521b8ac753c6a90925243cdd367dd5202e7c1e5d1a2507b11ad5d6a7"
+    "sha512=72bad53ce15ccc5113e4cfdc76b56c633926bb3702623964e006a99d21a758e7d47f0b9b67bebffe8b9a0c5f4d018cb7d4ae665568dfab52070ed355d5f9d31b"
+  ]
+}


### PR DESCRIPTION
Internationalization using C gettext library (i18n)

- Project page: <a href="https://github.com/gildor478/ocaml-gettext">https://github.com/gildor478/ocaml-gettext</a>
- Documentation: <a href="https://gildor478.github.io/ocaml-gettext/">https://gildor478.github.io/ocaml-gettext/</a>

##### CHANGES:

### Fixed
- Compatibility with OCaml 4.11. (Thanks to kit-ty-kate, closes: gildor478/ocaml-gettext#8)
