### PR TITLE
[new release] curly (0.2.0)

### DIFF
--- a/packages/curly/curly.0.2.0/opam
+++ b/packages/curly/curly.0.2.0/opam
@@ -25,7 +25,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version >= "4.05.0"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/curly/curly.0.2.0/opam
+++ b/packages/curly/curly.0.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Curly is a brain dead wrapper around the curl command line utility"
+maintainer: ["rudi.grinberg@gmail.com"]
+authors: ["Rudi Grinberg"]
+license: "ISC"
+homepage: "https://github.com/rgrinberg/curly"
+bug-reports: "https://github.com/rgrinberg/curly/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.02.3"}
+  "base-unix"
+  "result"
+  "alcotest" {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rgrinberg/curly.git"
+x-commit-hash: "9417bd97fdf293f469c38e726c169583638d5aa1"
+url {
+  src:
+    "https://github.com/rgrinberg/curly/releases/download/0.2.0/curly-0.2.0.tbz"
+  checksum: [
+    "sha256=d350f5fb4dc2ab12eb3e805b356a5228ecc00497fadc38502c0d6445676e781f"
+    "sha512=ae5a704e6849d60739203f7704ae0fb62408f171cfc910db5f2bfa62ae4be13edcec938387ee6a3680eebe3442c08b08b024fd4d65dbcb5bacb040cf43c69468"
+  ]
+}


### PR DESCRIPTION
Curly is a brain dead wrapper around the curl command line utility

- Project page: <a href="https://github.com/rgrinberg/curly">https://github.com/rgrinberg/curly</a>

##### CHANGES:

* Upgrade from jbuilder to dune (@shonfeder, fixes rgrinberg/curly#3)
