### PR TITLE
First beta release for OCaml 4.11.0

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+afl/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "First beta for 4.11.0, with afl-fuzz instrumentation"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
+    {os != "openbsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--with-afl"
+    "--disable-debug-runtime"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+beta1.tar.gz"
+  checksum: "sha256=0fd4b6595faee91257dac496bae593bc28de8b385aa9386a2b5cf37c093a1fe4"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+flambda/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "First beta for 4.11.0, with flambda activated"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
+    {os != "openbsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+beta1.tar.gz"
+  checksum: "sha256=0fd4b6595faee91257dac496bae593bc28de8b385aa9386a2b5cf37c093a1fe4"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp+flambda/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "First beta for 4.11.0, with frame-pointers and flambda activated"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+  ] {os != "openbsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+beta1.tar.gz"
+  checksum: "sha256=0fd4b6595faee91257dac496bae593bc28de8b385aa9386a2b5cf37c093a1fe4"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "First beta for 4.11.0, with frame pointers"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+  ] {os != "openbsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+beta1.tar.gz"
+  checksum: "sha256=0fd4b6595faee91257dac496bae593bc28de8b385aa9386a2b5cf37c093a1fe4"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "First beta for 4.11.0"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+beta1.tar.gz"
+  checksum: "sha256=0fd4b6595faee91257dac496bae593bc28de8b385aa9386a2b5cf37c093a1fe4"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]


### PR DESCRIPTION
There are a handful of new fixes for this beta:

### Compiler driver

- 9011: Allow linking .cmxa files with no units on MSVC by not requiring the
  .lib file to be present.
  (David Allsopp, report by Dimitry Bely, review by Xavier Leroy)

### Typechecker

- 9384, 9385: Fix copy scope bugs in substitutions
  (Leo White, review by Thomas Refis, report by Nick Roberts)

- 9695, 9702: no error when opening an alias to a missing module
  (Jacques Garrigue, report and review by Gabriel Scherer)

### Warning messages 
- 7897, 9537: Fix warning 38 for rebound extension constructors
  (Leo White, review by Florian Angeletti)

- 9244: Fix some missing usage warnings
  (Leo White, review by Florian Angeletti)

### Flambda backend

- 9163: Treat loops properly in un_anf
  (Leo White, review by Mark Shinwell, Pierre Chambart and Vincent Laviron)

### Toplevels

- 9415: Treat `open struct` as `include struct` in toplevel
  (Leo White, review by Thomas Refis)

- 9416: Avoid warning 58 in flambda ocamlnat
  (Leo White, review by Florian Angeletti)
