### PR TITLE
disable cohttp: 2.5.2 and 2.5.3

### DIFF
--- a/packages/cohttp/cohttp.2.5.2/opam
+++ b/packages/cohttp/cohttp.2.5.2/opam
@@ -53,6 +53,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
+available: false
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:

--- a/packages/cohttp/cohttp.2.5.3/opam
+++ b/packages/cohttp/cohttp.2.5.3/opam
@@ -53,6 +53,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
+available: false
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:


### PR DESCRIPTION
This is due to a breaking change in semantics in `Headers.replace` which is fixed in 2.5.2-1 and 2.5.4

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>