### PR TITLE
[new release] mdx (1.7.0)

### DIFF
--- a/packages/mdx/mdx.1.7.0/opam
+++ b/packages/mdx/mdx.1.7.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org"]
+homepage:     "https://github.com/realworldocaml/mdx"
+license:      "ISC"
+dev-repo:     "git+https://github.com/realworldocaml/mdx.git"
+bug-reports:  "https://github.com/realworldocaml/mdx/issues"
+doc:          "https://realworldocaml.github.io/mdx/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "2.0"}
+  "ocamlfind"
+  "fmt"
+  "cppo" {build}
+  "astring"
+  "logs"
+  "cmdliner" {>= "1.0.0"}
+  "re" {>= "1.7.2"}
+  "result"
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+  "ocaml-version" {>= "2.3.0"}
+  "odoc"
+  "lwt" {with-test}
+  "alcotest" {with-test}
+]
+
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date.
+
+`ocaml-mdx` is released as two binaries called `ocaml-mdx` and `mdx` which are
+the same, mdx being the deprecated name, kept for now for compatibility.
+"""
+x-commit-hash: "84e303587ef9d47b6cff30d921066ceaaae33490"
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/1.7.0/mdx-1.7.0.tbz"
+  checksum: [
+    "sha256=270e805d32923dadfaa45f09377a0863d691a2e772bb0c99bf7bd0673518ec6e"
+    "sha512=6ea55660ba3a79e4867a0b3ced2cb6bc8f46c0ce4633114365a929fb465070e46699b05daeeefc08bce83742c0e9931e55ad6cf9376d9b76313a28ebb8d05425"
+  ]
+}


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>
- Documentation: <a href="https://realworldocaml.github.io/mdx/">https://realworldocaml.github.io/mdx/</a>

##### CHANGES:

#### Added

- HTML comments can carry block labels (realworldocaml/mdx#234, @gpetiot)
  The syntax is: `<!-- $MDX labels -->`, where `labels` is a list of valid
  labels separated by a comma. This line has to immediately precede the block
  it is attached to. The legacy syntax is preserved and will be deprecated in a
  later release.
- Add support for toplevel blocks in `.mli` files' doc comments (realworldocaml/mdx#206, @jsomers)
- Add support for OCaml 4.11 (realworldocaml/mdx#261, @kit-ty-kate)

#### Changed

- Apply unnamed preludes to all environments (realworldocaml/mdx#271, @gpetiot)
  New behavior:
   * `env_and_file "a:f"` associates `f` to the environment named `a`
   * `env_and_file " :f"` associates `f` to the default environment
   * `env_and_file "f"` associates `f` to all environments.
- Errors in non toplevel OCaml blocks are now printed to a seperate `mdx-error` code block
  following the ocaml block instead of crashing the mdx process. Those `mdx-error` blocks
  are recognized and checked by mdx and can be intentionally used to show case specific
  compile errors. (realworldocaml/mdx#238, @gpetiot)
- Improve error reporting for invalid `(* $MDX part-... *)` delimiters (realworldocaml/mdx#250, @gpetiot)

#### Deprecated

- The command 'mdx rule' is deprecated and will be removed in 2.0.0 (realworldocaml/mdx#251, @gpetiot)

#### Fixed

- Fix the environment selection for preludes and slightly improve quality
  of type names in evaluations of toplevel phrases in certain cases. (realworldocaml/mdx#225, @gpetiot)
- Fix toplevel parsing when phrases contain tabs (realworldocaml/mdx#240, @gpetiot)
- Avoid adding newlines to empty blocks (realworldocaml/mdx#253, @gpetiot)
- Preserve the indentation of included files (realworldocaml/mdx#259, @gpetiot)
- Preserve the header in shell blocks (realworldocaml/mdx#249, @craigfe)
- Support underscores in environment variables in `set-` and `unset-` labels (realworldocaml/mdx#257, @shonfeder)
- Fix mdx on Windows which was looking for the ocaml-mdx-test binary at the wrong place
  (realworldocaml/mdx#263, @hcarty)
- Properly report mdx parsing errors instead of crashing with an uncaught exception (realworldocaml/mdx#267, @gpetiot)
