### PR TITLE
[new release] conduit-lwt-unix (2.2.2)

### DIFF
--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.2.2/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.2.2/opam
@@ -12,7 +12,7 @@ depends: [
   "dune"
   "base-unix"
   "ppx_sexp_conv" {>="v0.12.0"}
-  "conduit-lwt" {=version}
+  "conduit-lwt" {>="2.1.0" & <"2.3.0"}
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.9.4"}
   "ipaddr" {>= "4.0.0"}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.2.2/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.2.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.12.0"}
+  "conduit-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+depopts: ["tls" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls" {< "0.11.0"}
+  "ssl" {< "0.5.9"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.2.2/conduit-v2.2.2.tbz"
+  checksum: [
+    "sha256=a57cc1843aa7eaaa183a5d08d98a13e78c848b37aabb7b55ee88257c051f68fd"
+    "sha512=c2ca50cdae36f6b9cef4053844a4b719e4e065997a2dc6e1858f8c0bc3ce03d5728d10308368f1968154d217dfc84038cd1de007b1168e7adf476dc57af3f513"
+  ]
+}


### PR DESCRIPTION
CHANGES:
    
* conduit-lwt-unix no longer calls Mirage_crypto_rng_unix.initialize, and is compatible with tls 0.12.1 (mirage/ocaml-conduit#317 @hannesm)
