### PR TITLE
h2-{lwt,lwt-unix,mirage,async}: prepare for upcoming h2 release

### DIFF
--- a/packages/h2-async/h2-async.0.6.1/opam
+++ b/packages/h2-async/h2-async.0.6.1/opam
@@ -15,7 +15,7 @@ depends: [
   "faraday-async"
   "async" {< "v0.15"}
   "gluten-async"
-  "h2" {= version}
+  "h2" {>= version}
 ]
 depopts: ["async_ssl"]
 synopsis: "Async support for h2"

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.6.1/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.6.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06"}
   "faraday-lwt-unix"
-  "h2-lwt" {= version}
+  "h2-lwt" {>= version}
   "dune" {>= "1.7"}
   "lwt"
   "gluten-lwt-unix" {>= "0.2.1"}

--- a/packages/h2-lwt/h2-lwt.0.6.1/opam
+++ b/packages/h2-lwt/h2-lwt.0.6.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06"}
-  "h2" {= version}
+  "h2" {>= version}
   "dune" {>= "1.7"}
   "lwt"
   "gluten-lwt" {>= "0.2.1"}

--- a/packages/h2-mirage/h2-mirage.0.6.1/opam
+++ b/packages/h2-mirage/h2-mirage.0.6.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06"}
   "faraday-lwt"
-  "h2-lwt" {= version}
+  "h2-lwt" {>= version}
   "gluten-lwt" {>= "0.2.0"}
   "dune" {>= "1.7"}
   "lwt"


### PR DESCRIPTION
I'm planning on cutting a release for just h2, and I don't expect the I/O runtime adapters to change significantly now that gluten abstracts most of their functionality.

This PR just relaxes the constraints on the Lwt / Mirage/ Async runtimes to be forwards compatible with the upcoming release of h2.

I'm preparing a PR upstream that will mirror these constraints too.