### PR TITLE
Release plist-xml and plist-xml-lwt 0.2.0

### DIFF
--- a/packages/plist-xml-lwt/plist-xml-lwt.0.1/opam
+++ b/packages/plist-xml-lwt/plist-xml-lwt.0.1/opam
@@ -9,7 +9,7 @@ doc: "https://dosaylazy.github.io/ocaml-plist-xml/"
 bug-reports: "https://github.com/dosaylazy/ocaml-plist-xml/issues"
 depends: [
   "dune" {>= "2.6"}
-  "plist-xml"
+  "plist-xml" {= 0.1}
   "lwt" {>= "5.0" & < "6.0"}
   "markup-lwt" {>= "0.5" & < "0.6"}
   "odoc" {with-doc}

--- a/packages/plist-xml-lwt/plist-xml-lwt.0.1/opam
+++ b/packages/plist-xml-lwt/plist-xml-lwt.0.1/opam
@@ -9,7 +9,7 @@ doc: "https://dosaylazy.github.io/ocaml-plist-xml/"
 bug-reports: "https://github.com/dosaylazy/ocaml-plist-xml/issues"
 depends: [
   "dune" {>= "2.6"}
-  "plist-xml" {= 0.1}
+  "plist-xml" {= "0.1"}
   "lwt" {>= "5.0" & < "6.0"}
   "markup-lwt" {>= "0.5" & < "0.6"}
   "odoc" {with-doc}

--- a/packages/plist-xml-lwt/plist-xml-lwt.0.2.0/opam
+++ b/packages/plist-xml-lwt/plist-xml-lwt.0.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Reading of plist files in the XML format with Lwt"
+description: "Reading of plist files in the XML format with Lwt."
+maintainer: ["Alan Hu <hu.ala@northeastern.edu>"]
+authors: ["Alan Hu <hu.ala@northeastern.edu>"]
+license: "MIT"
+homepage: "https://github.com/dosaylazy/ocaml-plist-xml"
+doc: "https://dosaylazy.github.io/ocaml-plist-xml/"
+bug-reports: "https://github.com/dosaylazy/ocaml-plist-xml/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "plist-xml" {= "0.2.0"}
+  "lwt" {>= "5.0" & < "6.0"}
+  "markup-lwt" {>= "0.5" & < "0.6"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dosaylazy/ocaml-plist-xml.git"
+x-commit-hash: "58e2b25e6bf0864eee2564bfa783f8be4176a27b"
+url {
+  src:
+    "https://github.com/dosaylazy/ocaml-plist-xml/releases/download/0.2.0/plist-xml-lwt-0.2.0.tbz"
+  checksum: [
+    "sha256=99116ffa8246caa4a4bfb920f282413154e119c21771eff347b563b4dc5b2703"
+    "sha512=cb4d769fa7ce83209fdd7ff7b8f25f09319add35e967f9956da441d195c889c8fadea9d52f44f381ca8b61023b6c88a6ac6b25f4ae8269b8a3c46640b86bc0ff"
+  ]
+}

--- a/packages/plist-xml/plist-xml.0.1/opam
+++ b/packages/plist-xml/plist-xml.0.1/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/dosaylazy/ocaml-plist-xml/issues"
 depends: [
   "dune" {>= "2.6"}
   "base64" {>= "3.4" & < "4.0"}
-  "ISO8601" {>= "0.2.6" & < "1.0"}
+  "ISO8601" {>= "0.2.6" & < "0.3"}
   "markup" {>= "0.8" & < "0.9"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}

--- a/packages/plist-xml/plist-xml.0.2.0/opam
+++ b/packages/plist-xml/plist-xml.0.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Reading and writing of plist files in the XML format in pure OCaml"
+description: """
+Reading and writing of plist files in the XML format in pure OCaml.
+
+Implementation of https://www.apple.com/DTDs/PropertyList-1.0.dtd."""
+maintainer: ["Alan Hu <hu.ala@northeastern.edu>"]
+authors: ["Alan Hu <hu.ala@northeastern.edu>"]
+license: "MIT"
+homepage: "https://github.com/dosaylazy/ocaml-plist-xml"
+doc: "https://dosaylazy.github.io/ocaml-plist-xml/"
+bug-reports: "https://github.com/dosaylazy/ocaml-plist-xml/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "base64" {>= "3.4" & < "4.0"}
+  "ISO8601" {>= "0.2.6" & < "0.3"}
+  "markup" {>= "0.8" & < "0.9"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dosaylazy/ocaml-plist-xml.git"
+x-commit-hash: "58e2b25e6bf0864eee2564bfa783f8be4176a27b"
+url {
+  src:
+    "https://github.com/dosaylazy/ocaml-plist-xml/releases/download/0.2.0/plist-xml-lwt-0.2.0.tbz"
+  checksum: [
+    "sha256=99116ffa8246caa4a4bfb920f282413154e119c21771eff347b563b4dc5b2703"
+    "sha512=cb4d769fa7ce83209fdd7ff7b8f25f09319add35e967f9956da441d195c889c8fadea9d52f44f381ca8b61023b6c88a6ac6b25f4ae8269b8a3c46640b86bc0ff"
+  ]
+}


### PR DESCRIPTION
[new release] plist-xml and plist-xml-lwt (0.2.0)

CHANGES:

- `signals` now emits `xml` and `doctype` elements.
- `signals` now gives `plist` element the attribute `version="1.0"`.
- Add [?encoding] parameter to `signals` function.

I also refined the version bounds for `plist-xml.0.1` and `plist-xml-lwt.0.1`. Hopefully this release builds on the first try!