### PR TITLE
Package embedded_ocaml_templates.0.2

### DIFF
--- a/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.2/opam
+++ b/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "EML is a simple templating language that lets you generate text with plain OCaml"
+description: """
+EML is a simple templating language that lets you generate text with plain OCaml
+Inspired by EJS templates
+"""
+maintainer: "Emile Trotignon emile.trotignon@gmail.com"
+authors: "Emile Trotignon emile.trotignon@gmail.com"
+license: "MIT"
+homepage: "https://github.com/EmileTrotignon/embedded_ocaml_templates"
+bug-reports: "https://github.com/EmileTrotignon/embedded_ocaml_templates/issues"
+dev-repo: "git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git"
+depends: [ 
+    "ocaml" {>= "4.07.0"}
+    "dune" {>= "2.5.0"} 
+    "sedlex" 
+    "core" {>= "v0.12"}
+    "uutf" 
+    "menhir" 
+    "ppxlib" 
+    "containers"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/EmileTrotignon/embedded_ocaml_templates/archive/0.2.tar.gz"
+  checksum: [
+    "md5=8a7189c85de9edc4f643e8a22b100e9c"
+    "sha512=18184036d47791139fafb97790ae7daf9560f416ad6ea38e267188ed80a6443aa9457d8b5ead753f68b08997189c61b02cc8d04c550d8ce0e5df6202b0c9bef9"
+  ]
+}


### PR DESCRIPTION
### `embedded_ocaml_templates.0.2`
EML is a simple templating language that lets you generate text with plain OCaml
EML is a simple templating language that lets you generate text with plain OCaml
Inspired by EJS templates

There is an important bugfix in this release : the compiler is supposed to work recursively on a directory containing templates.
This feature was not working properly, it is now.


---
* Homepage: https://github.com/EmileTrotignon/embedded_ocaml_templates
* Source repo: git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git
* Bug tracker: https://github.com/EmileTrotignon/embedded_ocaml_templates/issues

---
:camel: Pull-request generated by opam-publish v2.0.2