### PR TITLE
OCamlnet 4.1.8 (with OCaml 4.11 support)

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.1.7/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.7/opam
@@ -21,7 +21,7 @@ build: [
   [make "opt"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "4.11.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/ocamlnet/ocamlnet.4.1.8/files/ocamlnet.install
+++ b/packages/ocamlnet/ocamlnet.4.1.8/files/ocamlnet.install
@@ -1,0 +1,4 @@
+bin: [
+  "src/rpc-generator/ocamlrpcgen"
+  "src/netplex/netplex-admin"
+]

--- a/packages/ocamlnet/ocamlnet.4.1.8/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.8/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+authors: "Gerd Stolpmann"
+maintainer: "gerd@gerd-stolpmann.de"
+homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+doc: "http://projects.camlcity.org/projects/dl/ocamlnet-4.1.8/doc/html-main/index.html"
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+build: [
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-%{conf-gssapi:enable}%-gssapi"
+    "-%{conf-gnutls:enable}%-gnutls"
+    "-%{pcre:enable}%-pcre"
+    "-%{lablgtk:enable}%-gtk2"
+    "-%{camlzip:enable}%-zip"
+    "-with-nethttpd"
+  ]
+  [make "all"]
+  [make "opt"]
+]
+depends: [
+  "ocaml" {>= "4.00.0"}
+  "ocamlfind"
+  "ocamlbuild" {build}
+  "base-bytes"
+]
+depopts: [
+  "conf-gnutls"
+  "conf-gssapi"
+  "lablgtk"
+  "pcre"
+  "camlzip"
+]
+install: [make "install"]
+synopsis:
+  "Internet protocols (HTTP, CGI, e-mail etc.) and helper data structures"
+description: """
+(mail messages, character sets, etc.)
+
+Ocamlnet is an enhanced system platform library for Ocaml. As the name
+suggests, large parts of it have to do with network programming, but
+it is actually not restricted to this. Other parts deal with the
+management of multiple worker processes, and the interaction with
+other programs running on the same machine. You can also view Ocamlnet
+as an extension of the system interface as provided by the Unix module
+of the standard library."""
+conflicts: [
+  "ocaml-variants"
+    {= "4.04.0+flambda" | = "4.04.1+flambda" | = "4.04.2+flambda"}
+]
+extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
+url {
+  src: "http://download.camlcity.org/download/ocamlnet-4.1.8.tar.gz"
+  checksum: "md5=0a76da5734e1861175f575c4e4ed3896"
+  mirrors: "http://download2.camlcity.org/download/ocamlnet-4.1.8.tar.gz"
+}


### PR DESCRIPTION
Fixes OCaml 4.11 support in https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/merge_requests/9
Constraining the previous version (4.1.7) to avoid this issue.