### PR TITLE
[new release] sihl (0.1.0)

### DIFF
--- a/packages/sihl/sihl.0.1.0/opam
+++ b/packages/sihl/sihl.0.1.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "The modular functional web framework"
+description: "Build web apps fast with long-term maintainability in mind."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.3.0"}
+  "base" {>= "v0.13.1"}
+  "opium" {>= "0.17.1"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.5.2"}
+  "tsort" {>= "2.0.0"}
+  "tls" {>= "0.11.1"}
+  "ssl" {>= "0.5.9"}
+  "lwt_ssl" {>= "1.1.3"}
+  "caqti" {>= "1.2.1"}
+  "caqti-lwt" {>= "1.2.0"}
+  "tyxml" {>= "4.3.0"}
+  "tyxml-jsx" {>= "4.3.0"}
+  "reason" {>= "3.0.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.8"}
+  "pcre" {>= "7.4.3"}
+  "safepass" {>= "3.0"}
+  "jwto" {>= "0.3.0"}
+  "uuidm" {>= "0.9.7"}
+  "letters" {>= "0.2.0"}
+  "sexplib" {>= "0.13.0"}
+  "ppx_fields_conv" {>= "0.13.0"}
+  "ppx_sexp_conv" {>= "0.13.0"}
+  "alcotest" {>= "1.2.0"}
+  "utop" {dev}
+  "merlin" {dev}
+  "ocamlformat" {dev}
+  "ocp-indent" {dev}
+  "tuareg" {dev}
+  "alcotest" {>= "1.2.0" & with-test}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "cohttp-lwt-unix" {>= "2.5.1" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "9d56ceacb2ab8782bef6dacdaa2104c46c038551"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.1.0/sihl-0.1.0.tbz"
+  checksum: [
+    "sha256=d24b6271118de56b14983e50310d3f5c43a5f4ffecfaf451a0bacd200f335045"
+    "sha512=c60cf995065299ca171b8278d3e232bebec881e668276ac799bc3ff5bddd9ce529b1525cb207644380d16d95fba2438d1e2b0b38ce69e4f1203c03466a7a7b13"
+  ]
+}

--- a/packages/sihl/sihl.0.1.0/opam
+++ b/packages/sihl/sihl.0.1.0/opam
@@ -31,16 +31,10 @@ depends: [
   "jwto" {>= "0.3.0"}
   "uuidm" {>= "0.9.7"}
   "letters" {>= "0.2.0"}
-  "sexplib" {>= "0.13.0"}
-  "ppx_fields_conv" {>= "0.13.0"}
-  "ppx_sexp_conv" {>= "0.13.0"}
+  "sexplib" {>= "v0.13.0"}
+  "ppx_fields_conv" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
   "alcotest" {>= "1.2.0"}
-  "utop" {dev}
-  "merlin" {dev}
-  "ocamlformat" {dev}
-  "ocp-indent" {dev}
-  "tuareg" {dev}
-  "alcotest" {>= "1.2.0" & with-test}
   "alcotest-lwt" {>= "1.2.0" & with-test}
   "cohttp-lwt-unix" {>= "2.5.1" & with-test}
 ]


### PR DESCRIPTION
The modular functional web framework

- Project page: <a href="https://github.com/oxidizing/sihl">https://github.com/oxidizing/sihl</a>
- Documentation: <a href="https://oxidizing.github.io/sihl/">https://oxidizing.github.io/sihl/</a>

##### CHANGES:

## [0.1.0] - 2020-09-03
### Fixed
- DB connection leaks caused deadlocks
- Provide all service dependencies using functors
- Move Opium & Cohttp specific stuff into the web server service implementation to allow for swappable implementation based on something like httpaf
- Inject log service to all other services by default

### Added
- Support letters 0.2.0 for SMTP emailing
- Switch to exception based service API
- HTTP Response API to respond with file `Sihl.Web.Res.file`

## [0.0.56] - 2020-08-17
### Fixed
- Stop running integration tests during OPAM release

## [0.0.55] - 2020-08-17
### Added
- Initial release of Sihl
