### PR TITLE
Fix OCaml 4.07.1+flambda on gcc10 with -fcommon (missed from #16722)

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
@@ -41,3 +41,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]


### PR DESCRIPTION
Extend #16722 to OCaml 4.07.1+flambda, the recommended compiler for Coq.
I asked in https://github.com/ocaml/opam-repository/pull/16722#issuecomment-662060005 if this patch was omitted for some reason.

Superseded by #16865.