### PR TITLE
Package embedded_ocaml_templates.0.3.1

### DIFF
--- a/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.3.1/opam
+++ b/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.3.1/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/EmileTrotignon/embedded_ocaml_templates"
 bug-reports: "https://github.com/EmileTrotignon/embedded_ocaml_templates/issues"
 dev-repo: "git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git"
 depends: [ 
-    "ocaml" {>= "4.07.0"}
+    "ocaml" {>= "4.08.0"}
     "dune" {>= "2.5.0"} 
     "sedlex" 
     "core" {>= "v0.12"}

--- a/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.3.1/opam
+++ b/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.3.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "EML is a simple templating language that lets you generate text with plain OCaml"
+description: """
+EML is a simple templating language that lets you generate text with plain OCaml
+Inspired by EJS templates
+"""
+maintainer: "Emile Trotignon emile.trotignon@gmail.com"
+authors: "Emile Trotignon emile.trotignon@gmail.com"
+license: "MIT"
+homepage: "https://github.com/EmileTrotignon/embedded_ocaml_templates"
+bug-reports: "https://github.com/EmileTrotignon/embedded_ocaml_templates/issues"
+dev-repo: "git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git"
+depends: [ 
+    "ocaml" {>= "4.07.0"}
+    "dune" {>= "2.5.0"} 
+    "sedlex" 
+    "core" {>= "v0.12"}
+    "uutf" 
+    "menhir" 
+    "ppxlib" 
+    "containers"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/EmileTrotignon/embedded_ocaml_templates/archive/0.3.1.tar.gz"
+  checksum: [
+    "md5=65dfebc97da6ad5038c6144a864a118d"
+    "sha512=98e42ba1e1e12311c434f88d8931cb308572f7ef96620517dec9d26a5ad5f8e3483dcdae7225c1d3c5f92ce178d0e73544b135a6d6f3e087e11c628d038261f9"
+  ]
+}


### PR DESCRIPTION
### `embedded_ocaml_templates.0.3.1`
EML is a simple templating language that lets you generate text with plain OCaml
EML is a simple templating language that lets you generate text with plain OCaml
Inspired by EJS templates



---
* Homepage: https://github.com/EmileTrotignon/embedded_ocaml_templates
* Source repo: git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git
* Bug tracker: https://github.com/EmileTrotignon/embedded_ocaml_templates/issues

---
:camel: Pull-request generated by opam-publish v2.0.2