### PR TITLE
Wrong gcc10 patch for ocaml-base-compiler.4.08.0

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/files/fix-gcc10.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/files/fix-gcc10.patch
@@ -1,21 +1,43 @@
-commit e0746ecf225f9928929162a9381acfe13cbe0cd2
+commit 3f10a16153308f967149917585d2bc0b9c06492c
 Author: Anil Madhavapeddy <anil@recoil.org>
-Date:   Sun Jun 21 19:06:50 2020 +0100
+Date:   Sun Jun 21 18:40:27 2020 +0100
 
     Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
     
     Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
 
 diff --git a/configure b/configure
-index 1316b3c1e..74d4dc86e 100755
+index 9a78a4554..0c54b560b 100755
 --- a/configure
 +++ b/configure
-@@ -474,7 +474,7 @@ case "$ccfamily" in
+@@ -2676,7 +2676,7 @@ mkexe="\$(CC) \$(OC_CFLAGS) \$(OC_CPPFLAGS) \$(OC_LDFLAGS)"
+ 
+ # Flags for building executable files with debugging symbols
+ mkexedebugflag="-g"
+-common_cflags=""
++common_cflags="-fcommon"
+ common_cppflags=""
+ internal_cflags=""
+ internal_cppflags=""
+@@ -12412,7 +12412,7 @@ $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
  -fno-builtin-memcmp";
-     internal_cflags="$gcc_warnings";;
-   gcc-*)
+       internal_cflags="$gcc_warnings" ;; #(
+   gcc-*) :
 -    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
 +    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
-     internal_cflags="$gcc_warnings";;
-   *)
-     common_cflags="-O";;
+       internal_cflags="$gcc_warnings" ;; #(
+   msvc-*) :
+     common_cflags="-nologo -O2 -Gy- -MD"
+diff --git a/configure.ac b/configure.ac
+index f5d8a2687..775e0e2db 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -540,7 +540,7 @@ AS_CASE([$host],
+ -fno-builtin-memcmp";
+       internal_cflags="$gcc_warnings"],
+     [gcc-*],
+-      [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++      [common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+       internal_cflags="$gcc_warnings"],
+     [msvc-*],
+       [common_cflags="-nologo -O2 -Gy- -MD"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
@@ -41,6 +41,6 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [
-  ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"]
+  ["fix-gcc10.patch" "md5=5efa6fb26d162b542284b66258725629"]
   ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
 ]


### PR DESCRIPTION
Original patch was based on 4.07.0 - this is an adapted version of the 4.08.1 patch.

Fixes #16704

More concerningly, looking at https://ci.ocaml.org/log/saved/docker-build-44a468768d4752c9208169b668fd12fd/5f35736b306c8acb99075df64492711ae80aeb25 and various other logs from #16583, it would appear that the CI doesn't actually test the package at all?