### PR TITLE
Mark ocaml-freestanding.0.6.2 compatible with OCaml 4.11

### DIFF
--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.2/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.2/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")
-  "ocaml" {>= "4.08.0" & < "4.11.0"}
+  "ocaml" {>= "4.08.0" & < "4.12.0"}
 ]
 substs: [
   "flags/cflags.tmp"


### PR DESCRIPTION
Tested with https://github.com/mirage/ocaml-freestanding/pull/79 for quite a while and didn't have any issues.

cc @mato