### PR TITLE
Various (mostly tests related) fixes

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.0.0/opam
+++ b/packages/alcotest-async/alcotest-async.1.0.0/opam
@@ -10,7 +10,6 @@ doc:         "https://mirage.github.io/alcotest/"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/alcotest-async/alcotest-async.1.0.1/opam
+++ b/packages/alcotest-async/alcotest-async.1.0.1/opam
@@ -10,7 +10,6 @@ doc:         "https://mirage.github.io/alcotest/"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/alcotest/alcotest.1.0.0/opam
+++ b/packages/alcotest/alcotest.1.0.0/opam
@@ -10,7 +10,6 @@ doc:         "https://mirage.github.io/alcotest/"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/alcotest/alcotest.1.0.1/opam
+++ b/packages/alcotest/alcotest.1.0.1/opam
@@ -10,7 +10,6 @@ doc:         "https://mirage.github.io/alcotest/"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/conf-texlive/conf-texlive.1/opam
+++ b/packages/conf-texlive/conf-texlive.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "http://tug.org/texlive/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "TeX Users Group"
+license: "LaTeX Project Public License and GPL-2"
+build: ["pdflatex" "-version"]
+depexts: [
+  ["texlive-latex-base"] {os-family = "debian"}
+  ["texlive-latex"] {os-distribution = "fedora"}
+  ["texlive-latex"] {os-distribution = "rhel"}
+  ["texlive-latex"] {os-distribution = "ol"}
+  ["texlive-latex"] {os-distribution = "centos"}
+  ["texlive"] {os-distribution = "alpine"}
+  ["texlive-latex-bin-bin"] {os-family = "suse"}
+  ["texlive-bin"] {os-distribution = "arch"}
+  ["tex-formats"] {os-distribution = "freebsd"}
+  ["basictex"] {os-distribution = "homebrew" & os = "macos"}
+]
+synopsis: "Virtual package relying on texlive / pdflatex"
+description:
+  "This package can only install if the pdflatex binary is installed on the system."
+flags: conf

--- a/packages/interval/interval.1.5.1/opam
+++ b/packages/interval/interval.1.5.1/opam
@@ -15,6 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
+  "dune" {>= "1.3"}
   "interval_base" {= version}
   "interval_intel" {= version}
   "interval_crlibm" {= version}

--- a/packages/interval/interval.1.5.1/opam
+++ b/packages/interval/interval.1.5.1/opam
@@ -9,9 +9,9 @@ bug-reports: "https://github.com/Chris00/ocaml-interval/issues"
 doc: "https://Chris00.github.io/ocaml-interval/doc"
 license: "LGPL-3.0"
 tags: ["interval" "science"]
