### PR TITLE
Package bogue.20200630

### DIFF
--- a/packages/bogue/bogue.20200630/opam
+++ b/packages/bogue/bogue.20200630/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Vu Ngoc San <san.vu-ngoc@laposte.net>"]
+authors: ["Vu Ngoc San <san.vu-ngoc@laposte.net>"]
+bug-reports: "https://github.com/sanette/bogue/issues"
+homepage: "https://github.com/sanette/bogue"
+doc: "http://sanette.github.io/bogue/Bogue.html"
+license: "IST"
+dev-repo: "git+https://github.com/sanette/bogue.git"
+synopsis: "GUI library for ocaml, with animations, based on SDL2"
+description: """
+bogue is a GUI library for ocaml, with animations, based on SDL2.
+
+This library can be used for games or for adding GUI elements to any
+ocaml program.
+
+It uses the SDL2 renderer library, which makes it quite fast.
+
+It is themable, and does not try to look like your desktop. Instead,
+it will look the same on every platform.
+
+Graphics output is scalable, and hence easily adapts to Hi-DPI
+displays.
+
+Programming with bogue is easy if you're used to GUIs with widgets,
+layouts, callbacks, and of course it has a functional flavor. It uses
+Threads when non-blocking reactions are needed."""
+depends: [
+  "stdlib-shims" {>= "0.1.0"}
+  "tsdl-image" {>= "0.2"}
+  "tsdl-ttf" {>= "0.2"}
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.10"}
+  "tsdl" {>= "0.9.0" & < "0.9.7"}
+]
+url {
+  src: "https://github.com/sanette/bogue/archive/20200630.tar.gz"
+  checksum: [
+    "md5=587556b986f3aa3cb9b7f1821dfee261"
+    "sha512=0180add49ebad4102136ea78243b202262f66e29f0529d19f4d36fbdcc54c55d86ff2bc1474a0099318d3b30868146c4fcda74da756bfb0893e3c58330a53a30"
+  ]
+}


### PR DESCRIPTION
### `bogue.20200630`
GUI library for ocaml, with animations, based on SDL2
bogue is a GUI library for ocaml, with animations, based on SDL2.

This library can be used for games or for adding GUI elements to any
ocaml program.

It uses the SDL2 renderer library, which makes it quite fast.

It is themable, and does not try to look like your desktop. Instead,
it will look the same on every platform.

Graphics output is scalable, and hence easily adapts to Hi-DPI
displays.

Programming with bogue is easy if you're used to GUIs with widgets,
layouts, callbacks, and of course it has a functional flavor. It uses
Threads when non-blocking reactions are needed.



---
* Homepage: https://github.com/sanette/bogue
* Source repo: git+https://github.com/sanette/bogue.git
* Bug tracker: https://github.com/sanette/bogue/issues

---
:camel: Pull-request generated by opam-publish v2.0.2