### PR TITLE
Package naboris.0.1.3

### DIFF
--- a/packages/naboris/naboris.0.1.3/opam
+++ b/packages/naboris/naboris.0.1.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Simple http server"
+description: "Simple http server built on httpaf and lwt"
+maintainer: "Shawn McGinty <loltempast@gmail.com>"
+authors: [ "Shawn McGinty <loltempast@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/shawn-mcginty/naboris"
+bug-reports: "https://github.com/shawn-mcginty/naboris/issues"
+dev-repo: "git+https://github.com/shawn-mcginty/naboris.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "base64" {>= "3.4.0"}
+  "dune" {>= "1.6"}
+  "digestif" {>= "0.8.0"}
+  "reason" {>= "3.4.0"}
+  "httpaf" {>= "0.6.0"}
+  "httpaf-lwt-unix" {>= "0.6.0"}
+  "lwt" {>= "5.1.1"}
+  "lwt_ppx" {>= "2.0.1"}
+  "uri" {>= "2.2.0"}
+]
+depopts: [
+  "conf-libev"
+]
+url {
+  src: "https://github.com/shawn-mcginty/naboris/archive/0.1.3.tar.gz"
+  checksum: [
+    "md5=f7d1c959627f93fdcf9fd0c346edb9c9"
+    "sha512=344a03d18170368a3fedcc595f6cc103fe47449a77a9923ab58a7d20d8d291edfda624d27bbfd8dc05d9af33a797064efcbeb52a4f9ea57fa862ebd39b97cfa1"
+  ]
+}


### PR DESCRIPTION
### `naboris.0.1.3`
Simple http server
Simple http server built on httpaf and lwt



---
* Homepage: https://github.com/shawn-mcginty/naboris
* Source repo: git+https://github.com/shawn-mcginty/naboris.git
* Bug tracker: https://github.com/shawn-mcginty/naboris/issues

---
:camel: Pull-request generated by opam-publish v2.0.2