### PR TITLE
[new release] lablgtk3-sourceview3, lablgtk3-gtkspell3 and lablgtk3 3.1.1

### DIFF
--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.1/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3, gtkspell library
+
+See https://garrigue.github.io/lablgtk/ for more information.
+
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                { >= "4.05.0" }
+  "dune"                 { >= "1.8.0"  }
+  "lablgtk3"             {  = version  }
+]
+depexts: [
+  ["gtkspell3-dev"] {os-distribution = "alpine"}
+  ["gtkspell3"] {os-distribution = "archlinux"}
+  ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
+  ["libgtkspell3-3-dev"] {os-distribution = "debian"}
+  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3"] {os = "freebsd"}
+  ["gtkspell3"] {os = "openbsd"}
+  ["gtkspell3-devel"] {os-family = "suse"}
+  ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
+  ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.1.1/lablgtk3-3.1.1.tbz"
+  checksum: [
+    "sha256=22c7061c8acb49c1ccd0a19396d2b1d7d1d677e0ce7954122404be94a00fecf9"
+    "sha512=193c340d9941680869eb90bc89f5b27cc5bdf294f4635081a9ba56a99fa2982266c4ee2eb5fd04d3a3f6150082800de5df786def8c72a276a779d843d914e9e3"
+  ]
+}

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.1.1/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.1.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+ gtksourceview library"
+description: """
+OCaml interface to GTK+3, gtksourceview3 library.
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                {         >= "4.05.0" }
+  "dune"                 {         >= "1.8.0"  }
+  "lablgtk3"             {          = version  }
+  "conf-gtksourceview3"  { build & >= "0"      }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.1.1/lablgtk3-3.1.1.tbz"
+  checksum: [
+    "sha256=22c7061c8acb49c1ccd0a19396d2b1d7d1d677e0ce7954122404be94a00fecf9"
+    "sha512=193c340d9941680869eb90bc89f5b27cc5bdf294f4635081a9ba56a99fa2982266c4ee2eb5fd04d3a3f6150082800de5df786def8c72a276a779d843d914e9e3"
+  ]
+}

--- a/packages/lablgtk3/lablgtk3.3.1.1/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.1/opam
@@ -23,7 +23,7 @@ depends: [
 ]
 
 build: [
-  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "build" "-p" name "-j"  jobs ]
 ]
 url {
   src:

--- a/packages/lablgtk3/lablgtk3.3.1.1/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL with linking exception"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3"
+
+depends: [
+  "ocaml"     {         >= "4.05.0" }
+  "dune"      {         >= "1.8.0"  }
+  "cairo2"    {         >= "0.6"    }
+  "conf-gtk3" { build & >= "18"     }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.1.1/lablgtk3-3.1.1.tbz"
+  checksum: [
+    "sha256=22c7061c8acb49c1ccd0a19396d2b1d7d1d677e0ce7954122404be94a00fecf9"
+    "sha512=193c340d9941680869eb90bc89f5b27cc5bdf294f4635081a9ba56a99fa2982266c4ee2eb5fd04d3a3f6150082800de5df786def8c72a276a779d843d914e9e3"
+  ]
+}


### PR DESCRIPTION
New release of lablgtk3 and friends to circumvent -fno-common.

CHANGES:

2020.03.17 [Jerry James]
  * Fix the build with -fno-common, the default for GCC 10