### PR TITLE
[new release] mirage-nat (2.2.2)

### DIFF
--- a/packages/mirage-nat/mirage-nat.2.2.2/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+name: "mirage-nat"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+homepage: "https://github.com/mirage/mirage-nat"
+bug-reports: "https://github.com/mirage/mirage-nat/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-nat.git"
+doc: "https://mirage.github.io/mirage-nat/"
+license: "ISC"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "ipaddr"
+  "cstruct"
+  "lwt"
+  "rresult"
+  "logs"
+  "lru" {>= "0.3.0"}
+  "ppx_deriving" {>= "4.2" }
+  "dune" {>= "1.0"}
+  "tcpip" { >= "4.1.0" }
+  "ethernet" { >= "2.0.0" }
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+]
+synopsis: "Mirage-nat is a library for network address translation to be used with MirageOS"
+description: """
+Mirage-nat is a library for [network address
+translation](https://tools.ietf.org/html/rfc2663).  It is intended for use in
+[MirageOS](https://mirage.io) and makes extensive use of
+[tcpip](https://github.com/mirage/mirage-tcpip), the network stack used by
+default in MirageOS unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-nat/releases/download/v2.2.2/mirage-nat-v2.2.2.tbz"
+  checksum: [
+    "sha256=13bb4311777e890132480e569775088bd0b874346dd34be3e5c495111fcb511c"
+    "sha512=9fa978426c72929da22580fc07004ec186812c844bda6b001d68712a980be399194d0ea6a604ea1424a458204f3ae7d59679e328478fc2b2bfb1003073b497ec"
+  ]
+}


### PR DESCRIPTION
Mirage-nat is a library for network address translation to be used with MirageOS

- Project page: <a href="https://github.com/mirage/mirage-nat">https://github.com/mirage/mirage-nat</a>
- Documentation: <a href="https://mirage.github.io/mirage-nat/">https://mirage.github.io/mirage-nat/</a>

##### CHANGES:

- Avoid stack overflow in remove_connections (mirage/mirage-nat#42 by @linse @hannesm,
  reported by @talex5 in mirage/qubes-mirage-firewall#105)
- Compatibilty with ipaddr 5.0.0 (mirage/mirage-nat#41 by @hannesm)
