### PR TITLE
[new release] mirage-crypto-pk, mirage-crypto, mirage-crypto-rng and mirage-crypto-rng-mirage (0.8.3)

### DIFF
--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.3/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.7"}
+  "rresult" {>= "0.6.0"}
+  ("mirage-no-xen" | "zarith-xen")
+  ("mirage-no-solo5" | "zarith-freestanding")
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.3/mirage-crypto-v0.8.3.tbz"
+  checksum: [
+    "sha256=9147ac044a56dfe22793ba25ec8d5c64da78f879db84d916b4d61030b3843523"
+    "sha512=d4f24c94c7d1e6929411ee3238d46cca43655a10581514d4d02d4a3b1511e9c0b9b08f078a65cb63abda1b9d93d46e7dfa8240c6e363f3f1416f8a8e2c6ad20b"
+  ]
+}

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.3/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.3/mirage-crypto-v0.8.3.tbz"
+  checksum: [
+    "sha256=9147ac044a56dfe22793ba25ec8d5c64da78f879db84d916b4d61030b3843523"
+    "sha512=d4f24c94c7d1e6929411ee3238d46cca43655a10581514d4d02d4a3b1511e9c0b9b08f078a65cb63abda1b9d93d46e7dfa8240c6e363f3f1416f8a8e2c6ad20b"
+  ]
+}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.3/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator"
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "mirage-crypto" {=version}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+# lwt sublibrary
+  "mtime"
+  "lwt" {>= "4.0.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.3/mirage-crypto-v0.8.3.tbz"
+  checksum: [
+    "sha256=9147ac044a56dfe22793ba25ec8d5c64da78f879db84d916b4d61030b3843523"
+    "sha512=d4f24c94c7d1e6929411ee3238d46cca43655a10581514d4d02d4a3b1511e9c0b9b08f078a65cb63abda1b9d93d46e7dfa8240c6e363f3f1416f8a8e2c6ad20b"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.8.2/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.2/opam
@@ -42,3 +42,4 @@ url {
     "sha512=20131b787ab7fba478a9846e253ce3c9adb83e955d06e480b90b3c22adb3c165f55816d2ff7da5aa332b4fc8ea9aa209637451eb794fcaa079f206343596d6c8"
   ]
 }
+available: arch != "ppc64"

--- a/packages/mirage-crypto/mirage-crypto.0.8.3/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "eqaf" {>= "0.7"}
+]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
+hashes (MD5, SHA-1, SHA-2).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.3/mirage-crypto-v0.8.3.tbz"
+  checksum: [
+    "sha256=9147ac044a56dfe22793ba25ec8d5c64da78f879db84d916b4d61030b3843523"
+    "sha512=d4f24c94c7d1e6929411ee3238d46cca43655a10581514d4d02d4a3b1511e9c0b9b08f078a65cb63abda1b9d93d46e7dfa8240c6e363f3f1416f8a8e2c6ad20b"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Fix ppc64le cycle_counter (add missing Val_long) (mirage/mirage-crypto#78 @hannesm)
  - test_entropy is now test_entropy_collection
  - test_entropy checks timer and bootstrap functions
* Avoid polluting symbol table with global non-prefixed symbols
  (reported by @anmonteiro in mirage/mirage-crypto#77, fixed mirage/mirage-crypto#78 @hannesm (suggested by @dinosaure))
* Avoid "caml_" prefix in entropy_stubs, use "mc_" instead (mirage/mirage-crypto#78 @hannesm)