### PR TITLE
[new release] postgresql (4.6.2)

### DIFF
--- a/packages/postgresql/postgresql.4.6.2/opam
+++ b/packages/postgresql/postgresql.4.6.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "dune-configurator"
+  "conf-postgresql" {build}
+  "base-bytes"
+]
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/4.6.2/postgresql-4.6.2.tbz"
+  checksum: [
+    "sha256=4bc5684dbfc3ed060841d1fc28e92f7725d9b8761d198f5c9c24a9987e8eb209"
+    "sha512=576c6b761efc88fad4a1aee481d776ab7a2854abbaa11c13e4ce65ef7f8c3ab04afd12f499ef998592a8b2ada17ef450b3b0548323930b1b403a0191be50666a"
+  ]
+}


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

* Removed `base` and `stdio` build dependencies.
