### PR TITLE
Package yices2_bindings.0.1

### DIFF
--- a/packages/yices2_bindings/yices2_bindings.0.1/opam
+++ b/packages/yices2_bindings/yices2_bindings.0.1/opam
@@ -29,7 +29,7 @@ install: [
 url {
   src: "https://github.com/SRI-CSL/yices2_ocaml_bindings/archive/0.1.tar.gz"
   checksum: [
-    "md5=69c2bb4868c1b5d774f14115b4e9f649"
-    "sha512=9fbd04b9354090d8145f5342a407d231313b9f2dfc64be0406332a4decd2fa7bb09ec9e4a7d77ceeadaf0255ebac0459914a4f50ad4857d205281fb14505409c"
+    "md5=c5097d0fd1e22b601594313a1ed85238"
+    "sha512=89310ced285fdea4bd3111bb83f5384b7cf1bed0e739e067fec7c133f480275b9e872b9910bfbbfb44f7a5f3122e49cc1764ccacf56c75427c3471c837d322bc"
   ]
 }

--- a/packages/yices2_bindings/yices2_bindings.0.1/opam
+++ b/packages/yices2_bindings/yices2_bindings.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Ocaml bindings for yices2"
+description: "Ocaml bindings for yices2"
+maintainer: "Stephane Graham-Lengrand <stephane.graham-lengrand@csl.sri.com>"
+authors: "Stephane Graham-Lengrand <stephane.graham-lengrand@csl.sri.com>"
+license: "GPLv3"
+homepage: "https://github.com/SRI-CSL/yices2_ocaml_bindings"
+bug-reports: "https://github.com/SRI-CSL/yices2_ocaml_bindings/issues"
+depends: [
+  "ocaml" {>= "4.08" & < "4.11"}
+  "ocamlbuild"
+  "ocamlfind"
+  "ctypes"
+  "ctypes-foreign"
+  "ppx_deriving"
+  "ppx_optcomp"
+  "sexplib"
+  "sexplib0"
+  "zarith"
+  "ctypes-zarith" {>= "0.2.0"}
+#  "ctypes-of-clang"
+]
+build: [
+  make
+]
+install: [
+  make "install"
+]
+remove: [
+  make "clean"
+]
+url {
+  src: "https://github.com/SRI-CSL/yices2_ocaml_bindings/archive/0.1.tar.gz"
+  checksum: [
+    "md5=69c2bb4868c1b5d774f14115b4e9f649"
+    "sha512=9fbd04b9354090d8145f5342a407d231313b9f2dfc64be0406332a4decd2fa7bb09ec9e4a7d77ceeadaf0255ebac0459914a4f50ad4857d205281fb14505409c"
+  ]
+}

--- a/packages/yices2_bindings/yices2_bindings.0.1/opam
+++ b/packages/yices2_bindings/yices2_bindings.0.1/opam
@@ -7,9 +7,9 @@ license: "GPLv3"
 homepage: "https://github.com/SRI-CSL/yices2_ocaml_bindings"
 bug-reports: "https://github.com/SRI-CSL/yices2_ocaml_bindings/issues"
 depends: [
-  "ocaml" {>= "4.08" & < "4.11"}
-  "ocamlbuild"
-  "ocamlfind"
+  "ocaml" {>= "4.08"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
   "ctypes"
   "ctypes-foreign"
   "ppx_deriving"
@@ -25,9 +25,6 @@ build: [
 ]
 install: [
   make "install"
-]
-remove: [
-  make "clean"
 ]
 url {
   src: "https://github.com/SRI-CSL/yices2_ocaml_bindings/archive/0.1.tar.gz"


### PR DESCRIPTION
### `yices2_bindings.0.1`
Ocaml bindings for yices2
Ocaml bindings for yices2



---
* Homepage: https://github.com/SRI-CSL/yices2_ocaml_bindings
* Bug tracker: https://github.com/SRI-CSL/yices2_ocaml_bindings/issues

---
:camel: Pull-request generated by opam-publish v2.0.2