### PR TITLE
Package sklearn.sk0.22-0.3.0

### DIFF
--- a/packages/sklearn/sklearn.sk0.22-0.3.0/opam
+++ b/packages/sklearn/sklearn.sk0.22-0.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Scikit-learn machine learning library for OCaml"
+description: """
+Scikit-learn machine learning library for OCaml
+These are bindings to Python's scikit-learn machine learning library:
+- Simple and efficient tools for predictive data analysis
+- Accessible to everybody, and reusable in various contexts
+- Built on NumPy, SciPy, and matplotlib
+- Open source, commercially usable - BSD license
+"""
+maintainer: ["Ronan Le Hy <ronan.lehy@gmail.com>"]
+authors: ["Ronan Le Hy"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/lehy/ocaml-sklearn"
+bug-reports: "https://github.com/lehy/ocaml-sklearn/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.07.1"}
+  "pyml" {>= "20200222"}
+  "np" {= "np1.18-0.3.0"}
+  "scipy" {= "sp1.4-0.3.0"}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lehy/ocaml-sklearn.git"
+url {
+  src: "https://github.com/lehy/ocaml-sklearn/archive/sk0.22-0.3.0.tar.gz"
+  checksum: [
+    "md5=6168f765a6303a52ef55b223a4ac751e"
+    "sha512=1b2c82ad3e0212574bc01b5226fab07f66ff98b580529a3c6a6d11bd74a7d78b21353e12bbbb385705fb316243b686879c5a4a2636a7a0addb81511a8b25ae5d"
+  ]
+}


### PR DESCRIPTION
### `sklearn.sk0.22-0.3.0`
Scikit-learn machine learning library for OCaml
Scikit-learn machine learning library for OCaml
These are bindings to Python's scikit-learn machine learning library:
- Simple and efficient tools for predictive data analysis
- Accessible to everybody, and reusable in various contexts
- Built on NumPy, SciPy, and matplotlib
- Open source, commercially usable - BSD license



---
* Homepage: https://github.com/lehy/ocaml-sklearn
* Source repo: git+https://github.com/lehy/ocaml-sklearn.git
* Bug tracker: https://github.com/lehy/ocaml-sklearn/issues

---
:camel: Pull-request generated by opam-publish v2.0.2