### PR TITLE
[new release] alcotest-async, alcotest, alcotest-mirage and alcotest-lwt (1.2.2)

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.2.2/opam
+++ b/packages/alcotest-async/alcotest-async.1.2.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Async-based helpers for Alcotest"
+description: "Async-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "async_unix" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "b16d4f5fec181705672df7b58b1039e2b1d14d60"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.2/alcotest-mirage-1.2.2.tbz"
+  checksum: [
+    "sha256=b4bbfdf8fc9597d845ec4024d8a260c6cca2eac51fe166c376a6929576ad051c"
+    "sha512=73ba44c028ac70a61bb19bc08d421bc7cd8158faaabc0101b3f4ce83d4faf691f4b6212f73cadabc859984b7509a47df6a7ed27ae2578ad2efd12d2e5f7e331e"
+  ]
+}

--- a/packages/alcotest-lwt/alcotest-lwt.1.2.2/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.2.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Lwt-based helpers for Alcotest"
+description: "Lwt-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "lwt"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "b16d4f5fec181705672df7b58b1039e2b1d14d60"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.2/alcotest-mirage-1.2.2.tbz"
+  checksum: [
+    "sha256=b4bbfdf8fc9597d845ec4024d8a260c6cca2eac51fe166c376a6929576ad051c"
+    "sha512=73ba44c028ac70a61bb19bc08d421bc7cd8158faaabc0101b3f4ce83d4faf691f4b6212f73cadabc859984b7509a47df6a7ed27ae2578ad2efd12d2e5f7e331e"
+  ]
+}

--- a/packages/alcotest-mirage/alcotest-mirage.1.2.2/opam
+++ b/packages/alcotest-mirage/alcotest-mirage.1.2.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Mirage implementation for Alcotest"
+description: "Mirage implementation for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "mirage-clock" {>= "2.0.0"}
+  "duration"
+  "lwt"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "b16d4f5fec181705672df7b58b1039e2b1d14d60"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.2/alcotest-mirage-1.2.2.tbz"
+  checksum: [
+    "sha256=b4bbfdf8fc9597d845ec4024d8a260c6cca2eac51fe166c376a6929576ad051c"
+    "sha512=73ba44c028ac70a61bb19bc08d421bc7cd8158faaabc0101b3f4ce83d4faf691f4b6212f73cadabc859984b7509a47df6a7ed27ae2578ad2efd12d2e5f7e331e"
+  ]
+}

--- a/packages/alcotest/alcotest.1.2.2/opam
+++ b/packages/alcotest/alcotest.1.2.2/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Alcotest is a lightweight and colourful test framework"
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "cmdliner"
+  "uuidm"
+  "re"
+  "stdlib-shims"
+  "uutf"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "b16d4f5fec181705672df7b58b1039e2b1d14d60"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.2/alcotest-mirage-1.2.2.tbz"
+  checksum: [
+    "sha256=b4bbfdf8fc9597d845ec4024d8a260c6cca2eac51fe166c376a6929576ad051c"
+    "sha512=73ba44c028ac70a61bb19bc08d421bc7cd8158faaabc0101b3f4ce83d4faf691f4b6212f73cadabc859984b7509a47df6a7ed27ae2578ad2efd12d2e5f7e331e"
+  ]
+}


### PR DESCRIPTION
Corresponding upstream PR: https://github.com/mirage/alcotest/pull/269.

#### CHANGES:

- Fail gracefully when the user supplies an empty suite name. (mirage/alcotest#265, @CraigFe)

- Fix compatibility with `fmt.0.8.8+dune` by adding a missing `fmt` dependency
  in `alcotest`'s dune file (mirage/alcotest#266, @NathanReb)

- Only show "in progress" lines when writing to a TTY. (mirage/alcotest#267, @CraigFe)
