### PR TITLE
[new release] sentry (v0.11.0)

### DIFF
--- a/packages/sentry/sentry.v0.11.0/opam
+++ b/packages/sentry/sentry.v0.11.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Unofficial Async Sentry error monitoring client"
+description:
+  "Sentry is an unofficial Async OCaml client for the Sentry error reporting."
+maintainer: ["Brendan Long <self@brendanlong.com>"]
+authors: ["Brendan Long <self@brendanlong.com>"]
+license: "Unlicense"
+homepage: "https://github.com/brendanlong/sentry-ocaml"
+doc: "https://brendanlong.github.io/sentry-ocaml"
+bug-reports: "https://github.com/brendanlong/sentry-ocaml/issues"
+depends: [
+  "core" {>= "v0.13.0"}
+  "atdgen"
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-async" {>= "2.0.0"}
+  "dune" {>= "1.11.0"}
+  "hex" {>= "1.2.0"}
+  "json-derivers"
+  "ppx_jane"
+  "ocaml" {>= "4.08.0"}
+  "re2"
+  "sexplib" {>= "v0.13.0"}
+  "uuidm"
+  "uri"
+  "yojson"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/brendanlong/sentry-ocaml.git"
+url {
+  src:
+    "https://github.com/brendanlong/sentry-ocaml/releases/download/v0.11.0/sentry-v0.11.0.tbz"
+  checksum: [
+    "sha256=f475f3b68fb7386da82ba2fa7d45bf19ab5d08c535b27d38d0b3699251ec05c2"
+    "sha512=aa37df63286cb744acb5ccd2923ce2e812f448ce80dac125f4985cf2aad31982c242bb222102c78ed9eb4af7d2f5452bad8b21ac55339adf9c4e55ce0a46e779"
+  ]
+}


### PR DESCRIPTION
Unofficial Async Sentry error monitoring client

- Project page: <a href="https://github.com/brendanlong/sentry-ocaml">https://github.com/brendanlong/sentry-ocaml</a>
- Documentation: <a href="https://brendanlong.github.io/sentry-ocaml">https://brendanlong.github.io/sentry-ocaml</a>

##### CHANGES:

- Support Async Monitor exceptions from v0.14
