### PR TITLE
[new release] mirage-crypto-pk, mirage-crypto, mirage-crypto-rng and mirage-crypto-rng-mirage (0.8.0)

### DIFF
--- a/packages/dns-cli/dns-cli.4.6.0/opam
+++ b/packages/dns-cli/dns-cli.4.6.0/opam
@@ -21,7 +21,7 @@ depends: [
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.10.0"}
   "mirage-crypto"
-  "mirage-crypto-rng" {>= "0.7.0"}
+  "mirage-crypto-rng" {>= "0.7.0" & < "0.8.0"}
   "hex" {>= "1.4.0"}
   "ptime" {>= "0.8.5"}
   "mtime" {>= "1.2.0"}

--- a/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.0/opam
+++ b/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "1.7.0"}
   "ocaml" {>= "4.07.0"}
   "cstruct" {>= "4.0.0"}
-  "mirage-runtime" {>= "3.7.0"}
+  "mirage-runtime" {>= "3.7.0" & < "3.8.0"}
   "lwt" {>= "4.0.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.1/opam
+++ b/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "1.7.0"}
   "ocaml" {>= "4.07.0"}
   "cstruct" {>= "4.0.0"}
-  "mirage-runtime" {>= "3.7.0"}
+  "mirage-runtime" {>= "3.7.0" & < "3.8.0"}
   "lwt" {>= "4.0.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.2/opam
+++ b/packages/mirage-crypto-entropy/mirage-crypto-entropy.0.6.2/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "1.7.0"}
   "ocaml" {>= "4.07.0"}
   "cstruct" {>= "4.0.0"}
-  "mirage-runtime" {>= "3.7.0"}
+  "mirage-runtime" {>= "3.7.0" & < "3.8.0"}
   "lwt" {>= "4.0.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.7"}
+  "rresult" {>= "0.6.0"}
+  ("mirage-no-xen" | "zarith-xen")
+  ("mirage-no-solo5" | "zarith-freestanding")
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.0/mirage-crypto-v0.8.0.tbz"
+  checksum: [
+    "sha256=30e65722b932523eeb5cf6ee3956e101980c687c2a1b83763ae19fb0874862f1"
+    "sha512=2bf0d94eddb5e513b72ccacbd1eec7d64001ac28b793e203a86cff483e2a308ad32a78f3c4bd5bfb1d0aa62e098f63834fa50c31b64a7842982bb5adef201556"
+  ]
+}

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.0/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.7.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.0/mirage-crypto-v0.8.0.tbz"
+  checksum: [
+    "sha256=30e65722b932523eeb5cf6ee3956e101980c687c2a1b83763ae19fb0874862f1"
+    "sha512=2bf0d94eddb5e513b72ccacbd1eec7d64001ac28b793e203a86cff483e2a308ad32a78f3c4bd5bfb1d0aa62e098f63834fa50c31b64a7842982bb5adef201556"
+  ]
+}

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.0/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.0/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-crypto-rng" {=version}
   "duration"
   "cstruct" {>= "4.0.0"}
-  "mirage-runtime" {>= "3.7.0"}
+  "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-unix" {with-test & >= "3.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.7.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.7.0/opam
@@ -26,7 +26,7 @@ depends: [
   "mtime"
   "lwt" {>= "4.0.0"}
 # mirage sublibrary
-  "mirage-runtime" {>= "3.7.0"}
+  "mirage-runtime" {>= "3.7.0" & < "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-unix" {with-test & >= "3.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator"
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "mirage-crypto" {=version}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+# lwt sublibrary
+  "mtime"
+  "lwt" {>= "4.0.0"}
+]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.0/mirage-crypto-v0.8.0.tbz"
+  checksum: [
+    "sha256=30e65722b932523eeb5cf6ee3956e101980c687c2a1b83763ae19fb0874862f1"
+    "sha512=2bf0d94eddb5e513b72ccacbd1eec7d64001ac28b793e203a86cff483e2a308ad32a78f3c4bd5bfb1d0aa62e098f63834fa50c31b64a7842982bb5adef201556"
+  ]
+}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.0/opam
@@ -26,6 +26,7 @@ depends: [
   "mtime"
   "lwt" {>= "4.0.0"}
 ]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
 description: """
 Mirage-crypto-rng provides a random number generator interface, and
 implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix

--- a/packages/mirage-crypto/mirage-crypto.0.8.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4), and hashes (MD5,
+SHA-1, SHA-2).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.0/mirage-crypto-v0.8.0.tbz"
+  checksum: [
+    "sha256=30e65722b932523eeb5cf6ee3956e101980c687c2a1b83763ae19fb0874862f1"
+    "sha512=2bf0d94eddb5e513b72ccacbd1eec7d64001ac28b793e203a86cff483e2a308ad32a78f3c4bd5bfb1d0aa62e098f63834fa50c31b64a7842982bb5adef201556"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* New package mirage-crypto-rng-mirage which contains the entropy collection
  code for MirageOS (mirage/mirage-crypto#69 requested by @samoht, implemented by @hannesm)
* Mirage_crypto_rng_lwt.initialize is not inside the Lwt monad anymore, and
  thus can be called by libraries at top level (mirage/mirage-crypto#69, requested by @avsm @xguerin
  @talex5 in mirage/ocaml-conduit#318, implemented by @hannesm)
* Both Mirage_crypto_rng_lwt.initialize and Mirage_crypto_rng_unix.initialize
  don't do anything if called a second time (mirage/mirage-crypto#69, implemented by @hannesm)
* Entropy source registration is now open and done via
  `Entropy.register_source : string -> source`, instead of a closed variant
  (mirage/mirage-crypto#69, fixes mirage/mirage-crypto#68, implemented by @hannesm)