### PR TITLE
[new release] letters (0.2.0)

### DIFF
--- a/packages/letters/letters.0.2.0/opam
+++ b/packages/letters/letters.0.2.0/opam
@@ -22,6 +22,7 @@ depends: [
   "alcotest-lwt" {>= "1.1.0" & with-test}
   "yojson" {>= "1.7.0" & with-test}
   "ocamlformat" {dev}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/letters/letters.0.2.0/opam
+++ b/packages/letters/letters.0.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Client library for sending emails over SMTP"
+description: "Simple to use SMTP client implementation for OCaml"
+maintainer: ["Miko Nieminen <miko.nieminen@iki.fi>"]
+authors: ["Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/letters/"
+doc: "https://oxidizing.github.io/letters/"
+bug-reports: "https://github.com/oxidizing/letters/issues"
+depends: [
+  "ocaml" {>= "4.08.1"}
+  "dune" {>= "2.3"}
+  "mrmime" {>= "0.3.0"}
+  "colombe" {>= "0.3.0"}
+  "sendmail-lwt" {>= "0.3.0"}
+  "fmt" {>= "0.8.8"}
+  "x509" {>= "0.9.0"}
+  "ptime" {>= "0.8.5"}
+  "lwt" {>= "5.2.0"}
+  "fpath" {>= "0.7.0"}
+  "alcotest" {>= "1.1.0" & with-test}
+  "alcotest-lwt" {>= "1.1.0" & with-test}
+  "yojson" {>= "1.7.0" & with-test}
+  "ocamlformat" {dev}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/letters.git"
+x-commit-hash: "7426b6b431520569508566adce96a415bc754cf7"
+url {
+  src:
+    "https://github.com/oxidizing/letters/releases/download/0.2.0/letters-0.2.0.tbz"
+  checksum: [
+    "sha256=5cbda38f8c891ae84b55aa27f07d598ea6e0251e4e4bd1435b3fde904efc935a"
+    "sha512=06a8612473331bcbcaa6e18743d53e9c3a94f82778ce2883327959c4d4be7b785a975fdad93ae34fd2a15cb1f66635346b10dc54a68cef5fbb0fdd750ff1b9e5"
+  ]
+}

--- a/packages/sihl/sihl.0.0.56/opam
+++ b/packages/sihl/sihl.0.0.56/opam
@@ -30,7 +30,7 @@ depends: [
   "safepass" {>= "3.0"}
   "jwto" {>= "0.3.0"}
   "uuidm" {>= "0.9.7"}
-  "letters" {>= "0.1.1"}
+  "letters" {>= "0.1.1" & < "0.2.0" }
   "sexplib" {>= "0.13.0"}
   "ppx_fields_conv" {>= "0.13.0"}
   "ppx_sexp_conv" {>= "0.13.0"}


### PR DESCRIPTION
Client library for sending emails over SMTP

- Project page: <a href="https://github.com/oxidizing/letters/">https://github.com/oxidizing/letters/</a>
- Documentation: <a href="https://oxidizing.github.io/letters/">https://oxidizing.github.io/letters/</a>

##### CHANGES:

## [0.2.0] - 2020-08-25
### Added
- Support for multipart/alternative emails supporting HTML and plain text bodies
  as alternative representation for the content
- Add documentation for basic use
- Add support for detecting CA certificates automatically for peer verification
- Add support defining bundle or single CA certificate for peer verification
- Add support for selecting mechanism for CA certificates used for peer
  verification
### Changed
- Refactor configurations into separate module
- Refactor structure of tests

## [0.1.1] - 2020-07-10
### Fixed
- Add missing `public_name` stanza in library's dune file to make it properly
available
- Fix minimum required OCaml version to 4.08.1
- Relax `mrmime` and `colombe` dependency constraints

## [0.1.0] - 2020-07-07
### Added
- Support sending email over TLS protected SMTP connection
- Support sending email over SMTP with STARTTLS
- Support sending HTML or plain text body
