### PR TITLE
[new release] sihl (0.0.56)

### DIFF
--- a/packages/sihl/sihl.0.0.56/opam
+++ b/packages/sihl/sihl.0.0.56/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "A web framework for Reason and OCaml"
+description: "A web framework for Reason and OCaml to build apps rapidly."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.3.0"}
+  "base" {>= "v0.13.1"}
+  "opium" {>= "0.17.1"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.5.2"}
+  "tsort" {>= "2.0.0"}
+  "tls" {>= "0.11.1"}
+  "ssl" {>= "0.5.9"}
+  "lwt_ssl" {>= "1.1.3"}
+  "caqti" {>= "1.2.1"}
+  "caqti-lwt" {>= "1.2.0"}
+  "tyxml" {>= "4.3.0"}
+  "tyxml-jsx" {>= "4.3.0"}
+  "reason" {>= "3.0.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.8"}
+  "pcre" {>= "7.4.3"}
+  "safepass" {>= "3.0"}
+  "jwto" {>= "0.3.0"}
+  "uuidm" {>= "0.9.7"}
+  "letters" {>= "0.1.1"}
+  "sexplib" {>= "0.13.0"}
+  "ppx_fields_conv" {>= "0.13.0"}
+  "ppx_sexp_conv" {>= "0.13.0"}
+  "alcotest" {>= "1.2.0"}
+  "utop" {dev}
+  "merlin" {dev}
+  "ocamlformat" {dev}
+  "ocp-indent" {dev}
+  "tuareg" {dev}
+  "alcotest" {>= "1.2.0" & with-test}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "cohttp-lwt-unix" {>= "2.5.1" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "7fc45be374a4a10c93cde167afa1a035a4115db2"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.0.56/sihl-0.0.56.tbz"
+  checksum: [
+    "sha256=38d5abd1d80aa4772c742a8bd4024afd39e23e2e02304b1cacfddde7dba2f43b"
+    "sha512=28f3236a51a501247a12f38441aab70e100936eca94a34d43a5734d1861021ac15dfa5457f87d9d0f87bc1f2fef9cda6d6fa6d11486797dd1b466d6bd85650ce"
+  ]
+}


### PR DESCRIPTION
A web framework for Reason and OCaml

- Project page: <a href="https://github.com/oxidizing/sihl">https://github.com/oxidizing/sihl</a>
- Documentation: <a href="https://oxidizing.github.io/sihl/">https://oxidizing.github.io/sihl/</a>

##### CHANGES:

## [0.0.56] - 2020-08-17
### Fixed
- Stop running integration tests during OPAM release

## [0.0.55] - 2020-08-17
### Added
- Initial release of Sihl
