### PR TITLE
[new release] cohttp-lwt-jsoo, cohttp, cohttp-lwt, cohttp-lwt-unix, cohttp-top, cohttp-async and cohttp-mirage (2.5.2)

### DIFF
--- a/packages/cohttp-async/cohttp-async.2.5.2/opam
+++ b/packages/cohttp-async/cohttp-async.2.5.2/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for the Async concurrency library"
+description: """
+An implementation of an HTTP client and server using the Async
+concurrency library. See the `Cohttp_async` module for information
+on how to use this.  The package also installs `cohttp-curl-async`
+and a `cohttp-server-async` binaries for quick uses of a HTTP(S)
+client and server respectively.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.1.0"}
+  "async_kernel" {>= "v0.13.0"}
+  "async_unix" {>= "v0.13.0"}
+  "async" {>= "v0.13.0"}
+  "base" {>= "v0.11.0"}
+  "core" {with-test}
+  "cohttp" {=version}
+  "conduit-async" {>="1.2.0"}
+  "magic-mime"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "sexplib0"
+  "stdlib-shims"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "ounit" {with-test}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.2/cohttp-v2.5.2.tbz"
+  checksum: [
+    "sha256=37bbb95e4b8f5fa9ffa6e3e38693c50369f32137eeae70d528cafe76a92a449a"
+    "sha512=736bf5ee0765096ea654a6378d349a8ae52b8c134bc959ae307cf830c84f4010aa8b152a8c1c141696616766f6a3b24e0a61c0873215cc7f24a0083c7d6a9197"
+  ]
+}

--- a/packages/cohttp-async/cohttp-async.2.5.2/opam
+++ b/packages/cohttp-async/cohttp-async.2.5.2/opam
@@ -25,9 +25,9 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.1.0"}
-  "async_kernel" {>= "v0.13.0"}
-  "async_unix" {>= "v0.13.0"}
-  "async" {>= "v0.13.0"}
+  "async_kernel" {>= "v0.13.0" & < "v0.14.0"}
+  "async_unix" {>= "v0.13.0" & < "v0.14.0"}
+  "async" {>= "v0.13.0" & < "v0.14.0"}
   "base" {>= "v0.11.0"}
   "core" {with-test}
   "cohttp" {=version}

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.5.2/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.5.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for the Js_of_ocaml JavaScript compiler"
+description: """
+An implementation of an HTTP client for JavaScript, but using the
+CoHTTP types.  This lets you build HTTP clients that can compile
+natively (using one of the other Cohttp backends such as `cohttp-lwt-unix`)
+and also to native JavaScript via js_of_ocaml.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.1.0"}
+  "cohttp" {=version}
+  "cohttp-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "js_of_ocaml" {>= "3.3.0"}
+  "js_of_ocaml-ppx" {>= "3.3.0"}
+  "js_of_ocaml-lwt" {>= "3.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.2/cohttp-v2.5.2.tbz"
+  checksum: [
+    "sha256=37bbb95e4b8f5fa9ffa6e3e38693c50369f32137eeae70d528cafe76a92a449a"
+    "sha512=736bf5ee0765096ea654a6378d349a8ae52b8c134bc959ae307cf830c84f4010aa8b152a8c1c141696616766f6a3b24e0a61c0873215cc7f24a0083c7d6a9197"
+  ]
+}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.5.2/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.5.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for Unix and Windows using Lwt"
+description: """
+An implementation of an HTTP client and server using the Lwt
+concurrency library. See the `Cohttp_lwt_unix` module for information
+on how to use this.  The package also installs `cohttp-curl-lwt`
+and a `cohttp-server-lwt` binaries for quick uses of a HTTP(S)
+client and server respectively.
+
+Although the name implies that this only works under Unix, it
+should also be fine under Windows too."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.1.0"}
+  "conduit-lwt-unix" {>= "1.0.3"}
+  "cmdliner"
+  "magic-mime"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "cohttp-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "base-unix"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.2/cohttp-v2.5.2.tbz"
+  checksum: [
+    "sha256=37bbb95e4b8f5fa9ffa6e3e38693c50369f32137eeae70d528cafe76a92a449a"
+    "sha512=736bf5ee0765096ea654a6378d349a8ae52b8c134bc959ae307cf830c84f4010aa8b152a8c1c141696616766f6a3b24e0a61c0873215cc7f24a0083c7d6a9197"
+  ]
+}

--- a/packages/cohttp-lwt/cohttp-lwt.2.5.2/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.2.5.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation using the Lwt concurrency library"
+description: """
+This is a portable implementation of HTTP that uses the Lwt
+concurrency library to multiplex IO.  It implements as much of the
+logic in an OS-independent way as possible, so that more specialised
+modules can be tailored for different targets.  For example, you
+can install `cohttp-lwt-unix` or `cohttp-lwt-jsoo` for a Unix or
+JavaScript backend, or `cohttp-mirage` for the MirageOS unikernel
+version of the library. All of these implementations share the same
+IO logic from this module."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.1.0"}
+  "cohttp" {=version}
+  "lwt" {>= "2.5.0"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.2/cohttp-v2.5.2.tbz"
+  checksum: [
+    "sha256=37bbb95e4b8f5fa9ffa6e3e38693c50369f32137eeae70d528cafe76a92a449a"
+    "sha512=736bf5ee0765096ea654a6378d349a8ae52b8c134bc959ae307cf830c84f4010aa8b152a8c1c141696616766f6a3b24e0a61c0873215cc7f24a0083c7d6a9197"
+  ]
+}

