### PR TITLE
Package tsdl.0.9.8

### DIFF
--- a/packages/tsdl/tsdl.0.9.8/opam
+++ b/packages/tsdl/tsdl.0.9.8/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The tsdl programmers"]
+homepage: "https://erratique.ch/software/tsdl"
+doc: "https://erratique.ch/software/tsdl/doc/Tsdl"
+dev-repo: "git+https://erratique.ch/repos/tsdl.git"
+bug-reports: "https://github.com/dbuenzli/tsdl/issues"
+tags: [ "audio" "bindings" "graphics" "media" "opengl" "input" "hci"
+        "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.1"}
+  "conf-sdl2"
+  "ctypes" {>= "0.9.0"}
+  "ctypes-foreign" ]
+build: [[ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]]
+
+synopsis: """Thin bindings to SDL for OCaml"""
+description: """\
+
+Tsdl is an OCaml library providing thin bindings to the cross-platform
+SDL C library.
+
+Tsdl depends on the [SDL 2.0.9][sdl] C library (or later),
+[ocaml-ctypes][ctypes] and the `result` compatibility package.
+Tsdl is distributed under the ISC license.
+
+[sdl]: http://www.libsdl.org/
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes
+"""
+url {
+archive: "https://erratique.ch/software/tsdl/releases/tsdl-0.9.8.tbz"
+checksum: "369236c7a00e485381722e3d9bae66c6"
+}


### PR DESCRIPTION
### `tsdl.0.9.8`
Thin bindings to SDL for OCaml
Tsdl is an OCaml library providing thin bindings to the cross-platform
SDL C library.

Tsdl depends on the [SDL 2.0.9][sdl] C library (or later),
[ocaml-ctypes][ctypes] and the `result` compatibility package.
Tsdl is distributed under the ISC license.

[sdl]: http://www.libsdl.org/
[ctypes]: https://github.com/ocamllabs/ocaml-ctypes



---
* Homepage: https://erratique.ch/software/tsdl
* Source repo: git+https://erratique.ch/repos/tsdl.git
* Bug tracker: https://github.com/dbuenzli/tsdl/issues

---
v0.9.8 2020-06-19 Zagreb
------------------------

- Fix bug in `Sdl.{queue_audio,dequeue_audio}`, sizes 
  were passed in terms of array length instead of bytes.
  Thanks to Enguerrand Decorne for the report and the patch.
- Release runtime lock during `Sdl.load_wav_rw`. Thanks 
  to Michael Bacarella for the patch.
- Add `Message_box.button_no_default` button flag. Thanks to 
  Simon Guilliams for the patch.

---
:camel: Pull-request generated by opam-publish v2.0.2