### PR TITLE
[new release] postgresql (4.6.3)

### DIFF
--- a/packages/postgresql/postgresql.4.6.3/opam
+++ b/packages/postgresql/postgresql.4.6.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+license: "LGPL-2.1+ with OCaml linking exception"
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.10"}
+  "dune-configurator"
+  "conf-postgresql" {build}
+  "base-bytes"
+]
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/4.6.3/postgresql-4.6.3.tbz"
+  checksum: [
+    "sha256=3c80aa80b13b046bddbe54955702a528720b96d347057953b3aa215e0e954179"
+    "sha512=bea2cf00cff03cf0368e8dd06f68e579cb83f20b9e483ccd31d0b259c3e003faa4732cc565b57f3055cdb000312533bb234ae69f771befbce77b2575a8461b8a"
+  ]
+}


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

* Removed incorrect `[@@noalloc]` from `is_busy` external call.

    Thanks to Dmitry Astapov for this patch!
