### PR TITLE
coq/coqide 8.12.0: disable native-compiler on Mac, following 8.11.2

### DIFF
--- a/packages/coq/coq.8.12.0/opam
+++ b/packages/coq/coq.8.12.0/opam
@@ -33,6 +33,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/packages/coqide/coqide.8.12.0/opam
+++ b/packages/coqide/coqide.8.12.0/opam
@@ -27,6 +27,7 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/16876#issuecomment-665587455.
EDIT: in short, that's still needed to work around https://github.com/coq/coq/issues/11178, see https://github.com/coq/coq/issues/11178#issuecomment-665589620.