### PR TITLE
Package camlp5.8.00~alpha01

### DIFF
--- a/packages/camlp5/camlp5.8.00~alpha01/opam
+++ b/packages/camlp5/camlp5.8.00~alpha01/opam
@@ -1,0 +1,54 @@
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description:
+"""
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel.
+"""
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+homepage: "https://camlp5.github.io"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+doc: "https://camlp5.github.io/doc/html"
+
+depends: [
+  "ocaml"       { >= "4.02" & < "4.12.0" }
+]
+depexts: [
+  [
+    "libstring-shellquote-perl"
+    "libipc-system-simple-perl"
+    "perl"
+  ] {os-family = "debian"}
+]
+
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha01.tar.gz"
+  checksum: [
+    "md5=7f7e23b1ca4b8cc768a50152b1b90a2f"
+    "sha512=7335231228aa098d7eb361e8b46f75a1fd7b89e3dd5156cc81ac7790f9c44b5a576c0ff7e6cc755758ceb698c8834325025cec1267fc9996d96ee15d91e9a58d"
+  ]
+}


### PR DESCRIPTION
### `camlp5.8.00~alpha01`
Preprocessor-pretty-printer of OCaml
Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.

As a preprocessor, it allows to:

extend the syntax of OCaml,
redefine the whole syntax of the language.
As a pretty printer, it allows to:

display OCaml programs in an elegant way,
convert from one syntax to another,
check the results of syntax extensions.
Camlp5 also provides some parsing and pretty printing tools:

extensible grammars
extensible printers
stream parsers and lexers
pretty print module
It works as a shell command and can also be used in the OCaml toplevel.



---
* Homepage: https://camlp5.github.io
* Source repo: git+https://github.com/camlp5/camlp5.git
* Bug tracker: https://github.com/camlp5/camlp5/issues

---
:camel: Pull-request generated by opam-publish v2.0.2