### PR TITLE
[new release] gsl (1.24.2)

### DIFF
--- a/packages/gsl/gsl.1.24.2/opam
+++ b/packages/gsl/gsl.1.24.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Olivier Andrieu <oandrieu@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+]
+bug-reports: "https://github.com/mmottl/gsl-ocaml/issues"
+homepage: "https://mmottl.github.io/gsl-ocaml"
+doc: "https://mmottl.github.io/gsl-ocaml/api"
+license: "GPL-3+"
+dev-repo: "git+https://github.com/mmottl/gsl-ocaml.git"
+synopsis: "GSL - Bindings to the GNU Scientific Library"
+description: """
+gsl-ocaml interfaces the GSL (GNU Scientific Library), providing many of the
+most frequently used functions for scientific computation including algorithms
+for optimization, differential equations, statistics, random number generation,
+linear algebra, etc."""
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "dune-configurator"
+  "conf-gsl" {build}
+  "conf-pkg-config" {build}
+  "base" {build}
+  "stdio" {build}
+]
+url {
+  src:
+    "https://github.com/mmottl/gsl-ocaml/releases/download/1.24.2/gsl-1.24.2.tbz"
+  checksum: [
+    "sha256=bac9cf86c46a38c10fad54faa834846bfce40ac628ba6bc612a6b5af3ca8be89"
+    "sha512=4e7692426e2f87b3c099f0cb2feed08f3b68cfedaffac131768638d09b84715636bc570f3a806387897df972fa9cdd191f5cc291a0c291fa120e157bce1fb1ed"
+  ]
+}


### PR DESCRIPTION
GSL - Bindings to the GNU Scientific Library

- Project page: <a href="https://mmottl.github.io/gsl-ocaml">https://mmottl.github.io/gsl-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/gsl-ocaml/api">https://mmottl.github.io/gsl-ocaml/api</a>

##### CHANGES:

* Switched to OPAM file generation via `dune-project`

  * Added support for const char strings in stubs due to stricter handling
    in newer OCaml runtimes.  This eliminates C-compiler warnings.
