### PR TITLE
[new release] tls-mirage and tls (0.12.1)

### DIFF
--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.1.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.1.0/opam
@@ -21,6 +21,7 @@ depends: [
 depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [
   "tls" {< "0.11.0"}
+  "tls" {>= "0.12.1"}
   "ssl" {< "0.5.9"}
 ]
 build: [

--- a/packages/tls-mirage/tls-mirage.0.12.1/opam
+++ b/packages/tls-mirage/tls-mirage.0.12.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.0"}
+  "tls" {= version}
+  "x509" {>= "0.10.0"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "hacl_x25519" {>= "0.1.1"}
+  "fiat-p256" {>= "0.2.1"}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"
+description: """
+Tls-mirage provides an effectful FLOW module to be used in the MirageOS
+ecosystem.
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.12.1/tls-v0.12.1.tbz"
+  checksum: [
+    "sha256=af739692a9ab95e76da9f63039d9bd85e8f42af5cf30e1eb2a348e68a1fc5026"
+    "sha512=78d0a7b99f75558f31b0c51314e7340d3c5c9dea91bfd1e4fe10d52878f72370321dd31c5f9735d4fbb788ccd987a61ba4c93e175dee9ca28d5c7b4218eab234"
+  ]
+}

--- a/packages/tls/tls.0.12.1/opam
+++ b/packages/tls/tls.0.12.1/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_cstruct" {>= "3.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "cstruct-sexp"
+  "sexplib"
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-rng"
+  "x509" {>= "0.11.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt"
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "ounit" {with-test & >= "2.2.0"}
+  "lwt" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "hacl_x25519"
+  "fiat-p256"
+  "hkdf"
+  "logs"
+  "alcotest" {with-test}
+]
+
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.12.1/tls-v0.12.1.tbz"
+  checksum: [
+    "sha256=af739692a9ab95e76da9f63039d9bd85e8f42af5cf30e1eb2a348e68a1fc5026"
+    "sha512=78d0a7b99f75558f31b0c51314e7340d3c5c9dea91bfd1e4fe10d52878f72370321dd31c5f9735d4fbb788ccd987a61ba4c93e175dee9ca28d5c7b4218eab234"
+  ]
+}


### PR DESCRIPTION
CHANGES:

in mirleft/ocaml-tls#414 by @hannesm
* Drop support for RC4 ciphersuite
* Raise lower TLS version in default configuration to 1.2
* tls_lwt no longer calls Mirage_crypto_rng_unix.initialize -- this needs to be
  done in the application, inside Lwt_main.run:
  `Mirage_crypto_rng_lwt.initialize () >>= fun () ->`
* Support ECDHE ciphersuites in TLS 1.2 and below as specified in RFC 8422
  (requested in mirleft/ocaml-tls#413 by @ryanakca, also in mirleft/ocaml-tls#362 by @orbitz @annubiz)
* drop "TLS_" prefix from ciphersuite constructors
* BUGFIX: TLS client (<= 1.2) assembling an empty Certificate message
  (noticed in mirleft/ocaml-tls#413, present since 0.12.0 release)
* Cleanup Packet.any_ciphersuite list (remove ARIA, CAMELLIA, KRB5, EXPORT)
* Adapt interoperability test scripts with TLS 1.3 support