### PR TITLE
Update asli upper bound on ott

### DIFF
--- a/packages/asli/asli.0.1/opam
+++ b/packages/asli/asli.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "menhir"
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "ott" {<= 0.30}
+  "ott" {< "0.31"}
   "pprint"
   "zarith"
   "z3" {<= "4.7.1"}

--- a/packages/asli/asli.0.1/opam
+++ b/packages/asli/asli.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "menhir"
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "ott"
+  "ott" {<= 0.30}
   "pprint"
   "zarith"
   "z3" {<= "4.7.1"}

--- a/packages/asli/asli.0.2.0/opam
+++ b/packages/asli/asli.0.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.5"}
   "ocaml" {>= "4.09"}
   "menhir" {build}
-  "ott" {<= 0.30 & build}
+  "ott" {< "0.31" & build}
   "linenoise"
   "pprint"
   "zarith"

--- a/packages/asli/asli.0.2.0/opam
+++ b/packages/asli/asli.0.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.5"}
   "ocaml" {>= "4.09"}
   "menhir" {build}
-  "ott" {build}
+  "ott" {<= 0.30 & build}
   "linenoise"
   "pprint"
   "zarith"


### PR DESCRIPTION
ASLI versions `<= 0.2.0` are not compatible with ott version `0.31` so I'm adding an upper bound. I will soon release ASLI `0.2.1` that builds on top of ott version `0.31` once both this PR and the ott PR are merged.