### PR TITLE
[new release] zxcvbn (2.4+1)

### DIFF
--- a/packages/zxcvbn/zxcvbn.2.4+1/opam
+++ b/packages/zxcvbn/zxcvbn.2.4+1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: "Nathan Rebours <nathan.p.rebours@gmail.com>"
+homepage: "https://github.com/cryptosense/ocaml-zxcvbn"
+bug-reports: "https://github.com/cryptosense/ocaml-zxcvbn/issues"
+license: "BSD-2"
+dev-repo:  "git+https://github.com/cryptosense/ocaml-zxcvbn.git"
+doc: "https://cryptosense.github.io/ocaml-zxcvbn/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "1.4.0"}
+  "ocaml" {>= "4.04.0"}
+  "ounit" {with-test}
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+]
+tags: ["org:cryptosense"]
+synopsis: "Bindings for the zxcvbn password strength estimation library"
+description: """
+This library provides functions to estimate the strength of a password.
+"""
+x-commit-hash: "ed5a58dc539b99aec3b2478a4c4a78d645802c09"
+url {
+  src:
+    "https://github.com/cryptosense/ocaml-zxcvbn/releases/download/v2.4%2B1/zxcvbn-v2.4.1.tbz"
+  checksum: [
+    "sha256=4c93ce9ee5c7620c316ab13f4d109c96d09a3ee483fb98c7647df9e890ea9bbd"
+    "sha512=a54c850bbd7e4ecec5c57f8652fc3314fb2cbec1f3bacd0d25e7b211bc8cd3976a14bdae35236ad83f87c24fbe9719e0958f7191e83e88004f435bc426adda55"
+  ]
+}


### PR DESCRIPTION
Bindings for the zxcvbn password strength estimation library

- Project page: <a href="https://github.com/cryptosense/ocaml-zxcvbn">https://github.com/cryptosense/ocaml-zxcvbn</a>
- Documentation: <a href="https://cryptosense.github.io/ocaml-zxcvbn/doc">https://cryptosense.github.io/ocaml-zxcvbn/doc</a>

##### CHANGES:

*2020-09-01*

- Upgrade to `zxcvbn-c` version 2.4.
- Fix compatibility with Dune 2.7.0.
