### PR TITLE
[new release] mirage-qubes and mirage-qubes-ipv4 (0.8.3)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.3/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "5.0.0" }
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-protocols" { >= "4.0.0" }
+  "cstruct" { >= "1.9.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.8.3/mirage-qubes-v0.8.3.tbz"
+  checksum: [
+    "sha256=5628b7f8076543a1d700d3d31c408b905cfad7506e05c97d3f8781c11133e548"
+    "sha512=527c9e35bd79311f720f3fe1c55c3628de3bcd20a51c7c63a0e8a13fe1eea4ce32d46ce22b3b5db409280a3549fcb61267844357ced6d23f3f7d49deffaf5c99"
+  ]
+}

--- a/packages/mirage-qubes/mirage-qubes.0.8.3/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.8.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "2.2.0" }
+  "ppx_cstruct"
+  "vchan-xen" { >= "5.0.0" }
+  "xen-evtchn"
+  "xen-gnt"
+  "mirage-xen" { >= "5.0.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.8.3/mirage-qubes-v0.8.3.tbz"
+  checksum: [
+    "sha256=5628b7f8076543a1d700d3d31c408b905cfad7506e05c97d3f8781c11133e548"
+    "sha512=527c9e35bd79311f720f3fe1c55c3628de3bcd20a51c7c63a0e8a13fe1eea4ce32d46ce22b3b5db409280a3549fcb61267844357ced6d23f3f7d49deffaf5c99"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- adapt to tcpip 5.0.0 API changes (mirage/mirage-qubes#53 @hannesm)