### PR TITLE
[RFC] Add opam config to set OCAMLPARAM per switch

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.12.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+trunk+flambda/opam
@@ -10,7 +10,10 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
-setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+setenv: [
+  [OCAMLPARAM = "%{ocamlparam}%"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+]
 build: [
   [
     "./configure"


### PR DESCRIPTION
It would be helpful to have an easier way to set up an opam switch where everything is compiled with flambda -O3 than manually setting OCAMLPARAM, etc. While this does not achieve anything that cannot be done with careful setting of OCAMLPARAM, it seems clear that doing so is not broadly known or common practice, and so flambda would have higher impact across the community with a switch such as this.  See https://discuss.ocaml.org/t/ann-bap-2-1-0-release/5906 for discussion and some benchmarks that indicate this is useful.

As a test, I checked the file sizes of e.g. `lib/base/base__Map.cmx` with this compiler variant vs the existing 4.10.0+flambda one, which indicates that -O3 has taken effect and led to larger files.

~~On the other hand, the same does not appear to hold for the stdlib, as the sizes of the `lib/ocaml/stdlib*.cmx` files are exactly the same. This is unexpected, right? Does anyone know how to adjust the build so that the stdlib is built with -O3? I expected the `build-env` clause to be enough.~~ Resolved, see comment below.

Pinging @ivg who might be interested.

For convenience, here is the diff with the existing flambda variant:
```diff
$ diff ocaml-variants.4.10.0+flambda/opam ocaml-variants.4.10.0+flambda+opt
2c2
< synopsis: "Official release 4.10.0, with flambda activated"
---
> synopsis: "Official release 4.10.0, with flambda -O3 activated"
16c16,20
< setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
---
> setenv: [
>  [OCAMLPARAM = "_,O3=1"]
>  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
> ]
> build-env: [OCAMLPARAM = "_,O3=1"]
```