### PR TITLE
[new release] dune, dune-build-info, dune-glob, dune-private-libs, dune-configurator and dune-action-plugin (2.6.1)

### DIFF
--- a/packages/dune-action-plugin/dune-action-plugin.2.6.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.6.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "dune-glob"
+  "ppx_expect" {with-test}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.6.1/dune-2.6.1.tbz"
+  checksum: [
+    "sha256=5ef959f286448ee172f1cffc86c439a6f7b662676e6015b282db071bb88899a0"
+    "sha512=67b750716563fde1135f3d0f3892f97e912d6f95a40bcd7cd854f3ae09ba0b037e7b8829bdaee141cb6c998396f2a51a380451db117571d77895781798d625e7"
+  ]
+}

--- a/packages/dune-build-info/dune-build-info.2.6.1/opam
+++ b/packages/dune-build-info/dune-build-info.2.6.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Embed build informations inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.5"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.6.1/dune-2.6.1.tbz"
+  checksum: [
+    "sha256=5ef959f286448ee172f1cffc86c439a6f7b662676e6015b282db071bb88899a0"
+    "sha512=67b750716563fde1135f3d0f3892f97e912d6f95a40bcd7cd854f3ae09ba0b037e7b8829bdaee141cb6c998396f2a51a380451db117571d77895781798d625e7"
+  ]
+}

--- a/packages/dune-configurator/dune-configurator.2.6.1/opam
+++ b/packages/dune-configurator/dune-configurator.2.6.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.6.1/dune-2.6.1.tbz"
+  checksum: [
+    "sha256=5ef959f286448ee172f1cffc86c439a6f7b662676e6015b282db071bb88899a0"
+    "sha512=67b750716563fde1135f3d0f3892f97e912d6f95a40bcd7cd854f3ae09ba0b037e7b8829bdaee141cb6c998396f2a51a380451db117571d77895781798d625e7"
+  ]
+}

--- a/packages/dune-glob/dune-glob.2.6.1/opam
+++ b/packages/dune-glob/dune-glob.2.6.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "dune-private-libs" {= version}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.6.1/dune-2.6.1.tbz"
+  checksum: [
+    "sha256=5ef959f286448ee172f1cffc86c439a6f7b662676e6015b282db071bb88899a0"
+    "sha512=67b750716563fde1135f3d0f3892f97e912d6f95a40bcd7cd854f3ae09ba0b037e7b8829bdaee141cb6c998396f2a51a380451db117571d77895781798d625e7"
+  ]
+}

--- a/packages/dune-private-libs/dune-private-libs.2.6.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.6.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "ocaml" {>= "4.07"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.6.1/dune-2.6.1.tbz"
+  checksum: [
+    "sha256=5ef959f286448ee172f1cffc86c439a6f7b662676e6015b282db071bb88899a0"
+    "sha512=67b750716563fde1135f3d0f3892f97e912d6f95a40bcd7cd854f3ae09ba0b037e7b8829bdaee141cb6c998396f2a51a380451db117571d77895781798d625e7"
+  ]
+}

--- a/packages/dune/dune.2.6.1/opam
+++ b/packages/dune/dune.2.6.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "1.3.0"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .travis.yml, dune-project
+  # and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.07"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.6.1/dune-2.6.1.tbz"
+  checksum: [
+    "sha256=5ef959f286448ee172f1cffc86c439a6f7b662676e6015b282db071bb88899a0"
+    "sha512=67b750716563fde1135f3d0f3892f97e912d6f95a40bcd7cd854f3ae09ba0b037e7b8829bdaee141cb6c998396f2a51a380451db117571d77895781798d625e7"
+  ]
+}


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- Fix crash when caching is enabled (@rgrinberg, ocaml/dune#3581, fixes ocaml/dune#3580)

- Do not use `-output-complete-exe` until 4.10.1 as it is broken in
  4.10.0 (@jeremiedimino, ocaml/dune#3187)

- Fix crash when an unknown pform is found (such as `%{unknown}`) (ocaml/dune#3560,
  @emillon)

- Improve error message when invalid package names (such as the empty string)
  are passed to `dune build -p`. (ocaml/dune#3561, @emillon)

- Fix a stack overflow when displaying large outputs (including diffs) (ocaml/dune#3537,
  fixes ocaml/dune#2767, ocaml/dune#3490, @emillon)
