### PR TITLE
[new release] current_web, current_github, current_docker, current, current_git, current_slack, current_ansi, current_rpc, current_incr and current_examples (0.3)

### DIFF
--- a/packages/current/current.0.3/opam
+++ b/packages/current/current.0.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Pipeline language for keeping things up-to-date"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+It is used in ocaml-ci (which provides CI for OCaml projects on GitHub),
+and in docker-base-images (a pipeline that builds Docker images for various
+Linux distributions, OCaml compiler versions and CPU types, and pushes them
+to Docker Hub).
+
+A pipeline is written much like you would write a one-shot sequential script,
+but OCurrent will automatically re-run steps when the inputs change, and will
+run steps in parallel where possible."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "current_incr" {= version}
+  "fmt"
+  "bos"
+  "ppx_deriving"
+  "lwt"
+  "cmdliner"
+  "sqlite3"
+  "duration"
+  "prometheus"
+  "dune" {>= "2.0"}
+  "re"
+  "lwt-dllist"
+  "alcotest-lwt" {>= "1.0.1" & with-test}
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.3/current-v0.3.tbz"
+  checksum: [
+    "sha256=c238a9abf176c1208577c74e884eed763a37f207b4571e7e7fde3d575cb238ec"
+    "sha512=888ed07200847055ea950dedf8148d87dfc5178bf873b45354b1bffd11dc128c4759c89cf4170e6252b685deb8fb931a95acf349623cbe6ea1207feca76e1ba6"
+  ]
+}

--- a/packages/current_ansi/current_ansi.0.3/opam
+++ b/packages/current_ansi/current_ansi.0.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "ANSI escape sequence parser"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a basic ANSI escape parser,
+allowing the OCurrent web UI to show logs in colour."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "astring"
+  "fmt"
+  "tyxml"
+  "dune" {>= "2.0"}
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.3/current-v0.3.tbz"
+  checksum: [
+    "sha256=c238a9abf176c1208577c74e884eed763a37f207b4571e7e7fde3d575cb238ec"
+    "sha512=888ed07200847055ea950dedf8148d87dfc5178bf873b45354b1bffd11dc128c4759c89cf4170e6252b685deb8fb931a95acf349623cbe6ea1207feca76e1ba6"
+  ]
+}

--- a/packages/current_docker/current_docker.0.3/opam
+++ b/packages/current_docker/current_docker.0.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "OCurrent Docker plugin"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a plugin for interacting with Docker.
+It can pull, build, run and push images, and can coordinate
+multiple Docker Engine instances."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "ppx_deriving"
+  "lwt"
+  "dockerfile"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune" {>= "2.0"}
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.3/current-v0.3.tbz"
+  checksum: [
+    "sha256=c238a9abf176c1208577c74e884eed763a37f207b4571e7e7fde3d575cb238ec"
+    "sha512=888ed07200847055ea950dedf8148d87dfc5178bf873b45354b1bffd11dc128c4759c89cf4170e6252b685deb8fb931a95acf349623cbe6ea1207feca76e1ba6"
+  ]
+}

--- a/packages/current_examples/current_examples.0.3/opam
+++ b/packages/current_examples/current_examples.0.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Example pipelines for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides some example pipelines.
+It exists mainly to test the integration of various OCurrent
+plugins."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "lwt"
+  "cmdliner"
+  "duration"
+  "current" {= version}
+  "current_web" {= version}
+  "current_git" {= version}
+  "current_github" {= version}
+  "current_docker" {= version}
+  "current_rpc" {= version}
+  "capnp-rpc-unix" {>= "0.5"}
+  "dune" {>= "2.0"}
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.3/current-v0.3.tbz"
+  checksum: [
+    "sha256=c238a9abf176c1208577c74e884eed763a37f207b4571e7e7fde3d575cb238ec"
+    "sha512=888ed07200847055ea950dedf8148d87dfc5178bf873b45354b1bffd11dc128c4759c89cf4170e6252b685deb8fb931a95acf349623cbe6ea1207feca76e1ba6"
+  ]
+}

