### PR TITLE
[new release] dockerfile-opam, dockerfile and dockerfile-cmd (6.6.0)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.6.6.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.6.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL - generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>="2.0.0"}
+  "dockerfile-opam" {=version}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "ppx_sexp_conv" {>="v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+x-commit-hash: "1c672f4e95e744e92fa93962c7baa0d58f5006fa"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.6.0/dockerfile-v6.6.0.tbz"
+  checksum: [
+    "sha256=941777ec9170cbc7aea1de9f4b86b4fa393fad477d333fcb5c25fb461e4b6bea"
+    "sha512=a0f7fc9ea9270c94cbd827721d1ac4c575543e39ca9028ccbb77b35abb6151ec2f8d37190efbf4634f357c60eacff378a544e0dfab0e9ff7151dee8a4c920692"
+  ]
+}

--- a/packages/dockerfile-opam/dockerfile-opam.6.6.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.6.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution
+support for generating dockerfiles."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>="2.0.0"}
+  "dockerfile" {= version}
+  "ocaml-version" {>= "1.0.0"}
+  "cmdliner"
+  "astring"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+x-commit-hash: "1c672f4e95e744e92fa93962c7baa0d58f5006fa"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.6.0/dockerfile-v6.6.0.tbz"
+  checksum: [
+    "sha256=941777ec9170cbc7aea1de9f4b86b4fa393fad477d333fcb5c25fb461e4b6bea"
+    "sha512=a0f7fc9ea9270c94cbd827721d1ac4c575543e39ca9028ccbb77b35abb6151ec2f8d37190efbf4634f357c60eacff378a544e0dfab0e9ff7151dee8a4c920692"
+  ]
+}

--- a/packages/dockerfile/dockerfile.6.6.0/opam
+++ b/packages/dockerfile/dockerfile.6.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>="2.0.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+x-commit-hash: "1c672f4e95e744e92fa93962c7baa0d58f5006fa"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.6.0/dockerfile-v6.6.0.tbz"
+  checksum: [
+    "sha256=941777ec9170cbc7aea1de9f4b86b4fa393fad477d333fcb5c25fb461e4b6bea"
+    "sha512=a0f7fc9ea9270c94cbd827721d1ac4c575543e39ca9028ccbb77b35abb6151ec2f8d37190efbf4634f357c60eacff378a544e0dfab0e9ff7151dee8a4c920692"
+  ]
+}


### PR DESCRIPTION
Dockerfile eDSL -- opam support

- Project page: <a href="https://github.com/avsm/ocaml-dockerfile">https://github.com/avsm/ocaml-dockerfile</a>
- Documentation: <a href="https://avsm.github.io/ocaml-dockerfile/">https://avsm.github.io/ocaml-dockerfile/</a>

##### CHANGES:

- Deprecate Ubuntu 19.10 (@talex5 avsm/ocaml-dockerfile#21)
- Add OpenSUSE 15.2 Leap (@avsm)
- Build Ubuntu ppc64le (@talex5 avsm/ocaml-dockerfile#21)
- Upgrade build files to dune 2.0 (@avsm)
