### PR TITLE
[new release] ounit2-lwt, ounit2, ounit-lwt and ounit (2.2.3)

### DIFF
--- a/packages/ounit-lwt/ounit-lwt.2.2.3/opam
+++ b/packages/ounit-lwt/ounit-lwt.2.2.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvaini+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ounit"
+dev-repo: "git+https://github.com/gildor478/ounit.git"
+bug-reports: "https://github.com/gildor478/ounit/issues"
+doc: "https://gildor478.github.io/ounit/"
+depends: [
+  "ocamlfind" {build}
+  "ounit2-lwt" {= version}
+]
+install: [
+  [make "install-ounit-lwt" "version=%{version}%"]
+]
+synopsis: "This is a transition package, ounit-lwt is now ounit2-lwt"
+description:"""
+More details for the transition:
+https://github.com/gildor478/ounit#transition-to-ounit2
+"""
+url {
+  src:
+    "https://github.com/gildor478/ounit/releases/download/v2.2.3/ounit-v2.2.3.tbz"
+  checksum: [
+    "sha256=e280a64aa7df64bd7335c9ed68a70d6ee168b39ae8bbfb6daedd2f4a04844ad9"
+    "sha512=dff04859d263e5f80a1606156d07493d0320a2756d0a7f134c63c53078550c7b056587486922bc66a288413af30c59a7e47157636502c6dd10626cf75587f981"
+  ]
+}

--- a/packages/ounit/ounit.2.2.3/opam
+++ b/packages/ounit/ounit.2.2.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvaini+ocaml@le-gall.net>"
+authors: [ "Maas-Maarten Zeeman" "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ounit"
+dev-repo: "git+https://github.com/gildor478/ounit.git"
+bug-reports: "https://github.com/gildor478/ounit/issues"
+doc: "https://gildor478.github.io/ounit/"
+depends: [
+  "ocamlfind" {build}
+  "ounit2" {= version}
+]
+install: [
+  [make "install-ounit" "version=%{version}%"]
+]
+synopsis: "This is a transition package, ounit is now ounit2"
+description:"""
+More details for the transition:
+https://github.com/gildor478/ounit#transition-to-ounit2
+"""
+url {
+  src:
+    "https://github.com/gildor478/ounit/releases/download/v2.2.3/ounit-v2.2.3.tbz"
+  checksum: [
+    "sha256=e280a64aa7df64bd7335c9ed68a70d6ee168b39ae8bbfb6daedd2f4a04844ad9"
+    "sha512=dff04859d263e5f80a1606156d07493d0320a2756d0a7f134c63c53078550c7b056587486922bc66a288413af30c59a7e47157636502c6dd10626cf75587f981"
+  ]
+}

--- a/packages/ounit2-lwt/ounit2-lwt.2.2.3/opam
+++ b/packages/ounit2-lwt/ounit2-lwt.2.2.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvaini+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ounit"
+dev-repo: "git+https://github.com/gildor478/ounit.git"
+bug-reports: "https://github.com/gildor478/ounit/issues"
+doc: "https://gildor478.github.io/ounit/"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.11.0"}
+  "lwt"
+  "ounit2" {= version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+synopsis: "OUnit testing framework (Lwt)"
+description:"""
+This library contains helper functions for building Lwt tests using OUnit.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ounit/releases/download/v2.2.3/ounit-v2.2.3.tbz"
+  checksum: [
+    "sha256=e280a64aa7df64bd7335c9ed68a70d6ee168b39ae8bbfb6daedd2f4a04844ad9"
+    "sha512=dff04859d263e5f80a1606156d07493d0320a2756d0a7f134c63c53078550c7b056587486922bc66a288413af30c59a7e47157636502c6dd10626cf75587f981"
+  ]
+}

--- a/packages/ounit2/ounit2.2.2.3/opam
+++ b/packages/ounit2/ounit2.2.2.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvaini+ocaml@le-gall.net>"
+authors: [ "Maas-Maarten Zeeman" "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ounit"
+dev-repo: "git+https://github.com/gildor478/ounit.git"
+bug-reports: "https://github.com/gildor478/ounit/issues"
+doc: "https://gildor478.github.io/ounit/"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.11.0"}
+  "base-bytes"
+  "base-unix"
+  "stdlib-shims"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+synopsis: "OUnit testing framework"
+description: """
+OUnit is a unit test framework for OCaml. It allows one to easily create
+unit-tests for OCaml code. It is loosely based on [HUnit], a unit testing
+framework for Haskell. It is similar to [JUnit], and other XUnit testing
+frameworks.
+"""
+url {
+  src:
+    "https://github.com/gildor478/ounit/releases/download/v2.2.3/ounit-v2.2.3.tbz"
+  checksum: [
+    "sha256=e280a64aa7df64bd7335c9ed68a70d6ee168b39ae8bbfb6daedd2f4a04844ad9"
+    "sha512=dff04859d263e5f80a1606156d07493d0320a2756d0a7f134c63c53078550c7b056587486922bc66a288413af30c59a7e47157636502c6dd10626cf75587f981"
+  ]
+}


### PR DESCRIPTION
OUnit testing framework (Lwt)

- Project page: <a href="https://github.com/gildor478/ounit">https://github.com/gildor478/ounit</a>
- Documentation: <a href="https://gildor478.github.io/ounit/">https://gildor478.github.io/ounit/</a>

##### CHANGES:

### Changed
- Minimal OCaml version is now 4.04.

### Fixed
- Make colored output and JUnit features more prominent in the documentation.
  (Closes: gildor478/ounit#13, gildor478/ounit#12)
- Increase default timeouts, so that they work as well for slow architecture
  like s390x. The fastest timeout is now 20s (immediate test) and the longest
  is 1h (huge test). (Closes: gildor478/ounit#18)
