### PR TITLE
Package camlp5 8.00~alpha02

### DIFF
--- a/packages/camlp5/camlp5.8.00~alpha02/opam
+++ b/packages/camlp5/camlp5.8.00~alpha02/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.02" & < "4.12.0"}
+  "conf-perl"
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "world.opt"]
+]
+install: [make "install"]
+depexts:
+  ["libstring-shellquote-perl" "libipc-system-simple-perl"]
+    {os-family = "debian"}
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha02.tar.gz"
+  checksum: [
+    "md5=49b601db7a7b13f43bde8eec5d74bd28"
+    "sha512=2b5ca5bf870c43461675e6049bccf31cedd9b168ddaedb6aeb441a1589ddf87ac867842a7a4c5c8280bb42b9ea41b3b098740a46f3d35a3ff0563566a89a3acd"
+  ]
+}

--- a/packages/pa_ppx/pa_ppx.0.01/opam
+++ b/packages/pa_ppx/pa_ppx.0.01/opam
@@ -35,7 +35,7 @@ doc: "https://github.com/chetmurthy/pa_ppx/doc"
 
 depends: [
   "ocaml"       { >= "4.10.0" & < "4.11.0" }
-  "camlp5"      { >= "8.00~alpha01" }
+  "camlp5"      { = "8.00~alpha01" }
   "not-ocamlfind" { >= "0.01" }
   "pcre" { >= "7.4.3" }
   "yojson" { >= "1.7.0" }


### PR DESCRIPTION
### `camlp5-rel8.00~alpha02`
Preprocessor-pretty-printer of OCaml
Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.

As a preprocessor, it allows to:

extend the syntax of OCaml,
redefine the whole syntax of the language.
As a pretty printer, it allows to:

display OCaml programs in an elegant way,
convert from one syntax to another,
check the results of syntax extensions.
Camlp5 also provides some parsing and pretty printing tools:

extensible grammars
extensible printers
stream parsers and lexers
pretty print module
It works as a shell command and can also be used in the OCaml toplevel.



---
* Homepage: https://camlp5.github.io
* Source repo: git+https://github.com/camlp5/camlp5.git
* Bug tracker: https://github.com/camlp5/camlp5/issues

---
:camel: Pull-request generated by opam-publish v2.0.2