### PR TITLE
Package binaryen.0.2.3

### DIFF
--- a/packages/binaryen/binaryen.0.2.3/opam
+++ b/packages/binaryen/binaryen.0.2.3/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs "--no-buffer" ]
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.6"}
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+]
+authors: "Oscar Spencer"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.2.3/binaryen-archive-v0.2.3.tar.gz"
+  checksum: [
+    "md5=f4cb5ad491901b6252cc8adcec7cfd8a"
+    "sha512=ebceb1b39a1dc69870b6b5d4d0364df609c0743c9f4af2b9d37fb46a255e3417ff34ccc0f8eac1f1d0b10f42f10f47987bd208f887b1a2bd89153aef42eb0a76"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.2.3`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0