### PR TITLE
also fix Coq 8.8 camlp5 dependency

### DIFF
--- a/packages/coq/coq.8.8.0/opam
+++ b/packages/coq/coq.8.8.0/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1"
 depends: [
   "ocaml" {>= "4.02.3" & < "4.10"}
   "ocamlfind" {build}
-  "camlp5"
+  "camlp5" {< "8"}
   "num"
   "conf-findutils" {build}
 ]

--- a/packages/coq/coq.8.8.1/opam
+++ b/packages/coq/coq.8.8.1/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1"
 depends: [
   "ocaml" {>= "4.02.3" & < "4.10"}
   "ocamlfind" {build}
-  "camlp5"
+  "camlp5" {< "8"}
   "num"
   "conf-findutils" {build}
 ]

--- a/packages/coq/coq.8.8.2/opam
+++ b/packages/coq/coq.8.8.2/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1"
 depends: [
   "ocaml" {>= "4.02.3" & < "4.10"}
   "ocamlfind" {build}
-  "camlp5"
+  "camlp5" {< "8"}
   "num"
   "conf-findutils" {build}
 ]


### PR DESCRIPTION
Same as https://github.com/ocaml/opam-repository/pull/16811 but for Coq 8.8 (turns out we need that one, too).