### PR TITLE
[new release] js_of_ocaml-webidl and js_of_ocaml-webgpu (0.2)

### DIFF
--- a/packages/js_of_ocaml-webgpu/js_of_ocaml-webgpu.0.2/opam
+++ b/packages/js_of_ocaml-webgpu/js_of_ocaml-webgpu.0.2/opam
@@ -18,7 +18,7 @@ depends: [
   "js_of_ocaml-ppx"
   "ppx_jane"
   "ocamlformat"
-  "js_of_ocaml-webidl" {= "version"}
+  "js_of_ocaml-webidl" {= version}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/js_of_ocaml-webgpu/js_of_ocaml-webgpu.0.2/opam
+++ b/packages/js_of_ocaml-webgpu/js_of_ocaml-webgpu.0.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Js_of_ocaml bindings for webgpu"
+description: "Js_of_ocaml bindings for webgpu"
+maintainer: ["Misha Aizatulin <mihhail.aizatulin@gmail.com>"]
+authors: ["Misha Aizatulin <mihhail.aizatulin@gmail.com>"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/tari3x/webgpu"
+doc: "https://tari3x.github.io/webgpu"
+bug-reports: "https://github.com/tari3x/webgpu"
+depends: [
+  "dune" {>= "2.2"}
+  "ocaml" {>= "4.08"}
+  "core" {>= "v0.12"}
+  "async" {>= "v0.12"}
+  "ppx_deriving"
+  "js_of_ocaml"
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "ppx_jane"
+  "ocamlformat"
+  "js_of_ocaml-webidl" {= "version"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tari3x/webgpu.git"
+url {
+  src:
+    "https://github.com/tari3x/webgpu/releases/download/0.2/js_of_ocaml-webgpu-0.2.tbz"
+  checksum: [
+    "sha256=3b1f3ba2420ad3b35abf04b2d99d807868a3aafc8b437c2ef4589fe8ddf76cde"
+    "sha512=01f71bc8fcdb73569a9f34e942f33f677b6b8ceb6823699ca8aeab292f7f2413f39e689e7dd3b368dd7474b055b18e9d6ff7dba500971dc4dce744d0cf2fddcc"
+  ]
+}

--- a/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.2/opam
+++ b/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Generate js_of_ocaml bindings from webidl definitions"
+description: "Generate js_of_ocaml bindings from webidl definitions"
+maintainer: ["Misha Aizatulin <mihhail.aizatulin@gmail.com>"]
+authors: ["Misha Aizatulin <mihhail.aizatulin@gmail.com>"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/tari3x/webgpu"
+doc: "https://tari3x.github.io/webgpu"
+bug-reports: "https://github.com/tari3x/webgpu"
+depends: [
+  "dune" {>= "2.2"}
+  "ocaml" {>= "4.08"}
+  "core" {>= "v0.12"}
+  "async" {>= "v0.12"}
+  "webidl"
+  "ppx_deriving"
+  "js_of_ocaml"
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "ppx_jane"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tari3x/webgpu.git"
+url {
+  src:
+    "https://github.com/tari3x/webgpu/releases/download/0.2/js_of_ocaml-webgpu-0.2.tbz"
+  checksum: [
+    "sha256=3b1f3ba2420ad3b35abf04b2d99d807868a3aafc8b437c2ef4589fe8ddf76cde"
+    "sha512=01f71bc8fcdb73569a9f34e942f33f677b6b8ceb6823699ca8aeab292f7f2413f39e689e7dd3b368dd7474b055b18e9d6ff7dba500971dc4dce744d0cf2fddcc"
+  ]
+}


### PR DESCRIPTION
Generate js_of_ocaml bindings from webidl definitions

- Project page: <a href="https://github.com/tari3x/webgpu">https://github.com/tari3x/webgpu</a>
- Documentation: <a href="https://tari3x.github.io/webgpu">https://tari3x.github.io/webgpu</a>

##### CHANGES:

Init
