### PR TITLE
[new release] git-http, git, git-unix and git-mirage (2.1.3)

### DIFF
--- a/packages/git-http/git-http.2.1.3/opam
+++ b/packages/git-http/git-http.2.1.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "Client implementation of the \"Smart\" HTTP Git protocol in pure OCaml"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"        {>= "4.07.0"}
+  "dune"
+  "git"          {= version}
+  "cohttp"       {>= "1.0.0"}
+  "cohttp-lwt"   {>= "1.0.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.3/git-2.1.3.tbz"
+  checksum: [
+    "sha256=5d614ae0404a2438c5cee98bf4aa64cee9980e2a382a437acd6ee65dcca6f4de"
+    "sha512=9a863552ad7fddfa37d92738dd1c793e888a3c544f97a7634aa9ed5cef1ca22db4e6bfa1908c58986af0bf1dcd665ba63308c1656e68397b7a87f1a09e94fe97"
+  ]
+}

--- a/packages/git-mirage/git-mirage.2.1.3/opam
+++ b/packages/git-mirage/git-mirage.2.1.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "MirageOS backend for the Git protocol(s)"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.07.0"}
+  "dune"
+  "cohttp-mirage"     {>= "1.0.0"}
+  "mirage-flow"       {>= "2.0.0"}
+  "mirage-channel"    {>= "4.0.0"}
+  "conduit-mirage"    {>= "2.2.0"}
+  "git-http"          {= version}
+  "git"               {= version}
+  "alcotest"          {with-test & >= "0.8.1"}
+  "mtime"             {with-test & >= "1.0.0"}
+  "mirage-crypto-rng" {with-test & >= "0.5.4"}
+  "tls"               {with-test}
+  "io-page"           {with-test & >= "1.6.1"}
+  "tcpip"             {with-test & >= "3.3.0"}
+  "io-page-unix"      {with-test}
+  "mirage-stack"      {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix"  {with-test & >= "2.0.1"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.3/git-2.1.3.tbz"
+  checksum: [
+    "sha256=5d614ae0404a2438c5cee98bf4aa64cee9980e2a382a437acd6ee65dcca6f4de"
+    "sha512=9a863552ad7fddfa37d92738dd1c793e888a3c544f97a7634aa9ed5cef1ca22db4e6bfa1908c58986af0bf1dcd665ba63308c1656e68397b7a87f1a09e94fe97"
+  ]
+}

--- a/packages/git-unix/git-unix.2.1.3/opam
+++ b/packages/git-unix/git-unix.2.1.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "Virtual package to install and configure ocaml-git's Unix backend"
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.07.0"}
+  "dune"
+  "mmap"              {>= "1.1.0"}
+  "cmdliner"
+  "git-http"          {= version}
+  "cohttp"            {>= "1.0.0"}
+  "cohttp-lwt-unix"   {>= "1.0.0"}
+  "mtime"             {>= "1.0.0"}
+  "base-unix"
+  "alcotest"          {with-test & >= "0.8.1"}
+  "mirage-crypto-rng" {with-test}
+  "tls"               {with-test}
+  "io-page"           {with-test & >= "1.6.1"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.3/git-2.1.3.tbz"
+  checksum: [
+    "sha256=5d614ae0404a2438c5cee98bf4aa64cee9980e2a382a437acd6ee65dcca6f4de"
+    "sha512=9a863552ad7fddfa37d92738dd1c793e888a3c544f97a7634aa9ed5cef1ca22db4e6bfa1908c58986af0bf1dcd665ba63308c1656e68397b7a87f1a09e94fe97"
+  ]
+}

--- a/packages/git/git.2.1.3/opam
+++ b/packages/git/git.2.1.3/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+maintainer:   [ "thomas@gazagnaire.org"
+                "romain.calascibetta@gmail.com" ]
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-git"
+bug-reports:  "https://github.com/mirage/ocaml-git/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-git.git"
+doc:          "https://mirage.github.io/ocaml-git/"
+synopsis:     "Git format and protocol in pure OCaml"
+description: """
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "dune"       {>= "1.1"}
+  "uri"        {>= "1.9.0"}
+  "lwt"        {>= "2.4.7"}
+  "angstrom"   {>= "0.14.0"}
+  "fpath"      {>= "0.7.0"}
+  "digestif"   {>= "0.7.2"}
+  "lru"        {>= "0.3.0"}
+  "decompress" {>= "0.9.0" & < "1.0.0"}
+  "checkseum"  {>= "0.0.9"}
+  "stdlib-shims"
+  "ke"
+  "encore"     {>= "0.5"}
+  "duff"
+  "hex"
+  "ocplib-endian"
+  "rresult"
+  "logs"
+  "fmt"
+  "astring"
+  "cstruct"
+  "ocamlgraph"
+  "alcotest"          {with-test & >= "0.8.1"}
+  "mirage-crypto-rng" {with-test & >= "0.5.4"}
+  "tls"               {with-test}
+  "mtime"             {with-test & >= "1.0.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/2.1.3/git-2.1.3.tbz"
+  checksum: [
+    "sha256=5d614ae0404a2438c5cee98bf4aa64cee9980e2a382a437acd6ee65dcca6f4de"
+    "sha512=9a863552ad7fddfa37d92738dd1c793e888a3c544f97a7634aa9ed5cef1ca22db4e6bfa1908c58986af0bf1dcd665ba63308c1656e68397b7a87f1a09e94fe97"
+  ]
+}


### PR DESCRIPTION
Client implementation of the "Smart" HTTP Git protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Move to `encoder.0.5` (mirage/ocaml-git#393, @dinosaure)
- Move to `angstrom.0.14.0` (mirage/ocaml-git#384, @sternenseemann)
- Add missing Time argument to `Resolver_mirage.Make_with_stack` (mirage/ocaml-git#389, @talex5)
- Fix .ocamlformat file (mirage/ocaml-git#389, @talex5)
- Enlarge internal buffer used to parse Git object (mirage/ocaml-git#389, @dinosaure)
- Update README.md (mirage/ocaml-git#383, @dinosaure)
- Use `mirage-crypto` instead `nocrypto` (mirage/ocaml-git#382, @hannesm)
- Add constraint on `dune` package (@kit-ty-kate)
