### PR TITLE
Add coq-native package flag & Update coq flags (native-compiler + flambda)

### DIFF
--- a/packages/coq-native/coq-native.1/opam
+++ b/packages/coq-native/coq-native.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Erik Martin-Dorel"
+authors: "Coq"
+homepage: "https://github.com/coq/coq/issues/12757"
+bug-reports: "https://github.com/coq/coq/issues"
+conflicts: [
+  "coq" {< "8.5"}
+]
+synopsis: "Dummy package enabling coq's native-compiler flag"
+description: """
+This package acts as a package flag for the ambient switch, taken into
+account by coq (and possibly any coq library) to enable native_compute
+at configure time, triggering the generation of .coq-native/* files.
+
+Library authors relying on the native_compute tactic should ensure all
+their coq dependencies have been built with the '-native-compiler yes'
+flag (otherwise the runtime overhead it raises removes any benefit for
+using native_compute in the first place). This package flag could then
+be very handy for them.
+
+REMARKS:
+- it is not advised to install this package flag in a flambda switch,
+  cf. <https://github.com/coq/coq/issues/11107>
+- it is not advised either to install this package flag under macOS,
+  cf. <https://github.com/coq/coq/issues/11178>
+- for more details, see <https://github.com/coq/coq/issues/12757>.
+"""

--- a/packages/coq/coq.8.10.0/opam
+++ b/packages/coq/coq.8.10.0/opam
@@ -26,6 +26,8 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.10.0/opam
+++ b/packages/coq/coq.8.10.0/opam
@@ -13,6 +13,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -23,6 +26,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/packages/coq/coq.8.10.1/opam
+++ b/packages/coq/coq.8.10.1/opam
@@ -23,6 +23,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -33,6 +36,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/packages/coq/coq.8.10.1/opam
+++ b/packages/coq/coq.8.10.1/opam
@@ -36,6 +36,8 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.10.2/opam
+++ b/packages/coq/coq.8.10.2/opam
@@ -23,6 +23,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -33,6 +36,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/packages/coq/coq.8.10.2/opam
+++ b/packages/coq/coq.8.10.2/opam
@@ -36,6 +36,8 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.11.0/opam
+++ b/packages/coq/coq.8.11.0/opam
@@ -23,6 +23,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -33,6 +36,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/packages/coq/coq.8.11.0/opam
+++ b/packages/coq/coq.8.11.0/opam
@@ -36,6 +36,8 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.11.1/opam
+++ b/packages/coq/coq.8.11.1/opam
@@ -36,6 +36,8 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.11.1/opam
+++ b/packages/coq/coq.8.11.1/opam
@@ -23,6 +23,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -33,7 +36,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
-    "-native-compiler" {os = "macos"} "no" {os = "macos"}
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/packages/coq/coq.8.11.2/opam
+++ b/packages/coq/coq.8.11.2/opam
@@ -36,6 +36,8 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.11.2/opam
+++ b/packages/coq/coq.8.11.2/opam
@@ -23,6 +23,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -33,7 +36,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
-    "-native-compiler" {os = "macos"} "no" {os = "macos"}
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/packages/coq/coq.8.12.0/opam
+++ b/packages/coq/coq.8.12.0/opam
@@ -23,6 +23,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -33,6 +36,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/packages/coq/coq.8.12.0/opam
+++ b/packages/coq/coq.8.12.0/opam
@@ -36,6 +36,8 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.5.0/opam
+++ b/packages/coq/coq.8.5.0/opam
@@ -5,21 +5,20 @@ homepage: "http://coq.inria.fr/"
 bug-reports: "https://coq.inria.fr/bugs/"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.0-only"
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
-    "-configdir"
-    "%{lib}%/coq/config"
-    "-mandir"
-    man
-    "-prefix"
-    prefix
+    "-configdir" "%{lib}%/coq/config"
+    "-mandir" man
+    "-prefix" prefix
     "-usecamlp5"
-    "-camlp5dir"
-    "%{camlp5:lib}%"
-    "-coqide"
-    "no"
+    "-camlp5dir" "%{camlp5:lib}%"
+    "-coqide" "no"
     "-debug"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
 ]
