### PR TITLE
[new release] mirage-crypto-pk, mirage-crypto, mirage-crypto-rng and mirage-crypto-rng-mirage (0.8.1)

### DIFF
--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.7"}
+  "rresult" {>= "0.6.0"}
+  ("mirage-no-xen" | "zarith-xen")
+  ("mirage-no-solo5" | "zarith-freestanding")
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.1/mirage-crypto-v0.8.1.tbz"
+  checksum: [
+    "sha256=f3494aa290f2b87859108b48b8c12152e649e771e4e87374e0717b25a38e128f"
+    "sha512=7a3f5a1528cc86831c6f7f78941a426757ef747bc94713f3d04e528cdeda0fab65fb61c944f04a3be9bf147d9b2d1b1c6b1e595697ddc839b245341fc821c3d0"
+  ]
+}

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.1/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.1/mirage-crypto-v0.8.1.tbz"
+  checksum: [
+    "sha256=f3494aa290f2b87859108b48b8c12152e649e771e4e87374e0717b25a38e128f"
+    "sha512=7a3f5a1528cc86831c6f7f78941a426757ef747bc94713f3d04e528cdeda0fab65fb61c944f04a3be9bf147d9b2d1b1c6b1e595697ddc839b245341fc821c3d0"
+  ]
+}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.1/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator"
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "mirage-crypto" {=version}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+# lwt sublibrary
+  "mtime"
+  "lwt" {>= "4.0.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.1/mirage-crypto-v0.8.1.tbz"
+  checksum: [
+    "sha256=f3494aa290f2b87859108b48b8c12152e649e771e4e87374e0717b25a38e128f"
+    "sha512=7a3f5a1528cc86831c6f7f78941a426757ef747bc94713f3d04e528cdeda0fab65fb61c944f04a3be9bf147d9b2d1b1c6b1e595697ddc839b245341fc821c3d0"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.8.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "eqaf" {>= "0.7"}
+]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4), and hashes (MD5,
+SHA-1, SHA-2).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.1/mirage-crypto-v0.8.1.tbz"
+  checksum: [
+    "sha256=f3494aa290f2b87859108b48b8c12152e649e771e4e87374e0717b25a38e128f"
+    "sha512=7a3f5a1528cc86831c6f7f78941a426757ef747bc94713f3d04e528cdeda0fab65fb61c944f04a3be9bf147d9b2d1b1c6b1e595697ddc839b245341fc821c3d0"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.8.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.1/opam
@@ -30,8 +30,8 @@ conflicts: [
   "ocaml-freestanding" {< "0.4.1"}
 ]
 description: """
-Mirage-crypto provides symmetric ciphers (DES, AES, RC4), and hashes (MD5,
-SHA-1, SHA-2).
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
+hashes (MD5, SHA-1, SHA-2).
 """
 url {
   src:

--- a/packages/tls/tls.0.11.0/opam
+++ b/packages/tls/tls.0.11.0/opam
@@ -21,7 +21,7 @@ depends: [
   "cstruct" {>= "4.0.0"}
   "cstruct-sexp"
   "sexplib" {< "v0.15"}
-  "mirage-crypto"
+  "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng"
   "x509" {>= "0.10.0" & < "0.11.0"}

--- a/packages/tls/tls.0.11.1/opam
+++ b/packages/tls/tls.0.11.1/opam
@@ -20,7 +20,7 @@ depends: [
   "cstruct" {>= "4.0.0"}
   "cstruct-sexp"
   "sexplib" {< "v0.15"}
-  "mirage-crypto"
+  "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng"
   "x509" {>= "0.11.0"}

--- a/packages/tls/tls.0.12.0/opam
+++ b/packages/tls/tls.0.12.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cstruct" {>= "4.0.0"}
   "cstruct-sexp"
   "sexplib" {< "v0.15"}
-  "mirage-crypto"
+  "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng"
   "x509" {>= "0.11.0"}

--- a/packages/tls/tls.0.12.1/opam
+++ b/packages/tls/tls.0.12.1/opam
@@ -21,7 +21,7 @@ depends: [
   "cstruct" {>= "4.0.0"}
   "cstruct-sexp"
   "sexplib"
-  "mirage-crypto"
+  "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng"
   "x509" {>= "0.11.0"}

--- a/packages/tls/tls.0.12.2/opam
+++ b/packages/tls/tls.0.12.2/opam
@@ -20,7 +20,7 @@ depends: [
   "cstruct" {>= "4.0.0"}
   "cstruct-sexp"
   "sexplib"
-  "mirage-crypto"
+  "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng" {>= "0.8.0"}
   "x509" {>= "0.11.0"}


### PR DESCRIPTION
CHANGES:
    
* Add Chacha20 implementation (based on abeaumont/ocaml-chacha), supporting
      both DJB's original specification (nonce 64 bit, counter 64 bit) and IETF
      (RFC 8439: nonce 96 bit, counter 32 bit)
      (mirage/mirage-crypto#72 @hannesm)
* Add Poly1305 implementation based on floodyberry/poly1305-donna (mirage/mirage-crypto#72 @hannesm)
* Unified AEAD module type, implemented by CCM, GCM, and Chacha20/Poly1305
      The functions "authenticate_encrypt" and "authenticate_decrypt" are defined,
      which append (encrypt) and check equality (decrypt, using Eqaf for
      constant-time comparison) the authentication tag directly.
      Breaking changes:
      - GCM "~iv" is now "~nonce"
      - GCM encrypt returns the encrypted data and authentication tag appended
      - GCM decrypt returns the plaintext as option (None on authentication failure)
      (mirage/mirage-crypto#73 @hannesm)