### PR TITLE
Promise 1.1.0 - native version of a JS Promise binding

### DIFF
--- a/packages/promise/promise.1.1.0/opam
+++ b/packages/promise/promise.1.1.0/opam
@@ -26,5 +26,5 @@ build: [
 
 url {
   src: "https://github.com/aantron/promise/releases/download/1.1.0/promise-1.1.0.tar.gz"
-  checksum: "md5=bdda2b249c55cd05d2adc70d74b0cde0"
+  checksum: "md5=7a47733b4f8e5f1fdfdf124a9c11abe4"
 }

--- a/packages/promise/promise.1.1.0/opam
+++ b/packages/promise/promise.1.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+
+synopsis: "Native implementation of a JS promise binding"
+
+version: "1.1.0"
+license: "MIT"
+homepage: "https://github.com/aantron/promise"
+doc: "https://github.com/aantron/promise"
+bug-reports: "https://github.com/aantron/promise/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/promise.git"
+
+depends: [
+  "dune"
+  "ocaml"
+  "reason" {build & >= "3.3.2"}
+  "result"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "exec" "test/test_main.exe" "-p" name "-j" jobs] {with-test}
+]
+
+url {
+  src: "https://github.com/aantron/promise/releases/download/1.1.0/promise-1.1.0.tar.gz"
+  checksum: "md5=bdda2b249c55cd05d2adc70d74b0cde0"
+}


### PR DESCRIPTION
Changelog:

- Add `allOk`, `allOk2`...`allOk6`, `allOkArray` &mdash; fast-fail versions of `all` (aantron/promise#54, requested Jay Mithani).
- Compatibility with BuckleScript 8.0.0 (aantron/promise#56, reported Christoph Knittel).