### PR TITLE
Add libtorch 1.6.0.

### DIFF
--- a/packages/libtorch/libtorch.1.6.0/opam
+++ b/packages/libtorch/libtorch.1.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage: "https://github.com/LaurentMazare/ocaml-torch"
+maintainer: "lmazare@gmail.com"
+bug-reports: "https://github.com/LaurentMazare/ocaml-torch/issues"
+authors: [
+  "Laurent Mazare"
+]
+install: [
+  [
+    "sh"
+    "-c"
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-linux.zip && mv -f libtorch %{lib}%/ )"
+  ] { os = "linux" }
+  [
+    "sh"
+    "-c"
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-macos.zip && mv -f libtorch %{lib}%/ && tar xzf mklml-macos.tgz && mv -f mklml_mac_2019.0.1.20181227/lib/libmklml.dylib %{lib}%/libtorch/lib/ && mv -f mklml_mac_2019.0.1.20181227/lib/libiomp5.dylib %{lib}%/libtorch/lib/ )"
+  ] { os = "macos" }
+]
+depexts: [
+  ["libomp"] {os-distribution = "homebrew" & os = "macos"}
+]
+synopsis: "LibTorch library package"
+description: """
+This is used by the torch package to trigger the install of the
+libtorch library."""
+extra-source "libtorch-linux.zip" {
+  src: "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.6.0%2Bcpu.zip"
+  checksum: "md5=21c5ef08e13aaeb16ec7c2eb1c0e75e9"
+}
+extra-source "libtorch-macos.zip" {
+  src: "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.6.0.zip"
+  checksum: "md5=da1ba1099f0d0151c78221e3f55506e2"
+}
+extra-source "mklml-macos.tgz" {
+  src: "https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_mac_2019.0.1.20181227.tgz"
+  checksum: "md5=a8b4b158dc8e7aad13c0d594a9a8d241"
+}


### PR DESCRIPTION
This upgrades the libtorch package to handle the recently released libtorch 1.6.0.
Once this has been released, the torch package will be updated to use this now version (the github tip is already up to date).