### PR TITLE
camlp5 release 8.00~alpha04

### DIFF
--- a/packages/camlp5/camlp5.8.00~alpha04/opam
+++ b/packages/camlp5/camlp5.8.00~alpha04/opam
@@ -1,0 +1,70 @@
+name: "camlp5"
+version: "8.00~alpha04"
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.02" & < "4.12.0"}
+  "conf-perl"
+  "pcre" { with-test }
+  "ounit2" { with-test }
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "world.opt"]
+]
+install: [make "install"]
+depexts: [
+  [
+    "libstring-shellquote-perl"
+    "libipc-system-simple-perl"
+  ] {os-family = "debian"}
+  [
+    "perl-string-shellquote"
+    "perl-ipc-system-simple"
+  ] {os-distribution = "alpine"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-distribution = "centos"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-family = "suse"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-family = "fedora"}
+]
+
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha04.tar.gz"
+  checksum: [
+    "md5=ebcb8fe96832dfc1402b51bb1b62b215"
+  ]
+}


### PR DESCRIPTION
Release camlp5 8.00~alpha04

fix configuration process, support ocaml 4.11.1.

# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# On branch opam-publish-camlp5-8.00-alpha04
# Changes to be committed:
#	new file:   packages/camlp5/camlp5.8.00~alpha04/opam
#