### PR TITLE
Package pa_ppx.0.01

### DIFF
--- a/packages/pa_ppx/pa_ppx.0.01/opam
+++ b/packages/pa_ppx/pa_ppx.0.01/opam
@@ -58,6 +58,10 @@ depexts: [
     "perl-string-shellquote"
     "perl-ipc-system-simple"
   ] {os-distribution = "alpine"}
+  [
+    "perl-string-shellquote"
+    "perl-ipc-system-simple"
+  ] {os-distribution = "centos"}
 ]
 
 build: [

--- a/packages/pa_ppx/pa_ppx.0.01/opam
+++ b/packages/pa_ppx/pa_ppx.0.01/opam
@@ -1,0 +1,69 @@
+synopsis: "PPX Rewriters for Ocaml, written using Camlp5"
+description:
+"""
+This is a collection of PPX rewriters, re-implementing those based on ppxlib
+and other libraries, but instead based on Camlp5.  Included is also a collection
+of support libraries for writing new PPX rewriters.  Included are:
+
+pa_assert: ppx_assert
+pa_ppx.deriving, pa_ppx.deriving_plugins (enum, eq, fold, iter, make, map, ord, sexp, show, yojson):
+  ppx_deriving, plugins, ppx_sexp_conv, ppx_deriving_yojson
+pa_ppx.expect_test: ppx_expect_test
+pa_ppx.here: ppx_here
+pa_ppx.import: ppx_import
+pa_ppx.inline_test: ppx_inline_test
+
+pa_ppx.undo_deriving: pa_ppx.deriving expands [@@deriving ...] into code; this rewriter undoes that.
+pa_ppx.unmatched_vala: expands to match-cases (support library for camlp5-based PPX rewriters)
+pa_ppx.hashrecons: support for writing AST rewriters that automatically fills in hash-consing boilerplate
+pa_dock: implements doc-comment extraction for camlp5 preprocessors
+
+Many of the reimplementations in fact offer significant enhanced
+function, described in the pa_ppx documentation.  In addition, there
+is an extensive test-suite, much of it slightly modified versions of
+the tests for the respective PPX rewriters.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/chetmurthy/pa_ppx"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/chetmurthy/pa_ppx/issues"
+dev-repo: "git+https://github.com/chetmurthy/pa_ppx.git"
+doc: "https://github.com/chetmurthy/pa_ppx/doc"
+
+depends: [
+  "ocaml"       { = "4.10.0" }
+  "camlp5"      { >= "8.00~alpha01" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "yojson" { >= "1.7.0" }
+  "bos" { >= "0.2.0" }
+  "ppx_deriving_protobuf" { >= "2.7" }
+  "uint" { >= "2.0.1" }
+  "ounit2" { >= "2.2.3" }
+  "ppx_import" { >= "1.7.1" }
+  "ppx_deriving_yojson" { >= "3.5.2" }
+  "ppx_here" { >= "0.13.0" }
+  "ppx_sexp_conv" { >= "0.13.0" }
+  "expect_test_helpers" { >= "0.13.0" }
+]
+depexts: [
+  [
+    "libstring-shellquote-perl"
+    "libipc-system-simple-perl"
+  ] {os-family = "debian"}
+]
+
+build: [
+  [make "all"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/chetmurthy/pa_ppx/archive/0.01.tar.gz"
+  checksum: [
+    "md5=7212c459eff3ea17974b2d47998f2038"
+    "sha512=f6e344a9ac8352c823d629e1c0cef9cf9aaf3bfa7800446f4087ed682c9e8ba3fbb834c83bc8276cdb5294951db559c0b19f364f2a7adf22bbd70313b7d0bd08"
+  ]
+}

--- a/packages/pa_ppx/pa_ppx.0.01/opam
+++ b/packages/pa_ppx/pa_ppx.0.01/opam
@@ -59,8 +59,8 @@ depexts: [
     "perl-ipc-system-simple"
   ] {os-distribution = "alpine"}
   [
-    "perl-string-shellquote"
-    "perl-ipc-system-simple"
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
   ] {os-distribution = "centos"}
 ]
 

--- a/packages/pa_ppx/pa_ppx.0.01/opam
+++ b/packages/pa_ppx/pa_ppx.0.01/opam
@@ -62,6 +62,14 @@ depexts: [
     "perl-String-ShellQuote"
     "perl-IPC-System-Simple"
   ] {os-distribution = "centos"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-family = "suse"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-family = "fedora"}
 ]
 
 build: [

--- a/packages/pa_ppx/pa_ppx.0.01/opam
+++ b/packages/pa_ppx/pa_ppx.0.01/opam
@@ -54,6 +54,10 @@ depexts: [
     "libstring-shellquote-perl"
     "libipc-system-simple-perl"
   ] {os-family = "debian"}
+  [
+    "perl-string-shellquote"
+    "perl-ipc-system-simple"
+  ] {os-distribution = "alpine"}
 ]
 
 build: [

--- a/packages/pa_ppx/pa_ppx.0.01/opam
+++ b/packages/pa_ppx/pa_ppx.0.01/opam
@@ -34,7 +34,7 @@ dev-repo: "git+https://github.com/chetmurthy/pa_ppx.git"
 doc: "https://github.com/chetmurthy/pa_ppx/doc"
 
 depends: [
-  "ocaml"       { = "4.10.0" }
+  "ocaml"       { >= "4.10.0" & < "4.11.0" }
   "camlp5"      { >= "8.00~alpha01" }
   "not-ocamlfind" { >= "0.01" }
   "pcre" { >= "7.4.3" }

--- a/packages/pa_ppx/pa_ppx.0.01/opam
+++ b/packages/pa_ppx/pa_ppx.0.01/opam
@@ -45,9 +45,9 @@ depends: [
   "ounit2" { >= "2.2.3" }
   "ppx_import" { >= "1.7.1" }
   "ppx_deriving_yojson" { >= "3.5.2" }
-  "ppx_here" { >= "0.13.0" }
-  "ppx_sexp_conv" { >= "0.13.0" }
-  "expect_test_helpers" { >= "0.13.0" }
+  "ppx_here" { >= "v0.13.0" }
+  "ppx_sexp_conv" { >= "v0.13.0" }
+  "expect_test_helpers" { >= "v0.13.0" }
 ]
 depexts: [
   [


### PR DESCRIPTION
### `pa_ppx.0.01`
PPX Rewriters for Ocaml, written using Camlp5
This is a collection of PPX rewriters, re-implementing those based on ppxlib
and other libraries, but instead based on Camlp5.  Included is also a collection
of support libraries for writing new PPX rewriters.  Included are:

pa_assert: ppx_assert
pa_ppx.deriving, pa_ppx.deriving_plugins (enum, eq, fold, iter, make, map, ord, sexp, show, yojson):
  ppx_deriving, plugins, ppx_sexp_conv, ppx_deriving_yojson
pa_ppx.expect_test: ppx_expect_test
pa_ppx.here: ppx_here
pa_ppx.import: ppx_import
pa_ppx.inline_test: ppx_inline_test

pa_ppx.undo_deriving: pa_ppx.deriving expands [@@deriving ...] into code; this rewriter undoes that.
pa_ppx.unmatched_vala: expands to match-cases (support library for camlp5-based PPX rewriters)
pa_ppx.hashrecons: support for writing AST rewriters that automatically fills in hash-consing boilerplate
pa_dock: implements doc-comment extraction for camlp5 preprocessors

Many of the reimplementations in fact offer significant enhanced
function, described in the pa_ppx documentation.  In addition, there
is an extensive test-suite, much of it slightly modified versions of
the tests for the respective PPX rewriters.



---
* Homepage: https://github.com/chetmurthy/pa_ppx
* Source repo: git+https://github.com/chetmurthy/pa_ppx.git
* Bug tracker: https://github.com/chetmurthy/pa_ppx/issues

---
:camel: Pull-request generated by opam-publish v2.0.2