### PR TITLE
Package camlp5.8.00~alpha01

### DIFF
--- a/packages/camlp5/camlp5.8.00~alpha01/opam
+++ b/packages/camlp5/camlp5.8.00~alpha01/opam
@@ -1,0 +1,53 @@
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description:
+"""
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel.
+"""
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+homepage: "https://camlp5.github.io"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+doc: "https://camlp5.github.io/doc/html"
+
+depends: [
+  "ocaml"       { >= "4.02" & < "4.12.0" }
+]
+depexts: [
+  [
+    "libstring-shellquote-perl"
+    "libipc-system-simple-perl"
+  ] {os-family = "debian"}
+]
+
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/camlp5/archive/8.00+alpha01.tar.gz"
+  checksum: [
+    "md5=364d6af8b54f8e4feb65260d89ec4a68"
+    "sha512=6fb0fca8685a8e2b6fc33b794b6f8c032248eb75632c8b229bd5c0b083ba89ef4a8492e203d3fcb5c7a8ca92b747e6f9f9d845a32f5561fc6eff30196600ffe8"
+  ]
+}


### PR DESCRIPTION
### `camlp5.8.00~alpha01`
Preprocessor-pretty-printer of OCaml
Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.

As a preprocessor, it allows to:

extend the syntax of OCaml,
redefine the whole syntax of the language.
As a pretty printer, it allows to:

display OCaml programs in an elegant way,
convert from one syntax to another,
check the results of syntax extensions.
Camlp5 also provides some parsing and pretty printing tools:

extensible grammars
extensible printers
stream parsers and lexers
pretty print module
It works as a shell command and can also be used in the OCaml toplevel.



---
* Homepage: https://camlp5.github.io
* Source repo: git+https://github.com/camlp5/camlp5.git
* Bug tracker: https://github.com/camlp5/camlp5/issues

---
:camel: Pull-request generated by opam-publish v2.0.2