### PR TITLE
[new release] h2 (0.7.0)

### DIFF
--- a/packages/h2/h2.0.7.0/opam
+++ b/packages/h2/h2.0.7.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.7"}
+  "alcotest" {with-test}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "base64"
+  "bigstringaf" {>= "0.5.0"}
+  "angstrom" {>= "0.14.0"}
+  "faraday" {>= "0.5.0"}
+  "psq"
+  "hpack"
+  "httpaf"
+]
+synopsis:
+  "A high-performance, memory-efficient, and scalable HTTP/2 library for OCaml"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml. It
+is based on the concepts in http/af, and therefore uses the Angstrom and
+Faraday libraries to implement the parsing and serialization layers of the
+HTTP/2 standard as a state machine that is agnostic to the underlying I/O
+specifics. It also preserves the same API as http/af wherever possible.
+"""
+x-commit-hash: "72c4a317f43269d8196ba4cabc070203b561ad38"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.7.0/h2-0.7.0.tbz"
+  checksum: [
+    "sha256=63a233a075247d23dfc45adf8435621480d41ef2a597cf807f072bb786405ebc"
+    "sha512=0e0aef2ab42c660f0f50391d9555ac21010481d3b496ebaa0d9b5eb7a5e94c148e8212ecb6e64abd15b865d5f0db2f9a1bd314263079d033a62075212435b72c"
+  ]
+}


### PR DESCRIPTION
A high-performance, memory-efficient, and scalable HTTP/2 library for OCaml

- Project page: <a href="https://github.com/anmonteiro/ocaml-h2">https://github.com/anmonteiro/ocaml-h2</a>
- Documentation: <a href="https://anmonteiro.github.io/ocaml-h2/">https://anmonteiro.github.io/ocaml-h2/</a>

##### CHANGES:


- h2: client / server: execute request/response body reads as data frames
  arrive ([#130](https://github.com/anmonteiro/ocaml-h2/pull/130))
- h2: client / server: only give back flow control tokens after surfacing reads
  to the application ([#131](https://github.com/anmonteiro/ocaml-h2/pull/131))
- h2: Set a default of 128MiB for the initial receiving window size
  ([#132](https://github.com/anmonteiro/ocaml-h2/pull/132))
- h2: don't attempt to write frames to an encoder that has closed
  ([#134](https://github.com/anmonteiro/ocaml-h2/pull/134))
- h2: Handle frame size errors in a more robust manner when parsing
  ([#133](https://github.com/anmonteiro/ocaml-h2/pull/133))
- h2: Create push streams with the right priority (as per
  [RFC7540§5.3.5](https://tools.ietf.org/html/rfc7540#section-5.3.5), pushed
  streams initially depend on their associated stream)
