### PR TITLE
Update LablTk's hasgot for clang 12

### DIFF
--- a/packages/conf-tcl/conf-tcl.1/files/check.sh
+++ b/packages/conf-tcl/conf-tcl.1/files/check.sh
@@ -2,4 +2,5 @@ pkg-config tcl || \
 cc -o /dev/null \
   -I/usr/include/tcl \
   -I/usr/local/include/tcl \
+  -I/usr/local/include/tcl8.6 \
   compiletest.c

--- a/packages/conf-tcl/conf-tcl.1/opam
+++ b/packages/conf-tcl/conf-tcl.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["tcl-devel"] {os-family = "rhel"}
   ["tcl-devel"] {os-family = "fedora"}
   ["tcl-devel"] {os-family = "suse"}
+  ["lang/tcl86"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on tcl"
 description:

--- a/packages/conf-tcl/conf-tcl.1/opam
+++ b/packages/conf-tcl/conf-tcl.1/opam
@@ -19,6 +19,6 @@ description:
   "This package can only install if tcl is installed on the system."
 extra-files: [
   ["compiletest.c" "md5=519d14d3baadfe9a94982fa58a596820"]
-  ["check.sh" "md5=23052a7642deaf090480b4162d365358"]
+  ["check.sh" "md5=5ce09426923c1f9f1f12e92a1c2223a6"]
 ]
 flags: conf

--- a/packages/conf-tk/conf-tk.1/files/check.sh
+++ b/packages/conf-tk/conf-tk.1/files/check.sh
@@ -2,6 +2,7 @@ pkg-config tk || \
 cc -o /dev/null \
   -I/usr/include/tk \
   -I/usr/local/include/tk \
+  -I/usr/local/include/tcl8.6 \
   -I/usr/local/include/tk8.6 \
   -I/opt/X11/include \
   compiletest.c

--- a/packages/conf-tk/conf-tk.1/files/check.sh
+++ b/packages/conf-tk/conf-tk.1/files/check.sh
@@ -3,7 +3,7 @@ cc -o /dev/null \
   -I/usr/include/tk \
   -I/usr/local/include/tk \
   -I/usr/local/include/tcl8.6 \
-  -I/usr/local/include/X11 \
   -I/usr/local/include/tk8.6 \
+  -I/usr/local/include \
   -I/opt/X11/include \
   compiletest.c

--- a/packages/conf-tk/conf-tk.1/files/check.sh
+++ b/packages/conf-tk/conf-tk.1/files/check.sh
@@ -2,5 +2,6 @@ pkg-config tk || \
 cc -o /dev/null \
   -I/usr/include/tk \
   -I/usr/local/include/tk \
+  -I/usr/local/include/tk8.6 \
   -I/opt/X11/include \
   compiletest.c

--- a/packages/conf-tk/conf-tk.1/files/check.sh
+++ b/packages/conf-tk/conf-tk.1/files/check.sh
@@ -3,6 +3,7 @@ cc -o /dev/null \
   -I/usr/include/tk \
   -I/usr/local/include/tk \
   -I/usr/local/include/tcl8.6 \
+  -I/usr/local/include/X11 \
   -I/usr/local/include/tk8.6 \
   -I/opt/X11/include \
   compiletest.c

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -20,6 +20,6 @@ description:
   "This package can only install if tk is installed on the system."
 extra-files: [
   ["compiletest.c" "md5=9495fa2a30a3dad2180634786f6bef2b"]
-  ["check.sh" "md5=1de16343d0ec4c7e1df3ed50eba665b3"]
+  ["check.sh" "md5=24616888c831ad560ed04536304ce57e"]
 ]
 flags: conf

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -20,6 +20,6 @@ description:
   "This package can only install if tk is installed on the system."
 extra-files: [
   ["compiletest.c" "md5=9495fa2a30a3dad2180634786f6bef2b"]
-  ["check.sh" "md5=24616888c831ad560ed04536304ce57e"]
+  ["check.sh" "md5=141b8130ac2c223579d120bf8e26244c"]
 ]
 flags: conf

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -20,6 +20,6 @@ description:
   "This package can only install if tk is installed on the system."
 extra-files: [
   ["compiletest.c" "md5=9495fa2a30a3dad2180634786f6bef2b"]
-  ["check.sh" "md5=141b8130ac2c223579d120bf8e26244c"]
+  ["check.sh" "md5=cabeef6eb2a1b283b5a7a34b66e0e19b"]
 ]
 flags: conf

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["tk-devel"] {os-family = "rhel"}
   ["tk-devel"] {os-family = "fedora"}
   ["tk-devel"] {os-family = "suse"}
+  ["x11-toolkits/tk86"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on tk"
 description:

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -20,6 +20,6 @@ description:
   "This package can only install if tk is installed on the system."
 extra-files: [
   ["compiletest.c" "md5=9495fa2a30a3dad2180634786f6bef2b"]
-  ["check.sh" "md5=9a83fb7a0b708bb6129c032fb27e1609"]
+  ["check.sh" "md5=1de16343d0ec4c7e1df3ed50eba665b3"]
 ]
 flags: conf

--- a/packages/labltk/labltk.8.06.8/files/configure.patch
+++ b/packages/labltk/labltk.8.06.8/files/configure.patch
@@ -1,0 +1,31 @@
+diff --git a/configure b/configure
+index 8ad5742..38ca86b 100755
+--- a/configure
++++ b/configure
+@@ -170,10 +170,15 @@ cc=`cat $where/Makefile.config | grep '^CC=' | sed -e 's/^CC=//'`
+ cclibs=`cat $where/Makefile.config | grep '^NATIVECCLIBS=' | sed -e 's/^NATIVECCLIBS=//'`
+ export cc cclibs
+ 
++if test -z "$tk_x11_include"; then
++  tk_x11_include="-I/usr/local/include"
++fi
++
+ if test $has_tk = true; then
+   tcl_version=''
+   tcl_version=`sh ./runtest $tk_defs $tk_x11_include tclversion.c`
+   for tk_incs in \
++    "" \
+     "-I/usr/local/include" \
+     "-I/opt/local/include" \
+     "-I/sw/include" \
+@@ -293,8 +298,8 @@ fi
+ 
+ if test $has_tk = true; then
+   if test $tk_x11 = yes; then
+-    echo "TK_DEFS=$tk_defs "'$(X11_INCLUDES)' >> Makefile
+-    echo "TK_LINK=$tk_libs "'$(X11_LINK)' >> Makefile
++    echo "TK_DEFS=$tk_defs $tk_x11_include" >> Makefile
++    echo "TK_LINK=$tk_libs $tk_x11_libs" >> Makefile
+   else
+     echo "TK_DEFS=$tk_defs" >> Makefile
+     echo "TK_LINK=$tk_libs" >> Makefile

--- a/packages/labltk/labltk.8.06.8/files/configure.patch
+++ b/packages/labltk/labltk.8.06.8/files/configure.patch
@@ -1,31 +1,63 @@
 diff --git a/configure b/configure
-index 8ad5742..38ca86b 100755
+index 8ad5742..4036166 100755
 --- a/configure
 +++ b/configure
-@@ -170,10 +170,15 @@ cc=`cat $where/Makefile.config | grep '^CC=' | sed -e 's/^CC=//'`
- cclibs=`cat $where/Makefile.config | grep '^NATIVECCLIBS=' | sed -e 's/^NATIVECCLIBS=//'`
- export cc cclibs
+@@ -158,6 +158,10 @@ fi
  
-+if test -z "$tk_x11_include"; then
-+  tk_x11_include="-I/usr/local/include"
-+fi
-+
+ if test $tk_x11 = no; then
+   has_tk=true
++  # May still need to read headers
++  if test -z "$tk_defs"; then
++    tk_x11_include="-I/usr/local/include"
++  fi
+ else
+ #  tk_x11_include=`cat $where/Makefile.config | grep '^X11_INCLUDES=' | sed -e 's/^X11_INCLUDES=//'`
+ #  tk_x11_libs=`cat $where/Makefile.config | grep '^X11_LIBS=' | sed -e 's/^X11_LIBS=//'`
+@@ -172,7 +176,7 @@ export cc cclibs
+ 
  if test $has_tk = true; then
    tcl_version=''
-   tcl_version=`sh ./runtest $tk_defs $tk_x11_include tclversion.c`
+-  tcl_version=`sh ./runtest $tk_defs $tk_x11_include tclversion.c`
++  tcl_version=`sh ./runtest $tk_defs tclversion.c`
    for tk_incs in \
-+    "" \
      "-I/usr/local/include" \
      "-I/opt/local/include" \
-     "-I/sw/include" \
-@@ -293,8 +298,8 @@ fi
+@@ -191,8 +195,8 @@ if test $has_tk = true; then
+     "-I/usr/local/include/tcl8.2 -I/usr/local/include/tk8.2" \
+     "-I/usr/include/tcl8.2 -I/usr/include/tk8.2"
+   do if test -z "$tcl_version"; then
+-    tk_defs="$tk_incs"
+-    tcl_version=`sh ./runtest $tk_defs $tk_x11_include tclversion.c`
++    tk_defs="$tk_incs $tk_x11_include"
++    tcl_version=`sh ./runtest $tk_defs tclversion.c`
+   fi; done
+   if test -n "$tcl_version" && test "x$tcl_version" != "xnone"; then
+     inf "tcl.h and tk.h version $tcl_version found with \"$tk_defs\"."
+@@ -218,12 +222,7 @@ system=`cat $where/Makefile.config | grep '^SYSTEM=' | sed -e 's/^SYSTEM=//'`
+ 
+ if test $has_tk = true && test -z "$tk_libs"; then
+   tklibdir=""
+-  if test -n "$tk_defs"; then
+-    tkinclude="$tk_defs"
+-  else
+-    tkinclude="$tk_x11_include"
+-  fi
+-  case "$tkinclude" in
++  case "$tk_defs" in
+   -I/opt/local/include*) tklibdir="/opt/local/lib" ;;
+   -I/usr/local/include*) tklibdir="/usr/local/lib" ;;
+   -I/sw/include*) tklibdir="/sw/lib" ;;
+@@ -292,11 +291,10 @@ if test $has_tk = true; then
+ fi
  
  if test $has_tk = true; then
