### PR TITLE
[new release] dockerfile-opam, dockerfile and dockerfile-cmd (7.0.0)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.7.0.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.7.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL - generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>="2.0.0"}
+  "dockerfile-opam" {=version}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "ppx_sexp_conv" {>="v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+x-commit-hash: "c0b652ed501935886b96f4e3129d7c0ee3c4e025"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v7.0.0/dockerfile-v7.0.0.tbz"
+  checksum: [
+    "sha256=7d6715ced171e622ba9ff31803d66919a2f1507ba725e47139f6a8d1ef71cbdc"
+    "sha512=d6c6f49367f318f3c53f392dca9a75987a7713426b383f13bb4ed1e5184081f4a7ba00aa56381387239a59bb74edaa8dfb4f3747a091f7ca2d2e78145c82b104"
+  ]
+}

--- a/packages/dockerfile-opam/dockerfile-opam.7.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.7.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution
+support for generating dockerfiles."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>="2.0.0"}
+  "dockerfile" {= version}
+  "ocaml-version" {>= "1.0.0"}
+  "cmdliner"
+  "astring"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+x-commit-hash: "c0b652ed501935886b96f4e3129d7c0ee3c4e025"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v7.0.0/dockerfile-v7.0.0.tbz"
+  checksum: [
+    "sha256=7d6715ced171e622ba9ff31803d66919a2f1507ba725e47139f6a8d1ef71cbdc"
+    "sha512=d6c6f49367f318f3c53f392dca9a75987a7713426b383f13bb4ed1e5184081f4a7ba00aa56381387239a59bb74edaa8dfb4f3747a091f7ca2d2e78145c82b104"
+  ]
+}

--- a/packages/dockerfile/dockerfile.7.0.0/opam
+++ b/packages/dockerfile/dockerfile.7.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>="2.0.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+x-commit-hash: "c0b652ed501935886b96f4e3129d7c0ee3c4e025"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v7.0.0/dockerfile-v7.0.0.tbz"
+  checksum: [
+    "sha256=7d6715ced171e622ba9ff31803d66919a2f1507ba725e47139f6a8d1ef71cbdc"
+    "sha512=d6c6f49367f318f3c53f392dca9a75987a7713426b383f13bb4ed1e5184081f4a7ba00aa56381387239a59bb74edaa8dfb4f3747a091f7ca2d2e78145c82b104"
+  ]
+}


### PR DESCRIPTION
Dockerfile eDSL -- opam support

- Project page: <a href="https://github.com/avsm/ocaml-dockerfile">https://github.com/avsm/ocaml-dockerfile</a>
- Documentation: <a href="https://avsm.github.io/ocaml-dockerfile/doc">https://avsm.github.io/ocaml-dockerfile/doc</a>

##### CHANGES:

- Do not install `opam-installer` in images any more. This turns
  out to be a largely optional component as the opam binary
  installer doesn't include it either.  It will be made optional
  in the final opam 2.1 release. (@avsm)

- Build multiple versions of opam in the base images. This results
  in an `opam-2.0` and `opam-2.1` binary being installed, with
  a hardlink to `opam <- opam.2.0` so the defaults are unchanged.
  This allows upstream CI images to switch the hardlink to make
  it easier to test newer releases of opam, and also upgrades.
