### PR TITLE
[new release] postgresql (4.6.1)

### DIFF
--- a/packages/postgresql/postgresql.4.6.1/opam
+++ b/packages/postgresql/postgresql.4.6.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "dune-configurator"
+  "base" {build}
+  "stdio" {build}
+  "conf-postgresql" {build}
+  "base-bytes"
+]
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/4.6.1/postgresql-4.6.1.tbz"
+  checksum: [
+    "sha256=e7b5819b6c2ffb524b08ecb7f28d4ef7c53c2f722428c5f6cc5e8e26ccceaa08"
+    "sha512=282fbeca893a5540e6e73151a0e453116c76acc8eafa4ccc3b77e8a057a1548e0b449c021e3c103c3bad17afe20bc745e958259c08f101d1376a50a6201e2c45"
+  ]
+}


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

* Fixed a bug in `request_cancel` that turned errors into success and
    success into an error.  Thanks to Dmitry Astapov for this patch!

  * Added support for const char strings in stubs due to stricter handling
    in newer OCaml runtimes.  This eliminates C-compiler warnings.
