### PR TITLE
Port fix-gcc10 patch to all ocaml-variants.4.07.1 versions

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
@@ -59,3 +59,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+BER/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+BER/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
@@ -37,3 +37,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+afl/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+afl/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
@@ -40,3 +40,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
@@ -40,3 +40,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
@@ -47,3 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
@@ -49,3 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
@@ -41,3 +41,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
@@ -42,3 +42,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
@@ -49,3 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
@@ -46,3 +46,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
@@ -46,3 +46,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
@@ -55,3 +55,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
@@ -47,3 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
@@ -59,3 +59,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
@@ -40,3 +40,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
@@ -47,3 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
@@ -49,3 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
@@ -41,3 +41,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
@@ -42,3 +42,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
@@ -49,3 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
@@ -46,3 +46,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
@@ -40,3 +40,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
@@ -41,3 +41,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/files/fix-gcc10.patch
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/files/fix-gcc10.patch
@@ -1,0 +1,21 @@
+commit e312163ad1349cb767cb38e64908d0dc6247b8f9
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 19:06:50 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 1316b3c1e..74d4dc86e 100755
+--- a/configure
++++ b/configure
+@@ -474,7 +474,7 @@ case "$ccfamily" in
+ -fno-builtin-memcmp";
+     internal_cflags="$gcc_warnings";;
+   gcc-*)
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+     internal_cflags="$gcc_warnings";;
+   *)
+     common_cflags="-O";;

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
@@ -40,3 +40,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+patches: ["fix-gcc10.patch"]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]


### PR DESCRIPTION
Extend https://github.com/ocaml/opam-repository/pull/16722 to apply to all 4.07.1 variants, which were initially missed.

This supersedes https://github.com/ocaml/opam-repository/pull/16854, which does this for `4.07.1+flambda` only. (Thanks @Blaisorblade!)

CC: @avsm.