### PR TITLE
[new release] httpaf_caged (1.0.1)

### DIFF
--- a/packages/httpaf_caged/httpaf_caged.1.0.1/opam
+++ b/packages/httpaf_caged/httpaf_caged.1.0.1/opam
@@ -14,9 +14,9 @@ depends: [
   "angstrom" {>= "0.14.1"}
   "uri" {>= "3.1.0"}
   "odoc" {with-doc}
-  "async" {>= "0.13.0"}
-  "core" {>= "0.13.0"}
-  "ppx_jane" {>= "0.13.0"}
+  "async" {>= "v0.13.0"}
+  "core" {>= "v0.13.0"}
+  "ppx_jane" {>= "v0.13.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/httpaf_caged/httpaf_caged.1.0.1/opam
+++ b/packages/httpaf_caged/httpaf_caged.1.0.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/thedufer/httpaf_caged"
 bug-reports: "https://github.com/thedufer/httpaf_caged/issues"
 depends: [
   "dune" {>= "2.6"}
-  "httpaf" {>= "0.6.6"}
+  "httpaf-async" {>= "0.6.6"}
   "angstrom" {>= "0.14.1"}
   "uri" {>= "3.1.0"}
 ]

--- a/packages/httpaf_caged/httpaf_caged.1.0.1/opam
+++ b/packages/httpaf_caged/httpaf_caged.1.0.1/opam
@@ -14,6 +14,9 @@ depends: [
   "angstrom" {>= "0.14.1"}
   "uri" {>= "3.1.0"}
   "odoc" {with-doc}
+  "async" {>= "0.13.0"}
+  "core" {>= "0.13.0"}
+  "ppx_jane" {>= "0.13.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/httpaf_caged/httpaf_caged.1.0.1/opam
+++ b/packages/httpaf_caged/httpaf_caged.1.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+version: "1.0.1"
+synopsis: "A higher-level httpaf-async server interface"
+description:
+  "Exposes a standard request->response server interface, as well as helpers for parsing various standard headers (cookies, accept, etc)."
+maintainer: ["thedufer@gmail.com"]
+authors: ["Aaron Dufour"]
+license: "BSD-3-clause"
+homepage: "https://github.com/thedufer/httpaf_caged"
+bug-reports: "https://github.com/thedufer/httpaf_caged/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "httpaf" {>= "0.6.6"}
+  "angstrom" {>= "0.14.1"}
+  "uri" {>= "3.1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thedufer/httpaf_caged.git"
+url {
+  src:
+    "https://github.com/thedufer/httpaf_caged/releases/download/1.0.1/httpaf_caged-1.0.1.tbz"
+  checksum: [
+    "sha256=f3f36a664cebaa727325ef20c3ec10653fd36a48717f54c587e3e4149c853f3e"
+    "sha512=7a7adeaac67c75ccc188657999a72764b1fc32221407709a0b1d539ba7e82dba744f7c40e47510a5eee8d5754907836b7385f4399772128e6add2a356e388dba"
+  ]
+}


### PR DESCRIPTION
A higher-level httpaf-async server interface

- Project page: <a href="https://github.com/thedufer/httpaf_caged">https://github.com/thedufer/httpaf_caged</a>

##### CHANGES:

fix a couple of release issues (such as the duplicate dune requirement)