### PR TITLE
Release tuntap 2.0.0

### DIFF
--- a/packages/charrua-unix/charrua-unix.0.1/opam
+++ b/packages/charrua-unix/charrua-unix.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "sexplib" {< "113.09.00"}
   "camlp4" {build}
   "ocamlbuild" {build}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "cstruct" {< "2.0"}
   "mtime" {< "1.0.0"}
 ]

--- a/packages/charrua-unix/charrua-unix.0.10/opam
+++ b/packages/charrua-unix/charrua-unix.0.10/opam
@@ -19,7 +19,7 @@ depends: [
   "cstruct-unix"
   "cmdliner"
   "rawlink" {<"1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "mtime" {>= "1.0.0"}
 ]
 synopsis: "DHCP - a DHCP client, server and wire frame encoder and decoder"

--- a/packages/charrua-unix/charrua-unix.0.11.0/opam
+++ b/packages/charrua-unix/charrua-unix.0.11.0/opam
@@ -18,7 +18,7 @@ depends: [
   "cstruct-unix"
   "cmdliner"
   "rawlink" {< "1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "mtime" {>= "1.0.0"}
 ]
 synopsis: "Unix DHCP daemon"

--- a/packages/charrua-unix/charrua-unix.0.11.1/opam
+++ b/packages/charrua-unix/charrua-unix.0.11.1/opam
@@ -18,7 +18,7 @@ depends: [
   "cstruct-unix"
   "cmdliner"
   "rawlink" {< "1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "mtime" {>= "1.0.0"}
 ]
 synopsis: "Unix DHCP daemon"

--- a/packages/charrua-unix/charrua-unix.0.11.2/opam
+++ b/packages/charrua-unix/charrua-unix.0.11.2/opam
@@ -18,7 +18,7 @@ depends: [
   "cstruct-unix"
   "cmdliner"
   "rawlink" {>= "1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "mtime" {>="1.0.0"}
 ]
 synopsis: "Unix DHCP daemon"

--- a/packages/charrua-unix/charrua-unix.0.12.0/opam
+++ b/packages/charrua-unix/charrua-unix.0.12.0/opam
@@ -18,7 +18,7 @@ depends: [
   "cstruct-unix"
   "cmdliner"
   "rawlink" {>= "1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "mtime" {>="1.0.0"}
 ]
 synopsis: "Unix DHCP daemon"

--- a/packages/charrua-unix/charrua-unix.0.3/opam
+++ b/packages/charrua-unix/charrua-unix.0.3/opam
@@ -18,7 +18,7 @@ depends: [
   "charrua-core" {>= "0.3" & < "0.4"}
   "cmdliner"
   "rawlink" {< "1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "Charrua DHCP Unix Server"
 description: """

--- a/packages/charrua-unix/charrua-unix.0.4/opam
+++ b/packages/charrua-unix/charrua-unix.0.4/opam
@@ -18,7 +18,7 @@ depends: [
   "charrua-core" {= "0.4"}
   "cmdliner"
   "rawlink" {< "1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
 ]
 synopsis: "Charrua DHCP Unix Server"
 description: """

--- a/packages/charrua-unix/charrua-unix.0.5/opam
+++ b/packages/charrua-unix/charrua-unix.0.5/opam
@@ -17,7 +17,7 @@ depends: [
   "charrua-core" {>= "0.5"}
   "cmdliner"
   "rawlink" {< "1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "mtime" {< "1.0.0"}
   "cstruct-unix" {= "0"}
 ]

--- a/packages/charrua-unix/charrua-unix.0.6/opam
+++ b/packages/charrua-unix/charrua-unix.0.6/opam
@@ -20,7 +20,7 @@ depends: [
   "charrua-core" {>= "0.5"}
   "cmdliner"
   "rawlink" {< "1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "mtime" {< "1.0.0"}
 ]
 synopsis: "DHCP Unix Server"

--- a/packages/charrua-unix/charrua-unix.0.9/opam
+++ b/packages/charrua-unix/charrua-unix.0.9/opam
@@ -18,7 +18,7 @@ depends: [
   "cstruct-unix"
   "cmdliner"
   "rawlink" {<"0.9"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "mtime" {>= "1.0.0"}
 ]
 synopsis: "DHCP - a DHCP client, server and wire frame encoder and decoder"

--- a/packages/charrua-unix/charrua-unix.1.0.0/opam
+++ b/packages/charrua-unix/charrua-unix.1.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "cstruct-unix"
   "cmdliner"
   "rawlink" {>= "1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "mtime" {>="1.0.0"}
 ]
 synopsis: "Unix DHCP daemon"

--- a/packages/charrua-unix/charrua-unix.1.1.0/opam
+++ b/packages/charrua-unix/charrua-unix.1.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "cstruct-unix"
   "cmdliner"
   "rawlink" {>= "1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "mtime" {>="1.0.0"}
 ]
 synopsis: "Unix DHCP daemon"

--- a/packages/charrua-unix/charrua-unix.1.2.0/opam
+++ b/packages/charrua-unix/charrua-unix.1.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "cstruct-unix"
   "cmdliner"
   "rawlink" {>= "1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "mtime" {>="1.0.0"}
 ]
 synopsis: "Unix DHCP daemon"

--- a/packages/charrua-unix/charrua-unix.1.2.1/opam
+++ b/packages/charrua-unix/charrua-unix.1.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "cstruct-unix"
   "cmdliner"
   "rawlink" {>= "1.0"}
-  "tuntap" {>= "1.2.0"}
+  "tuntap" {>= "1.2.0" & < "2.0.0"}
   "mtime" {>="1.0.0"}
 ]
 synopsis: "Unix DHCP daemon"

--- a/packages/tuntap/tuntap.2.0.0/opam
+++ b/packages/tuntap/tuntap.2.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "vb@luminar.eu.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-tuntap"
+doc: "https://mirage.github.io/ocaml-tuntap/"
+bug-reports: "https://github.com/mirage/ocaml-tuntap/issues"
+synopsis: "OCaml library for handling TUN/TAP devices"
+description: """
+This is an OCaml library for handling TUN/TAP devices.  TUN refers to layer 3
+virtual interfaces whereas TAP refers to layer 2 Ethernet ones.
+
+See <http://en.wikipedia.org/wiki/TUN/TAP> for more information.
+
+Linux, FreeBSD, OpenBSD and macOS should all be supported.  You will need
+to install the third-party <http://tuntaposx.sourceforge.net/> on macOS before
+using this library.
+"""
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "cmdliner"
+  "ounit" {with-test}
+  "lwt" {with-test & >= "5.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+dev-repo: "git+https://github.com/mirage/ocaml-tuntap.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tuntap/releases/download/v2.0.0/tuntap-v2.0.0.tbz"
+  checksum: [
+    "sha256=4abba9727156222a261e0daecfa54d4c337f5c690870e7f98c5f0e8884a6958b"
+    "sha512=e3bf0379906b5070ae5681ae74a1a74b9b987d1f37ff142fb10622d79db8df435c9db54a2d4d5d4dadaeab9aa9427b1d40262dbf445a88b3c3fe64bc93417647"
+  ]
+}


### PR DESCRIPTION
CHANGES:
    
* Adapt to ipaddr 5.0.0 interface (mirage/ocaml-tuntap#35 @hannesm)
* Since Ipaddr.Prefix.t now contain both IP address and netmask, the functions
      `getifaddrs{,_v4,_v6}`, `addrs_of_ifname`, and `{v4,v6}_of_ifname` no longer
      return Ipaddr.{V4,V6}.t * Ipaddr.{V4,V6}.Prefix.t, but only the latter part
      (mirage/ocaml-tuntap#35 @hannesm)
