### PR TITLE
LablGtk 2.18.11

### DIFF
--- a/packages/lablgtk/lablgtk.2.18.11/files/lablgldir.patch
+++ b/packages/lablgtk/lablgtk.2.18.11/files/lablgldir.patch
@@ -1,0 +1,12 @@
+diff -Naur lablgtk-2.16.0.orig/configure lablgtk-2.16.0/configure
+--- lablgtk-2.16.0.orig/configure	2012-08-23 12:37:48.000000000 +0200
++++ lablgtk-2.16.0/configure	2013-08-21 11:16:50.707187151 +0200
+@@ -4066,7 +4066,7 @@
+       cat > conftest.ml << EOF
+       open Raw
+ EOF
+-      if $CAMLC -c -I "${LABLGLDIR:=+lablGL}" conftest.ml > /dev/null 2>&1 ; then
++      if $CAMLC -c -I "$LABLGLDIR" conftest.ml > /dev/null 2>&1 ; then
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LABLGLDIR" >&5
+ $as_echo "$LABLGLDIR" >&6; }
+       else

--- a/packages/lablgtk/lablgtk.2.18.11/files/lablgtk.install
+++ b/packages/lablgtk/lablgtk.2.18.11/files/lablgtk.install
@@ -1,0 +1,5 @@
+bin: [
+  "src/lablgtk2"
+  "src/gdk_pixbuf_mlsource"
+  "?src/lablgladecc2"
+]

--- a/packages/lablgtk/lablgtk.2.18.11/opam
+++ b/packages/lablgtk/lablgtk.2.18.11/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "http://lablgtk.forge.ocamlcore.org/"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]
+  [make "world"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.05"}
+  "ocamlfind" {>= "1.2.1"}
+]
+depopts: [
+  "conf-gtksourceview"
+  "conf-gnomecanvas"
+  "conf-glade"
+  "lablgl"
+]
+depexts: [
+  ["libgtk2.0-dev" "libexpat1-dev"] {os-family = "debian"}
+  ["gtk" "expat"] {os-distribution = "homebrew" & os = "macos"}
+  ["gtk2-devel"] {os-distribution = "centos"}
+  ["gtk2-devel"] {os-distribution = "fedora"}
+  ["gtk2-devel"] {os-distribution = "ol"}
+  ["gtk+2.0-dev"] {os-distribution = "alpine"}
+  ["gtk2-devel"] {os-family = "suse"}
+]
+patches: ["lablgldir.patch"]
+post-messages: [
+  "This package requires gtk+ 2.0 development packages installed on your system"
+    {failure}
+  """
+To solve pkg-config issues, you may need to do
+'export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig' and retry"""
+    {failure & os = "macos"}
+]
+synopsis: "OCaml interface to GTK+"
+extra-files: [
+  ["lablgtk.install" "md5=1a3468258dd50aab33b9844db158b11a"]
+  ["lablgldir.patch" "md5=8cf5f3efbcb7bb8294424c30f77ea81f"]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/archive/2.18.11.tar.gz"
+  checksum: "md5=a21a5b52bfd8de0fad705e67817750ef"
+}


### PR DESCRIPTION
New release of lablgtk3 and friends to circumvent -fno-common.

CHANGES:

2020.03.17 [Jerry James]
  * Fix the build with -fno-common, the default for GCC 10