--- a/packages/current_git/current_git.0.3/opam
+++ b/packages/current_git/current_git.0.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Git plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Git.
+It can pull from remote repositories, or monitor local ones for changes."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "ppx_deriving"
+  "lwt"
+  "irmin-watcher"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune" {>= "2.0"}
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.3/current-v0.3.tbz"
+  checksum: [
+    "sha256=c238a9abf176c1208577c74e884eed763a37f207b4571e7e7fde3d575cb238ec"
+    "sha512=888ed07200847055ea950dedf8148d87dfc5178bf873b45354b1bffd11dc128c4759c89cf4170e6252b685deb8fb931a95acf349623cbe6ea1207feca76e1ba6"
+  ]
+}

--- a/packages/current_github/current_github.0.3/opam
+++ b/packages/current_github/current_github.0.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "GitHub plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with GitHub.
+It can monitor and clone remote GitHub repositories, and can
+push GitHub status messages to show the results of testing
+PRs and branches."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "current_web" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "lwt"
+  "yojson"
+  "cohttp-lwt-unix"
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "x509" {>= "0.10.0"}
+  "tls" {>= "0.11.0"}
+  "dune" {>= "2.0"}
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.3/current-v0.3.tbz"
+  checksum: [
+    "sha256=c238a9abf176c1208577c74e884eed763a37f207b4571e7e7fde3d575cb238ec"
+    "sha512=888ed07200847055ea950dedf8148d87dfc5178bf873b45354b1bffd11dc128c4759c89cf4170e6252b685deb8fb931a95acf349623cbe6ea1207feca76e1ba6"
+  ]
+}

--- a/packages/current_incr/current_incr.0.3/opam
+++ b/packages/current_incr/current_incr.0.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Self-adjusting computations"
+description: """
+This is a small, self-contained library for self-adjusting (incremental) computations.
+It was written for OCurrent, but can be used separately too.
+
+It is similar to Jane Street's incremental library, but much smaller and
+has no external dependencies.
+
+It is also similar to the react library, but the results do not depend on the
+behaviour of the garbage collector. In particular, functions stop being called
+as soon as they are no longer needed.
+"""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.3/current-v0.3.tbz"
+  checksum: [
+    "sha256=c238a9abf176c1208577c74e884eed763a37f207b4571e7e7fde3d575cb238ec"
+    "sha512=888ed07200847055ea950dedf8148d87dfc5178bf873b45354b1bffd11dc128c4759c89cf4170e6252b685deb8fb931a95acf349623cbe6ea1207feca76e1ba6"
+  ]
+}

--- a/packages/current_rpc/current_rpc.0.3/opam
+++ b/packages/current_rpc/current_rpc.0.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Cap'n Proto RPC plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a Cap'n Proto RPC interface, allowing
+an OCurrent engine to be controlled remotely."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp-rpc-lwt" {>= "0.4"}
+  "fpath"
+  "dune" {>= "2.0"}
+]
+conflicts: [
+  "x509" {= "0.11.0"}
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.3/current-v0.3.tbz"
+  checksum: [
+    "sha256=c238a9abf176c1208577c74e884eed763a37f207b4571e7e7fde3d575cb238ec"
+    "sha512=888ed07200847055ea950dedf8148d87dfc5178bf873b45354b1bffd11dc128c4759c89cf4170e6252b685deb8fb931a95acf349623cbe6ea1207feca76e1ba6"
+  ]
+}

--- a/packages/current_slack/current_slack.0.3/opam
+++ b/packages/current_slack/current_slack.0.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Slack plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Slack.
+It can post messages to slack channels."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "yojson"
+  "lwt"
+  "tls" {>= "0.12.0"}
+  "cohttp-lwt-unix"
+  "dune" {>= "2.0"}
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.3/current-v0.3.tbz"
+  checksum: [
+    "sha256=c238a9abf176c1208577c74e884eed763a37f207b4571e7e7fde3d575cb238ec"
+    "sha512=888ed07200847055ea950dedf8148d87dfc5178bf873b45354b1bffd11dc128c4759c89cf4170e6252b685deb8fb931a95acf349623cbe6ea1207feca76e1ba6"
+  ]
+}

