### PR TITLE
[new release] ppx_irmin, irmin, irmin-test, irmin-mem, irmin-pack and irmin-graphql (2.2.0)

### DIFF
--- a/packages/irmin-chunk/irmin-chunk.2.2.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.2.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Mounir Nasr Allah" "Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.8.0"}
+  "irmin"      {>= "2.0.0"}
+  "lwt"
+  "irmin-mem"  {with-test & >= "2.0.0"}
+  "irmin-test" {with-test & >= "2.0.0"}
+]
+
+synopsis: "Irmin backend which allow to store values into chunks"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/irmin-fs/irmin-fs.2.2.0/opam
+++ b/packages/irmin-fs/irmin-fs.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "1.8.0"}
+  "irmin"      {>= "2.0.0"}
+  "irmin-test" {with-test & >= "2.0.0"}
+]
+
+synopsis: "Generic file-system backend for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/irmin-git/irmin-git.2.2.0/opam
+++ b/packages/irmin-git/irmin-git.2.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.8.0"}
+  "irmin"      {>= "2.0.0"}
+  "git"        {>= "2.1.1"}
+  "digestif"   {>= "0.7.3"}
+  "irmin-test" {with-test & >= "2.0.0"}
+  "irmin-mem"  {with-test & >= "2.0.0"}
+  "git-unix"   {with-test & >= "2.1.1"}
+  "mtime"      {with-test & >= "1.0.0"}
+]
+
+synopsis: "Git backend for Irmin"
+description: """
+`Irmin_git` expose a bi-directional bridge between Git repositories and
+Irmin stores.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/irmin-graphql/irmin-graphql.2.2.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors:      "Andreas Garnaes <andreas.garnaes@gmail.com>"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.03.0"}
+  "dune"    {>= "1.8.0"}
+  "irmin"   {>= "2.0.0"}
+  "graphql" {>= "0.13.0"}
+  "graphql-lwt" {>= "0.13.0"}
+  "graphql-cohttp" {>= "0.13.0"}
+  "cohttp-lwt"
+  "graphql_parser" {>= "0.13.0"}
+  "alcotest-lwt" {>= "1.1.0" & with-test}
+  "yojson" {with-test}
+  "irmin-mem" {with-test}
+  "cohttp-lwt-unix" {with-test}
+]
+
+
+synopsis: "GraphQL server for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/irmin-graphql/irmin-graphql.2.2.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.2.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"   {>= "4.03.0"}
   "dune"    {>= "1.8.0"}
-  "irmin"   {>= "2.0.0"}
+  "irmin"   {>= "2.2.0"}
   "graphql" {>= "0.13.0"}
   "graphql-lwt" {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}

--- a/packages/irmin-http/irmin-http.2.2.0/opam
+++ b/packages/irmin-http/irmin-http.2.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.8.0"}
+  "crunch"     {>= "2.2.0"}
+  "webmachine" {>= "0.6.0"}
+  "irmin"      {>= "2.0.0"}
+  "cohttp-lwt" {>= "1.0.0"}
+  "irmin-git"  {with-test & >= "2.0.0"}
+  "irmin-mem"  {with-test & >= "2.0.0"}
+  "irmin-test" {with-test & >= "2.0.0"}
+  "git-unix"   {with-test}
+  "digestif"   {with-test & >= "0.6.1"}
+]
+
+synopsis: "HTTP client and server for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/irmin-http/irmin-http.2.2.0/opam
+++ b/packages/irmin-http/irmin-http.2.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"       {>= "1.8.0"}
   "crunch"     {>= "2.2.0"}
   "webmachine" {>= "0.6.0"}
-  "irmin"      {>= "2.0.0"}
+  "irmin"      {>= "2.2.0"}
   "cohttp-lwt" {>= "1.0.0"}
   "irmin-git"  {with-test & >= "2.0.0"}
   "irmin-mem"  {with-test & >= "2.0.0"}

--- a/packages/irmin-mem/irmin-mem.2.2.0/opam
+++ b/packages/irmin-mem/irmin-mem.2.2.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"      {>= "4.03.0"}
   "dune"       {>= "1.8.0"}
-  "irmin"      {>= "2.0.0"}
+  "irmin"      {>= "2.2.0"}
   "irmin-test" {with-test}
 ]
 

--- a/packages/irmin-mem/irmin-mem.2.2.0/opam
+++ b/packages/irmin-mem/irmin-mem.2.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "1.8.0"}
+  "irmin"      {>= "2.0.0"}
+  "irmin-test" {with-test}
+]
+
+
+synopsis: "Generic in-memory Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.2.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"       {>= "1.8.0"}
+  "irmin-mirage"
+  "irmin-git"  {>= "2.0.0"}
+  "git-mirage" {>= "2.1.2"}
+  "mirage-kv" {>= "3.0.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.2.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"    {>= "1.8.0"}
+  "irmin-mirage"
+  "git-mirage" {>= "2.1.1"}
+  "irmin-graphql"
+  "mirage-clock"
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/irmin-mirage/irmin-mirage.2.2.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"       {>= "1.8.0"}
+  "irmin"      {>= "2.0.0"}
+  "irmin-mem"  {>= "2.0.0"}
+  "ptime"
+  "mirage-clock" {>= "3.0.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/irmin-pack/irmin-pack.2.2.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.2.0/opam
@@ -15,10 +15,10 @@ build: [
 depends: [
   "ocaml"      {>= "4.02.3"}
   "dune"       {>= "1.8.0"}
-  "irmin"      {>= "2.0.0"}
+  "irmin"      {>= "2.2.0"}
   "index"      {>= "1.2.1"}
   "lwt"
-  "irmin-test" {with-test & >= "2.0.0"}
+  "irmin-test" {with-test & >= "2.2.0"}
   "alcotest-lwt" {with-test}
 ]
 

--- a/packages/irmin-pack/irmin-pack.2.2.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.8.0"}
+  "irmin"      {>= "2.0.0"}
+  "index"      {>= "1.2.1"}
+  "lwt"
+  "irmin-test" {with-test & >= "2.0.0"}
+  "alcotest-lwt" {with-test}
+]
+
+synopsis: "Irmin backend which stores values in a pack file"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/irmin-test/irmin-test.2.2.0/opam
+++ b/packages/irmin-test/irmin-test.2.2.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml"    {>= "4.02.3"}
   "dune"     {>= "1.8.0"}
-  "irmin"    {>= "2.0.0"}
+  "irmin"    {>= "2.2.0"}
   "alcotest" {>= "1.0.1"}
   "mtime"    {>= "1.0.0"}
   "metrics-unix"

--- a/packages/irmin-test/irmin-test.2.2.0/opam
+++ b/packages/irmin-test/irmin-test.2.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"    {>= "4.02.3"}
+  "dune"     {>= "1.8.0"}
+  "irmin"    {>= "2.0.0"}
+  "alcotest" {>= "1.0.1"}
+  "mtime"    {>= "1.0.0"}
+  "metrics-unix"
+]
+
+synopsis: "Irmin test suite"
+description: """
+`irmin-test` provides access to the Irmin test suite for testing storage backend
+implementations.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/irmin-unix/irmin-unix.2.2.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.2.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.01.0"}
+  "dune"          {>= "1.8.0"}
+  "irmin"         {>= "2.1.0"}
+  "irmin-mem"     {>= "2.0.0"}
+  "irmin-git"     {>= "2.0.0"}
+  "irmin-http"    {>= "2.0.0"}
+  "irmin-fs"      {>= "2.0.0"}
+  "irmin-pack"    {>= "2.0.0"}
+  "irmin-graphql"
+  "git-unix"      {>= "1.11.4"}
+  "digestif"      {>= "0.6.1"}
+  "irmin-watcher" {>= "0.2.0"}
+  "yaml"          {>= "0.1.0"}
+  "irmin-test"    {with-test & >= "2.0.0"}
+]
+
+synopsis: "Unix backends for Irmin"
+description: """
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/irmin/irmin.2.2.0/opam
+++ b/packages/irmin/irmin.2.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.07.0"}
+  "dune"    {>= "1.8.0"}
+  "fmt"     {>= "0.8.0"}
+  "uri"     {>= "1.3.12"}
+  "jsonm"   {>= "1.0.0"}
+  "lwt"     {>= "2.4.7"}
+  "base64"  {>= "2.0.0"}
+  "digestif"
+  "ocamlgraph"
+  "logs"    {>= "0.5.0"}
+  "astring"
+  "hex"      {with-test}
+  "alcotest" {with-test}
+  "ppx_irmin" {with-test}
+]
+synopsis: """
+Irmin, a distributed database that follows the same design principles as Git
+"""
+description: """
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}

