### PR TITLE
[new release] letters (0.1.1)

### DIFF
--- a/packages/letters/letters.0.1.1/opam
+++ b/packages/letters/letters.0.1.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+version: "0.1.1"
+synopsis: "Client library for sending emails over SMTP"
+description: "Simple to use SMTP client implementation for OCaml"
+maintainer: ["Miko Nieminen <miko.nieminen@iki.fi>"]
+authors: ["Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/letters/"
+doc: "https://oxidizing.github.io/letters/"
+bug-reports: "https://github.com/oxidizing/letters/issues"
+depends: [
+  "ocaml" {>= "4.08.1"}
+  "dune" {>= "2.3"}
+  "mrmime" {>= "0.3.0"}
+  "colombe" {>= "0.3.0"}
+  "sendmail-lwt" {>= "0.3.0"}
+  "fmt" {>= "0.8.8"}
+  "x509" {>= "0.9.0"}
+  "ptime" {>= "0.8.5"}
+  "lwt" {>= "5.2.0"}
+  "fpath" {>= "0.7.0"}
+  "alcotest" {>= "1.1.0" & with-test}
+  "alcotest-lwt" {>= "1.1.0" & with-test}
+  "yojson" {>= "1.7.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/letters.git"
+url {
+  src:
+    "https://github.com/oxidizing/letters/releases/download/0.1.1/letters-0.1.1.tbz"
+  checksum: [
+    "sha256=e514f9edf4018dbeb743155dd0399feba8920fac3c190c5cda8ec0fb52103c08"
+    "sha512=a479b992d76be6d0883562a6106f6aee926a64faad0930e89f9a0f800b6eb372a69180c5bddc6e035120fad183d7b247c37ab339afe44b3180db13d4d3c8560c"
+  ]
+}


### PR DESCRIPTION
Client library for sending emails over SMTP

- Project page: <a href="https://github.com/oxidizing/letters/">https://github.com/oxidizing/letters/</a>
- Documentation: <a href="https://oxidizing.github.io/letters/">https://oxidizing.github.io/letters/</a>

##### CHANGES:

## [0.1.1] - 2020-07-10
### Fixed
- Add missing `public_name` stanza in library's dune file to make it properly
  available

## [0.1.0] - 2020-07-07
### Added
- Support sending email over TLS protected SMTP connection
- Support sending email over SMTP with STARTTLS
- Support sending HTML or plain text body