-build: [
-  [make "test-speed"] {with-test}
-  [make "tests"] {with-test}
+run-test: [
+  ["dune" "exec" "--profile=release" "tests/tests_speed.exe"]
+  ["dune" "build" "--profile=release" "-j" jobs "@runtest" "@examples"]
 ]
 depends: [
   "ocaml" {>= "4.03"}

--- a/packages/interval/interval.1.5/opam
+++ b/packages/interval/interval.1.5/opam
@@ -15,6 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
+  "dune" {>= "1.3"}
   "interval_base" {= version}
   "interval_intel" {= version}
   "interval_crlibm" {= version}

--- a/packages/interval/interval.1.5/opam
+++ b/packages/interval/interval.1.5/opam
@@ -9,9 +9,9 @@ bug-reports: "https://github.com/Chris00/ocaml-interval/issues"
 doc: "https://Chris00.github.io/ocaml-interval/doc"
 license: "LGPL-3.0"
 tags: ["interval" "science"]
-build: [
-  [make "test-speed"] {with-test}
-  [make "tests"] {with-test}
+run-test: [
+  ["dune" "exec" "--profile=release" "tests/tests_speed.exe"]
+  ["dune" "build" "--profile=release" "-j" jobs "@runtest" "@examples"]
 ]
 depends: [
   "ocaml" {>= "4.03"}

--- a/packages/interval_base/interval_base.1.5.1/opam
+++ b/packages/interval_base/interval_base.1.5.1/opam
@@ -16,7 +16,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "dune"
+  "dune" {>= "1.3"}
   "dune-configurator"
 ]
 synopsis: "An interval library for OCaml (base package)"

--- a/packages/interval_base/interval_base.1.5/opam
+++ b/packages/interval_base/interval_base.1.5/opam
@@ -16,7 +16,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "dune"
+  "dune" {>= "1.3"}
   "dune-configurator"
 ]
 synopsis: "An interval library for OCaml (base package)"

--- a/packages/interval_crlibm/interval_crlibm.1.5.1/opam
+++ b/packages/interval_crlibm/interval_crlibm.1.5.1/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "interval_base" {= version}
-  "dune"
+  "dune" {>= "1.3"}
   "dune-configurator"
   "crlibm"
 ]

--- a/packages/interval_crlibm/interval_crlibm.1.5/opam
+++ b/packages/interval_crlibm/interval_crlibm.1.5/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "interval_base" {= version}
-  "dune"
+  "dune" {>= "1.3"}
   "dune-configurator"
   "crlibm"
 ]

--- a/packages/interval_intel/interval_intel.1.5.1/opam
+++ b/packages/interval_intel/interval_intel.1.5.1/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "interval_base" {= version}
-  "dune"
+  "dune" {>= "1.3"}
 ]
 available: [ arch = "x86_64" ]
 synopsis: "An interval library for OCaml"

--- a/packages/interval_intel/interval_intel.1.5/opam
+++ b/packages/interval_intel/interval_intel.1.5/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "interval_base" {= version}
-  "dune"
+  "dune" {>= "1.3"}
 ]
 available: [ arch = "x86_64" ]
 synopsis: "An interval library for OCaml"

--- a/packages/merlin/merlin.3.3.4/opam
+++ b/packages/merlin/merlin.3.3.4/opam
@@ -7,7 +7,6 @@ dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos" & ocaml:version >= "4.03"}
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.11"}

--- a/packages/merlin/merlin.3.3.5/opam
+++ b/packages/merlin/merlin.3.3.5/opam
@@ -7,7 +7,6 @@ dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos" & ocaml:version >= "4.03"}
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.11"}

