### PR TITLE
[new release] pcre (7.4.6)

### DIFF
--- a/packages/pcre/pcre.7.4.6/opam
+++ b/packages/pcre/pcre.7.4.6/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "dune-configurator"
+  "conf-libpcre" {build}
+  "base-bytes"
+]
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/7.4.6/pcre-7.4.6.tbz"
+  checksum: [
+    "sha256=ca3f02ede75740d9461098ed6abcd39c904b3d551f54e06eb17df6a232a0529d"
+    "sha512=a356c78dc19d3b3741d1fa0277c4fb0cb545f12499165526fae80a0ff8a7b1f1e6e5e916b16f8336bcec3661de811686b814fe4afc677965fec7a63d4fc53b1f"
+  ]
+}


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

* Removed mistakenly kept base library configuration dependency.
