### PR TITLE
restrict mirage and mirage-runtime to ipaddr < 5.0.0

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.4.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.4.0/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria-runtime"  {>= "2.2.2"}
   "fmt"
   "logs"

--- a/packages/mirage-runtime/mirage-runtime.3.4.1/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.4.1/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria-runtime"  {>= "2.2.2"}
   "fmt"
   "logs"

--- a/packages/mirage-runtime/mirage-runtime.3.5.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.5.0/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria-runtime"  {>= "2.2.2"}
   "fmt"
   "logs"

--- a/packages/mirage-runtime/mirage-runtime.3.5.1/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.5.1/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria-runtime"  {>= "2.2.2"}
   "fmt"
   "logs"

--- a/packages/mirage-runtime/mirage-runtime.3.5.2/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.5.2/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria-runtime"  {>= "2.2.2"}
   "fmt"
   "logs"

--- a/packages/mirage-runtime/mirage-runtime.3.6.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.6.0/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria-runtime"  {>= "2.2.2"}
   "fmt"
   "logs"

--- a/packages/mirage-runtime/mirage-runtime.3.7.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.7.0/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria-runtime"  {>= "2.2.2"}
   "fmt"
   "logs"

--- a/packages/mirage-runtime/mirage-runtime.3.7.1/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.7.1/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria-runtime"  {>= "3.0.2"}
   "fmt"
   "logs"

--- a/packages/mirage-runtime/mirage-runtime.3.7.5/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.7.5/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria-runtime"  {>= "3.0.2"}
   "fmt"
   "logs"

--- a/packages/mirage-runtime/mirage-runtime.3.7.6/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.7.6/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria-runtime"  {>= "3.0.2"}
   "fmt"
   "logs"

--- a/packages/mirage/mirage.3.1.1/opam
+++ b/packages/mirage/mirage.3.1.1/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {>= "1.0+beta10"}
-  "ipaddr" {>= "2.6.0"}
+  "ipaddr" {>= "2.6.0" & < "5.0.0"}
   "functoria" {>= "2.2.0"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.2.0/opam
+++ b/packages/mirage/mirage.3.2.0/opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/mirage/mirage/issues/"
 depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {>= "1.0+beta10"}
-  "ipaddr" {>= "2.6.0"}
+  "ipaddr" {>= "2.6.0" & < "5.0.0"}
   "functoria" {>= "2.2.0"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.3.0/opam
+++ b/packages/mirage/mirage.3.3.0/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "2.6.0"}
+  "ipaddr"             {>= "2.6.0" & < "5.0.0"}
   "functoria"          {>= "2.2.2"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.3.1/opam
+++ b/packages/mirage/mirage.3.3.1/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "2.6.0"}
+  "ipaddr"             {>= "2.6.0" & < "5.0.0"}
   "functoria"          {>= "2.2.3"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.4.0/opam
+++ b/packages/mirage/mirage.3.4.0/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "2.2.3"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.4.1/opam
+++ b/packages/mirage/mirage.3.4.1/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "2.2.3"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.5.0/opam
+++ b/packages/mirage/mirage.3.5.0/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "2.2.3"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.5.1/opam
+++ b/packages/mirage/mirage.3.5.1/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "2.2.3"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.5.2/opam
+++ b/packages/mirage/mirage.3.5.2/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "2.2.3"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.6.0/opam
+++ b/packages/mirage/mirage.3.6.0/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "2.2.3"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.7.1/opam
+++ b/packages/mirage/mirage.3.7.1/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "3.0.2"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.7.2/opam
+++ b/packages/mirage/mirage.3.7.2/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "3.0.2"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.7.3/opam
+++ b/packages/mirage/mirage.3.7.3/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "3.0.2"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.7.4/opam
+++ b/packages/mirage/mirage.3.7.4/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "3.0.2"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.7.5/opam
+++ b/packages/mirage/mirage.3.7.5/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "3.1.0"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.7.6/opam
+++ b/packages/mirage/mirage.3.7.6/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "3.1.0"}
   "bos"
   "astring"

--- a/packages/mirage/mirage.3.7.7/opam
+++ b/packages/mirage/mirage.3.7.7/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "3.1.0"}
   "bos"
   "astring"


### PR DESCRIPTION
the ipaddr 5.0.0 package, soon to be released, will have some API breaking changes in Prefix submodule. this requires mirage and mirage-runtime to be adapted.