### PR TITLE
Use pixel_pusher release 1.1, which is compatible with both jane 13 and 14

### DIFF
--- a/packages/pixel_pusher/pixel_pusher.1.1/opam
+++ b/packages/pixel_pusher/pixel_pusher.1.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Control LED strips on Pixel Pusher hardware"
+description: """
+Light up LED strips by driving Pixel Pusher hardware modules over UDP/IP networks
+"""
+maintainer: "Michael Bacarella <michael.bacarella@gmail.com>"
+authors: ["Michael Bacarella <michael.bacarella@gmail.com>"]
+homepage: "https://github.com/mbacarella/pixel_pusher"
+bug-reports: "https://github.com/mbacarella/pixel_pusher/issues"
+dev-repo: "git+https://github.com/mbacarella/pixel_pusher.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "async_udp" {>= "v0.12.0"}
+  "core" {>= "v0.12.0"}
+  "bitstring"   {>= "3.1.1"}
+]
+url {
+  src: "https://github.com/mbacarella/pixel_pusher/archive/1.1.tar.gz"
+  checksum: [
+    "md5=c695d3842c55a08e4e131ccee028a51f"
+    "sha512=32c721fa071240033bbbec420de3cfea028f832f9176e1bd10dd7033cb4fdd43a3343345d3218e284e79a3028845f5409a8f3bd72c27b0315397a55131069039"
+  ]
+}


### PR DESCRIPTION
The opam file for pixel_pusher 1.0 was modified to hard-code jane <14.