### PR TITLE
Release tls 0.12.2

### DIFF
--- a/packages/tls-mirage/tls-mirage.0.12.2/opam
+++ b/packages/tls-mirage/tls-mirage.0.12.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "tls" {= version}
+  "x509" {>= "0.10.0"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "hacl_x25519" {>= "0.1.1"}
+  "fiat-p256" {>= "0.2.1"}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"
+description: """
+Tls-mirage provides an effectful FLOW module to be used in the MirageOS
+ecosystem.
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.12.2/tls-v0.12.2.tbz"
+  checksum: [
+    "sha256=73787feb1bf8e2283f32dbaf6c473a0ae68bacec84c4602d2594a7d318d0eff2"
+    "sha512=da05243ba5c4141811487e2a6a7bf7a7df547bdb8f8fef9e23ac4ecf4cbc67cb8485d5078f0c59f4a66cd73cc39644cca4a53b6ae1fbce693829bc2284d93ec9"
+  ]
+}

--- a/packages/tls/tls.0.12.1/opam
+++ b/packages/tls/tls.0.12.1/opam
@@ -6,6 +6,7 @@ doc:          "https://mirleft.github.io/ocaml-tls/doc"
 maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
 license:      "BSD-2-Clause"
 
+available: false
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tls/tls.0.12.2/opam
+++ b/packages/tls/tls.0.12.2/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_cstruct" {>= "3.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "cstruct-sexp"
+  "sexplib"
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "x509" {>= "0.11.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt"
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "ounit" {with-test & >= "2.2.0"}
+  "lwt" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "hacl_x25519"
+  "fiat-p256"
+  "hkdf"
+  "logs"
+  "alcotest" {with-test}
+]
+
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.12.2/tls-v0.12.2.tbz"
+  checksum: [
+    "sha256=73787feb1bf8e2283f32dbaf6c473a0ae68bacec84c4602d2594a7d318d0eff2"
+    "sha512=da05243ba5c4141811487e2a6a7bf7a7df547bdb8f8fef9e23ac4ecf4cbc67cb8485d5078f0c59f4a66cd73cc39644cca4a53b6ae1fbce693829bc2284d93ec9"
+  ]
+}


### PR DESCRIPTION
CHANGES:
    
* tls_lwt again calls Mirage_crypto_rng_lwt.initialize () -- which is since
      mirage-crypto-rng 0.8 no longer inside the lwt monad, and safe to be called
      multiple times and on top level (mirleft/ocaml-tls#415 by @hannesm)

this also marks 0.12.1 as `available: false` due to semantics change in respect to RNG initialization between 0.12.0 and 0.12.1, which has been reverted in 0.12.2