### PR TITLE
[new release] pcre (7.4.4)

### DIFF
--- a/packages/pcre/pcre.7.4.4/opam
+++ b/packages/pcre/pcre.7.4.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "dune-configurator"
+  "conf-libpcre" {build}
+  "base" {build}
+  "base-bytes"
+]
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/7.4.4/pcre-7.4.4.tbz"
+  checksum: [
+    "sha256=1e9db45646daaa5770e9f7bf2230697986698adb6969b4fb9ecade17facabf24"
+    "sha512=3c41ca1ea9f50ee4bd4b52ddb5e728c5489347fac1741e66ab318f424f3e5858f72dba1c8d04aa56524179411d103eb827b8251794a0e0be47ddedb002d23cb2"
+  ]
+}


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

* Added missing dune-configurator dependency.

  * Added support for const char strings in stubs due to stricter handling
    in newer OCaml runtimes.  This eliminates C-compiler warnings.
