### PR TITLE
Package binaryen.0.2.0

### DIFF
--- a/packages/binaryen/binaryen.0.2.0/opam
+++ b/packages/binaryen/binaryen.0.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs "--no-buffer" ]
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.6"}
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+]
+authors: "Oscar Spencer"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.2.0/binaryen-archive-v0.2.0.tar.gz"
+  checksum: [
+    "md5=c91ee506c766a1897302d65f2ecb0929"
+    "sha512=e436ee3c28bc2b3edb9e4779b8829af2a4442f1d087ee962f194513a175abc77931997bb9489e6a4844e0e2e0e8d912fdd4bbeddb8ee9af9dfe1a5af88bec7ed"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.2.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0