### PR TITLE
[new release] digestif (0.8.1)

### DIFF
--- a/packages/digestif/digestif.0.8.1/opam
+++ b/packages/digestif/digestif.0.8.1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+name:         "digestif"
+maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/digestif"
+bug-reports:  "https://github.com/mirage/digestif/issues"
+dev-repo:     "git+https://github.com/mirage/digestif.git"
+doc:          "https://mirage.github.io/digestif/"
+license:      "MIT"
+synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+description: """
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {>= "2.6.0"}
+  "eqaf"
+  "base-bytes"
+  "bigarray-compat"
+  "stdlib-shims"
+  "fmt"            {with-test}
+  "alcotest"       {with-test}
+]
+
+depopts: [
+  "ocaml-freestanding"
+  "mirage-xen-posix"
+]
+
+conflicts: [
+  "mirage-xen-posix" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.3"}
+  "mirage-runtime" {< "4.0.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/digestif/releases/download/v0.8.1/digestif-v0.8.1.tbz"
+  checksum: [
+    "sha256=19ac8458a978857f76c9324093767b40920f4734053a67d686cf874282189459"
+    "sha512=590e70b9ca3a94ec6279c271c506879d21faebe8fe4c9f499c5d33921b15b5efc1b4f184d47de70cef4f863faf0f872d4209c0d1c3d35ab8bdba0db482e6aad3"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- Move to `dune.2.6.0` (mirage/digestif#97)
- Apply `ocamlformat.0.14.2` (mirage/digestif#97)
- Fix tests according `alcotest.1.0.0` (mirage/digestif#95)