### PR TITLE
duplicate suse deps for opensuse

### DIFF
--- a/packages/alsa/alsa.0.2.3/opam
+++ b/packages/alsa/alsa.0.2.3/opam
@@ -16,6 +16,7 @@ depexts: [
   ["alsa-lib-devel"] {os-distribution = "centos"}
   ["alsa-lib-devel"] {os-distribution = "fedora"}
   ["alsa-lib-devel"] {os-family = "suse"}
+  ["alsa-lib-devel"] {os-family = "opensuse"}
   ["libasound2-dev"] {os-family = "debian"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-alsa/issues"

--- a/packages/alsa/alsa.0.3.0/opam
+++ b/packages/alsa/alsa.0.3.0/opam
@@ -34,6 +34,7 @@ depexts: [
   ["alsa-lib-devel"] {os-distribution = "centos"}
   ["alsa-lib-devel"] {os-distribution = "fedora"}
   ["alsa-lib-devel"] {os-family = "suse"}
+  ["alsa-lib-devel"] {os-family = "opensuse"}
   ["libasound2-dev"] {os-family = "debian"}
 ]
 available: [os = "linux"]

--- a/packages/ao/ao.0.2.1/opam
+++ b/packages/ao/ao.0.2.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["libao-devel"] {os-distribution = "centos"}
   ["libao-devel"] {os-distribution = "fedora"}
   ["libao-devel"] {os-family = "suse"}
+  ["libao-devel"] {os-family = "opensuse"}
   ["libao"] {os = "macos" & os-distribution = "homebrew"}
   ["libao-dev"] {os-family = "debian"}
   ["libao"] {os = "freebsd"}

--- a/packages/augeas/augeas.0.6/opam
+++ b/packages/augeas/augeas.0.6/opam
@@ -28,6 +28,7 @@ depexts: [
   ["augeas-devel"] {os-distribution = "ol"}
   ["augeas-devel"] {os-distribution = "fedora"}
   ["augeas-devel"] {os-family = "suse"}
+  ["augeas-devel"] {os-family = "opensuse"}
   ["libaugeas-devel"] {os-distribution = "mageia"}
   ["augeas"] {os = "macos" & os-distribution = "homebrew"}
   ["augeas-dev"] {os-distribution = "alpine"}

--- a/packages/conf-aclocal/conf-aclocal.1.0.0/opam
+++ b/packages/conf-aclocal/conf-aclocal.1.0.0/opam
@@ -10,6 +10,7 @@ depexts: [
   ["automake"] {os-distribution = "centos"}
   ["automake"] {os-distribution = "fedora"}
   ["automake"] {os-family = "suse"}
+  ["automake"] {os-family = "opensuse"}
   ["automake"] {os-family = "debian"}
   ["automake"] {os-distribution = "nixos"}
   ["automake"] {os-distribution = "arch"}

--- a/packages/conf-blas/conf-blas.1/opam
+++ b/packages/conf-blas/conf-blas.1/opam
@@ -18,6 +18,7 @@ depexts: [
   ["blas-devel"] {os-distribution = "rhel"}
   ["lapack-dev"] {os-distribution = "alpine"}
   ["blas-devel"] {os-family = "suse"}
+  ["blas-devel"] {os-family = "opensuse"}
   ["blas" "gcc"] {os = "freebsd"}
 ]
 synopsis: "Virtual package for BLAS configuration"

--- a/packages/conf-bluetooth/conf-bluetooth.1/opam
+++ b/packages/conf-bluetooth/conf-bluetooth.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["bluez-libs-devel"] {os-distribution = "fedora"}
   ["bluez-libs-devel"] {os-distribution = "mageia"}
   ["bluez-devel"] {os-family = "suse"}
+  ["bluez-devel"] {os-family = "opensuse"}
   ["bluez-dev"] {os-distribution = "alpine"}
 ]
 synopsis: "Virtual package for Bluetooth library"

--- a/packages/conf-boost/conf-boost.1/opam
+++ b/packages/conf-boost/conf-boost.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["boost-devel"] {os-distribution = "centos"}
   ["boost-devel"] {os-distribution = "rhel"}
   ["boost-devel"] {os-family = "suse"}
+  ["boost-devel"] {os-family = "opensuse"}
   ["boost"] {os-distribution = "arch"}
   ["boost"] {os = "macos" & os-distribution = "homebrew"}
   ["boost-all"] {os = "freebsd"}

--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["cairo" "cairo-devel"] {os-distribution = "centos"}
   ["cairo-devel"] {os-distribution = "fedora"}
   ["cairo-devel"] {os-family = "suse"}
+  ["cairo-devel"] {os-family = "opensuse"}
   ["cairo-dev"] {os-distribution = "alpine"}
   ["graphics/cairo"] {os = "freebsd"}
   ["graphics/cairo"] {os = "openbsd"}

--- a/packages/conf-capnproto/conf-capnproto.0/opam
+++ b/packages/conf-capnproto/conf-capnproto.0/opam
@@ -22,6 +22,7 @@ depexts: [
   ["capnp"] {os-distribution = "homebrew" & os = "macos"}
   ["capnproto"] {os-distribution = "macports" & os = "macos"}
   ["capnproto"] {os-family = "suse"}
+  ["capnproto"] {os-family = "opensuse"}
   ["capnproto"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on captnproto installation"

--- a/packages/conf-clang/conf-clang.1/opam
+++ b/packages/conf-clang/conf-clang.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["clang"] {os-distribution = "centos"}
   ["clang"] {os-distribution = "alpine"}
   ["clang"] {os-family = "suse"}
+  ["clang"] {os-family = "opensuse"}
   ["clang"] {os-distribution = "ol"}
   ["clang"] {os-distribution = "arch"}
 ]

--- a/packages/conf-cmake/conf-cmake.1/opam
+++ b/packages/conf-cmake/conf-cmake.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["cmake"] {os-distribution = "alpine"}
   ["cmake"] {os-distribution = "arch"}
   ["cmake"] {os-family = "suse"}
+  ["cmake"] {os-family = "opensuse"}
   ["cmake"] {os-distribution = "ol"}
   ["dev-util/cmake"] {os-distribution = "gentoo"}
   ["devel/cmake"] {os = "freebsd"}

--- a/packages/conf-cpio/conf-cpio.1/opam
+++ b/packages/conf-cpio/conf-cpio.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["cpio"] {os-distribution = "centos"}
   ["cpio"] {os-distribution = "alpine"}
   ["cpio"] {os-family = "suse"}
+  ["cpio"] {os-family = "opensuse"}
   ["cpio"] {os-distribution = "ol"}
   ["cpio"] {os-distribution = "arch"}
 ]

--- a/packages/conf-emacs/conf-emacs.1/opam
+++ b/packages/conf-emacs/conf-emacs.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["emacs-nox"] {os-distribution = "fedora"}
   ["emacs-nox"] {os-distribution = "alpine"}
   ["emacs-nox"] {os-family = "suse"}
+  ["emacs-nox"] {os-family = "opensuse"}
   ["emacs-nox"] {os-distribution = "ol"}
 ]
 synopsis: "Virtual package to install the Emacs editor"

--- a/packages/conf-fftw3/conf-fftw3.1/opam
+++ b/packages/conf-fftw3/conf-fftw3.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["fftw-devel"] {os-distribution = "rhel"}
   ["libfftw-devel"] {os-distribution = "mageia"}
   ["fftw3-devel"] {os-family = "suse"}
+  ["fftw3-devel"] {os-family = "opensuse"}
   ["math/fftw3"] {os = "freebsd"}
   ["math/fftw3"] {os = "openbsd"}
   ["fftw"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-findutils/conf-findutils.1/opam
+++ b/packages/conf-findutils/conf-findutils.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["findutils"] {os-distribution = "alpine"}
   ["findutils"] {os-distribution = "nixos"}
   ["findutils"] {os-family = "suse"}
+  ["findutils"] {os-family = "opensuse"}
   ["findutils"] {os-distribution = "ol"}
   ["findutils"] {os-distribution = "arch"}
 ]

--- a/packages/conf-freetype/conf-freetype.1/opam
+++ b/packages/conf-freetype/conf-freetype.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["freetype-devel"] {os-distribution = "rhel"}
   ["libfreetype2-devel"] {os-distribution = "mageia"}
   ["freetype2-devel"] {os-family = "suse"}
+  ["freetype2-devel"] {os-family = "opensuse"}
   ["print/freetype2"] {os = "freebsd"}
   ["print/freetype2"] {os = "openbsd"}
   ["freetype"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-g++/conf-g++.1.0/opam
+++ b/packages/conf-g++/conf-g++.1.0/opam
@@ -9,6 +9,7 @@ depexts: [
   ["gcc-c++"] {os-distribution = "centos"}
   ["gcc-c++"] {os-distribution = "fedora"}
   ["gcc-c++"] {os-family = "suse"}
+  ["gcc-c++"] {os-family = "opensuse"}
   ["g++"] {os-family = "debian"}
   ["gcc"] {os-distribution = "nixos"}
   ["gcc"] {os-distribution = "arch"}

--- a/packages/conf-gd/conf-gd.1/opam
+++ b/packages/conf-gd/conf-gd.1/opam
@@ -11,6 +11,7 @@ depexts: [
   ["libgd3-devel"] {os-distribution = "centos"}
   ["libgd3-devel"] {os-distribution = "fedora"}
   ["libgd3-devel"] {os-family = "suse"}
+  ["libgd3-devel"] {os-family = "opensuse"}
   ["libgd-dev"] {os-family = "debian"}
   ["gd"] {os-distribution = "nixos"}
   ["gd"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-gfortran/conf-gfortran.0/opam
+++ b/packages/conf-gfortran/conf-gfortran.0/opam
@@ -15,6 +15,7 @@ depexts: [
   ["gcc-gfortran"] {os-distribution = "mageia"}
   ["gcc-gfortran"] {os-distribution = "rhel"}
   ["gcc-fortran"] {os-family = "suse"}
+  ["gcc-fortran"] {os-family = "opensuse"}
   ["lang/gcc"] {os = "freebsd"}
   ["lang/gcc"] {os = "openbsd"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-git/conf-git.1.0/opam
+++ b/packages/conf-git/conf-git.1.0/opam
@@ -12,6 +12,7 @@ depexts: [
   ["git"] {os-distribution = "centos"}
   ["git"] {os-distribution = "fedora"}
   ["git"] {os-family = "suse"}
+  ["git"] {os-family = "opensuse"}
   ["git"] {os-family = "debian"}
   ["git"] {os-distribution = "nixos"}
   ["git"] {os-distribution = "arch"}

--- a/packages/conf-glfw3/conf-glfw3.1/opam
+++ b/packages/conf-glfw3/conf-glfw3.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["glfw-devel"] {os-distribution = "fedora"}
   ["glfw-dev"] {os-distribution = "alpine"}
   ["libglfw-devel"] {os-family = "suse"}
+  ["libglfw-devel"] {os-family = "opensuse"}
   ["libglfw-devel"] {os-distribution = "mageia"}
   ["glfw"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-glfw3/conf-glfw3.2/opam
+++ b/packages/conf-glfw3/conf-glfw3.2/opam
@@ -17,6 +17,7 @@ depexts: [
   ["glfw-devel" "mesa-libGL-devel"] {os-distribution = "fedora"}
   ["glfw-dev"] {os-distribution = "alpine"}
   ["libglfw-devel" "Mesa-libGL-devel"] {os-family = "suse"}
+  ["libglfw-devel" "Mesa-libGL-devel"] {os-family = "opensuse"}
   ["libglfw-devel" "mesagl-devel"] {os-distribution = "mageia"}
   ["glfw"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-glpk/conf-glpk.1/opam
+++ b/packages/conf-glpk/conf-glpk.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["glpk"] {os-distribution = "centos"}
   ["glpk"] {os-distribution = "rhel"}
   ["glpk"] {os-family = "suse"}
+  ["glpk"] {os-family = "opensuse"}
   ["glpk"] {os-distribution = "arch"}
   ["glpk"] {os-distribution = "homebrew"}
 ]

--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -20,6 +20,7 @@ depexts: [
   ["gmp"] {os = "freebsd"}
   ["gmp-dev"] {os-distribution = "alpine"}
   ["gmp-devel"] {os-family = "suse"}
+  ["gmp-devel"] {os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on a GMP lib system installation"
 description:

--- a/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
+++ b/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
@@ -9,6 +9,7 @@ depexts: [
   ["gnome-icon-theme"] {os = "macos" & os-distribution = "homebrew"}
   ["adwaita-icon-theme"] {os = "macos" & os-distribution = "macports"}
   ["gnome-icon-theme"] {os-family = "suse"}
+  ["gnome-icon-theme"] {os-family = "opensuse"}
   ["gnome-icon-theme"] {os-distribution = "arch"}
   ["gnome-icon-theme"] {os-distribution = "alpine"}
   ["gnome-icon-theme"] {os-distribution = "nixos"}

--- a/packages/conf-gnuplot/conf-gnuplot.0.1/opam
+++ b/packages/conf-gnuplot/conf-gnuplot.0.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["gnuplot"] {os = "macos" & os-distribution = "homebrew"}
   ["gnuplot"] {os-distribution = "alpine"}
   ["gnuplot"] {os-family = "suse"}
+  ["gnuplot"] {os-family = "opensuse"}
   ["gnuplot"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on gnuplot installation"

--- a/packages/conf-gobject-introspection/conf-gobject-introspection.1.0/opam
+++ b/packages/conf-gobject-introspection/conf-gobject-introspection.1.0/opam
@@ -12,6 +12,7 @@ depexts: [
   ["gobject-introspection-devel"] {os-distribution = "centos"}
   ["gobject-introspection-dev"] {os-distribution = "alpine"}
   ["gobject-introspection-devel"] {os-family = "suse"}
+  ["gobject-introspection-devel"] {os-family = "opensuse"}
   ["gobject-introspection"] {os = "macos" & os-distribution = "homebrew"}
   ["gobject-introspection"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/conf-gsl/conf-gsl.1/opam
+++ b/packages/conf-gsl/conf-gsl.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["gsl-devel"] {os-distribution = "rhel"}
   ["gsl-dev"] {os-distribution = "alpine"}
   ["gsl-devel"] {os-family = "suse"}
+  ["gsl-devel"] {os-family = "opensuse"}
   ["gsl"] {os = "freebsd"}
   ["gsl"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-gsl/conf-gsl.2/opam
+++ b/packages/conf-gsl/conf-gsl.2/opam
@@ -12,6 +12,7 @@ depexts: [
   ["gsl-devel"] {os-distribution = "rhel"}
   ["gsl-dev"] {os-distribution = "alpine"}
   ["gsl-devel"] {os-family = "suse"}
+  ["gsl-devel"] {os-family = "opensuse"}
   ["gsl"] {os = "freebsd"}
   ["gsl"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -14,6 +14,7 @@ depexts: [
   ["gtk3-devel"] {os-distribution = "ol"}
   ["gtk+3.0-dev"] {os-distribution = "alpine"}
   ["gtk3-devel"] {os-family = "suse"}
+  ["gtk3-devel"] {os-family = "opensuse"}
 ]
 post-messages: [
   "This package requires gtk+ 3.0 development packages installed on your system"

--- a/packages/conf-gtksourceview/conf-gtksourceview.2/opam
+++ b/packages/conf-gtksourceview/conf-gtksourceview.2/opam
@@ -15,6 +15,7 @@ depexts: [
   ["gtksourceview2"] {os = "freebsd"}
   ["gtksourceview"] {os = "openbsd"}
   ["gtksourceview2-devel"] {os-family = "suse"}
+  ["gtksourceview2-devel"] {os-family = "opensuse"}
   ["gtksourceview" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
   ["gnome2.gtksourceview" "gtk2"] {os-distribution = "nixos"}
 ]

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+1/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["gtksourceview3"] {os = "freebsd"}
   ["gtksourceview3"] {os = "openbsd"}
   ["gtksourceview-devel"] {os-family = "suse"}
+  ["gtksourceview-devel"] {os-family = "opensuse"}
   ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a GtkSourceView-3 system installation"

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
@@ -15,6 +15,7 @@ depexts: [
   ["gtksourceview3"] {os = "freebsd"}
   ["gtksourceview3"] {os = "openbsd"}
   ["gtksourceview-devel"] {os-family = "suse"}
+  ["gtksourceview-devel"] {os-family = "opensuse"}
   ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
   ["gtksourceview3 +quartz" "libxml2"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
@@ -15,6 +15,7 @@ depexts: [
   ["gtksourceview3"] {os = "freebsd"}
   ["gtksourceview3"] {os = "openbsd"}
   ["gtksourceview3-devel"] {os-family = "suse"}
+  ["gtksourceview3-devel"] {os-family = "opensuse"}
   ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a GtkSourceView-3 system installation"

--- a/packages/conf-haveged/conf-haveged.1.0.0/opam
+++ b/packages/conf-haveged/conf-haveged.1.0.0/opam
@@ -14,6 +14,7 @@ depexts: [
   ["haveged"] {os-distribution = "arch"}
   ["haveged"] {os-distribution = "gentoo"}
   ["haveged"] {os-family = "suse"}
+  ["haveged"] {os-family = "opensuse"}
 ]
 synopsis: "Check if havaged is installed on the system"
 description: """

--- a/packages/conf-hidapi/conf-hidapi.0/opam
+++ b/packages/conf-hidapi/conf-hidapi.0/opam
@@ -12,6 +12,7 @@ depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libhidapi-dev"] {os-family = "debian"}
   ["libhidapi-devel"] {os-family = "suse"}
+  ["libhidapi-devel"] {os-family = "opensuse"}
   ["hidapi"] {os-distribution = "arch"}
   ["hidapi-devel"] {os-distribution = "fedora"}
   ["hidapi"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-jq/conf-jq.1/opam
+++ b/packages/conf-jq/conf-jq.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["jq"] {os-distribution = "centos"}
   ["jq"] {os-distribution = "alpine"}
   ["jq"] {os-family = "suse"}
+  ["jq"] {os-family = "opensuse"}
   ["jq"] {os-distribution = "ol"}
   ["jq"] {os-distribution = "arch"}
   ["jq"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-lapack/conf-lapack.1/opam
+++ b/packages/conf-lapack/conf-lapack.1/opam
@@ -18,6 +18,7 @@ depexts: [
   ["lapack-devel"] {os-distribution = "rhel"}
   ["lapack-dev"] {os-distribution = "alpine"}
   ["lapack-devel"] {os-family = "suse"}
+  ["lapack-devel"] {os-family = "opensuse"}
   ["lapack" "gcc"] {os = "freebsd"}
 ]
 synopsis: "Virtual package for LAPACK configuration"

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -17,6 +17,7 @@ depexts: [
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
     {os-distribution = "fedora"}
   ["llvm-clang-devel"] {os-family = "suse"}
+  ["llvm-clang-devel"] {os-family = "opensuse"}
 #  ["devel/clang" "devel/llvm"] {os = "freebsd"}
   ["sys-devel/clang"] {os-distribution = "gentoo"}
 ]

--- a/packages/conf-libclang/conf-libclang.10/opam
+++ b/packages/conf-libclang/conf-libclang.10/opam
@@ -17,6 +17,7 @@ depexts: [
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
     {os-distribution = "fedora"}
   ["llvm-clang-devel"] {os-family = "suse"}
+  ["llvm-clang-devel"] {os-family = "opensuse"}
   ["devel/llvm10"] {os = "freebsd"}
   ["sys-devel/clang"] {os-distribution = "gentoo"}
 ]

--- a/packages/conf-libcurl/conf-libcurl.1/opam
+++ b/packages/conf-libcurl/conf-libcurl.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["curl"] {os-distribution = "arch"}
   ["curl-dev"] {os-distribution = "alpine"}
   ["libcurl-devel"] {os-family = "suse"}
+  ["libcurl-devel"] {os-family = "opensuse"}
   ["libcurl-devel"] {os-distribution = "fedora"}
 ]
 synopsis: "Virtual package relying on a libcurl system installation"

--- a/packages/conf-libev/conf-libev.4-11/opam
+++ b/packages/conf-libev/conf-libev.4-11/opam
@@ -12,6 +12,7 @@ depexts: [
   ["libev-devel"] {os-distribution = "rhel"}
   ["libev-devel"] {os-distribution = "centos"}
   ["libev-devel"] {os-family = "suse"}
+  ["libev-devel"] {os-family = "opensuse"}
   ["libev"] {os = "freebsd"}
   ["libev"] {os = "openbsd"}
   ["libev"] {os-distribution = "arch"}

--- a/packages/conf-libffi/conf-libffi.2.0.0/opam
+++ b/packages/conf-libffi/conf-libffi.2.0.0/opam
@@ -14,6 +14,7 @@ depexts: [
   ["libffi-devel"] {os-distribution = "mageia"}
   ["libffi-devel"] {os-distribution = "ol"}
   ["libffi-devel"] {os-family = "suse"}
+  ["libffi-devel"] {os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on libffi system installation"
 description: "This package can only install if libffi is installed on the system."

--- a/packages/conf-liblz4/conf-liblz4.1/opam
+++ b/packages/conf-liblz4/conf-liblz4.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["lz4-devel"] {os-distribution = "fedora"}
   ["lz4-dev"] {os-distribution = "alpine"}
   ["liblz4-devel"] {os-family = "suse"}
+  ["liblz4-devel"] {os-family = "opensuse"}
   ["lz4"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on liblz4 system installation"

--- a/packages/conf-libmagic/conf-libmagic.1/opam
+++ b/packages/conf-libmagic/conf-libmagic.1/opam
@@ -8,6 +8,7 @@ depexts: [
   ["file-devel"] {os-distribution = "centos"}
   ["file-devel"] {os-distribution = "fedora"}
   ["file-devel"] {os-family = "suse"}
+  ["file-devel"] {os-family = "opensuse"}
   ["libmagic-dev"] {os-family = "debian"}
   ["libmagic"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-libmaxminddb/conf-libmaxminddb.1/opam
+++ b/packages/conf-libmaxminddb/conf-libmaxminddb.1/opam
@@ -17,6 +17,7 @@ depexts: [
   ["libmaxminddb-dev"] {os-distribution = "alpine"}
   ["libmaxminddb-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "mageia"}
   ["libmaxminddb-devel"] {os-family = "suse"}
+  ["libmaxminddb-devel"] {os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on a libmaxminddb system installation"
 description:

--- a/packages/conf-libpcre/conf-libpcre.1/opam
+++ b/packages/conf-libpcre/conf-libpcre.1/opam
@@ -18,6 +18,7 @@ depexts: [
   ["pcre-devel"] {os-distribution = "rhel"}
   ["pcre-dev"] {os-distribution = "alpine"}
   ["pcre-devel"] {os-family = "suse"}
+  ["pcre-devel"] {os-family = "opensuse"}
   ["pcre"] {os = "freebsd"}
   ["pcre"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-libseccomp/conf-libseccomp.1/opam
+++ b/packages/conf-libseccomp/conf-libseccomp.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["libseccomp-devel"] {os-distribution = "rhel"}
   ["libseccomp-devel"] {os-distribution = "centos"}
   ["libseccomp-devel"] {os-family = "suse"}
+  ["libseccomp-devel"] {os-family = "opensuse"}
   ["libseccomp"] {os-distribution = "arch"}
   ["libseccomp"] {os-distribution = "nixos"}
 ]

--- a/packages/conf-libssl/conf-libssl.1/opam
+++ b/packages/conf-libssl/conf-libssl.1/opam
@@ -21,6 +21,7 @@ depexts: [
   ["openssl"] {os-distribution = "nixos"}
   ["openssl"] {os-distribution = "arch"}
   ["libopenssl-devel"] {os-family = "suse"}
+  ["libopenssl-devel"] {os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on an OpenSSL library system installation"
 description:

--- a/packages/conf-libssl/conf-libssl.2/opam
+++ b/packages/conf-libssl/conf-libssl.2/opam
@@ -22,6 +22,7 @@ depexts: [
   ["openssl"] {os-distribution = "nixos"}
   ["openssl"] {os-distribution = "arch"}
   ["libopenssl-devel"] {os-family = "suse"}
+  ["libopenssl-devel"] {os-family = "opensuse"}
 ]
 post-messages: [
   "Make sure libssl/openssl is installed and accessible using pkg-config." {failure}

--- a/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
+++ b/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
@@ -8,6 +8,7 @@ build: [["ls" "/usr/include/linux/stddef.h"]]
 depexts: [
   ["linux-libc-dev"] {os-family = "debian"}
   ["linux-glibc-devel"] {os-family = "suse"}
+  ["linux-glibc-devel"] {os-family = "opensuse"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["kernel-headers"] {os-distribution = "centos"}
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/conf-llvm/conf-llvm.10.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.10.0.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["llvm-10-dev"] {os-family = "debian"}
   ["llvm10-dev"] {os-distribution = "alpine"}
   ["llvm10-devel"] {os-family = "suse"}
+  ["llvm10-devel"] {os-family = "opensuse"}
   ["devel/llvm10"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"

--- a/packages/conf-llvm/conf-llvm.4.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.4.0.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["llvm-4.0-dev"] {os-family = "debian"}
   ["llvm4-dev"] {os-distribution = "alpine"}
   ["llvm4"] {os-family = "suse"}
+  ["llvm4"] {os-family = "opensuse"}
   ["devel/llvm40"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"

--- a/packages/conf-llvm/conf-llvm.5.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.5.0.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["llvm-5.0-dev"] {os-family = "debian"}
   ["llvm5-dev"] {os-distribution = "alpine"}
   ["llvm5-devel"] {os-family = "suse"}
+  ["llvm5-devel"] {os-family = "opensuse"}
   ["devel/llvm50"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"

--- a/packages/conf-llvm/conf-llvm.6.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.6.0.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["llvm-6.0-dev"] {os-family = "debian"}
   ["llvm6-dev"] {os-distribution = "alpine"}
   ["llvm6-devel"] {os-family = "suse"}
+  ["llvm6-devel"] {os-family = "opensuse"}
   ["devel/llvm60"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"

--- a/packages/conf-llvm/conf-llvm.7.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.7.0.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["llvm-7-dev"] {os-family = "debian"}
   ["llvm7-dev"] {os-distribution = "alpine"}
   ["llvm7-devel"] {os-family = "suse"}
+  ["llvm7-devel"] {os-family = "opensuse"}
   ["devel/llvm70"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"

--- a/packages/conf-llvm/conf-llvm.8.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.8.0.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["llvm-8-dev"] {os-family = "debian"}
   ["llvm8-dev"] {os-distribution = "alpine"}
   ["llvm8-devel"] {os-family = "suse"}
+  ["llvm8-devel"] {os-family = "opensuse"}
   ["devel/llvm80"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"

--- a/packages/conf-llvm/conf-llvm.9.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.9.0.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["llvm-9-dev"] {os-family = "debian"}
   ["llvm9-dev"] {os-distribution = "alpine"}
   ["llvm9-devel"] {os-family = "suse"}
+  ["llvm9-devel"] {os-family = "opensuse"}
   ["devel/llvm90"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"

--- a/packages/conf-lz4/conf-lz4.1.0.0/opam
+++ b/packages/conf-lz4/conf-lz4.1.0.0/opam
@@ -12,6 +12,7 @@ depexts: [
   ["lz4"] {os-distribution = "fedora"}
   ["lz4"] {os-distribution = "alpine"}
   ["lz4"] {os-family = "suse"}
+  ["lz4"] {os-family = "opensuse"}
   ["lz4"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package requiring the lz4 command to be available"

--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["m4"] {os-distribution = "alpine"}
   ["m4"] {os-distribution = "nixos"}
   ["m4"] {os-family = "suse"}
+  ["m4"] {os-family = "opensuse"}
   ["m4"] {os-distribution = "ol"}
   ["m4"] {os-distribution = "arch"}
 ]

--- a/packages/conf-mbedtls/conf-mbedtls.1/opam
+++ b/packages/conf-mbedtls/conf-mbedtls.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["libmbedtls-dev"] {os-family = "debian"}
   ["mbedtls-devel"] {os-distribution = "fedora"}
   ["mbedtls-devel"] {os-family = "suse"}
+  ["mbedtls-devel"] {os-family = "opensuse"}
   ["mbedtls-devel" "epel-release"] {os-distribution = "centos"}
   ["mbedtls"] {os-distribution = "nixos"}
   ["mbedtls"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/conf-mpfr/conf-mpfr.1/opam
+++ b/packages/conf-mpfr/conf-mpfr.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["mpfr-dev"] {os-distribution = "alpine"}
   ["mpfr-devel"] {os-distribution = "centos"}
   ["mpfr-devel"] {os-family = "suse"}
+  ["mpfr-devel"] {os-family = "opensuse"}
 ]
 depends: ["conf-gmp"]
 synopsis: "Virtual package relying on library MPFR installation"

--- a/packages/conf-mpfr/conf-mpfr.2/opam
+++ b/packages/conf-mpfr/conf-mpfr.2/opam
@@ -18,6 +18,7 @@ depexts: [
   ["mpfr-dev"] {os-distribution = "alpine"}
   ["mpfr-devel"] {os-distribution = "centos"}
   ["mpfr-devel"] {os-family = "suse"}
+  ["mpfr-devel"] {os-family = "opensuse"}
 ]
 depends: ["conf-gmp"]
 synopsis: "Virtual package relying on library MPFR installation"

--- a/packages/conf-mpi/conf-mpi.1/opam
+++ b/packages/conf-mpi/conf-mpi.1/opam
@@ -10,6 +10,7 @@ depexts: [
   ["openmpi-devel"] {os-distribution = "centos"}
   ["openmpi-devel"] {os-distribution = "fedora"}
   ["openmpi"] {os-family = "suse"}
+  ["openmpi"] {os-family = "opensuse"}
   ["openmpi"] {os-distribution = "arch"}
   ["openmpi-dev"] {os-distribution = "alpine"}
   ["openmpi"] {os = "freebsd"}

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["ncurses-devel"] {os-distribution = "centos"}
   ["ncurses-devel"] {os-distribution = "rhel"}
   ["ncurses-devel"] {os-family = "suse"}
+  ["ncurses-devel"] {os-family = "opensuse"}
   ["ncurses"] {os-distribution = "arch"}
 ]
 synopsis: "Virtual package relying on ncurses"

--- a/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
+++ b/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
@@ -10,6 +10,7 @@ depexts: [
   ["net-snmp-libs" "net-snmp-devel"] {os-distribution = "centos"}
   ["net-snmp-libs" "net-snmp-devel"] {os-distribution = "fedora"}
   ["libsnmp30" "net-snmp-devel"] {os-family = "suse"}
+  ["libsnmp30" "net-snmp-devel"] {os-family = "opensuse"}
   ["net-snmp-libs" "net-snmp-dev"] {os-distribution = "alpine"}
   [] {os = "freebsd"}
   [] {os = "openbsd"}

--- a/packages/conf-npm/conf-npm.1/opam
+++ b/packages/conf-npm/conf-npm.1/opam
@@ -20,6 +20,7 @@ depexts: [
   ["nodejs"] {os = "netbsd"}
   ["node"] {os = "openbsd"}
   ["npm"] {os-family = "suse"}
+  ["npm"] {os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on npm installation"
 flags: conf

--- a/packages/conf-numa/conf-numa.0.1.0/opam
+++ b/packages/conf-numa/conf-numa.0.1.0/opam
@@ -10,6 +10,7 @@ depexts: [
   ["numactl-libs" "numactl-devel"] {os-distribution = "centos"}
   ["numactl-libs" "numactl-devel"] {os-distribution = "fedora"}
   ["libnuma-devel"] {os-family = "suse"}
+  ["libnuma-devel"] {os-family = "opensuse"}
   ["libnuma-dev"] {os-distribution = "alpine"}
 ]
 available: os != "macos" & os != "freebsd" & os != "openbsd"

--- a/packages/conf-openblas/conf-openblas.0.2.0/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.0/opam
@@ -7,6 +7,7 @@ license: "BSD-3-Clause"
 build: [
   ["sh" "-exc" "cc $CFLAGS -I/usr/include/openblas test.c -lopenblas"]
     {os-distribution = "fedora" | os-distribution = "centos" | os-family = "suse"}
+    {os-distribution = "fedora" | os-distribution = "centos" | os-family = "opensuse"}
   [
     "sh"
     "-exc"
@@ -23,6 +24,7 @@ depexts: [
   ["libopenblas-dev" "liblapacke-dev"] {os-family = "debian"}
   ["openblas-devel"] {os-distribution = "fedora"}
   ["openblas-devel"] {os-family = "suse"}
+  ["openblas-devel"] {os-family = "opensuse"}
   ["openblas" "lapacke" "cblas"] {os-distribution = "arch"}
   ["openblas"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-opencc0/conf-opencc0.1/opam
+++ b/packages/conf-opencc0/conf-opencc0.1/opam
@@ -16,6 +16,7 @@ build: [
 depexts: [
   ["libopencc1"] {os-family = "debian"}
   ["libopencc1"] {os-family = "suse"}
+  ["libopencc1"] {os-family = "opensuse"}
 ]
 post-messages: [
   "If the libopencc0 library is not installed by the system package manager, make sure that the path of the directory containing libopencc.so.1 is included in env-var LD_LIBRARY_PATH(for ld) and LIBRARY_PATH(for cc)" {failure}

--- a/packages/conf-opencc1/conf-opencc1.1/opam
+++ b/packages/conf-opencc1/conf-opencc1.1/opam
@@ -16,6 +16,7 @@ build: [
 depexts: [
   ["libopencc2"] {os-family = "debian"}
   ["libopencc2"] {os-family = "suse"}
+  ["libopencc2"] {os-family = "opensuse"}
   ["opencc"] {os-distribution = "arch"}
   ["app-i18n/opencc"] {os-distribution = "gentoo"}
   ["opencc"] {os-distribution = "fedora"}

--- a/packages/conf-openssl/conf-openssl.2/opam
+++ b/packages/conf-openssl/conf-openssl.2/opam
@@ -16,6 +16,7 @@ depexts: [
   ["openssl"] {os-distribution = "nixos"}
   ["openssl"] {os-distribution = "arch"}
   ["openssl"] {os-family = "suse"}
+  ["openssl"] {os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on an OpenSSL binary system installation"
 description:

--- a/packages/conf-pandoc/conf-pandoc.0.1/opam
+++ b/packages/conf-pandoc/conf-pandoc.0.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["pandoc"] {os-distribution = "fedora"}
   ["pandoc"] {os = "macos" & os-distribution = "homebrew"}
   ["pandoc"] {os-family = "suse"}
+  ["pandoc"] {os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on pandoc installation"
 description: """

--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-devel"] {os-family = "suse"}
+  ["postgresql-devel"] {os-family = "opensuse"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-protoc/conf-protoc.0.9/opam
+++ b/packages/conf-protoc/conf-protoc.0.9/opam
@@ -16,6 +16,7 @@ depexts: [
   ["protobuf"]          {os-distribution = "alpine"}
   ["protobuf"]          {os-distribution = "arch"}
   ["protobuf-devel"]    {os-family = "suse"}
+  ["protobuf-devel"]    {os-family = "opensuse"}
   ["protobuf"]          {os = "freebsd"}
   ["protobuf"]          {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-protoc/conf-protoc.1.0.0/opam
+++ b/packages/conf-protoc/conf-protoc.1.0.0/opam
@@ -16,6 +16,7 @@ depexts: [
   ["protobuf" "protobuf-dev"]               {os-distribution = "alpine"}
   ["protobuf"]                              {os-distribution = "arch"}
   ["protobuf-devel"]                        {os-family = "suse"}
+  ["protobuf-devel"]                        {os-family = "opensuse"}
   ["protobuf"]                              {os = "freebsd"}
   ["protobuf"]                              {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-python-2-7/conf-python-2-7.1.0/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["python2"] {os-distribution = "fedora"}
   ["python2"] {os-distribution = "arch"}
   ["python"] {os-family = "suse"}
+  ["python"] {os-family = "opensuse"}
   ["dev-lang/python:2.7"] {os-distribution = "gentoo"}
   ["python/2.7"] {os = "openbsd"}
   ["lang/python27"] {os = "netbsd"}

--- a/packages/conf-python-2-7/conf-python-2-7.1.1/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["python2"] {os-distribution = "fedora"}
   ["python2"] {os-distribution = "arch"}
   ["python"] {os-family = "suse"}
+  ["python"] {os-family = "opensuse"}
   ["dev-lang/python:2.7"] {os-distribution = "gentoo"}
   ["python/2.7"] {os = "openbsd"}
   ["lang/python27"] {os = "netbsd"}

--- a/packages/conf-python-3-dev/conf-python-3-dev.1/opam
+++ b/packages/conf-python-3-dev/conf-python-3-dev.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["python3-devel"] {os-distribution = "fedora"}
   ["python3-devel" "epel-release"] {os-distribution = "centos"}
   ["python3-devel"] {os-family = "suse"}
+  ["python3-devel"] {os-family = "opensuse"}
   ["python3-dev"] {os-distribution = "alpine"}
   ["python3"] {os = "macos" & os-distribution = "homebrew"}
   ["python38"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-python-3/conf-python-3.1.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.1.0.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["python3"] {os-distribution = "fedora"}
   ["python3"] {os-distribution = "arch"}
   ["python3"] {os-family = "suse"}
+  ["python3"] {os-family = "opensuse"}
   ["dev-lang/python:3.6"] {os-distribution = "gentoo"}
   ["python3"] {os = "openbsd"}
   ["lang/python36"] {os = "netbsd"}

--- a/packages/conf-qt/conf-qt.5.2.1/opam
+++ b/packages/conf-qt/conf-qt.5.2.1/opam
@@ -39,6 +39,7 @@ depexts: [
   ["qt-devel" "qt5-qtbase-devel" "qt5-qtdeclarative-devel"] {os-distribution = "centos"}
   ["qtchooser" "qt5-qtbase-devel" "qt5-qtdeclarative-devel"] {os-distribution = "fedora"}
   ["libqt5-qtbase-common-devel" "libqt5-qtbase-devel" "libqt5-qtdeclarative-devel" ] {os-family = "suse" }
+  ["libqt5-qtbase-common-devel" "libqt5-qtbase-devel" "libqt5-qtdeclarative-devel" ] {os-family = "opensuse" }
 ]
 synopsis: "Installation of Qt5 using APT packages or from source"
 flags: conf

--- a/packages/conf-r-mathlib/conf-r-mathlib.1/opam
+++ b/packages/conf-r-mathlib/conf-r-mathlib.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["libRmath-devel"] {os-distribution = "rhel"}
   ["R-mathlib"] {os-distribution = "alpine"}
   ["R-base"] {os-family = "suse"}
+  ["R-base"] {os-family = "opensuse"}
   ["libRmath"] {os = "freebsd"}
   ["r"] {os = "macos" & os-distribution = "homebrew"}
   ["r"] {os-distribution = "arch"}

--- a/packages/conf-r/conf-r.1.0.0/opam
+++ b/packages/conf-r/conf-r.1.0.0/opam
@@ -10,6 +10,7 @@ depexts: [
   ["r"] {os-distribution = "arch"}
   ["r-base-core"] {os-family = "debian"}
   ["R-core"] {os-family = "suse"}
+  ["R-core"] {os-family = "opensuse"}
   ["R"] {os-distribution = "alpine"}
   ["epel-release" "R"] {os-distribution = "centos"}
   ["R"] {os-distribution = "fedora"}

--- a/packages/conf-ruby/conf-ruby.1.0.0/opam
+++ b/packages/conf-ruby/conf-ruby.1.0.0/opam
@@ -19,6 +19,7 @@ depexts: [
   ["ruby"] {os-distribution = "nixos"}
   ["ruby"] {os = "openbsd"}
   ["ruby"] {os-family = "suse"}
+  ["ruby"] {os-family = "opensuse"}
   ["ruby"] {os-distribution = "ol"}
 ]
 synopsis: "Virtual package relying on Ruby"

--- a/packages/conf-rust-2018/conf-rust-2018.1/opam
+++ b/packages/conf-rust-2018/conf-rust-2018.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["cargo"] {os-distribution = "centos"}
   ["cargo"] {os-distribution = "fedora"}
   ["cargo"] {os-family = "suse"}
+  ["cargo"] {os-family = "opensuse"}
   ["cargo"] {os-family = "debian"}
   ["cargo"] {os-distribution = "nixos"}
   ["cargo"] {os-distribution = "alpine"}

--- a/packages/conf-rust/conf-rust.0.1/opam
+++ b/packages/conf-rust/conf-rust.0.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["cargo"] {os-distribution = "centos"}
   ["cargo"] {os-distribution = "fedora"}
   ["cargo"] {os-family = "suse"}
+  ["cargo"] {os-family = "opensuse"}
   ["cargo"] {os-family = "debian"}
   ["cargo"] {os-distribution = "nixos"}
   ["cargo"] {os-distribution = "alpine"}

--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["libsdl2-devel"] {os-distribution = "mageia"}
   ["sdl2"] {os = "openbsd"}
   ["sdl2"] {os-family = "suse"}
+  ["sdl2"] {os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on a SDL2 system installation"
 description:

--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -21,6 +21,7 @@ depexts: [
   ["sqlite-devel"] {os-distribution = "fedora"}
   ["sqlite-dev"] {os-distribution = "alpine"}
   ["sqlite3-devel"] {os-family = "suse"}
+  ["sqlite3-devel"] {os-family = "opensuse"}
   ["sqlite"] {os-distribution = "nixos"}
   ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
   ["sqlite3"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-tcl/conf-tcl.1/opam
+++ b/packages/conf-tcl/conf-tcl.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["tcl-devel"] {os-family = "rhel"}
   ["tcl-devel"] {os-family = "fedora"}
   ["tcl-devel"] {os-family = "suse"}
+  ["tcl-devel"] {os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on tcl"
 description:

--- a/packages/conf-texlive/conf-texlive.1/opam
+++ b/packages/conf-texlive/conf-texlive.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["texlive-latex"] {os-distribution = "centos"}
   ["texlive"] {os-distribution = "alpine"}
   ["texlive-latex-bin-bin"] {os-family = "suse"}
+  ["texlive-latex-bin-bin"] {os-family = "opensuse"}
   ["texlive-bin"] {os-distribution = "arch"}
   ["tex-formats"] {os-distribution = "freebsd"}
   ["basictex"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["tk-devel"] {os-family = "rhel"}
   ["tk-devel"] {os-family = "fedora"}
   ["tk-devel"] {os-family = "suse"}
+  ["tk-devel"] {os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on tk"
 description:

--- a/packages/conf-which/conf-which.1/opam
+++ b/packages/conf-which/conf-which.1/opam
@@ -9,6 +9,7 @@ depexts: [
   ["which"] {os-distribution = "centos"}
   ["which"] {os-distribution = "fedora"}
   ["which"] {os-family = "suse"}
+  ["which"] {os-family = "opensuse"}
   ["debianutils"] {os-family = "debian"}
   ["which"] {os-distribution = "nixos"}
   ["which"] {os-distribution = "arch"}

--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["zeromq"] {os-distribution = "arch"}
   ["zeromq-devel"] {os-distribution = "fedora"}
   ["zeromq-devel"] {os-family = "suse"}
+  ["zeromq-devel"] {os-family = "opensuse"}
   ["libzmq4"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on zmq library installation"

--- a/packages/ctypes-foreign/ctypes-foreign.0.4.0/opam
+++ b/packages/ctypes-foreign/ctypes-foreign.0.4.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["libffi-devel"] {os-distribution = "fedora"}
   ["libffi-dev"] {os-distribution = "alpine"}
   ["libffi-devel"] {os-family = "suse"}
+  ["libffi-devel"] {os-family = "opensuse"}
 ]
 tags: ["org:ocamllabs" "org:mirage"]
 post-messages: [

--- a/packages/ctypes/ctypes.0.1.1/opam
+++ b/packages/ctypes/ctypes.0.1.1/opam
@@ -24,6 +24,7 @@ depexts: [
   ["libffi-devel"] {os-distribution = "fedora"}
   ["libffi-dev"] {os-distribution = "alpine"}
   ["libffi-devel"] {os-family = "suse"}
+  ["libffi-devel"] {os-family = "opensuse"}
 ]
 dev-repo: "git://github.com/ocamllabs/ocaml-ctypes"
 install: [make "install"]

--- a/packages/ctypes/ctypes.0.2.3/opam
+++ b/packages/ctypes/ctypes.0.2.3/opam
@@ -20,6 +20,7 @@ depexts: [
   ["libffi-devel"] {os-distribution = "fedora"}
   ["libffi-dev"] {os-distribution = "alpine"}
   ["libffi-devel"] {os-family = "suse"}
+  ["libffi-devel"] {os-family = "opensuse"}
 ]
 tags: ["org:ocamllabs" "org:mirage"]
 dev-repo: "git://github.com/ocamllabs/ocaml-ctypes"

--- a/packages/ctypes/ctypes.0.3.4/opam
+++ b/packages/ctypes/ctypes.0.3.4/opam
@@ -21,6 +21,7 @@ depexts: [
   ["libffi-devel"] {os-distribution = "fedora"}
   ["libffi-dev"] {os-distribution = "alpine"}
   ["libffi-devel"] {os-family = "suse"}
+  ["libffi-devel"] {os-family = "opensuse"}
 ]
 tags: ["org:ocamllabs" "org:mirage"]
 patches: [ "build_with_trunk.patch" ]

--- a/packages/dlm/dlm.0.3.0/opam
+++ b/packages/dlm/dlm.0.3.0/opam
@@ -27,6 +27,7 @@ depexts: [
   ["dlm-devel"] {os-distribution = "ol"}
   ["dlm-git"] {os-distribution = "arch"}
   ["libdlm-devel"] {os-family = "suse"}
+  ["libdlm-devel"] {os-family = "opensuse"}
 ]
 available: [ os = "linux" & os != "alpine" ]
 synopsis: "Libdlm bindings"

--- a/packages/dssi/dssi.0.1.2/opam
+++ b/packages/dssi/dssi.0.1.2/opam
@@ -16,6 +16,7 @@ depexts: [
   ["dssi-devel"] {os-distribution = "centos"}
   ["dssi-devel"] {os-distribution = "fedora"}
   ["dssi-devel"] {os-family = "suse"}
+  ["dssi-devel"] {os-family = "opensuse"}
   ["dssi"] {os-distribution = "nixos"}
   ["dssi"] {os-distribution = "arch"}
 ]

--- a/packages/faad/faad.0.4.0/opam
+++ b/packages/faad/faad.0.4.0/opam
@@ -29,6 +29,7 @@ depexts: [
   ["faad2-devel"] {os-distribution = "centos"}
   ["faad2-devel"] {os-distribution = "fedora"}
   ["faad2-devel"] {os-family = "suse"}
+  ["faad2-devel"] {os-family = "opensuse"}
   ["libfaad-dev"] {os-family = "debian"}
   ["faad2"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/fdkaac/fdkaac.0.2.1/opam
+++ b/packages/fdkaac/fdkaac.0.2.1/opam
@@ -23,6 +23,7 @@ depexts: [
   ["fdk-aac-devel"] {os-distribution = "centos"}
   ["fdk-aac-devel"] {os-distribution = "fedora"}
   ["fdk-aac-devel"] {os-family = "suse"}
+  ["fdk-aac-devel"] {os-family = "opensuse"}
   ["libfdk-aac-dev"] {os-family = "debian"}
   ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/fdkaac/fdkaac.0.3.0/opam
+++ b/packages/fdkaac/fdkaac.0.3.0/opam
@@ -26,6 +26,7 @@ depexts: [
   ["fdk-aac-devel"] {os-distribution = "centos"}
   ["fdk-aac-devel"] {os-distribution = "fedora"}
   ["fdk-aac-devel"] {os-family = "suse"}
+  ["fdk-aac-devel"] {os-family = "opensuse"}
   ["libfdk-aac-dev"] {os-family = "debian"}
   ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/fdkaac/fdkaac.0.3.1/opam
+++ b/packages/fdkaac/fdkaac.0.3.1/opam
@@ -27,6 +27,7 @@ depexts: [
   ["fdk-aac-devel"] {os-distribution = "centos"}
   ["fdk-aac-devel"] {os-distribution = "fedora"}
   ["fdk-aac-devel"] {os-family = "suse"}
+  ["fdk-aac-devel"] {os-family = "opensuse"}
   ["libfdk-aac-dev"] {os-family = "debian"}
   ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/fdkaac/fdkaac.0.3.2/opam
+++ b/packages/fdkaac/fdkaac.0.3.2/opam
@@ -32,6 +32,7 @@ depexts: [
   ["fdk-aac-devel"] {os-distribution = "centos"}
   ["fdk-aac-devel"] {os-distribution = "fedora"}
   ["fdk-aac-devel"] {os-family = "suse"}
+  ["fdk-aac-devel"] {os-family = "opensuse"}
   ["libfdk-aac-dev"] {os-family = "debian"}
   ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ffmpeg/ffmpeg.0.1.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.1/opam
@@ -23,6 +23,7 @@ depexts: [
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse"}
+  ["ffmpeg-devel"] {os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ffmpeg/ffmpeg.0.1.2/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.2/opam
@@ -22,6 +22,7 @@ depexts: [
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse"}
+  ["ffmpeg-devel"] {os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ffmpeg/ffmpeg.0.2.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.0/opam
@@ -24,6 +24,7 @@ depexts: [
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse"}
+  ["ffmpeg-devel"] {os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ffmpeg/ffmpeg.0.2.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.1/opam
@@ -31,6 +31,7 @@ depexts: [
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse"}
+  ["ffmpeg-devel"] {os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ffmpeg/ffmpeg.0.3.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.3.0/opam
@@ -35,6 +35,7 @@ depexts: [
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse"}
+  ["ffmpeg-devel"] {os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ffmpeg/ffmpeg.0.4.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.0/opam
@@ -35,6 +35,7 @@ depexts: [
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse"}
+  ["ffmpeg-devel"] {os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ffmpeg/ffmpeg.0.4.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.1/opam
@@ -35,6 +35,7 @@ depexts: [
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse"}
+  ["ffmpeg-devel"] {os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ffmpeg/ffmpeg.0.4.2/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.2/opam
@@ -30,6 +30,7 @@ depexts: [
   ["ffmpeg-devel"] {os-distribution = "centos"}
   ["ffmpeg-devel"] {os-distribution = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse"}
+  ["ffmpeg-devel"] {os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/fftw3/fftw3.0.8.1/opam
+++ b/packages/fftw3/fftw3.0.8.1/opam
@@ -39,6 +39,7 @@ depexts: [
   ["fftw-devel"] {os-distribution = "rhel"}
   ["libfftw-devel"] {os-distribution = "mageia"}
   ["fftw3-devel"] {os-family = "suse"}
+  ["fftw3-devel"] {os-family = "opensuse"}
   ["math/fftw3"] {os = "freebsd"}
   ["math/fftw3"] {os = "openbsd"}
   ["fftw"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/flac/flac.0.1.1/opam
+++ b/packages/flac/flac.0.1.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}
+  ["flac-devel"] {os-family = "opensuse"}
   ["libflac-dev"] {os-family = "debian"}
   ["flac"] {os-distribution = "nixos"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/flac/flac.0.1.2/opam
+++ b/packages/flac/flac.0.1.2/opam
@@ -27,6 +27,7 @@ depexts: [
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}
+  ["flac-devel"] {os-family = "opensuse"}
   ["libflac-dev"] {os-family = "debian"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/flac/flac.0.1.3/opam
+++ b/packages/flac/flac.0.1.3/opam
@@ -29,6 +29,7 @@ depexts: [
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}
+  ["flac-devel"] {os-family = "opensuse"}
   ["libflac-dev"] {os-family = "debian"}
   ["flac"] {os-distribution = "nixos"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/flac/flac.0.1.4/opam
+++ b/packages/flac/flac.0.1.4/opam
@@ -29,6 +29,7 @@ depexts: [
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}
+  ["flac-devel"] {os-family = "opensuse"}
   ["libflac-dev"] {os-family = "debian"}
   ["flac"] {os-distribution = "nixos"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/flac/flac.0.1.5/opam
+++ b/packages/flac/flac.0.1.5/opam
@@ -30,6 +30,7 @@ depexts: [
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}
+  ["flac-devel"] {os-family = "opensuse"}
   ["libflac-dev"] {os-family = "debian"}
   ["flac"] {os-distribution = "nixos"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/flac/flac.0.1.6/opam
+++ b/packages/flac/flac.0.1.6/opam
@@ -28,6 +28,7 @@ depexts: [
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}
+  ["flac-devel"] {os-family = "opensuse"}
   ["libflac-dev"] {os-family = "debian"}
   ["flac"] {os-distribution = "nixos"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/flac/flac.0.1.7/opam
+++ b/packages/flac/flac.0.1.7/opam
@@ -30,6 +30,7 @@ depexts: [
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse"}
+  ["flac-devel"] {os-family = "opensuse"}
   ["libflac-dev"] {os-family = "debian"}
   ["flac"] {os-distribution = "nixos"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/freetds/freetds.0.6/opam
+++ b/packages/freetds/freetds.0.6/opam
@@ -36,6 +36,7 @@ depexts: [
   ["freetds-devel"] {os-distribution = "rhel"}
   ["libfreetds-devel"] {os-distribution = "mageia"}
   ["freetds-devel"] {os-family = "suse"}
+  ["freetds-devel"] {os-family = "opensuse"}
   ["freetds-devel"] {os = "freebsd"}
   ["freetds"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/freetds/freetds.0.7/opam
+++ b/packages/freetds/freetds.0.7/opam
@@ -34,6 +34,7 @@ depexts: [
   ["freetds-devel"] {os-distribution = "rhel"}
   ["libfreetds-devel"] {os-distribution = "mageia"}
   ["freetds-devel"] {os-family = "suse"}
+  ["freetds-devel"] {os-family = "opensuse"}
   ["freetds-devel"] {os = "freebsd"}
   ["freetds"] {os = "macos" & os-distribution = "homebrew"}
   ["freetds"] {os = "win32" & os-distribution = "cygwinports"}

--- a/packages/frei0r/frei0r.0.1.1/opam
+++ b/packages/frei0r/frei0r.0.1.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["frei0r-devel"] {os-distribution = "centos"}
   ["frei0r-devel"] {os-distribution = "fedora"}
   ["frei0r-devel"] {os-family = "suse"}
+  ["frei0r-devel"] {os-family = "opensuse"}
   ["frei0r"] {os = "macos" & os-distribution = "homebrew"}
   ["frei0r-plugins-dev"] {os-family = "debian"}
 ]

--- a/packages/gammu/gammu.0.9.1/opam
+++ b/packages/gammu/gammu.0.9.1/opam
@@ -25,6 +25,7 @@ depexts: [
   ["gammu-devel"] {os-distribution = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}
   ["gammu-devel"] {os-family = "suse"}
+  ["gammu-devel"] {os-family = "opensuse"}
   ["gammu-dev"] {os-distribution = "alpine"}
   ["gammu"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/gammu/gammu.0.9.2/opam
+++ b/packages/gammu/gammu.0.9.2/opam
@@ -27,6 +27,7 @@ depexts: [
   ["gammu-devel"] {os-distribution = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}
   ["gammu-devel"] {os-family = "suse"}
+  ["gammu-devel"] {os-family = "opensuse"}
   ["gammu-dev"] {os-distribution = "alpine"}
   ["gammu"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/gammu/gammu.0.9.3/opam
+++ b/packages/gammu/gammu.0.9.3/opam
@@ -33,6 +33,7 @@ depexts: [
   ["gammu-devel"] {os-distribution = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}
   ["gammu-devel"] {os-family = "suse"}
+  ["gammu-devel"] {os-family = "opensuse"}
   ["gammu-dev"] {os-distribution = "alpine"}
   ["gammu"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/gammu/gammu.0.9.4/opam
+++ b/packages/gammu/gammu.0.9.4/opam
@@ -29,6 +29,7 @@ depexts: [
   ["gammu-devel"] {os-distribution = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}
   ["gammu-devel"] {os-family = "suse"}
+  ["gammu-devel"] {os-family = "opensuse"}
   ["gammu-dev"] {os-distribution = "alpine"}
   ["gammu"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/gavl/gavl.0.1.6/opam
+++ b/packages/gavl/gavl.0.1.6/opam
@@ -16,6 +16,7 @@ depexts: [
   ["gavl-devel"] {os-distribution = "centos"}
   ["gavl-devel"] {os-distribution = "fedora"}
   ["gavl-devel"] {os-family = "suse"}
+  ["gavl-devel"] {os-family = "opensuse"}
   ["libgavl-dev"] {os-family = "debian"}
   ["drfill/liquidsoap/libgavl"] {os = "macos" & os-distribution = "homebrew"}
   ["gavl"] {os-distribution = "arch"}

--- a/packages/gstreamer/gstreamer.0.2.3/opam
+++ b/packages/gstreamer/gstreamer.0.2.3/opam
@@ -17,6 +17,7 @@ depends: [
 depexts: [
   ["gstreamer1-dev" "gst-plugins-base1-dev"] {os-distribution = "alpine"}
   ["gstreamer-devel" "gstreamer-plugins-base-devel"] {os-family = "suse"}
+  ["gstreamer-devel" "gstreamer-plugins-base-devel"] {os-family = "opensuse"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
     {os-distribution = "fedora"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]

--- a/packages/gstreamer/gstreamer.0.3.0/opam
+++ b/packages/gstreamer/gstreamer.0.3.0/opam
@@ -17,6 +17,7 @@ depends: [
 depexts: [
   ["gstreamer-dev" "gst-plugins-base-dev"] {os-distribution = "alpine"}
   ["gstreamer-devel" "gstreamer-plugins-base-devel"] {os-family = "suse"}
+  ["gstreamer-devel" "gstreamer-plugins-base-devel"] {os-family = "opensuse"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
     {os-distribution = "fedora"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]

--- a/packages/lablgl/lablgl.1.06/opam
+++ b/packages/lablgl/lablgl.1.06/opam
@@ -28,6 +28,7 @@ depexts: [
   ["freeglut-devel"] {os-distribution = "centos"}
   ["freeglut-devel"] {os-distribution = "fedora"}
   ["freeglut-devel"] {os-family = "suse"}
+  ["freeglut-devel"] {os-family = "opensuse"}
 ]
 synopsis: "Interface to OpenGL"
 description: """

--- a/packages/lablgtk/lablgtk.2.16.0/opam
+++ b/packages/lablgtk/lablgtk.2.16.0/opam
@@ -25,6 +25,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "ol"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
   ["gtk2-devel"] {os-family = "suse"}
+  ["gtk2-devel"] {os-family = "opensuse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.10/opam
+++ b/packages/lablgtk/lablgtk.2.18.10/opam
@@ -30,6 +30,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "ol"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
   ["gtk2-devel"] {os-family = "suse"}
+  ["gtk2-devel"] {os-family = "opensuse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.11/opam
+++ b/packages/lablgtk/lablgtk.2.18.11/opam
@@ -30,6 +30,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "ol"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
   ["gtk2-devel"] {os-family = "suse"}
+  ["gtk2-devel"] {os-family = "opensuse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.2/opam
+++ b/packages/lablgtk/lablgtk.2.18.2/opam
@@ -25,6 +25,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "ol"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
   ["gtk2-devel"] {os-family = "suse"}
+  ["gtk2-devel"] {os-family = "opensuse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.3/opam
+++ b/packages/lablgtk/lablgtk.2.18.3/opam
@@ -25,6 +25,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "ol"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
   ["gtk2-devel"] {os-family = "suse"}
+  ["gtk2-devel"] {os-family = "opensuse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.4/opam
+++ b/packages/lablgtk/lablgtk.2.18.4/opam
@@ -31,6 +31,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "ol"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
   ["gtk2-devel"] {os-family = "suse"}
+  ["gtk2-devel"] {os-family = "opensuse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.5/opam
+++ b/packages/lablgtk/lablgtk.2.18.5/opam
@@ -31,6 +31,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "ol"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
   ["gtk2-devel"] {os-family = "suse"}
+  ["gtk2-devel"] {os-family = "opensuse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.6/opam
+++ b/packages/lablgtk/lablgtk.2.18.6/opam
@@ -32,6 +32,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "ol"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
   ["gtk2-devel"] {os-family = "suse"}
+  ["gtk2-devel"] {os-family = "opensuse"}
   ["gtk2"] {os-distribution = "nixos"}
 ]
 patches: ["lablgldir.patch"]

--- a/packages/lablgtk/lablgtk.2.18.7/opam
+++ b/packages/lablgtk/lablgtk.2.18.7/opam
@@ -31,6 +31,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "ol"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
   ["gtk2-devel"] {os-family = "suse"}
+  ["gtk2-devel"] {os-family = "opensuse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.8/opam
+++ b/packages/lablgtk/lablgtk.2.18.8/opam
@@ -31,6 +31,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "ol"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
   ["gtk2-devel"] {os-family = "suse"}
+  ["gtk2-devel"] {os-family = "opensuse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk/lablgtk.2.18.9/opam
+++ b/packages/lablgtk/lablgtk.2.18.9/opam
@@ -30,6 +30,7 @@ depexts: [
   ["gtk2-devel"] {os-distribution = "ol"}
   ["gtk+2.0-dev"] {os-distribution = "alpine"}
   ["gtk2-devel"] {os-family = "suse"}
+  ["gtk2-devel"] {os-family = "opensuse"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta5/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta5/opam
@@ -33,6 +33,7 @@ depexts: [
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse"}
+  ["gtkspell3-devel"] {os-family = "opensuse"}
   ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]
 build: [

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
@@ -32,6 +32,7 @@ depexts: [
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse"}
+  ["gtkspell3-devel"] {os-family = "opensuse"}
   ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]
 build: [

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
@@ -32,6 +32,7 @@ depexts: [
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse"}
+  ["gtkspell3-devel"] {os-family = "opensuse"}
   ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
   ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta8/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta8/opam
@@ -30,6 +30,7 @@ depexts: [
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse"}
+  ["gtkspell3-devel"] {os-family = "opensuse"}
   ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
   ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.0/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.0/opam
@@ -30,6 +30,7 @@ depexts: [
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse"}
+  ["gtkspell3-devel"] {os-family = "opensuse"}
   ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
   ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.1/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.1/opam
@@ -30,6 +30,7 @@ depexts: [
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse"}
+  ["gtkspell3-devel"] {os-family = "opensuse"}
   ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
   ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/labrys/labrys.0.1/opam
+++ b/packages/labrys/labrys.0.1/opam
@@ -29,6 +29,7 @@ depexts: [
   ["gc-devel"] {os-distribution = "centos"}
   ["gc-devel"] {os-distribution = "fedora"}
   ["gc-devel"] {os-family = "suse"}
+  ["gc-devel"] {os-family = "opensuse"}
   ["gc"] {os-distribution = "arch"}
   ["gc-dev"] {os-distribution = "alpine"}
   ["boehmgc"] {os-distribution = "macports" & os = "macos"}

--- a/packages/ladspa/ladspa.0.1.5/opam
+++ b/packages/ladspa/ladspa.0.1.5/opam
@@ -24,6 +24,7 @@ depexts: [
   ["ladspa-devel"] {os-distribution = "centos"}
   ["ladspa-devel"] {os-distribution = "fedora"}
   ["ladspa-devel"] {os-family = "suse"}
+  ["ladspa-devel"] {os-family = "opensuse"}
   ["ladspa-sdk"] {os-family = "debian"}
   ["drfill/liquidsoap/ladspa_header"]
     {os = "macos" & os-distribution = "homebrew"}

--- a/packages/lame/lame.0.3.3/opam
+++ b/packages/lame/lame.0.3.3/opam
@@ -24,6 +24,7 @@ depexts: [
   ["lame-devel"] {os-distribution = "centos"}
   ["lame-devel"] {os-distribution = "fedora"}
   ["lame-devel"] {os-family = "suse"}
+  ["lame-devel"] {os-family = "opensuse"}
   ["libmp3lame-dev"] {os-family = "debian"}
   ["lame"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/lbfgs/lbfgs.0.9.1/opam
+++ b/packages/lbfgs/lbfgs.0.9.1/opam
@@ -30,6 +30,7 @@ depexts: [
   ["gcc-gfortran"] {os-distribution = "mageia"}
   ["gcc-gfortran"] {os-distribution = "rhel"}
   ["gcc-fortran"] {os-family = "suse"}
+  ["gcc-fortran"] {os-family = "opensuse"}
   ["gcc"] {os = "freebsd"}
   ["mingw64-x86_64-gcc-fortran"] {os = "cygwin"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/lbfgs/lbfgs.0.9/opam
+++ b/packages/lbfgs/lbfgs.0.9/opam
@@ -32,6 +32,7 @@ depexts: [
   ["gcc-gfortran"] {os-distribution = "mageia"}
   ["gcc-gfortran"] {os-distribution = "rhel"}
   ["gcc-fortran"] {os-family = "suse"}
+  ["gcc-fortran"] {os-family = "opensuse"}
   ["gcc"] {os = "freebsd"}
   ["mingw64-x86_64-gcc-fortran"] {os = "cygwin"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/libevent/libevent.0.8.1/opam
+++ b/packages/libevent/libevent.0.8.1/opam
@@ -34,6 +34,7 @@ depexts: [
   ["libevent-devel"] {os-distribution = "centos"}
   ["libevent-dev"] {os-distribution = "alpine"}
   ["libevent-devel"] {os-family = "suse"}
+  ["libevent-devel"] {os-family = "opensuse"}
   ["libevent"] {os-distribution = "homebrew"}
 ]
 synopsis: "OCaml wrapper for the libevent API"

--- a/packages/lmdb/lmdb.0.1/opam
+++ b/packages/lmdb/lmdb.0.1/opam
@@ -31,6 +31,7 @@ depexts: [
   ["lmdb"] {os = "macos" & os-distribution = "macports"}
   ["lmdb-devel"] {os-distribution = "fedora"}
   ["lmdb-devel"] {os-family = "suse"}
+  ["lmdb-devel"] {os-family = "opensuse"}
   ["lmdb"] {os-distribution = "arch"}
 ]
 url {

--- a/packages/lmdb/lmdb.1.0/opam
+++ b/packages/lmdb/lmdb.1.0/opam
@@ -36,6 +36,7 @@ depexts: [
   ["lmdb-dev"] {os-family = "alpine"}
   ["lmdb-devel"] {os-family = "fedora"}
   ["lmdb-devel"] {os-family = "suse"}
+  ["lmdb-devel"] {os-family = "opensuse"}
   ["liblmdb-devel"] {os-family = "mageia"}
 ]
 url {

--- a/packages/lo/lo.0.1.2/opam
+++ b/packages/lo/lo.0.1.2/opam
@@ -25,6 +25,7 @@ depexts: [
   ["liblo-devel"] {os-distribution = "centos"}
   ["liblo-devel"] {os-distribution = "fedora"}
   ["liblo-devel"] {os-family = "suse"}
+  ["liblo-devel"] {os-family = "opensuse"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-lo/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-lo.git"

--- a/packages/mad/mad.0.4.5/opam
+++ b/packages/mad/mad.0.4.5/opam
@@ -17,6 +17,7 @@ depexts: [
   ["libmad-devel"] {os-distribution = "centos"}
   ["libmad-devel"] {os-distribution = "fedora"}
   ["libmad-devel"] {os-family = "suse"}
+  ["libmad-devel"] {os-family = "opensuse"}
   ["libmad0-dev"] {os-family = "debian"}
   ["libmad"] {os-distribution = "nixos"}
   ["mad"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/magic/magic.0.7.3/opam
+++ b/packages/magic/magic.0.7.3/opam
@@ -14,6 +14,7 @@ depexts: [
   ["file-devel"] {os-distribution = "centos"}
   ["file-devel"] {os-distribution = "fedora"}
   ["file-devel"] {os-family = "suse"}
+  ["file-devel"] {os-family = "opensuse"}
   ["libmagic-dev"] {os-family = "debian"}
   ["libmagic"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/milter/milter.1.0.4/opam
+++ b/packages/milter/milter.1.0.4/opam
@@ -21,6 +21,7 @@ depexts: [
   ["libmilter-dev"] {os-family = "debian"}
   ["sendmail-devel"] {os-distribution = "mageia"}
   ["sendmail-devel"] {os-family = "suse"}
+  ["sendmail-devel"] {os-family = "opensuse"}
   ["libmilter"] {os = "netbsd"}
 ]
 synopsis: "OCaml libmilter bindings"

--- a/packages/mirage-block-unix/mirage-block-unix.2.10.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.10.0/opam
@@ -34,6 +34,7 @@ depends: [
 depexts: [
   ["linux-libc-dev"] {os-family = "debian"}
   ["linux-glibc-devel"] {os-family = "suse"}
+  ["linux-glibc-devel"] {os-family = "opensuse"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["kernel-headers"] {os-distribution = "centos"}
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.4/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.4/opam
@@ -30,6 +30,7 @@ depends: [
 depexts: [
   ["linux-libc-dev"] {os-family = "debian"}
   ["linux-glibc-devel"] {os-family = "suse"}
+  ["linux-glibc-devel"] {os-family = "opensuse"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["kernel-headers"] {os-distribution = "centos"}
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.9.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.9.0/opam
@@ -30,6 +30,7 @@ depends: [
 depexts: [
   ["linux-libc-dev"] {os-family = "debian"}
   ["linux-glibc-devel"] {os-family = "suse"}
+  ["linux-glibc-devel"] {os-family = "opensuse"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["kernel-headers"] {os-distribution = "centos"}
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/misuja/misuja.0.0.0/opam
+++ b/packages/misuja/misuja.0.0.0/opam
@@ -21,6 +21,7 @@ depexts: [
     {os-distribution = "centos"}
   ["jack-audio-connection-kit-devel"] {os-distribution = "rhel"}
   ["libjack-devel"] {os-family = "suse"}
+  ["libjack-devel"] {os-family = "opensuse"}
   ["jack"] {os-distribution = "homebrew" & os = "macos"}
 ]
 synopsis:

--- a/packages/ocaml-lua/ocaml-lua.1.0/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.0/opam
@@ -25,6 +25,7 @@ depexts: [
   ["liblua5.1-0-dev"] {os-family = "debian"}
   ["lua-dev"] {os-distribution = "alpine"}
   ["lua51-devel"] {os-family = "suse"}
+  ["lua51-devel"] {os-family = "opensuse"}
 ]
 available: os = "linux"
 install: [make "install"]

--- a/packages/ocaml-lua/ocaml-lua.1.1/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.1/opam
@@ -35,6 +35,7 @@ depexts: [
   ["liblua5.1-0-dev"] {os-family = "debian"}
   ["lua-dev"] {os-distribution = "alpine"}
   ["lua51-devel"] {os-family = "suse"}
+  ["lua51-devel"] {os-family = "opensuse"}
 ]
 available: os = "linux"
 install: [make "install"]

--- a/packages/ocaml-lua/ocaml-lua.1.2/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.2/opam
@@ -35,6 +35,7 @@ depexts: [
   ["liblua5.1-0-dev"] {os-family = "debian"}
   ["lua-dev"] {os-distribution = "alpine"}
   ["lua51-devel"] {os-family = "suse"}
+  ["lua51-devel"] {os-family = "opensuse"}
 ]
 available: os = "linux"
 install: [make "install"]

--- a/packages/ocaml-lua/ocaml-lua.1.3/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.3/opam
@@ -37,6 +37,7 @@ depexts: [
   ["lua-devel"] {os-distribution = "centos"}
   ["lua-dev"] {os-distribution = "alpine"}
   ["lua51-devel"] {os-family = "suse"}
+  ["lua51-devel"] {os-family = "opensuse"}
 ]
 available: os = "linux"
 install: [make "install"]

--- a/packages/ocaml-lua/ocaml-lua.1.4/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.4/opam
@@ -38,6 +38,7 @@ depexts: [
   ["lua51"] {os = "macos" & os-distribution = "homebrew"}
   ["lua-dev"] {os-distribution = "alpine"}
   ["lua51-devel"] {os-family = "suse"}
+  ["lua51-devel"] {os-family = "opensuse"}
 ]
 install: [make "install"]
 synopsis: "Lua bindings"

--- a/packages/ocaml-lua/ocaml-lua.1.5/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.5/opam
@@ -38,6 +38,7 @@ depexts: [
   ["lua51"] {os = "macos" & os-distribution = "homebrew"}
   ["lua-dev"] {os-distribution = "alpine"}
   ["lua51-devel"] {os-family = "suse"}
+  ["lua51-devel"] {os-family = "opensuse"}
 ]
 install: [make "install"]
 synopsis: "Lua bindings"

--- a/packages/ocaml-lua/ocaml-lua.1.6/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.6/opam
@@ -38,6 +38,7 @@ depexts: [
   ["lua51"] {os = "macos" & os-distribution = "homebrew"}
   ["lua-dev"] {os-distribution = "alpine"}
   ["lua51-devel"] {os-family = "suse"}
+  ["lua51-devel"] {os-family = "opensuse"}
 ]
 install: [make "install"]
 synopsis: "Lua bindings"

--- a/packages/ocaml-lua/ocaml-lua.1.7/opam
+++ b/packages/ocaml-lua/ocaml-lua.1.7/opam
@@ -38,6 +38,7 @@ depexts: [
   ["lua51"] {os = "macos" & os-distribution = "homebrew"}
   ["lua-dev"] {os-distribution = "alpine"}
   ["lua51-devel"] {os-family = "suse"}
+  ["lua51-devel"] {os-family = "opensuse"}
 ]
 install: [make "install"]
 synopsis: "Lua bindings"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs4/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs4/opam
@@ -27,6 +27,7 @@ depexts: [
   ["fuse-devel"] {os-distribution = "centos"}
   ["fuse-devel"] {os-distribution = "fedora"}
   ["fuse-devel"] {os-family = "suse"}
+  ["fuse-devel"] {os-family = "opensuse"}
   ["Caskroom/cask/osxfuse"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs5/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs5/opam
@@ -27,6 +27,7 @@ depexts: [
   ["fuse-devel"] {os-distribution = "centos"}
   ["fuse-devel"] {os-distribution = "fedora"}
   ["fuse-devel"] {os-family = "suse"}
+  ["fuse-devel"] {os-family = "opensuse"}
   ["Caskroom/cask/osxfuse"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs6/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs6/opam
@@ -23,6 +23,7 @@ depexts: [
   ["fuse-devel"] {os-distribution = "centos"}
   ["fuse-devel"] {os-distribution = "fedora"}
   ["fuse-devel"] {os-family = "suse"}
+  ["fuse-devel"] {os-family = "opensuse"}
   ["Caskroom/cask/osxfuse"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs7/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs7/opam
@@ -23,6 +23,7 @@ depexts: [
   ["fuse-devel"] {os-distribution = "centos"}
   ["fuse-devel"] {os-distribution = "fedora"}
   ["fuse-devel"] {os-family = "suse"}
+  ["fuse-devel"] {os-family = "opensuse"}
   ["Caskroom/cask/osxfuse"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"

--- a/packages/ogg/ogg.0.5.0/opam
+++ b/packages/ogg/ogg.0.5.0/opam
@@ -18,6 +18,7 @@ depexts: [
   ["libogg-devel"] {os-distribution = "centos"}
   ["libogg-devel"] {os-distribution = "fedora"}
   ["libogg-devel"] {os-family = "suse"}
+  ["libogg-devel"] {os-family = "opensuse"}
   ["libogg"] {os-distribution = "nixos"}
   ["libogg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ogg/ogg.0.5.1/opam
+++ b/packages/ogg/ogg.0.5.1/opam
@@ -18,6 +18,7 @@ depexts: [
   ["libogg-devel"] {os-distribution = "centos"}
   ["libogg-devel"] {os-distribution = "fedora"}
   ["libogg-devel"] {os-family = "suse"}
+  ["libogg-devel"] {os-family = "opensuse"}
   ["libogg"] {os-distribution = "nixos"}
   ["libogg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/ogg/ogg.0.5.2/opam
+++ b/packages/ogg/ogg.0.5.2/opam
@@ -22,6 +22,7 @@ depexts: [
   ["libogg-devel"] {os-distribution = "centos"}
   ["libogg-devel"] {os-distribution = "fedora"}
   ["libogg-devel"] {os-family = "suse"}
+  ["libogg-devel"] {os-family = "opensuse"}
   ["libogg"] {os-distribution = "nixos"}
   ["libogg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/opus/opus.0.1.2/opam
+++ b/packages/opus/opus.0.1.2/opam
@@ -22,6 +22,7 @@ depexts: [
   ["opus-devel"] {os-distribution = "centos"}
   ["opus-devel"] {os-distribution = "fedora"}
   ["opus-devel"] {os-family = "suse"}
+  ["opus-devel"] {os-family = "opensuse"}
   ["libopus"] {os-distribution = "nixos"}
   ["opus"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/opus/opus.0.1.3/opam
+++ b/packages/opus/opus.0.1.3/opam
@@ -23,6 +23,7 @@ depexts: [
   ["opus-devel"] {os-distribution = "centos"}
   ["opus-devel"] {os-distribution = "fedora"}
   ["libopus-devel"] {os-family = "suse"}
+  ["libopus-devel"] {os-family = "opensuse"}
   ["libopus"] {os-distribution = "nixos"}
   ["opus"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/pa_ppx/pa_ppx.0.01/opam
+++ b/packages/pa_ppx/pa_ppx.0.01/opam
@@ -66,6 +66,7 @@ depexts: [
     "perl-String-ShellQuote"
     "perl-IPC-System-Simple"
   ] {os-family = "suse"}
+  ] {os-family = "opensuse"}
   [
     "perl-String-ShellQuote"
     "perl-IPC-System-Simple"

--- a/packages/pcre/pcre.7.2.3/opam
+++ b/packages/pcre/pcre.7.2.3/opam
@@ -28,6 +28,7 @@ depexts: [
   ["ocaml-ocamldoc"] {os-distribution = "centos"}
   ["ocaml-ocamldoc"] {os-distribution = "fedora"}
   ["ocaml-ocamldoc"] {os-family = "suse"}
+  ["ocaml-ocamldoc"] {os-family = "opensuse"}
 ]
 synopsis:
   "Bindings to the Perl Compatibility Regular Expressions library"

--- a/packages/plplot/plplot.5.11.0-1/opam
+++ b/packages/plplot/plplot.5.11.0-1/opam
@@ -21,6 +21,7 @@ depexts: [
   ["plplot-devel"] {os-family = "rhel"}
   ["plplot-devel"] {os-family = "fedora"}
   ["plplot-devel"] {os-family = "suse"}
+  ["plplot-devel"] {os-family = "opensuse"}
   ["plplot-devel" "epel-release"] {os-distribution = "centos"}
   ["plplot"] {os-distribution = "nixos"}
 ]

--- a/packages/plplot/plplot.5.11.0/opam
+++ b/packages/plplot/plplot.5.11.0/opam
@@ -25,6 +25,7 @@ depexts: [
   ["plplot-devel"] {os-family = "rhel"}
   ["plplot-devel"] {os-family = "fedora"}
   ["plplot-devel"] {os-family = "suse"}
+  ["plplot-devel"] {os-family = "opensuse"}
   ["plplot-devel" "epel-release"] {os-distribution = "centos"}
   ["plplot"] {os-distribution = "nixos"}
 ]

--- a/packages/postgresql/postgresql.3.2.1/opam
+++ b/packages/postgresql/postgresql.3.2.1/opam
@@ -52,6 +52,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql"] {os-distribution = "gentoo"}
   ["postgresql-devel"] {os-family = "suse"}
+  ["postgresql-devel"] {os-family = "opensuse"}
 ]
 synopsis: "Bindings to the PostgreSQL library"
 description: """

--- a/packages/postgresql/postgresql.4.0.0/opam
+++ b/packages/postgresql/postgresql.4.0.0/opam
@@ -55,6 +55,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql"] {os-distribution = "gentoo"}
   ["postgresql-devel"] {os-family = "suse"}
+  ["postgresql-devel"] {os-family = "opensuse"}
 ]
 synopsis: "Bindings to the PostgreSQL library"
 description: """

--- a/packages/postgresql/postgresql.4.0.1/opam
+++ b/packages/postgresql/postgresql.4.0.1/opam
@@ -52,6 +52,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql"] {os-distribution = "gentoo"}
   ["postgresql-devel"] {os-family = "suse"}
+  ["postgresql-devel"] {os-family = "opensuse"}
 ]
 synopsis: "Bindings to the PostgreSQL library"
 description: """

--- a/packages/postgresql/postgresql.4.1.0/opam
+++ b/packages/postgresql/postgresql.4.1.0/opam
@@ -34,6 +34,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os-family = "suse"}
+  ["postgresql"] {os-family = "opensuse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/postgresql/postgresql.4.2.0/opam
+++ b/packages/postgresql/postgresql.4.2.0/opam
@@ -34,6 +34,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os-family = "suse"}
+  ["postgresql"] {os-family = "opensuse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/postgresql/postgresql.4.2.1/opam
+++ b/packages/postgresql/postgresql.4.2.1/opam
@@ -34,6 +34,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os-family = "suse"}
+  ["postgresql"] {os-family = "opensuse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/postgresql/postgresql.4.3.0/opam
+++ b/packages/postgresql/postgresql.4.3.0/opam
@@ -34,6 +34,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os-family = "suse"}
+  ["postgresql"] {os-family = "opensuse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/postgresql/postgresql.4.4.0/opam
+++ b/packages/postgresql/postgresql.4.4.0/opam
@@ -33,6 +33,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os-family = "suse"}
+  ["postgresql"] {os-family = "opensuse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/postgresql/postgresql.4.4.1/opam
+++ b/packages/postgresql/postgresql.4.4.1/opam
@@ -33,6 +33,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-devel"] {os-family = "suse"}
+  ["postgresql-devel"] {os-family = "opensuse"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}

--- a/packages/protocell/protocell.1.0.0/opam
+++ b/packages/protocell/protocell.1.0.0/opam
@@ -15,6 +15,7 @@ depexts: [
   ["protobuf-devel" "protobuf-compiler"] {os-distribution = "rhel"}
   ["protobuf-dev" "protobuf"] {os-distribution = "alpine"}
   ["protobuf-devel"] {os-family = "suse"}
+  ["protobuf-devel"] {os-family = "opensuse"}
   ["protobuf"] {os = "freebsd"}
   ["protobuf"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/pulseaudio/pulseaudio.0.1.2/opam
+++ b/packages/pulseaudio/pulseaudio.0.1.2/opam
@@ -11,6 +11,7 @@ depexts: [
   ["pulseaudio-libs-devel"] {os-distribution = "centos"}
   ["pulseaudio-libs-devel"] {os-distribution = "fedora"}
   ["pulseaudio-libs-devel"] {os-family = "suse"}
+  ["pulseaudio-libs-devel"] {os-family = "opensuse"}
   ["pulseaudio"] {os = "macos" & os-distribution = "homebrew"}
   ["libpulse-dev"] {os-family = "debian"}
 ]

--- a/packages/pulseaudio/pulseaudio.0.1.3/opam
+++ b/packages/pulseaudio/pulseaudio.0.1.3/opam
@@ -16,6 +16,7 @@ depexts: [
   ["pulseaudio-libs-devel"] {os-distribution = "centos"}
   ["pulseaudio-libs-devel"] {os-distribution = "fedora"}
   ["pulseaudio-libs-devel"] {os-family = "suse"}
+  ["pulseaudio-libs-devel"] {os-family = "opensuse"}
   ["pulseaudio"] {os = "macos" & os-distribution = "homebrew"}
   ["libpulse-dev"] {os-family = "debian"}
 ]

--- a/packages/samplerate/samplerate.0.1.4/opam
+++ b/packages/samplerate/samplerate.0.1.4/opam
@@ -15,6 +15,7 @@ depexts: [
   ["libsamplerate-devel"] {os-distribution = "centos"}
   ["libsamplerate-devel"] {os-distribution = "fedora"}
   ["libsamplerate-devel"] {os-family = "suse"}
+  ["libsamplerate-devel"] {os-family = "opensuse"}
   ["libsamplerate-dev"] {os-distribution = "alpine"}
   ["libsamplerate0-dev"] {os-family = "debian"}
   ["libsamplerate"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/shine/shine.0.2.1/opam
+++ b/packages/shine/shine.0.2.1/opam
@@ -22,6 +22,7 @@ depexts: [
   ["libshine-devel"] {os-distribution = "centos"}
   ["libshine-devel"] {os-distribution = "fedora"}
   ["libshine-devel"] {os-family = "suse"}
+  ["libshine-devel"] {os-family = "opensuse"}
   ["libshine-dev"] {os-family = "debian"}
   ["drfill/liquidsoap/libshine"]
     {os = "macos" & os-distribution = "homebrew"}

--- a/packages/soundtouch/soundtouch.0.1.8/opam
+++ b/packages/soundtouch/soundtouch.0.1.8/opam
@@ -16,6 +16,7 @@ depexts: [
   ["soundtouch-devel"] {os-distribution = "centos"}
   ["soundtouch-devel"] {os-distribution = "fedora"}
   ["soundtouch-devel"] {os-family = "suse"}
+  ["soundtouch-devel"] {os-family = "opensuse"}
   ["libsoundtouch-dev"] {os-family = "debian"}
   ["drfill/homebrew-liquidsoap/soundtouch"]
     {os = "macos" & os-distribution = "homebrew"}

--- a/packages/speex/speex.0.2.1/opam
+++ b/packages/speex/speex.0.2.1/opam
@@ -24,6 +24,7 @@ depexts: [
   ["speex-devel"] {os-distribution = "centos"}
   ["speex-devel"] {os-distribution = "fedora"}
   ["speex-devel"] {os-family = "suse"}
+  ["speex-devel"] {os-family = "opensuse"}
   ["libspeex-dev"] {os-family = "debian"}
   ["speex"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/spf/spf.2.0.2/opam
+++ b/packages/spf/spf.2.0.2/opam
@@ -22,6 +22,7 @@ depexts: [
   ["libspf2"] {os = "netbsd"}
   ["libspf2"] {os = "openbsd"}
   ["libspf2-devel"] {os-family = "suse"}
+  ["libspf2-devel"] {os-family = "opensuse"}
 ]
 synopsis: "OCaml bindings for libspf2"
 description: "OCaml-SPF provides C bindings for OCaml programs."

--- a/packages/srt/srt.0.1.0/opam
+++ b/packages/srt/srt.0.1.0/opam
@@ -21,6 +21,7 @@ depexts: [
   ["srt-devel"] {os-distribution = "centos"}
   ["srt-devel"] {os-distribution = "fedora"}
   ["srt-devel"] {os-family = "suse"}
+  ["srt-devel"] {os-family = "opensuse"}
   ["libsrt-dev"] {os-family = "debian"}
   ["srt"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/srt/srt.0.1.1/opam
+++ b/packages/srt/srt.0.1.1/opam
@@ -36,6 +36,7 @@ depexts: [
   ["srt-devel"] {os-distribution = "centos"}
   ["srt-devel"] {os-distribution = "fedora"}
   ["srt-devel"] {os-family = "suse"}
+  ["srt-devel"] {os-family = "opensuse"}
   ["libsrt-dev"] {os-family = "debian"}
   ["srt"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/taglib/taglib.0.3.3/opam
+++ b/packages/taglib/taglib.0.3.3/opam
@@ -18,6 +18,7 @@ depends: [
 depexts: [
   ["taglib-dev"] {os-distribution = "alpine"}
   ["gcc-c++" "taglib-devel"] {os-family = "suse"}
+  ["gcc-c++" "taglib-devel"] {os-family = "opensuse"}
   ["gcc-c++" "taglib-devel"] {os-distribution = "fedora"}
   ["gcc-c++" "taglib-devel"] {os-distribution = "centos"}
   ["libtag1-dev"] {os-family = "debian"}

--- a/packages/taglib/taglib.0.3.6/opam
+++ b/packages/taglib/taglib.0.3.6/opam
@@ -20,6 +20,7 @@ install: [make "install"]
 depexts: [
   ["taglib-dev"] {os-distribution = "alpine"}
   ["gcc-c++" "taglib-devel"] {os-family = "suse"}
+  ["gcc-c++" "taglib-devel"] {os-family = "opensuse"}
   ["gcc-c++" "taglib-devel"] {os-distribution = "fedora"}
   ["gcc-c++" "taglib-devel"] {os-distribution = "centos"}
   ["libtag1-dev"] {os-family = "debian"}

--- a/packages/theora/theora.0.3.1/opam
+++ b/packages/theora/theora.0.3.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["libtheora-devel"] {os-distribution = "centos"}
   ["libtheora-devel"] {os-distribution = "fedora"}
   ["libtheora-devel"] {os-family = "suse"}
+  ["libtheora-devel"] {os-family = "opensuse"}
   ["theora"] {os = "macos" & os-distribution = "homebrew"}
   ["libtheora-dev"] {os-family = "debian"}
 ]

--- a/packages/travis-opam/travis-opam.1.1.0/opam
+++ b/packages/travis-opam/travis-opam.1.1.0/opam
@@ -20,6 +20,7 @@ depexts: [
   ["jq"] {os-distribution = "fedora"}
   ["jq"] {os-distribution = "homebrew" & os = "macos"}
   ["jq"] {os-family = "suse"}
+  ["jq"] {os-family = "opensuse"}
   ["jq"] {os-distribution = "ol"}
 ]
 build: [make]

--- a/packages/usb/usb.1.3.1/opam
+++ b/packages/usb/usb.1.3.1/opam
@@ -22,6 +22,7 @@ depexts: [
   ["libusb1-devel"] {os-family = "rhel"}
   ["libusb1-devel"] {os-family = "fedora"}
   ["libusb-1_0-devel"] {os-family = "suse"}
+  ["libusb-1_0-devel"] {os-family = "opensuse"}
   ["libusb1.0-devel"] {os-family = "mageia"}
 ]
 

--- a/packages/vorbis/vorbis.0.6.2/opam
+++ b/packages/vorbis/vorbis.0.6.2/opam
@@ -19,6 +19,7 @@ depexts: [
   ["libvorbis-devel"] {os-distribution = "centos"}
   ["libvorbis-devel"] {os-distribution = "fedora"}
   ["libvorbis-devel"] {os-family = "suse"}
+  ["libvorbis-devel"] {os-family = "opensuse"}
   ["libvorbis-dev"] {os-family = "debian"}
   ["libvorbis"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/vorbis/vorbis.0.7.0/opam
+++ b/packages/vorbis/vorbis.0.7.0/opam
@@ -20,6 +20,7 @@ depexts: [
   ["libvorbis-devel"] {os-distribution = "centos"}
   ["libvorbis-devel"] {os-distribution = "fedora"}
   ["libvorbis-devel"] {os-family = "suse"}
+  ["libvorbis-devel"] {os-family = "opensuse"}
   ["libvorbis-dev"] {os-family = "debian"}
   ["libvorbis"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/vorbis/vorbis.0.7.1/opam
+++ b/packages/vorbis/vorbis.0.7.1/opam
@@ -20,6 +20,7 @@ depexts: [
   ["libvorbis-devel"] {os-distribution = "centos"}
   ["libvorbis-devel"] {os-distribution = "fedora"}
   ["libvorbis-devel"] {os-family = "suse"}
+  ["libvorbis-devel"] {os-family = "opensuse"}
   ["pkg-config" "libvorbis-dev"] {os-family = "debian"}
   ["libvorbis"] {os = "macos" & os-distribution = "homebrew"}
 ]


### PR DESCRIPTION
diff created via

```
rg 'os-family = "suse"' -l | xargs sed -i.'bak' -n 'p; s/os-family = "suse"/os-family = "opensuse"/p'
git clean -f
```
* ripgrep to search for files that contain os details for suse
* -n in sed prevents lines from printing unless it is explicitly printed
* p in the sed pattern forces printing if there is a match
* `git clean -f` to remove the backup files created by sed

closes #17004