### PR TITLE
[new release] ppxlib (0.14.0)

### DIFF
--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.2/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.5.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.11.1"}
   "js_of_ocaml" {= version}
   "ocaml-migrate-parsetree"
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
 ]
 url {
   src:

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.6.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.6.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.5"}
   "js_of_ocaml" {= version}
   "ocaml-migrate-parsetree"
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
 ]
 url {
   src:

--- a/packages/nuscr/nuscr.1.1.0/opam
+++ b/packages/nuscr/nuscr.1.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_inline_test" {with-test & < "v0.15"}
   "odoc" {with-doc}
   "ocamlgraph" {>= "1.8.8"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/obus/obus.1.2.1/opam
+++ b/packages/obus/obus.1.2.1/opam
@@ -21,7 +21,7 @@ depends: [
   "lwt_log"
   "lwt_react"
   "ocaml-migrate-parsetree"
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
 ]
 
 url {

--- a/packages/obus/obus.1.2.2/opam
+++ b/packages/obus/obus.1.2.2/opam
@@ -21,7 +21,7 @@ depends: [
   "lwt_log"
   "lwt_react"
   "ocaml-migrate-parsetree"
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
 ]
 
 url {

--- a/packages/pattern/pattern.0.1.1/opam
+++ b/packages/pattern/pattern.0.1.1/opam
@@ -20,7 +20,7 @@ the list of differences between a pattern and a value.
 """
 depends: [
   "dune" {>= "1.10.0"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
   "ppx_deriving" {>= "4.4"}
   "stdcompat" {>= "10"}
 ]

--- a/packages/ppx_accessor/ppx_accessor.v0.14.1/opam
+++ b/packages/ppx_accessor/ppx_accessor.v0.14.1/opam
@@ -14,7 +14,7 @@ depends: [
   "accessor"{>= "v0.14.1" & < "v0.15"}
   "base"{>= "v0.14" & < "v0.15"}
   "dune"  {>= "2.0.0"}
-  "ppxlib"   {>= "0.11.0"}
+  "ppxlib"   {>= "0.11.0" & < "0.14.0"}
 ]
 synopsis: "[@@deriving] plugin to generate accessors for use with the Accessor libraries"
 description: "

--- a/packages/ppx_bench/ppx_bench.v0.13.0/opam
+++ b/packages/ppx_bench/ppx_bench.v0.13.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"           {>= "4.04.2"}
   "ppx_inline_test" {>= "v0.13" & < "v0.14"}
   "dune"            {>= "1.5.1"}
-  "ppxlib"          {>= "0.9.0"}
+  "ppxlib"          {>= "0.9.0" & < "0.14.0"}
 ]
 synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
 description: "

--- a/packages/ppx_bench/ppx_bench.v0.14.0/opam
+++ b/packages/ppx_bench/ppx_bench.v0.14.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"           {>= "4.04.2"}
   "ppx_inline_test" {>= "v0.14" & < "v0.15"}
   "dune"            {>= "2.0.0"}
-  "ppxlib"          {>= "0.11.0"}
+  "ppxlib"          {>= "0.11.0" & < "0.14.0"}
 ]
 synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
 description: "

--- a/packages/ppx_factory/ppx_factory.0.1.1/opam
+++ b/packages/ppx_factory/ppx_factory.0.1.1/opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "1.1"}
   "ocaml" {>= "4.07.0"}
   "ounit" {with-test & >= "2.0.0"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
   "ppx_deriving" {with-test}
 ]
 tags: ["org:cryptosense"]

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.13.0/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.13.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"      {>= "v0.13" & < "v0.14"}
   "fieldslib" {>= "v0.13" & < "v0.14"}
   "dune"      {>= "1.5.1"}
-  "ppxlib"    {>= "0.9.0"}
+  "ppxlib"    {>= "0.9.0" & < "0.14.0"}
 ]
 synopsis: "Generation of accessor and iteration functions for ocaml records"
 description: "

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.14.0/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.14.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"      {>= "v0.14" & < "v0.15"}
   "fieldslib" {>= "v0.14" & < "v0.15"}
   "dune"      {>= "2.0.0"}
-  "ppxlib"    {>= "0.11.0"}
+  "ppxlib"    {>= "0.11.0" & < "0.14.0"}
 ]
 synopsis: "Generation of accessor and iteration functions for ocaml records"
 description: "

--- a/packages/ppx_inline_test/ppx_inline_test.v0.13.0/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.13.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.13" & < "v0.14"}
   "dune"   {>= "1.5.1"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
 ]
 synopsis: "Syntax extension for writing in-line tests in ocaml code"
 description: "

--- a/packages/ppx_inline_test/ppx_inline_test.v0.13.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.13.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.13" & < "v0.14"}
   "dune"   {>= "1.10"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
 ]
 synopsis: "Syntax extension for writing in-line tests in ocaml code"
 description: "

--- a/packages/ppx_inline_test/ppx_inline_test.v0.14.0/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.14.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"     {>= "v0.14" & < "v0.15"}
   "time_now" {>= "v0.14" & < "v0.15"}
   "dune"     {>= "2.0.0"}
-  "ppxlib"   {>= "0.11.0"}
+  "ppxlib"   {>= "0.11.0" & < "0.14.0"}
 ]
 synopsis: "Syntax extension for writing in-line tests in ocaml code"
 description: "

--- a/packages/ppx_stable/ppx_stable.v0.13.0/opam
+++ b/packages/ppx_stable/ppx_stable.v0.13.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.13" & < "v0.14"}
   "dune"   {>= "1.5.1"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
 ]
 synopsis: "Stable types conversions generator"
 description: "

--- a/packages/ppx_stable/ppx_stable.v0.14.0/opam
+++ b/packages/ppx_stable/ppx_stable.v0.14.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "4.04.2"}
   "base"   {>= "v0.14" & < "v0.15"}
   "dune"   {>= "2.0.0"}
-  "ppxlib" {>= "0.11.0"}
+  "ppxlib" {>= "0.11.0" & < "0.14.0"}
 ]
 synopsis: "Stable types conversions generator"
 description: "

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.13.0/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.13.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"    {>= "v0.13" & < "v0.14"}
   "typerep" {>= "v0.13" & < "v0.14"}
   "dune"    {>= "1.5.1"}
-  "ppxlib"  {>= "0.9.0"}
+  "ppxlib"  {>= "0.9.0" & < "0.14.0"}
 ]
 synopsis: "Generation of runtime types from type declarations"
 description: "

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.14.0/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.14.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"    {>= "v0.14" & < "v0.15"}
   "typerep" {>= "v0.14" & < "v0.15"}
   "dune"    {>= "2.0.0"}
-  "ppxlib"  {>= "0.11.0"}
+  "ppxlib"  {>= "0.11.0" & < "0.14.0"}
 ]
 synopsis: "Generation of runtime types from type declarations"
 description: "

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.13.0/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.13.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"        {>= "v0.13" & < "v0.14"}
   "variantslib" {>= "v0.13" & < "v0.14"}
   "dune"        {>= "1.5.1"}
-  "ppxlib"      {>= "0.9.0"}
+  "ppxlib"      {>= "0.9.0" & < "0.14.0"}
 ]
 synopsis: "Generation of accessor and iteration functions for ocaml variant types"
 description: "

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.14.0/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.14.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"        {>= "v0.14" & < "v0.15"}
   "variantslib" {>= "v0.14" & < "v0.15"}
   "dune"        {>= "2.0.0"}
-  "ppxlib"      {>= "0.11.0"}
+  "ppxlib"      {>= "0.11.0" & < "0.14.0"}
 ]
 synopsis: "Generation of accessor and iteration functions for ocaml variant types"
 description: "

--- a/packages/ppxlib/ppxlib.0.14.0/opam
+++ b/packages/ppxlib/ppxlib.0.14.0/opam
@@ -16,7 +16,7 @@ run-test: [
 depends: [
   "ocaml"                   {>= "4.04.1"}
   "base"                    {>= "v0.11.0"}
-  "dune"
+  "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.5.0"}
   "ppx_derivers"            {>= "1.0"}

--- a/packages/ppxlib/ppxlib.0.14.0/opam
+++ b/packages/ppxlib/ppxlib.0.14.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.10" }
+]
+depends: [
+  "ocaml"                   {>= "4.04.1"}
+  "base"                    {>= "v0.11.0"}
+  "dune"
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ppx_derivers"            {>= "1.0"}
+  "stdio"                   {>= "v0.11.0"}
+  "ocamlfind"               {with-test}
+  "cinaps"                  {with-test & >= "v0.12.1"}
+]
+synopsis: "Base library and tools for ppx rewriters"
+description: """
+A comprehensive toolbox for ppx development. It features:
+- a OCaml AST / parser / pretty-printer snapshot,to create a full
+   frontend independent of the version of OCaml;
+- a library for library for ppx rewriters in general, and type-driven
+  code generators in particular;
+- a feature-full driver for OCaml AST transformers;
+- a quotation mechanism allowing  to write values representing the
+   OCaml AST in the OCaml syntax;
+- a generator of open recursion classes from type definitions.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.14.0/ppxlib-0.14.0.tbz"
+  checksum: [
+    "sha256=a1a398f7c8f670d7de80468ff4639862b126f4dcac3de416e0c5c4d5860f3854"
+    "sha512=987062ecaa406a0bc4d87350947ab7da06b650c2f3c991a3aba470bd45c0a26619536bd50753de958a8a1f3b41f89fbcf7206bf3b5acc33002a9b2debd686d6c"
+  ]
+}

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.13.0/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.13.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune"                {>= "1.5.1"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ocamlfind"           {>= "1.7.2"}
-  "ppxlib"              {>= "0.9.0"}
+  "ppxlib"              {>= "0.9.0" & < "0.14.0"}
 ]
 synopsis: "Expectation tests for the OCaml toplevel"
 description: "

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.14.0/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.14.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune"                {>= "2.0.0"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ocamlfind"           {>= "1.7.2"}
-  "ppxlib"              {>= "0.11.0"}
+  "ppxlib"              {>= "0.11.0" & < "0.14.0"}
 ]
 synopsis: "Expectation tests for the OCaml toplevel"
 description: "


### PR DESCRIPTION
Base library and tools for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Bump ppxlib's AST to 4.10 (ocaml-ppx/ppxlib#130, @NathanReb)

- Remove omp_config from `Expansion_context` and replace it with `tool_name`
  (ocaml-ppx/ppxlib#149, @NathanReb)

- Change undocumented `Ppxlib.Driver.map_structure` to return a ppxlib's
  `structure` instead of a `Migrate_parsetree.Driver.some_structure`.
  (ocaml-ppx/ppxlib#153, @NathanReb)
