### PR TITLE
[new release] mirage-net-solo5 (0.6.2)

### DIFF
--- a/packages/mirage-net-solo5/mirage-net-solo5.0.6.2/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.6.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-net-solo5"
+bug-reports:   "https://github.com/mirage/mirage-net-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-solo5.git"
+doc:           "https://mirage.github.io/mirage-net-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "macaddr" { >= "4.0.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
+  "logs" {>= "0.6.0"}
+  "metrics"
+  "fmt"
+]
+synopsis: "Solo5 implementation of MirageOS network interface"
+description:
+  "This library implements the MirageOS network interface for Solo5 targets."
+x-commit-hash: "2e7fed8f67063df65b69a31fb987e8d2947426eb"
+url {
+  src:
+    "https://github.com/mirage/mirage-net-solo5/releases/download/v0.6.2/mirage-net-solo5-v0.6.2.tbz"
+  checksum: [
+    "sha256=a16b6fdf2ce606a0cd74a39a17e5beaed93c93f34cb7d72a4f665765773a3390"
+    "sha512=c9535ef5ce32f3bbba03ce914fda22e7aa33d7958920872d5d73340cac6733cf0371a3feb96b4b7e9819c224793f6332cd733e6c0506e6ce978c46a9d9b11223"
+  ]
+}


### PR DESCRIPTION
Solo5 implementation of MirageOS network interface

- Project page: <a href="https://github.com/mirage/mirage-net-solo5">https://github.com/mirage/mirage-net-solo5</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-solo5/">https://mirage.github.io/mirage-net-solo5/</a>

##### CHANGES:

* Netif.listen does not catch Out_of_memory anymore (@hannesm, mirage/mirage-net-solo5#36)
* Each network interface is now a metrics source reporting statistics
  (see https://github.com/mirage/metrics for further information, @hannesm, mirage/mirage-net-solo5#34)
