### PR TITLE
Add smart-print.0.3.0

### DIFF
--- a/packages/atd2cconv/atd2cconv.0.0.0/opam
+++ b/packages/atd2cconv/atd2cconv.0.0.0/opam
@@ -5,6 +5,7 @@ build: [make "-f" "Makefile-ocamlbuild"]
 remove: [make "-f" "Makefile-ocamlbuild" "uninstall" "BINDIR=%{bin}%"]
 depends: [
   "ocaml" {>= "4.01.0"}
+  "ocamlbuild" {build}
   "ocamlfind"
   "nonstd"
   "smart-print"

--- a/packages/smart-print/smart-print.0.3.0/opam
+++ b/packages/smart-print/smart-print.0.3.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+
+maintainer: "dev@clarus.me"
+authors: ["Guillaume Claret <dev@clarus.me>"]
+homepage: "https://github.com/clarus/smart-print"
+bug-reports: "https://github.com/clarus/smart-print/issues"
+license: "BSD-3-Clause"
+
+depends: [
+  "ocaml" {>= "4.00.0"}
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+]
+build: make
+dev-repo: "git://github.com/clarus/smart-print"
+install: [make "install"]
+synopsis: "A pretty-printing library in OCaml"
+
+url {
+  src: "https://github.com/clarus/smart-print/archive/v0.3.0.tar.gz"
+  checksum: [
+    "sha256=c28d6260af67666c5d70542dc496d3a0c3e48be441aa23f82df3cf2898d1884f"
+    "sha512=45e1485eaab0633f352868ab85d7551ec6c32a4b8a56dd882c0e3145a10630da746b92f0b4870f6c141abd12ceac161ac916d774627616e6929dfa485059d33e"
+  ]
+}


### PR DESCRIPTION
Add a new release for smart-print. We also modify `atd2cconv.0.0.0` as it requires `ocamlbuild` which was previously provided by smart-print.