### PR TITLE
Package alsa.0.3.0

### DIFF
--- a/packages/alsa/alsa.0.3.0/opam
+++ b/packages/alsa/alsa.0.3.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings for the ALSA library which provides functions for using soundcards"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-alsa"
+bug-reports: "https://github.com/savonet/ocaml-alsa/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {> "2.0"}
+  "dune-configurator"
+]
+conflicts: [
+  "liquidsoap" {<= "1.4.2"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-alsa.git"
+depexts: [
+  ["alsa-lib-dev"] {os-distribution = "alpine"}
+  ["alsa-lib-devel"] {os-distribution = "centos"}
+  ["alsa-lib-devel"] {os-distribution = "fedora"}
+  ["alsa-lib-devel"] {os-family = "suse"}
+  ["libasound2-dev"] {os-family = "debian"}
+]
+available: [os = "linux"]
+url {
+  src: "https://github.com/savonet/ocaml-alsa/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=abe2eed424387f316e09d90886c3dde1"
+    "sha512=2ea42175e97dd8bc1db2f0f890c3f969493c71ba231ffd254501975ffa027aea037e29d2ecbeebcba4d161b2a50e02ba91d968449f2b3c9b6c4fe7c2adb78b35"
+  ]
+}


### PR DESCRIPTION
### `alsa.0.3.0`
Bindings for the ALSA library which provides functions for using soundcards



---
* Homepage: https://github.com/savonet/ocaml-alsa
* Source repo: git+https://github.com/savonet/ocaml-alsa.git
* Bug tracker: https://github.com/savonet/ocaml-alsa/issues

---
:camel: Pull-request generated by opam-publish v2.0.2