### PR TITLE
[new release] lacaml (11.0.7)

### DIFF
--- a/packages/lacaml/lacaml.11.0.7/opam
+++ b/packages/lacaml/lacaml.11.0.7/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+authors: [
+  "Egbert Ammicht <eammicht@lucent.com>"
+  "Patrick Cousot <Patrick.Cousot@ens.fr>"
+  "Sam Ehrlichman <sehrlichman@janestreet.com>"
+  "Florent Hoareau <h.florent@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Liam Stewart <liam@cs.toronto.edu>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Oleg Trott <ot14@columbia.edu>"
+  "Martin Willensdorfer <ma.wi@gmx.at>"
+]
+bug-reports: "https://github.com/mmottl/lacaml/issues"
+homepage: "https://mmottl.github.io/lacaml"
+doc: "https://mmottl.github.io/lacaml/api"
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/mmottl/lacaml.git"
+synopsis: "Lacaml - OCaml-bindings to BLAS and LAPACK"
+description: """
+Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
+LAPACK-library (Linear Algebra routines).  It also contains many additional
+convenience functions for vectors and matrices."""
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "dune-configurator"
+  "conf-blas" {build}
+  "conf-lapack" {build}
+  "base-bytes"
+  "base-bigarray"
+]
+url {
+  src:
+    "https://github.com/mmottl/lacaml/releases/download/11.0.7/lacaml-11.0.7.tbz"
+  checksum: [
+    "sha256=78140861cf76b28bd2f4e04247fb5bc0cdd2331a3cc0b5188715b1fc470d78b8"
+    "sha512=08cae562e8987dfb26f0ba96da6e725716f0070125db67412a0eeafa5da3c98dba39ddc9bea5554a8ceafbb88ab70e9aa48fcca586f4ee26d8084b705196c6e6"
+  ]
+}


### PR DESCRIPTION
Lacaml - OCaml-bindings to BLAS and LAPACK

- Project page: <a href="https://mmottl.github.io/lacaml">https://mmottl.github.io/lacaml</a>
- Documentation: <a href="https://mmottl.github.io/lacaml/api">https://mmottl.github.io/lacaml/api</a>

##### CHANGES:

* Removed package dependencies on `stdio` and `base`.  This allows
    testing with the new OCaml multicore compiler, which as of now does not
    yet support these libraries.

    Thanks to Anthony Scemama for this contribution!

  * Added support for const char strings in stubs due to stricter handling
    in newer OCaml runtimes.  This eliminates C-compiler warnings.
