### PR TITLE
2 packages from project-everest/hacl-star at 0.2.1

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.2.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `hacl-star` package, of
+which `hacl-star-raw` is a dependency."""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ctypes"
+  "ctypes-foreign"
+]
+build: [
+  ["sh" "-exc" "cd raw && ./configure"]
+  [make "-C" "raw"]
+]
+install: [make "-C" "raw" "install-hacl-star-raw"]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.2.1/hacl-star.0.2.1.tar.gz"
+  checksum: [
+    "md5=a8fc22a701608018cded326be1990af9"
+    "sha512=de185640ddd9ec63e5f07274f45dee68cea30e476cd58cb7e7be3e7bd6c062b347236e2a20e6b54238212a2c2e351f7717893b79ed9e381419dffeb962fd744c"
+  ]
+}

--- a/packages/hacl-star/hacl-star.0.2.1/opam
+++ b/packages/hacl-star/hacl-star.0.2.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "OCaml API for EverCrypt/HACL*"
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.2"}
+  "hacl-star-raw" {= version}
+  "zarith"
+  "cppo" {build}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.2.1/hacl-star.0.2.1.tar.gz"
+  checksum: [
+    "md5=a8fc22a701608018cded326be1990af9"
+    "sha512=de185640ddd9ec63e5f07274f45dee68cea30e476cd58cb7e7be3e7bd6c062b347236e2a20e6b54238212a2c2e351f7717893b79ed9e381419dffeb962fd744c"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`hacl-star.0.2.1`: OCaml API for EverCrypt/HACL*
-`hacl-star-raw.0.2.1`: Auto-generated low-level OCaml bindings for EverCrypt/HACL*



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.2