### PR TITLE
Package astring.0.8.5

### DIFF
--- a/packages/astring/astring.0.8.5/opam
+++ b/packages/astring/astring.0.8.5/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The astring programmers"]
+homepage: "https://erratique.ch/software/astring"
+doc: "https://erratique.ch/software/astring/doc"
+dev-repo: "git+http://erratique.ch/repos/astring.git"
+bug-reports: "https://github.com/dbuenzli/astring/issues"
+tags: [ "string" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build} ]
+build: [[ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]]
+
+synopsis: """Alternative String module for OCaml"""
+description: """\
+
+Astring exposes an alternative `String` module for OCaml. This module
+tries to balance minimality and expressiveness for basic, index-free,
+string processing and provides types and functions for substrings,
+string sets and string maps.
+
+Remaining compatible with the OCaml `String` module is a non-goal. The
+`String` module exposed by Astring has exception safe functions,
+removes deprecated and rarely used functions, alters some signatures
+and names, adds a few missing functions and fully exploits OCaml's
+newfound string immutability.
+
+Astring depends only on the OCaml standard library. It is distributed
+under the ISC license.
+"""
+url {
+archive: "https://erratique.ch/software/astring/releases/astring-0.8.5.tbz"
+checksum: "e148907c24157d1df43bec89b58b3ec8"
+}


### PR DESCRIPTION
### `astring.0.8.5`
Alternative String module for OCaml
Astring exposes an alternative `String` module for OCaml. This module
tries to balance minimality and expressiveness for basic, index-free,
string processing and provides types and functions for substrings,
string sets and string maps.

Remaining compatible with the OCaml `String` module is a non-goal. The
`String` module exposed by Astring has exception safe functions,
removes deprecated and rarely used functions, alters some signatures
and names, adds a few missing functions and fully exploits OCaml's
newfound string immutability.

Astring depends only on the OCaml standard library. It is distributed
under the ISC license.



---
* Homepage: https://erratique.ch/software/astring
* Source repo: git+http://erratique.ch/repos/astring.git
* Bug tracker: https://github.com/dbuenzli/astring/issues

---
v0.8.5 2020-08-08 Zagreb
------------------------

- Support OCaml 4.12 injectiviy annotation of Map.S (#18).
  Thanks to Jeremy Yallop for the patch. 
  

---
:camel: Pull-request generated by opam-publish v2.0.2