### PR TITLE
conf-secp256k1: macOS package is in domt4/crypto tap

### DIFF
--- a/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
+++ b/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/dakk/conf-secp256k1"
 depexts: [
   ["libsecp256k1-0" "libsecp256k1-dev"] {os-family = "debian"}
   ["dev-libs/libsecp256k1"] {os-distribution = "gentoo"}
-  ["secp256k1"] {os-distribution = "homebrew" & os = "macos"}
+  ["domt4/crypto/secp256k1"] {os-distribution = "homebrew" & os = "macos"}
   ["libsecp256k1-git"] {os-distribution = "arch"}
 ]
 synopsis: "Virtual package relying on a secp256k1 lib system installation"


### PR DESCRIPTION
`secp256k1` is not part of the Homebrew core anymore and instead is available as a *tap*. This is the tap's current address: https://github.com/DomT4/homebrew-crypto. `opam depext` fails to install `secp256k1` because of this.