### PR TITLE
ocaml-variant.4.12.0+trunk*: Use --disable-warn-error + Factorize the build rule

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.12.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+trunk+afl/opam
@@ -12,15 +12,14 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--with-afl" ]
-    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "CC=cc"
-    "ASPP=cc -c"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
     "--with-afl"
-  ] {os = "openbsd" | os = "macos"}
+    "--disable-warn-error"
+  ]
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+trunk+flambda/opam
@@ -12,15 +12,14 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
-    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "--enable-flambda"
-    "CC=cc"
-    "ASPP=cc -c"
-  ] {os = "openbsd" | os = "macos"}
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+    "--disable-warn-error"
+  ]
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+trunk/opam
@@ -12,14 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%"]
-    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "CC=cc"
-    "ASPP=cc -c"
-  ] {os = "openbsd" | os = "macos"}
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+    "--disable-warn-error"
+  ]
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]


### PR DESCRIPTION
https://github.com/ocaml/ocaml/pull/9625 brings the ability for the compiler during its dev phase, to not pass `-Werror` to the C linker, which is not enabled on releases. This option should not be given to the C linker by default.

This PR also reorganize the build rules to avoid copy/pasting.