--- a/packages/merlin/merlin.3.3.7~4.11preview1/opam
+++ b/packages/merlin/merlin.3.3.7~4.11preview1/opam
@@ -7,7 +7,6 @@ dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos" & ocaml:version >= "4.03"}
 ]
 depends: [
   "ocaml" {= "4.11.0"}

--- a/packages/mesh-display/mesh-display.0.8.9/opam
+++ b/packages/mesh-display/mesh-display.0.8.9/opam
@@ -9,7 +9,6 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml"

--- a/packages/mesh-graphics/mesh-graphics.0.9.0/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.0/opam
@@ -9,7 +9,6 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
@@ -18,7 +17,6 @@ depends: [
   "configurator" {build & < "v0.15"}
   "mesh" {= "0.9.0"}
   "graphics"
-  "mesh-easymesh" {with-test}
 ]
 synopsis: "Triangular mesh representation using the graphics module"
 url {

--- a/packages/mesh-graphics/mesh-graphics.0.9.1/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.1/opam
@@ -9,7 +9,6 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
@@ -18,7 +17,6 @@ depends: [
   "configurator" {build & < "v0.15"}
   "mesh" {= "0.9.1"}
   "graphics"
-  "mesh-easymesh" {with-test}
 ]
 synopsis: "Triangular mesh representation using the graphics module"
 url {

--- a/packages/mesh-graphics/mesh-graphics.0.9.2/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.2/opam
@@ -9,7 +9,6 @@ bug-reports: "https://github.com/Chris00/mesh/issues"
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
@@ -18,7 +17,6 @@ depends: [
   "configurator" {build & < "v0.15"}
   "mesh" {= "0.9.2"}
   "graphics"
-  "mesh-easymesh" {with-test}
 ]
 synopsis: "Triangular mesh representation using the graphics module"
 url {

--- a/packages/mirage-block-unix/mirage-block-unix.2.12.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.12.0/opam
@@ -25,7 +25,6 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 synopsis: "MirageOS disk block driver for Unix"
 description: """

--- a/packages/mrmime/mrmime.0.1.0/opam
+++ b/packages/mrmime/mrmime.0.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "fmt"
   "hxd" {with-test}
   "angstrom" {>= "0.11.0" & < "0.14.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.1.0"}
   "jsonm" {with-test}
   "crowbar" {with-test}
 ]

--- a/packages/obelisk/obelisk.0.2.0/opam
+++ b/packages/obelisk/obelisk.0.2.0/opam
@@ -16,6 +16,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "menhir" {build}
+  "conf-texlive" {with-test}
 ]
 synopsis:
   "Obelisk is a simple tool which produces pretty-printed output from a Menhir parser file (.mly)."

--- a/packages/obelisk/obelisk.0.3.0/opam
+++ b/packages/obelisk/obelisk.0.3.0/opam
@@ -16,6 +16,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "menhir" {build}
+  "conf-texlive" {with-test}
 ]
 synopsis:
   "Obelisk is a simple tool which produces pretty-printed output from a Menhir parser file (.mly)."

--- a/packages/opam-devel/opam-devel.2.0.0/opam
+++ b/packages/opam-devel/opam-devel.2.0.0/opam
@@ -18,7 +18,7 @@ dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
+  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/opam-devel/opam-devel.2.0.0~rc3/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~rc3/opam
@@ -18,7 +18,7 @@ dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
+  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/opam-devel/opam-devel.2.0.1/opam
+++ b/packages/opam-devel/opam-devel.2.0.1/opam
@@ -23,7 +23,7 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
+  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.2/opam
+++ b/packages/opam-devel/opam-devel.2.0.2/opam
@@ -23,7 +23,7 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
+  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.3/opam
+++ b/packages/opam-devel/opam-devel.2.0.3/opam
@@ -23,7 +23,7 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
+  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.4/opam
+++ b/packages/opam-devel/opam-devel.2.0.4/opam
@@ -23,7 +23,7 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
+  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.5/opam
+++ b/packages/opam-devel/opam-devel.2.0.5/opam
@@ -23,7 +23,7 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
+  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.6/opam
+++ b/packages/opam-devel/opam-devel.2.0.6/opam
@@ -23,7 +23,7 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
+  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.7/opam
+++ b/packages/opam-devel/opam-devel.2.0.7/opam
@@ -23,7 +23,7 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
+  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/root1d/root1d.0.4/opam
+++ b/packages/root1d/root1d.0.4/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.0.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
+  "benchmark" {with-test}
 ]
 depopts: [
   "benchmark"

--- a/packages/root1d/root1d.0.5/opam
+++ b/packages/root1d/root1d.0.5/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "jbuilder" {>= "1.0+beta9"}
+  "benchmark" {with-test}
 ]
 depopts: [
   "benchmark"

--- a/packages/salsa20-core/salsa20-core.0.1.0/opam
+++ b/packages/salsa20-core/salsa20-core.0.1.0/opam
@@ -17,6 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "cstruct" {>= "1.7.0"}
+  "cstruct" {with-test & < "3.2.0"}
   "nocrypto" {>= "0.5.3"}
   "alcotest" {with-test}
 ]

--- a/packages/salsa20-core/salsa20-core.0.2.0/opam
+++ b/packages/salsa20-core/salsa20-core.0.2.0/opam
@@ -19,6 +19,7 @@ depends: [
   "topkg" {build}
   "ocb-stubblr" {build}
   "cstruct" {>= "1.7.0"}
+  "cstruct" {with-test & < "3.2.0"}
   "nocrypto" {with-test}
   "alcotest" {with-test}
 ]

--- a/packages/scrypt-kdf/scrypt-kdf.0.1.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.1.0/opam
@@ -29,6 +29,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.7.0"}
+  "cstruct" {with-test & < "3.2.0"}
   "nocrypto" {>= "0.5.0"}
   "pbkdf" {>= "0.1.0"}
   "alcotest" {with-test}

--- a/packages/spin/spin.0.6.0/opam
+++ b/packages/spin/spin.0.6.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.4"}
   "mdx" {with-test}
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.2.0"}
   "odoc" {with-doc}
   "crunch" {build}
   "base" {< "v0.15"}

--- a/packages/stringext/stringext.1.2.0/opam
+++ b/packages/stringext/stringext.1.2.0/opam
@@ -6,10 +6,8 @@ bug-reports: "https://github.com/rgrinberg/stringext/issues"
 license: "MIT"
 dev-repo: "git+https://github.com/rgrinberg/stringext.git"
 build: [
-  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--enable-tests" {with-test}]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
-  ["ocaml" "setup.ml" "-build"] {with-test}
   ["ocaml" "setup.ml" "-test"] {with-test}
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]

--- a/packages/stringext/stringext.1.3.0/opam
+++ b/packages/stringext/stringext.1.3.0/opam
@@ -6,10 +6,8 @@ bug-reports:  "https://github.com/rgrinberg/stringext/issues"
 license:      "MIT"
 dev-repo: "git+https://github.com/rgrinberg/stringext.git"
 build: [
-  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--enable-tests" {with-test}]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
-  ["ocaml" "setup.ml" "-build"] {with-test}
   ["ocaml" "setup.ml" "-test"] {with-test}
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]

--- a/packages/stringext/stringext.1.3.1/opam
+++ b/packages/stringext/stringext.1.3.1/opam
@@ -6,10 +6,8 @@ bug-reports:  "https://github.com/rgrinberg/stringext/issues"
 license:      "MIT"
 dev-repo: "git+https://github.com/rgrinberg/stringext.git"
 build: [
-  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--enable-tests" {with-test}]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
-  ["ocaml" "setup.ml" "-build"] {with-test}
   ["ocaml" "setup.ml" "-test"] {with-test}
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]

--- a/packages/tree_layout/tree_layout.0.1.0/opam
+++ b/packages/tree_layout/tree_layout.0.1.0/opam
@@ -24,7 +24,7 @@ remove: ["ocamlfind" "remove" "tree_layout"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
-  "tyxml" {with-test & < "4.0.0"}
+  "tyxml" {with-test & >= "3.0.0" & < "4.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "Algorithms to layout trees in a pretty manner."

--- a/packages/unix-errno/unix-errno.0.4.1/opam
+++ b/packages/unix-errno/unix-errno.0.4.1/opam
@@ -19,6 +19,7 @@ depends: [
   "alcotest" {with-test}
   "base-bytes"
   "result"
+  "ctypes" {with-test}
 ]
 depopts: ["base-unix" "ctypes"]
 conflicts: [

--- a/packages/unix-errno/unix-errno.0.4.2/opam
+++ b/packages/unix-errno/unix-errno.0.4.2/opam
@@ -19,6 +19,7 @@ depends: [
   "alcotest" {with-test}
   "base-bytes"
   "result"
+  "ctypes" {with-test}
 ]
 depopts: ["base-unix" "ctypes"]
 conflicts: [


### PR DESCRIPTION
cc @Chris00 For `interval*`. Could you return the fix upstream for future releases? Not calling `dune` with `--profile=release` (or `-p`) makes compilation of the tests fail.

cc @rjbou for `opam-devel`. I'll open an issue with more details soon.