### PR TITLE
Package binaryen.0.2.1

### DIFF
--- a/packages/binaryen/binaryen.0.2.1/opam
+++ b/packages/binaryen/binaryen.0.2.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs "--no-buffer" ]
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.6"}
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+]
+authors: "Oscar Spencer"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.2.1/binaryen-archive-v0.2.1.tar.gz"
+  checksum: [
+    "md5=d887f868b4bf9728656970a424826b97"
+    "sha512=c32de6230257d3df4eaa31643b4bbcee86ae1784281aa4e2f71fca2a1307ba62c14e13af6d4ad52f8d22dca89c49d8cae75f4c7d0ea8b7510ae857c6f7f663b5"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.2.1`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0