### PR TITLE
Add nixos distribution to sqlite3 depexts

### DIFF
--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -21,6 +21,7 @@ depexts: [
   ["sqlite-devel"] {os-distribution = "fedora"}
   ["sqlite-dev"] {os-distribution = "alpine"}
   ["sqlite3-devel"] {os-family = "suse"}
+  ["sqlite"] {os-distribution = "nixos"}
   ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
   ["sqlite3"] {os = "macos" & os-distribution = "macports"}
 ]


### PR DESCRIPTION
opam2nix tool uses `os-distribution = "nixos"` for depexts:
https://github.com/timbertson/opam2nix#how-do-opam-depexts-work