### PR TITLE
Travis: Disallow failures on FreeBSD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ matrix:
     env: OCAML_VERSION=4.09 INSTALL_LOCAL=1
   - os: linux
     env: OCAML_VERSION=4.11.0+trunk OCAML_BETA=enable
-  allow_failures:
-  - os: freebsd
-    env: OCAML_VERSION=4.09
 notifications:
   email:
   - opam-commits@lists.ocaml.org


### PR DESCRIPTION
Having to look on Travis to detect failures is kind of annoying, most of the packages I look at seem to be working fine and the rest can just be discarded manually, it doesn't make our life as maintainers that much worse.

FreeBSD is still an experimental platform of Travis-CI but it has been fairly stable for the last 2+ months