### PR TITLE
Package ppx_getenv.2.0

### DIFF
--- a/packages/ppx_getenv/ppx_getenv.2.0/opam
+++ b/packages/ppx_getenv/ppx_getenv.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A sample syntax extension using OCaml's new extension points API"
+maintainer: ["whitequark <whitequark@whitequark.org>"]
+authors: ["whitequark <whitequark@whitequark.org>"]
+license: "Public domain"
+tags: ["syntax"]
+homepage: "https://github.com/ocaml-ppx/ppx_getenv"
+bug-reports: "https://github.com/ocaml-ppx/ppx_getenv/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.04.0"}
+  "ppxlib" {>= "0.9.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_getenv.git"
+url {
+  src: "https://github.com/ocaml-ppx/ppx_getenv/archive/v2.0.tar.gz"
+  checksum: [
+    "md5=f7822fc5bb7e9fbeb18ac7433e3eb38b"
+    "sha512=9add1c4182e8d18e21a7e8d9d4ee3bb1273541de772604829814f3718397febfbd790f2bf24bc7437c0715568857b27f837ad96f4805b833ab36c127ae124994"
+  ]
+}


### PR DESCRIPTION
### `ppx_getenv.2.0`
A sample syntax extension using OCaml's new extension points API



---
* Homepage: https://github.com/ocaml-ppx/ppx_getenv
* Source repo: git+https://github.com/ocaml-ppx/ppx_getenv.git
* Bug tracker: https://github.com/ocaml-ppx/ppx_getenv/issues

---
:camel: Pull-request generated by opam-publish v2.0.2