### PR TITLE
conduit-lwt-unix.2.2.2: disable package

### DIFF
--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.2.2/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.2.2/opam
@@ -29,6 +29,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 synopsis: "A network connection establishment library for Lwt_unix"
+available: false
 url {
   src:
     "https://github.com/mirage/ocaml-conduit/releases/download/v2.2.2/conduit-v2.2.2.tbz"


### PR DESCRIPTION
This causes a number of upstream users of cohttp-lwt-unix to
dynamically fail. Fix being discussed in https://github.com/mirage/ocaml-conduit/issues/318
so disabling package for now.