### PR TITLE
Package ppx_cstubs.0.4.3

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.4.3/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.4.3/opam
@@ -36,9 +36,9 @@ with c stub code and an OCaml file with all additional boilerplate
 code.
 """
 url {
-  src: "https://github.com/fdopen/ppx_cstubs/archive/0.4.2.tar.gz"
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.4.3.tar.gz"
   checksum: [
-    "md5=27d8c936b4972ef561d31c1a978957a4"
-    "sha512=fec8fbee966347c4360d82fded6d10322fc017f02236f0564c53544b632346543fa1fac4038d98380ed7be3c70c5438bb7bc3f14b46b851632f7d786151ad90f"
+    "md5=7cd0a2dd6be6f20bb762618b70157c86"
+    "sha512=47290393242bdbf798ba1983274ca74a4c3055b30bf06d58cda0847c392cf3909ebdcdbc00a8615d62c05a6010dfaacd52999847567a6aab29e8789d71c7529b"
   ]
 }


### PR DESCRIPTION
### `ppx_cstubs.0.4.3`
Preprocessor for easier stub generation with ctypes
ppx_cstubs is a ppx-based preprocessor for stub generation with
ctypes. ppx_cstubs creates two files from a single ml file: a file
with c stub code and an OCaml file with all additional boilerplate
code.



---
* Homepage: https://fdopen.github.io/ppx_cstubs/
* Source repo: git+https://github.com/fdopen/ppx_cstubs.git
* Bug tracker: https://github.com/fdopen/ppx_cstubs/issues

---
:camel: Pull-request generated by opam-publish v2.0.2