### PR TITLE
Package tda_ocaml.0.1

### DIFF
--- a/packages/tda_ocaml/tda_ocaml.0.1/opam
+++ b/packages/tda_ocaml/tda_ocaml.0.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "Jordan Merrick"
+authors: ["Jordan Merrick <jordanmerrick@me.com>"]
+homepage: "https://github.com/tottenhamjm/tda_ocaml"
+bug-reports: "https://github.com/tottenhamjm/tda_ocaml/issues"
+license: "MIT"
+build: [
+    ["dune" "build" name]
+]
+depends: [
+    "ocaml" {>= "4.07.0"}
+    "cohttp"
+    "core"
+    "async"
+    "cohttp"
+    "cohttp-async"
+    "yojson"
+    "dune"
+]
+synopsis: "An OCaml wrapper for TDAmeritrade's API (developer.tdameritrade.com/apis)"


### PR DESCRIPTION
### `tda_ocaml.0.1`
An OCaml wrapper for TDAmeritrade's API (developer.tdameritrade.com/apis)



---
* Homepage: https://github.com/tottenhamjm/tda_ocaml
* Bug tracker: https://github.com/tottenhamjm/tda_ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2