### PR TITLE
Package grain_dypgen.0.2

### DIFF
--- a/packages/grain_dypgen/grain_dypgen.0.2/files/dypgen.install
+++ b/packages/grain_dypgen/grain_dypgen.0.2/files/dypgen.install
@@ -1,0 +1,5 @@
+bin: [
+  "dypgen/dypgen.opt"
+  "dypgen/dypgen"
+  "dyp2gram.pl" {"dyp2gram"}
+]

--- a/packages/grain_dypgen/grain_dypgen.0.2/files/install-bsd-compatible.patch
+++ b/packages/grain_dypgen/grain_dypgen.0.2/files/install-bsd-compatible.patch
@@ -1,0 +1,62 @@
+--- dypgen.20120619-1/Makefile.orig	2013-04-02 16:17:00.000000000 +0200
++++ dypgen.20120619-1/Makefile	2013-04-02 16:21:59.000000000 +0200
+@@ -22,20 +22,24 @@
+ 
+ #install with ocaml-findlib
+ install: install_opt
+-	install -D --mode=755 dypgen/dypgen $(BINDIR)
+-	install -D --mode=755 dyp2gram.pl $(BINDIR)/dyp2gram
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dypgen.1
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dypgen.opt.1
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dyp2gram.1
++	install -d $(BINDIR)
++	install -m 755 dypgen/dypgen $(BINDIR)
++	install -m 755 dyp2gram.pl $(BINDIR)/dyp2gram
++	install -d $(MANDIR)
++	install -m 644 doc/dypgen.1 $(MANDIR)/dypgen.1
++	install -m 644 doc/dypgen.1 $(MANDIR)/dypgen.opt.1
++	install -m 644 doc/dypgen.1 $(MANDIR)/dyp2gram.1
+ 	cd dyplib; $(MAKE) install
+ 
+ #install without ocaml-findlib
+ install2: install_opt
+-	install -D --mode=755 dypgen/dypgen $(BINDIR)
+-	install -D --mode=755 dyp2gram.pl $(BINDIR)/dyp2gram
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dypgen.1
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dypgen.opt.1
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dyp2gram.1
++	install -d $(BINDIR)
++	install -m 755 dypgen/dypgen $(BINDIR)
++	install -m 755 dyp2gram.pl $(BINDIR)/dyp2gram
++	install -d $(MANDIR)
++	install -m 644 doc/dypgen.1 $(MANDIR)/dypgen.1
++	install -m 644 doc/dypgen.1 $(MANDIR)/dypgen.opt.1
++	install -m 644 doc/dypgen.1 $(MANDIR)/dyp2gram.1
+ 	cd dyplib; $(MAKE) install2
+ 
+ ifdef CAMLOPT
+--- dypgen.20120619-1/dyplib/Makefile.orig	2013-04-02 16:15:48.000000000 +0200
++++ dypgen.20120619-1/dyplib/Makefile	2013-04-02 16:16:41.000000000 +0200
+@@ -28,15 +28,18 @@
+ 	- $(OCAMLFIND) remove -destdir $(DYPGENLIBDIR) dyp
+ 
+ install2: install_dyp install_opt
+-	install -D --mode=644 dyp.cmi $(DYPGENLIBDIR)/dyp
++	install -d $(DYPGENLIBDIR)/dyp
++	install -m 644 dyp.cmi $(DYPGENLIBDIR)/dyp
+ 
+ install_dyp:
+-	install -D --mode=644 dyp.cma $(DYPGENLIBDIR)/dyp
++	install -d $(DYPGENLIBDIR)/dyp
++	install -m 644 dyp.cma $(DYPGENLIBDIR)/dyp
+ 
+ ifdef CAMLOPT
+ install_opt:
+-	install -D --mode=644 dyp.cmxa $(DYPGENLIBDIR)/dyp
+-	install -D --mode=644 dyp.a $(DYPGENLIBDIR)/dyp
++	install -d $(DYPGENLIBDIR)/dyp
++	install -m 644 dyp.cmxa $(DYPGENLIBDIR)/dyp
++	install -m 644 dyp.a $(DYPGENLIBDIR)/dyp
+ else
+ install_opt:
+ endif

--- a/packages/grain_dypgen/grain_dypgen.0.2/opam
+++ b/packages/grain_dypgen/grain_dypgen.0.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Emmanuel Onzo" "Philip Blair"]
+homepage: "https://github.com/grain-lang/dypgen"
+license: "CeCILL-B"
+build: make
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "ocamlfind" {build}
+]
+patches: ["install-bsd-compatible.patch"]
+install: [
+  [make "install" "DYPGENLIBDIR=%{lib}%" "BINDIR=%{bin}%" "MANDIR=%{man}%/man1"]
+  ["sh.exe" "-c" "if [ -f '%{bin}%/dypgen' ] && [ ! -f '%{bin}%/dypgen.exe' ] ; then mv '%{bin}%/dypgen' '%{bin}%/dypgen.exe' ; fi" ] { os = "win32" }
+  ["sh.exe" "-c" "if [ -f '%{bin}%/dypgen.opt' ] && [ ! -f '%{bin}%/dypgen.opt.exe' ] ; then mv '%{bin}%/dypgen.opt' '%{bin}%/dypgen.opt.exe' ; fi" ] { os = "win32" }
+]
+synopsis: "Self-extensible parsers and lexers for OCaml"
+description: """
+dypgen is a GLR parser generator for OCaml, it is able to
+generate self-extensible parsers (also called adaptive parsers) as
+well as extensible lexers for the parsers it produces.
+(fork of pre-4.06 dypgen: http://dypgen.free.fr/)"""
+extra-files: [
+  ["install-bsd-compatible.patch" "md5=f4885881bb9e16bae3f9e88ebb54c582"]
+  ["dypgen.install" "md5=3af2bc7343588caf1a6de8af49a3b1b5"]
+]
+url {
+  src: "https://github.com/grain-lang/dypgen/archive/0.2.tar.gz"
+  checksum: [
+    "md5=321d677c64368b4b6fae4a31aa8def64"
+    "sha512=b01044243d76550194ea1a9e93eb53f525ae9e88ef0a1d69c5c00ef7adf3791d88df72f8ccb47fe0966c54fc214ff8e54f3cdf34c7627ea10b3a1a64f2e683a0"
+  ]
+}


### PR DESCRIPTION
### `grain_dypgen.0.2`
Self-extensible parsers and lexers for OCaml
dypgen is a GLR parser generator for OCaml, it is able to
generate self-extensible parsers (also called adaptive parsers) as
well as extensible lexers for the parsers it produces.
(fork of pre-4.06 dypgen: http://dypgen.free.fr/)



---
* Homepage: https://github.com/grain-lang/dypgen

---
:camel: Pull-request generated by opam-publish v2.0.0