### PR TITLE
[new release] icalendar (0.1.4)

### DIFF
--- a/packages/icalendar/icalendar.0.1.4/opam
+++ b/packages/icalendar/icalendar.0.1.4/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/roburio/icalendar"
+bug-reports: "https://github.com/roburio/icalendar/issues"
+dev-repo: "git+https://github.com/roburio/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://roburio.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom" {>= "0.14.0"}
+  "re"
+  "uri"
+  "astring"
+  "rresult"
+  "ptime"
+  "ppx_deriving"
+  "stdlib-shims"
+  "gmap" {>= "0.3.0"}
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+x-commit-hash: "6fdf5158499ef5354f5b3777127f7f6385f09afb"
+url {
+  src:
+    "https://github.com/roburio/icalendar/releases/download/v0.1.4/icalendar-v0.1.4.tbz"
+  checksum: [
+    "sha256=42ff0100fdafef7fa5733313939b6431d6289eca6166063c50548a0c37db1b15"
+    "sha512=bab64d8a214538e56f867b5009060600cd7c8d14c6036ac14a922d0534a3741f3eece4560f6ed8307b179f1763f23bff869ff40d13bb0f5e5b73a88b8c42ee89"
+  ]
+}


### PR DESCRIPTION
A library to parse and print the iCalendar (RFC 5545) format

- Project page: <a href="https://github.com/roburio/icalendar">https://github.com/roburio/icalendar</a>
- Documentation: <a href="https://roburio.github.io/icalendar/">https://roburio.github.io/icalendar/</a>

##### CHANGES:

* Adapt to angstrom 0.14.0 API change roburio/icalendar#6
