### PR TITLE
Update the GSL depext for Debian

### DIFF
--- a/packages/conf-gsl/conf-gsl.2/opam
+++ b/packages/conf-gsl/conf-gsl.2/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "blue-prawn"
+homepage: "http://www.gnu.org/software/gsl/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+build: [["pkg-config" "gsl"]]
+depexts: [
+  ["libgsl-dev"] {os-family = "debian"}
+  ["libgsl-devel"] {os-distribution = "mageia"}
+  ["gsl-devel"] {os-distribution = "centos"}
+  ["gsl-devel"] {os-distribution = "fedora"}
+  ["gsl-devel"] {os-distribution = "rhel"}
+  ["gsl-dev"] {os-distribution = "alpine"}
+  ["gsl-devel"] {os-family = "suse"}
+  ["gsl"] {os = "freebsd"}
+  ["gsl"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on a GSL lib system installation"
+description:
+  "This package can only install if the GSL lib is installed on the system."
+authors: "blue-prawn"
+depends: ["conf-pkg-config" {build}]
+flags: conf


### PR DESCRIPTION
libgsl0-dev is a virtual package provided by libgsl-dev and [only available in Debian stable](https://packages.debian.org/search?keywords=libgsl0&searchon=names&suite=stable&section=all).