### PR TITLE
Coq 8.9: fix camlp5 dependency

### DIFF
--- a/packages/coq/coq.8.9.0/opam
+++ b/packages/coq/coq.8.9.0/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1"
 depends: [
   "ocaml" {>= "4.02.3" & < "4.10"}
   "ocamlfind" {build}
-  "camlp5"
+  "camlp5" {< "8"}
   "num"
   "conf-findutils" {build}
 ]

--- a/packages/coq/coq.8.9.1/opam
+++ b/packages/coq/coq.8.9.1/opam
@@ -10,7 +10,7 @@ synopsis: "Formal proof management system"
 depends: [
   "ocaml" {>= "4.02.3" & < "4.10"}
   "ocamlfind" {build}
-  "camlp5"
+  "camlp5" {< "8"}
   "num"
   "conf-findutils" {build}
 ]


### PR DESCRIPTION
When camlp5 8.00~alpha01 got added to the repo, it got picked up automatically by our CI through `opam upgrade` (seems a bit weird for alpha versions to be released like that), breaking the build of Coq 8.9. This adjusts the Coq 8.9 package to fix that.

(Newer versions of Coq lucky enough to not depend on camlp5 any more.)