### PR TITLE
[new release] ppxlib (0.16.0)

### DIFF
--- a/packages/ppx_string_interpolation/ppx_string_interpolation.1.0.0/opam
+++ b/packages/ppx_string_interpolation/ppx_string_interpolation.1.0.0/opam
@@ -26,5 +26,5 @@ depends: [
   "dune" {>= "1.5"}
   "ocaml" {>= "4.04.1"}
   "ppxlib"
-  "sedlex"
+  "sedlex" {>= "1.99.4"}
 ]

--- a/packages/ppxlib/ppxlib.0.16.0/opam
+++ b/packages/ppxlib/ppxlib.0.16.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.10" }
+]
+depends: [
+  "ocaml"                   {>= "4.04.1"}
+  "dune"                    {>= "1.11"}
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "2.0.0"}
+  "ppx_derivers"            {>= "1.0"}
+  "result"
+  "sexplib0"
+  "stdlib-shims"
+  "ocamlfind"               {with-test}
+  "cinaps"                  {with-test & >= "v0.12.1"}
+  "base"                    {with-test}
+  "stdio"                   {with-test}
+]
+synopsis: "Standard library for ppx rewriters"
+description: """
+Ppxlib is the standard library for ppx rewriters and other programs
+that manipulate the in-memory reprensation of OCaml programs, a.k.a
+the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+x-commit-hash: "9b447ff8abd42ec2800df17815431f335056ffce"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.16.0/ppxlib-0.16.0.tbz"
+  checksum: [
+    "sha256=a2b7b86206b80f17df2cd30fcaf034023b00afbff6704cf6290374db7c6c5ed5"
+    "sha512=67db32012e06591b6fd45b211e1620db3815e6b586214a42cced0fd2e55339360a6f1fa05f4ce5688b994d6179e7d7adbdb08b01085d7c737f0af1d1fa3f7cc9"
+  ]
+}


### PR DESCRIPTION
Standard library for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- `Driver.register_transformation`: add optional parameter `~instrument`
  (ocaml-ppx/ppxlib#161, @pitag-ha)
- Add missing `Location.init` (ocaml-ppx/ppxlib#165, @pitag-ha)
- Upgrade to ocaml-migrate-parsetree.2.0.0 (ocaml-ppx/ppxlib#164, @ceastlund)
