### PR TITLE
Add coq-of-ocaml.2.2.0

### DIFF
--- a/packages/coq-of-ocaml/coq-of-ocaml.2.2.0/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "dev@clarus.me"
+homepage: "https://github.com/clarus/coq-of-ocaml"
+dev-repo: "git+https://github.com/clarus/coq-of-ocaml.git"
+bug-reports: "https://github.com/clarus/coq-of-ocaml/issues"
+authors: ["Guillaume Claret"]
+license: "MIT"
+build: [
+  ["sh" "-c" "cd OCaml && ./configure.sh"] {coq:installed}
+  [make "-C" "OCaml" "-j%{jobs}%"] {coq:installed}
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "OCaml" "install"] {coq:installed}
+]
+depends: [
+  "dune" {build}
+  "menhir" {build}
+  "ocaml" {>= "4.09" & < "4.10"}
+  "ocamlfind" {build}
+  "smart-print"
+  "yojson" {>= "1.6.0"}
+]
+depopts: [
+  "coq"
+]
+conflicts: [
+  "coq" {< "8.11"}
+]
+tags: [
+  "keyword:compilation"
+  "keyword:ocaml"
+  "logpath:OCaml"
+]
+synopsis: "Compile a subset of OCaml to Coq"
+
+url {
+  src: "https://github.com/clarus/coq-of-ocaml/archive/2.2.0.tar.gz"
+  checksum: [
+    "sha256=ebbdecf7814cf0f122ea262d0d933240359641ac36514ebe0dc3569b8b531109"
+    "sha512=4f41ba7ea4059b11d29f945fa538aa36917a4f1e24524f4453cc4c2aac50c8114f917983252af766b23bfc504999cd52b2172d2c0fd960454db68ab7d0872655"
+  ]
+}

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.2.0/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.2.0/opam
@@ -8,7 +8,7 @@ license: "MIT"
 build: [
   ["sh" "-c" "cd OCaml && ./configure.sh"] {coq:installed}
   [make "-C" "OCaml" "-j%{jobs}%"] {coq:installed}
-  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "src/coqOfOCaml.exe"]
 ]
 install: [
   [make "-C" "OCaml" "install"] {coq:installed}

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.2.0/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.2.0/opam
@@ -14,7 +14,7 @@ install: [
   [make "-C" "OCaml" "install"] {coq:installed}
 ]
 depends: [
-  "dune" {build}
+  "dune" {>= "1.11"}
   "menhir" {build}
   "ocaml" {>= "4.09" & < "4.10"}
   "ocamlfind" {build}

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.2.0/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.2.0/opam
@@ -8,7 +8,7 @@ license: "MIT"
 build: [
   ["sh" "-c" "cd OCaml && ./configure.sh"] {coq:installed}
   [make "-C" "OCaml" "-j%{jobs}%"] {coq:installed}
-  [make "-j%{jobs}%"]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 install: [
   [make "-C" "OCaml" "install"] {coq:installed}

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.2.0/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.2.0/opam
@@ -8,7 +8,7 @@ license: "MIT"
 build: [
   ["sh" "-c" "cd OCaml && ./configure.sh"] {coq:installed}
   [make "-C" "OCaml" "-j%{jobs}%"] {coq:installed}
-  ["dune" "build" "-p" name "-j" jobs "src/coqOfOCaml.exe"]
+  ["dune" "build" "--profile=release" "-j" jobs "src/coqOfOCaml.exe"]
 ]
 install: [
   [make "-C" "OCaml" "install"] {coq:installed}


### PR DESCRIPTION
New release of coq-of-ocaml. The previous releases were on the Coq opam repository. The rationale for doing a release here is that it does not necessarily depend on Coq anymore (could be used as a lint tool for a CI for example).