### PR TITLE
Package ctypes-zarith.0.2.0

### DIFF
--- a/packages/ctypes-zarith/ctypes-zarith.0.2.0/opam
+++ b/packages/ctypes-zarith/ctypes-zarith.0.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "Andreas Hauptmann" "Stephane Graham-Lengrand" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/fdopen/ctypes-zarith.git"
+homepage: "https://github.com/fdopen/ctypes-zarith"
+bug-reports: "https://github.com/fdopen/ctypes-zarith/issues"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {>= "1.2"}
+  "dune-configurator"
+  "zarith"
+  "ctypes"
+  "ppx_cstubs" {>= "0.4.1"}
+  "conf-pkg-config" {build}
+  "ctypes-foreign" {with-test}
+  "alcotest" {with-test}
+]
+
+synopsis: """
+Ctypes wrapper for zarith
+"""
+url {
+  src: "https://github.com/fdopen/ctypes-zarith/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=3f487940ed886f52d1c24436c0571a5c"
+    "sha512=8f4139330d0b33f7a5a75c17c05579e62a0f95f27876d0b0541ba0395489bb9b86417e49ae73fb76da0c159832e170dca177ddcad49f032988b9e08506c2ed39"
+  ]
+}


### PR DESCRIPTION
### `ctypes-zarith.0.2.0`
Ctypes wrapper for zarith



---
* Homepage: https://github.com/fdopen/ctypes-zarith
* Source repo: git+https://github.com/fdopen/ctypes-zarith.git
* Bug tracker: https://github.com/fdopen/ctypes-zarith/issues

---
:camel: Pull-request generated by opam-publish v2.0.2