### PR TITLE
[new release] sentry (v0.10.2)

### DIFF
--- a/packages/sentry/sentry.v0.10.2/opam
+++ b/packages/sentry/sentry.v0.10.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Unofficial Async Sentry error monitoring client"
+description:
+  "Sentry is an unofficial Async OCaml client for the Sentry error reporting."
+maintainer: ["Brendan Long <self@brendanlong.com>"]
+authors: ["Brendan Long <self@brendanlong.com>"]
+license: "Unlicense"
+homepage: "https://github.com/brendanlong/sentry-ocaml"
+doc: "https://brendanlong.github.io/sentry-ocaml"
+bug-reports: "https://github.com/brendanlong/sentry-ocaml/issues"
+depends: [
+  "core" {>= "v0.13.0"}
+  "atdgen"
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-async" {>= "2.0.0"}
+  "dune" {>= "1.11.0"}
+  "hex" {>= "1.2.0"}
+  "json-derivers"
+  "ppx_jane"
+  "ocaml" {>= "4.08.0"}
+  "re2"
+  "sexplib" {>= "v0.13.0"}
+  "uuidm"
+  "uri"
+  "yojson"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/brendanlong/sentry-ocaml.git"
+url {
+  src:
+    "https://github.com/brendanlong/sentry-ocaml/releases/download/v0.10.2/sentry-v0.10.2.tbz"
+  checksum: [
+    "sha256=097c2d80b8320d5ccc937154a0791ebb205cfb7e7a1b6de7eb33b10814e32612"
+    "sha512=dd0df2e5c975200307841519a624e3787e3d04a32222f5072e95f141fc41e9a573968e124a63578003ab6402e6f968ce6bef8bf055cd5e8de53e462a01082517"
+  ]
+}


### PR DESCRIPTION
Unofficial Async Sentry error monitoring client

- Project page: <a href="https://github.com/brendanlong/sentry-ocaml">https://github.com/brendanlong/sentry-ocaml</a>
- Documentation: <a href="https://brendanlong.github.io/sentry-ocaml">https://brendanlong.github.io/sentry-ocaml</a>

##### CHANGES:

- Drain cohttp response bodies so we don't leak connections on redirect or error
