### PR TITLE
Package naboris.0.1.3

### DIFF
--- a/packages/naboris/naboris.0.1.3/opam
+++ b/packages/naboris/naboris.0.1.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built on httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "base64" {>= "3.4.0"}
+  "dune" {>= "1.6"}
+  "reason" {>= "3.4.0"}
+  "httpaf" {>= "0.6.0"}
+  "httpaf-lwt-unix" {>= "0.6.0"}
+  "lwt" {>= "5.1.1"}
+  "uri" {>= "2.2.0"}
+]
+depopts: [
+  "conf-libev"
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/0.1.3.tar.gz"
+  checksum: [
+    "md5=b400a0ab14ec33e257a31adff44acf82"
+    "sha512=24734441c0c40a01b691777c3ce238f96e58edf0a1de8dc0dc64cc325210b08bd71916b9f79b3059b4dbd8841e9ac627954a4314a578bb0eb42c8475099b3f34"
+  ]
+}


### PR DESCRIPTION
### `naboris.0.1.3`
Simple http server
Simple http server built on httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.2