### PR TITLE
[new release] pcre (7.4.5)

### DIFF
--- a/packages/pcre/pcre.7.4.5/opam
+++ b/packages/pcre/pcre.7.4.5/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "dune-configurator"
+  "conf-libpcre" {build}
+  "base-bytes"
+]
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/7.4.5/pcre-7.4.5.tbz"
+  checksum: [
+    "sha256=edb1b135115d822fb72c66f51f0985f0a19d601577b3156846488b2f91871f19"
+    "sha512=f81c07154ff1d91a543c9dc8c56e9dcc207fc1d700f26ac2249aaf5977fa6117f72952bc7f5291003c7ae17e795a338ddd736af2d50e0929a75546e4c1a7ffbe"
+  ]
+}


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

* Removed excessive build dependency on `base` package.
