### PR TITLE
[new release] tcpip (5.0.0)

### DIFF
--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.6.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.6.0/opam
@@ -22,7 +22,7 @@ depends: [
   "arp-mirage" {with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
   "io-page-unix" {with-test}
-  "tcpip" {with-test}
+  "tcpip" {with-test & < "5.0.0"}
   "mirage-vnetif" {with-test}
   "dune" {>= "1.0"}
 ]

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.7.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.7.0/opam
@@ -22,7 +22,7 @@ depends: [
   "arp-mirage" {with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
   "io-page-unix" {with-test}
-  "tcpip" {with-test}
+  "tcpip" {with-test & < "5.0.0"}
   "mirage-vnetif" {with-test}
   "dune" {>= "1.0"}
 ]

--- a/packages/charrua/charrua.1.0.0/opam
+++ b/packages/charrua/charrua.1.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ipaddr"        {>= "3.0.0" & < "4.0.0"}
   "macaddr"
   "ethernet"      {>= "2.0.0"}
-  "tcpip"         {>= "3.7.0"}
+  "tcpip"         {>= "3.7.0" & < "5.0.0"}
   "rresult"
 ]
 synopsis: "DHCP wire frame encoder and decoder"

--- a/packages/charrua/charrua.1.1.0/opam
+++ b/packages/charrua/charrua.1.1.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ipaddr-sexp"
   "macaddr-sexp"
   "ethernet"      {>= "2.0.0"}
-  "tcpip"         {>= "3.7.0"}
+  "tcpip"         {>= "3.7.0" & < "5.0.0"}
   "rresult"
 ]
 synopsis: "DHCP wire frame encoder and decoder"

--- a/packages/charrua/charrua.1.2.0/opam
+++ b/packages/charrua/charrua.1.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ipaddr-sexp"
   "macaddr-sexp"
   "ethernet"      {>= "2.2.0"}
-  "tcpip"         {>= "4.0.0"}
+  "tcpip"         {>= "4.0.0" & < "5.0.0"}
   "rresult"
 ]
 synopsis: "DHCP wire frame encoder and decoder"

--- a/packages/charrua/charrua.1.2.1/opam
+++ b/packages/charrua/charrua.1.2.1/opam
@@ -24,7 +24,7 @@ depends: [
   "ipaddr-sexp"
   "macaddr-sexp"
   "ethernet"      {>= "2.2.0"}
-  "tcpip"         {>= "4.0.0"}
+  "tcpip"         {>= "4.0.0" & < "5.0.0"}
   "rresult"
 ]
 synopsis: "DHCP wire frame encoder and decoder"

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6.1/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6.1/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "jbuilder" {>= "1.0+beta9"}
   "mirage-qubes" {>= "0.6" & < "0.7.0"}
-  "tcpip" {>= "3.5.0"}
+  "tcpip" {>= "3.5.0" & < "5.0.0"}
   "ipaddr" {>= "3.0.0"}
   "mirage-random" {< "2.0.0"}
   "mirage-clock" {< "3.0.0"}

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.6/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {>= "1.0+beta9"}
   "mirage-qubes" {>= "0.6" & < "0.7.0"}
-  "tcpip" {>= "3.5.0"}
+  "tcpip" {>= "3.5.0" & < "5.0.0"}
   "ipaddr" {< "3.0.0"}
   "mirage-random" {< "2.0.0"}
   "mirage-clock" {< "3.0.0"}

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.7.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.7.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune" {>= "1.0"}
   "mirage-qubes" {>= "0.7.0"}
-  "tcpip" {>= "3.5.0"}
+  "tcpip" {>= "3.5.0" & < "5.0.0"}
   "ipaddr" {>= "3.0.0"}
   "mirage-random" {< "2.0.0"}
   "mirage-clock" {< "3.0.0"}

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "4.0.0" }
+  "tcpip" { >= "4.0.0" & < "5.0.0" }
   "ipaddr" { >= "3.0.0" }
   "mirage-random" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.1/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.1/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "4.0.0" }
+  "tcpip" { >= "4.0.0" & < "5.0.0" }
   "ipaddr" { >= "3.0.0" }
   "mirage-random" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.2/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.2/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "4.0.0" }
+  "tcpip" { >= "4.0.0" & < "5.0.0" }
   "ipaddr" { >= "3.0.0" }
   "mirage-random" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/tcpip/tcpip.5.0.0/opam
+++ b/packages/tcpip/tcpip.5.0.0/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs]
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depopts: ["mirage-xen-ocaml"]
+depends: [
+  "dune"
+  "dune-configurator"
+  "ocaml" {>= "4.06.0"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {>= "3.2.0"}
+  "cstruct-lwt"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv"
+  "ethernet" {>= "2.0.0"}
+  "mirage-flow" {with-test & >= "2.0.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "alcotest" {with-test & >="0.7.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "arp-mirage" {with-test & >= "2.0.0"}
+  "lru" {>= "0.3.0"}
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v5.0.0/tcpip-v5.0.0.tbz"
+  checksum: [
+    "sha256=e42e277b2abc354ca2d1dba6c66ce0e279647935e253983331bb563c6c13b8e0"
+    "sha512=d33cbb451462a4e299a5466cac6eab7ffff36dbaf784ebd243ee362e34f2d27e8e04a503b2d015c80a602971aeec07eeec167d50dde391af195e280f6d67713b"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Static_ipv4.connect API change: takes a cidr:Ipaddr.V4.Prefix.t instead of
  ip:Ipaddr.V4.t and network:Ipaddr.V4.Prefix.t (mirage/mirage-tcpip#426 @hannesm)
* Adapt to ipaddr 5.0.0 API changes (mirage/mirage-tcpip#426 @hannesm)