### PR TITLE
Release conjury 2.0.1 (An OMake library).

### DIFF
--- a/packages/conjury/conjury.2.0.1/opam
+++ b/packages/conjury/conjury.2.0.1/opam
@@ -20,5 +20,5 @@ build: [
 install: [ "omake" "install" ]
 url {
     src: "https://bitbucket.org/jhw/conjury/get/r2.0.1.tar.gz"
-    checksum: "md5=f87fbb815bd88a8a1c7f9e372fb59451"
+    checksum: "md5=7a8e09b77c1ea31361f63f306d0af5d0"
 }

--- a/packages/conjury/conjury.2.0.1/opam
+++ b/packages/conjury/conjury.2.0.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+name: "conjury" version: "2.0.1"
+synopsis: "Conjury library for OMake"
+maintainer: "james woodyatt <jhw@conjury.org>"
+authors: "james woodyatt <jhw@conjury.org>"
+homepage: "https://bitbucket.org/jhw/conjury/"
+bug-reports: "https://bitbucket.org/jhw/conjury/issues"
+dev-repo: "git+https://bitbucket.org/jhw/conjury"
+tags: [ "org:conjury.org" ]
+depends: [
+    "ocaml" { with-test & >= "4.04" }
+    "ocamlfind" { with-test & >= "1.7.3" }
+    "omake" { >= "0.10.3" }
+    "ounit2" { with-test >= "2.2" }
+]
+build: [
+    [ "omake" "--configure" ]
+    [ "omake" "test" ] { with-test }
+]
+install: [ "omake" "install" ]
+url {
+    src: "https://bitbucket.org/jhw/conjury/get/r2.0.1.tar.gz"
+    checksum: "md5=f87fbb815bd88a8a1c7f9e372fb59451"
+}


### PR DESCRIPTION
This corrects some compatibility errors in the not very widely used Conjury library for OMake.