### PR TITLE
Package radare2.0.0.7

### DIFF
--- a/packages/radare2/radare2.0.0.7/opam
+++ b/packages/radare2/radare2.0.0.7/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
+authors: [ "Edgar Aroutiounian <edgar.factorial@gmail.com>" ]
+license: "BSD-3-Clause"
+homepage: "https://github.com/fxfactorial/ocaml-radare2"
+dev-repo: "git+https://github.com/fxfactorial/ocaml-radare2.git"
+bug-reports: "https://github.com/fxfactorial/ocaml-radare2/issues"
+build: [
+	["dune" "subst"] {pinned}
+	["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "base-unix"
+  "yojson" {>= "1.3.2"} | "yojson-android" {>= "1.3.2"}
+  "conf-radare2"
+]
+messages:[
+"You need to have r2 (radare2) >= 2.3.0 installed and in your path"
+"Use `opam depext radare2` to get it installed with your system package manager"
+]
+
+post-messages:[
+"Play with radare2 interactively from within an OCaml repl like utop"
+"Example in utop:"
+""
+"#require \"radare2\";;"
+"let result = R2.with_command_j ~cmd:\"/j COLUMNS\" \"/bin/ls\";;
+val result : Yojson.t =
+`List
+  [`Assoc
+     [(\"offset\", `Int 109075); (\"type\", `String \"string\");
+      (\"data\", `String \"eQUOTING_STYLECOLUMNSTABSIZEinvalid\")];
+   `Assoc
+     [(\"offset\", `Int 118247); (\"type\", `String \"string\");
+      (\"data\", `String \"onment variable COLUMNS: %signori\")]]"
+{success}]
+synopsis: "OCaml interface to r2"
+description: """
+Interact with radare2,
+See the mli for documentation, example usage in utop:
+
+#require "radare2";;
+let result = R2.with_command_j ~cmd:"/j COLUMNS" "/bin/ls";;
+val result : Yojson.t =
+`List
+  [`Assoc
+     [("offset", `Int 109075); ("type", `String "string");
+      ("data", `String "eQUOTING_STYLECOLUMNSTABSIZEinvalid")];
+   `Assoc
+     [("offset", `Int 118247); ("type", `String "string");
+      ("data", `String "onment variable COLUMNS: %signori")]]\""""
+url {
+  src: "https://github.com/fxfactorial/ocaml-radare2/archive/v0.0.7.tar.gz"
+  checksum: [
+    "md5=4de0594aeea2495e5d992c14a696ebce"
+    "sha512=93a89d07941de6fdc3df3dd740ebfe3def6fb5eb775cc79e698dd9d0a1e0f83638c136708ddb1af0065d5f8b4aec4914f5c3286fbe2d4e5abc70e8c13032eb65"
+  ]
+}


### PR DESCRIPTION
- Rewritten IPC with `radare2` process to reduce amount of used descriptors and quit gracefully by @ivg 
- Removed depext and depend on `conf-radare2` package instead.