### PR TITLE
Package pg_query.0.9.5

### DIFF
--- a/packages/pg_query/pg_query.0.9.5/opam
+++ b/packages/pg_query/pg_query.0.9.5/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Bindings to libpg_query for parsing PostgreSQL"
+description:
+  "OCaml bindings to libpg_query for parsing PostgreSQL, and a command-line tool that uses them"
+maintainer: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+authors: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+license: "MIT"
+homepage: "https://github.com/roddyyaga/pg_query-ocaml"
+doc: "https://roddyyaga.github.io/pg_query-ocaml/pg_query-ocaml/index.html"
+bug-reports: "https://github.com/roddyyaga/pg_query-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "2.0"}
+  "core"
+  "ctypes"
+  "ctypes-foreign"
+  "ppx_deriving"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/roddyyaga/pg_query-ocaml.git"
+url {
+  src: "https://github.com/roddyyaga/pg_query-ocaml/archive/0.9.5.tar.gz"
+  checksum: [
+    "md5=26278704b2df581a305c91ad9f596d2e"
+    "sha512=d509459e17402b32a1e92de7b63c592e0a1d42273d7ea0223b5b2f06e3f2b319d909beedffe71a12b58630bf4c877f8ca58af42684fab246ca9ab5cee3fc78ef"
+  ]
+}


### PR DESCRIPTION
### `pg_query.0.9.5`
Bindings to libpg_query for parsing PostgreSQL
OCaml bindings to libpg_query for parsing PostgreSQL, and a command-line tool that uses them



---
* Homepage: https://github.com/roddyyaga/pg_query-ocaml
* Source repo: git+https://github.com/roddyyaga/pg_query-ocaml.git
* Bug tracker: https://github.com/roddyyaga/pg_query-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2