### PR TITLE
[new release] gsl (1.24.3)

### DIFF
--- a/packages/gsl/gsl.1.24.3/opam
+++ b/packages/gsl/gsl.1.24.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Olivier Andrieu <oandrieu@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+]
+bug-reports: "https://github.com/mmottl/gsl-ocaml/issues"
+homepage: "https://mmottl.github.io/gsl-ocaml"
+doc: "https://mmottl.github.io/gsl-ocaml/api"
+license: "GPL-3+"
+dev-repo: "git+https://github.com/mmottl/gsl-ocaml.git"
+synopsis: "GSL - Bindings to the GNU Scientific Library"
+description: """
+gsl-ocaml interfaces the GSL (GNU Scientific Library), providing many of the
+most frequently used functions for scientific computation including algorithms
+for optimization, differential equations, statistics, random number generation,
+linear algebra, etc."""
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "dune-configurator"
+  "conf-gsl" {build}
+  "conf-pkg-config" {build}
+]
+url {
+  src:
+    "https://github.com/mmottl/gsl-ocaml/releases/download/1.24.3/gsl-1.24.3.tbz"
+  checksum: [
+    "sha256=366f2becd41603fd64b1e5f5e9b5b5556c648c18b62e3c6344542898d763ffd6"
+    "sha512=c6e2578618591d1bef428693b69026cdea0f1606cd25d9f02d637a90256a5685eee70ecd0259d2595a1cd7b292c34e3c913c007e2706aa125af045d37e55d9c4"
+  ]
+}


### PR DESCRIPTION
GSL - Bindings to the GNU Scientific Library

- Project page: <a href="https://mmottl.github.io/gsl-ocaml">https://mmottl.github.io/gsl-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/gsl-ocaml/api">https://mmottl.github.io/gsl-ocaml/api</a>

##### CHANGES:

* Removed `base` and `stdio` build dependencies.
