### PR TITLE
[new release] ppx_mysql 1.1.1, 1.1.2 and 1.1.3

### DIFF
--- a/packages/ppx_mysql/ppx_mysql.1.1.1/opam
+++ b/packages/ppx_mysql/ppx_mysql.1.1.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Dario Teixeira <dte@issuu.com>"
+synopsis: "Syntax extension for facilitating usage of MySQL bindings"
+description: """
+This syntax extension aims to reduce the pain and boilerplate associated with
+using MySQL bindings from OCaml.  It is similar in spirit to PG'OCaml, but
+without the compile-time communication with the DB engine for type inference.
+"""
+homepage: "https://github.com/issuu/ppx_mysql"
+dev-repo: "git+https://github.com/issuu/ppx_mysql.git"
+bug-reports: "https://github.com/issuu/ppx_mysql/issues"
+doc: "https://issuu.github.io/ppx_mysql/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "alcotest" {with-test & >= "0.8" & < "0.9"}
+  "dune" {>= "1.4"}
+  "ocamlformat" {with-test & >= "0.9" & < "0.10"}
+  "ocaml" {>= "4.06.0" }
+  "ppx_deriving" {with-test & >= "4.2" & < "5.0"}
+  "ppxlib" {>= "0.2" & < "0.9"}
+  "stdlib-shims"
+]
+authors: "Team Raccoons at Issuu"
+url {
+  src:
+    "https://github.com/issuu/ppx_mysql/releases/download/1.1.1/ppx_mysql-1.1.1.tbz"
+  checksum: [
+    "sha256=910ab811ed663a9e06c0690dabc2d8ceec6984d8d71060cce531a9bc74bfd603"
+    "sha512=c6744c3fefbeca7b8ecac85174c2e2c76987f0491a265f49e19cc61b64ee7d3c62234d3d01106e9a9d6dcd8318d88c277c00957eae1a6d30d7bd4607088b989f"
+  ]
+}

--- a/packages/ppx_mysql/ppx_mysql.1.1.2/opam
+++ b/packages/ppx_mysql/ppx_mysql.1.1.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Dario Teixeira <dte@issuu.com>"
+synopsis: "Syntax extension for facilitating usage of MySQL bindings"
+description: """
+This syntax extension aims to reduce the pain and boilerplate associated with
+using MySQL bindings from OCaml.  It is similar in spirit to PG'OCaml, but
+without the compile-time communication with the DB engine for type inference.
+"""
+homepage: "https://github.com/issuu/ppx_mysql"
+dev-repo: "git+https://github.com/issuu/ppx_mysql.git"
+bug-reports: "https://github.com/issuu/ppx_mysql/issues"
+doc: "https://issuu.github.io/ppx_mysql/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "alcotest" {with-test & >= "0.8" & < "0.9"}
+  "dune" {>= "1.4"}
+  "ocamlformat" {with-test & >= "0.9" & < "0.10"}
+  "ocaml" {>= "4.06.0" }
+  "ppx_deriving" {with-test & >= "4.2" & < "5.0"}
+  "ppxlib" {>= "0.2" & < "0.13"}
+  "stdlib-shims"
+]
+authors: "Team Raccoons at Issuu"
+url {
+  src:
+    "https://github.com/issuu/ppx_mysql/releases/download/1.1.2/ppx_mysql-1.1.2.tbz"
+  checksum: [
+    "sha256=362134d1a1a4c1f811e4a0b95200b342dedea44ce94d5a579822e9f454460e57"
+    "sha512=e24217c3f445b3b8d41038b841fcd0fc690e5cefa6463a368a1fc5f7cfb026c33c9a8240215bc5465a4fdd0add31b3b641dacc579f4b40e68cfb78ea7fa162f3"
+  ]
+}

--- a/packages/ppx_mysql/ppx_mysql.1.1.3/opam
+++ b/packages/ppx_mysql/ppx_mysql.1.1.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Dario Teixeira <dte@issuu.com>"
+synopsis: "Syntax extension for facilitating usage of MySQL bindings"
+description: """
+This syntax extension aims to reduce the pain and boilerplate associated with
+using MySQL bindings from OCaml.  It is similar in spirit to PG'OCaml, but
+without the compile-time communication with the DB engine for type inference.
+"""
+homepage: "https://github.com/issuu/ppx_mysql"
+dev-repo: "git+https://github.com/issuu/ppx_mysql.git"
+bug-reports: "https://github.com/issuu/ppx_mysql/issues"
+doc: "https://issuu.github.io/ppx_mysql/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "alcotest" {with-test & >= "0.8" & < "0.9"}
+  "dune" {>= "1.4"}
+  "ocamlformat" {with-test & >= "0.9" & < "0.10"}
+  "ocaml" {>= "4.06.0" }
+  "ppx_deriving" {with-test & >= "4.2" & < "5.0"}
+  "ppxlib" {>= "0.2"}
+  "stdlib-shims"
+]
+x-commit-hash: "bb9cc084c9b9422591fefefd7589255ae7d3b504"
+authors: "Team Raccoons at Issuu"
+url {
+  src:
+    "https://github.com/issuu/ppx_mysql/releases/download/1.1.3/ppx_mysql-1.1.3.tbz"
+  checksum: [
+    "sha256=7ac90d54b649692b9d2c2bedb3a2f9cce4d100d4db5443fc482f1e8337e19911"
+    "sha512=d47a05607a526bb1c2f3a0a3a79f84d181362810845f2c1e1004b80cb41ee748e9216be971c5e3c9c1e4027eec91de2d9effe57fd8e0d83b8861d5d0bfd6c3d1"
+  ]
+}


### PR DESCRIPTION
Syntax extension aiming to reduce the pain and boilerplate associated with using MySQL bindings from OCaml. Project homepage: https://github.com/issuu/ppx_mysql