### PR TITLE
[new release] elpi (1.11.4)

### DIFF
--- a/packages/elpi/elpi.1.11.4/opam
+++ b/packages/elpi/elpi.1.11.4/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/LPCIC/elpi/issues"
 build: [
   ["dune" "subst"] {pinned}
   [make "build" "DUNE_OPTS=-p %{name}% -j %{jobs}%"]
-  [make "tests" "DUNE_OPTS=-p %{name}%" "TIMEOUT=120"] {with-test & os != "macos" & os-distribution != "alpine"}
+  [make "tests" "DUNE_OPTS=-p %{name}%" "TIMEOUT=120"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"}
   [make "fix-elpi.install"]
 ]
 


### PR DESCRIPTION
CHANGES:

- do not rely on /bin/bash in Makefile (helps on nix and freebsd)