### PR TITLE
[new release] letters (0.2.0)

### DIFF
--- a/packages/letters/letters.0.2.0/opam
+++ b/packages/letters/letters.0.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Client library for sending emails over SMTP"
+description: "Simple to use SMTP client implementation for OCaml"
+maintainer: ["Miko Nieminen <miko.nieminen@iki.fi>"]
+authors: ["Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/letters/"
+doc: "https://oxidizing.github.io/letters/"
+bug-reports: "https://github.com/oxidizing/letters/issues"
+depends: [
+  "ocaml" {>= "4.08.1"}
+  "dune" {>= "2.3"}
+  "mrmime" {>= "0.3.0"}
+  "colombe" {>= "0.3.0"}
+  "sendmail-lwt" {>= "0.3.0"}
+  "fmt" {>= "0.8.8"}
+  "x509" {>= "0.9.0"}
+  "ptime" {>= "0.8.5"}
+  "lwt" {>= "5.2.0"}
+  "fpath" {>= "0.7.0"}
+  "alcotest" {>= "1.1.0" & with-test}
+  "alcotest-lwt" {>= "1.1.0" & with-test}
+  "yojson" {>= "1.7.0" & with-test}
+  "ocamlformat" {dev}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/letters.git"
+x-commit-hash: "bea7f7a0b6c52e210efe85adf03cccbf8b34752b"
+url {
+  src:
+    "https://github.com/oxidizing/letters/releases/download/0.2.0/letters-0.2.0.tbz"
+  checksum: [
+    "sha256=c7b607e2d97bd6bcb10a3139674d8c795836071be14ef5e14fcb769f093b1ab4"
+    "sha512=aef53eb7c1377d04e66db807d4343638354e9397759e679c1e000cbcb9e683216ebc0bd240207f90c2bf4c6859d8c72eb815dd273e51526ba38cb4fc6d51ce72"
+  ]
+}


### PR DESCRIPTION
Client library for sending emails over SMTP

- Project page: <a href="https://github.com/oxidizing/letters/">https://github.com/oxidizing/letters/</a>
- Documentation: <a href="https://oxidizing.github.io/letters/">https://oxidizing.github.io/letters/</a>

##### CHANGES:

## [0.2.0] - 2020-08-25
### Added
- Support for multipart/alternative emails supporting HTML and plain text bodies
  as alternative representation for the content
- Add documentation for basic use
- Add support for detecting CA certificates automatically for peer verification
- Add support defining bundle or single CA certificate for peer verification
- Add support for selecting mechanism for CA certificates used for peer
  verification
### Changed
- Refactor configurations into separate module
- Refactor structure of tests

## [0.1.1] - 2020-07-10
### Fixed
- Add missing `public_name` stanza in library's dune file to make it properly
available
- Fix minimum required OCaml version to 4.08.1
- Relax `mrmime` and `colombe` dependency constraints

## [0.1.0] - 2020-07-07
### Added
- Support sending email over TLS protected SMTP connection
- Support sending email over SMTP with STARTTLS
- Support sending HTML or plain text body
