### PR TITLE
Package not-ocamlfind.0.07

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.07/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.07/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.8.0"}
+  "fmt" {>= "0.8.8"}
+  "sexplib" {>= "v0.13.0"}
+  "rresult" {>= "0.6.0"}
+  "ocamlgraph" {>= "1.8.8"}
+]
+depexts: [
+  [
+    "xdot"
+  ] {os-family = "debian"}
+]
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/0.07.tar.gz"
+  checksum: [
+    "md5=56fac6f7bb91e4e4f4f7220f133979d6"
+    "sha512=a1edac4403dd56ca820c061fe5a272dd6358862f7a3a0deb89d4070a42463f47c707550c54c754780a58716310880670f1536be779d606b6dab11d445eb42970"
+  ]
+}


### PR DESCRIPTION
### `not-ocamlfind.0.07`
A small frontend for ocamlfind that adds a few useful commands



---
* Homepage: https://github.com/chetmurthy/not-ocamlfind
* Source repo: git+https://github.com/chetmurthy/not-ocamlfind
* Bug tracker: Chet Murthy <chetsky@gmail.com>

---
:camel: Pull-request generated by opam-publish v2.0.2