### PR TITLE
Package camlp5.8.00~alpha01

### DIFF
--- a/packages/camlp5/camlp5.8.00~alpha01/opam
+++ b/packages/camlp5/camlp5.8.00~alpha01/opam
@@ -49,5 +49,6 @@ url {
   src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha01.tar.gz"
   checksum: [
     "md5=bd9ab4c95186761a94f715775f9140a3"
+    "sha512=6701d0eb05c527e7fd837ad6cbbd429275d1df064bb20e33b5e02ef22b6678d79e96e403dd7503659a43e624092ead083ed5945f51da51d0a2138beccb20b27c"
   ]
 }

--- a/packages/camlp5/camlp5.8.00~alpha01/opam
+++ b/packages/camlp5/camlp5.8.00~alpha01/opam
@@ -1,0 +1,54 @@
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description:
+"""
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel.
+"""
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+homepage: "https://camlp5.github.io"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+doc: "https://camlp5.github.io/doc/html"
+
+depends: [
+  "ocaml"       { >= "4.02" & < "4.12.0" }
+  "conf-perl"
+]
+depexts: [
+  [
+    "libstring-shellquote-perl"
+    "libipc-system-simple-perl"
+  ] {os-family = "debian"}
+]
+
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha01.tar.gz"
+  checksum: [
+    "md5=869f8b382fe69f78260b35545b2eea0f"
+    "sha512=59c0cb3cd230c9a59a73fb571b1ae01f238b6a710d201d08df4dd856788b034e0677564b8d5c764e9aeb42937d7bff402fcff368509a9f5caa3729a872371e96"
+  ]
+}

--- a/packages/camlp5/camlp5.8.00~alpha01/opam
+++ b/packages/camlp5/camlp5.8.00~alpha01/opam
@@ -48,7 +48,6 @@ install: [make "install"]
 url {
   src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha01.tar.gz"
   checksum: [
-    "md5=869f8b382fe69f78260b35545b2eea0f"
-    "sha512=59c0cb3cd230c9a59a73fb571b1ae01f238b6a710d201d08df4dd856788b034e0677564b8d5c764e9aeb42937d7bff402fcff368509a9f5caa3729a872371e96"
+    "md5=bd9ab4c95186761a94f715775f9140a3"
   ]
 }

--- a/packages/elpi/elpi.1.0.5/opam
+++ b/packages/elpi/elpi.1.0.5/opam
@@ -20,7 +20,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.1.0/opam
+++ b/packages/elpi/elpi.1.1.0/opam
@@ -20,7 +20,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.1.1/opam
+++ b/packages/elpi/elpi.1.1.1/opam
@@ -20,7 +20,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.02.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.10.0/opam
+++ b/packages/elpi/elpi.1.10.0/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.10.1/opam
+++ b/packages/elpi/elpi.1.10.1/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.10.2/opam
+++ b/packages/elpi/elpi.1.10.2/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.11.0/opam
+++ b/packages/elpi/elpi.1.11.0/opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppxlib"
   "ppx_deriving"
   "re" {>= "1.7.2"}

--- a/packages/elpi/elpi.1.11.1/opam
+++ b/packages/elpi/elpi.1.11.1/opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppxlib" {>= "0.12.0"}
   "ocaml-migrate-parsetree" {>= "1.6.0"}
   "ppx_deriving"

--- a/packages/elpi/elpi.1.11.2/opam
+++ b/packages/elpi/elpi.1.11.2/opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppxlib" {>= "0.12.0"}
   "ocaml-migrate-parsetree" {>= "1.6.0"}
   "ppx_deriving"

--- a/packages/elpi/elpi.1.2.0/opam
+++ b/packages/elpi/elpi.1.2.0/opam
@@ -17,7 +17,7 @@ install: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.3.1/opam
+++ b/packages/elpi/elpi.1.3.1/opam
@@ -17,7 +17,7 @@ install: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "ocamlfind" {build}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.4.0/opam
+++ b/packages/elpi/elpi.1.4.0/opam
@@ -13,7 +13,7 @@ run-test: [ make "tests" "TIME=" {os = "macos"} ]
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.4.1/opam
+++ b/packages/elpi/elpi.1.4.1/opam
@@ -12,7 +12,7 @@ run-test: [ make "tests" "TIME=" {os = "macos"} ]
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.5.2/opam
+++ b/packages/elpi/elpi.1.5.2/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.6.0/opam
+++ b/packages/elpi/elpi.1.6.0/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.7.0/opam
+++ b/packages/elpi/elpi.1.7.0/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.8.0/opam
+++ b/packages/elpi/elpi.1.8.0/opam
@@ -16,7 +16,7 @@ patches: [ "0001-Makefile-pass-DUNE_OPTS-to-dune.patch" ]
 extra-files: [ ["0001-Makefile-pass-DUNE_OPTS-to-dune.patch" "810836aa85bdb52d6a02947e93353ced"] ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.9.0/opam
+++ b/packages/elpi/elpi.1.9.0/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/elpi/elpi.1.9.1/opam
+++ b/packages/elpi/elpi.1.9.1/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ppx_tools_versioned"
   "ppx_deriving"
   "ocaml-migrate-parsetree"

--- a/packages/ledit/ledit.2.03/opam
+++ b/packages/ledit/ledit.2.03/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 build: make
 depends: [
   "ocaml" {< "4.06.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
 ]
 install: [
   make

--- a/packages/ledit/ledit.2.04/opam
+++ b/packages/ledit/ledit.2.04/opam
@@ -6,7 +6,7 @@ maintainer: "Pierre Boutillier <pierre.boutillier@laposte.net>"
 build: [ make "all" ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "camlp5"
+  "camlp5" {<= "7.99"}
 ]
 synopsis: "Line editor, a la rlwrap"
 description: """

--- a/packages/ulex-camlp5/ulex-camlp5.1.2/opam
+++ b/packages/ulex-camlp5/ulex-camlp5.1.2/opam
@@ -15,7 +15,7 @@ flags: light-uninstall
 depends: [
   "ocaml" {>="4.02.0"} 
   "ocamlfind" {build}
-  "camlp5"
+  "camlp5" {<= "7.99"}
   "ocamlbuild" {build}
 ]
 url {


### PR DESCRIPTION
### `camlp5.8.00~alpha01`
Preprocessor-pretty-printer of OCaml
Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.

As a preprocessor, it allows to:

extend the syntax of OCaml,
redefine the whole syntax of the language.
As a pretty printer, it allows to:

display OCaml programs in an elegant way,
convert from one syntax to another,
check the results of syntax extensions.
Camlp5 also provides some parsing and pretty printing tools:

extensible grammars
extensible printers
stream parsers and lexers
pretty print module
It works as a shell command and can also be used in the OCaml toplevel.



---
* Homepage: https://camlp5.github.io
* Source repo: git+https://github.com/camlp5/camlp5.git
* Bug tracker: https://github.com/camlp5/camlp5/issues

---
:camel: Pull-request generated by opam-publish v2.0.2