### PR TITLE
[new release] dune-release (1.4.0)

### DIFF
--- a/packages/dune-release/dune-release.1.4.0/opam
+++ b/packages/dune-release/dune-release.1.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: ["Daniel Bünzli" "Thomas Gazagnaire" "Nathan Rebours"]
+homepage: "https://github.com/ocamllabs/dune-release"
+license: "ISC"
+dev-repo: "git+https://github.com/ocamllabs/dune-release.git"
+bug-reports: "https://github.com/ocamllabs/dune-release/issues"
+doc: "https://ocamllabs.github.io/dune-release/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.4.0"}
+  "curly"
+  "fmt"
+  "bos"
+  "cmdliner"
+  "re"
+  "opam-format"
+  "opam-state"
+  "opam-core"
+  "rresult"
+  "logs"
+  "odoc"
+  "alcotest" {with-test}
+  "mdx" {with-test & >= "1.6.0"}
+  "yojson"
+]
+
+synopsis: "Release dune packages in opam"
+description: """
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports projects built
+with [Dune](https://github.com/ocaml/dune) and hosted on
+[GitHub](https://github.com).
+"""
+url {
+  src:
+    "https://github.com/ocamllabs/dune-release/releases/download/1.4.0/dune-release-1.4.0.tbz"
+  checksum: [
+    "sha256=96061b82b882119eb0b9faf4fe1ae76d427db9d62c52260d06a3669dc3b631bb"
+    "sha512=81516b6bbd7e793190e52f5d371c5d94aeca67d1a85d4c8d247f2aa3d881f0bcad50e89e01179c6e641a1e7e9fb3084043e71160dc8e36944073e5f93205e3ed"
+  ]
+}


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/ocamllabs/dune-release">https://github.com/ocamllabs/dune-release</a>
- Documentation: <a href="https://ocamllabs.github.io/dune-release/">https://ocamllabs.github.io/dune-release/</a>

##### CHANGES:

### Added

- Add a `dune-release config` subcommand to display and edit the global
  configuration (ocamllabs/dune-release#220, @NathanReb).
- Add command `delegate-info` to print information needed by external
  release scripts (ocamllabs/dune-release#221, @pitag-ha)
- Use Curly instead of Cmd to interact with github (ocamllabs/dune-release#202, @gpetiot)
- Add `x-commit-hash` field to the opam file when releasing (ocamllabs/dune-release#224, @gpetiot)
- Add support for common alternative names for the license and 
  ChangeLog file (ocamllabs/dune-release#204, @paurkedal)

### Changed

- Command `tag`: improve error and log messages by comparing the provided
  commit with the commit correspondent to the provided tag (ocamllabs/dune-release#226, @pitag-ha)
- Error logs: when an external command fails, include its error message in
  the error message posted by `dune-release` (ocamllabs/dune-release#231, @pitag-ha)
- Error log formatting: avoid unnecessary line-breaks; indent only slightly
  in multi-lines (ocamllabs/dune-release#234, @pitag-ha)
- Linting step of `dune-release distrib` does not fail when opam's `doc` field
  is missing. Do not try to generate nor publish the documentation when opam's
  `doc` field is missing. (ocamllabs/dune-release#235, @gpetiot)

### Deprecated

- Deprecate opam 1.x (ocamllabs/dune-release#195, @gpetiot)

### Fixed

- Separate packages names by spaces in `publish` logs (ocamllabs/dune-release#171, @hannesm)
- Fix uncaught exceptions in distrib subcommand and replace them with proper
  error messages (ocamllabs/dune-release#176, @gpetiot)
- Use the 'user' field in the configuration before inferring it from repo URI
  and handles HTTPS URIs (ocamllabs/dune-release#183, @gpetiot)
- Ignore backup files when looking for README, CHANGES and LICENSE files
  (ocamllabs/dune-release#194, @gpetiot)
- Do not echo input characters when reading token (ocamllabs/dune-release#199, @gpetiot)
- Improve the output of VCS command errors (ocamllabs/dune-release#193, @gpetiot)
- Better error handling when checking opam version (ocamllabs/dune-release#195, @gpetiot)
- Do not write 'version' and 'name' fields in opam file (ocamllabs/dune-release#200, @gpetiot)
- Use Yojson to parse github json response and avoid parsing bugs.
  (ocamllabs/dune-release#177, @gpetiot)
- The `git` command used in `publish doc` should check `DUNE_RELEASE_GIT` (even
  if deprecated) before `PATH`. (ocamllabs/dune-release#242, @gpetiot)
- Adapt the docs to the removal of the `log` subcommand (ocamllabs/dune-release#196, @gpetiot)