### PR TITLE
[new release] capnp-rpc-mirage, capnp-rpc-unix, capnp-rpc-lwt, capnp-rpc and capnp-rpc-net (0.8.0)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.8.0/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.8.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "lwt"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.8.0/capnp-rpc-v0.8.0.tbz"
+  checksum: [
+    "sha256=bddcf743f2df7aeb650e8759465dbc03869fc7a35f16cbf6663b748e8a995a11"
+    "sha512=8558f8f15a93c32539ac10d3ae951038be6bf2075bb018e11e48e4e4cba1a642f7817744b3cf980a2a16fee80a653a4d12961708d6414438d27a82bfd4c5f9f8"
+  ]
+}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.8.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.8.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp" {>= "3.1.0"}
+  "capnp-rpc-net" {= version}
+  "astring"
+  "fmt"
+  "logs"
+  "dns-client" {>= "4.5.0"}
+  "tls-mirage"
+  "mirage-stack" {>="2.0.0"}
+  "arp-mirage" {with-test}
+  "alcotest-lwt" {>= "1.0.1" & with-test}
+  "io-page-unix" {with-test}
+  "tcpip" {>= "5.0.0" & with-test}
+  "mirage-vnetif" {with-test}
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.8.0/capnp-rpc-v0.8.0.tbz"
+  checksum: [
+    "sha256=bddcf743f2df7aeb650e8759465dbc03869fc7a35f16cbf6663b748e8a995a11"
+    "sha512=8558f8f15a93c32539ac10d3ae951038be6bf2075bb018e11e48e4e4cba1a642f7817744b3cf980a2a16fee80a653a4d12961708d6414438d27a82bfd4c5f9f8"
+  ]
+}

--- a/packages/capnp-rpc-net/capnp-rpc-net.0.8.0/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.0.8.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "capnp-rpc-lwt" {= version}
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "mirage-flow" {>="2.0.0"}
+  "tls" {>= "0.8.0"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "0.11.0"}
+  "tls-mirage"
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.8.0/capnp-rpc-v0.8.0.tbz"
+  checksum: [
+    "sha256=bddcf743f2df7aeb650e8759465dbc03869fc7a35f16cbf6663b748e8a995a11"
+    "sha512=8558f8f15a93c32539ac10d3ae951038be6bf2075bb018e11e48e4e4cba1a642f7817744b3cf980a2a16fee80a653a4d12961708d6414438d27a82bfd4c5f9f8"
+  ]
+}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.8.0/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.8.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "capnp-rpc-net" {= version}
+  "cmdliner"
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.4"}
+  "logs"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "2.0"}
+  "alcotest-lwt" {with-test & >= "1.0.1"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.8.0/capnp-rpc-v0.8.0.tbz"
+  checksum: [
+    "sha256=bddcf743f2df7aeb650e8759465dbc03869fc7a35f16cbf6663b748e8a995a11"
+    "sha512=8558f8f15a93c32539ac10d3ae951038be6bf2075bb018e11e48e4e4cba1a642f7817744b3cf980a2a16fee80a653a4d12961708d6414438d27a82bfd4c5f9f8"
+  ]
+}

--- a/packages/capnp-rpc/capnp-rpc.0.8.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.8.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "stdint"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "dune" {>= "2.0"}
+  "alcotest" {with-test & >= "1.0.1"}
+  "afl-persistent" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.8.0/capnp-rpc-v0.8.0.tbz"
+  checksum: [
+    "sha256=bddcf743f2df7aeb650e8759465dbc03869fc7a35f16cbf6663b748e8a995a11"
+    "sha512=8558f8f15a93c32539ac10d3ae951038be6bf2075bb018e11e48e4e4cba1a642f7817744b3cf980a2a16fee80a653a4d12961708d6414438d27a82bfd4c5f9f8"
+  ]
+}


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

Bug fixes and diagnostics:

- Don't GC imports with callbacks (@talex5, mirage/capnp-rpc#210).

- Improve "Already resolved!" error message (@talex5, mirage/capnp-rpc#209).
  Show the state of the promise we were trying to set, and what we tried to set it to.

- Reject attempts to send after disconnecting (@talex5, mirage/capnp-rpc#208).

- Unix: don't leak FDs if `Network.connect` fails (@talex5, mirage/capnp-rpc#206).
  Also, use `Lwt` to open connections so we don't block the whole process.

New functions:

- Add `Sturdy_ref.with_cap` and `with_cap_exn` convenience functions (@talex5, mirage/capnp-rpc#207).
  Using the plain `connect` functions, it's easy to forget to release the live-ref at the end.

Build changes:

- capnp-rpc-mirage: adapt test to tcpip 5.0.0 API (@hannesm, mirage/capnp-rpc#205).

- Upgrade to dune 2 (@talex5, mirage/capnp-rpc#204).

- Switch tests to build in native code and use the test stanza (@avsm, mirage/capnp-rpc#203).

Documentation:

- Show how to make a connection directly (@talex5, mirage/capnp-rpc#202).
  The new `test-bin/calc_direct.ml` example shows how a parent process can
  spawn a child and communicate with it directly over a socketpair.
