### PR TITLE
[new release] jose (0.5.0)

### DIFF
--- a/packages/jose/jose.0.5.0/opam
+++ b/packages/jose/jose.0.5.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "JOSE implementation for OCaml and ReasonML"
+description:
+  "JavaScript Object Signing and Encryption built ontop of pure OCaml libs"
+maintainer: ["ulrik.strid@outlook.com"]
+authors: ["Ulrik Strid"]
+license: "MIT"
+homepage: "https://ulrikstrid.github.io/reason-jose"
+doc: "https://ulrikstrid.github.io/reason-jose"
+bug-reports: "https://github.com/ulrikstrid/reason-jose/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base64" {>= "3.0.0"}
+  "dune" {>= "1.11"}
+  "eqaf" {>= "0.7"}
+  "mirage-crypto" {>= "0.8.1"}
+  "x509" {>= "0.10.0"}
+  "cstruct" {>= "4.0.0"}
+  "astring"
+  "yojson"
+  "result"
+  "zarith"
+  "containers" {with-test}
+  "bisect_ppx" {with-test}
+  "alcotest" {with-test}
+  "junit" {with-test}
+  "junit_alcotest" {with-test}
+  "lwt" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
+x-commit-hash: "207db96bee33c10b062734383760db4792d5f282"
+url {
+  src:
+    "https://github.com/ulrikstrid/reason-jose/releases/download/v0.5.0/jose-v0.5.0.tbz"
+  checksum: [
+    "sha256=ce1b8304b3090dce83b1c84dc4c6b46805587fcde9429abd86f46a53731ab90e"
+    "sha512=6d76d17fb654c74b14cf3c6fb940b0d42fb46db32e42c245d882f82bdd099c5e82f740bb0ebfa4188d52aad6cb243c101ca09a6252bc117a595edab2c0e99bf1"
+  ]
+}


### PR DESCRIPTION
JOSE implementation for OCaml and ReasonML

- Project page: <a href="https://ulrikstrid.github.io/reason-jose">https://ulrikstrid.github.io/reason-jose</a>
- Documentation: <a href="https://ulrikstrid.github.io/reason-jose">https://ulrikstrid.github.io/reason-jose</a>

##### CHANGES:

- JWS: compare computed HMAC signatures in constant-time (by @anmonteiro)
- Adapt to Mirage-crypto 0.8.1, drops support for OCaml < 4.8.0 (breaking) (by @anmonteiro)
