### PR TITLE
[new release] kafka_async, kafka_lwt and kafka (0.5)

### DIFF
--- a/packages/kafka/kafka.0.5/opam
+++ b/packages/kafka/kafka.0.5/opam
@@ -30,9 +30,9 @@ depexts: [
   ["librdkafka-devel"] {os-distribution = "fedora"}
   ["librdkafka"] {os-distribution = "homebrew" & os = "macos"}
   ["librdkafka-dev"] {os-distribution = "ubuntu"}
-  ["librdkafka"] {os = "freebsd"}
-  ["librdkafka"] {os = "netbsd"}
-  ["librdkafka"] {os = "dragonfly"}
+  ["librdkafka"] {os-distribution = "freebsd"}
+  ["librdkafka"] {os-distribution = "netbsd"}
+  ["librdkafka"] {os-distribution = "dragonfly"}
 ]
 x-commit-hash: "8a4c8309af0072b3c23a9a3164913e5b5aaea416"
 url {

--- a/packages/kafka/kafka.0.5/opam
+++ b/packages/kafka/kafka.0.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Didier Wenzek <didier.wenzek@acidalie.com>"]
+authors: ["Didier Wenzek <didier.wenzek@acidalie.com>"]
+bug-reports: "https://github.com/didier-wenzek/ocaml-kafka/issues"
+homepage: "https://github.com/didier-wenzek/ocaml-kafka"
+doc: "https://didier-wenzek.github.io/ocaml-kafka"
+license: "MIT"
+dev-repo: "git+https://github.com/didier-wenzek/ocaml-kafka.git"
+synopsis: "OCaml bindings for Kafka"
+description: """
+
+Kafka is a high-throughput distributed messaging system.
+"""
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "conf-zlib"
+  "dune" {>= "1.10"}
+]
+depexts: [
+  ["librdkafka-dev"] {os-distribution = "alpine"}
+  ["librdkafka"] {os-distribution = "archlinux"}
+  ["librdkafka-devel"] {os-distribution = "centos"}
+  ["librdkafka-dev"] {os-distribution = "debian"}
+  ["librdkafka-devel"] {os-distribution = "fedora"}
+  ["librdkafka"] {os-distribution = "homebrew" & os = "macos"}
+  ["librdkafka-dev"] {os-distribution = "ubuntu"}
+]
+x-commit-hash: "8a4c8309af0072b3c23a9a3164913e5b5aaea416"
+url {
+  src:
+    "https://github.com/didier-wenzek/ocaml-kafka/releases/download/0.5/kafka-0.5.tbz"
+  checksum: [
+    "sha256=7ec32681c104062a4fad43e2736e206128eb88273118071a044081abbc082255"
+    "sha512=7485d83cb20705f21b39c7e40cc6564cee30dba2c1993dc93c2791b4527488a33ef557e9fdaa47d3c0777986468f42460bb16c4d6d4076b1c43443f2cb5c6e3f"
+  ]
+}

