### PR TITLE
2 packages from sneeuwballen/benchpress at 0.1

### DIFF
--- a/packages/benchpress-server/benchpress-server.0.1/opam
+++ b/packages/benchpress-server/benchpress-server.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+synopsis: "Server and web UI for benchpress"
+maintainer: "simon.cruanes.2007@m4x.org"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-unix"
+  "containers" { >= "2.7" }
+  "csv"
+  "benchpress" { = version }
+  "cmdliner"
+  "logs"
+  "uuidm"
+  "base64"
+  "gnuplot" { >= "0.6" & < "0.8" }
+  "sqlite3"
+  "sqlite3_utils" { >= "0.3" & < "0.4" }
+  "tiny_httpd" { >= "0.6" & < "0.7" }
+  "tiny_httpd_camlzip" { >= "0.5" }
+  "printbox" { >= "0.5" & < "0.6" }
+  "tyxml"  # for printbox.tyxml
+  "ocaml" {>= "4.03" }
+]
+homepage: "https://github.com/sneeuwballen/benchpress/"
+dev-repo: "git+https://github.com/sneeuwballen/benchpress.git"
+bug-reports: "https://github.com/sneeuwballen/benchpress/issues"
+url {
+  src: "https://github.com/sneeuwballen/benchpress/archive/0.1.tar.gz"
+  checksum: [
+    "md5=e6d75a16321e4840e05052ee4c6bfa7f"
+    "sha512=79173afcebe9dbdeabf8e8d6cf31b757bff1021c20d3f29b618081b3601289a939f032773dd3fc939dd005596f3cebc4407c542624ec1fcb2ff6f595b9914834"
+  ]
+}

--- a/packages/benchpress-server/benchpress-server.0.1/opam
+++ b/packages/benchpress-server/benchpress-server.0.1/opam
@@ -7,7 +7,7 @@ build: [
   ["dune" "build" "@doc" "-p" name] {with-doc}
 ]
 depends: [
-  "dune" { >= "1.1" }
+  "dune" { >= "1.11" }
   "base-unix"
   "containers" { >= "2.7" }
   "csv"

--- a/packages/benchpress/benchpress.0.1/opam
+++ b/packages/benchpress/benchpress.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+synopsis: "Tool to run one or more logic programs, on a set of files, and collect the results"
+maintainer: "simon.cruanes.2007@m4x.org"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-unix"
+  "containers" { >= "2.7" }
+  "re" { >= "1.8" & < "2.0" }
+  "csv"
+  "cmdliner"
+  "iter" { >= "1.0" } # TODO: remove
+  "logs"
+  "uuidm"
+  "base64"
+  "ocaml-protoc" { >= "2.0" & < "3.0" }
+  "gnuplot" { >= "0.6" & < "0.8" }
+  "sqlite3"
+  "sqlite3_utils" { >= "0.3" & < "0.4" }
+  "printbox" { >= "0.5" & < "0.6" }
+  "decoders" { >= "0.3.0" & < "0.4" }
+  "ocaml" {>= "4.03" }
+]
+homepage: "https://github.com/sneeuwballen/benchpress/"
+dev-repo: "git+https://github.com/sneeuwballen/benchpress.git"
+bug-reports: "https://github.com/sneeuwballen/benchpress/issues"
+url {
+  src: "https://github.com/sneeuwballen/benchpress/archive/0.1.tar.gz"
+  checksum: [
+    "md5=e6d75a16321e4840e05052ee4c6bfa7f"
+    "sha512=79173afcebe9dbdeabf8e8d6cf31b757bff1021c20d3f29b618081b3601289a939f032773dd3fc939dd005596f3cebc4407c542624ec1fcb2ff6f595b9914834"
+  ]
+}

--- a/packages/benchpress/benchpress.0.1/opam
+++ b/packages/benchpress/benchpress.0.1/opam
@@ -7,7 +7,7 @@ build: [
   ["dune" "build" "@doc" "-p" name] {with-doc}
 ]
 depends: [
-  "dune" { >= "1.1" }
+  "dune" { >= "1.11" }
   "base-unix"
   "containers" { >= "2.7" }
   "re" { >= "1.8" & < "2.0" }


### PR DESCRIPTION
This pull-request concerns:
-`benchpress.0.1`: Tool to run one or more logic programs, on a set of files, and collect the results
-`benchpress-server.0.1`: Server and web UI for benchpress



---
* Homepage: https://github.com/sneeuwballen/benchpress/
* Source repo: git+https://github.com/sneeuwballen/benchpress.git
* Bug tracker: https://github.com/sneeuwballen/benchpress/issues

---
:camel: Pull-request generated by opam-publish v2.0.0