### PR TITLE
[new release] mirage-net-xen and netchannel (1.13.1)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.1.13.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.13.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "5.0.0"}
+  "netchannel" {= version}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v1.13.1/mirage-net-xen-v1.13.1.tbz"
+  checksum: [
+    "sha256=3399a80e1cf4cacfdd5e1b9665040af42b61b6f1fcaed4d3d9772a0ac78cea17"
+    "sha512=8b57e3eb28159a9348657fd2a78f8245fadb2f66771f181daf440540265cb7a73fb263ce02085bd44e10bc4b2ede6200edcd94e4a3257e7c158a3d6602624ad2"
+  ]
+}

--- a/packages/netchannel/netchannel.1.13.1/opam
+++ b/packages/netchannel/netchannel.1.13.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "io-page-xen" {>= "2.0.0"}
+  "mirage-xen" {>= "5.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-profile" {>="0.3"}
+  "shared-memory-ring" {>="3.0.0"}
+  "sexplib" {>= "113.01.00"}
+  "logs" {>= "0.5.0"}
+  "rresult"
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+
+Note: the `Netif` module is the public API.
+The `Netchannel` API is still under development.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v1.13.1/mirage-net-xen-v1.13.1.tbz"
+  checksum: [
+    "sha256=3399a80e1cf4cacfdd5e1b9665040af42b61b6f1fcaed4d3d9772a0ac78cea17"
+    "sha512=8b57e3eb28159a9348657fd2a78f8245fadb2f66771f181daf440540265cb7a73fb263ce02085bd44e10bc4b2ede6200edcd94e4a3257e7c158a3d6602624ad2"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* MirageOS (mirage-net) defines the MTU as the link-level payload size, adjust from 1514 to 1500 (@hannesm, mirage/mirage-net-xen#98)
* Only pass the sub-buffer of requested size to the fill function (solves mirage/qubes-mirage-firewall#111, @hannesm, mirage/mirage-net-xen#98)
* listen: do not catch out of memory exception (@hannesm, mirage/mirage-net-xen#97)