### PR TITLE
[new release] ezjsonm-lwt and ezjsonm (1.2.0)

### DIFF
--- a/packages/ezjsonm-lwt/ezjsonm-lwt.1.2.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/mirage/ezjsonm"
+doc: "https://mirage.github.io/ezjsonm"
+bug-reports: "https://github.com/mirage/ezjsonm/issues"
+depends: [
+  "ocaml"
+  "ezjsonm"
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.4.0"}
+  "ppx_sexp_conv" {with-test}
+  "jsonm" {>= "1.0.0"}
+  "sexplib"
+  "hex"
+  "lwt" {>= "2.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ezjsonm.git"
+synopsis: "Simple Lwt-based interface to the Jsonm JSON library"
+description: """
+This simple interface over the Jsonm library provides an
+Lwt variant of the serialisation functions.
+"""
+x-commit-hash: "6f6dedcb0105191e589c42c53b972a98bd9efbfc"
+url {
+  src:
+    "https://github.com/mirage/ezjsonm/releases/download/v1.2.0/ezjsonm-v1.2.0.tbz"
+  checksum: [
+    "sha256=4b13a9a76211d77d62c6c1fb91eaf209db8a1239879ea70503183dce3d2a034c"
+    "sha512=594d9a11172339b16956869ddaa38a98f33eb2684f93c90b3d9bf41e23717a43b9775b0ea467c85153eb627b790d86861aa7155991a7d4d2ad3ca3f6fd88ce69"
+  ]
+}

--- a/packages/ezjsonm/ezjsonm.1.2.0/opam
+++ b/packages/ezjsonm/ezjsonm.1.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/mirage/ezjsonm"
+doc: "https://mirage.github.io/ezjsonm/"
+bug-reports: "https://github.com/mirage/ezjsonm/issues"
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune" {>= "2.0"}
+  "alcotest" {with-test & >= "0.4.0"}
+  "jsonm" {>= "1.0.0"}
+  "sexplib0"
+  "hex"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ezjsonm.git"
+synopsis: "Simple interface on top of the Jsonm JSON library"
+description: """
+Ezjsonm provides more convenient (but far less flexible)
+input and output functions that go to and from `string` values.
+This avoids the need to write signal code, which is useful for
+quick scripts that manipulate JSON.
+
+More advanced users should go straight to the Jsonm library and
+use it directly, rather than be saddled with the Ezjsonm interface.
+"""
+x-commit-hash: "6f6dedcb0105191e589c42c53b972a98bd9efbfc"
+url {
+  src:
+    "https://github.com/mirage/ezjsonm/releases/download/v1.2.0/ezjsonm-v1.2.0.tbz"
+  checksum: [
+    "sha256=4b13a9a76211d77d62c6c1fb91eaf209db8a1239879ea70503183dce3d2a034c"
+    "sha512=594d9a11172339b16956869ddaa38a98f33eb2684f93c90b3d9bf41e23717a43b9775b0ea467c85153eb627b790d86861aa7155991a7d4d2ad3ca3f6fd88ce69"
+  ]
+}


### PR DESCRIPTION
Simple Lwt-based interface to the Jsonm JSON library

- Project page: <a href="https://github.com/mirage/ezjsonm">https://github.com/mirage/ezjsonm</a>
- Documentation: <a href="https://mirage.github.io/ezjsonm">https://mirage.github.io/ezjsonm</a>

##### CHANGES:

* Upgrade build rules to dune 2.0 (@avsm)
* Depend on Sexplib0 instead of Sexplib since we only need
  the type definition. This reduces the dependency cone of
  Ezjsonm (and skips Base). (@avsm)
