### PR TITLE
Beta packages for OCaml 4.11.0+beta2

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+afl/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Second beta for 4.11.0, with afl-fuzz instrumentation"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
+    {os != "openbsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--with-afl"
+    "--disable-debug-runtime"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+beta2.tar.gz"
+  checksum: "sha256=a84ff5e8b768ea6ec0a95e10698387c84236cd7bdae0660299113356a86d8b97"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+flambda/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Second beta for 4.11.0, with flambda activated"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
+    {os != "openbsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+beta2.tar.gz"
+  checksum: "sha256=a84ff5e8b768ea6ec0a95e10698387c84236cd7bdae0660299113356a86d8b97"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp+flambda/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Second beta for 4.11.0, with frame-pointers and flambda activated"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+  ] {os != "openbsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+beta2.tar.gz"
+  checksum: "sha256=a84ff5e8b768ea6ec0a95e10698387c84236cd7bdae0660299113356a86d8b97"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Second beta for 4.11.0, with frame pointers"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+  ] {os != "openbsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+beta2.tar.gz"
+  checksum: "sha256=a84ff5e8b768ea6ec0a95e10698387c84236cd7bdae0660299113356a86d8b97"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Second beta for 4.11.0"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.11.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.11.0+beta2.tar.gz"
+  checksum: "sha256=a84ff5e8b768ea6ec0a95e10698387c84236cd7bdae0660299113356a86d8b97"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]


### PR DESCRIPTION
The usual packages created with @Octachron looking over my shoulder

Changes since beta1:

## Manual and documentation

- 8644: fix formatting comment about @raise in stdlib's mli files
  (Élie Brami, review by David Allsopp)

- 9712: Update the version format to allow "~".
  The new format is "major.minor[.patchlevel][(+|~)additional-info]",
  for instance "4.12.0~beta1+flambda".
  This is a documentation-only change for the 4.11 branch, the new format
  will be used starting with the 4.12 branch.
  (Florian Angeletti, review by Damien Doligez and Xavier Leroy)

## Runtime

- 9714, 9724: Use the C++ alignas keyword when compiling in C++.
  Fixes a bug with MSVC C++ 2015/2017. Add a terminator to the
  `caml_domain_state` structure to better ensure that members are
  correctly spaced.
  (Antonin Décimo, review by David Allsopp and Xavier Leroy)