### PR TITLE
Release ocaml-jupyter kernel 2.7.2

### DIFF
--- a/packages/jupyter/jupyter.2.7.2/opam
+++ b/packages/jupyter/jupyter.2.7.2/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: [
+  "Akinori ABE <aabe.65535@gmail.com>"
+]
+authors: [
+  "Akinori ABE"
+]
+license: "MIT"
+homepage: "https://akabe.github.io/ocaml-jupyter/"
+bug-reports: "https://github.com/akabe/ocaml-jupyter/issues"
+dev-repo: "git+https://github.com/akabe/ocaml-jupyter.git"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.04.0" & < "4.12"}
+  "base-threads"
+  "base-unix"
+  "uuidm" {>= "0.9.6"}
+  "base64" {>= "3.2.0"}
+  "lwt" {>= "4.0.0"}
+  "lwt_ppx" {>= "1.0.0"}
+  "logs" {>= "0.6.0"}
+  "stdint" {>= "0.4.2"}
+  "zmq" {>= "5.0.0"}
+  "zmq-lwt" {>= "5.0.0"}
+  "yojson" {>= "1.3.3"}
+  "ppx_deriving_yojson" {>= "3.0"}
+  "cryptokit" {>= "1.12"}
+  "dune" {>= "1.0.0"}
+]
+depopts: [
+  "merlin"
+]
+conflicts: [
+  "merlin" {< "3.0.0"}
+]
+
+post-messages: [
+  "Please run for registration of ocaml-jupyter kernel:"
+  ""
+  "$ ocaml-jupyter-opam-genspec"
+  "$ jupyter kernelspec install --name ocaml-jupyter \\"
+  "    %{share}%/jupyter"
+  {success}
+]
+
+synopsis: "An OCaml kernel for Jupyter notebook"
+description:
+  "OCaml Jupyter provides an OCaml REPL on Jupyter (a great interface with markdown/HTML documentation, LaTeX formula by MathJax, and image embedding). This is useful for data analysis in OCaml."
+url {
+  src: "https://github.com/akabe/ocaml-jupyter/releases/download/v2.7.2/jupyter-v2.7.2.tbz"
+  checksum: "sha256=0a1c41b5c8aa14840694eab6ae7eb7e974292052861fa58b7f2737a2631626cc"
+}


### PR DESCRIPTION
ocaml-jupyter kernel now supports ocaml 4.11.

Release note: https://github.com/akabe/ocaml-jupyter/releases/tag/v2.7.2