### PR TITLE
Fix ocsigenserver for GNU Make 4.3

### DIFF
--- a/packages/ocsigenserver/ocsigenserver.2.1/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.1/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.1/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.1/files/fix-gmake-4.3.patch
@@ -20,19 +20,6 @@ index 45064a32..5811b260 100644
  OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
  OCAMLDOC := $(OCAMLFIND) ocamldoc
  OCAMLDEP := $(OCAMLFIND) ocamldep
-diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
-index d0a1fc14..9c4f31b2 100644
---- a/src/extensions/ocsipersist-pgsql/Makefile
-+++ b/src/extensions/ocsipersist-pgsql/Makefile
-@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
- 
- LIBS     := -I ../../baselib -I ../../http -I ../../server \
- 	    ${addprefix -package ,${PACKAGE}}
--OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
-+OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
- OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
- OCAMLDOC := $(OCAMLFIND) ocamldoc
- OCAMLDEP := $(OCAMLFIND) ocamldep
 diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
 index 6b0f6fea..13b1b2a6 100644
 --- a/src/extensions/ocsipersist-sqlite/Makefile

--- a/packages/ocsigenserver/ocsigenserver.2.1/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.1/opam
@@ -58,7 +58,7 @@ authentication, etc."""
 flags: light-uninstall
 extra-files: [
   ["ocsigenserver.install" "md5=58a7d6a5d2c3fec7ac19eb0b17fd87f7"]
-  ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
+  ["fix-gmake-4.3.patch" "md5=664dcb683501e6649e1ef1dc9a977d4a"]
 ]
 url {
   src: "http://ocsigen.org/download/ocsigenserver-2.1.tar.gz"

--- a/packages/ocsigenserver/ocsigenserver.2.1/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.1/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dev@ocsigen.org"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -55,7 +56,10 @@ OCaml modules for generating pages. Many extensions are already
 written, like a reverse proxy, content compression, access control,
 authentication, etc."""
 flags: light-uninstall
