### PR TITLE
[new release] dockerfile-opam, dockerfile and dockerfile-cmd (6.6.1)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.6.6.1/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.6.6.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL - generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>="2.0.0"}
+  "dockerfile-opam" {=version}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "ppx_sexp_conv" {>="v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+x-commit-hash: "7e8ea4822861d019d377c0821ce7a8df015cc2f3"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.6.1/dockerfile-v6.6.1.tbz"
+  checksum: [
+    "sha256=92c6405cc25b49787ad23792ba00905b47d3773e9f01c7635876c4eef88aa6a2"
+    "sha512=a8217f307c0c03ba8f7eb95da7c979f64badfd74755a446b233cb03585ca6f5a59ee392314f985151043741182fef411458b0ad63649a51985389bdc2fc0cf5e"
+  ]
+}

--- a/packages/dockerfile-opam/dockerfile-opam.6.6.1/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.6.6.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution
+support for generating dockerfiles."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>="2.0.0"}
+  "dockerfile" {= version}
+  "ocaml-version" {>= "1.0.0"}
+  "cmdliner"
+  "astring"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+x-commit-hash: "7e8ea4822861d019d377c0821ce7a8df015cc2f3"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.6.1/dockerfile-v6.6.1.tbz"
+  checksum: [
+    "sha256=92c6405cc25b49787ad23792ba00905b47d3773e9f01c7635876c4eef88aa6a2"
+    "sha512=a8217f307c0c03ba8f7eb95da7c979f64badfd74755a446b233cb03585ca6f5a59ee392314f985151043741182fef411458b0ad63649a51985389bdc2fc0cf5e"
+  ]
+}

--- a/packages/dockerfile/dockerfile.6.6.1/opam
+++ b/packages/dockerfile/dockerfile.6.6.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>="2.0.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+x-commit-hash: "7e8ea4822861d019d377c0821ce7a8df015cc2f3"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v6.6.1/dockerfile-v6.6.1.tbz"
+  checksum: [
+    "sha256=92c6405cc25b49787ad23792ba00905b47d3773e9f01c7635876c4eef88aa6a2"
+    "sha512=a8217f307c0c03ba8f7eb95da7c979f64badfd74755a446b233cb03585ca6f5a59ee392314f985151043741182fef411458b0ad63649a51985389bdc2fc0cf5e"
+  ]
+}


### PR DESCRIPTION
Dockerfile eDSL -- opam support

- Project page: <a href="https://github.com/avsm/ocaml-dockerfile">https://github.com/avsm/ocaml-dockerfile</a>
- Documentation: <a href="https://avsm.github.io/ocaml-dockerfile/">https://avsm.github.io/ocaml-dockerfile/</a>

##### CHANGES:

- Ensure debconf remains non-interactive (@avsm)
- Do not build ppc64le on Debian:9 as upstream has stopped
  providing images. Debian 10 ppc64le remains unchanged. (@avsm).
