### PR TITLE
Travis-CI: Enable ARM64 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ install: bash -e .travis-ci-install.sh
 script: bash -e .travis-ci.sh
 cache: apt
 dist: xenial
-sudo: required
-env:
-  global:
-#    - OPAM_VERSION=2.0
 matrix:
   include:
   - os: osx
@@ -16,6 +12,9 @@ matrix:
     env: OCAML_VERSION=4.09
   - os: linux
     env: OCAML_VERSION=4.09 INSTALL_LOCAL=1
+arch:
+  - amd64
+  - arm64
 notifications:
   email:
   - opam-commits@lists.ocaml.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ matrix:
     - os: linux
       arch: arm64
       env: OCAML_VERSION=4.11
-arch:
-  - amd64
-  - arm64
 notifications:
   email:
   - opam-commits@lists.ocaml.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,14 @@ matrix:
     - os: freebsd
       env: OCAML_VERSION=4.09
     - os: linux
+      arch: amd64
       env: OCAML_VERSION=4.09 INSTALL_LOCAL=1
-  arch:
-    - amd64
-    - arm64
+    - os: linux
+      arch: arm64
+      env: OCAML_VERSION=4.11
+arch:
+  - amd64
+  - arm64
 notifications:
   email:
   - opam-commits@lists.ocaml.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ cache: apt
 dist: xenial
 matrix:
   include:
-  - os: osx
-    osx_image: xcode11.3
-    env: OCAML_VERSION=4.09
-  - os: freebsd
-    env: OCAML_VERSION=4.09
-  - os: linux
-    env: OCAML_VERSION=4.09 INSTALL_LOCAL=1
-arch:
-  - amd64
-  - arm64
+    - os: osx
+      osx_image: xcode11.3
+      env: OCAML_VERSION=4.09
+    - os: freebsd
+      env: OCAML_VERSION=4.09
+    - os: linux
+      env: OCAML_VERSION=4.09 INSTALL_LOCAL=1
+  arch:
+    - amd64
+    - arm64
 notifications:
   email:
   - opam-commits@lists.ocaml.org


### PR DESCRIPTION
While waiting for our next generation CI, this might be useful.
For the moment only Linux is supported. MacOS and FreeBSD are not yet supported. Hopefully it'll come sooner or later on mac at least.