### PR TITLE
Package ocsigen-toolkit.2.8.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.8.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.8.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.13.0"}
+  "calendar"
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.8.0.tar.gz"
+  checksum: [
+    "md5=7dbf0bca8c12b8226f7950a14a956723"
+    "sha512=5cba9789128253479f8be691facb120ec3309e0372284b3e799a96d45d992dcbb6f335f66307c17c49a10730b9d81902ec3d06d9157bb74d746f3c59f31d9af6"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.8.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.2