### PR TITLE
allow OCaml < 4.10 for fstar dev-repo

### DIFF
--- a/packages/fstar/fstar.0.9.7.0-alpha1/opam
+++ b/packages/fstar/fstar.0.9.7.0-alpha1/opam
@@ -5,7 +5,7 @@ authors: "Nik Swamy <nswamy@microsoft.com>,Jonathan Protzenko <protz@microsoft.c
 homepage: "http://fstar-lang.org"
 license: "Apache-2.0"
 depends: [
-  "ocaml" {>= "4.04.0" & < "4.08.0"}
+  "ocaml" {>= "4.04.0" & ( < "4.08.0" | (dev & < "4.10.0")) }
   "ocamlfind"
   "batteries"
   "zarith"


### PR DESCRIPTION
Requested by @catalin-hritcu 

The current opam packages for F* do not allow OCaml >= 4.08. However, the latest F* `master` does compile with OCaml < 4.10.
Thus, this pull request is meant to make `opam pin fstar --dev-repo` work for OCaml < 4.10, as documented at https://github.com/FStarLang/FStar/blob/3025f90e008f5793e3755ab115aecb4c17ab3714/INSTALL.md#opam-package