### PR TITLE
[new release] mirage-stack (2.1.0)

### DIFF
--- a/packages/mirage-stack/mirage-stack.2.1.0/opam
+++ b/packages/mirage-stack/mirage-stack.2.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-stack"
+doc: "https://mirage.github.io/mirage-stack/"
+bug-reports: "https://github.com/mirage/mirage-stack/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-stack.git"
+synopsis: "MirageOS signatures for network stacks"
+description: """
+mirage-stack provides a set of module types which libraries intended to be used
+as MirageOS network stacks should implement.
+"""
+x-commit-hash: "71e87c92dad32d3a38f1f11c300988d3aa25b603"
+url {
+  src:
+    "https://github.com/mirage/mirage-stack/releases/download/v2.1.0/mirage-stack-v2.1.0.tbz"
+  checksum: [
+    "sha256=abed5d082df1ee5cb0776351e766ab080f3be202b0e0112558036439490421f8"
+    "sha512=9e855db0f30440eb909a0ccd6472cd3c4d54eddb7579ae94babf03768cc0985675a9f3f4d194af06ec07e88de59d6c8fec224b52fcc2ce41110d36b610576b12"
+  ]
+}


### PR DESCRIPTION
MirageOS signatures for network stacks

- Project page: <a href="https://github.com/mirage/mirage-stack">https://github.com/mirage/mirage-stack</a>
- Documentation: <a href="https://mirage.github.io/mirage-stack/">https://mirage.github.io/mirage-stack/</a>

##### CHANGES:

* add Mirage_stack.V6 module type (mirage/mirage-stack#18 @MagnusS)
