### PR TITLE
[new release] ppxlib (0.15.0)

### DIFF
--- a/packages/ppxlib/ppxlib.0.15.0/opam
+++ b/packages/ppxlib/ppxlib.0.15.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.10" }
+]
+depends: [
+  "ocaml"                   {>= "4.04.1"}
+  "dune"                    {>= "1.11"}
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ppx_derivers"            {>= "1.0"}
+  "sexplib0"
+  "stdlib-shims"
+  "ocamlfind"               {with-test}
+  "cinaps"                  {with-test & >= "v0.12.1"}
+  "base"                    {with-test}
+  "stdio"                   {with-test}
+]
+synopsis: "Standard library for ppx rewriters"
+description: """
+Ppxlib is the standard library for ppx rewriters and other programs
+that manipulate the in-memory reprensation of OCaml programs, a.k.a
+the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+x-commit-hash: "20cacbfc311f1baef6454051e0edd7b1628cb721"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.15.0/ppxlib-0.15.0.tbz"
+  checksum: [
+    "sha256=0b630d7f8d74a899a55cc27188b5ce03e735a93f07ea0c2de56532d8fd93b330"
+    "sha512=ecf0fff77ff6f1b356f018b6861b9e40bb8513092a7a486a3aa6024d12f5c15135899b77a188a44abc1c2ca84ebccb8bf9a78241e0383e023663fd7f86fbca72"
+  ]
+}


### PR DESCRIPTION
Standard library for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Remove `base` and `stdio` dependencies (ocaml-ppx/ppxlib#151, @ceastlund)

- Update README and opam description (ocaml-ppx/ppxlib#155, @jeremiedimino)

- Fix `Driver.partition_transformation` (ocaml-ppx/ppxlib#156, @NathanReb)

- Implement name mangling for `ppxlib_traverse` (ocaml-ppx/ppxlib#159, @ceastlund)