--- a/packages/current_web/current_web.0.3/opam
+++ b/packages/current_web/current_web.0.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Test web UI for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a basic web UI for service administrators.
+It shows the current pipeline visually and allows viewing job
+logs and configuring the log analyser."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "current" {= version}
+  "current_ansi" {= version}
+  "ocaml" {>= "4.08.0"}
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "base64"
+  "session"
+  "session-cohttp-lwt"
+  "mirage-crypto-rng"
+  "fmt"
+  "bos"
+  "lwt"
+  "cmdliner"
+  "prometheus-app"
+  "cohttp-lwt-unix" {>= "2.2.0"}
+  "tyxml"
+  "routes" {>= "0.8.0"}
+  "dune" {>= "2.0"}
+]
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.3/current-v0.3.tbz"
+  checksum: [
+    "sha256=c238a9abf176c1208577c74e884eed763a37f207b4571e7e7fde3d575cb238ec"
+    "sha512=888ed07200847055ea950dedf8148d87dfc5178bf873b45354b1bffd11dc128c4759c89cf4170e6252b685deb8fb931a95acf349623cbe6ea1207feca76e1ba6"
+  ]
+}


### PR DESCRIPTION
Test web UI for OCurrent

- Project page: <a href="https://github.com/ocurrent/ocurrent">https://github.com/ocurrent/ocurrent</a>

##### CHANGES:

The main changes are:

- "latching" of a previous pipeline stage output while building the new one.
  For example, while doing `docker pull` to check for updates to an image
  it will continue using the old one until the check finishes.
  Jobs with latched results are scheduled at a lower priority than jobs without
  any output yet.

- Many improvements to the web UI, including access controls, streaming of
  logs, improved querying, and custom extra pages.

Core:

