### PR TITLE
[new release] ocamlformat (0.14.3)

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.14.3/opam
+++ b/packages/ocamlformat/ocamlformat.0.14.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06" & < "4.11"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune" {>= "2.2.0"}
+  "fix"
+  "fpath"
+  "menhir"
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+x-commit-hash: "0beb199bfeed6a1b43a9b88c5cfaf6d0dad59acf"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.14.3/ocamlformat-0.14.3.tbz"
+  checksum: [
+    "sha256=d461fe0f3d08deb3e9d3ed131c3adc8b2ba651a2e006735920b53566db54ee8e"
+    "sha512=dce4e12b9c010747fac8f92cc668756b33dd77af3fbc24936a5997f7e8d90444739262d6544b5f7e7be5e8347098013dd0d844a6af143f63dae37f5549367155"
+  ]
+}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### Changes

  + No functional changes from 0.14.2. The goal of this release is to be
    compatible with base and stdio v0.14.0.

  + Backport the following PRs:
    - ocaml-ppx/ocamlformat#1386 - Update opam metadata
    - ocaml-ppx/ocamlformat#1396 - Add compatibility with base.v0.14.0
    - ocaml-ppx/ocamlformat#1399 - Allow stdio.v0.14
