### PR TITLE
Package tdigest.0.1.0

### DIFF
--- a/packages/tdigest/tdigest.0.1.0/opam
+++ b/packages/tdigest/tdigest.0.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Simon Grondin"
+authors: [
+  "Simon Grondin"
+  "Will Welch"
+]
+synopsis: "OCaml implementation of the T-Digest algorithm"
+description: """
+The T-Digest is a data structure and algorithm for constructing an approximate distribution for a collection of real numbers presented as a stream.
+
+The T-Digest can estimate percentiles or quantiles extremely accurately even at the tails, while using a fraction of the space.
+
+Additionally, the T-Digest is concatenable, making it a good fit for distributed systems. The internal state of a T-Digest can be exported as a binary string, and the concatenation of any number of those strings can then be imported to form a new T-Digest.
+"""
+license: "MIT"
+homepage: "https://github.com/SGrondin/tdigest"
+dev-repo: "git://github.com/SGrondin/tdigest"
+doc: "https://github.com/SGrondin/tdigest"
+bug-reports: "https://github.com/SGrondin/tdigest/issues"
+depends: [
+  "ocaml" {>= "4.08.1"}
+  "dune" {>= "1.9.0"}
+
+  "core_kernel" { >= "v0.13.0" & < "v0.15.0" }
+
+  "alcotest" { with-test }
+  "yojson" { with-test }
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/SGrondin/tdigest/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=a5253dec749621a8dc2484c92f087975"
+    "sha512=2eb1428a137fc2515af945e15a06cb49c3d7e8c0260f82b7f1391f94861ceea788f9f3a44671ed95d22f994a524cd0ce677913ac52aa0f3f589a28c1e664089c"
+  ]
+}


### PR DESCRIPTION
### `tdigest.0.1.0`
OCaml implementation of the T-Digest algorithm
OCaml implementation of the T-Digest algorithm.

The T-Digest is a data structure and algorithm for constructing an approximate distribution for a collection of real numbers presented as a stream.

The T-Digest can estimate percentiles or quantiles extremely accurately even at the tails, while using a fraction of the space.

Additionally, the T-Digest is concatenable, making a good fit for distributed systems. The internal state of a T-Digest can be exported as a binary string, and the concatenation of any number of those strings can then be imported to form a new T-Digest.



---
* Homepage: https://github.com/SGrondin/tdigest
* Bug tracker: https://github.com/SGrondin/tdigest/issues

---
:camel: Pull-request generated by opam-publish v2.0.2