### PR TITLE
core: does not build on ppc64

### DIFF
--- a/packages/core/core.v0.12.0/opam
+++ b/packages/core/core.v0.12.0/opam
@@ -30,3 +30,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/core-v0.12.0.tar.gz"
   checksum: "md5=22ea4ee001f178c0f9d878c145530fd3"
 }
+available: arch != "ppc64" 

--- a/packages/core/core.v0.12.1/opam
+++ b/packages/core/core.v0.12.1/opam
@@ -31,3 +31,4 @@ url {
     "https://github.com/janestreet/core/releases/download/v0.12.1/core-v0.12.1.tbz"
   checksum: "md5=3a1b7e7324b9884768eb1f85a3d49ad6"
 }
+available: arch != "ppc64" 

--- a/packages/core/core.v0.12.2/opam
+++ b/packages/core/core.v0.12.2/opam
@@ -30,3 +30,4 @@ url {
     "https://github.com/janestreet/core/archive/v0.12.2.tar.gz"
   checksum: "md5=c521d9ae441683154b0008146c112ff4"
 }
+available: arch != "ppc64" 

--- a/packages/core/core.v0.12.3/opam
+++ b/packages/core/core.v0.12.3/opam
@@ -30,3 +30,4 @@ url {
     "https://github.com/janestreet/core/archive/v0.12.3.tar.gz"
   checksum: "md5=7bd476a69141c1b921dee8c1b4dd6353"
 }
+available: arch != "ppc64" 

--- a/packages/core/core.v0.12.4/opam
+++ b/packages/core/core.v0.12.4/opam
@@ -29,3 +29,4 @@ url {
   src: "https://github.com/janestreet/core/archive/v0.12.4.tar.gz"
   checksum: "md5=85f006b0666f4fe05c566be8fda64cb2"
 }
+available: arch != "ppc64" 

--- a/packages/core/core.v0.13.0/opam
+++ b/packages/core/core.v0.13.0/opam
@@ -30,3 +30,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.13/files/core-v0.13.0.tar.gz"
   checksum: "md5=0dedfb21e756427ea39ab4dc173d67a9"
 }
+available: arch != "ppc64" 

--- a/packages/core/core.v0.14.0/opam
+++ b/packages/core/core.v0.14.0/opam
@@ -31,3 +31,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/core-v0.14.0.tar.gz"
   checksum: "md5=571dc65fff922c86951068d66e4a05ca"
 }
+available: arch != "ppc64"


### PR DESCRIPTION
upstream at https://github.com/janestreet/core/issues/140
Reported originally at https://github.com/mirage/ocaml-cohttp/pull/709