### PR TITLE
camlp5 7.13 release (with minimal support for ocaml 4.11.1).

### DIFF
--- a/packages/camlp5/camlp5.7.13/opam
+++ b/packages/camlp5/camlp5.7.13/opam
@@ -1,0 +1,46 @@
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description:
+"""
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel.
+"""
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre"]
+homepage: "https://camlp5.github.io"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+doc: "https://camlp5.github.io/doc/html"
+
+depends: [
+  "ocaml"       { >= "4.02" & <= "4.11.1" }
+]
+
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/camlp5/archive/rel713.tar.gz"
+  checksum: [
+    "md5=5b54e31b7f43447dfaacab95859dfd14"
+  ]
+}


### PR DESCRIPTION
This is a minor release, solely to update camlp5 with support for ocaml 4.11.1.

# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# On branch opam-publish-camlp5-7.13
# Changes to be committed:
#	new file:   packages/camlp5/camlp5.7.13/opam
#