### PR TITLE
Package integers_stubs_js.1.0

### DIFF
--- a/packages/integers_stubs_js/integers_stubs_js.1.0/opam
+++ b/packages/integers_stubs_js/integers_stubs_js.1.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/o1-labs/integers_stubs_js/issues"
 depends: [
   "js_of_ocaml" {>= "3.6.0"}
   "zarith_stubs_js"
-  "dune" {build & >= "1.6"}
+  "dune" {>= "1.6"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/o1-labs/integers_stubs_js.git"

--- a/packages/integers_stubs_js/integers_stubs_js.1.0/opam
+++ b/packages/integers_stubs_js/integers_stubs_js.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "Javascript stubs for the integers library in js_of_ocaml"
+description: "Javascript stubs for the integers library in js_of_ocaml."
+maintainer: "opensource@o1labs.org"
+authors: "O(1) Labs, LLC <opensource@o1labs.org>"
+license: "MIT"
+homepage: "https://github.com/o1-labs/integers_stubs_js"
+bug-reports: "https://github.com/o1-labs/integers_stubs_js/issues"
+depends: [
+  "js_of_ocaml" {>= "3.6.0"}
+  "zarith_stubs_js"
+  "dune" {build & >= "1.6"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/o1-labs/integers_stubs_js.git"
+url {
+  src: "https://github.com/o1-labs/integers_stubs_js/archive/1.0.tar.gz"
+  checksum: [
+    "md5=c04d6e98f2f3b4c9cf0f085357e06a81"
+    "sha512=f783ee3908508b1f2b36aca80d7d5942b8f402063f6697bd51abb9ee440f42957a5ee8f3a54115a8a16d32ab1ceb1dbedb668c1970aeda0fb5f5d0af55a57a12"
+  ]
+}


### PR DESCRIPTION
### `integers_stubs_js.1.0`
Javascript stubs for the integers library in js_of_ocaml
Javascript stubs for the integers library in js_of_ocaml.



---
* Homepage: https://github.com/o1-labs/integers_stubs_js
* Source repo: git+https://github.com/o1-labs/integers_stubs_js.git
* Bug tracker: https://github.com/o1-labs/integers_stubs_js/issues

---
:camel: Pull-request generated by opam-publish v2.0.2