### PR TITLE
Package eliom.6.12.1

### DIFF
--- a/packages/eliom/eliom.6.12.1/opam
+++ b/packages/eliom/eliom.6.12.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: "Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppx_tools" {>= "0.99.3"}
+  "js_of_ocaml-compiler" {>= "3.5.1"}
+  "js_of_ocaml" {>= "3.5.1"}
+  "js_of_ocaml-lwt" {>= "3.5.1"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx" {>= "3.5.1"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1"}
+  "js_of_ocaml-tyxml" {>= "3.5.1"}
+  "lwt_log"
+  "lwt_ppx"
+  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "ocsigenserver" {>= "2.10"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+]
+url {
+  src: "https://github.com/ocsigen/eliom/archive/6.12.1.tar.gz"
+  checksum: [
+    "md5=c7bda213c85559822bd38b007237ff67"
+    "sha512=2ec7e66442b9d0e7230eb6dfd0ec4367efa31e931250d279d1857cab80b3b37fddc1102f685c5632233fb51392573b3597f53c21cb2605ffff8fd5bf0e33c609"
+  ]
+}


### PR DESCRIPTION
### `eliom.6.12.1`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.0.2