### PR TITLE
[new release] mirage-crypto-rng, mirage-crypto, mirage-crypto-rng-mirage and mirage-crypto-pk (0.8.2)

### DIFF
--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.2/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.7"}
+  "rresult" {>= "0.6.0"}
+  ("mirage-no-xen" | "zarith-xen")
+  ("mirage-no-solo5" | "zarith-freestanding")
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+x-commit-hash: "df53132eda1cd44a0d9b3fba9015a669537cc729"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.2/mirage-crypto-v0.8.2.tbz"
+  checksum: [
+    "sha256=e2f103e6faef2f99576918933deb75ce288e9ccbe71f9de8418a007c16f95a26"
+    "sha512=20131b787ab7fba478a9846e253ce3c9adb83e955d06e480b90b3c22adb3c165f55816d2ff7da5aa332b4fc8ea9aa209637451eb794fcaa079f206343596d6c8"
+  ]
+}

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.2/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+x-commit-hash: "df53132eda1cd44a0d9b3fba9015a669537cc729"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.2/mirage-crypto-v0.8.2.tbz"
+  checksum: [
+    "sha256=e2f103e6faef2f99576918933deb75ce288e9ccbe71f9de8418a007c16f95a26"
+    "sha512=20131b787ab7fba478a9846e253ce3c9adb83e955d06e480b90b3c22adb3c165f55816d2ff7da5aa332b4fc8ea9aa209637451eb794fcaa079f206343596d6c8"
+  ]
+}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.2/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator"
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "mirage-crypto" {=version}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+# lwt sublibrary
+  "mtime"
+  "lwt" {>= "4.0.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+x-commit-hash: "df53132eda1cd44a0d9b3fba9015a669537cc729"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.2/mirage-crypto-v0.8.2.tbz"
+  checksum: [
+    "sha256=e2f103e6faef2f99576918933deb75ce288e9ccbe71f9de8418a007c16f95a26"
+    "sha512=20131b787ab7fba478a9846e253ce3c9adb83e955d06e480b90b3c22adb3c165f55816d2ff7da5aa332b4fc8ea9aa209637451eb794fcaa079f206343596d6c8"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.8.2/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "eqaf" {>= "0.7"}
+]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
+hashes (MD5, SHA-1, SHA-2).
+"""
+x-commit-hash: "df53132eda1cd44a0d9b3fba9015a669537cc729"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.2/mirage-crypto-v0.8.2.tbz"
+  checksum: [
+    "sha256=e2f103e6faef2f99576918933deb75ce288e9ccbe71f9de8418a007c16f95a26"
+    "sha512=20131b787ab7fba478a9846e253ce3c9adb83e955d06e480b90b3c22adb3c165f55816d2ff7da5aa332b4fc8ea9aa209637451eb794fcaa079f206343596d6c8"
+  ]
+}


### PR DESCRIPTION
A cryptographically secure PRNG

- Project page: <a href="https://github.com/mirage/mirage-crypto">https://github.com/mirage/mirage-crypto</a>
- Documentation: <a href="https://mirage.github.io/mirage-crypto/doc">https://mirage.github.io/mirage-crypto/doc</a>

##### CHANGES:

* Add support for ppc64le. (mirage/mirage-crypto#76 @avsm)
