### PR TITLE
conf-python-2.7: fix depext for alpine

### DIFF
--- a/packages/conf-python-2-7/conf-python-2-7.1.1/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.1/opam
@@ -8,7 +8,7 @@ build: ["python2.7" "test.py"]
 depexts: [
   ["python2.7"] {os-family = "debian"}
   ["python27"] {os-distribution = "nixos"}
-  ["python"] {os-distribution = "alpine"}
+  ["python2"] {os-distribution = "alpine"}
   ["python2"] {os-distribution = "centos"}
   ["python2"] {os-distribution = "fedora"}
   ["python2"] {os-distribution = "arch"}


### PR DESCRIPTION
seems to be 'python2' and not 'python', at least in alpine 3.11.
    
('python' is a virtual package, so 'apk add python' would work, but opam would still detect the depext as uninstalled)
    
Q: why are there two versions of this package, with apparently just one depext fixed between the two ?