### PR TITLE
[new release] ptmap (1.0.1)

### DIFF
--- a/packages/ptmap/ptmap.1.0.1/opam
+++ b/packages/ptmap/ptmap.1.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jean-Christophe.Filliatre@lri.fr"
+authors: "Jean-Christophe Filliâtre"
+synopsis: "Maps of integers implemented as Patricia trees"
+description: "An implementation inspired by Okasaki & Gill's paper
+'Fast Mergeable Integer Maps'"
+license: "LGPL-2.1"
+homepage: "https://github.com/backtracking/ptmap"
+doc: "https://backtracking.github.io/ptmap"
+bug-reports: "https://github.com/backtracking/ptmap/issues"
+depends: [
+  "ocaml"
+  "stdlib-shims"
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/backtracking/ptmap.git"
+x-commit-hash: "64607259e21b0924538ae6f89733e9d08fc8151e"
+url {
+  src:
+    "https://github.com/backtracking/ptmap/releases/download/1.0.1/ptmap-1.0.1.tbz"
+  checksum: [
+    "sha256=bd19a3ee2d20616e739beae93a4514c402af7b8beb2b44694dad4acbebd9d804"
+    "sha512=596537bf0c54ab50280c73f566bde9676c62fee57e30c75ea541fc628d8b6b6aefc032658e48132e36f9115b181614dddb2062c25ab5163b2782f39a92777b85"
+  ]
+}


### PR DESCRIPTION
Maps of integers implemented as Patricia trees

- Project page: <a href="https://github.com/backtracking/ptmap">https://github.com/backtracking/ptmap</a>
- Documentation: <a href="https://backtracking.github.io/ptmap">https://backtracking.github.io/ptmap</a>

##### CHANGES:

- switch from obuild to dune
  - now uses stdlib-shims
