### PR TITLE
[new release] sqlite3 (5.0.2)

### DIFF
--- a/packages/sqlite3/sqlite3.5.0.2/opam
+++ b/packages/sqlite3/sqlite3.5.0.2/opam
@@ -21,7 +21,7 @@ sqlite3-ocaml is an OCaml library with bindings to the SQLite3 client API.
 Sqlite3 is a self-contained, serverless, zero-configuration, transactional SQL
 database engine with outstanding performance for many use cases."""
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.06"}
   "dune" {>= "1.11"}
   "dune-configurator"
   "conf-sqlite3" {build}

--- a/packages/sqlite3/sqlite3.5.0.2/opam
+++ b/packages/sqlite3/sqlite3.5.0.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christian Szegedy <csdontspam@metamatix.com>"
+]
+bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
+homepage: "https://mmottl.github.io/sqlite3-ocaml"
+doc: "https://mmottl.github.io/sqlite3-ocaml/api"
+license: "Expat"
+dev-repo: "git+https://github.com/mmottl/sqlite3-ocaml.git"
+synopsis: "SQLite3 bindings for OCaml"
+description: """
+sqlite3-ocaml is an OCaml library with bindings to the SQLite3 client API.
+Sqlite3 is a self-contained, serverless, zero-configuration, transactional SQL
+database engine with outstanding performance for many use cases."""
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "1.11"}
+  "dune-configurator"
+  "conf-sqlite3" {build}
+  "ppx_inline_test" {with-test}
+]
+url {
+  src:
+    "https://github.com/mmottl/sqlite3-ocaml/releases/download/5.0.2/sqlite3-5.0.2.tbz"
+  checksum: [
+    "sha256=02ddd45536ea432f4cc149ca140f77de0c1a99c67741caf28afd6f092c396a69"
+    "sha512=d982094454d06dc4f070da20fb9b02a112bfe17bae8d7889a370b6d7c88a44d09746675f1f061f107a9382b21032368505c889886278be3310a0545075133e11"
+  ]
+}


### PR DESCRIPTION
SQLite3 bindings for OCaml

- Project page: <a href="https://mmottl.github.io/sqlite3-ocaml">https://mmottl.github.io/sqlite3-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/sqlite3-ocaml/api">https://mmottl.github.io/sqlite3-ocaml/api</a>

##### CHANGES:

* Added missing `dune-configurator` dependency.

  * Removed redundant build dependencies.

  * Use `caml_alloc_initialized_string` wherever possible.

  * Fixed documentation typos and wording.

  * Added support for const char strings in stubs due to stricter handling
    in newer OCaml runtimes.  This eliminates C-compiler warnings.
