### PR TITLE
Package opam-file-format.2.1.0

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.1.0/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Parser and printer for the opam file syntax"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-file-format/issues"
+depends: ["ocaml"]
+depopts: ["dune"]
+build: [
+  [make "byte" {!ocaml-native} "all" {ocaml-native}] {!dune:installed}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+    {dune:installed}
+]
+install: [make "install" "PREFIX=%{prefix}%"] {!dune:installed}
+dev-repo: "git+https://github.com/ocaml/opam-file-format"
+url {
+  src: "https://github.com/ocaml/opam-file-format/archive/2.1.0.tar.gz"
+  checksum: [
+    "md5=f3daefb6f6041d6c1baed0c63d88f0fb"
+    "sha512=b948545497de0386457a9b5772924572249e38164aa49d5ab2ac9442d1231a56a3b8132a95197d74cbbe34336a7edc04eaca351a8763c4a009a512085ca0ab25"
+  ]
+}


### PR DESCRIPTION
### `opam-file-format.2.1.0`
Parser and printer for the opam file syntax



---
* Homepage: https://opam.ocaml.org
* Source repo: git+https://github.com/ocaml/opam-file-format
* Bug tracker: https://github.com/ocaml/opam-file-format/issues

---
:camel: Pull-request generated by opam-publish v2.0.2