### PR TITLE
3 packages from c-cube/ocaml-containers at 3.0

### DIFF
--- a/packages/archsat/archsat.1.1/opam
+++ b/packages/archsat/archsat.1.1/opam
@@ -26,7 +26,7 @@ depends: [
   "qcheck"      { with-test & >= "0.8" }
   "dolmen"      { >= "0.4" }
   "msat"        { >= "0.7" & < "0.8" }
-  "containers"  { >= "2.0" }
+  "containers"  { >= "2.0" & < "3.0" }
   "cmdliner"    { >= "0.9.8" }
   "zarith"
   "ocamlgraph"

--- a/packages/calculon/calculon.0.3/opam
+++ b/packages/calculon/calculon.0.3/opam
@@ -22,7 +22,7 @@ depends: [
   "irc-client-tls"
   "tls"
   "yojson"
-  "containers" {>= "1.0"}
+  "containers" {>= "1.0" & < "3.0"}
   "ISO8601"
   "stringext"
   "re" {>= "1.7.2"}

--- a/packages/calculon/calculon.0.4/opam
+++ b/packages/calculon/calculon.0.4/opam
@@ -16,7 +16,7 @@ depends: [
   "irc-client-tls"
   "tls"
   "yojson"
-  "containers" {>= "1.0"}
+  "containers" {>= "1.0" & < "3.0"}
   "ISO8601"
   "stringext"
   "re" {>= "1.7.2"}

--- a/packages/calculon/calculon.0.5/opam
+++ b/packages/calculon/calculon.0.5/opam
@@ -17,7 +17,7 @@ depends: [
   "irc-client-lwt"
   "irc-client-lwt-ssl"
   "yojson"
-  "containers" { >= "1.0" }
+  "containers" { >= "1.0" & < "3.0" }
   "ISO8601"
   "stringext"
   "re" { >= "1.7.2" }

--- a/packages/calculon/calculon.0.6/opam
+++ b/packages/calculon/calculon.0.6/opam
@@ -16,7 +16,7 @@ depends: [
   "irc-client-lwt-ssl"
   "logs"
   "yojson" { >= "1.6" }
-  "containers" { >= "1.0" }
+  "containers" { >= "1.0" & < "3.0" }
   "ISO8601"
   "stringext"
   "re" { >= "1.7.2" }

--- a/packages/containers-data/containers-data.3.0/opam
+++ b/packages/containers-data/containers-data.3.0/opam
@@ -4,7 +4,7 @@ synopsis: "A set of advanced datatypes for containers"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-data/containers-data.3.0/opam
+++ b/packages/containers-data/containers-data.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A set of advanced datatypes for containers"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "containers" { = version }
+  "seq"
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  #"mdx" { with-test & >= "1.5.0" & < "2.0.0" }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "RAL" "functional" "vector" "okasaki" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.0.tar.gz"
+  checksum: [
+    "md5=00ba20a8c8824991cab96aff8f8e5a3c"
+    "sha512=4126045d58b9408eecaaad005c334081ade151f291dafc32ce9a33e8f796d41f72df62b617528f272996f3c93cb9b4293545ab86ac416288960f5a2b60b41932"
+  ]
+}

--- a/packages/containers-thread/containers-thread.3.0/opam
+++ b/packages/containers-thread/containers-thread.3.0/opam
@@ -4,7 +4,7 @@ synopsis: "An extension of containers for threading"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-thread/containers-thread.3.0/opam
+++ b/packages/containers-thread/containers-thread.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "An extension of containers for threading"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "base-threads"
+  "dune-configurator"
+  "containers" { = version }
+  "iter" { with-test }
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "thread" "semaphore" "blocking queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.0.tar.gz"
+  checksum: [
+    "md5=00ba20a8c8824991cab96aff8f8e5a3c"
+    "sha512=4126045d58b9408eecaaad005c334081ade151f291dafc32ce9a33e8f796d41f72df62b617528f272996f3c93cb9b4293545ab86ac416288960f5a2b60b41932"
+  ]
+}

--- a/packages/containers/containers.3.0/opam
+++ b/packages/containers/containers.3.0/opam
@@ -4,7 +4,7 @@ synopsis: "A modular, clean and powerful extension of the OCaml standard library
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers/containers.3.0/opam
+++ b/packages/containers/containers.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A modular, clean and powerful extension of the OCaml standard library"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "dune-configurator"
+  "seq"
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+depopts: [
+  "base-unix"
+  "base-threads"
+]
+tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.0.tar.gz"
+  checksum: [
+    "md5=00ba20a8c8824991cab96aff8f8e5a3c"
+    "sha512=4126045d58b9408eecaaad005c334081ade151f291dafc32ce9a33e8f796d41f72df62b617528f272996f3c93cb9b4293545ab86ac416288960f5a2b60b41932"
+  ]
+}

--- a/packages/electrod/electrod.0.1.4/opam
+++ b/packages/electrod/electrod.0.1.4/opam
@@ -15,7 +15,7 @@ depends: [
   "jbuilder" {>= "1.0+beta9"}
   "ppxfind" {build}
   "cmdliner" {>= "1.0.2"}
-  "containers" {>= "2.0"}
+  "containers" {>= "2.0" & < "3.0"}
   "fmt" {< "0.8.7"}
   "gen"
   "hashcons"

--- a/packages/electrod/electrod.0.1.6/opam
+++ b/packages/electrod/electrod.0.1.6/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {>= "1.0+beta20"}
   "ppxfind" {build}
   "cmdliner" {>= "1.0.2"}
-  "containers" {>= "2.0"}
+  "containers" {>= "2.0" & < "3.0"}
   "fmt" {< "0.8.7"}
   "gen"
   "hashcons"

--- a/packages/electrod/electrod.0.1.7/opam
+++ b/packages/electrod/electrod.0.1.7/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {>= "1.0+beta20"}
   "ppxfind" {build}
   "cmdliner" {>= "1.0.2"}
-  "containers" {>= "2.0"}
+  "containers" {>= "2.0" & < "3.0"}
   "fmt" {< "0.8.7"}
   "gen"
   "hashcons"

--- a/packages/electrod/electrod.0.2.1/opam
+++ b/packages/electrod/electrod.0.2.1/opam
@@ -13,8 +13,8 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "dune" {>= "1.4"}
-  "cmdliner" 
-  "containers" {>= "2.0"}
+  "cmdliner"
+  "containers" {>= "2.0" & < "3.0"}
   "fmt"
   "gen"
   "hashcons"

--- a/packages/electrod/electrod.0.2.3/opam
+++ b/packages/electrod/electrod.0.2.3/opam
@@ -14,8 +14,8 @@ depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "1.4"}
   "dune-build-info"
-  "cmdliner" 
-  "containers" {>= "2.0"}
+  "cmdliner"
+  "containers" {>= "2.0" & < "3.0"}
   "fmt"
   "gen"
   "hashcons"

--- a/packages/electrod/electrod.0.3.2/opam
+++ b/packages/electrod/electrod.0.3.2/opam
@@ -25,7 +25,7 @@ depends: [
   "dune" {>= "1.10"}
   "dune-build-info"
   "cmdliner"
-  "containers" {>= "2.0"}
+  "containers" {>= "2.0" & < "3.0"}
   "fmt" {>= "0.8.7"}
   "gen"
   "hashcons"

--- a/packages/electrod/electrod.0.4.1/opam
+++ b/packages/electrod/electrod.0.4.1/opam
@@ -25,7 +25,7 @@ depends: [
   "dune" {>= "1.10"}
   "dune-build-info"
   "cmdliner"
-  "containers" {>= "2.7"}
+  "containers" {>= "2.7" & < "3.0"}
   "fmt" {>= "0.8.7"}
   "gen"
   "hashcons"

--- a/packages/electrod/electrod.0.5/opam
+++ b/packages/electrod/electrod.0.5/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.0"}
   "dune-build-info"
   "cmdliner"
-  "containers" {>= "2.8"}
+  "containers" {>= "2.8" & < "3.0"}
   "fmt" {>= "0.8.7"}
   "gen"
   "hashcons"

--- a/packages/electrod/electrod.0.6.2/opam
+++ b/packages/electrod/electrod.0.6.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.0"}
   "dune-build-info"
   "cmdliner"
-  "containers" {>= "2.8"}
+  "containers" {>= "2.8" & < "3.0"}
   "fmt" {>= "0.8.7"}
   "gen"
   "hashcons"

--- a/packages/electrod/electrod.0.6/opam
+++ b/packages/electrod/electrod.0.6/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.0"}
   "dune-build-info"
   "cmdliner"
-  "containers" {>= "2.8"}
+  "containers" {>= "2.8" & < "3.0"}
   "fmt" {>= "0.8.7"}
   "gen"
   "hashcons"

--- a/packages/electrod/electrod.0.7.1/opam
+++ b/packages/electrod/electrod.0.7.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.0"}
   "dune-build-info"
   "cmdliner"
-  "containers" {>= "2.8"}
+  "containers" {>= "2.8" & < "3.0"}
   "fmt" {>= "0.8.7"}
   "gen"
   "hashcons"

--- a/packages/gdbprofiler/gdbprofiler.0.1/opam
+++ b/packages/gdbprofiler/gdbprofiler.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "lwt" {>= "2.4.6" & < "4.0.0"}
   "ppx_deriving_yojson" {>= "2.0"}
   "oasis" {build & >= "0.4"}
-  "containers" {>= "0.20"}
+  "containers" {>= "0.20" & < "3.0"}
 ]
 synopsis: "gdbprofiler, a profiler for native OCaml and other executables"
 description:

--- a/packages/gdbprofiler/gdbprofiler.0.2/opam
+++ b/packages/gdbprofiler/gdbprofiler.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "jbuilder"
   "menhir" {build}
   "lwt" {>= "2.4.6" & < "4.0.0"}
-  "containers" {>= "0.20"}
+  "containers" {>= "0.20" & < "3.0"}
   "yojson"
   "ocaml-migrate-parsetree"
 ]

--- a/packages/gdbprofiler/gdbprofiler.0.3/opam
+++ b/packages/gdbprofiler/gdbprofiler.0.3/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt" {>= "3.2.0"}
   "lwt_ppx"
   "lwt_log"
-  "containers" {>= "0.20"}
+  "containers" {>= "0.20" & < "3.0"}
   "yojson"
 ]
 synopsis: "gdbprofiler, a profiler for native OCaml and other executables"

--- a/packages/labrys/labrys.0.1/opam
+++ b/packages/labrys/labrys.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "msgpack"
   "uutf" {>= "1.0.0"}
   "llvm" {>= "3.8"}
-  "containers" {>= "2.0"}
+  "containers" {>= "2.0" & < "3.0"}
   "craml" {with-test}
 ]
 depexts: [

--- a/packages/libzipperposition/libzipperposition.1.5.1/opam
+++ b/packages/libzipperposition/libzipperposition.1.5.1/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix"
   "zarith"
   "logtk" { = version }
-  "containers" { >= "1.0" }
+  "containers" { >= "1.0" & < "3.0" }
   "iter" { >= "1.2" }
   "dune" { >= "1.1" }
-  "msat" { >= "0.8" < "0.9" }
+  "msat" { >= "0.8" & < "0.9" }
   "menhir" {build}
   "logtk"
   "ocaml" {>= "4.03"}

--- a/packages/libzipperposition/libzipperposition.1.6/opam
+++ b/packages/libzipperposition/libzipperposition.1.6/opam
@@ -12,11 +12,11 @@ depends: [
   "base-unix"
   "zarith"
   "logtk" { = version }
-  "containers" { >= "1.0" }
+  "containers" { >= "1.0" & < "3.0" }
   "iter" { >= "1.2" }
   "oseq"
   "dune" { >= "1.1" }
-  "msat" { >= "0.8" < "0.9" }
+  "msat" { >= "0.8" & < "0.9" }
   "menhir" {build}
   "logtk"
   "ocaml" {>= "4.03"}

--- a/packages/logtk/logtk.1.5.1/opam
+++ b/packages/logtk/logtk.1.5.1/opam
@@ -11,7 +11,7 @@ depends: [
   "base-bytes"
   "base-unix"
   "zarith"
-  "containers" { >= "1.0" }
+  "containers" { >= "1.0" & < "3.0" }
   "iter" { >= "1.2" }
   "menhir" {build}
   "dune" { >= "1.1" }

--- a/packages/logtk/logtk.1.6/opam
+++ b/packages/logtk/logtk.1.6/opam
@@ -13,7 +13,7 @@ depends: [
   "base-unix"
   "zarith"
   "oseq"
-  "containers" { >= "1.0" }
+  "containers" { >= "1.0" & < "3.0" }
   "iter" { >= "1.2" }
   "menhir" {build}
   "dune" { >= "1.1" }

--- a/packages/msat/msat.0.8.1/opam
+++ b/packages/msat/msat.0.8.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" { >= "4.03" }
   "dune" { >= "1.1" }
   "iter" { >= "1.2" }
-  "containers" {with-test}
+  "containers" {with-test & < "3.0"}
   "mdx" {with-test}
 ]
 tags: [ "sat" "smt" ]

--- a/packages/msat/msat.0.8.2/opam
+++ b/packages/msat/msat.0.8.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" { >= "4.03" }
   "dune" { >= "1.1" }
   "iter" { >= "1.2" }
-  "containers" {with-test}
+  "containers" {with-test & < "3.0"}
   "mdx" {with-test}
 ]
 tags: [ "sat" "smt" "cdcl" "functor" ]

--- a/packages/prom/prom.0.2/opam
+++ b/packages/prom/prom.0.2/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "1.11.4"}
   "fmt" {>= "0.8.8"}
   "ptime" {>= "0.8.5"}
-  "containers" {>= "2.8"}
+  "containers" {>= "2.8" & < "3.0"}
   "alcotest" {with-test & >= "1.0.1"}
 ]
 synopsis: "Types and pretty printer for Prometheus text-based exposition format"

