### PR TITLE
Coq 8.11.2: enable flambda if the compiler supports it

### DIFF
--- a/packages/coq/coq.8.11.2/opam
+++ b/packages/coq/coq.8.11.2/opam
@@ -33,6 +33,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-flambda-opts" "-O3 -unbox-closures"
     "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%"]


### PR DESCRIPTION
Code taken from
https://github.com/Blaisorblade/opam-overlay/blob/master/packages/coq/coq.8.11.2%2Bflambda-byte/opam#L36

Discussion on this change is on
https://coq.discourse.group/t/install-notes-on-coq-and-ocaml-versions-configuration/713/7.

- I'd like to wait for @ejgallego's feedback on merging this. To make this clear, I'm marking it as a draft PR.
- If approved, I'm happy to backport it as far back as 8.10.1 (or as appropriate), as long as we can also disable native-compute on Mac on those versions (to avoid risking regressions due to the flambda/native-compute interaction).

https://github.com/Blaisorblade/opam-overlay/tree/master/packages/coq
- [ ] Add `ocaml:version >= "4.07"` as proposed by @erikmd:
https://github.com/coq-community/docker-coq/issues/10#issuecomment-655793711