### PR TITLE
[new release] ocamlformat (0.15.0)

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.15.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.15.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06" & < "4.12"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune" {>= "2.2.0"}
+  "fix"
+  "fpath"
+  "menhir"
+  "ocaml-migrate-parsetree" {>= "1.7.3"}
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+x-commit-hash: "e9e70f4d3aea202ec8ea4afd7ccb828b36822799"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.15.0/ocamlformat-0.15.0.tbz"
+  checksum: [
+    "sha256=263b4a8907e1b820ae0c1db55183ac3a44c4eaa05e8f1a144baa1a9bcadf2005"
+    "sha512=2bc0b826567fa71201031a730568b822938c66c56da47b05b8896b68439da3d0a8b9bc552fa5cacab95bf9192a1b6e583655fd90095aa686daa91cd2bdf4725a"
+  ]
+}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### Changes

  + Do not break inline elements such as `{i blah}` in docstrings (ocaml-ppx/ocamlformat#1346, @jberdine)

  + Distinguish hash-getter from hash-comparison infix operators. Operators of the form `#**#` or `#**.` where `**` can be 0 or more operator chars are considered getter operators and are not surrounded by spaces, as opposed to regular infix operators (ocaml-ppx/ocamlformat#1376, @gpetiot)

  + Type constraint on return type of functions is now always printed before the function body (ocaml-ppx/ocamlformat#1381, ocaml-ppx/ocamlformat#1397, @gpetiot)

#### Bug fixes

  + Restore previous functionality for pre-post extension points (ocaml-ppx/ocamlformat#1342, @jberdine)

  + Fix extra break before `function` body of a `fun` (ocaml-ppx/ocamlformat#1343, @jberdine)
    Indent further args of anonymous functions (ocaml-ppx/ocamlformat#1440, @gpetiot)

  + Do not clear the emacs `*compilation*` buffer on successful reformat (ocaml-ppx/ocamlformat#1350, @jberdine)

  + Fix disabling with attributes on OCaml < 4.08 (ocaml-ppx/ocamlformat#1322, @emillon)

  + Preserve unwrapped comments by not adding artificial breaks when `wrap-comments=false` and `ocp-indent-compat=true` are set to avoid interfering with ocp-indent indentation. (ocaml-ppx/ocamlformat#1352, @gpetiot)

  + Break long literal strings at the margin (ocaml-ppx/ocamlformat#1367, @gpetiot)

  + Break after a multiline argument in an argument list (ocaml-ppx/ocamlformat#1360, @gpetiot)

  + Remove unnecessary parens around object (ocaml-ppx/ocamlformat#1379, @gpetiot)

  + Fix placement of comments on constants (ocaml-ppx/ocamlformat#1383, @gpetiot)

  + Do not escape arguments of some Odoc tags (ocaml-ppx/ocamlformat#1391, 1408, @gpetiot, @Julow)
    The characters `[]{}` must not be escaped in the arguments of `@raise`, `@author`, `@version` and others.

  + Fix missing open line between multi-line let-binding with poly-typexpr (ocaml-ppx/ocamlformat#1372, @jberdine)

  + Remove trailing space after expression when followed by an attribute and break before attributes attached to multi-line phrases (ocaml-ppx/ocamlformat#1382, @gpetiot)

  + Do not add a space to minimal comments `(* *)`, `(** *)` and `(*$ *)` (ocaml-ppx/ocamlformat#1407, @gpetiot)

  + Fix attributes position in labelled arguments type (ocaml-ppx/ocamlformat#1434, @gpetiot)

  + Add missing parens around type annotation in anonymous function (ocaml-ppx/ocamlformat#1433, @gpetiot)

  + Fix alignment of 'then' keyword in parenthesised expression (ocaml-ppx/ocamlformat#1421, @gpetiot)

#### New features

  + Support quoted extensions (added in ocaml 4.11) (ocaml-ppx/ocamlformat#1405, @gpetiot)

  + Recognise eliom file extensions (ocaml-ppx/ocamlformat#1430, @jrochel)