--- a/packages/regenerate/regenerate.0.1/opam
+++ b/packages/regenerate/regenerate.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "jbuilder"
   "cmdliner"
   "fmt"
-  "containers"
+  "containers" {< "3.0"}
   "mtime"
   "oseq"
   "sequence" {>= "0.3.4"}

--- a/packages/regenerate/regenerate.0.2/opam
+++ b/packages/regenerate/regenerate.0.2/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "1.2"}
   "cmdliner"
   "fmt"
-  "containers"
+  "containers" {< "3.0"}
   "mtime"
   "oseq"
   "iter"

--- a/packages/smbc/smbc.0.4.2/opam
+++ b/packages/smbc/smbc.0.4.2/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "jbuilder" {>= "1.0+beta6"}
   "base-bytes"
-  "containers" {>= "1.0"}
+  "containers" {>= "1.0" & < "3.0"}
   "sequence" {>= "0.4"}
   "msat" {>= "0.5" & < "0.8"}
   "tip-parser" {>= "0.3" & < "0.4"}

--- a/packages/smbc/smbc.0.6.1/opam
+++ b/packages/smbc/smbc.0.6.1/opam
@@ -8,7 +8,7 @@ build: [
 depends: [
   "dune" { >= "1.0" }
   "base-bytes"
-  "containers" { >= "2.0" }
+  "containers" { >= "2.0" & < "3.0" }
   "iter" { >= "1.0" }
   "msat" { >= "0.8" & < "0.9" }
   "tip-parser" { >= "0.6" & < "0.7" }

--- a/packages/zipperposition/zipperposition.1.5.1/opam
+++ b/packages/zipperposition/zipperposition.1.5.1/opam
@@ -11,10 +11,10 @@ depends: [
   "zarith"
   "logtk" { = version }
   "libzipperposition" { = version }
-  "containers" { >= "1.0" }
+  "containers" { >= "1.0" & < "3.0" }
   "iter" { >= "1.2" }
   "dune" { >= "1.1" }
-  "msat" { >= "0.8" < "0.9" }
+  "msat" { >= "0.8" & < "0.9" }
   "menhir" {build}
   "ocaml" {>= "4.03"}
 ]

--- a/packages/zipperposition/zipperposition.1.5/opam
+++ b/packages/zipperposition/zipperposition.1.5/opam
@@ -15,7 +15,7 @@ depends: [
   "base-bytes"
   "base-unix"
   "zarith" {< "1.8"}
-  "containers" {>= "1.0"}
+  "containers" {>= "1.0" & < "3.0"}
   "sequence" {>= "0.4"}
   "jbuilder" {>= "1.0+beta7"}
   "msat" {>= "0.5" & < "0.8"}

--- a/packages/zipperposition/zipperposition.1.6/opam
+++ b/packages/zipperposition/zipperposition.1.6/opam
@@ -12,11 +12,11 @@ depends: [
   "zarith"
   "logtk" { = version }
   "libzipperposition" { = version }
-  "containers" { >= "1.0" }
+  "containers" { >= "1.0" & < "3.0" }
   "iter" { >= "1.2" }
   "oseq"
   "dune" { >= "1.1" }
-  "msat" { >= "0.8" < "0.9" }
+  "msat" { >= "0.8" & < "0.9" }
   "menhir" {build}
   "ocaml" {>= "4.03"}
 ]


### PR DESCRIPTION
This pull-request concerns:
-`containers.3.0`: A modular, clean and powerful extension of the OCaml standard library
-`containers-data.3.0`: A set of advanced datatypes for containers
-`containers-thread.3.0`: An extension of containers for threading



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: git+https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0