### PR TITLE
[new release] digestif (0.9.0)

### DIFF
--- a/packages/digestif/digestif.0.9.0/opam
+++ b/packages/digestif/digestif.0.9.0/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+name:         "digestif"
+maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/digestif"
+bug-reports:  "https://github.com/mirage/digestif/issues"
+dev-repo:     "git+https://github.com/mirage/digestif.git"
+doc:          "https://mirage.github.io/digestif/"
+license:      "MIT"
+synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+description: """
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "./install/install.ml" ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+install:  [
+  [ "dune" "install" "-p" name ] {with-test}
+  [ "./test/test_runes.ml" ] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {>= "2.6.0"}
+  "eqaf"
+  "base-bytes"
+  "bigarray-compat"
+  "stdlib-shims"
+  "fmt"            {with-test}
+  "alcotest"       {with-test}
+  "bos"            {with-test}
+  "astring"        {with-test}
+  "fpath"          {with-test}
+  "rresult"        {with-test}
+  "ocamlfind"      {build & with-test}
+]
+
+depopts: [
+  "ocaml-freestanding"
+  "mirage-xen-posix"
+]
+
+conflicts: [
+  "mirage-xen-posix" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.3"}
+]
+url {
+  src:
+    "https://github.com/mirage/digestif/releases/download/v0.9.0/digestif-v0.9.0.tbz"
+  checksum: [
+    "sha256=040f1558635c7fc49609406866ab1752e26ae4fcfae01f31d2dd902b5fbe696e"
+    "sha512=a3b904ed1b3e2354f5efd71ee546041d2bb31091161597acb82e4bc2d0686b34d348adba1aef5b927efa28e1764b60f65c171019dd11952c72a76c92510878ee"
+  ]
+}


### PR DESCRIPTION
Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)

- Project page: <a href="https://github.com/mirage/digestif">https://github.com/mirage/digestif</a>
- Documentation: <a href="https://mirage.github.io/digestif/">https://mirage.github.io/digestif/</a>

##### CHANGES:

- Add sha3 implementation (mirage/digestif#98), @lyrm, @dinosaure, @hannesm and @cfcs
