### PR TITLE
4 packages from c-cube/qcheck at 0.15

### DIFF
--- a/packages/qcheck-alcotest/qcheck-alcotest.0.10/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.10/opam
@@ -10,7 +10,7 @@ depends: [
   "dune"
   "base-bytes"
   "base-unix"
-  "qcheck-core" {>= "0.9"}
+  "qcheck-core" {>= "0.9" & < "0.15"}
   "alcotest"
   "odoc" {with-doc}
   "ocaml" {>= "4.03.0"}

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.15/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.15/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Alcotest backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: ["test" "quickcheck" "qcheck" "alcotest"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {= version}
+  "alcotest"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.15.tar.gz"
+  checksum: [
+    "md5=1afd9ea21b86a726f337ea26920ce918"
+    "sha512=83bde44aa688a590450ca803c1704fda04ab33135ecbc16cbd41758728e65cc4629fa859d4e7e14953ca3ab0c709555b165c05770aafb8711e4101b1a9f211e1"
+  ]
+}

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.9/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "base-bytes"
   "base-unix"
-  "qcheck-core" {>= "0.9"}
+  "qcheck-core" {>= "0.9" & < "0.15"}
   "alcotest" {>= "0.8.0"}
   "odoc" {with-doc}
 ]

--- a/packages/qcheck-core/qcheck-core.0.15/opam
+++ b/packages/qcheck-core/qcheck-core.0.15/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Core qcheck library"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.15.tar.gz"
+  checksum: [
+    "md5=1afd9ea21b86a726f337ea26920ce918"
+    "sha512=83bde44aa688a590450ca803c1704fda04ab33135ecbc16cbd41758728e65cc4629fa859d4e7e14953ca3ab0c709555b165c05770aafb8711e4101b1a9f211e1"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.10/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.10/opam
@@ -10,7 +10,7 @@ depends: [
   "dune"
   "base-bytes"
   "base-unix"
-  "qcheck-core" {>= "0.9"}
+  "qcheck-core" {>= "0.9" & < "0.15"}
   "ounit" {>= "2.0"}
   "odoc" {with-doc}
   "ocaml" {>= "4.03.0"}

--- a/packages/qcheck-ounit/qcheck-ounit.0.15/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.15/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "OUnit backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: ["qcheck" "quickcheck" "ounit"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {= version}
+  "ounit2"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.15.tar.gz"
+  checksum: [
+    "md5=1afd9ea21b86a726f337ea26920ce918"
+    "sha512=83bde44aa688a590450ca803c1704fda04ab33135ecbc16cbd41758728e65cc4629fa859d4e7e14953ca3ab0c709555b165c05770aafb8711e4101b1a9f211e1"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.9/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.9/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "base-bytes"
   "base-unix"
-  "qcheck-core" {>= "0.9"}
+  "qcheck-core" {>= "0.9" & < "0.15"}
   "ounit" {>= "2.0"}
   "odoc" {with-doc}
 ]

--- a/packages/qcheck/qcheck.0.15/opam
+++ b/packages/qcheck/qcheck.0.15/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Compatibility package for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {= version}
+  "qcheck-ounit" {= version}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.15.tar.gz"
+  checksum: [
+    "md5=1afd9ea21b86a726f337ea26920ce918"
+    "sha512=83bde44aa688a590450ca803c1704fda04ab33135ecbc16cbd41758728e65cc4629fa859d4e7e14953ca3ab0c709555b165c05770aafb8711e4101b1a9f211e1"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`qcheck.0.15`: Compatibility package for qcheck
-`qcheck-alcotest.0.15`: Alcotest backend for qcheck
-`qcheck-core.0.15`: Core qcheck library
-`qcheck-ounit.0.15`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.0.0