### PR TITLE
fix colombe 0.1.0

### DIFF
--- a/packages/colombe/colombe.0.1.0/opam
+++ b/packages/colombe/colombe.0.1.0/opam
@@ -26,7 +26,7 @@ depends: [
   "rresult"
   "hxd"
   "domain-name" {>= "0.2.1"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0"}
   "crowbar" {with-test}
 ]
 


### PR DESCRIPTION
I got a bit tired of the CI issue:
```
         test alias test/runtest (exit 125)
 (cd _build/default/test && ./test.exe)
 test.exe: internal error, uncaught exception:
           Alcotest__Core.Registration_error("Duplicate test name: requests")
```

so, it is not compatible with the newest and shiniest alcotest

//cc @dinosaure (but I don't really expect this to be of much interest, since there are newer releases of colombe -- I just repeatedly saw it in tls releases)