### PR TITLE
Remove implicit dep on bash in alt-ergo-x >=2.3.0 pkgs

### DIFF
--- a/packages/alt-ergo-lib/alt-ergo-lib.2.3.0/opam
+++ b/packages/alt-ergo-lib/alt-ergo-lib.2.3.0/opam
@@ -5,7 +5,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/alt-ergo-lib/alt-ergo-lib.2.3.1/opam
+++ b/packages/alt-ergo-lib/alt-ergo-lib.2.3.1/opam
@@ -3,7 +3,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/alt-ergo-lib/alt-ergo-lib.2.3.2/opam
+++ b/packages/alt-ergo-lib/alt-ergo-lib.2.3.2/opam
@@ -3,7 +3,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/alt-ergo-parsers/alt-ergo-parsers.2.3.0/opam
+++ b/packages/alt-ergo-parsers/alt-ergo-parsers.2.3.0/opam
@@ -5,7 +5,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/alt-ergo-parsers/alt-ergo-parsers.2.3.1/opam
+++ b/packages/alt-ergo-parsers/alt-ergo-parsers.2.3.1/opam
@@ -3,7 +3,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/alt-ergo-parsers/alt-ergo-parsers.2.3.2/opam
+++ b/packages/alt-ergo-parsers/alt-ergo-parsers.2.3.2/opam
@@ -3,7 +3,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/alt-ergo/alt-ergo.2.3.0/opam
+++ b/packages/alt-ergo/alt-ergo.2.3.0/opam
@@ -5,7 +5,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/alt-ergo/alt-ergo.2.3.1/opam
+++ b/packages/alt-ergo/alt-ergo.2.3.1/opam
@@ -3,7 +3,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/alt-ergo/alt-ergo.2.3.2/opam
+++ b/packages/alt-ergo/alt-ergo.2.3.2/opam
@@ -3,7 +3,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/altgr-ergo/altgr-ergo.2.3.0/opam
+++ b/packages/altgr-ergo/altgr-ergo.2.3.0/opam
@@ -5,7 +5,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/altgr-ergo/altgr-ergo.2.3.1/opam
+++ b/packages/altgr-ergo/altgr-ergo.2.3.1/opam
@@ -3,7 +3,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/altgr-ergo/altgr-ergo.2.3.2/opam
+++ b/packages/altgr-ergo/altgr-ergo.2.3.2/opam
@@ -3,7 +3,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]


### PR DESCRIPTION
As was found recently (cf https://github.com/OCamlPro/alt-ergo/issues/344 ), the configure script of alt-ergo packages since the switch to use dune uses `bash`, which is not always available, and might result in rather hard to debug errors. Case in point, issue#344 presented with an empty output and a 127 error code (file not found) when trying to run the configure script, which is disturbing as it was not the configure script but rather `/bin/bash` that was missing. A PR is open to replace `bash` by `sh` in the configure script (see https://github.com/OCamlPro/alt-ergo/pull/345 ) for upstream alt-ergo.

Fortunately, this problem can reasonably be fixed in the already published alt-ergo packages: the `configure` script ( cf https://github.com/OCamlPro/alt-ergo/blob/next/configure ) is actually a very small wrapper to call the ocaml compiler on `configure.ml` with the unix library. Thus, we can simply bypass the script and replace the `["./configure" name]` step of build instructions by the contents of the script, i.e. `["ocaml" "unix.cma" "configure.ml" name]` (I might have missed if there was a specific opam variable to call the compiler, akin to the `make` one).

While this patch is not absolutely necessary (we hadn't had any report of people hitting this until today), it might help ease automated installation of alt-ergo in CI-like environments that might not have `bash` installed.