### PR TITLE
conf-perl: Add missing perl tool on CentOS 8

### DIFF
--- a/packages/conf-perl/conf-perl.1/opam
+++ b/packages/conf-perl/conf-perl.1/opam
@@ -11,6 +11,7 @@ depexts: [
   ["perl"] {os-distribution = "nixos"}
   ["perl"] {os-distribution = "arch"}
   ["perl-Pod-Html"] {os-distribution = "fedora"}
+  ["perl-Pod-Html"] {os-distribution = "centos" & os-version >= "8"}
 ]
 synopsis: "Virtual package relying on perl"
 description:


### PR DESCRIPTION
Should fix https://github.com/ocaml/opam-repository/issues/16359