### PR TITLE
[new release] csexp (1.3.0)

### DIFF
--- a/packages/csexp/csexp.1.3.0/opam
+++ b/packages/csexp/csexp.1.3.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Parsing and printing of S-expressions in Canonical form"
+description: """
+
+This library provides minimal support for Canonical S-expressions
+[1]. Canonical S-expressions are a binary encoding of S-expressions
+that is super simple and well suited for communication between
+programs.
+
+This library only provides a few helpers for simple applications. If
+you need more advanced support, such as parsing from more fancy input
+sources, you should consider copying the code of this library given
+how simple parsing S-expressions in canonical form is.
+
+To avoid a dependency on a particular S-expression library, the only
+module of this library is parameterised by the type of S-expressions.
+
+[1] https://en.wikipedia.org/wiki/Canonical_S-expressions
+"""
+maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
+authors: [
+  "Quentin Hocquet <mefyl@gruntech.org>"
+  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jeremie Dimino <jeremie@dimino.org>"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-dune/csexp"
+doc: "https://ocaml-dune.github.io/csexp/"
+bug-reports: "https://github.com/ocaml-dune/csexp/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "ocaml" {>= "4.02.3"}
+  "ppx_expect" {with-test}
+  "result" {>= "1.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-dune/csexp.git"
+url {
+  src:
+    "https://github.com/ocaml-dune/csexp/releases/download/1.3.0/csexp-1.3.0.tbz"
+  checksum: [
+    "sha256=9a462624f3c13ebabe8be833f0e738971c5d95389c1a2643ae86e1b8036589ae"
+    "sha512=87c98c5e9555a6e4335013074a92271c34e6ed37200280b2bc67e3ed9194ded5fe429e80c53582bc481d7f207fd53823a95ffaa35ba369b21ef64ca2911436a2"
+  ]
+}


### PR DESCRIPTION
Parsing and printing of S-expressions in Canonical form

- Project page: <a href="https://github.com/ocaml-dune/csexp">https://github.com/ocaml-dune/csexp</a>
- Documentation: <a href="https://ocaml-dune.github.io/csexp/">https://ocaml-dune.github.io/csexp/</a>

##### CHANGES:

- Add a "feed" API for parsing. This new API let the user feed
  characters one by one to the parser. It gives more control to the
  user and the handling of IO errors is simpler and more
  explicit. Finally, it allocates less (ocaml-dune/csexp#9, @jeremiedimino)

- Fixes `input_opt`; it was could never return [None] (ocaml-dune/csexp#9, fixes ocaml-dune/csexp#7,
  @jeremiedimino)

- Fixes `parse_many`; it was returning s-expressions in the wrong
  order (ocaml-dune/csexp#10, @rgrinberg)
