### PR TITLE
[new release] alcotest-lwt, alcotest, alcotest-async and alcotest-mirage (1.2.0)

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.2.0/opam
+++ b/packages/alcotest-async/alcotest-async.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Async-based helpers for Alcotest"
+description: "Async-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "async_unix" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.0/alcotest-mirage-1.2.0.tbz"
+  checksum: [
+    "sha256=d82b7236081362320bd6dd968b192096bb68e3c688beab825fb0ebd3994daa87"
+    "sha512=67ec5355bb4f8cb806b8b0cecf4831c4ad20aa53ab161c8991bf46642c6d828a4e1de0aa2a16f880ebe528dbf7800e2a99778bf8397a9b7cb921301d0c0f4b70"
+  ]
+}

--- a/packages/alcotest-lwt/alcotest-lwt.1.2.0/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Lwt-based helpers for Alcotest"
+description: "Lwt-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "lwt"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.0/alcotest-mirage-1.2.0.tbz"
+  checksum: [
+    "sha256=d82b7236081362320bd6dd968b192096bb68e3c688beab825fb0ebd3994daa87"
+    "sha512=67ec5355bb4f8cb806b8b0cecf4831c4ad20aa53ab161c8991bf46642c6d828a4e1de0aa2a16f880ebe528dbf7800e2a99778bf8397a9b7cb921301d0c0f4b70"
+  ]
+}

--- a/packages/alcotest-mirage/alcotest-mirage.1.2.0/opam
+++ b/packages/alcotest-mirage/alcotest-mirage.1.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Mirage implementation for Alcotest"
+description: "Mirage implementation for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "mirage-clock" {>= "2.0.0"}
+  "duration"
+  "lwt"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.0/alcotest-mirage-1.2.0.tbz"
+  checksum: [
+    "sha256=d82b7236081362320bd6dd968b192096bb68e3c688beab825fb0ebd3994daa87"
+    "sha512=67ec5355bb4f8cb806b8b0cecf4831c4ad20aa53ab161c8991bf46642c6d828a4e1de0aa2a16f880ebe528dbf7800e2a99778bf8397a9b7cb921301d0c0f4b70"
+  ]
+}

--- a/packages/alcotest/alcotest.1.2.0/opam
+++ b/packages/alcotest/alcotest.1.2.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Alcotest is a lightweight and colourful test framework"
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "cmdliner"
+  "uuidm"
+  "re"
+  "stdlib-shims"
+  "uutf"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.0/alcotest-mirage-1.2.0.tbz"
+  checksum: [
+    "sha256=d82b7236081362320bd6dd968b192096bb68e3c688beab825fb0ebd3994daa87"
+    "sha512=67ec5355bb4f8cb806b8b0cecf4831c4ad20aa53ab161c8991bf46642c6d828a4e1de0aa2a16f880ebe528dbf7800e2a99778bf8397a9b7cb921301d0c0f4b70"
+  ]
+}


### PR DESCRIPTION
- Project page: <a href="https://github.com/mirage/alcotest">https://github.com/mirage/alcotest</a>
- Documentation: <a href="https://mirage.github.io/alcotest">https://mirage.github.io/alcotest</a>

##### CHANGES:

- Add an `alcotest-mirage` package, allowing the construction of MirageOS
  unikernels that run Alcotest test suites. (mirage/alcotest#238, @hannesm @linse)

- Add `Alcotest.check'`, a variant of `Alcotest.check` with labeled arguments.
  (mirage/alcotest#239, @hartmut27)

- Add a testable for the `bytes` type. (mirage/alcotest#253, @mefyl)

- Many assorted improvements to Alcotest output formatting. (mirage/alcotest#246, @CraigFe)

- Default to `--color=always` when running inside Dune (mirage/alcotest#242, @CraigFe). The
  value can be overridden by setting the `ALCOTEST_COLOR` variable in a `dune`
  file, for example:

```dune
(env
 (_
  (env-vars
   (ALCOTEST_COLOR auto))))
```

- Support all UTF-8 characters in test names and suite names, by normalising
  them for file-system interactions. (mirage/alcotest#249, @gs0510; mirage/alcotest#246, @CraigFe)

- Fix various crashes when using non-filesystem-safe characters in test suite
  names (these break Alcotest when attempting to generate a corresponding log
  file). (mirage/alcotest#241, @mefyl; mirage/alcotest#246 @CraigFe)
