### PR TITLE
[new release] ocaml-version (3.0.0)

### DIFF
--- a/packages/ocaml-version/ocaml-version.3.0.0/opam
+++ b/packages/ocaml-version/ocaml-version.3.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+x-commit-hash: "35c6f2d3793a6c050833e86fbfb12e13b14709ac"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v3.0.0/ocaml-version-v3.0.0.tbz"
+  checksum: [
+    "sha256=24b2f324ea91cff98bb8790a6746ccce3173bac5f57cb457156e5c50a0467397"
+    "sha512=a1936198e6e563ed703c8cd9d481394660fb25e9e700ea481e5326536c2734d9356c99750ae3ef8a55614776cc040c05cbcf2e03f609ab1f78c34aab0c5de830"
+  ]
+}


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/ocurrent/ocaml-version">https://github.com/ocurrent/ocaml-version</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-version/doc">https://ocurrent.github.io/ocaml-version/doc</a>

##### CHANGES:

* Update for release of 4.11.0 and 4.10.1.

Interface changes:
* Change signature of `Configure_options.to_configure_flag` to
  take an OCaml version, and add support for post-autoconf
  flags in OCaml 4.08+ (ocurrent/ocaml-version#13 @avsm).
* Add some extra configure options for modern OCaml (@avsm).
* Add a `trunk_variants` that has additional tests that a
  full OCaml test run can use (like disable-flat-float-array).
* Add comparison and equality functions to `Configure_options`.
* Remove dependency on Result compatibility module and use
  Stdlib, which bumps up the minimum OCaml version to 4.07.0 (@avsm)
* Add conversion functions to go from Docker and opam
  representations of architecture strings (@avsm)

Base images:
* Remove safe-string variants from the compiler build images,
  as the era of safe string migration is behind us.
* Add in no-naked-pointers, disable-float-array to compiler
  trunk variants, as they need to be actively tested.
