### PR TITLE
Fixes for daypack-lib.0.0.1 - 0.0.2 opam files

### DIFF
--- a/packages/daypack-lib/daypack-lib.0.0.1/opam
+++ b/packages/daypack-lib/daypack-lib.0.0.1/opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name: "daypack-lib"
-version: "0.0.1"
 synopsis: "A schedule, time and time slots handling library"
 description: """
 Daypack-lib is WIP and subject to drastic changes between versions, do not use it for anything serious
@@ -24,9 +22,8 @@ depends: [
   "containers"
 ]
 build: [
-  ["dune" "build" "-p" name "-j" jobs ]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
-install: ["dune" "build" "@install"]
 url {
   src:
     "https://github.com/daypack-dev/daypack-lib/archive/v0.0.1.tar.gz"

--- a/packages/daypack-lib/daypack-lib.0.0.2/opam
+++ b/packages/daypack-lib/daypack-lib.0.0.2/opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name: "daypack-lib"
-version: "0.0.2"
 synopsis: "A schedule, time and time slots handling library"
 description: """
 Daypack-lib is WIP and subject to drastic changes between versions, do not use it for anything serious
@@ -24,9 +22,8 @@ depends: [
   "containers"
 ]
 build: [
-  ["dune" "build" "-p" name "-j" jobs ]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
-install: ["dune" "build" "@install"]
 url {
   src:
     "https://github.com/daypack-dev/daypack-lib/archive/v0.0.2.tar.gz"


### PR DESCRIPTION
Backporting fix for daypack-lib.0.0.4 opam file to previous published versions

Context: https://github.com/ocaml/opam-repository/pull/17122