### PR TITLE
mark conduit-lwt-unix 2.2.2 as available now that tls 0.12.2 is merged

### DIFF
--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.2.2/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.2.2/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depopts: ["tls" "lwt_ssl" "launchd"]
 conflicts: [
-  "tls" {< "0.11.0"}
+  "tls" {< "0.12.2"}
   "ssl" {< "0.5.9"}
 ]
 build: [
@@ -29,7 +29,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 synopsis: "A network connection establishment library for Lwt_unix"
-available: false
 url {
   src:
     "https://github.com/mirage/ocaml-conduit/releases/download/v2.2.2/conduit-v2.2.2.tbz"


### PR DESCRIPTION
fixes https://github.com/mirage/ocaml-conduit/issues/318 //cc @avsm