### PR TITLE
new package zarith-freestanding 1.9.1

### DIFF
--- a/packages/zarith-freestanding/zarith-freestanding.1.9.1/files/mirage-build.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.9.1/files/mirage-build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+# WARNING: if you pass invalid cflags here, zarith will silently
+# fall back to compiling with the default flags instead!
+CFLAGS="$(pkg-config --cflags gmp-freestanding ocaml-freestanding)" \
+LDFLAGS="$(pkg-config --libs gmp-freestanding)" \
+CC=cc \
+./configure -nodynlink -gmp
+
+if [ `uname -s` = "FreeBSD" ] || [ `uname -s` = "OpenBSD" ]; then
+    gmake
+else
+    make
+fi

--- a/packages/zarith-freestanding/zarith-freestanding.1.9.1/files/mirage-install.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.9.1/files/mirage-install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+export PKG_CONFIG_PATH
+
+cp libzarith.a "$PREFIX/lib/zarith/libzarith-freestanding.a"
+
+# This is a hack to get freestanding_linkopts into the host 'zarith' package.
+cat >>"$PREFIX/lib/zarith/META" <<EOM
+freestanding_linkopts = "-lzarith-freestanding -L@gmp-freestanding -lgmp-freestanding"
+EOM

--- a/packages/zarith-freestanding/zarith-freestanding.1.9.1/files/mirage-uninstall.sh
+++ b/packages/zarith-freestanding/zarith-freestanding.1.9.1/files/mirage-uninstall.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -eux
+
+PREFIX=`opam config var prefix`
+
+rm -f "$PREFIX/lib/zarith/libzarith-freestanding.a"
+
+mv "$PREFIX/lib/zarith/META" "$PREFIX/lib/zarith/META.tmp"
+cat "$PREFIX/lib/zarith/META.tmp" | grep -v freestanding_linkopts > "$PREFIX/lib/zarith/META"
+rm -f "$PREFIX/lib/zarith/META.tmp"

