### PR TITLE
[new release] decompress and rfc1951 (1.2.0)

### DIFF
--- a/packages/decompress/decompress.1.2.0/opam
+++ b/packages/decompress/decompress.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name:         "decompress"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"
+  "base-bytes"
+  "bigarray-compat"
+  "optint"      {>= "0.0.4"}
+  "checkseum"   {>= "0.2.0"}
+  "bigstringaf" {with-test}
+  "alcotest"    {with-test}
+  "hxd"         {with-test}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.2.0/decompress-v1.2.0.tbz"
+  checksum: [
+    "sha256=51983d4497ccb27c253e7464b03d38544aad51e0e7d537e405f4df6954c27ab0"
+    "sha512=17c7e3dc79b7cedaf649c208874a50a810002c71d061c133239b9813a9dfe424ba303a968ba68c728862bb20ceaa23465097334bc16b819317390d01c2f91f89"
+  ]
+}

--- a/packages/decompress/decompress.1.2.0/opam
+++ b/packages/decompress/decompress.1.2.0/opam
@@ -18,7 +18,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"       {>= "4.07.0"}
-  "dune"
+  "dune"        {>= "1.0"}
   "base-bytes"
   "bigarray-compat"
   "optint"      {>= "0.0.4"}

--- a/packages/rfc1951/rfc1951.1.2.0/opam
+++ b/packages/rfc1951/rfc1951.1.2.0/opam
@@ -18,7 +18,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"      {>= "4.07.0"}
-  "dune"
+  "dune"       {>= "1.0"}
   "decompress" {= version}
 ]
 url {

--- a/packages/rfc1951/rfc1951.1.2.0/opam
+++ b/packages/rfc1951/rfc1951.1.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name:         "rfc1951"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "dune"
+  "decompress" {= version}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.2.0/decompress-v1.2.0.tbz"
+  checksum: [
+    "sha256=51983d4497ccb27c253e7464b03d38544aad51e0e7d537e405f4df6954c27ab0"
+    "sha512=17c7e3dc79b7cedaf649c208874a50a810002c71d061c133239b9813a9dfe424ba303a968ba68c728862bb20ceaa23465097334bc16b819317390d01c2f91f89"
+  ]
+}


### PR DESCRIPTION
Implementation of Zlib and GZip in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- add LZO support (@dinosaure, @cfcs, @XVilka, mirage/decompress#82)
- update binaries (@dinosaure, @XVilka, mirage/decompress#89)
- fix an exception leak (@dinosaure, @b1gtang, mirage/decompress#88)
- update README.md (@dinosaure, @XVilka, mirage/decompress#87)
- fix a mis-use of `Zl` API (@dinosaure, mirage/decompress#85)
- add `dune` as a dependency of `rfc1951` (@kit-ty-kate)
- real non-blocking state with `Zl` (@dinosaure, mirage/decompress#84)
