### PR TITLE
Mark bitmasks.1.1.0 as unavailable on OCaml 4.11

### DIFF
--- a/packages/bitmasks/bitmasks.1.1.0/opam
+++ b/packages/bitmasks/bitmasks.1.1.0/opam
@@ -11,7 +11,7 @@ build: [
   [make "doc"] {with-doc}
 ]
 depends: [
-  "ocaml" {< "4.11"}
+  "ocaml" {< "4.07"}
   "jbuilder"
   "odoc" {with-doc}
 ]

--- a/packages/bitmasks/bitmasks.1.1.0/opam
+++ b/packages/bitmasks/bitmasks.1.1.0/opam
@@ -11,7 +11,7 @@ build: [
   [make "doc"] {with-doc}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.11"}
   "jbuilder"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Following @dra27's comment in https://github.com/ocaml/opam-repository/pull/16824#discussion_r455564178