### PR TITLE
smart-print.0.3.0: dune install is not necessary when using deprecated_package_name

### DIFF
--- a/packages/smart-print/smart-print.0.3.0/opam
+++ b/packages/smart-print/smart-print.0.3.0/opam
@@ -9,12 +9,10 @@ license: "BSD-3-Clause"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.00.0"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
 ]
-build: make
+build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git://github.com/clarus/smart-print"
-install: [make "install"]
 synopsis: "A pretty-printing library in OCaml"
 
 url {


### PR DESCRIPTION
@clarus hi, sorry to make you change the opam description again. I thought the `(deprecate_package/library_name smart_print)` you're having was the reason you had a `dune install` in the first place. However after trying it, the resulting install file cleverly has the deprecate library in a separate section `lib_root` so everything is installed using the install file as it is the usual. So no need for calling `dune install` in the end.

Could you return the fix upstream?