### PR TITLE
[new release] clangml.4.2.0, refl 0.2.1, clangml-transforms 0.26

### DIFF
--- a/packages/clangml-transforms/clangml-transforms.0.26/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.26/opam
@@ -9,10 +9,11 @@ bug-reports: "https://gitlab.inria.fr/memcad/clangml-transforms/issues"
 depends: [
   "ocaml" {>= "4.03.0" & < "4.12.0"}
   "dune" {>= "1.11.0"}
-  "clangml" {>= "4.1.0" & < "4.2.0"}
+  "clangml" {>= "4.2.0"}
   "dolog" {>= "4.0.0"}
   "traverse" {>= "0.2.0"}
-  "refl" {>= "0.1.0"}
+  "refl" {>= "0.2.1"}
+  "odoc" {with-doc & >= "1.5.1"}
 ]
 build: [
   ["dune" "subst"] {pinned}
@@ -30,6 +31,6 @@ build: [
 ]
 dev-repo: "git+https://gitlab.inria.fr/memcad/clangml-transforms"
 url {
-  src: "https://gitlab.inria.fr/memcad/clangml-transforms/-/archive/v0.25/clangml-transforms-v0.25.tar.gz"
-  checksum: "sha512=7432844f7be84ce89299d8611fe6379b1174eb24723dc9e8805ba75f2b700475f281cef13c7b8a40f54776e57200a288fcde1210c77686c0f693df665f535414"
+  src: "https://gitlab.inria.fr/memcad/clangml-transforms/-/archive/v0.26/clangml-transforms-v0.26.tar.gz"
+  checksum: "sha512=857529df94db8c07e55b3919ef3e8a3fa4b297faedb9811d181d3f8554392898fc56985dfcd86726b1925d4ba7846158a907a5e18133cd597de639c780be615e"
 }

--- a/packages/clangml/clangml.4.2.0/opam
+++ b/packages/clangml/clangml.4.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Clang API"
+description: """
+clangml provides bindings to call the Clang API from OCaml.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://memcad.gitlabpages.inria.fr/clangml/"
+doc: "https://memcad.gitlabpages.inria.fr/clangml/doc/clangml/index.html"
+bug-reports: "https://gitlab.inria.fr/memcad/clangml/issues"
+depends: [
+  "conf-libclang"
+  "conf-ncurses"
+  "conf-zlib"
+  "dune" {>= "1.11.0"}
+  "stdcompat" {>= "13"}
+  "ocaml" {>= "4.03.0" & < "4.12.0"}
+  "ocamlfind" {build & >= "1.8.0"}
+  "ocamlcodoc" {with-test & >= "1.0.1"}
+  "pattern" {with-test & >= "0.2.0"}
+  "metapp" {>= "0.1.0"}
+  "metaquot" {>= "0.1.0"}
+  "refl" {>= "0.2.0"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%"]
+  ["dune" "build" "-p" name "-j" jobs "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}]]
+url {
+  src: "https://gitlab.inria.fr/memcad/clangml/-/archive/v4.2.0/clangml-v4.2.0.tar.gz"
+  checksum: "sha512=67957797a1d97072c001056f60f831c1cb4942435f07fc36e3dad6696c6a2dd3fdb5ba1d7ffc50a54b1dda31b2c13d117ec9fa80ca43cfd3ea2856a5110ba9f9"
+}

--- a/packages/conf-libclang/conf-libclang.10/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.10/files/configure.sh
@@ -10,7 +10,8 @@ find_llvm_config () {
         fi
         for llvm_config in \
             llvm-config-${version} llvm-config-${version}.0 \
-            llvm-config${version}0 llvm-config-mp-$version \
+            llvm-config${version}0 llvm-config${version} \
+            llvm-config-mp-$version \
             llvm-config-mp-${version}.0 $brew_llvm_config \
             /usr/lib64/llvm/${version}/bin/llvm-config \
             /usr/lib/llvm/${version}/bin/llvm-config \

--- a/packages/conf-libclang/conf-libclang.10/opam
+++ b/packages/conf-libclang/conf-libclang.10/opam
@@ -17,11 +17,11 @@ depexts: [
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
     {os-distribution = "fedora"}
   ["llvm-clang-devel"] {os-family = "suse"}
-#  ["devel/clang" "devel/llvm"] {os = "freebsd"}
+  ["devel/llvm10"] {os = "freebsd"}
   ["sys-devel/clang"] {os-distribution = "gentoo"}
 ]
 extra-files: [[
-  "configure.sh" "sha512=3cb05a41bed0441d44c6e73561741e85e2ddd23d8df1c645d45048a911d62bf3d82d726e9fc8a279ee28f9a0cc73612558dec5f223291646be73c391f21823d4"
+  "configure.sh" "sha512=8c95b2f06ce5bc161fd68ff8f8ddc0b9b7ea1a318732b79e4131d0adf9222662dd95a60becf28ef5db83fecf1081266a6ccf128864c019571948a232ba18fe82"
 ]]
 synopsis: "Virtual package relying on the installation of llvm and clang libraries (any version)"
 flags: conf

--- a/packages/refl/refl.0.2.1/opam
+++ b/packages/refl/refl.0.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "PPX deriver for reflection"
+description: """
+PPX deriver for reflection
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/refl"
+doc: "https://github.com/thierry-martinez/refl"
+bug-reports: "https://github.com/thierry-martinez/refl"
+depends: [
+  "ocaml" {>= "4.03.0" & < "4.12.0"}
+  "dune" {>= "1.11.0"}
+  "stdcompat" {>= "14"}
+  "fix" {>= "20200131"}
+  "metapp" {>= "0.2.0"}
+  "metaquot" {>= "0.2.0"}
+  "traverse" {>= "0.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry-martinez/refl"
+url {
+  src: "https://github.com/thierry-martinez/refl/archive/v0.2.1.tar.gz"
+  checksum: "sha512=e7eeb7e3a2831db4fccc9e133b63bfac950f231350ff5f726d800bc0a7a2eb1313d38ffff0e1a0b399ca431cd8b9c792b5a2846f537775df8f338b1e1670e5d9"
+}


### PR DESCRIPTION
This PR provides a new clangml release, and an update for its dependency refl and its rev-dependency clangml-transforms.

- Support for Clang/LLVM 10.0.1

- Support for all C/C++ Clang attributes (including `_Alignas` (C) and `alignas` (C++) attributes, that have been requested by Damien Rouhling).  See the auto-generated `bootstrap/attributes.ml`.

- class base specifiers now expose a full `qual_type` instead of a mere `ident` string.

- `ident_ref` now carries a `template_arguments` parameter.

- `function_decl` now exposes `inline_specified` and `inlined` fields.

- `function_type` now exposes `ref_qualifier` field.

- `TypeLoc` are used broaderly to compute `qual_type`: in particular, parameters in function types have now correct names.  The type `type_loc` and the functions `Clang.Decl.get_type_loc` and `Clang.Parameter.get_type_loc` are kept for compatibility, but `qual_type` should contain all the informations.

- `Clang.Lazy` exposes a lazy AST, that is to say that each `desc` field is a lazy value that is computed on demand. This is useful to explore large ASTs efficiently (note that Clang parsing itself can still be slow; the lazy part only concerns the conversion into the `Clang.Lazy.Ast` datatypes). Modules `Clang.Ast`, `Clang.Expr`, `Clang.Stmt`, `Clang.Type`, ..., have their lazy counter-parts: `Clang.Lazy.Ast`, `Clang.Lazy.Expr`, `Clang.Lazy.Stmt`, `Clang.Lazy.Type`, etc.

- The common signature exposed by every AST node module (`Clang.Expr`, `Clang.Stmt`, ...) now declares a `hash` function and and a `Hashtbl` module.

- `Clang.format_diagnostics` now prints presumed locations by default and the behavior can be changed through the optional `?options` argument. The implementation now relies on the new `Clang.pp_diagnostic` which is an OCaml reimplementation of `clang_formatDiagnostic` from libclang.

- `Clang.Expr.parse_string` parses strings as C expressions.  (suggested by Damien Rouhling)

- `Clangml_printer` has now moved to `Clang.Printer`. The package `clangml.printer` still exists for compatibility and reexposes the `Clang.Printer` interface.