### PR TITLE
Add `jq` depext to `conf-jq` for freebsd

### DIFF
--- a/packages/conf-jq/conf-jq.1/opam
+++ b/packages/conf-jq/conf-jq.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["jq"] {os-family = "suse"}
   ["jq"] {os-distribution = "ol"}
   ["jq"] {os-distribution = "arch"}
+  ["jq"] {os = "freebsd"}
   ["jq"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on jq"


### PR DESCRIPTION
In the quest to fix Merlin CI this should solve the Travis FreeBSD issue.