### PR TITLE
Package herdtools7.7.56

### DIFF
--- a/packages/herdtools7/herdtools7.7.56/opam
+++ b/packages/herdtools7/herdtools7.7.56/opam
@@ -15,7 +15,7 @@ install: ["sh" "./dune-install.sh" "%{prefix}%"]
 # @todo Add "build-test" field
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune"  {>= "1.2" }
+  "dune"  {>= "1.4" }
   "ocamlfind" { build }
   "menhir" {>= "20180530"}
 ]

--- a/packages/herdtools7/herdtools7.7.56/opam
+++ b/packages/herdtools7/herdtools7.7.56/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "The herdtools suite for simulating and studying weak memory models"
+maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
+authors: [
+  "Luc Maranget <Luc.Maranget@inria.fr>"
+  "Jade Alglave <j.alglave@ucl.ac.uk>"
+]
+homepage: "http://diy.inria.fr/"
+bug-reports: "http://github.com/herd/herdtools7/issues/"
+doc: "http://diy.inria.fr/doc/index.html"
+dev-repo: "git+https://github.com/herd/herdtools7.git"
+build: ["sh" "./dune-build.sh" "%{prefix}%"]
+install: ["sh" "./dune-install.sh" "%{prefix}%"]
+# @todo Add "build-doc" field
+# @todo Add "build-test" field
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune"  {>= "1.2" }
+  "ocamlfind" { build }
+  "menhir" {>= "20180530"}
+]
+url {
+  src: "https://github.com/herd/herdtools7/archive/7.56.tar.gz"
+  checksum: [
+    "md5=7dbe6469ed2450d753f2c4771413dbb0"
+    "sha512=795836ea09c6c4aebb53f1e2c2e646ab1483f74d8c933ab800161a8a9646c3baa0aaba092005438b831a31cbc455416a18cbcb4ebc54cd2ba11cc4bfccf894f0"
+  ]
+}


### PR DESCRIPTION
### `herdtools7.7.56`
The herdtools suite for simulating and studying weak memory models



---
* Homepage: http://diy.inria.fr/
* Source repo: git+https://github.com/herd/herdtools7.git
* Bug tracker: http://github.com/herd/herdtools7/issues/

---
:camel: Pull-request generated by opam-publish v2.0.2