- Allow user-defined pools (@talex5, ocurrent/ocurrent#206).
  Add `Pool.of_fn` so that users can provide their own pools. This allows
  waiting for resources from an external service before marking a job as
  started.

- Add simple job priorities (@talex5, ocurrent/ocurrent#187).
  Pools now have high and low priority queues.
  The cache puts jobs on the low priority queue if they have a latched result available.

- Allow jobs to latch previous output while rebuilding (@talex5, ocurrent/ocurrent#178).
  If a rebuild is triggered by the schedule, do the rebuild in the background
  without changing the output to pending. This allows polling for changes
  without disrupting the rest of the pipeline.
  Such jobs are displayed with a gradient background (from the pending
  colour on the left to the latched output's colour on the right).

- Add `Current_cache.Generic` to control latching behaviour (@talex5, ocurrent/ocurrent#179).
  This provides the full API. `BUILDER` and `PUBLISHER` are now special cases of `GENERIC`.

- Also latch failed results when cache entries expire (@talex5, ocurrent/ocurrent#202).

- Don't clear latched result when auto-cancelling (@talex5, ocurrent/ocurrent#195).

- Fix rebuilding of stale cache entries (@talex5, ocurrent/ocurrent#169).
  If a build was already invalid when we loaded it from the database, we invalidated the key but didn't trigger an update properly.

- Fix `Option.get` crash when shutting down (@talex5, ocurrent/ocurrent#205).
  If an error occurs on startup and a cache entry has expired then
  we set config to None to exit the engine, and the timer thread tries to
  read the config and crashes, hiding the real error.

- Fix scheduled builds for very fast jobs (@talex5, ocurrent/ocurrent#185).
  We cleared the expiry timer when the job reported an active state. However,
  if the job was very quick (no async operations) we wouldn't see this state.
  Then we'd think the old timer was still in place and would be good to handle
  the new deadline too. Reported by Kate.

- Move `Current_cache.output` to new `Instance` submodule (@talex5, ocurrent/ocurrent#201).
  The name "output" came from before the build and publish caches were unified and was confusing.

- Handle uncaught exceptions in monitor read functions (@talex5, ocurrent/ocurrent#191).

- Add missing `?cwd` to `Current.Process.exec` (@kit-ty-kate, ocurrent/ocurrent#177).

- Delete directories with `Lwt` (@talex5, ocurrent/ocurrent#192).
  Using `Unix.unlink` was causing high latencies in some cases.

Web UI:

- Improvements to query page (@talex5, ocurrent/ocurrent#196).
  - Add toggles to query page to allow rebuilding multiple jobs at once.
  - Filter by job ID prefix in the query page. This makes it easy to restrict results to a particular day (or month, hour, etc).
  - Filter by operation type in query page.
  - Allow filtering by rebuild status in query page.
  - Show job queue time and run time in query page.

- Stream log files (@talex5, ocurrent/ocurrent#165).
  If the job is still running, keep the connection open and stream the data as it arrives.

- Add `Site` and `Context` modules (@talex5, ocurrent/ocurrent#170).

- Auto-generate links in nav-bar from routes (@talex5, ocurrent/ocurrent#182).
  Expose routes in web API. This allows the user to provide whatever routes they like, or to use their own server.

- Update to new Routes API (@anuragsoni, ocurrent/ocurrent#189 ocurrent/ocurrent#190).

- Add a basic access control system (@talex5, ocurrent/ocurrent#172).
  - `Site` now takes `authn` and `has_role` arguments.
  - `authn` (if given) is used to create a "Login" link in the navbar.
  - `has_role` is used to decide who can access which resource.
  - The GitHub plugin now provides an authentication backend that authenticates users with GitHub.

- Display the build history in the job page (@talex5, ocurrent/ocurrent#166).
  Allows navigating to previous build results easily.

Diagram generation:

- Extend, rather than replace, the context in `with_context` (@talex5, ocurrent/ocurrent#197).

- Truncate long tooltips in Graphviz diagrams. Graphviz rejects long messages with the error `longer than 16384?`.

Docker plugin:

- Return the RepoId after pushing a manifest (@talex5, ocurrent/ocurrent#207).

- Add `Raw` module with low-level API (@talex5, ocurrent/ocurrent#168).
  This is useful if you need to create your own custom components (for example,
  because you want to use a `Current.t` input to generate one of the fixed
  arguments such as `~run_args`). See `examples/docker_custom.ml` for an example.

Git plugin:

- Add `?pool` argument to `Git.with_checkout` (@talex5, ocurrent/ocurrent#184).
  Git checkout operations can use a lot of CPU and IO, so allow users to supply a pool to limit the number of concurrent operations.

- Make `Commit_id.pp_user_clone` public (@talex5, ocurrent/ocurrent#176).
  Also, `Commit.id` now returns a `Commit_id.t`. Use `Commit.hash` to get the hash.

- Fix clone instructions for GitHub PRs (@talex5, ocurrent/ocurrent#164).
  GitHub only provides the `refs/pull/NNN/head` branches when fetching, not when cloning (with the default refspec).
  Detect this case and show an alternative command that the user can run to reproduce the operation.

GitHub plugin:

- Get all installation repositories, not just the first 30 (@talex5, ocurrent/ocurrent#193).
  For now, as a precaution, ignore any installation that has configured all repositories to be tested (this is likely an accident).

- If listing repositories fails, retry after 30s (@talex5, ocurrent/ocurrent#198).

- Add `Installation.repositories ?include_archived` option (@talex5, ocurrent/ocurrent#203).
  Filtering archived repositories is now the default.
  There's not much point doing CI on them as you can't write the status result back.

- Add `GitHub.Installation.account` to get account name (@talex5, ocurrent/ocurrent#204).

- Add `Api.Anonymous.head_of` (@talex5, ocurrent/ocurrent#200).
  This allows monitoring the head of a public GitHub repository without needing
  an OAuth token. It's useful for the `ocaml-ci-local` command, allowing users
  to test the pipeline easily.

- Catch cohttp end-of-file exceptions (@talex5, ocurrent/ocurrent#175).

- Remove unicorn from error string (@talex5, ocurrent/ocurrent#183).
  When a GraphQL query returned a server error, we previously returned the body
  of the HTTP response as the error message. However, this includes a large
  picture of a unicorn, which is not suitable as an error string.

Slack plugin:

- Upgrade TLS library to cope with Slack's new TLS policy (@talex5, ocurrent/ocurrent#174 ocurrent/ocurrent#194).

Build:

- Update to dune 2 (@talex5, ocurrent/ocurrent#171).

- Add missing alcotest dependency (@talex5, ocurrent/ocurrent#163).
