### PR TITLE
Package not-ocamlfind.0.06

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.06/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.06/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.8.0"}
+  "fmt" {>= "0.8.8"}
+  "sexplib" {>= "v0.13.0"}
+  "rresult" {>= "0.6.0"}
+  "ocamlgraph" {>= "1.8.8"}
+]
+depexts: [
+  [
+    "xdot"
+  ] {os-family = "debian"}
+]
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/0.06.tar.gz"
+  checksum: [
+    "md5=dfee20fda67add28bed15ac66263e8f3"
+    "sha512=09c7a96e6e6a2abada006c360561445aecee47497d2284eaabcdd6e6b60cbff8db17f8dbb3e0a838a325b8306e3c6e2dff0131be241c8b870660f1c7d937c308"
+  ]
+}


### PR DESCRIPTION
### `not-ocamlfind.0.06`
A small frontend for ocamlfind that adds a few useful commands



---
* Homepage: https://github.com/chetmurthy/not-ocamlfind
* Source repo: git+https://github.com/chetmurthy/not-ocamlfind
* Bug tracker: Chet Murthy <chetsky@gmail.com>

---
:camel: Pull-request generated by opam-publish v2.0.2