### PR TITLE
2 packages from sneeuwballen/benchpress at dev

### DIFF
--- a/packages/benchpress-server/benchpress-server.dev/opam
+++ b/packages/benchpress-server/benchpress-server.dev/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+synopsis: "Server and web UI for benchpress"
+maintainer: "simon.cruanes.2007@m4x.org"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-unix"
+  "containers" { >= "2.7" }
+  "csv"
+  "benchpress" { = version }
+  "cmdliner"
+  "logs"
+  "uuidm"
+  "base64"
+  "gnuplot" { >= "0.6" & < "0.8" }
+  "sqlite3"
+  "sqlite3_utils" { >= "0.3" & < "0.4" }
+  "tiny_httpd" { >= "0.6" & < "0.7" }
+  "tiny_httpd_camlzip" { >= "0.5" }
+  "printbox" { >= "0.5" & < "0.6" }
+  "tyxml"  # for printbox.tyxml
+  "ocaml" {>= "4.03" }
+]
+homepage: "https://github.com/sneeuwballen/benchpress/"
+dev-repo: "git+https://github.com/sneeuwballen/benchpress.git"
+bug-reports: "https://github.com/sneeuwballen/benchpress/issues"
+url {
+  src: "https://github.com/sneeuwballen/benchpress/archive/0.1.tar.gz"
+  checksum: [
+    "md5=0bba85a5823d7f5fcc7529223d760b88"
+    "sha512=3a5c60b987dead0df9b7bff6b7ce1dea50857cdd70a7b79f022b32781b8cebd2d22fb64e3c7b1748e8917367399dde766092188d91fa9d467070c0308c4cc958"
+  ]
+}

--- a/packages/benchpress/benchpress.dev/opam
+++ b/packages/benchpress/benchpress.dev/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+synopsis: "Tool to run one or more logic programs, on a set of files, and collect the results"
+maintainer: "simon.cruanes.2007@m4x.org"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-unix"
+  "containers" { >= "2.7" }
+  "re" { >= "1.8" & < "2.0" }
+  "csv"
+  "cmdliner"
+  "iter" { >= "1.0" } # TODO: remove
+  "logs"
+  "uuidm"
+  "base64"
+  "ocaml-protoc" { >= "2.0" & < "3.0" }
+  "gnuplot" { >= "0.6" & < "0.8" }
+  "sqlite3"
+  "sqlite3_utils" { >= "0.3" & < "0.4" }
+  "printbox" { >= "0.5" & < "0.6" }
+  "decoders" { >= "0.3.0" & < "0.4" }
+  "ocaml" {>= "4.03" }
+]
+homepage: "https://github.com/sneeuwballen/benchpress/"
+dev-repo: "git+https://github.com/sneeuwballen/benchpress.git"
+bug-reports: "https://github.com/sneeuwballen/benchpress/issues"
+url {
+  src: "https://github.com/sneeuwballen/benchpress/archive/0.1.tar.gz"
+  checksum: [
+    "md5=0bba85a5823d7f5fcc7529223d760b88"
+    "sha512=3a5c60b987dead0df9b7bff6b7ce1dea50857cdd70a7b79f022b32781b8cebd2d22fb64e3c7b1748e8917367399dde766092188d91fa9d467070c0308c4cc958"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`benchpress.dev`: Tool to run one or more logic programs, on a set of files, and collect the results
-`benchpress-server.dev`: Server and web UI for benchpress



---
* Homepage: https://github.com/sneeuwballen/benchpress/
* Source repo: git+https://github.com/sneeuwballen/benchpress.git
* Bug tracker: https://github.com/sneeuwballen/benchpress/issues

---
:camel: Pull-request generated by opam-publish v2.0.0