### PR TITLE
[new release] csexp (1.2.3)

### DIFF
--- a/packages/csexp/csexp.1.2.3/opam
+++ b/packages/csexp/csexp.1.2.3/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Parsing and printing of S-expressions in Canonical form"
+description: """
+
+This library provides minimal support for Canonical S-expressions
+[1]. Canonical S-expressions are a binary encoding of S-expressions
+that is super simple and well suited for communication between
+programs.
+
+This library only provides a few helpers for simple applications. If
+you need more advanced support, such as parsing from more fancy input
+sources, you should consider copying the code of this library given
+how simple parsing S-expressions in canonical form is.
+
+To avoid a dependency on a particular S-expression library, the only
+module of this library is parameterised by the type of S-expressions.
+
+[1] https://en.wikipedia.org/wiki/Canonical_S-expressions
+"""
+maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
+authors: [
+  "Quentin Hocquet <mefyl@gruntech.org>"
+  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jeremie Dimino <jeremie@dimino.org>"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-dune/csexp"
+doc: "https://ocaml-dune.github.io/csexp/"
+bug-reports: "https://github.com/ocaml-dune/csexp/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "ocaml" {>= "4.02.3"}
+  "ppx_expect" {with-test}
+  "result" {>= "1.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-dune/csexp.git"
+url {
+  src:
+    "https://github.com/ocaml-dune/csexp/releases/download/1.2.3/csexp-1.2.3.tbz"
+  checksum: [
+    "sha256=67023909a49dc872ed6c27bb0c85b628c18ceb0b89b9c9277d118e583307baa7"
+    "sha512=80793bb5b99301a73f56ef1f7c50dd4a4e415a21622025774ee4851215a163db008d891a3ed1007d63cb7296efe52078f881b242fd445e8d8cacef9c55c935b6"
+  ]
+}


### PR DESCRIPTION
Parsing and printing of S-expressions in Canonical form

- Project page: <a href="https://github.com/ocaml-dune/csexp">https://github.com/ocaml-dune/csexp</a>
- Documentation: <a href="https://ocaml-dune.github.io/csexp/">https://ocaml-dune.github.io/csexp/</a>

##### CHANGES:

- Fix `parse_string_many`; it used to fail on all inputs (ocaml-dune/csexp#6, @rgrinberg)
