### PR TITLE
[new release] alcotest, alcotest-async, alcotest-mirage and alcotest-lwt (1.2.3)

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.2.3/opam
+++ b/packages/alcotest-async/alcotest-async.1.2.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Async-based helpers for Alcotest"
+description: "Async-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.2"}
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "async_unix" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "5a20344177b8cdf369957c0268dc7acea2dc838e"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.3/alcotest-mirage-1.2.3.tbz"
+  checksum: [
+    "sha256=085c481aeedf80d766ff9ba4d9929688bed01ef390915dc28a9bb4ba7664b2ae"
+    "sha512=ca489811d3f13a2604a4b0a2b7463d611741bf8a96655e3ae1dfbeb60f2e81f589d389f12379543e5e2a31e973170134855f10d1ba94ffdc6123e34227a7d37a"
+  ]
+}

--- a/packages/alcotest-lwt/alcotest-lwt.1.2.3/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.2.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Lwt-based helpers for Alcotest"
+description: "Lwt-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.2"}
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "lwt"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "5a20344177b8cdf369957c0268dc7acea2dc838e"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.3/alcotest-mirage-1.2.3.tbz"
+  checksum: [
+    "sha256=085c481aeedf80d766ff9ba4d9929688bed01ef390915dc28a9bb4ba7664b2ae"
+    "sha512=ca489811d3f13a2604a4b0a2b7463d611741bf8a96655e3ae1dfbeb60f2e81f589d389f12379543e5e2a31e973170134855f10d1ba94ffdc6123e34227a7d37a"
+  ]
+}

--- a/packages/alcotest-mirage/alcotest-mirage.1.2.3/opam
+++ b/packages/alcotest-mirage/alcotest-mirage.1.2.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Mirage implementation for Alcotest"
+description: "Mirage implementation for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.2"}
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "mirage-clock" {>= "2.0.0"}
+  "duration"
+  "lwt"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "5a20344177b8cdf369957c0268dc7acea2dc838e"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.3/alcotest-mirage-1.2.3.tbz"
+  checksum: [
+    "sha256=085c481aeedf80d766ff9ba4d9929688bed01ef390915dc28a9bb4ba7664b2ae"
+    "sha512=ca489811d3f13a2604a4b0a2b7463d611741bf8a96655e3ae1dfbeb60f2e81f589d389f12379543e5e2a31e973170134855f10d1ba94ffdc6123e34227a7d37a"
+  ]
+}

--- a/packages/alcotest/alcotest.1.2.3/opam
+++ b/packages/alcotest/alcotest.1.2.3/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Alcotest is a lightweight and colourful test framework"
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.2"}
+  "ocaml" {>= "4.03.0"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "cmdliner"
+  "uuidm"
+  "re"
+  "stdlib-shims"
+  "uutf"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "5a20344177b8cdf369957c0268dc7acea2dc838e"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.2.3/alcotest-mirage-1.2.3.tbz"
+  checksum: [
+    "sha256=085c481aeedf80d766ff9ba4d9929688bed01ef390915dc28a9bb4ba7664b2ae"
+    "sha512=ca489811d3f13a2604a4b0a2b7463d611741bf8a96655e3ae1dfbeb60f2e81f589d389f12379543e5e2a31e973170134855f10d1ba94ffdc6123e34227a7d37a"
+  ]
+}


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework

- Project page: <a href="https://github.com/mirage/alcotest">https://github.com/mirage/alcotest</a>
- Documentation: <a href="https://mirage.github.io/alcotest">https://mirage.github.io/alcotest</a>

The corresponding PR downstream is: https://github.com/mirage/alcotest/pull/276.

##### CHANGES:

- Require Dune 2.2. (mirage/alcotest#274, @CraigFe)

- Fix a bug in the handling of the `~and_exit:false` option when the test suite
  fails. (mirage/alcotest#271, @CraigFe)
