### PR TITLE
[new release] github-jsoo, github-unix and github (4.3.1)

### DIFF
--- a/packages/github-jsoo/github-jsoo.4.3.1/opam
+++ b/packages/github-jsoo/github-jsoo.4.3.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 JavaScript library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+(JSON). This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "github" {= version}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt-jsoo" {>= "0.99.0"}
+  "js_of_ocaml-lwt" {>= "3.4.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.3.1/github-unix-4.3.1.tbz"
+  checksum: [
+    "sha256=da8f8cc3c5d69d55000b8c9c15cab0f08f36f787fc5e25111451d0e7468593d1"
+    "sha512=5293b7fb1b8e46c801506998b9a1b34e88bd86be38ccd28ac5138b736de5cc233a95b3e7f2da43dd3ccd0aa87b5c25ebc7a0afca81240d99ec5054f9239213d6"
+  ]
+}

--- a/packages/github-unix/github-unix.4.3.1/opam
+++ b/packages/github-unix/github-unix.4.3.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 Unix library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+(JSON).  This package installs the Unix (Lwt) version."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "github" {= version}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt-unix" {>= "0.99.0"}
+  "stringext"
+  "lambda-term" {>= "2.0"}
+  "cmdliner" {>= "0.9.8"}
+  "base-unix"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.3.1/github-unix-4.3.1.tbz"
+  checksum: [
+    "sha256=da8f8cc3c5d69d55000b8c9c15cab0f08f36f787fc5e25111451d0e7468593d1"
+    "sha512=5293b7fb1b8e46c801506998b9a1b34e88bd86be38ccd28ac5138b736de5cc233a95b3e7f2da43dd3ccd0aa87b5c25ebc7a0afca81240d99ec5054f9239213d6"
+  ]
+}

--- a/packages/github/github.4.3.1/opam
+++ b/packages/github/github.4.3.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 OCaml library"
+description: """
+This library provides an OCaml interface to the
+[GitHub APIv3](https://developer.github.com/v3/) (JSON).
+
+It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
+JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt" {>= "0.99"}
+  "lwt" {>= "2.4.4"}
+  "atdgen" {>= "2.0.0"}
+  "yojson" {>= "1.6.0"}
+  "stringext"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.3.1/github-unix-4.3.1.tbz"
+  checksum: [
+    "sha256=da8f8cc3c5d69d55000b8c9c15cab0f08f36f787fc5e25111451d0e7468593d1"
+    "sha512=5293b7fb1b8e46c801506998b9a1b34e88bd86be38ccd28ac5138b736de5cc233a95b3e7f2da43dd3ccd0aa87b5c25ebc7a0afca81240d99ec5054f9239213d6"
+  ]
+}


### PR DESCRIPTION
GitHub APIv3 JavaScript library

- Project page: <a href="https://github.com/mirage/ocaml-github">https://github.com/mirage/ocaml-github</a>
- Documentation: <a href="https://mirage.github.io/ocaml-github/">https://mirage.github.io/ocaml-github/</a>

##### CHANGES:

- Fix a bug introduced by mirage/ocaml-github#228, by adding a default value when `user_type` is
  not defined (mirage/ocaml-github#232 @Aaylor)
- Do not print errors on `stderr`. (mirage/ocaml-github#234 @emillon)
