### PR TITLE
Added MacPorts solution for depext for a few conf packages

### DIFF
--- a/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
+++ b/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
@@ -7,6 +7,7 @@ depexts: [
   ["gnome-icon-theme"] {os-family = "debian"}
   ["gnome-icon-theme"] {os-family = "fedora" | os-family = "rhel"}
   ["gnome-icon-theme"] {os = "macos" & os-distribution = "homebrew"}
+  ["adwaita-icon-theme"] {os = "macos" & os-distribution = "macports"}
   ["gnome-icon-theme"] {os-family = "suse"}
   ["gnome-icon-theme"] {os-distribution = "arch"}
   ["gnome-icon-theme"] {os-distribution = "alpine"}

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -8,6 +8,7 @@ depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libgtk-3-dev" "libexpat1-dev"] {os-family = "debian"}
   ["gtk+3" "expat"] {os-distribution = "homebrew" & os = "macos"}
+  ["gtk3 +quartz" "expat"] {os-distribution = "macports" & os = "macos"}
   ["gtk3-devel"] {os-distribution = "centos"}
   ["gtk3-devel"] {os-distribution = "fedora"}
   ["gtk3-devel"] {os-distribution = "ol"}

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: "The gtksourceview programmers"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://projects.gnome.org/gtksourceview/"
+license: "LGPL-2.1-or-later"
+build: [["pkg-config" "--short-errors" "--print-errors" "gtksourceview-3.0"]]
+depends: ["conf-pkg-config" {build}]
+depexts: [
+  ["gtksourceview-dev"] {os-distribution = "alpine"}
+  ["gtksourceview3"] {os-distribution = "arch"}
+  ["epel-release" "gtksourceview3-devel"] {os-distribution = "centos"}
+  ["libgtksourceview-3.0-dev"] {os-family = "debian"}
+  ["gtksourceview3-devel"] {os-distribution = "fedora"}
+  ["gtksourceview3"] {os = "freebsd"}
+  ["gtksourceview3"] {os = "openbsd"}
+  ["gtksourceview-devel"] {os-family = "suse"}
+  ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
+  ["gtksourceview3 +quartz" "libxml2"] {os = "macos" & os-distribution = "macports"}
+]
+synopsis: "Virtual package relying on a GtkSourceView-3 system installation"
+description:
+  "This package can only install if libgtksourceview-3.0-dev is installed on the system."
+flags: conf

--- a/packages/conf-pkg-config/conf-pkg-config.1.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: ["Francois Berenger"]
+homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+build: [
+  ["pkg-config" "--help"]
+]
+install: [
+  ["ln" "-s" "/usr/local/bin/pkgconf" "%{bin}%/pkg-config"] {os = "openbsd"}
+]
+remove: [
+  ["rm" "-f" "%{bin}%/pkg-config"] {os = "openbsd"}
+]
+post-messages: [
+  "conf-pkg-config: A symlink to /usr/local/bin/pkgconf has been installed in the OPAM bin directory (%{bin}%) on your PATH as 'pkg-config'. This is necessary for correct operation." {os = "openbsd"}
+]
+depexts: [
+  ["pkg-config"] {os-family = "debian"}
+  ["pkgconf"] {os-distribution = "arch"}
+  ["pkgconfig"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "mageia"}
+  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "ol"}
+  ["pkgconf"] {os-distribution = "alpine"}
+  ["pkgconfig"] {os-distribution = "nixos"}
+  ["devel/pkgconf"] {os = "openbsd"}
+  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
+  ["pkgconf"] {os = "freebsd"}
+  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  ["pkg-config"] {os-distribution = "cygwinports"}
+]
+synopsis: "Virtual package relying on pkg-config installation"
+description: """
+This package can only install if the pkg-config package is installed
+on the system."""
+flags: conf


### PR DESCRIPTION
This PR adds a MacPorts solution for 4 conf packages which only had a homebrew solution on macOS.

What I am unsure about are the rules if an existing package should be modified or a package with a new / incremented version should be created. I followed what seems to be common practice for each individual package but ended up to do it differently. I would appreciate some general advice on this and some special advice for the case of adding a depext MacPorts solution.

Note: the handling of variants in MacPorts (like "gtk3 +quartz") doesn't look solid. It seems to work but depext treats this partly as separate packages (e.g. when listing what to install) and partly as one package (e.g. when sorting packages).