### PR TITLE
Package qtest.2.11.1

### DIFF
--- a/packages/qtest/qtest.2.11.1/opam
+++ b/packages/qtest/qtest.2.11.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes <simon.cruanes.2007@m4x.org"
+authors: [
+  "Vincent Hugot <vincent.hugot@gmail.com>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org"
+]
+synopsis: "Lightweight inline test extraction from comments"
+homepage: "https://github.com/vincent-hugot/qtest"
+bug-reports: "https://github.com/vincent-hugot/qtest/issues"
+doc:
+  "https://github.com/vincent-hugot/qtest/blob/master/README.adoc#introduction"
+dev-repo: "git+https://github.com/vincent-hugot/qtest.git"
+build: [
+  [ "dune" "build" "@install" "-j" jobs "-p" name ]
+]
+depends: [
+  "base-bytes"
+  "ounit2"
+  "dune" { >= "1.1" }
+  "qcheck" { >= "0.14" }
+  "ocaml" { >= "4.03.0" }
+]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+url {
+  src: "https://github.com/vincent-hugot/qtest/archive/v2.11.1.tar.gz"
+  checksum: [
+    "md5=07d9aa2708cdce21d9445908c080c868"
+    "sha512=73f7f273b0d0086ab466e87385ea82e9e01395ae2002cc0371c1df1af801bb3598a1986e2013ef8f12d00a4c09dfb467b5fee749b5a2d9581045e500244b91d5"
+  ]
+}


### PR DESCRIPTION
### `qtest.2.11.1`
Lightweight inline test extraction from comments



---
* Homepage: https://github.com/vincent-hugot/qtest
* Source repo: git+https://github.com/vincent-hugot/qtest.git
* Bug tracker: https://github.com/vincent-hugot/qtest/issues

---
:camel: Pull-request generated by opam-publish v2.0.0