### PR TITLE
11 packages from oxidizing/sihl at 0.0.35

### DIFF
--- a/packages/sihl/sihl.0.0.35/opam
+++ b/packages/sihl/sihl.0.0.35/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis: "A web framework for Reason and OCaml"
+description: "A web framework for Reason and OCaml to build apps rapidly."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.3.0"}
+  "base" {>= "v0.13.1"}
+  "opium" {>= "0.17.1"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.5.2"}
+  "tls" {>= "0.11.1"}
+  "ssl" {>= "0.5.9"}
+  "lwt_ssl" {>= "1.1.3"}
+  "caqti" {>= "1.2.1"}
+  "caqti-lwt" {>= "1.2.0"}
+  "tyxml" {>= "4.3.0"}
+  "tyxml-jsx" {>= "4.3.0"}
+  "reason" {>= "3.0.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.8"}
+  "pcre" {>= "7.4.3"}
+  "safepass" {>= "3.0"}
+  "jwto" {>= "0.3.0"}
+  "uuidm" {>= "0.9.7"}
+  "sexplib" {>= "0.13.0"}
+  "ppx_fields_conv" {>= "0.13.0"}
+  "ppx_sexp_conv" {>= "0.13.0"}
+  "utop" {dev}
+  "merlin" {dev}
+  "ocamlformat" {dev}
+  "ocp-indent" {dev}
+  "tuareg" {dev}
+  "alcotest" {>= "1.1.0" & with-test}
+  "alcotest-lwt" {>= "1.1.0" & with-test}
+  "cohttp-lwt-unix" {>= "2.5.1" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+pin-depends: [
+  [ "jwto.0.3.0"
+    "git+https://github.com/sporto/jwto.git#0.3.0" ]
+]
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.35.tar.gz"
+  checksum: [
+    "md5=db2cccd68af68221edaa3c157b7f9416"
+    "sha512=635fc56f17f82e74e6b1a58caa5173e32a1ac4ba6f857fc6728bcfbc1c979ed3de18bc5084c1fe8d13beab0e91d7e6b343f227fa14b45571a2aa5c0f7b36d4f4"
+  ]
+}

--- a/packages/sihl_admin/sihl_admin.0.0.35/opam
+++ b/packages/sihl_admin/sihl_admin.0.0.35/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "A Sihl app to build backoffice web applications for administrators"
+description:
+  "This app provides a building blocks to build and register admin pages to increase visibility and provide administrators with internal tools.."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.3.0"}
+  "sihl" {>= "0.0.35"}
+  "base" {>= "v0.13.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.35.tar.gz"
+  checksum: [
+    "md5=db2cccd68af68221edaa3c157b7f9416"
+    "sha512=635fc56f17f82e74e6b1a58caa5173e32a1ac4ba6f857fc6728bcfbc1c979ed3de18bc5084c1fe8d13beab0e91d7e6b343f227fa14b45571a2aa5c0f7b36d4f4"
+  ]
+}

--- a/packages/sihl_email/sihl_email.0.0.35/opam
+++ b/packages/sihl_email/sihl_email.0.0.35/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A Sihl app for email management"
+description:
+  "Use this app to send single emails and schedule sending over various email backends."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.3.0"}
+  "sihl" {>= "0.0.35"}
+  "base" {>= "v0.13.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.35.tar.gz"
+  checksum: [
+    "md5=db2cccd68af68221edaa3c157b7f9416"
+    "sha512=635fc56f17f82e74e6b1a58caa5173e32a1ac4ba6f857fc6728bcfbc1c979ed3de18bc5084c1fe8d13beab0e91d7e6b343f227fa14b45571a2aa5c0f7b36d4f4"
+  ]
+}

--- a/packages/sihl_email_mariadb/sihl_email_mariadb.0.0.35/opam
+++ b/packages/sihl_email_mariadb/sihl_email_mariadb.0.0.35/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A storage for emails, templates and email queues using MariaDB"
+description:
+  "A storage for emails, templates and email queues using MariaDB."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.1"}
+  "sihl_email" {>= "0.0.35"}
+  "caqti-driver-mariadb" {>= "1.2.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.35.tar.gz"
+  checksum: [
+    "md5=db2cccd68af68221edaa3c157b7f9416"
+    "sha512=635fc56f17f82e74e6b1a58caa5173e32a1ac4ba6f857fc6728bcfbc1c979ed3de18bc5084c1fe8d13beab0e91d7e6b343f227fa14b45571a2aa5c0f7b36d4f4"
+  ]
+}

--- a/packages/sihl_email_postgresql/sihl_email_postgresql.0.0.35/opam
+++ b/packages/sihl_email_postgresql/sihl_email_postgresql.0.0.35/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A storage for emails, templates and email queues using PostgreSQL"
+description:
+  "A storage for emails, templates and email queues using PostgreSQL."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.1"}
+  "sihl_email" {>= "0.0.35"}
+  "caqti-driver-postgresql" {>= "1.2.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.35.tar.gz"
+  checksum: [
+    "md5=db2cccd68af68221edaa3c157b7f9416"
+    "sha512=635fc56f17f82e74e6b1a58caa5173e32a1ac4ba6f857fc6728bcfbc1c979ed3de18bc5084c1fe8d13beab0e91d7e6b343f227fa14b45571a2aa5c0f7b36d4f4"
+  ]
+}

--- a/packages/sihl_session/sihl_session.0.0.35/opam
+++ b/packages/sihl_session/sihl_session.0.0.35/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A Sihl app for anonymous sessions"
+description:
+  "This app provides a generic interface to store and retrieve anonymous session data. It is mainly used to build other apps on top."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.3.0"}
+  "sihl" {>= "0.0.35"}
+  "base" {>= "v0.13.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.35.tar.gz"
+  checksum: [
+    "md5=db2cccd68af68221edaa3c157b7f9416"
+    "sha512=635fc56f17f82e74e6b1a58caa5173e32a1ac4ba6f857fc6728bcfbc1c979ed3de18bc5084c1fe8d13beab0e91d7e6b343f227fa14b45571a2aa5c0f7b36d4f4"
+  ]
+}

--- a/packages/sihl_session_mariadb/sihl_session_mariadb.0.0.35/opam
+++ b/packages/sihl_session_mariadb/sihl_session_mariadb.0.0.35/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "An implementation of the session store using MariaDB"
+description: "An implementation of the session store using MariaDB."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.1"}
+  "sihl_session" {>= "0.0.35"}
+  "caqti-driver-mariadb" {>= "1.2.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.35.tar.gz"
+  checksum: [
+    "md5=db2cccd68af68221edaa3c157b7f9416"
+    "sha512=635fc56f17f82e74e6b1a58caa5173e32a1ac4ba6f857fc6728bcfbc1c979ed3de18bc5084c1fe8d13beab0e91d7e6b343f227fa14b45571a2aa5c0f7b36d4f4"
+  ]
+}

--- a/packages/sihl_session_postgresql/sihl_session_postgresql.0.0.35/opam
+++ b/packages/sihl_session_postgresql/sihl_session_postgresql.0.0.35/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "An implementation of the session store using PostgreSQL"
+description: "An implementation of the session store using PostgreSQL."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.1"}
+  "sihl_session" {>= "0.0.35"}
+  "caqti-driver-postgresql" {>= "1.2.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.35.tar.gz"
+  checksum: [
+    "md5=db2cccd68af68221edaa3c157b7f9416"
+    "sha512=635fc56f17f82e74e6b1a58caa5173e32a1ac4ba6f857fc6728bcfbc1c979ed3de18bc5084c1fe8d13beab0e91d7e6b343f227fa14b45571a2aa5c0f7b36d4f4"
+  ]
+}

--- a/packages/sihl_user/sihl_user.0.0.35/opam
+++ b/packages/sihl_user/sihl_user.0.0.35/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A user management app for Sihl"
+description:
+  "This app provides an Admin UI, Email confirmation & Password reset workflows, an HTTP API and a Service API supporting MariaDB and Postgres."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.3.0"}
+  "sihl" {>= "0.0.35"}
+  "sihl_email" {>= "0.0.35"}
+  "base" {>= "v0.13.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.35.tar.gz"
+  checksum: [
+    "md5=db2cccd68af68221edaa3c157b7f9416"
+    "sha512=635fc56f17f82e74e6b1a58caa5173e32a1ac4ba6f857fc6728bcfbc1c979ed3de18bc5084c1fe8d13beab0e91d7e6b343f227fa14b45571a2aa5c0f7b36d4f4"
+  ]
+}

--- a/packages/sihl_user_mariadb/sihl_user_mariadb.0.0.35/opam
+++ b/packages/sihl_user_mariadb/sihl_user_mariadb.0.0.35/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A storage for users using MariaDB"
+description: "A storage for users using MariaDB."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.1"}
+  "sihl_user" {>= "0.0.35"}
+  "caqti-driver-mariadb" {>= "1.2.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.35.tar.gz"
+  checksum: [
+    "md5=db2cccd68af68221edaa3c157b7f9416"
+    "sha512=635fc56f17f82e74e6b1a58caa5173e32a1ac4ba6f857fc6728bcfbc1c979ed3de18bc5084c1fe8d13beab0e91d7e6b343f227fa14b45571a2aa5c0f7b36d4f4"
+  ]
+}

--- a/packages/sihl_user_postgresql/sihl_user_postgresql.0.0.35/opam
+++ b/packages/sihl_user_postgresql/sihl_user_postgresql.0.0.35/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A storage for users using PostgreSQL"
+description: "A storage for users using PostgreSQL."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://github.com/oxidizing/sihl"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.1"}
+  "sihl_user" {>= "0.0.35"}
+  "caqti-driver-postgresql" {>= "1.2.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.0.35.tar.gz"
+  checksum: [
+    "md5=db2cccd68af68221edaa3c157b7f9416"
+    "sha512=635fc56f17f82e74e6b1a58caa5173e32a1ac4ba6f857fc6728bcfbc1c979ed3de18bc5084c1fe8d13beab0e91d7e6b343f227fa14b45571a2aa5c0f7b36d4f4"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`sihl.0.0.35`: A web framework for Reason and OCaml
-`sihl_admin.0.0.35`: A Sihl app to build backoffice web applications for administrators
-`sihl_email.0.0.35`: A Sihl app for email management
-`sihl_email_mariadb.0.0.35`: A storage for emails, templates and email queues using MariaDB
-`sihl_email_postgresql.0.0.35`: A storage for emails, templates and email queues using PostgreSQL
-`sihl_session.0.0.35`: A Sihl app for anonymous sessions
-`sihl_session_mariadb.0.0.35`: An implementation of the session store using MariaDB
-`sihl_session_postgresql.0.0.35`: An implementation of the session store using PostgreSQL
-`sihl_user.0.0.35`: A user management app for Sihl
-`sihl_user_mariadb.0.0.35`: A storage for users using MariaDB
-`sihl_user_postgresql.0.0.35`: A storage for users using PostgreSQL



---
* Homepage: https://github.com/oxidizing/sihl
* Source repo: git+https://github.com/oxidizing/sihl.git
* Bug tracker: https://github.com/oxidizing/sihl/issues

---
:camel: Pull-request generated by opam-publish v2.0.2