### PR TITLE
[new release] alcotest-lwt, alcotest, alcotest-async and alcotest-mirage (1.2.1)

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.2.1/opam
+++ b/packages/alcotest-async/alcotest-async.1.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Async-based helpers for Alcotest"
+description: "Async-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "async_unix" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "6ca7cc04ea07f5bd5b001fed4a0313d82e4b3cc0"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.1/alcotest-mirage-1.2.1.tbz"
+  checksum: [
+    "sha256=4cc037abb03d9685003d7313c9209f0481dca9fbcf3f7f0bc4802b1d75e3cc6c"
+    "sha512=31b2b460042e0cebb21a143dbd3bda81858ff58ddd1b8a1b91dcbb6547284eaab5d33c3d03da6cbf11c99eb046cd40438097ac37cf8cd1bacfc0eed54111c1b4"
+  ]
+}

--- a/packages/alcotest-lwt/alcotest-lwt.1.2.1/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Lwt-based helpers for Alcotest"
+description: "Lwt-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "lwt"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "6ca7cc04ea07f5bd5b001fed4a0313d82e4b3cc0"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.1/alcotest-mirage-1.2.1.tbz"
+  checksum: [
+    "sha256=4cc037abb03d9685003d7313c9209f0481dca9fbcf3f7f0bc4802b1d75e3cc6c"
+    "sha512=31b2b460042e0cebb21a143dbd3bda81858ff58ddd1b8a1b91dcbb6547284eaab5d33c3d03da6cbf11c99eb046cd40438097ac37cf8cd1bacfc0eed54111c1b4"
+  ]
+}

--- a/packages/alcotest-mirage/alcotest-mirage.1.2.1/opam
+++ b/packages/alcotest-mirage/alcotest-mirage.1.2.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Mirage implementation for Alcotest"
+description: "Mirage implementation for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "mirage-clock" {>= "2.0.0"}
+  "duration"
+  "lwt"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "6ca7cc04ea07f5bd5b001fed4a0313d82e4b3cc0"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.1/alcotest-mirage-1.2.1.tbz"
+  checksum: [
+    "sha256=4cc037abb03d9685003d7313c9209f0481dca9fbcf3f7f0bc4802b1d75e3cc6c"
+    "sha512=31b2b460042e0cebb21a143dbd3bda81858ff58ddd1b8a1b91dcbb6547284eaab5d33c3d03da6cbf11c99eb046cd40438097ac37cf8cd1bacfc0eed54111c1b4"
+  ]
+}

--- a/packages/alcotest/alcotest.1.2.1/opam
+++ b/packages/alcotest/alcotest.1.2.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Alcotest is a lightweight and colourful test framework"
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "cmdliner"
+  "uuidm"
+  "re"
+  "stdlib-shims"
+  "uutf"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "6ca7cc04ea07f5bd5b001fed4a0313d82e4b3cc0"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.1/alcotest-mirage-1.2.1.tbz"
+  checksum: [
+    "sha256=4cc037abb03d9685003d7313c9209f0481dca9fbcf3f7f0bc4802b1d75e3cc6c"
+    "sha512=31b2b460042e0cebb21a143dbd3bda81858ff58ddd1b8a1b91dcbb6547284eaab5d33c3d03da6cbf11c99eb046cd40438097ac37cf8cd1bacfc0eed54111c1b4"
+  ]
+}

--- a/packages/current/current.0.2/opam
+++ b/packages/current/current.0.2/opam
@@ -35,7 +35,7 @@ depends: [
   "dune" {>= "1.9"}
   "re"
   "lwt-dllist"
-  "alcotest-lwt" {>= "1.0.1" & with-test}
+  "alcotest-lwt" {>= "1.0.1" & < "1.2.0" & with-test}
 ]
 url {
   src:

--- a/packages/current/current.0.3/opam
+++ b/packages/current/current.0.3/opam
@@ -35,7 +35,7 @@ depends: [
   "dune" {>= "2.0"}
   "re"
   "lwt-dllist"
-  "alcotest-lwt" {>= "1.0.1" & with-test}
+  "alcotest-lwt" {>= "1.0.1" & < "1.2.0" & with-test}
 ]
 url {
   src:


### PR DESCRIPTION
- Project page: <a href="https://github.com/mirage/alcotest">https://github.com/mirage/alcotest</a>
- Documentation: <a href="https://mirage.github.io/alcotest">https://mirage.github.io/alcotest</a>

##### CHANGES:

- Surround pretty-printed diffs with quotes to make trailing whitespace more
  obvious. (mirage/alcotest#261, @CraigFe)
  
- Allow `.` characters to appear unescaped in symlinks and test directories.
  (mirage/alcotest#259, @CraigFe)
