### PR TITLE
[new release] mirage-crypto-pk, mirage-crypto, mirage-crypto-rng and mirage-crypto-rng-mirage (0.8.4)

### DIFF
--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.4/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.7"}
+  "rresult" {>= "0.6.0"}
+  ("mirage-no-xen" | "zarith-xen")
+  ("mirage-no-solo5" | "zarith-freestanding")
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+x-commit-hash: "162d04ec4684f8d5a0c05154ca8219d217ad0b39"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.4/mirage-crypto-v0.8.4.tbz"
+  checksum: [
+    "sha256=b94b1e4ac8e5d93802f95843e323ebc0b6645c778e2b80970a37134d29e509f0"
+    "sha512=d320b55e66d546c877f6398bac0a1ea17d90b6473082bd3911ef7f338ee821fa965c359326215fc521a64e41ea577ee35adbe3ce9155964530434c8c624db99e"
+  ]
+}

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.4/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+x-commit-hash: "162d04ec4684f8d5a0c05154ca8219d217ad0b39"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.4/mirage-crypto-v0.8.4.tbz"
+  checksum: [
+    "sha256=b94b1e4ac8e5d93802f95843e323ebc0b6645c778e2b80970a37134d29e509f0"
+    "sha512=d320b55e66d546c877f6398bac0a1ea17d90b6473082bd3911ef7f338ee821fa965c359326215fc521a64e41ea577ee35adbe3ce9155964530434c8c624db99e"
+  ]
+}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.4/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator"
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "mirage-crypto" {=version}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+# lwt sublibrary
+  "mtime"
+  "lwt" {>= "4.0.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+x-commit-hash: "162d04ec4684f8d5a0c05154ca8219d217ad0b39"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.4/mirage-crypto-v0.8.4.tbz"
+  checksum: [
+    "sha256=b94b1e4ac8e5d93802f95843e323ebc0b6645c778e2b80970a37134d29e509f0"
+    "sha512=d320b55e66d546c877f6398bac0a1ea17d90b6473082bd3911ef7f338ee821fa965c359326215fc521a64e41ea577ee35adbe3ce9155964530434c8c624db99e"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.8.4/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "eqaf" {>= "0.7"}
+]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
+hashes (MD5, SHA-1, SHA-2).
+"""
+x-commit-hash: "162d04ec4684f8d5a0c05154ca8219d217ad0b39"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.4/mirage-crypto-v0.8.4.tbz"
+  checksum: [
+    "sha256=b94b1e4ac8e5d93802f95843e323ebc0b6645c778e2b80970a37134d29e509f0"
+    "sha512=d320b55e66d546c877f6398bac0a1ea17d90b6473082bd3911ef7f338ee821fa965c359326215fc521a64e41ea577ee35adbe3ce9155964530434c8c624db99e"
+  ]
+}


### PR DESCRIPTION
Simple public-key cryptography for the modern age

- Project page: <a href="https://github.com/mirage/mirage-crypto">https://github.com/mirage/mirage-crypto</a>
- Documentation: <a href="https://mirage.github.io/mirage-crypto/doc">https://mirage.github.io/mirage-crypto/doc</a>

##### CHANGES:

* Mirage_crypto_rng: avoid using rdseed if it returned 0 during bootstrap
  (mirage/mirage-crypto#82 @hannesm)
* Avoid misaligned cast in xor (mirage/mirage-crypto#79 reported by @talex5 on arm32, fixed in mirage/mirage-crypto#81
  by @hannesm)
