### PR TITLE
Package ocsigen-toolkit.2.8.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.8.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.8.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.12.1"}
+  "calendar"
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.8.0.tar.gz"
+  checksum: [
+    "md5=2d00e424d2f1ff44c9a6392f7e9b9926"
+    "sha512=7b56ad4a0aeb4640d99db46f157debdba31958909a0bda34803be0f0d316e87399d68a00590c00f00946d38e5058094d69064a9e084edf4f81a29ab6a10dce8e"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.8.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.2