### PR TITLE
coq is compatible with OCaml 4.11 since coq 8.11.1

### DIFF
--- a/packages/coq/coq.8.11.1/opam
+++ b/packages/coq/coq.8.11.1/opam
@@ -18,7 +18,7 @@ and homotopy type theory) and teaching.
 """
 
 depends: [
-  "ocaml" {>= "4.05.0" & < "4.11"}
+  "ocaml" {>= "4.05.0" & < "4.12"}
   "ocamlfind" {build}
   "num"
   "conf-findutils" {build}

--- a/packages/coq/coq.8.11.2/opam
+++ b/packages/coq/coq.8.11.2/opam
@@ -18,7 +18,7 @@ and homotopy type theory) and teaching.
 """
 
 depends: [
-  "ocaml" {>= "4.05.0" & < "4.11"}
+  "ocaml" {>= "4.05.0" & < "4.12"}
   "ocamlfind" {build}
   "num"
   "conf-findutils" {build}


### PR DESCRIPTION
The following PR in coq https://github.com/coq/coq/pull/11131 added OCaml 4.11 to the list of CI tests. It seems to indicate that coq was compatible with OCaml 4.11 since coq.8.11.1.

I'll let our CI tell us if I miss something but I believe it should be correct. If it breaks in the future I'll put the constraints back but as of now they seem to be working perfectly.

cc @ejgallego is that ok?