### PR TITLE
ocaml-freestanding 0.6.1

### DIFF
--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.1/opam
@@ -8,7 +8,6 @@ tags: "org:mirage"
 dev-repo: "git+https://github.com/mirage/ocaml-freestanding.git"
 build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
-remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "conf-pkg-config"
   "ocamlfind" {build}

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-freestanding"
+bug-reports: "https://github.com/mirage/ocaml-freestanding/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-freestanding.git"
+build: [make]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: [make "uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "ocamlfind" {build}
+  "ocaml-src" {build}
+  ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")
+  "ocaml" {>= "4.08.0" & < "4.11.0"}
+]
+substs: [
+  "flags/cflags.tmp"
+  "flags/libs.tmp"
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+synopsis: "Freestanding OCaml runtime"
+description:
+  "This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer."
+url {
+  src: "https://github.com/mirage/ocaml-freestanding/archive/v0.6.1.tar.gz"
+  checksum: "sha512=c8c28fa18370449d26a9be5a6f472192376d3b18b71df62b2c293853200a813a5d242c393ff8212b41b56f7a20a6cb0f9f34762098898172ea5716b9c6cd7dbd"
+}


### PR DESCRIPTION
* Add support for Solo5/xen bindings, `posix_memalign()`. (#81, @mato)
* nolibc: Implement `assert()` which was previously a no-op. (#80, @mato)

Downstream OPAM packages with C code that wish to use the interfaces/headers added in this release should depend on `ocaml-freestanding { >= 0.6.1 }`.

Part of mirage/mirage#1159.