### PR TITLE
Tezos node.7.3

### DIFF
--- a/packages/tezos-base/tezos-base.7.3/opam
+++ b/packages/tezos-base/tezos-base.7.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-clic" { = version }
+  "tezos-crypto" { = version }
+  "tezos-micheline" { = version }
+  "ptime" { >= "0.8.4" }
+  "ezjsonm" { >= "0.5.0" }
+  "ipaddr" { >= "4.0.0" & < "5.0.0" }
+  "re" { >= "1.7.2" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_base/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: meta-package and pervasive type definitions for Tezos"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-clic/tezos-clic.7.3/opam
+++ b/packages/tezos-clic/tezos-clic.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-stdlib-unix" { = version }
+  "re" { >= "1.7.2" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_clic/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented command-line-parsing combinators"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-crypto/tezos-crypto.7.3/opam
+++ b/packages/tezos-crypto/tezos-crypto.7.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-rpc" { = version }
+  "blake2"
+  "hacl" { >= "0.2" }
+  "zarith"
+  "secp256k1-internal"
+  "uecc"
+  "alcotest" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_crypto/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library with all the cryptographic primitives used by Tezos"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-000-Ps9mPmXa/tezos-embedded-protocol-000-Ps9mPmXa.7.3/opam
+++ b/packages/tezos-embedded-protocol-000-Ps9mPmXa/tezos-embedded-protocol-000-Ps9mPmXa.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.11" }
+  "tezos-protocol-000-Ps9mPmXa" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_000_Ps9mPmXa/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 000-Ps9mPmXa (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-001-PtCJ7pwo/tezos-embedded-protocol-001-PtCJ7pwo.7.3/opam
+++ b/packages/tezos-embedded-protocol-001-PtCJ7pwo/tezos-embedded-protocol-001-PtCJ7pwo.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.11" }
+  "tezos-protocol-001-PtCJ7pwo" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_001_PtCJ7pwo/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 001_PtCJ7pwo (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-002-PsYLVpVv/tezos-embedded-protocol-002-PsYLVpVv.7.3/opam
+++ b/packages/tezos-embedded-protocol-002-PsYLVpVv/tezos-embedded-protocol-002-PsYLVpVv.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.11" }
+  "tezos-protocol-002-PsYLVpVv" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_002_PsYLVpVv/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 002_PsYLVpVv (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-003-PsddFKi3/tezos-embedded-protocol-003-PsddFKi3.7.3/opam
+++ b/packages/tezos-embedded-protocol-003-PsddFKi3/tezos-embedded-protocol-003-PsddFKi3.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.11" }
+  "tezos-protocol-003-PsddFKi3" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_003_PsddFKi3/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 003_PsddFKi3 (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-004-Pt24m4xi/tezos-embedded-protocol-004-Pt24m4xi.7.3/opam
+++ b/packages/tezos-embedded-protocol-004-Pt24m4xi/tezos-embedded-protocol-004-Pt24m4xi.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-004-Pt24m4xi" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_004_Pt24m4xi/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-005-PsBABY5H/tezos-embedded-protocol-005-PsBABY5H.7.3/opam
+++ b/packages/tezos-embedded-protocol-005-PsBABY5H/tezos-embedded-protocol-005-PsBABY5H.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-005-PsBABY5H" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBABY5H/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-005-PsBabyM1/tezos-embedded-protocol-005-PsBabyM1.7.3/opam
+++ b/packages/tezos-embedded-protocol-005-PsBabyM1/tezos-embedded-protocol-005-PsBabyM1.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-005-PsBabyM1" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBabyM1/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-006-PsCARTHA/tezos-embedded-protocol-006-PsCARTHA.7.3/opam
+++ b/packages/tezos-embedded-protocol-006-PsCARTHA/tezos-embedded-protocol-006-PsCARTHA.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-006-PsCARTHA" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-alpha/tezos-embedded-protocol-alpha.7.3/opam
+++ b/packages/tezos-embedded-protocol-alpha/tezos-embedded-protocol-alpha.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-alpha" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-demo-counter/tezos-embedded-protocol-demo-counter.7.3/opam
+++ b/packages/tezos-embedded-protocol-demo-counter/tezos-embedded-protocol-demo-counter.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-demo-counter" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_demo_counter/lib_protocol/%{name}%.install" "./"]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_counter (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-demo-noops/tezos-embedded-protocol-demo-noops.7.3/opam
+++ b/packages/tezos-embedded-protocol-demo-noops/tezos-embedded-protocol-demo-noops.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-demo-noops" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_demo_noops/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_noops (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-genesis-carthagenet/tezos-embedded-protocol-genesis-carthagenet.7.3/opam
+++ b/packages/tezos-embedded-protocol-genesis-carthagenet/tezos-embedded-protocol-genesis-carthagenet.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-genesis-carthagenet" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis_carthagenet/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis_carthagenet (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-embedded-protocol-genesis/tezos-embedded-protocol-genesis.7.3/opam
+++ b/packages/tezos-embedded-protocol-genesis/tezos-embedded-protocol-genesis.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-genesis" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-error-monad/tezos-error-monad.7.3/opam
+++ b/packages/tezos-error-monad/tezos-error-monad.7.3/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-stdlib" { = version }
+  "data-encoding" { >= "0.2" }
+  "lwt-canceler" { >= "0.2" }
+  "alcotest-lwt" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_error_monad/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: error monad"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-event-logging/tezos-event-logging.7.3/opam
+++ b/packages/tezos-event-logging/tezos-event-logging.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-error-monad" { = version }
+  "lwt_log"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_event_logging/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos event logging library"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-lmdb/tezos-lmdb.7.3/opam
+++ b/packages/tezos-lmdb/tezos-lmdb.7.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "contact@tezos.com"
+license: "ISC"
+synopsis: "Legacy Tezos OCaml binding to LMDB (Consider ocaml-lmdb instead)"
+homepage: "https://gitlab.com/tezos/tezos"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+build: [
+  ["dune" "build" "-j" jobs "-p" name "@install"]
+  ["mv" "vendors/ocaml-lmdb/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" {>= "1.11"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {with-test & >= "3.2.1"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-mempool-006-PsCARTHA/tezos-mempool-006-PsCARTHA.7.3/opam
+++ b/packages/tezos-mempool-006-PsCARTHA/tezos-mempool-006-PsCARTHA.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-embedded-protocol-006-PsCARTHA" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_mempool/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: mempool-filters for protocol 006-PsCARTHA"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-micheline/tezos-micheline.7.3/opam
+++ b/packages/tezos-micheline/tezos-micheline.7.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-error-monad" { = version }
+  "uutf"
+  "alcotest-lwt" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_micheline/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: internal AST and parser for the Michelson language"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-node/tezos-node.7.3/opam
+++ b/packages/tezos-node/tezos-node.7.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-rpc-http-server" { = version }
+  "tezos-validator" { = version }
+  "tezos-embedded-protocol-genesis-carthagenet" { = version }
+  "tezos-embedded-protocol-000-Ps9mPmXa" { = version }
+  "tezos-embedded-protocol-001-PtCJ7pwo" { = version }
+  "tezos-embedded-protocol-002-PsYLVpVv" { = version }
+  "tezos-embedded-protocol-003-PsddFKi3" { = version }
+  "tezos-embedded-protocol-004-Pt24m4xi" { = version }
+  "tezos-embedded-protocol-005-PsBABY5H" { = version }
+  "tezos-embedded-protocol-005-PsBabyM1" { = version }
+  "tezos-embedded-protocol-006-PsCARTHA" { = version }
+  "tezos-mempool-006-PsCARTHA" { = version }
+  "tls"
+]
+depopts: [
+  "tezos-embedded-protocol-genesis" { = version }
+  "tezos-embedded-protocol-demo-noops" { = version }
+  "tezos-embedded-protocol-demo-counter" { = version }
+  "tezos-embedded-protocol-alpha" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/bin_node/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `tezos-node` binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-p2p-services/tezos-p2p-services.7.3/opam
+++ b/packages/tezos-p2p-services/tezos-p2p-services.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-workers" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_p2p_services/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: descriptions of RPCs exported by `tezos-p2p`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-p2p/tezos-p2p.7.3/opam
+++ b/packages/tezos-p2p/tezos-p2p.7.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-p2p-services" { = version }
+  "alcotest-lwt" { with-test & = "0.8.5" }
+  "lwt" { >= "4.0" & < "4.3" }
+  "lwt-watcher" { >= "0.1" }
+  "lwt-canceler" { >= "0.2" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_p2p/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library for a pool of P2P connections"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-000-Ps9mPmXa/tezos-protocol-000-Ps9mPmXa.7.3/opam
+++ b/packages/tezos-protocol-000-Ps9mPmXa/tezos-protocol-000-Ps9mPmXa.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_000_Ps9mPmXa/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 000_Ps9mPmXa (economic-protocol definition, functor version)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-001-PtCJ7pwo/tezos-protocol-001-PtCJ7pwo.7.3/opam
+++ b/packages/tezos-protocol-001-PtCJ7pwo/tezos-protocol-001-PtCJ7pwo.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_001_PtCJ7pwo/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 001_PtCJ7pwo (economic-protocol definition, functor version)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-002-PsYLVpVv/tezos-protocol-002-PsYLVpVv.7.3/opam
+++ b/packages/tezos-protocol-002-PsYLVpVv/tezos-protocol-002-PsYLVpVv.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_002_PsYLVpVv/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 002_PsYLVpVv (economic-protocol definition, functor version)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-003-PsddFKi3/tezos-protocol-003-PsddFKi3.7.3/opam
+++ b/packages/tezos-protocol-003-PsddFKi3/tezos-protocol-003-PsddFKi3.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_003_PsddFKi3/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 003_PsddFKi3 (economic-protocol definition, functor version)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-004-Pt24m4xi/tezos-protocol-004-Pt24m4xi.7.3/opam
+++ b/packages/tezos-protocol-004-Pt24m4xi/tezos-protocol-004-Pt24m4xi.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_004_Pt24m4xi/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-005-PsBABY5H/tezos-protocol-005-PsBABY5H.7.3/opam
+++ b/packages/tezos-protocol-005-PsBABY5H/tezos-protocol-005-PsBABY5H.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBABY5H/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-005-PsBabyM1/tezos-protocol-005-PsBabyM1.7.3/opam
+++ b/packages/tezos-protocol-005-PsBabyM1/tezos-protocol-005-PsBabyM1.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBabyM1/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-006-PsCARTHA/tezos-protocol-006-PsCARTHA.7.3/opam
+++ b/packages/tezos-protocol-006-PsCARTHA/tezos-protocol-006-PsCARTHA.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-alpha/tezos-protocol-alpha.7.3/opam
+++ b/packages/tezos-protocol-alpha/tezos-protocol-alpha.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-compiler/tezos-protocol-compiler.7.3/opam
+++ b/packages/tezos-protocol-compiler/tezos-protocol-compiler.7.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "ocaml" { = "4.09.1" }
+  "dune" { >= "1.11" }
+  "base-unix"
+  "tezos-base" { = version }
+  "tezos-protocol-environment" { = version }
+  "ocp-ocamlres" { >= "0.4" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_compiler/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: economic-protocol compiler"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-demo-counter/tezos-protocol-demo-counter.7.3/opam
+++ b/packages/tezos-protocol-demo-counter/tezos-protocol-demo-counter.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_demo_counter/lib_protocol/%{name}%.install" "./"]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_counter economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-demo-noops/tezos-protocol-demo-noops.7.3/opam
+++ b/packages/tezos-protocol-demo-noops/tezos-protocol-demo-noops.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_demo_noops/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_noops economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-environment-sigs/tezos-protocol-environment-sigs.7.3/opam
+++ b/packages/tezos-protocol-environment-sigs/tezos-protocol-environment-sigs.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "ocaml" { >= "4.08.0" }
+  "tezos-stdlib" { with-test & = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_environment/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: restricted typing environment for the economic protocols"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-environment/tezos-protocol-environment.7.3/opam
+++ b/packages/tezos-protocol-environment/tezos-protocol-environment.7.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-base" { = version }
+  "tezos-protocol-environment-sigs" { = version }
+  "alcotest-lwt" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_environment/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: custom economic-protocols environment implementation for `tezos-client` and testing"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-genesis-carthagenet/tezos-protocol-genesis-carthagenet.7.3/opam
+++ b/packages/tezos-protocol-genesis-carthagenet/tezos-protocol-genesis-carthagenet.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis_carthagenet/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis_carthagenet economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-genesis/tezos-protocol-genesis.7.3/opam
+++ b/packages/tezos-protocol-genesis/tezos-protocol-genesis.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-protocol-updater/tezos-protocol-updater.7.3/opam
+++ b/packages/tezos-protocol-updater/tezos-protocol-updater.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-compiler" { = version }
+  "tezos-shell-context" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_updater/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: economic-protocol dynamic loading for `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-requester/tezos-requester.7.3/opam
+++ b/packages/tezos-requester/tezos-requester.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-base" { = version }
+  "lwt-watcher"
+  "alcotest-lwt" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_requester/%{name}%.install" "./"]
+]
+synopsis: "Tezos: generic resource fetching service"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.3/opam
+++ b/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.11" }
+  "tezos-rpc-http" { = version }
+  "resto-cohttp-server"
+  "tezos-tooling" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc_http/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (http server)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-rpc-http/tezos-rpc-http.7.3/opam
+++ b/packages/tezos-rpc-http/tezos-rpc-http.7.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-base" { = version }
+  "resto-directory"
+  "resto-cohttp"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc_http/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (http server and client)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-rpc/tezos-rpc.7.3/opam
+++ b/packages/tezos-rpc/tezos-rpc.7.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-error-monad" { = version }
+  "resto"
+  "resto-directory"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (service and hierarchy descriptions)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-shell-context/tezos-shell-context.7.3/opam
+++ b/packages/tezos-shell-context/tezos-shell-context.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-environment" { = version }
+  "tezos-storage" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_environment/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: economic-protocols environment implementation for `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-shell-services/tezos-shell-services.7.3/opam
+++ b/packages/tezos-shell-services/tezos-shell-services.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-version" { = version }
+  "tezos-p2p-services" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_shell_services/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: descriptions of RPCs exported by `tezos-shell`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-shell/tezos-shell.7.3/opam
+++ b/packages/tezos-shell/tezos-shell.7.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-p2p" { = version }
+  "tezos-validation" { = version }
+  "tezos-requester" { = version }
+  "alcotest-lwt" { with-test & = "0.8.5" }
+  "tezos-embedded-protocol-demo-noops" { with-test & = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_shell/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: core of `tezos-node` (gossip, validation scheduling, mempool, ...)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.3/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "base-unix"
+  "dune" { >= "1.11" }
+  "tezos-event-logging" { = version }
+  "tezos-rpc" { = version }
+  "lwt" { >= "3.0.0" }
+  "ptime" { >= "0.8.4" }
+  "mtime" { >= "1.0.0" }
+  "conf-libev"
+  "ipaddr" { >= "4.0.0" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_stdlib_unix/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: yet-another local-extension of the OCaml standard library (unix-specific fragment)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-stdlib/tezos-stdlib.7.3/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.7.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "ocaml" { >= "4.08.0" }
+  "hex"
+  "lwt"
+  "zarith"
+  "bigstring" { with-test }
+  "lwt_log" { with-test }
+  "alcotest" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_stdlib/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: yet-another local-extension of the OCaml standard library"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-storage/tezos-storage.7.3/opam
+++ b/packages/tezos-storage/tezos-storage.7.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-lmdb" { = version }
+  "irmin" { >= "2.1" & < "2.2" }
+  "irmin-pack" { >= "2.1" & < "2.2" }
+  "digestif" {>= "0.7.3"}
+  "tezos-shell-services" { = version }
+  "alcotest-lwt" { with-test & = "0.8.5" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_storage/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: low-level key-value store for `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-tooling/tezos-tooling.7.3/opam
+++ b/packages/tezos-tooling/tezos-tooling.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "1.11" }
+  "ocamlformat" { = "0.10" }
+  "ocaml" { >= "4.8.0" } (*ocamlformat result differs with 4.06 & 4.07*)
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/tooling/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: tooling for the project"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-validation/tezos-validation.7.3/opam
+++ b/packages/tezos-validation/tezos-validation.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_validation/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library for blocks validation"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-validator/tezos-validator.7.3/opam
+++ b/packages/tezos-validator/tezos-validator.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-shell" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/bin_validation/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `tezos-validator` binary for external validation of blocks"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-version/tezos-version.7.3/opam
+++ b/packages/tezos-version/tezos-version.7.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "ocaml" { >= "4.03.0" }
+  "tezos-base" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_version/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: version information generated from Git"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}

--- a/packages/tezos-workers/tezos-workers.7.3/opam
+++ b/packages/tezos-workers/tezos-workers.7.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" { >= "1.11" }
+  "tezos-base" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_workers/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: worker library"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.3/tezos-v7.3.tar.bz2"
+  checksum: [
+    "sha256=898faf36eae39567c23b8cfc8df1fc6075ae420c02f857f0abc1c7817209a09e"
+    "sha512=1bf5e15c7e7a9d39d1e1b7eee4cd1d50b99c6c4d196fa109f4978e74012a6f60d84aae54b66e1c767661e9f41d22b4ccbab69f023ba5e094274385516139d941"
+  ]
+}


### PR DESCRIPTION
This is the first half of the Tezos 7.3 (bugfix) release. Nothing much (but 2 security holes less in the peer2peer layer :-) ) has changed.

I reactivated `tezos-requester` tests as I packaged `tezos-test-services`. We also removed the non deterministic test of `tezos-p2p`so tests should now always pass. Thank you again for all the testing and feedback!