@@ -32,7 +31,7 @@ depends: [
 ]
 patches: ["ephemeron-rename.patch"]
 install: [make "install"]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: [
   ["ephemeron-rename.patch" "md5=9fa070d977a9f672ef1909babb5a4776"]

--- a/packages/coq/coq.8.5.0~camlp4/opam
+++ b/packages/coq/coq.8.5.0~camlp4/opam
@@ -5,19 +5,19 @@ homepage: "http://coq.inria.fr/"
 bug-reports: "https://coq.inria.fr/bugs/"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.0-only"
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
-    "-configdir"
-    "%{lib}%/coq/config"
-    "-mandir"
-    man
-    "-prefix"
-    prefix
+    "-configdir" "%{lib}%/coq/config"
+    "-mandir" man
+    "-prefix" prefix
     "-usecamlp4"
-    "-coqide"
-    "no"
+    "-coqide" "no"
     "-debug"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
 ]
@@ -29,7 +29,7 @@ depends: [
 ]
 patches: ["ephemeron-rename.patch"]
 install: [make "install"]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 extra-files: [
   ["ephemeron-rename.patch" "md5=9fa070d977a9f672ef1909babb5a4776"]
   ["coq.install" "md5=26c6de669a7d377c2be8592c4e3c0260"]

--- a/packages/coq/coq.8.5.1/opam
+++ b/packages/coq/coq.8.5.1/opam
@@ -5,21 +5,20 @@ homepage: "http://coq.inria.fr/"
 bug-reports: "https://coq.inria.fr/bugs/"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.0-only"
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
-    "-configdir"
-    "%{lib}%/coq/config"
-    "-mandir"
-    man
-    "-prefix"
-    prefix
+    "-configdir" "%{lib}%/coq/config"
+    "-mandir" man
+    "-prefix" prefix
     "-usecamlp5"
-    "-camlp5dir"
-    "%{camlp5:lib}%"
-    "-coqide"
-    "no"
+    "-camlp5dir" "%{camlp5:lib}%"
+    "-coqide" "no"
     "-debug"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
 ]
@@ -31,7 +30,7 @@ depends: [
   "conf-findutils" {build}
 ]
 install: [make "install"]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=26c6de669a7d377c2be8592c4e3c0260"]
 url {

--- a/packages/coq/coq.8.5.2/opam
+++ b/packages/coq/coq.8.5.2/opam
@@ -5,21 +5,20 @@ homepage: "https://coq.inria.fr/"
 bug-reports: "https://coq.inria.fr/bugs/"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.0-only"
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
-    "-configdir"
-    "%{lib}%/coq/config"
-    "-mandir"
-    man
-    "-prefix"
-    prefix
+    "-configdir" "%{lib}%/coq/config"
+    "-mandir" man
+    "-prefix" prefix
     "-usecamlp5"
-    "-camlp5dir"
-    "%{camlp5:lib}%"
-    "-coqide"
-    "no"
+    "-camlp5dir" "%{camlp5:lib}%"
+    "-coqide" "no"
     "-debug"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
 ]
@@ -31,7 +30,7 @@ depends: [
   "conf-findutils" {build}
 ]
 install: [make "install"]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=26c6de669a7d377c2be8592c4e3c0260"]
 url {

--- a/packages/coq/coq.8.5.2~camlp4/opam
+++ b/packages/coq/coq.8.5.2~camlp4/opam
@@ -5,19 +5,19 @@ homepage: "https://coq.inria.fr/"
 bug-reports: "https://coq.inria.fr/bugs/"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.0-only"
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
-    "-configdir"
-    "%{lib}%/coq/config"
-    "-mandir"
-    man
-    "-prefix"
-    prefix
+    "-configdir" "%{lib}%/coq/config"
+    "-mandir" man
+    "-prefix" prefix
     "-usecamlp4"
-    "-coqide"
-    "no"
+    "-coqide" "no"
     "-debug"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
 ]
@@ -28,7 +28,7 @@ depends: [
   "conf-findutils" {build}
 ]
 install: [make "install"]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 extra-files: ["coq.install" "md5=26c6de669a7d377c2be8592c4e3c0260"]
 url {
   src: "https://github.com/coq/coq/archive/V8.5pl2.tar.gz"

--- a/packages/coq/coq.8.5.3/opam
+++ b/packages/coq/coq.8.5.3/opam
@@ -7,21 +7,20 @@ homepage: "https://coq.inria.fr/"
 bug-reports: "https://coq.inria.fr/bugs/"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.0-only"
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
-    "-configdir"
-    "%{lib}%/coq/config"
-    "-mandir"
-    man
-    "-prefix"
-    prefix
+    "-configdir" "%{lib}%/coq/config"
+    "-mandir" man
+    "-prefix" prefix
     "-usecamlp5"
-    "-camlp5dir"
-    "%{camlp5:lib}%"
-    "-coqide"
-    "no"
+    "-camlp5dir" "%{camlp5:lib}%"
+    "-coqide" "no"
     "-debug"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
 ]
