### PR TITLE
ipaddr 5.0.0 reverse dependencies: charrua, mirage-nat (test), tcpip (test), tuntap

### DIFF
--- a/packages/charrua-server/charrua-server.1.1.0/opam
+++ b/packages/charrua-server/charrua-server.1.1.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml"         {>= "4.04.2"}
   "cstruct"       {>= "3.0.1"}
   "sexplib"       {< "v0.14"}
-  "ipaddr"        {>= "4.0.0"}
+  "ipaddr"        {>= "4.0.0" & < "5.0.0"}
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"

--- a/packages/charrua-server/charrua-server.1.2.0/opam
+++ b/packages/charrua-server/charrua-server.1.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "charrua"       {= version}
   "cstruct"       {>= "3.0.1"}
   "sexplib"       {< "v0.14"}
-  "ipaddr"        {>= "4.0.0"}
+  "ipaddr"        {>= "4.0.0" & < "5.0.0"}
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"

--- a/packages/charrua-server/charrua-server.1.2.1/opam
+++ b/packages/charrua-server/charrua-server.1.2.1/opam
@@ -21,7 +21,7 @@ depends: [
   "charrua"       {= version}
   "cstruct"       {>= "3.0.1"}
   "sexplib"       {< "v0.14"}
-  "ipaddr"        {>= "4.0.0"}
+  "ipaddr"        {>= "4.0.0" & < "5.0.0"}
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"

--- a/packages/charrua/charrua.1.1.0/opam
+++ b/packages/charrua/charrua.1.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_cstruct"
   "cstruct"       {>= "3.0.1"}
   "sexplib"       {< "v0.14"}
-  "ipaddr"        {>= "4.0.0"}
+  "ipaddr"        {>= "4.0.0" & < "5.0.0"}
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"

--- a/packages/charrua/charrua.1.2.0/opam
+++ b/packages/charrua/charrua.1.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_cstruct"
   "cstruct"       {>= "3.0.1"}
   "sexplib"       {< "v0.14"}
-  "ipaddr"        {>= "4.0.0"}
+  "ipaddr"        {>= "4.0.0" & < "5.0.0"}
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"

--- a/packages/charrua/charrua.1.2.1/opam
+++ b/packages/charrua/charrua.1.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_cstruct"
   "cstruct"       {>= "3.0.1"}
   "sexplib"       {< "v0.14"}
-  "ipaddr"        {>= "4.0.0"}
+  "ipaddr"        {>= "4.0.0" & < "5.0.0"}
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"

--- a/packages/mirage-nat/mirage-nat.1.2.0/opam
+++ b/packages/mirage-nat/mirage-nat.1.2.0/opam
@@ -14,6 +14,7 @@ build: [
 ]
 depends: [
   "ipaddr"
+  "ipaddr" {with-test & < "5.0.0"}
   "cstruct"
   "mirage-time-lwt"
   "mirage-clock-lwt"

--- a/packages/mirage-nat/mirage-nat.2.0.0/opam
+++ b/packages/mirage-nat/mirage-nat.2.0.0/opam
@@ -15,6 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "ipaddr"
+  "ipaddr" {with-test & < "5.0.0"}
   "cstruct"
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/mirage-nat/mirage-nat.2.1.0/opam
+++ b/packages/mirage-nat/mirage-nat.2.1.0/opam
@@ -15,6 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "ipaddr"
+  "ipaddr" {with-test & < "5.0.0"}
   "cstruct"
   "lwt"
   "rresult"

--- a/packages/mirage-nat/mirage-nat.2.2.0/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.0/opam
@@ -15,6 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "ipaddr"
+  "ipaddr" {with-test & < "5.0.0"}
   "cstruct"
   "lwt"
   "rresult"

--- a/packages/mirage-nat/mirage-nat.2.2.1/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.1/opam
@@ -15,6 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "ipaddr"
+  "ipaddr" {with-test & < "5.0.0"}
   "cstruct"
   "lwt"
   "rresult"

--- a/packages/tcpip/tcpip.4.0.0/opam
+++ b/packages/tcpip/tcpip.4.0.0/opam
@@ -33,6 +33,7 @@ depends: [
   "mirage-protocols" {>= "4.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "4.0.0"}
+  "ipaddr" {with-test & < "5.0.0"}
   "macaddr" {>="4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}

--- a/packages/tcpip/tcpip.4.1.0/opam
+++ b/packages/tcpip/tcpip.4.1.0/opam
@@ -33,6 +33,7 @@ depends: [
   "mirage-protocols" {>= "4.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "4.0.0"}
+  "ipaddr" {with-test & < "5.0.0"}
   "macaddr" {>="4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}

--- a/packages/tuntap/tuntap.1.8.1/opam
+++ b/packages/tuntap/tuntap.1.8.1/opam
@@ -24,7 +24,7 @@ using this library.
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune"
-  "ipaddr" {>= "4.0.0"}
+  "ipaddr" {>= "4.0.0" & < "5.0.0"}
   "macaddr" {>= "4.0.0"}
   "cmdliner"
   "ounit" {with-test}


### PR DESCRIPTION
followup of #16640, in order to get #16644 merged //cc @avsm