### PR TITLE
[new release] duff (0.3)

### DIFF
--- a/packages/duff/duff.0.3/opam
+++ b/packages/duff/duff.0.3/opam
@@ -30,9 +30,6 @@ depends: [
   "crowbar"     {with-test}
 ]
 
-conflicts: [
-  "git" {<= "2.1.3"}
-]
 url {
   src: "https://github.com/mirage/duff/releases/download/v0.3/duff-v0.3.tbz"
   checksum: [

--- a/packages/duff/duff.0.3/opam
+++ b/packages/duff/duff.0.3/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "duff"
 maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
 authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
 homepage:     "https://github.com/mirage/duff"

--- a/packages/duff/duff.0.3/opam
+++ b/packages/duff/duff.0.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+name:         "duff"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/duff"
+bug-reports:  "https://github.com/mirage/duff/issues"
+dev-repo:     "git+https://github.com/mirage/duff.git"
+doc:          "https://mirage.github.io/duff/"
+license:      "MIT"
+synopsis:     "Rabin's fingerprint and diff algorithm in OCaml"
+description: """
+This library provides a pure implementation of Rabin's fingerprint and diff algorithm in OCaml.
+
+It follows libXdiff C library. It is used by ocaml-git project.
+"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {>= "2.0.0"}
+  "fmt"
+  "bigarray-compat"
+  "stdlib-shims"
+  "alcotest"    {with-test}
+  "bigstringaf" {with-test}
+  "hxd"         {with-test}
+  "crowbar"     {with-test}
+]
+
+conflicts: [
+  "git" {<= "2.1.3"}
+]
+url {
+  src: "https://github.com/mirage/duff/releases/download/v0.3/duff-v0.3.tbz"
+  checksum: [
+    "sha256=d5fee97be9ce3183375fe2e8df8d44be176997e47ac47049922e8e34bb3f66d1"
+    "sha512=406e137dba3a8c16460b25d0c5f757823e9c53ec40cc8f9538bf2d05e693b4af016801346a72b1c934577432eb506f5d63e65cf53cf5e85f09a90ee4cb40c0b2"
+  ]
+}

--- a/packages/git/git.2.0.0/opam
+++ b/packages/git/git.2.0.0/opam
@@ -35,7 +35,7 @@ depends: [
   "decompress" {>= "0.8.1" & < "0.9.0"}
   "checkseum"  {>= "0.0.3"}
   "encore"     {< "0.3"}
-  "duff"
+  "duff"       {< "0.3"}
   "hex"
   "ocplib-endian"
   "rresult"

--- a/packages/git/git.2.1.0/opam
+++ b/packages/git/git.2.1.0/opam
@@ -36,7 +36,7 @@ depends: [
   "checkseum"  {>= "0.1.0"}
   "ke"
   "encore" {< "0.6"}
-  "duff"
+  "duff" {< "0.3"}
   "hex"
   "ocplib-endian"
   "rresult"

--- a/packages/git/git.2.1.1/opam
+++ b/packages/git/git.2.1.1/opam
@@ -37,7 +37,7 @@ depends: [
   "stdlib-shims"
   "ke"
   "encore" {< "0.6"}
-  "duff"
+  "duff" {< "0.3"}
   "hex"
   "ocplib-endian"
   "rresult"

--- a/packages/git/git.2.1.2/opam
+++ b/packages/git/git.2.1.2/opam
@@ -37,7 +37,7 @@ depends: [
   "stdlib-shims"
   "ke"
   "encore" {< "0.6"}
-  "duff"
+  "duff" {< "0.3"}
   "hex"
   "ocplib-endian"
   "rresult"

--- a/packages/git/git.2.1.3/opam
+++ b/packages/git/git.2.1.3/opam
@@ -37,7 +37,7 @@ depends: [
   "stdlib-shims"
   "ke"
   "encore"     {>= "0.5" & < "0.6"}
-  "duff"
+  "duff" {< "0.3"}
   "hex"
   "ocplib-endian"
   "rresult"


### PR DESCRIPTION
Rabin's fingerprint and diff algorithm in OCaml

- Project page: <a href="https://github.com/mirage/duff">https://github.com/mirage/duff</a>
- Documentation: <a href="https://mirage.github.io/duff/">https://mirage.github.io/duff/</a>

##### CHANGES:

__breaking changes__ 

* Add a constraint with `git.2.1.3` (mirage/duff#7)
* Update the documentation (mirage/duff#6)
* Work on the new API (mirage/duff#2)
* Delete provided binary (mirage/duff#5)
* Move to `dune.2.0.0` (mirage/duff#5)
* Integrate fuzzer into tests (mirage/duff#5)
* Apply ocamlformat (mirage/duff#5)