--- a/packages/cohttp-mirage/cohttp-mirage.2.5.2/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.5.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+synopsis: "CoHTTP implementation for the MirageOS unikernel"
+description: """
+This HTTP implementation uses the Cohttp portable implementaiton
+along with the Lwt threading library in order to provide a
+`Cohttp_mirage` functor that can be used in MirageOS unikernels
+to build very small and efficient HTTP clients and servers
+without having a hard dependency on an underlying operating
+system.
+
+Please see <https://mirage.io> for a self-hosted explanation
+and instructions on how to use this library."""
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+  "conduit" {>= "2.0.2"}
+  "conduit-mirage" {>= "2.0.2"}
+  "mirage-kv" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp"
+  "cohttp-lwt"
+  "astring"
+  "magic-mime"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.2/cohttp-v2.5.2.tbz"
+  checksum: [
+    "sha256=37bbb95e4b8f5fa9ffa6e3e38693c50369f32137eeae70d528cafe76a92a449a"
+    "sha512=736bf5ee0765096ea654a6378d349a8ae52b8c134bc959ae307cf830c84f4010aa8b152a8c1c141696616766f6a3b24e0a61c0873215cc7f24a0083c7d6a9197"
+  ]
+}

--- a/packages/cohttp-top/cohttp-top.2.5.2/opam
+++ b/packages/cohttp-top/cohttp-top.2.5.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP toplevel pretty printers for HTTP types"
+description: """
+This library installs toplevel prettyprinters for CoHTTP
+types such as the `Request`, `Response` and `Types` modules.
+Once this library has been loaded, you can directly see the
+values of those types in toplevels such as `utop` or `ocaml`."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.1.0"}
+  "cohttp" {=version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.2/cohttp-v2.5.2.tbz"
+  checksum: [
+    "sha256=37bbb95e4b8f5fa9ffa6e3e38693c50369f32137eeae70d528cafe76a92a449a"
+    "sha512=736bf5ee0765096ea654a6378d349a8ae52b8c134bc959ae307cf830c84f4010aa8b152a8c1c141696616766f6a3b24e0a61c0873215cc7f24a0083c7d6a9197"
+  ]
+}

--- a/packages/cohttp/cohttp.2.5.2/opam
+++ b/packages/cohttp/cohttp.2.5.2/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries.
+
+See the cohttp-async, cohttp-lwt, cohttp-lwt-unix, cohttp-lwt-jsoo and
+cohttp-mirage libraries for concrete implementations for particular
+targets.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.1.0"}
+  "re" {>= "1.9.0"}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "fieldslib"
+  "sexplib0"
+  "ppx_fields_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "stringext"
+  "base64" {>= "3.1.0"}
+  "stdlib-shims"
+  "fmt" {with-test}
+  "jsonm" {build}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.2/cohttp-v2.5.2.tbz"
+  checksum: [
+    "sha256=37bbb95e4b8f5fa9ffa6e3e38693c50369f32137eeae70d528cafe76a92a449a"
+    "sha512=736bf5ee0765096ea654a6378d349a8ae52b8c134bc959ae307cf830c84f4010aa8b152a8c1c141696616766f6a3b24e0a61c0873215cc7f24a0083c7d6a9197"
+  ]
+}


### PR DESCRIPTION
CoHTTP 

- Project page: <a href="https://github.com/mirage/ocaml-cohttp">https://github.com/mirage/ocaml-cohttp</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cohttp/">https://mirage.github.io/ocaml-cohttp/</a>

##### CHANGES:

- cohttp, cohttp-async: correctly set host header for unix domain sockets,
  implement Unix domain socket support for cohttp-async (mirage/ocaml-cohttp#698 @Leonidas-from-XIV)
- cohttp: better body encoding management when creating request and
  response, and correction of Header.replace function (mirage/ocaml-cohttp#694 @lyrm)
