### PR TITLE
[new release] ptset (1.0.1)

### DIFF
--- a/packages/ptset/ptset.1.0.1/opam
+++ b/packages/ptset/ptset.1.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jean-Christophe.Filliatre@lri.fr"
+authors: "Jean-Christophe Filliâtre"
+synopsis: "Sets of integers implemented as Patricia trees"
+description: "An implementation inspired by Okasaki & Gill's paper
+'Fast Mergeable Integer Maps'"
+license: "LGPL-2.1"
+homepage: "https://github.com/backtracking/ptset"
+doc: "https://backtracking.github.io/ptset"
+bug-reports: "https://github.com/backtracking/ptset/issues"
+depends: [
+  "ocaml"
+  "stdlib-shims"
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/backtracking/ptset.git"
+x-commit-hash: "12245246af9efd9688393830fb628aca772a195e"
+url {
+  src:
+    "https://github.com/backtracking/ptset/releases/download/1.0.1/ptset-1.0.1.tbz"
+  checksum: [
+    "sha256=4490119ee0eb40f9b148b0343286ee2a336696d8daf1805b1d898a305f0528df"
+    "sha512=c8ddaa078319639ffb778d64feca6b2d590bd9b77b9e9d0b055aaf2d46400be3898939aa63a5b319267c034a43ba233f8f019f178f166ea2961480fb5bd00037"
+  ]
+}


### PR DESCRIPTION
Sets of integers implemented as Patricia trees

- Project page: <a href="https://github.com/backtracking/ptset">https://github.com/backtracking/ptset</a>
- Documentation: <a href="https://backtracking.github.io/ptset">https://backtracking.github.io/ptset</a>

##### CHANGES:

- switch from obuild to dune
  - now uses stdlib-shims
