### PR TITLE
[new release] ipaddr-cstruct, macaddr, macaddr-sexp, ipaddr, ipaddr-sexp and macaddr-cstruct (5.0.0)

### DIFF
--- a/packages/ipaddr-cstruct/ipaddr-cstruct.5.0.0/opam
+++ b/packages/ipaddr-cstruct/ipaddr-cstruct.5.0.0/opam
@@ -9,8 +9,8 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"
-  "ipaddr" {=version}
+  "dune" {>= "1.9"}
+  "ipaddr" {= version}
   "cstruct"
 ]
 build: [

--- a/packages/ipaddr-cstruct/ipaddr-cstruct.5.0.0/opam
+++ b/packages/ipaddr-cstruct/ipaddr-cstruct.5.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations using Cstructs"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"
+  "ipaddr" {=version}
+  "cstruct"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Cstruct convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.0.0/ipaddr-v5.0.0.tbz"
+  checksum: [
+    "sha256=2e8f35b1ddf3f5b9847f59fccdd61475e7771f34d693fa69271b41ff9119c7ac"
+    "sha512=b2a250e96ad10376f592c38df7f5d2d849d58252dad787176d24f8d41c3c5f8420dfe215f50fee32046f84a45d8327ff2a317b50ce96266094d8df34bda5ab73"
+  ]
+}

--- a/packages/ipaddr-sexp/ipaddr-sexp.5.0.0/opam
+++ b/packages/ipaddr-sexp/ipaddr-sexp.5.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations usnig sexp"
+description: """
+Sexp convertions for ipaddr
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"
+  "ipaddr"
+  "ipaddr-cstruct" {with-test}
+  "ounit" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.0.0/ipaddr-v5.0.0.tbz"
+  checksum: [
+    "sha256=2e8f35b1ddf3f5b9847f59fccdd61475e7771f34d693fa69271b41ff9119c7ac"
+    "sha512=b2a250e96ad10376f592c38df7f5d2d849d58252dad787176d24f8d41c3c5f8420dfe215f50fee32046f84a45d8327ff2a317b50ce96266094d8df34bda5ab73"
+  ]
+}

--- a/packages/ipaddr-sexp/ipaddr-sexp.5.0.0/opam
+++ b/packages/ipaddr-sexp/ipaddr-sexp.5.0.0/opam
@@ -13,9 +13,9 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"
-  "ipaddr"
-  "ipaddr-cstruct" {with-test}
+  "dune" {>= "1.9"}
+  "ipaddr" {= version}
+  "ipaddr-cstruct" {with-test & = version}
   "ounit" {with-test}
   "ppx_sexp_conv" {>= "v0.9.0"}
 ]

--- a/packages/ipaddr/ipaddr.5.0.0/opam
+++ b/packages/ipaddr/ipaddr.5.0.0/opam
@@ -28,8 +28,8 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"
-  "macaddr" {=version}
+  "dune" {>= "1.9"}
+  "macaddr" {= version}
   "stdlib-shims"
   "domain-name" {>= "0.3.0"}
   "ounit" {with-test}

--- a/packages/ipaddr/ipaddr.5.0.0/opam
+++ b/packages/ipaddr/ipaddr.5.0.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP (and MAC) address representations"
+description: """
+Features:
+ * Depends only on sexplib (conditionalization under consideration)
+ * oUnit-based tests
+ * IPv4 and IPv6 support
+ * IPv4 and IPv6 CIDR prefix support
+ * IPv4 and IPv6 [CIDR-scoped address](http://tools.ietf.org/html/rfc4291#section-2.3) support
+ * `Ipaddr.V4` and `Ipaddr.V4.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr.V6` and `Ipaddr.V6.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr` and `Ipaddr.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr_unix` in findlib subpackage `ipaddr.unix` provides compatibility with the standard library `Unix` module
+ * `Ipaddr_top` in findlib subpackage `ipaddr.top` provides top-level pretty printers (requires compiler-libs default since OCaml 4.0)
+ * IP address scope classification
+ * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"
+  "macaddr" {=version}
+  "stdlib-shims"
+  "domain-name" {>= "0.3.0"}
+  "ounit" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.0.0/ipaddr-v5.0.0.tbz"
+  checksum: [
+    "sha256=2e8f35b1ddf3f5b9847f59fccdd61475e7771f34d693fa69271b41ff9119c7ac"
+    "sha512=b2a250e96ad10376f592c38df7f5d2d849d58252dad787176d24f8d41c3c5f8420dfe215f50fee32046f84a45d8327ff2a317b50ce96266094d8df34bda5ab73"
+  ]
+}

--- a/packages/macaddr-cstruct/macaddr-cstruct.5.0.0/opam
+++ b/packages/macaddr-cstruct/macaddr-cstruct.5.0.0/opam
@@ -9,8 +9,8 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"
-  "macaddr" {=version}
+  "dune" {>= "1.9"}
+  "macaddr" {= version}
   "cstruct"
 ]
 build: [

--- a/packages/macaddr-cstruct/macaddr-cstruct.5.0.0/opam
+++ b/packages/macaddr-cstruct/macaddr-cstruct.5.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations using Cstructs"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"
+  "macaddr" {=version}
+  "cstruct"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Cstruct convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.0.0/ipaddr-v5.0.0.tbz"
+  checksum: [
+    "sha256=2e8f35b1ddf3f5b9847f59fccdd61475e7771f34d693fa69271b41ff9119c7ac"
+    "sha512=b2a250e96ad10376f592c38df7f5d2d849d58252dad787176d24f8d41c3c5f8420dfe215f50fee32046f84a45d8327ff2a317b50ce96266094d8df34bda5ab73"
+  ]
+}

