### PR TITLE
Package qiskit.0.1.0

### DIFF
--- a/packages/qiskit/qiskit.0.1.0/opam
+++ b/packages/qiskit/qiskit.0.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "Qiskit for OCaml"
+description: "An OCaml wrapper for the Qiskit quantum computing toolkit"
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: "Davide Gessa <gessadavide@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dakk/caml_qiskit"
+bug-reports: "https://github.com/dakk/caml_qiskit/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "2.5.0"}
+  "pyml" {>= "20200518"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dakk/caml_qiskit.git"
+url {
+  src: "https://github.com/dakk/caml_qiskit/archive/v0.1.0.zip"
+  checksum: [
+    "md5=6b76c7cae259eba2df5385e686c94f68"
+    "sha512=a6dbd9045d86986d0230c4d1e77971142595ed80e8487bd290c3b771b695d544a463b311d252b7ac198081d6d8199d90d3c5126ae639f8ae645b97cc942f8f76"
+  ]
+}


### PR DESCRIPTION
### `qiskit.0.1.0`
Qiskit for OCaml
An OCaml wrapper for the Qiskit quantum computing toolkit



---
* Homepage: https://github.com/dakk/caml_qiskit
* Source repo: git+https://github.com/dakk/caml_qiskit.git
* Bug tracker: https://github.com/dakk/caml_qiskit/issues

---
:camel: Pull-request generated by opam-publish v2.0.2