### PR TITLE
stdlib-shims: fails to build on 4.12.0+trunk

### DIFF
--- a/packages/stdlib-shims/stdlib-shims.0.1.0/opam
+++ b/packages/stdlib-shims/stdlib-shims.0.1.0/opam
@@ -10,7 +10,7 @@ license: ["typeof OCaml system"]
 depends: [
   "ocaml" {>="4.02.3"}
   "dune"
- ("dune" {> "2.7.0"} | "ocaml" {<"4.12.0~~"})
+ ("dune" {>= "2.7.0"} | "ocaml" {<"4.12.0~~"})
 ]
 build: [ "dune" "build" "-p" name "-j" jobs ]
 synopsis: "Backport some of the new stdlib features to older compiler"

--- a/packages/stdlib-shims/stdlib-shims.0.1.0/opam
+++ b/packages/stdlib-shims/stdlib-shims.0.1.0/opam
@@ -8,8 +8,9 @@ bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
 tags: ["stdlib" "compatibility" "org:ocaml"]
 license: ["typeof OCaml system"]
 depends: [
+  "ocaml" {>="4.02.3"}
   "dune"
-  "ocaml" {>= "4.02.3" & < "4.12.0"}
+ ("dune" {> "2.7.0"} | "ocaml" {<"4.12.0~~"})
 ]
 build: [ "dune" "build" "-p" name "-j" jobs ]
 synopsis: "Backport some of the new stdlib features to older compiler"

--- a/packages/stdlib-shims/stdlib-shims.0.1.0/opam
+++ b/packages/stdlib-shims/stdlib-shims.0.1.0/opam
@@ -9,7 +9,7 @@ tags: ["stdlib" "compatibility" "org:ocaml"]
 license: ["typeof OCaml system"]
 depends: [
   "dune"
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.12.0"}
 ]
 build: [ "dune" "build" "-p" name "-j" jobs ]
 synopsis: "Backport some of the new stdlib features to older compiler"

--- a/packages/stdlib-shims/stdlib-shims.0.1.0/opam
+++ b/packages/stdlib-shims/stdlib-shims.0.1.0/opam
@@ -10,7 +10,7 @@ license: ["typeof OCaml system"]
 depends: [
   "ocaml" {>="4.02.3"}
   "dune"
- ("dune" {>= "2.7.0"} | "ocaml" {<"4.12.0~~"})
+ ("dune" {>= "2.7.0"} | "dune" & "ocaml" {<"4.12.0~~"})
 ]
 build: [ "dune" "build" "-p" name "-j" jobs ]
 synopsis: "Backport some of the new stdlib features to older compiler"


### PR DESCRIPTION
upstream fix proposed at https://github.com/ocaml/stdlib-shims/pull/17