### PR TITLE
Package jhupllib.0.2.2

### DIFF
--- a/packages/jhupllib/jhupllib.0.2.2/opam
+++ b/packages/jhupllib/jhupllib.0.2.2/opam
@@ -18,12 +18,10 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "base-threads"
   "batteries"
-  "dune" {build & >= "1.0+beta17"}
+  "dune" {>= "1.0"}
   "monadlib"
   "ocaml-monadic" {>= "0.4.1"}
-  "ocamlbuild" {build}
-  "ocamlfind" {build}
-  "ounit" {build}
+  "ounit" {with-test}
   "ppx_deriving" {>= "2.0"}
   "ppx_deriving_yojson"
   "yojson" {>= "1.7.0"}

--- a/packages/jhupllib/jhupllib.0.2.2/opam
+++ b/packages/jhupllib/jhupllib.0.2.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: [ "JHU PL Lab <pl.cs@jhu.edu>" ]
+synopsis: "A collection of OCaml utilities used by the JHU PL lab"
+description: """
+A collection of OCaml utilities used by the JHU PL lab.  These are miscellaneous
+utilities which did not appear readily in standard libraries when they were
+written.
+"""
+license: "Apache"
+homepage: "http://pl.cs.jhu.edu/"
+doc: "https://github.com/JHU-PL-Lab/jhu-pl-lib/"
+dev-repo: "git+https://github.com/JHU-PL-Lab/jhu-pl-lib.git"
+bug-reports: "https://github.com/JHU-PL-Lab/jhu-pl-lib/issues"
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "base-threads"
+  "batteries"
+  "dune" {build & >= "1.0+beta17"}
+  "monadlib"
+  "ocaml-monadic" {>= "0.4.1"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "ounit" {build}
+  "ppx_deriving" {>= "2.0"}
+  "ppx_deriving_yojson"
+  "yojson" {>= "1.7.0"}
+]
+url {
+  src: "https://github.com/JHU-PL-Lab/jhupllib/archive/0.2.2.tar.gz"
+  checksum: [
+    "md5=8518b1ea79fce913120da2506a597e7b"
+    "sha512=57e531641341ee4ab8915fe46558ae84e23004e132d8a37e03969c5f476186578c1347ddf9f78563327cd1c2797ee198621158f4777e1e18cca3da424bf43e53"
+  ]
+}


### PR DESCRIPTION
### `jhupllib.0.2.2`
A collection of OCaml utilities used by the JHU PL lab
A collection of OCaml utilities used by the JHU PL lab.  These are miscellaneous
utilities which did not appear readily in standard libraries when they were
written.



---
* Homepage: http://pl.cs.jhu.edu/
* Source repo: git+https://github.com/JHU-PL-Lab/jhu-pl-lib.git
* Bug tracker: https://github.com/JHU-PL-Lab/jhu-pl-lib/issues

---
:camel: Pull-request generated by opam-publish v2.0.2