### PR TITLE
Package lame.0.3.4

### DIFF
--- a/packages/lame/lame.0.3.4/opam
+++ b/packages/lame/lame.0.3.4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "MP3 encoding library"
+description:
+  "Bindings for the lame library which provides functions for encoding mp3 files"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-lame"
+bug-reports: "https://github.com/savonet/ocaml-lame/issues"
+depends: [
+  "dune" {> "2.0"}
+  "dune-configurator"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-lame.git"
+depexts: [
+  ["lame-dev"] {os-distribution = "alpine"}
+  ["lame-devel"] {os-distribution = "centos"}
+  ["lame-devel"] {os-distribution = "fedora"}
+  ["lame-devel"] {os-family = "suse"}
+  ["libmp3lame-dev"] {os-family = "debian"}
+  ["lame"] {os = "macos" & os-distribution = "homebrew"}
+  ["lame"] {os = "freebsd"}
+]
+url {
+  src: "https://github.com/savonet/ocaml-lame/archive/v0.3.4.tar.gz"
+  checksum: [
+    "md5=4313552dcb92f02a8a8ceeb4ee0dbbdc"
+    "sha512=d4737a8e4395bea5d361cc739a9a13aeb41f69b9dfc8e508e3e5b0249ae998fc38a809c7700b0ad95a7bdfb029d3b6c8bede3043e2709336f37c4450f2cda6cc"
+  ]
+}


### PR DESCRIPTION
### `lame.0.3.4`
MP3 encoding library
Bindings for the lame library which provides functions for encoding mp3 files



---
* Homepage: https://github.com/savonet/ocaml-lame
* Source repo: git+https://github.com/savonet/ocaml-lame.git
* Bug tracker: https://github.com/savonet/ocaml-lame/issues

---
:camel: Pull-request generated by opam-publish v2.0.2