### PR TITLE
[new release] ptmap (2.0.5)

### DIFF
--- a/packages/ptmap/ptmap.2.0.5/opam
+++ b/packages/ptmap/ptmap.2.0.5/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jean-Christophe.Filliatre@lri.fr"
+authors: "Jean-Christophe Filliâtre"
+synopsis: "Maps of integers implemented as Patricia trees"
+description: "An implementation inspired by Okasaki & Gill's paper
+'Fast Mergeable Integer Maps'"
+license: "LGPL-2.1"
+homepage: "https://github.com/backtracking/ptmap"
+doc: "https://backtracking.github.io/ptmap"
+bug-reports: "https://github.com/backtracking/ptmap/issues"
+depends: [
+  "ocaml"
+  "stdlib-shims"
+  "seq"
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/backtracking/ptmap.git"
+x-commit-hash: "f2fcc6b2f71ba8aa8ad5594f124a3060ac5f0870"
+url {
+  src:
+    "https://github.com/backtracking/ptmap/releases/download/2.0.5/ptmap-2.0.5.tbz"
+  checksum: [
+    "sha256=b45610ec13d2aa1129d465b567b5d8f4fb60a9612115fbb59d14bd533626d694"
+    "sha512=a56a64d33045c8fc7387d1135193812100f10b3abf4202db045d48d2e99589d25c7d8811ccad2ef075ae35860a0eca747ceab84b1bf52ad1cab722aa094e001b"
+  ]
+}


### PR DESCRIPTION
Maps of integers implemented as Patricia trees

- Project page: <a href="https://github.com/backtracking/ptmap">https://github.com/backtracking/ptmap</a>
- Documentation: <a href="https://backtracking.github.io/ptmap">https://backtracking.github.io/ptmap</a>

##### CHANGES:

- document the difference wrt `Map.S` specs (issue backtracking/ptmap#11)
  - switch from obuild to dune and to opam 2.0
  - now uses `stdlib-shims` and `seq`
  - no more use of qtest, move tests from ptmap.ml to test.ml
  - add `update` (Andy Li)
  - add `filter_map` (rwmjones)