@@ -33,7 +32,7 @@ depends: [
   "conf-findutils" {build}
 ]
 install: [make "install"]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=26c6de669a7d377c2be8592c4e3c0260"]
 url {

--- a/packages/coq/coq.8.6.1/opam
+++ b/packages/coq/coq.8.6.1/opam
@@ -7,21 +7,21 @@ homepage: "https://coq.inria.fr/"
 bug-reports: "https://coq.inria.fr/bugs/"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.0-only"
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
     "-configdir"
     "%{lib}%/coq/config"
-    "-mandir"
-    man
-    "-prefix"
-    prefix
+    "-mandir" man
+    "-prefix" prefix
     "-usecamlp5"
-    "-camlp5dir"
-    "%{camlp5:lib}%"
-    "-coqide"
-    "no"
+    "-camlp5dir" "%{camlp5:lib}%"
+    "-coqide" "no"
     "-debug"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
 ]
@@ -34,7 +34,7 @@ depends: [
   "conf-findutils" {build}
 ]
 install: [make "install"]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=26c6de669a7d377c2be8592c4e3c0260"]
 url {

--- a/packages/coq/coq.8.6/opam
+++ b/packages/coq/coq.8.6/opam
@@ -7,21 +7,20 @@ homepage: "https://coq.inria.fr/"
 bug-reports: "https://coq.inria.fr/bugs/"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.0-only"
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
-    "-configdir"
-    "%{lib}%/coq/config"
-    "-mandir"
-    man
-    "-prefix"
-    prefix
+    "-configdir" "%{lib}%/coq/config"
+    "-mandir" man
+    "-prefix" prefix
     "-usecamlp5"
-    "-camlp5dir"
-    "%{camlp5:lib}%"
-    "-coqide"
-    "no"
+    "-camlp5dir" "%{camlp5:lib}%"
+    "-coqide" "no"
     "-debug"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
 ]
