### PR TITLE
[new release] lacaml (11.0.8)

### DIFF
--- a/packages/lacaml/lacaml.11.0.8/opam
+++ b/packages/lacaml/lacaml.11.0.8/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+authors: [
+  "Egbert Ammicht <eammicht@lucent.com>"
+  "Patrick Cousot <Patrick.Cousot@ens.fr>"
+  "Sam Ehrlichman <sehrlichman@janestreet.com>"
+  "Florent Hoareau <h.florent@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Liam Stewart <liam@cs.toronto.edu>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Oleg Trott <ot14@columbia.edu>"
+  "Martin Willensdorfer <ma.wi@gmx.at>"
+]
+bug-reports: "https://github.com/mmottl/lacaml/issues"
+homepage: "https://mmottl.github.io/lacaml"
+doc: "https://mmottl.github.io/lacaml/api"
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/mmottl/lacaml.git"
+synopsis: "Lacaml - OCaml-bindings to BLAS and LAPACK"
+description: """
+Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
+LAPACK-library (Linear Algebra routines).  It also contains many additional
+convenience functions for vectors and matrices."""
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "dune-configurator"
+  "conf-blas" {build}
+  "conf-lapack" {build}
+  "base-bytes"
+  "base-bigarray"
+]
+url {
+  src:
+    "https://github.com/mmottl/lacaml/releases/download/11.0.8/lacaml-11.0.8.tbz"
+  checksum: [
+    "sha256=cdc539e67f7b04c8f87dd9881acd85ea8954d685cafd1457b3c6c7d42ce687c4"
+    "sha512=933fbbe2e9c1739f052daf15e4c2863b4bede7ee69f29c08862be18b0c11a25b3e09fc67d3f2421892c194ebfdfc1dc3ad0501d4250a5bdbfbbb35528c4cc7dd"
+  ]
+}


### PR DESCRIPTION
Lacaml - OCaml-bindings to BLAS and LAPACK

- Project page: <a href="https://mmottl.github.io/lacaml">https://mmottl.github.io/lacaml</a>
- Documentation: <a href="https://mmottl.github.io/lacaml/api">https://mmottl.github.io/lacaml/api</a>

##### CHANGES:

* Improved detection of (complex) `dotu` and `dotc` calling conventions.
