### PR TITLE
[new release] ezjsonm-lwt and ezjsonm (1.2.0)

### DIFF
--- a/packages/ezjsonm-lwt/ezjsonm-lwt.1.2.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.1.2.0/opam
@@ -8,10 +8,10 @@ doc: "https://mirage.github.io/ezjsonm"
 bug-reports: "https://github.com/mirage/ezjsonm/issues"
 depends: [
   "ocaml"
-  "ezjsonm"
+  "ezjsonm" {=version}
   "dune" {>= "1.0"}
   "alcotest" {with-test & >= "0.4.0"}
-  "ppx_sexp_conv" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
   "jsonm" {>= "1.0.0"}
   "sexplib"
   "hex"

--- a/packages/ezjsonm-lwt/ezjsonm-lwt.1.2.0/opam
+++ b/packages/ezjsonm-lwt/ezjsonm-lwt.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/mirage/ezjsonm"
+doc: "https://mirage.github.io/ezjsonm"
+bug-reports: "https://github.com/mirage/ezjsonm/issues"
+depends: [
+  "ocaml"
+  "ezjsonm"
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.4.0"}
+  "ppx_sexp_conv" {with-test}
+  "jsonm" {>= "1.0.0"}
+  "sexplib"
+  "hex"
+  "lwt" {>= "2.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ezjsonm.git"
+synopsis: "Simple Lwt-based interface to the Jsonm JSON library"
+description: """
+This simple interface over the Jsonm library provides an
+Lwt variant of the serialisation functions.
+"""
+x-commit-hash: "5986fd927c7a804b09867f43ca82a75407dcdadb"
+url {
+  src:
+    "https://github.com/mirage/ezjsonm/releases/download/v1.2.0/ezjsonm-v1.2.0.tbz"
+  checksum: [
+    "sha256=870bbe1c24484bb7e1acce44859dd521c24cb8a8f0e74042a62418c68671cce0"
+    "sha512=f603642ecdd01696017d0a8fef0ae8867777fbced53ad670afa3da8f12e2c101a5c6cd201b7917685323bc9033793dd406c6d333ed4a24d2d4d4d6c88527693b"
+  ]
+}

--- a/packages/ezjsonm/ezjsonm.1.2.0/opam
+++ b/packages/ezjsonm/ezjsonm.1.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/mirage/ezjsonm"
+doc: "https://mirage.github.io/ezjsonm/"
+bug-reports: "https://github.com/mirage/ezjsonm/issues"
+depends: [
+  "ocaml" {>="4.04.0"}
+  "dune" {>= "2.0"}
+  "alcotest" {with-test & >= "0.4.0"}
+  "jsonm" {>= "1.0.0"}
+  "sexplib0"
+  "hex"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ezjsonm.git"
+synopsis: "Simple interface on top of the Jsonm JSON library"
+description: """
+Ezjsonm provides more convenient (but far less flexible)
+input and output functions that go to and from `string` values.
+This avoids the need to write signal code, which is useful for
+quick scripts that manipulate JSON.
+
+More advanced users should go straight to the Jsonm library and
+use it directly, rather than be saddled with the Ezjsonm interface.
+"""
+x-commit-hash: "5986fd927c7a804b09867f43ca82a75407dcdadb"
+url {
+  src:
+    "https://github.com/mirage/ezjsonm/releases/download/v1.2.0/ezjsonm-v1.2.0.tbz"
+  checksum: [
+    "sha256=870bbe1c24484bb7e1acce44859dd521c24cb8a8f0e74042a62418c68671cce0"
+    "sha512=f603642ecdd01696017d0a8fef0ae8867777fbced53ad670afa3da8f12e2c101a5c6cd201b7917685323bc9033793dd406c6d333ed4a24d2d4d4d6c88527693b"
+  ]
+}

--- a/packages/mirage-tc/mirage-tc.0.3.0/opam
+++ b/packages/mirage-tc/mirage-tc.0.3.0/opam
@@ -15,7 +15,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "tc"]
 depends: [
   "ocaml" {>= "4.01.0"}
-  "ezjsonm" {>= "0.4.0"}
+  "ezjsonm" {>= "0.4.0" & <"1.2.0"}
   "mstruct" {>= "1.3.1"}
   "cstruct"
   "bin_prot" {< "v0.15"}

--- a/packages/mustache/mustache.2.0.0/opam
+++ b/packages/mustache/mustache.2.0.0/opam
@@ -20,7 +20,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & <"4.06.0"}
   "ocamlfind" {build}
   "oasis" {build & >= "0.4.0"}
   "ezjsonm" {>= "0.4.0"}

--- a/packages/opium_kernel/opium_kernel.0.16.0/opam
+++ b/packages/opium_kernel/opium_kernel.0.16.0/opam
@@ -17,7 +17,7 @@ depends: [
   "hmap"
   "cohttp" {>= "0.99.0"}
   "cohttp-lwt" {>= "0.99.0"}
-  "ezjsonm" {>= "0.4.0"}
+  "ezjsonm" {>= "0.4.0" & < "1.2.0"}
   "base64" {>= "2.0.0" & < "3.0.0"}
   "lwt"
   "fieldslib" {>= "v0.9.0" & < "v0.15"}

--- a/packages/opium_kernel/opium_kernel.0.16.0/opam
+++ b/packages/opium_kernel/opium_kernel.0.16.0/opam
@@ -26,6 +26,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
   "re" {>= "1.3.0"}
   "alcotest" {with-test}
+  "uri" {<"2.0.0"}
   "cow" {with-test & >= "0.10.0"}
 ]
 synopsis: "Sinatra like web toolkit based on Lwt + Cohttp"

--- a/packages/opium_kernel/opium_kernel.0.17.0/opam
+++ b/packages/opium_kernel/opium_kernel.0.17.0/opam
@@ -31,6 +31,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.9.0" & < "v0.15"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
   "re" {>= "1.3.0"}
+  "uri" {<"2.0.0"}
   "alcotest" {with-test}
   "cow" {with-test & >= "0.10.0"}
 ]

--- a/packages/opium_kernel/opium_kernel.0.17.0/opam
+++ b/packages/opium_kernel/opium_kernel.0.17.0/opam
@@ -23,7 +23,7 @@ depends: [
   "hmap"
   "cohttp" {>= "0.99.0"}
   "cohttp-lwt" {>= "0.99.0"}
-  "ezjsonm" {>= "0.4.0"}
+  "ezjsonm" {>= "0.4.0" & < "1.2.0"}
   "base64" {>= "2.0.0" & < "3.0.0"}
   "lwt"
   "fieldslib" {>= "v0.9.0" & < "v0.15"}

--- a/packages/opium_kernel/opium_kernel.0.17.1/opam
+++ b/packages/opium_kernel/opium_kernel.0.17.1/opam
@@ -23,7 +23,7 @@ depends: [
   "hmap"
   "cohttp" {>= "0.99.0"}
   "cohttp-lwt" {>= "0.99.0"}
-  "ezjsonm" {>= "0.4.0"}
+  "ezjsonm" {>= "0.4.0" & < "1.2.0"}
   "base64" {>= "2.0.0"}
   "lwt"
   "fieldslib" {>= "v0.9.0" & < "v0.15"}


### PR DESCRIPTION
Simple Lwt-based interface to the Jsonm JSON library

- Project page: <a href="https://github.com/mirage/ezjsonm">https://github.com/mirage/ezjsonm</a>
- Documentation: <a href="https://mirage.github.io/ezjsonm">https://mirage.github.io/ezjsonm</a>

##### CHANGES:

* Add `find_opt` to provide an exception-less version of `find` (mirage/ezjsonm#39 @avsm)
* Raise `Parse_error` instead of assert failure if the input
  to `from_string` is not a valid JSON array or object (mirage/ezjsonm#39 @avsm).
* Upgrade build rules to dune 2.0 (mirage/ezjsonm#38 @avsm)
* Depend on Sexplib0 instead of Sexplib since we only need
  the type definition. This reduces the dependency cone of
  Ezjsonm (and skips Base). (mirage/ezjsonm#38 @avsm)
