### PR TITLE
[new release] refl.0.2.0

### DIFF
--- a/packages/refl/refl.0.2.0/opam
+++ b/packages/refl/refl.0.2.0/opam
@@ -17,6 +17,7 @@ depends: [
   "metapp" {>= "0.2.0"}
   "metaquot" {>= "0.2.0"}
   "traverse" {>= "0.2.0"}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/refl/refl.0.2.0/opam
+++ b/packages/refl/refl.0.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "PPX deriver for reflection"
+description: """
+PPX deriver for reflection
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/refl"
+doc: "https://github.com/thierry-martinez/refl"
+bug-reports: "https://github.com/thierry-martinez/refl"
+depends: [
+  "ocaml" {>= "4.03.0" & < "4.12.0"}
+  "dune" {>= "1.11.0"}
+  "stdcompat" {>= "14"}
+  "fix" {>= "20200131"}
+  "metapp" {>= "0.2.0"}
+  "metaquot" {>= "0.2.0"}
+  "traverse" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry-martinez/refl"
+url {
+  src: "https://github.com/thierry-martinez/refl/archive/v0.2.0.tar.gz"
+  checksum: "sha512=27e4c0884dafdc7a0897f88889dabb0a2827f1828ad2b018bd3408efeec0a676c92d5b45fcd8484289034289952dd8449442549ed717fd166b0b061fead7962e"
+}


### PR DESCRIPTION
- Add: Refl.hash provides an hash function for every comparable structure.

- Fix: lazy structure were not annotated with `Lazy kind.

- Fix: Kinds.all did not include `Poly.