-extra-files: ["ocsigenserver.install" "md5=58a7d6a5d2c3fec7ac19eb0b17fd87f7"]
+extra-files: [
+  ["ocsigenserver.install" "md5=58a7d6a5d2c3fec7ac19eb0b17fd87f7"]
+  ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
+]
 url {
   src: "http://ocsigen.org/download/ocsigenserver-2.1.tar.gz"
   checksum: "md5=d0cccecbfac701eeeee0ad48d743f3d0"

--- a/packages/ocsigenserver/ocsigenserver.2.10/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.10/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.10/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.10/opam
@@ -7,6 +7,7 @@ homepage: "http://ocsigen.org/ocsigenserver/"
 bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -67,6 +68,7 @@ conflicts: [
   "pgocaml" {< "2.2"}
 ]
 flags: light-uninstall
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.10.tar.gz"
   checksum: [

--- a/packages/ocsigenserver/ocsigenserver.2.11.0/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.11.0/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.11.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.11.0/opam
@@ -7,6 +7,7 @@ homepage: "http://ocsigen.org/ocsigenserver/"
 bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -67,6 +68,7 @@ conflicts: [
   "pgocaml" {< "2.2"}
 ]
 flags: light-uninstall
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.11.0.tar.gz"
   checksum: [

--- a/packages/ocsigenserver/ocsigenserver.2.12.0/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.12.0/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.12.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.12.0/opam
@@ -7,6 +7,7 @@ homepage: "http://ocsigen.org/ocsigenserver/"
 bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -61,6 +62,7 @@ conflicts: [
   "camlzip" {< "1.04"}
   "pgocaml" {< "2.2"}
 ]
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.12.0.tar.gz"
   checksum: [

--- a/packages/ocsigenserver/ocsigenserver.2.13.0/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.13.0/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.13.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.13.0/opam
@@ -7,6 +7,7 @@ homepage: "http://ocsigen.org/ocsigenserver/"
 bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -61,6 +62,7 @@ conflicts: [
   "camlzip" {< "1.04"}
   "pgocaml" {< "2.2"}
 ]
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.13.0.tar.gz"
   checksum: [

--- a/packages/ocsigenserver/ocsigenserver.2.14.0/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.14.0/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.14.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.14.0/opam
@@ -7,6 +7,7 @@ homepage: "http://ocsigen.org/ocsigenserver/"
 bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -61,6 +62,7 @@ conflicts: [
   "camlzip" {< "1.04"}
   "pgocaml" {< "2.2"}
 ]
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.14.0.tar.gz"
   checksum: [

--- a/packages/ocsigenserver/ocsigenserver.2.15.0/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.15.0/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.15.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.15.0/opam
@@ -7,6 +7,7 @@ homepage: "http://ocsigen.org/ocsigenserver/"
 bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -61,6 +62,7 @@ conflicts: [
   "camlzip" {< "1.04"}
   "pgocaml" {< "2.2"}
 ]
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.15.0.tar.gz"
   checksum: [

--- a/packages/ocsigenserver/ocsigenserver.2.16.0/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.16.0/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.16.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.16.0/opam
@@ -7,6 +7,7 @@ homepage: "http://ocsigen.org/ocsigenserver/"
 bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
 license: "LGPL-2.1 with OCaml linking exception"
 dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -61,6 +62,7 @@ conflicts: [
   "camlzip" {< "1.04"}
   "pgocaml" {< "2.2"}
 ]
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.16.0.tar.gz"
   checksum: [

--- a/packages/ocsigenserver/ocsigenserver.2.2.0/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.2.0/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.2.0/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.2.0/files/fix-gmake-4.3.patch
@@ -20,19 +20,6 @@ index 45064a32..5811b260 100644
  OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
  OCAMLDOC := $(OCAMLFIND) ocamldoc
  OCAMLDEP := $(OCAMLFIND) ocamldep
-diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
-index d0a1fc14..9c4f31b2 100644
---- a/src/extensions/ocsipersist-pgsql/Makefile
-+++ b/src/extensions/ocsipersist-pgsql/Makefile
-@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
- 
- LIBS     := -I ../../baselib -I ../../http -I ../../server \
- 	    ${addprefix -package ,${PACKAGE}}
--OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
-+OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
- OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
- OCAMLDOC := $(OCAMLFIND) ocamldoc
- OCAMLDEP := $(OCAMLFIND) ocamldep
 diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
 index 6b0f6fea..13b1b2a6 100644
 --- a/src/extensions/ocsipersist-sqlite/Makefile

--- a/packages/ocsigenserver/ocsigenserver.2.2.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.2.0/opam
@@ -43,7 +43,7 @@ depends: [
   ("dbm" | "sqlite3")
 ]
 depopts: ["camlzip"]
-patches: ["use_netstring-pcre.patch"]
+patches: ["use_netstring-pcre.patch" "fix-gmake-4.3.patch"]
 conflicts: [
   "camlzip" {< "1.04"}
 ]
@@ -59,6 +59,7 @@ flags: light-uninstall
 extra-files: [
   ["use_netstring-pcre.patch" "md5=535e3c5d64af6077dcaea84eacddc33b"]
   ["ocsigenserver.install" "md5=58a7d6a5d2c3fec7ac19eb0b17fd87f7"]
+  ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 ]
 url {
   src: "http://ocsigen.org/download/ocsigenserver-2.2.0.tar.gz"

--- a/packages/ocsigenserver/ocsigenserver.2.2.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.2.0/opam
@@ -59,7 +59,7 @@ flags: light-uninstall
 extra-files: [
   ["use_netstring-pcre.patch" "md5=535e3c5d64af6077dcaea84eacddc33b"]
   ["ocsigenserver.install" "md5=58a7d6a5d2c3fec7ac19eb0b17fd87f7"]
-  ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
+  ["fix-gmake-4.3.patch" "md5=664dcb683501e6649e1ef1dc9a977d4a"]
 ]
 url {
   src: "http://ocsigen.org/download/ocsigenserver-2.2.0.tar.gz"

--- a/packages/ocsigenserver/ocsigenserver.2.3.1/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.3.1/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.3.1/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.3.1/files/fix-gmake-4.3.patch
@@ -20,19 +20,6 @@ index 45064a32..5811b260 100644
  OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
  OCAMLDOC := $(OCAMLFIND) ocamldoc
  OCAMLDEP := $(OCAMLFIND) ocamldep
-diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
-index d0a1fc14..9c4f31b2 100644
---- a/src/extensions/ocsipersist-pgsql/Makefile
-+++ b/src/extensions/ocsipersist-pgsql/Makefile
-@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
- 
- LIBS     := -I ../../baselib -I ../../http -I ../../server \
- 	    ${addprefix -package ,${PACKAGE}}
--OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
-+OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
- OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
- OCAMLDOC := $(OCAMLFIND) ocamldoc
- OCAMLDEP := $(OCAMLFIND) ocamldep
 diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
 index 6b0f6fea..13b1b2a6 100644
 --- a/src/extensions/ocsipersist-sqlite/Makefile

--- a/packages/ocsigenserver/ocsigenserver.2.3.1/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.3.1/opam
@@ -59,7 +59,7 @@ OCaml modules for generating pages. Many extensions are already
 written, like a reverse proxy, content compression, access control,
 authentication, etc."""
 flags: light-uninstall
-extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
+extra-files: ["fix-gmake-4.3.patch" "md5=664dcb683501e6649e1ef1dc9a977d4a"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.3.1.tar.gz"
   checksum: "md5=f263df53365397f96681a0495718d0aa"

--- a/packages/ocsigenserver/ocsigenserver.2.3.1/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.3.1/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dev@ocsigen.org"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -58,6 +59,7 @@ OCaml modules for generating pages. Many extensions are already
 written, like a reverse proxy, content compression, access control,
 authentication, etc."""
 flags: light-uninstall
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.3.1.tar.gz"
   checksum: "md5=f263df53365397f96681a0495718d0aa"

--- a/packages/ocsigenserver/ocsigenserver.2.4.0/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.4.0/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.4.0/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.4.0/files/fix-gmake-4.3.patch
@@ -20,19 +20,6 @@ index 45064a32..5811b260 100644
  OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
  OCAMLDOC := $(OCAMLFIND) ocamldoc
  OCAMLDEP := $(OCAMLFIND) ocamldep
-diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
-index d0a1fc14..9c4f31b2 100644
---- a/src/extensions/ocsipersist-pgsql/Makefile
-+++ b/src/extensions/ocsipersist-pgsql/Makefile
-@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
- 
- LIBS     := -I ../../baselib -I ../../http -I ../../server \
- 	    ${addprefix -package ,${PACKAGE}}
--OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
-+OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
- OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
- OCAMLDOC := $(OCAMLFIND) ocamldoc
- OCAMLDEP := $(OCAMLFIND) ocamldep
 diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
 index 6b0f6fea..13b1b2a6 100644
 --- a/src/extensions/ocsipersist-sqlite/Makefile

--- a/packages/ocsigenserver/ocsigenserver.2.4.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.4.0/opam
@@ -62,7 +62,7 @@ OCaml modules for generating pages. Many extensions are already
 written, like a reverse proxy, content compression, access control,
 authentication, etc."""
 flags: light-uninstall
-extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
+extra-files: ["fix-gmake-4.3.patch" "md5=664dcb683501e6649e1ef1dc9a977d4a"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.4.0.tar.gz"
   checksum: "md5=646594a1b2e362cd0e346ac09a3f6316"

--- a/packages/ocsigenserver/ocsigenserver.2.4.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.4.0/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dev@ocsigen.org"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -61,6 +62,7 @@ OCaml modules for generating pages. Many extensions are already
 written, like a reverse proxy, content compression, access control,
 authentication, etc."""
 flags: light-uninstall
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.4.0.tar.gz"
   checksum: "md5=646594a1b2e362cd0e346ac09a3f6316"

--- a/packages/ocsigenserver/ocsigenserver.2.5/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.5/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.5/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.5/files/fix-gmake-4.3.patch
@@ -20,19 +20,6 @@ index 45064a32..5811b260 100644
  OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
  OCAMLDOC := $(OCAMLFIND) ocamldoc
  OCAMLDEP := $(OCAMLFIND) ocamldep
-diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
-index d0a1fc14..9c4f31b2 100644
---- a/src/extensions/ocsipersist-pgsql/Makefile
-+++ b/src/extensions/ocsipersist-pgsql/Makefile
-@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
- 
- LIBS     := -I ../../baselib -I ../../http -I ../../server \
- 	    ${addprefix -package ,${PACKAGE}}
--OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
-+OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
- OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
- OCAMLDOC := $(OCAMLFIND) ocamldoc
- OCAMLDEP := $(OCAMLFIND) ocamldep
 diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
 index 6b0f6fea..13b1b2a6 100644
 --- a/src/extensions/ocsipersist-sqlite/Makefile

--- a/packages/ocsigenserver/ocsigenserver.2.5/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.5/opam
@@ -56,6 +56,7 @@ conflicts: [ "camlzip" {< "1.04" } ]
 patches: [
   "build-against-recent-lwt.diff"
   "fix-build-with-ocsipersist-sqlite.diff"
+  "fix-gmake-4.3.patch"
 ]
 authors: "dev@ocsigen.org"
 install: [make "install"]
@@ -73,6 +74,7 @@ extra-files: [
     "md5=e3fcf2c006c39a249a84331a80bf760f"
   ]
   ["build-against-recent-lwt.diff" "md5=515ffb99616af2160f341d95178e9c48"]
+  ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 ]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.5.tar.gz"

--- a/packages/ocsigenserver/ocsigenserver.2.5/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.5/opam
@@ -74,7 +74,7 @@ extra-files: [
     "md5=e3fcf2c006c39a249a84331a80bf760f"
   ]
   ["build-against-recent-lwt.diff" "md5=515ffb99616af2160f341d95178e9c48"]
-  ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
+  ["fix-gmake-4.3.patch" "md5=664dcb683501e6649e1ef1dc9a977d4a"]
 ]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.5.tar.gz"

--- a/packages/ocsigenserver/ocsigenserver.2.6/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.6/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.6/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.6/files/fix-gmake-4.3.patch
@@ -20,19 +20,6 @@ index 45064a32..5811b260 100644
  OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
  OCAMLDOC := $(OCAMLFIND) ocamldoc
  OCAMLDEP := $(OCAMLFIND) ocamldep
-diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
-index d0a1fc14..9c4f31b2 100644
---- a/src/extensions/ocsipersist-pgsql/Makefile
-+++ b/src/extensions/ocsipersist-pgsql/Makefile
-@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
- 
- LIBS     := -I ../../baselib -I ../../http -I ../../server \
- 	    ${addprefix -package ,${PACKAGE}}
--OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
-+OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
- OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
- OCAMLDOC := $(OCAMLFIND) ocamldoc
- OCAMLDEP := $(OCAMLFIND) ocamldep
 diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
 index 6b0f6fea..13b1b2a6 100644
 --- a/src/extensions/ocsipersist-sqlite/Makefile

--- a/packages/ocsigenserver/ocsigenserver.2.6/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.6/opam
@@ -4,6 +4,7 @@ homepage: "http://ocsigen.org/ocsigenserver/"
 bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
 dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   ["sh" "configure" "--prefix" "%{prefix}%" "--ocsigen-user" "%{user}%" "--ocsigen-group" "%{group}%" "--commandpipe" "%{lib}%/ocsigenserver/var/run/ocsigenserver_command" "--logdir" "%{lib}%/ocsigenserver/var/log/ocsigenserver" "--mandir" "%{man}%/man1" "--docdir" "%{lib}%/ocsigenserver/share/doc/ocsigenserver" "--commandpipe" "%{lib}%/ocsigenserver/var/run/ocsigenserver_command" "--staticpagesdir" "%{lib}%/ocsigenserver/var/www" "--datadir" "%{lib}%/ocsigenserver/var/lib/ocsigenserver" "--sysconfdir" "%{lib}%/ocsigenserver/etc/ocsigenserver"]
   [make]
@@ -41,6 +42,7 @@ written, like a reverse proxy, content compression, access control,
 authentication, etc."""
 authors: "dev@ocsigen.org"
 flags: light-uninstall
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.6.tar.gz"
   checksum: "md5=be5dad42a57cda19ab20e0600c0dd023"

--- a/packages/ocsigenserver/ocsigenserver.2.6/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.6/opam
@@ -42,7 +42,7 @@ written, like a reverse proxy, content compression, access control,
 authentication, etc."""
 authors: "dev@ocsigen.org"
 flags: light-uninstall
-extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
+extra-files: ["fix-gmake-4.3.patch" "md5=664dcb683501e6649e1ef1dc9a977d4a"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.6.tar.gz"
   checksum: "md5=be5dad42a57cda19ab20e0600c0dd023"

--- a/packages/ocsigenserver/ocsigenserver.2.7/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.7/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.7/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.7/files/fix-gmake-4.3.patch
@@ -20,19 +20,6 @@ index 45064a32..5811b260 100644
  OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
  OCAMLDOC := $(OCAMLFIND) ocamldoc
  OCAMLDEP := $(OCAMLFIND) ocamldep
-diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
-index d0a1fc14..9c4f31b2 100644
---- a/src/extensions/ocsipersist-pgsql/Makefile
-+++ b/src/extensions/ocsipersist-pgsql/Makefile
-@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
- 
- LIBS     := -I ../../baselib -I ../../http -I ../../server \
- 	    ${addprefix -package ,${PACKAGE}}
--OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
-+OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
- OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
- OCAMLDOC := $(OCAMLFIND) ocamldoc
- OCAMLDEP := $(OCAMLFIND) ocamldep
 diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
 index 6b0f6fea..13b1b2a6 100644
 --- a/src/extensions/ocsipersist-sqlite/Makefile

--- a/packages/ocsigenserver/ocsigenserver.2.7/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.7/opam
@@ -5,6 +5,7 @@ homepage: "http://ocsigen.org/ocsigenserver/"
 bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -68,6 +69,7 @@ your own OCaml modules for generating pages. Many extensions are
 already implemented, like a reverse proxy, content compression, access
 control, authentication, etc."""
 flags: light-uninstall
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.7.tar.gz"
   checksum: "md5=c918913321572a412f872640824c3530"

--- a/packages/ocsigenserver/ocsigenserver.2.7/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.7/opam
@@ -69,7 +69,7 @@ your own OCaml modules for generating pages. Many extensions are
 already implemented, like a reverse proxy, content compression, access
 control, authentication, etc."""
 flags: light-uninstall
-extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
+extra-files: ["fix-gmake-4.3.patch" "md5=664dcb683501e6649e1ef1dc9a977d4a"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.7.tar.gz"
   checksum: "md5=c918913321572a412f872640824c3530"

--- a/packages/ocsigenserver/ocsigenserver.2.8/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.8/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.8/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.8/opam
@@ -5,6 +5,7 @@ homepage: "http://ocsigen.org/ocsigenserver/"
 bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -69,6 +70,7 @@ your own OCaml modules for generating pages. Many extensions are
 already implemented, like a reverse proxy, content compression, access
 control, authentication, etc."""
 flags: light-uninstall
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.8.tar.gz"
   checksum: "md5=108674a6a014e525f06b29db69d119cd"

--- a/packages/ocsigenserver/ocsigenserver.2.9/files/fix-gmake-4.3.patch
+++ b/packages/ocsigenserver/ocsigenserver.2.9/files/fix-gmake-4.3.patch
@@ -1,0 +1,48 @@
+commit 014aefc4e460686a361b974f16ebb7e0c993b36b (from e9ab14a4437640656117aed30a1ee5b6227f07de)
+Merge: e9ab14a4 5cc446bd
+Author: Jerome Vouillon <jvouillon@besport.com>
+Date:   Mon Feb 10 13:33:26 2020 +0100
+
+    Merge pull request #182 from Codeizer/patch-1
+    
+    Compilation error
+
+diff --git a/src/extensions/ocsipersist-dbm/Makefile b/src/extensions/ocsipersist-dbm/Makefile
+index 45064a32..5811b260 100644
+--- a/src/extensions/ocsipersist-dbm/Makefile
++++ b/src/extensions/ocsipersist-dbm/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt.unix lwt_log xml-light dbm
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-pgsql/Makefile b/src/extensions/ocsipersist-pgsql/Makefile
+index d0a1fc14..9c4f31b2 100644
+--- a/src/extensions/ocsipersist-pgsql/Makefile
++++ b/src/extensions/ocsipersist-pgsql/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := xml-light pgocaml lwt lwt_log
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep
+diff --git a/src/extensions/ocsipersist-sqlite/Makefile b/src/extensions/ocsipersist-sqlite/Makefile
+index 6b0f6fea..13b1b2a6 100644
+--- a/src/extensions/ocsipersist-sqlite/Makefile
++++ b/src/extensions/ocsipersist-sqlite/Makefile
+@@ -4,7 +4,7 @@ PACKAGE  := lwt lwt_log xml-light sqlite3
+ 
+ LIBS     := -I ../../baselib -I ../../http -I ../../server \
+ 	    ${addprefix -package ,${PACKAGE}}
+-OCAMLC   := $(OCAMLFIND) ocamlc${BYTEDBG} ${THREAD}
++OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+ OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+ OCAMLDOC := $(OCAMLFIND) ocamldoc
+ OCAMLDEP := $(OCAMLFIND) ocamldep

--- a/packages/ocsigenserver/ocsigenserver.2.9/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.9/opam
@@ -6,6 +6,7 @@ homepage: "http://ocsigen.org/ocsigenserver/"
 bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+patches: ["fix-gmake-4.3.patch"]
 build: [
   [
     "sh"
@@ -72,6 +73,7 @@ your own OCaml modules for generating pages. Many extensions are
 already implemented, like a reverse proxy, content compression, access
 control, authentication, etc."""
 flags: light-uninstall
+extra-files: ["fix-gmake-4.3.patch" "md5=beec17b6c45d93efecf2256a2369e402"]
 url {
   src: "https://github.com/ocsigen/ocsigenserver/archive/2.9.tar.gz"
   checksum: "md5=1b7866f28cda7b922a54d41c9507021f"


### PR DESCRIPTION
cc @vouillon as told in https://github.com/ocsigen/ocsigenserver/pull/182#issuecomment-643302846 I believe users are going to experience this pretty soon. GNU Make 4.3 has only been around in Debian Sid for 3 weeks so far but if it's not a bug that is going to be fixed soon on their side I would rather see it fixed here.

For the record for everyone interested here is the change of behaviour. Using the following Makefile:
```
TEST :=
TEST += test
AAA := echo aaa${TEST}

all:
	$(AAA)
```
With GNU Make 4.2.1:
```
$ make --version
GNU Make 4.2.1
$ make
echo aaa test
aaa test
```
With GNU Make 4.3 on the same machine:
```
$ sudo apt-get upgrade make
[...]
$ make --version
GNU Make 4.3
$ make
echo aaatest
aaatest
```