### PR TITLE
Package np.np1.18-0.3.0

### DIFF
--- a/packages/np/np.np1.18-0.3.0/opam
+++ b/packages/np/np.np1.18-0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Fundamental scientific computing with Numpy for OCaml"
+description: """
+These are OCaml bindings to Numpy, the fundamental package for scientific computing with Python:
+- powerful n-dimensional arrays
+- numerical computing tools
+- interoperable
+- performant
+- easy to use
+- open source.
+"""
+maintainer: ["Ronan Le Hy <ronan.lehy@gmail.com>"]
+authors: ["Ronan Le Hy"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/lehy/ocaml-sklearn"
+bug-reports: "https://github.com/lehy/ocaml-sklearn/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.07.1"}
+  "pyml" {>= "20200222"}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lehy/ocaml-sklearn.git"
+url {
+  src: "https://github.com/lehy/ocaml-sklearn/archive/np1.18-0.3.0.tar.gz"
+  checksum: [
+    "md5=5f6d590b91fbb4e0449c30dd42866c56"
+    "sha512=e082d2a22ca671183b5a6fc1ba93e5740d6f1907b250f1d3b87aa417ce35a9c5fcefcd5181f13a8ecfb7ceef7c8f2c731284814846b14762853c28caf28b860b"
+  ]
+}


### PR DESCRIPTION
### `np.np1.18-0.3.0`
Fundamental scientific computing with Numpy for OCaml
These are OCaml bindings to Numpy, the fundamental package for scientific computing with Python:
- powerful n-dimensional arrays
- numerical computing tools
- interoperable
- performant
- easy to use
- open source.



---
* Homepage: https://github.com/lehy/ocaml-sklearn
* Source repo: git+https://github.com/lehy/ocaml-sklearn.git
* Bug tracker: https://github.com/lehy/ocaml-sklearn/issues

---
:camel: Pull-request generated by opam-publish v2.0.2