### PR TITLE
[new release] js_of_ocaml-ocamlbuild, js_of_ocaml-compiler, js_of_ocaml-ppx, js_of_ocaml-lwt, js_of_ocaml-toplevel, js_of_ocaml-tyxml, js_of_ocaml and js_of_ocaml-ppx_deriving_json (3.7.0)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "ppx_expect" {with-test & >= "v0.12.0"}
+  "cmdliner"
+  "menhir"
+  "ocaml-migrate-parsetree"
+  "yojson" # It's optional, but we want users to be able to use source-map without pain.
+]
+
+depopts: [ "ocamlfind" ]
+
+conflicts: [
+  "ocamlfind"   {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+x-commit-hash: "d50221f1cf19f7637dfca7407762a85dcd420f46"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.7.0/js_of_ocaml-3.7.0.tbz"
+  checksum: [
+    "sha256=dcf4ffea23d4a2b2709c75bf5c7e2de355897bcfef7081d1569efe41a7638667"
+    "sha512=de3fcd7b2e0a7fdd074a236efa759178888559d28db35d4431a342567b4a068bb6581545bdfca02bacdf23e08499119879d37e71c5b0e860d79252116430160e"
+  ]
+}

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.7.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.7.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "lwt" {>= "2.4.4"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+]
+depopts: [ "graphics" "lwt_log" ]
+x-commit-hash: "d50221f1cf19f7637dfca7407762a85dcd420f46"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.7.0/js_of_ocaml-3.7.0.tbz"
+  checksum: [
+    "sha256=dcf4ffea23d4a2b2709c75bf5c7e2de355897bcfef7081d1569efe41a7638667"
+    "sha512=de3fcd7b2e0a7fdd074a236efa759178888559d28db35d4431a342567b4a068bb6581545bdfca02bacdf23e08499119879d37e71c5b0e860d79252116430160e"
+  ]
+}

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.7.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.7.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.5"}
+  "ocamlbuild"
+]
+x-commit-hash: "d50221f1cf19f7637dfca7407762a85dcd420f46"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.7.0/js_of_ocaml-3.7.0.tbz"
+  checksum: [
+    "sha256=dcf4ffea23d4a2b2709c75bf5c7e2de355897bcfef7081d1569efe41a7638667"
+    "sha512=de3fcd7b2e0a7fdd074a236efa759178888559d28db35d4431a342567b4a068bb6581545bdfca02bacdf23e08499119879d37e71c5b0e860d79252116430160e"
+  ]
+}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.7.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.7.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "ocaml-migrate-parsetree" {>= "1.4"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "js_of_ocaml" {= version}
+]
+x-commit-hash: "d50221f1cf19f7637dfca7407762a85dcd420f46"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.7.0/js_of_ocaml-3.7.0.tbz"
+  checksum: [
+    "sha256=dcf4ffea23d4a2b2709c75bf5c7e2de355897bcfef7081d1569efe41a7638667"
+    "sha512=de3fcd7b2e0a7fdd074a236efa759178888559d28db35d4431a342567b4a068bb6581545bdfca02bacdf23e08499119879d37e71c5b0e860d79252116430160e"
+  ]
+}

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.7.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.7.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "2.5"}
+  "js_of_ocaml" {= version}
+  "ocaml-migrate-parsetree"
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
+]
+x-commit-hash: "d50221f1cf19f7637dfca7407762a85dcd420f46"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.7.0/js_of_ocaml-3.7.0.tbz"
+  checksum: [
+    "sha256=dcf4ffea23d4a2b2709c75bf5c7e2de355897bcfef7081d1569efe41a7638667"
+    "sha512=de3fcd7b2e0a7fdd074a236efa759178888559d28db35d4431a342567b4a068bb6581545bdfca02bacdf23e08499119879d37e71c5b0e860d79252116430160e"
+  ]
+}

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.7.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.7.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "ocamlfind" {>= "1.5.1"}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= version}
+]
+x-commit-hash: "d50221f1cf19f7637dfca7407762a85dcd420f46"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.7.0/js_of_ocaml-3.7.0.tbz"
+  checksum: [
+    "sha256=dcf4ffea23d4a2b2709c75bf5c7e2de355897bcfef7081d1569efe41a7638667"
+    "sha512=de3fcd7b2e0a7fdd074a236efa759178888559d28db35d4431a342567b4a068bb6581545bdfca02bacdf23e08499119879d37e71c5b0e860d79252116430160e"
+  ]
+}

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.7.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.7.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "tyxml" {>= "4.3"}
+  "reactiveData" {>= "0.2"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+]
+x-commit-hash: "d50221f1cf19f7637dfca7407762a85dcd420f46"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.7.0/js_of_ocaml-3.7.0.tbz"
+  checksum: [
+    "sha256=dcf4ffea23d4a2b2709c75bf5c7e2de355897bcfef7081d1569efe41a7638667"
+    "sha512=de3fcd7b2e0a7fdd074a236efa759178888559d28db35d4431a342567b4a068bb6581545bdfca02bacdf23e08499119879d37e71c5b0e860d79252116430160e"
+  ]
+}

--- a/packages/js_of_ocaml/js_of_ocaml.3.7.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.7.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "ocaml-migrate-parsetree" {>= "1.4"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "uchar"
+  "js_of_ocaml-compiler" {= version}
+]
+x-commit-hash: "d50221f1cf19f7637dfca7407762a85dcd420f46"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.7.0/js_of_ocaml-3.7.0.tbz"
+  checksum: [
+    "sha256=dcf4ffea23d4a2b2709c75bf5c7e2de355897bcfef7081d1569efe41a7638667"
+    "sha512=de3fcd7b2e0a7fdd074a236efa759178888559d28db35d4431a342567b4a068bb6581545bdfca02bacdf23e08499119879d37e71c5b0e860d79252116430160e"
+  ]
+}


### PR DESCRIPTION
Compiler from OCaml bytecode to Javascript

- Project page: <a href="http://ocsigen.github.io/js_of_ocaml">http://ocsigen.github.io/js_of_ocaml</a>

##### CHANGES:

## Features/Changes
* Runtime: allow one to override xmlHttpRequest.create (ocsigen/js_of_ocaml#1002)
* Runtime: Change the semantic of MlBytes.toString, introduce MlBytes.toUtf16
* Compiler: initial support for OCaml 4.11
* Compiler: initial support for OCaml 4.12
* Compiler: improve the javascript parser by relying on menhir
  incremental api.
* Compiler: Eliminate allocation of dummy function ocsigen/js_of_ocaml#1013

## Bug fixes
* Compiler: fix code generation for recursive function under for-loops (ocsigen/js_of_ocaml#1009)
* Compiler: the jsoo compiler compiled to javascript was not behaving correctly
            when parsing constant in the from the bytecode
* Compiler: make sure inline doesn't loop indefinitly (ocsigen/js_of_ocaml#1043)
* Compiler: fix bug generating invalid javascript for if-then construct (ocsigen/js_of_ocaml#1046)
* Compiler: do not use polymorphic comparison when joining float values (ocsigen/js_of_ocaml#1048)
* Lib: Rename msg to message in Worker (ocsigen/js_of_ocaml#1037)
* Lib: fix graphics_js when build with separate compilation (ocsigen/js_of_ocaml#1029)
