### PR TITLE
bap: make 0.9.1/2 by specifying a valid version of ocaml

### DIFF
--- a/packages/bap/bap.0.9.1/opam
+++ b/packages/bap/bap.0.9.1/opam
@@ -18,7 +18,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {= "4.01"}
+  "ocaml" {= "4.01.0" }
   "base-unix"
   "bitstring"
   "cmdliner"

--- a/packages/bap/bap.0.9.2/opam
+++ b/packages/bap/bap.0.9.2/opam
@@ -19,7 +19,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {= "4.01"}
+  "ocaml" {= "4.01.0"}
   "base-unix"
   "bitstring"
   "cmdliner"


### PR DESCRIPTION
These are previously uninstallable according to `opam admin check`. cc @ivg