### PR TITLE
Package astring.0.8.4

### DIFF
--- a/packages/astring/astring.0.8.4/opam
+++ b/packages/astring/astring.0.8.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The astring programmers"]
+homepage: "https://erratique.ch/software/astring"
+doc: "https://erratique.ch/software/astring/doc"
+dev-repo: "git+http://erratique.ch/repos/astring.git"
+bug-reports: "https://github.com/dbuenzli/astring/issues"
+tags: [ "string" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build} ]
+build: [[ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]]
+
+synopsis: """Alternative String module for OCaml"""
+description: """\
+
+Astring exposes an alternative `String` module for OCaml. This module
+tries to balance minimality and expressiveness for basic, index-free,
+string processing and provides types and functions for substrings,
+string sets and string maps.
+
+Remaining compatible with the OCaml `String` module is a non-goal. The
+`String` module exposed by Astring has exception safe functions,
+removes deprecated and rarely used functions, alters some signatures
+and names, adds a few missing functions and fully exploits OCaml's
+newfound string immutability.
+
+Astring depends only on the OCaml standard library. It is distributed
+under the ISC license.
+"""
+url {
+archive: "https://erratique.ch/software/astring/releases/astring-0.8.4.tbz"
+checksum: "548fcbf501ca4cb816d219ca4f25f660"
+}


### PR DESCRIPTION
### `astring.0.8.4`
Alternative String module for OCaml
Astring exposes an alternative `String` module for OCaml. This module
tries to balance minimality and expressiveness for basic, index-free,
string processing and provides types and functions for substrings,
string sets and string maps.

Remaining compatible with the OCaml `String` module is a non-goal. The
`String` module exposed by Astring has exception safe functions,
removes deprecated and rarely used functions, alters some signatures
and names, adds a few missing functions and fully exploits OCaml's
newfound string immutability.

Astring depends only on the OCaml standard library. It is distributed
under the ISC license.



---
* Homepage: https://erratique.ch/software/astring
* Source repo: git+http://erratique.ch/repos/astring.git
* Bug tracker: https://github.com/dbuenzli/astring/issues

---
v0.8.4 2020-06-18 Zagreb
------------------------

- Handle `Pervasives`'s deprecation.
- Require OCaml 4.05
- Add conversions to/from Stdlib sets and maps. Thanks 
  to Hezekiah M. Carty for the patch.

---
:camel: Pull-request generated by opam-publish v2.0.2