--- a/packages/zarith-freestanding/zarith-freestanding.1.9.1/files/no-dynlink.patch
+++ b/packages/zarith-freestanding/zarith-freestanding.1.9.1/files/no-dynlink.patch
@@ -1,0 +1,86 @@
+This patch is required to build Zarith on an ocaml-freestanding type setup. It
+does three things:
+
+1. Add an option to configure to forcibly disable dynlink.
+2. Stop configure from adding a host -lgmp.
+3. In addition to (1), force project.mak to use "ocamlmklib -custom" instead of
+   "ocamlmklib -failsafe".
+
+We need all three because the Zarith build system is TOTALLY INSANE and has
+never even remotely heard of such a thing as cross compiling, and we need it to
+just shut up and build ONLY with the flags we pass it. KTHXBYE
+
+--- a/configure	2019-08-28 16:17:04.000000000 +0200
++++ b/configure	2020-08-26 17:55:33.488824000 +0200
+@@ -21,6 +21,7 @@
+ host='auto'
+ gmp='auto'
+ perf='no'
++nodynlink='no'
+ 
+ ar='ar'
+ ocaml='ocaml'
+@@ -59,6 +60,7 @@
+   -gmp                 use GMP library (default if found)
+   -mpir                use MPIR library instead of GMP
+   -perf                enable performance statistics
++  -nodynlink           disable dynamic linking
+   -prefixnonocaml      add for non ocaml tool, e.g. -prefixnonocaml x86_64-w64-mingw32-
+ 
+ Environment variables that affect configuration:
+@@ -101,6 +103,8 @@
+             gmp='mpir';;
+         -perf|--perf)
+             perf='yes';;
++        -nodynlink|--nodynlink)
++            nodynlink='yes';;
+         -prefixnonocaml|--prefixnonocaml)
+             prefixnonocaml="$2"
+             shift;;
+@@ -268,7 +272,7 @@
+ 
+ hasdynlink='no'
+ 
+-if test $hasocamlopt = yes
++if test $hasocamlopt = yes -a $nodynlink = no
+ then
+     checkcmxalib dynlink.cmxa
+     if test $? -eq 1; then hasdynlink='yes'; fi
+@@ -368,12 +372,8 @@
+ if test "$gmp" = 'gmp' -o "$gmp" = 'auto'; then
+     checkinc gmp.h
+     if test $? -eq 1; then
+-        checklib gmp
+-        if test $? -eq 1; then 
+-            gmp='OK'
+-            cclib="$cclib -lgmp"
+-            ccdef="-DHAS_GMP $ccdef"
+-        fi
++        gmp='OK'
++        ccdef="-DHAS_GMP $ccdef"
+     fi
+ fi
+ if test "$gmp" = 'mpir' -o "$gmp" = 'auto'; then
+diff -ur zarith.1.9.1.orig/project.mak zarith.1.9.1/project.mak
+--- a/project.mak	2019-08-28 16:17:04.000000000 +0200
++++ b/project.mak	2020-08-26 17:55:49.996798000 +0200
+@@ -70,16 +70,16 @@
+ 	make -C tests test
+ 
+ zarith.cma: $(MLSRC:%.ml=%.cmo)
+-	$(OCAMLMKLIB) -failsafe -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
+ 
+ zarith.cmxa zarith.$(LIBSUFFIX): $(MLSRC:%.ml=%.cmx)
+-	$(OCAMLMKLIB) -failsafe -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
+ 
+ zarith.cmxs: zarith.cmxa libzarith.$(LIBSUFFIX)
+ 	$(OCAMLOPT) -shared -o $@ -I . zarith.cmxa -linkall
+ 
+ libzarith.$(LIBSUFFIX) dllzarith.$(DLLSUFFIX): $(SSRC:%.S=%.$(OBJSUFFIX)) $(CSRC:%.c=%.$(OBJSUFFIX)) 
+-	$(OCAMLMKLIB) -failsafe -o zarith $+ $(LIBS)
++	$(OCAMLMKLIB) -custom -o zarith $+ $(LIBS)
+ 
+ zarith_top.cma: zarith_top.cmo
+ 	$(OCAMLC) -o $@ -a $<

--- a/packages/zarith-freestanding/zarith-freestanding.1.9.1/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.9.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+authors: "Xavier Leroy"
+maintainer: "mirageos-devel"
+homepage: "https://forge.ocamlcore.org/projects/zarith"
+bug-reports:  "mirageos-devel@lists.xenproject.org"
+build: ["sh" "-eux" "./mirage-build.sh"]
+install: ["sh" "-eux" "./mirage-install.sh"]
+remove: ["sh" "-eux" "./mirage-uninstall.sh"]
+depends: [
+  "ocaml"
+  "ocaml-freestanding" {>= "0.4.1"}
+  "gmp-freestanding" {>= "6.1.2-2"}
+  "zarith" {= "1.9.1"}
+  "ocamlfind" {build}
+]
+patches: [ "no-dynlink.patch" ]
+synopsis:
+  "Implements arithmetic and logical operations over arbitrary-precision integers"
+description: """
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy."""
+extra-files: [
+  ["mirage-uninstall.sh" "md5=de37d98a1987c89bc53a7a032b7278df"]
+  ["mirage-install.sh" "md5=f195dd0b56296a61d3233389c032a03d"]
+  ["mirage-build.sh" "md5=d8585e00ab3353746f2fc4c15abe7cfa"]
+  ["no-dynlink.patch" "md5=2437531740d788bbeba56241d54debc2"]
+]
+url {
+  src: "https://github.com/ocaml/Zarith/archive/release-1.9.1.tar.gz"
+  checksum: [
+    "md5=af41b7534a4c91a8f774f04e307c1c66"
+    "sha512=e77620c66a59d35811acfc45c7ef3f0d50d3042194654b1f5b652a2ed5fb9d5f88e9173222e5ced286c61854434da05a4d96668089faa66ff2917afa677fc32f"
+  ]
+}


### PR DESCRIPTION
zarith-freestanding is a cross-compiled zarith to be used with MirageOS (and freestanding).