### PR TITLE
new file:   packages/cpm/cpm.10.2.1/opam

### DIFF
--- a/packages/cpm/cpm.10.2.1/opam
+++ b/packages/cpm/cpm.10.2.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/cpmlib"
+bug-reports: "https://github.com/UnixJunkie/cpmlib/issues"
+dev-repo: "git+https://github.com/UnixJunkie/cpmlib.git"
+license: "LGPL-2.0-or-later"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "1.0"}
+  "batteries"
+  "ocaml"
+  "conf-gnuplot"
+]
+synopsis: "The Classification and Regression Performance Metrics library"
+description: """
+For classification/ranking: ROC AUC, BEDROC AUC, Enrichment Factor,
+Robust Initial Enhancement, Power Metric, Matthews' Correlation Coefficient,
+Platt scaling.
+
+For regression: Root Mean Squared Error, Mean Absolute Error,
+r^2 coefficient of determination, Raw Regression Error Characteristic Curve.
+
+Also features a TopKeeper module; to keep in memory the top 'k'
+scored items when dealing with very large datasets.
+"""
+url {
+  src: "https://github.com/UnixJunkie/cpmlib/archive/v10.2.1.tar.gz"
+  checksum: "md5=9fabbb7d06e147eb528edaf29bf43272"
+}


### PR DESCRIPTION
New functionalities in the Utls module; which is no more private.

Utls.{lines_of_file|train_test_split|shuffle_then_cut|list_nparts|cv_folds|shuffle_then_nfolds}