--- a/packages/kafka/kafka.0.5/opam
+++ b/packages/kafka/kafka.0.5/opam
@@ -30,6 +30,9 @@ depexts: [
   ["librdkafka-devel"] {os-distribution = "fedora"}
   ["librdkafka"] {os-distribution = "homebrew" & os = "macos"}
   ["librdkafka-dev"] {os-distribution = "ubuntu"}
+  ["librdkafka"] {os = "freebsd"}
+  ["librdkafka"] {os = "netbsd"}
+  ["librdkafka"] {os = "dragonfly"}
 ]
 x-commit-hash: "8a4c8309af0072b3c23a9a3164913e5b5aaea416"
 url {

--- a/packages/kafka/kafka.0.5/opam
+++ b/packages/kafka/kafka.0.5/opam
@@ -30,9 +30,9 @@ depexts: [
   ["librdkafka-devel"] {os-distribution = "fedora"}
   ["librdkafka"] {os-distribution = "homebrew" & os = "macos"}
   ["librdkafka-dev"] {os-distribution = "ubuntu"}
-  ["librdkafka"] {os-distribution = "freebsd"}
-  ["librdkafka"] {os-distribution = "netbsd"}
-  ["librdkafka"] {os-distribution = "dragonfly"}
+  ["net/librdkafka"] {os = "freebsd"}
+  ["devel/librdkafka"] {os = "netbsd"}
+  ["net/librdkafka"] {os = "dragonfly"}
 ]
 x-commit-hash: "8a4c8309af0072b3c23a9a3164913e5b5aaea416"
 url {

--- a/packages/kafka_async/kafka_async.0.5/opam
+++ b/packages/kafka_async/kafka_async.0.5/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Didier Wenzek <didier.wenzek@acidalie.com>"]
+authors: ["Didier Wenzek <didier.wenzek@acidalie.com>"]
+bug-reports: "https://github.com/didier-wenzek/ocaml-kafka/issues"
+homepage: "https://github.com/didier-wenzek/ocaml-kafka"
+doc: "https://didier-wenzek.github.io/ocaml-kafka"
+license: "MIT"
+dev-repo: "git+https://github.com/didier-wenzek/ocaml-kafka.git"
+synopsis: "OCaml bindings for Kafka, Async bindings"
+description: """
+
+Kafka is a high-throughput distributed messaging system.
+"""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "kafka" {= version}
+  "async" {>= "v0.11"}
+  "core" {>= "v0.11"}
+  "dune" {>= "1.10"}
+]
+x-commit-hash: "8a4c8309af0072b3c23a9a3164913e5b5aaea416"
+url {
+  src:
+    "https://github.com/didier-wenzek/ocaml-kafka/releases/download/0.5/kafka-0.5.tbz"
+  checksum: [
+    "sha256=7ec32681c104062a4fad43e2736e206128eb88273118071a044081abbc082255"
+    "sha512=7485d83cb20705f21b39c7e40cc6564cee30dba2c1993dc93c2791b4527488a33ef557e9fdaa47d3c0777986468f42460bb16c4d6d4076b1c43443f2cb5c6e3f"
+  ]
+}

--- a/packages/kafka_lwt/kafka_lwt.0.5/opam
+++ b/packages/kafka_lwt/kafka_lwt.0.5/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Didier Wenzek <didier.wenzek@acidalie.com>"]
+authors: ["Didier Wenzek <didier.wenzek@acidalie.com>"]
+bug-reports: "https://github.com/didier-wenzek/ocaml-kafka/issues"
+homepage: "https://github.com/didier-wenzek/ocaml-kafka"
+doc: "https://didier-wenzek.github.io/ocaml-kafka"
+license: "MIT"
+dev-repo: "git+https://github.com/didier-wenzek/ocaml-kafka.git"
+synopsis: "OCaml bindings for Kafka, Lwt bindings"
+description: """
+
+Kafka is a high-throughput distributed messaging system.
+"""
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "kafka" {= version}
+  "cmdliner"
+  "lwt"
+  "conf-zlib"
+  "dune" {>= "1.10"}
+]
+x-commit-hash: "8a4c8309af0072b3c23a9a3164913e5b5aaea416"
+url {
+  src:
+    "https://github.com/didier-wenzek/ocaml-kafka/releases/download/0.5/kafka-0.5.tbz"
+  checksum: [
+    "sha256=7ec32681c104062a4fad43e2736e206128eb88273118071a044081abbc082255"
+    "sha512=7485d83cb20705f21b39c7e40cc6564cee30dba2c1993dc93c2791b4527488a33ef557e9fdaa47d3c0777986468f42460bb16c4d6d4076b1c43443f2cb5c6e3f"
+  ]
+}


### PR DESCRIPTION
OCaml bindings for Kafka, Async bindings

- Project page: <a href="https://github.com/didier-wenzek/ocaml-kafka">https://github.com/didier-wenzek/ocaml-kafka</a>
- Documentation: <a href="https://didier-wenzek.github.io/ocaml-kafka">https://didier-wenzek.github.io/ocaml-kafka</a>

##### CHANGES:

* Add Async bindings
* Split sync and Lwt variants into separate OPAM packages
* Fix compatibility with OCaml 4.09
* Register callbacks as GC roots
* Port to `dune`
* Port to OPAM 2 format
* Make `dune` generate `opam` files automatically
* Add Changelog to facilitate releases with `dune-release`
* Depend ob `zlib` depext instead of explicit package names
