### PR TITLE
[new release] ptmap (2.0.5)

### DIFF
--- a/packages/ptmap/ptmap.2.0.5/opam
+++ b/packages/ptmap/ptmap.2.0.5/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jean-Christophe.Filliatre@lri.fr"
+authors: "Jean-Christophe Filliâtre"
+synopsis: "Maps of integers implemented as Patricia trees"
+description: "An implementation inspired by Okasaki & Gill's paper
+'Fast Mergeable Integer Maps'"
+license: "LGPL-2.1"
+homepage: "https://github.com/backtracking/ptmap"
+doc: "https://backtracking.github.io/ptmap"
+bug-reports: "https://github.com/backtracking/ptmap/issues"
+depends: [
+  "ocaml"
+  "stdlib-shims"
+  "seq"
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/backtracking/ptmap.git"
+x-commit-hash: "e08084caa43fa7c1e08c43858cb04cb6c42cf2df"
+url {
+  src:
+    "https://github.com/backtracking/ptmap/releases/download/2.0.5/ptmap-2.0.5.tbz"
+  checksum: [
+    "sha256=ebd1f8afe8679a226fdcbcdb323788e6f63db57521b151473f2ff8c05c30f3aa"
+    "sha512=4a3f20d189d905cb588de3148361495adc40d5892473bf9cd7e49bc98558de29feb51efefb5aab77cad892dd288ad8fa0348832c78cc21e66539768a5a9cab5b"
+  ]
+}


### PR DESCRIPTION
Maps of integers implemented as Patricia trees

- Project page: <a href="https://github.com/backtracking/ptmap">https://github.com/backtracking/ptmap</a>
- Documentation: <a href="https://backtracking.github.io/ptmap">https://backtracking.github.io/ptmap</a>

##### CHANGES:

- switch from obuild to dune and to opam 2.0
  - fixed compilation with old versions of OCaml
  - document the difference wrt `Map.S` specs (issue backtracking/ptmap#11)
  - more efficient implementation of `union` (issue backtracking/ptmap#7)
  - add `update` (Andy Li)
  - add `filter_map` (rwmjones)
  - no more use of qtest, move tests from ptmap.ml to test.ml
