### PR TITLE
async_ssl does not build with dune-configurator.1.0.0

### DIFF
--- a/packages/async_ssl/async_ssl.v0.13.0/opam
+++ b/packages/async_ssl/async_ssl.v0.13.0/opam
@@ -22,6 +22,9 @@ depends: [
   "dune"           {>= "1.5.1"}
   "dune-configurator"
 ]
+conflicts: [
+  "dune-configurator" {= "1.0.0"}
+]
 synopsis: "An Async-pipe-based interface with OpenSSL"
 description: "
 This library allows you to create an SSL client and server, with


### PR DESCRIPTION
I currently don't have the time to investigate whether this is the case with newer versions as well so here's the PR for v0.13.0 which had the issue for me.

Closes #16729.