### PR TITLE
Package resource-pooling.1.2

### DIFF
--- a/packages/resource-pooling/resource-pooling.1.2/opam
+++ b/packages/resource-pooling/resource-pooling.1.2/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "Jan Rochel <jan@besport.com>"
+authors: [ "Jan Rochel (BeSport)" ]
+synopsis: "Library for pooling resources like connections, threads, or similar"
+description: "This package is derived from the module Lwt_pool from the lwt package, which implements resource pooling. With Resource_pool this package provides a modified version with additional features. Also there is a module called Server_pool that manages resource clusters, specifically a cluster of servers each with its own connection pool."
+license: "MIT"
+homepage: "https://github.com/ocsigen/resource-pooling"
+dev-repo: "git+https://github.com/ocsigen/resource-pooling.git"
+bug-reports: "https://github.com/ocsigen/resource-pooling/issues"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.11"}
+  "lwt" {>= "2.4.7"}
+  "lwt_log"
+]
+url {
+  src: "https://github.com/ocsigen/resource-pooling/archive/1.2.tar.gz"
+  checksum: [
+    "md5=235d1fe3719d5a87479cbb1b286cd9b2"
+    "sha512=7d1ba3524a320c5748928438e0d9df6c80e5dc054b3f5439b2d1786359699aaeb48c88220c8b3d9ec023171c8a2944cedeee68107630bbc98994c67a99a237f8"
+  ]
+}


### PR DESCRIPTION
### `resource-pooling.1.2`
Library for pooling resources like connections, threads, or similar
This package is derived from the module Lwt_pool from the lwt package, which implements resource pooling. With Resource_pool this package provides a modified version with additional features. Also there is a module called Server_pool that manages resource clusters, specifically a cluster of servers each with its own connection pool.



---
* Homepage: https://github.com/ocsigen/resource-pooling
* Source repo: git+https://github.com/ocsigen/resource-pooling.git
* Bug tracker: https://github.com/ocsigen/resource-pooling/issues

---
:camel: Pull-request generated by opam-publish v2.0.2