### PR TITLE
Package embedded_ocaml_templates.0.3

### DIFF
--- a/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.3/opam
+++ b/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.3/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "0.3.1"
 synopsis: "EML is a simple templating language that lets you generate text with plain OCaml"
 description: """
 EML is a simple templating language that lets you generate text with plain OCaml
@@ -25,9 +26,9 @@ build: [
 ]
 url {
   src:
-    "https://github.com/EmileTrotignon/embedded_ocaml_templates/archive/0.3.tar.gz"
+    "https://github.com/EmileTrotignon/embedded_ocaml_templates/archive/0.3.1.tar.gz"
   checksum: [
-    "md5=74d087a6bf95b95e64460a327dfc164f"
-    "sha512=cd6a0b73cbe7d82b8d24f91114b34c6f283581d789c3f81701855e0d9edcb77f9afef8faef9d6d87d7aa3839ad417ce21fa0927c3c5a7a4917c9ec909414e2d1"
+    "md5=65dfebc97da6ad5038c6144a864a118d"
+    "sha512=98e42ba1e1e12311c434f88d8931cb308572f7ef96620517dec9d26a5ad5f8e3483dcdae7225c1d3c5f92ce178d0e73544b135a6d6f3e087e11c628d038261f9"
   ]
 }

--- a/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.3/opam
+++ b/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "EML is a simple templating language that lets you generate text with plain OCaml"
+description: """
+EML is a simple templating language that lets you generate text with plain OCaml
+Inspired by EJS templates
+"""
+maintainer: "Emile Trotignon emile.trotignon@gmail.com"
+authors: "Emile Trotignon emile.trotignon@gmail.com"
+license: "MIT"
+homepage: "https://github.com/EmileTrotignon/embedded_ocaml_templates"
+bug-reports: "https://github.com/EmileTrotignon/embedded_ocaml_templates/issues"
+dev-repo: "git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git"
+depends: [ 
+    "ocaml" {>= "4.07.0"}
+    "dune" {>= "2.5.0"} 
+    "sedlex" 
+    "core" {>= "v0.12"}
+    "uutf" 
+    "menhir" 
+    "ppxlib" 
+    "containers"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/EmileTrotignon/embedded_ocaml_templates/archive/0.3.tar.gz"
+  checksum: [
+    "md5=74d087a6bf95b95e64460a327dfc164f"
+    "sha512=cd6a0b73cbe7d82b8d24f91114b34c6f283581d789c3f81701855e0d9edcb77f9afef8faef9d6d87d7aa3839ad417ce21fa0927c3c5a7a4917c9ec909414e2d1"
+  ]
+}


### PR DESCRIPTION
### `embedded_ocaml_templates.0.3`
EML is a simple templating language that lets you generate text with plain OCaml
EML is a simple templating language that lets you generate text with plain OCaml
Inspired by EJS templates

This version adds a ppx rewriter that lets you inline EML templates in OCaml code.

---
* Homepage: https://github.com/EmileTrotignon/embedded_ocaml_templates
* Source repo: git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git
* Bug tracker: https://github.com/EmileTrotignon/embedded_ocaml_templates/issues

---
:camel: Pull-request generated by opam-publish v2.0.2