--- a/packages/ppx_irmin/ppx_irmin.2.2.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Craig Ferguson <craig@tarides.com>"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mirage/irmin.git"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.06.0"}
+  "ocaml-syntax-shims"
+  "ppxlib" {= "0.12.0"}
+  "irmin" {with-test & >= "2.0.0"}
+]
+
+synopsis: "PPX deriver for Irmin generics"
+authors: "Craig Ferguson <craig@tarides.com>"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.2.0/irmin-2.2.0.tbz"
+  checksum: [
+    "sha256=a44e018495336e0f632433fcae7b4e84699938a7110212da9e3818b35048fc3f"
+    "sha512=8dd9e9f09877a5541ee1be3387e041f63e6b522f9efac388d72199f965b0692f2502e93c1ddc2a5f959289fa2f75f06849582cffbcc201de19e9bd50413f6115"
+  ]
+}


### PR DESCRIPTION
Packages for the Irmin distributed database library.

The corresponding PR on Irmin is https://github.com/mirage/irmin/pull/1018.

- Project page: <a href="https://github.com/mirage/irmin">https://github.com/mirage/irmin</a>

##### CHANGES:

#### Added

- **irmin**:
  - Added `Irmin.Type.empty` to represent an uninhabited type. (mirage/irmin#961, @CraigFe)
  - Added `Store.Tree.concrete_t`. (mirage/irmin#1003, @CraigFe)

- **ppx_irmin**
  - Added support for the `@nobuiltin` attribute, which can be used when
    shadowing primitive types such as `unit`. See `README_PPX` for details.
    (mirage/irmin#993, @CraigFe)

  - Added support for a `lib` argument, which can be used to supply primitive
    type representations from modules other than `Irmin.Type`. (mirage/irmin#994, @CraigFe)

#### Changed

- **irmin**:
  - Require OCaml 4.07 (mirage/irmin#961, @CraigFe)
  - Add sanity checks when creating `Irmin.Type` records, variants and enums
    (mirage/irmin#956 and mirage/irmin#966, @liautaud):
     - `Irmin.Type.{sealr,sealv,enum}` will now raise `Invalid_argument` if two
       components have the same name;
     - `Irmin.Type.{field,case0,case1}` will now raise `Invalid_argument` if
       the component name is not a valid UTF-8 string.
  - Changed the JSON encoding of options and unit to avoid ambiguous cases
    (mirage/irmin#967, @liautaud):
    - `()` is now encoded as `{}`;
    - `None` is now encoded as `null`;
    - `Some x` is now encoded as `{"some": x}`;
    - Fields of records which have value `None` are still omitted;
    - Fields of records which have value `Some x` are still unboxed into `x`.

  - Changed pretty-printing of Irmin types to more closely resemble OCaml types.
    e.g. `pair int string` prints as `int * string`. (mirage/irmin#997, @CraigFe)

  - The type `Irmin.S.tree` is now abstract. The previous form can be coerced
    to/from the abstract representation with the new functions
    `Irmin.S.Tree.{v,destruct}` respectively. (mirage/irmin#990, @CraigFe)
    
- **irmin-mem**
  - Stores created with `KV` now expose their unit metadata type. (mirage/irmin#995,
    @CraigFe)

#### Fixed

- **irmin-graphql**
  - Fixed an issue with keys inside `get_{contents,tree}` fields having
    incorrect ordering (mirage/irmin#989, @CraigFe)
