### PR TITLE
[new release] merlin-extend (0.6)

### DIFF
--- a/packages/merlin-extend/merlin-extend.0.6/opam
+++ b/packages/merlin-extend/merlin-extend.0.6/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/merlin-extend"
+bug-reports: "https://github.com/let-def/merlin-extend"
+license: "MIT"
+dev-repo: "git+https://github.com/let-def/merlin-extend.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "1.0"}
+  "cppo" {build}
+  "ocaml" {>= "4.02.3"}
+]
+synopsis: "A protocol to provide custom frontend to Merlin"
+description: """
+This protocol allows to replace the OCaml frontend of Merlin.
+It extends what used to be done with the `-pp' flag to handle a few more cases."""
+doc: "https://let-def.github.io/merlin-extend"
+x-commit-hash: "640620568a5f5c7798239ecf7c707c813e3df3cf"
+url {
+  src:
+    "https://github.com/let-def/merlin-extend/releases/download/v0.6/merlin-extend-v0.6.tbz"
+  checksum: [
+    "sha256=c2f236ae97feb6ba0bc90f33beb7b7343e42f9871b66de9ba07974917e256c43"
+    "sha512=4c64a490e2ece04fc89aef679c1d9202175df4fe045b5fdc7a37cd7cebe861226fddd9648c1bf4f06175ecfcd2ed7686c96bd6a8cae003a5096f6134c240f857"
+  ]
+}


### PR DESCRIPTION
A protocol to provide custom frontend to Merlin

- Project page: <a href="https://github.com/let-def/merlin-extend">https://github.com/let-def/merlin-extend</a>
- Documentation: <a href="https://let-def.github.io/merlin-extend">https://let-def.github.io/merlin-extend</a>

##### CHANGES:

Remove META.transition (defining `merlin_extend`) because reasons (no pun
intended, fix let-def/merlin-extend#11).
