### PR TITLE
Package naboris.0.1.3

### DIFF
--- a/packages/naboris/naboris.0.1.3/opam
+++ b/packages/naboris/naboris.0.1.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built on httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "base64" {>= "3.4.0"}
+  "dune" {>= "1.6"}
+  "reason" {>= "3.4.0"}
+  "httpaf" {>= "0.6.0"}
+  "httpaf-lwt-unix" {>= "0.6.0"}
+  "lwt" {>= "5.1.1"}
+  "lwt_ppx" {>= "2.0.1"}
+  "uri" {>= "2.2.0"}
+]
+depopts: [
+  "conf-libev"
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/0.1.3.tar.gz"
+  checksum: [
+    "md5=63034268d75ab03a1dcb8b8e7c361f42"
+    "sha512=57fad5b2d39613121069599b894022cc657b7c98939060ff5644f9ce0b15f348e45a429174971df93c9f4619e7c5a22eec4011e9b1c739ab06b0c1bf3a6ae446"
+  ]
+}


### PR DESCRIPTION
### `naboris.0.1.3`
Simple http server
Simple http server built on httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.2