### PR TITLE
2 packages from gitlab.com/nomadic-labs/ringo/-/archive/v0.5/ringo-v0.5.tar.gz

### DIFF
--- a/packages/ringo-lwt/ringo-lwt.0.5/opam
+++ b/packages/ringo-lwt/ringo-lwt.0.5/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+  "ringo" {= version }
+  "lwt"
+  "unix" { with-test }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Lwt-wrappers for Ringo caches"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.5/ringo-v0.5.tar.gz"
+  checksum: [
+    "md5=849b464c922398958bdd8c88994da58e"
+    "sha512=612838fe7bd2bc31c4cd541ca1821ac2d30520edda5345fcf1d90d687eba8a98103298e05682954c903de015ee4f2905d3e74181932b57c1cfc93a807a8b3b21"
+  ]
+}

--- a/packages/ringo/ringo.0.5/opam
+++ b/packages/ringo/ringo.0.5/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Caches (bounded-size key-value stores) and other bounded-size stores"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.5/ringo-v0.5.tar.gz"
+  checksum: [
+    "md5=849b464c922398958bdd8c88994da58e"
+    "sha512=612838fe7bd2bc31c4cd541ca1821ac2d30520edda5345fcf1d90d687eba8a98103298e05682954c903de015ee4f2905d3e74181932b57c1cfc93a807a8b3b21"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ringo.0.5`: Caches (bounded-size key-value stores) and other bounded-size stores
-`ringo-lwt.0.5`: Lwt-wrappers for Ringo caches



---
* Homepage: https://gitlab.com/nomadic-labs/ringo
* Source repo: git+https://gitlab.com/nomadic-labs/ringo.git
* Bug tracker: https://gitlab.com/nomadic-labs/ringo/issues

---
:camel: Pull-request generated by opam-publish v2.0.2