### PR TITLE
[new release] ocaml-version (2.6.0)

### DIFF
--- a/packages/ocaml-version/ocaml-version.2.6.0/opam
+++ b/packages/ocaml-version/ocaml-version.2.6.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune"
+  "result"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v2.6.0/ocaml-version-v2.6.0.tbz"
+  checksum: [
+    "sha256=d779acea63ca11e385f8bbebfaa11af52f98687a389881f04c66ae6d9a5ef095"
+    "sha512=4b55d1d53bde15fdd4f0dcfddaa6280d195e558be628b4d19f19809a069af66852af1e3a61728e1e4c25226844afea82e01c207654dbce5dde670068816a2903"
+  ]
+}


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/ocurrent/ocaml-version">https://github.com/ocurrent/ocaml-version</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-version/doc">https://ocurrent.github.io/ocaml-version/doc</a>

##### CHANGES:

* Mark trunk as 4.12.0 and add the 4.11 as a development beta (@avsm).
* Add i386 architecture (@dinosaure @avsm)
* Add a `arch_is_32bit` to determine if wordsize is 32-bits. (@avsm)