++  echo "TK_DEFS=$tk_defs" >> Makefile
    if test $tk_x11 = yes; then
 -    echo "TK_DEFS=$tk_defs "'$(X11_INCLUDES)' >> Makefile
 -    echo "TK_LINK=$tk_libs "'$(X11_LINK)' >> Makefile
-+    echo "TK_DEFS=$tk_defs $tk_x11_include" >> Makefile
 +    echo "TK_LINK=$tk_libs $tk_x11_libs" >> Makefile
    else
-     echo "TK_DEFS=$tk_defs" >> Makefile
+-    echo "TK_DEFS=$tk_defs" >> Makefile
      echo "TK_LINK=$tk_libs" >> Makefile
+   fi
+   otherlibraries="$otherlibraries labltk"

--- a/packages/labltk/labltk.8.06.8/files/hasgot.patch
+++ b/packages/labltk/labltk.8.06.8/files/hasgot.patch
@@ -1,0 +1,14 @@
+diff --git a/config/auto-aux/hasgot b/config/auto-aux/hasgot
+index 53d5786..5248229 100755
+--- a/config/auto-aux/hasgot
++++ b/config/auto-aux/hasgot
+@@ -30,7 +30,8 @@ while : ; do
+   shift
+ done
+ 
+-(echo "main() {"
++(for f in $*; do echo "int $f();"; done
++ echo "int main() {"
+  for f in $*; do echo "  $f();"; done
+  echo "}") >> hasgot.c
+ 

--- a/packages/labltk/labltk.8.06.8/opam
+++ b/packages/labltk/labltk.8.06.8/opam
@@ -24,6 +24,10 @@ post-messages: [
 synopsis: "OCaml interface to Tcl/Tk"
 description: "ocamlbrowser is now a separate package.\n\
              For details, see https://garrigue.github.io/labltk/"
+patches: ["hasgot.patch"]
+extra-files: [
+  ["hasgot.patch" "md5=1e4bf6b5aa4740e7fbffff97d18bfc30"]
+]
 url {
   src: "https://github.com/garrigue/labltk/archive/8.06.8.tar.gz"
   checksum: "md5=ec4e7ed25f0938a9b6f9207d15e1f982"

--- a/packages/labltk/labltk.8.06.8/opam
+++ b/packages/labltk/labltk.8.06.8/opam
@@ -24,8 +24,9 @@ post-messages: [
 synopsis: "OCaml interface to Tcl/Tk"
 description: "ocamlbrowser is now a separate package.\n\
              For details, see https://garrigue.github.io/labltk/"
-patches: ["hasgot.patch"]
+patches: ["configure.patch" "hasgot.patch"]
 extra-files: [
+  ["configure.patch" "md5=4220a37718b7df912dfda0a7e1903cb6"]
   ["hasgot.patch" "md5=1e4bf6b5aa4740e7fbffff97d18bfc30"]
 ]
 url {

--- a/packages/labltk/labltk.8.06.8/opam
+++ b/packages/labltk/labltk.8.06.8/opam
@@ -26,7 +26,7 @@ description: "ocamlbrowser is now a separate package.\n\
              For details, see https://garrigue.github.io/labltk/"
 patches: ["configure.patch" "hasgot.patch"]
 extra-files: [
-  ["configure.patch" "md5=4220a37718b7df912dfda0a7e1903cb6"]
+  ["configure.patch" "md5=9cdd0d2152f177899c37da0a56007079"]
   ["hasgot.patch" "md5=1e4bf6b5aa4740e7fbffff97d18bfc30"]
 ]
 url {

--- a/packages/ocamlbrowser/ocamlbrowser.4.10.0/files/hasgot.patch
+++ b/packages/ocamlbrowser/ocamlbrowser.4.10.0/files/hasgot.patch
@@ -1,0 +1,14 @@
+diff --git a/config/auto-aux/hasgot b/config/auto-aux/hasgot
+index 53d5786..5248229 100755
+--- a/config/auto-aux/hasgot
++++ b/config/auto-aux/hasgot
+@@ -30,7 +30,8 @@ while : ; do
+   shift
+ done
+ 
+-(echo "main() {"
++(for f in $*; do echo "int $f();"; done
++ echo "int main() {"
+  for f in $*; do echo "  $f();"; done
+  echo "}") >> hasgot.c
+ 

--- a/packages/ocamlbrowser/ocamlbrowser.4.10.0/opam
+++ b/packages/ocamlbrowser/ocamlbrowser.4.10.0/opam
@@ -24,6 +24,10 @@ post-messages: [
 ]
 synopsis: "OCamlBrowser Library Explorer"
 description: "Require LablTk. For details, see https://forge.ocamlcore.org/projects/labltk/"
+patches: ["hasgot.patch"]
+extra-files: [
+  ["hasgot.patch" "md5=1e4bf6b5aa4740e7fbffff97d18bfc30"]
+]
 url {
   src: "https://github.com/garrigue/labltk/archive/8.06.8.tar.gz"
   checksum: "md5=ec4e7ed25f0938a9b6f9207d15e1f982"


### PR DESCRIPTION
clang 12 seems to requires function to have prototypes, which breaks the `hasgot.c` generated during configuration.
This PR should allow to compile labltk and ocamlbrowser for ocaml 4.10 on MacOS.