### PR TITLE
[conf-gmp] fix test to avoid warning about undeclared function

### DIFF
--- a/packages/conf-gmp/conf-gmp.2/files/test.c
+++ b/packages/conf-gmp/conf-gmp.2/files/test.c
@@ -1,0 +1,10 @@
+#include <gmp.h>
+#ifndef __GMP_H__
+#error "No GMP header"
+#endif
+
+void test(void) {
+  mpz_t n;
+  mpz_init(n);
+  mpz_clear(n);
+}

--- a/packages/conf-gmp/conf-gmp.2/opam
+++ b/packages/conf-gmp/conf-gmp.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "nbraud"
+homepage: "http://gmplib.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+build: [
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos"}
+  [
+    "sh"
+    "-exc"
+    "cc -c $CFLAGS -I/opt/local/include -I/usr/local/include test.c"
+  ] {os = "macos"}
+]
+depexts: [
+  ["libgmp-dev"] {os-family = "debian"}
+  ["gmp"] {os = "macos" & os-distribution = "homebrew"}
+  ["gmp" "gmp-devel"] {os-distribution = "centos"}
+  ["gmp" "gmp-devel"] {os-distribution = "fedora"}
+  ["gmp"] {os = "openbsd"}
+  ["gmp"] {os = "freebsd"}
+  ["gmp-dev"] {os-distribution = "alpine"}
+  ["gmp-devel"] {os-family = "suse"}
+]
+synopsis: "Virtual package relying on a GMP lib system installation"
+description:
+  "This package can only install if the GMP lib is installed on the system."
+authors: "nbraud"
+extra-files: ["test.c" "md5=2fd2970c293c36222a6d299ec155823f"]
+flags: conf


### PR DESCRIPTION
A user of a package depending on `conf-gmp` reported having issues on macOS, possibly due to a non-standard `CFLAGS` in their environment (containing `-Werror`). We noticed the `test.c` file in the `conf-gmp` package always generates a warning due to usage of a function which is not declared (the function is actually not exported, so the user is never supposed to call it directly). I modified the code to use some basic GMP features, but without triggering the warning.

For information, before this PR, simply installing `conf-gmp` with `--verbose` results in:

```
- + cc -c -I/usr/local/include test.c
- test.c: In function ‘test’:
- test.c:7:2: warning: implicit declaration of function ‘__gmp_init’; did you mean ‘__gmpf_init’? [-Wimplicit-function-declaration]
-     7 |  __gmp_init();
-       |  ^~~~~~~~~~
```

So, in practice, the package did correctly detect whether gmp was installed (otherwise the `#include <gmp.h>` would fail), but generated a warning that could in some cases lead to errors even when GMP is installed.

(Explanation and suggestions by @zilbuz)