@@ -34,7 +33,7 @@ depends: [
   "conf-findutils" {build}
 ]
 install: [make "install"]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=26c6de669a7d377c2be8592c4e3c0260"]
 url {

--- a/packages/coq/coq.8.7.0/opam
+++ b/packages/coq/coq.8.7.0/opam
@@ -7,6 +7,9 @@ homepage: "https://coq.inria.fr/"
 bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -19,6 +22,7 @@ build: [
     "-usecamlp5"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]
@@ -58,7 +62,7 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=b85e0eb533d6836c15581f0e5cb0ebc2"]
 url {

--- a/packages/coq/coq.8.7.0/opam
+++ b/packages/coq/coq.8.7.0/opam
@@ -22,6 +22,8 @@ build: [
     "-usecamlp5"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.7.1+1/opam
+++ b/packages/coq/coq.8.7.1+1/opam
@@ -8,6 +8,9 @@ license: "LGPL-2.1"
 patches: [ "0001_make_install_static_plug.patch"
            "0002_alpine_linux.patch"
          ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -19,6 +22,7 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j1"]
   [make "-j1" "byte"]
@@ -58,7 +62,7 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: [
   ["coq.install" "md5=b85e0eb533d6836c15581f0e5cb0ebc2"]

--- a/packages/coq/coq.8.7.1+1/opam
+++ b/packages/coq/coq.8.7.1+1/opam
@@ -22,6 +22,8 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j1"]

--- a/packages/coq/coq.8.7.1+2/opam
+++ b/packages/coq/coq.8.7.1+2/opam
@@ -10,6 +10,9 @@ patches: [ "0001_make_install_static_plug.patch"
            "0003_fix_num_ocamlfind_detection.patch"
            "0004_fix_more_num.patch"
          ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -21,6 +24,7 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]
@@ -60,7 +64,7 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: [
   ["coq.install" "md5=b85e0eb533d6836c15581f0e5cb0ebc2"]

--- a/packages/coq/coq.8.7.1+2/opam
+++ b/packages/coq/coq.8.7.1+2/opam
@@ -24,6 +24,8 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.7.1/opam
+++ b/packages/coq/coq.8.7.1/opam
@@ -19,6 +19,8 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.7.1/opam
+++ b/packages/coq/coq.8.7.1/opam
@@ -5,6 +5,9 @@ homepage: "https://coq.inria.fr/"
 bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -16,6 +19,7 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]
@@ -55,7 +59,7 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=b85e0eb533d6836c15581f0e5cb0ebc2"]
 url {

--- a/packages/coq/coq.8.7.2/opam
+++ b/packages/coq/coq.8.7.2/opam
@@ -13,6 +13,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -24,6 +27,7 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]
@@ -56,7 +60,7 @@ remove: [
   "%{share}%/emacs/site-lisp/gallina-syntax.el"
   ]
 ]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=b85e0eb533d6836c15581f0e5cb0ebc2"]
 url {

--- a/packages/coq/coq.8.7.2/opam
+++ b/packages/coq/coq.8.7.2/opam
@@ -27,6 +27,8 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.8.0/opam
+++ b/packages/coq/coq.8.8.0/opam
@@ -13,6 +13,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -24,6 +27,7 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]
@@ -56,7 +60,7 @@ remove: [
   "%{share}%/emacs/site-lisp/gallina-syntax.el"
   ]
 ]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=6e8ff2905b5508b143a8acb16e3b5150"]
 url {

--- a/packages/coq/coq.8.8.0/opam
+++ b/packages/coq/coq.8.8.0/opam
@@ -27,6 +27,8 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.8.1/opam
+++ b/packages/coq/coq.8.8.1/opam
@@ -13,6 +13,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -24,6 +27,7 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]
@@ -56,7 +60,7 @@ remove: [
   "%{share}%/emacs/site-lisp/gallina-syntax.el"
   ]
 ]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=6e8ff2905b5508b143a8acb16e3b5150"]
 url {

--- a/packages/coq/coq.8.8.1/opam
+++ b/packages/coq/coq.8.8.1/opam
@@ -27,6 +27,8 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.8.2/opam
+++ b/packages/coq/coq.8.8.2/opam
@@ -13,6 +13,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -24,6 +27,7 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]
@@ -56,7 +60,7 @@ remove: [
   "%{share}%/emacs/site-lisp/gallina-syntax.el"
   ]
 ]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=6e8ff2905b5508b143a8acb16e3b5150"]
 url {

--- a/packages/coq/coq.8.8.2/opam
+++ b/packages/coq/coq.8.8.2/opam
@@ -27,6 +27,8 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.9.0/opam
+++ b/packages/coq/coq.8.9.0/opam
@@ -13,6 +13,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 patches: [ "Makefile.checker.patch" ]
 build: [
   [
@@ -25,6 +28,7 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/packages/coq/coq.8.9.0/opam
+++ b/packages/coq/coq.8.9.0/opam
@@ -28,6 +28,8 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.9.1/opam
+++ b/packages/coq/coq.8.9.1/opam
@@ -28,6 +28,8 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-flambda-opts" {ocaml:version >= "4.07"}
+    "-O3 -unbox-closures" {ocaml:version >= "4.07"}
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]

--- a/packages/coq/coq.8.9.1/opam
+++ b/packages/coq/coq.8.9.1/opam
@@ -14,6 +14,9 @@ depends: [
   "num"
   "conf-findutils" {build}
 ]
+depopts: [
+  "coq-native"
+]
 build: [
   [
     "./configure"
@@ -25,6 +28,7 @@ build: [
     "-datadir" "%{share}%/coq"
     "-camlp5dir" "%{camlp5:lib}%"
     "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]


### PR DESCRIPTION
Implements the packaging strategy described in https://github.com/coq/coq/issues/12757

In particular, I inserted a conditional line (`-native-compiler (yes|no)`) in all coq releases supporting native_compute for the sake of uniformity (i.e., `coq {>= "8.5"}`), and this thereby amounts to changing the packaging specification of 25 versions of Coq. (Hopefully this large number of `opam` files touched does not raise an issue w.r.t. opam-repository's CI)

Cc @maximedenes @Blaisorblade could one of you (ideally both! :) have a look at my PR to be sure everything looks fine from a coq / `native_compute` perspective?