--- a/packages/macaddr-sexp/macaddr-sexp.5.0.0/opam
+++ b/packages/macaddr-sexp/macaddr-sexp.5.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations using sexp"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"
+  "macaddr"
+  "macaddr-cstruct" {with-test}
+  "ounit" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+]
+conflicts: [ "ipaddr" {< "3.0.0"} ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Sexp convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.0.0/ipaddr-v5.0.0.tbz"
+  checksum: [
+    "sha256=2e8f35b1ddf3f5b9847f59fccdd61475e7771f34d693fa69271b41ff9119c7ac"
+    "sha512=b2a250e96ad10376f592c38df7f5d2d849d58252dad787176d24f8d41c3c5f8420dfe215f50fee32046f84a45d8327ff2a317b50ce96266094d8df34bda5ab73"
+  ]
+}

--- a/packages/macaddr-sexp/macaddr-sexp.5.0.0/opam
+++ b/packages/macaddr-sexp/macaddr-sexp.5.0.0/opam
@@ -9,9 +9,9 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"
-  "macaddr"
-  "macaddr-cstruct" {with-test}
+  "dune" {>= "1.9"}
+  "macaddr" {= version}
+  "macaddr-cstruct" {with-test & = version}
   "ounit" {with-test}
   "ppx_sexp_conv" {>= "v0.9.0"}
 ]

--- a/packages/macaddr/macaddr.5.0.0/opam
+++ b/packages/macaddr/macaddr.5.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune"
+  "ounit" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+]
+conflicts: [ "ipaddr" {< "3.0.0"} ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+A library for manipulation of MAC address representations.
+
+Features:
+
+ * oUnit-based tests
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers optionally via the `Macaddr_sexp` library.
+ """
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.0.0/ipaddr-v5.0.0.tbz"
+  checksum: [
+    "sha256=2e8f35b1ddf3f5b9847f59fccdd61475e7771f34d693fa69271b41ff9119c7ac"
+    "sha512=b2a250e96ad10376f592c38df7f5d2d849d58252dad787176d24f8d41c3c5f8420dfe215f50fee32046f84a45d8327ff2a317b50ce96266094d8df34bda5ab73"
+  ]
+}

--- a/packages/macaddr/macaddr.5.0.0/opam
+++ b/packages/macaddr/macaddr.5.0.0/opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"
+  "dune" {>= "1.9"}
   "ounit" {with-test}
   "ppx_sexp_conv" {with-test & >= "v0.9.0"}
 ]


### PR DESCRIPTION
A library for manipulation of IP address representations using Cstructs

- Project page: <a href="https://github.com/mirage/ocaml-ipaddr">https://github.com/mirage/ocaml-ipaddr</a>
- Documentation: <a href="https://mirage.github.io/ocaml-ipaddr/">https://mirage.github.io/ocaml-ipaddr/</a>

##### CHANGES:

* Do not zero out the non-prefix-length part of the address in
  `{V4,V6}.Prefix.t` (mirage/ocaml-ipaddr#99 @hannesm)
  Removed `{V4,V6}.Prefix.of_address_string{,_exn}` and
  `{V4,V6}.Prefix.to_address_{string.buffer}`

  To port code:
  - if you rely on `Prefix.of_string` to zero out the non-prefix-length address
    bits, call `Prefix.prefix : t -> t` subsequently.
  - `Prefix.of_address_string{,_exn}` can be replaced by
    `Prefix.of_string{,_exn}`, to retrieve the address use
    `Prefix.address : t -> addr`.
  - The `Prefix.to_address_{string,buffer}` can be replaced by
    `Prefix.to_{string,buffer}`, where `Prefix.t` already contains the IP
    address to be printed.
  - Instead of passing `{V4,V6}.t * {V4,V6}.Prefix.t` for an
    address and subnet configuration, `{V4,V6}.Prefix.t` is sufficient.

* Implement `{V4,V6,}.succ`, `{V4,V6,}.pred`, `{V4,V6}.Prefix.first`, and
  `{V4,V6}.Prefix.last` functions (mirage/ocaml-ipaddr#94 @NightBlues)

* Rename `Prefix.of_netmask` to `Prefix.of_netmask_exn` with labelled
  arguments (~netmask and ~address), provide `Prefix.of_netmask` which returns
  a (t, [> `Msg of string ]) result value (mirage/ocaml-ipaddr#95 @hannesm)

* Fix undefined behaviour of `V4.Prefix.mem` with a CIDR with prefix length 0
  (mirage/ocaml-ipaddr#98 @verbosemode)

* Use stdlib-shims to prevent deprecation warnings on OCaml 4.08
  (@avsm)

* Remove unnecessary "sexplib0" dependency (mirage/ocaml-ipaddr#95 @hannesm)

* Remove "{build}" directive from "dune" dependency (mirage/ocaml-ipaddr#93 @CraigFe)
