### PR TITLE
[new release] sihl (0.1.2)

### DIFF
--- a/packages/sihl/sihl.0.1.2/opam
+++ b/packages/sihl/sihl.0.1.2/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "The modular functional web framework"
+description: "Build web apps fast with long-term maintainability in mind."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.3.0"}
+  "base" {>= "v0.13.1"}
+  "opium" {>= "0.17.1"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.5.2"}
+  "tsort" {>= "2.0.0"}
+  "tls" {>= "0.11.1"}
+  "ssl" {>= "0.5.9"}
+  "lwt_ssl" {>= "1.1.3"}
+  "caqti" {>= "1.2.1"}
+  "caqti-lwt" {>= "1.2.0"}
+  "tyxml" {>= "4.3.0"}
+  "tyxml-jsx" {>= "4.3.0"}
+  "reason" {>= "3.0.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.8"}
+  "pcre" {>= "7.4.3"}
+  "safepass" {>= "3.0"}
+  "jwto" {>= "0.3.0"}
+  "uuidm" {>= "0.9.7"}
+  "letters" {>= "0.2.0"}
+  "sexplib" {>= "v0.13.0"}
+  "ppx_fields_conv" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "alcotest" {>= "1.2.0"}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "cohttp-lwt-unix" {>= "2.5.1" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "d6a95f2f66ca1854e6fded0a735bd6c040128b26"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.1.2/sihl-0.1.2.tbz"
+  checksum: [
+    "sha256=69705a3a35f204acfdda62f61056e3f0ec3ef5bcd1df1508be65b066a0b1df9c"
+    "sha512=1987d211f56d0261eefbae978065a4e6781d60ad94b08597875307e5cf6e5a1b79787d9c79f784f5a9f77c35203cfd0b488841a07adfd87b0710d6fd65422b94"
+  ]
+}


### PR DESCRIPTION
The modular functional web framework

- Project page: <a href="https://github.com/oxidizing/sihl">https://github.com/oxidizing/sihl</a>
- Documentation: <a href="https://oxidizing.github.io/sihl/">https://oxidizing.github.io/sihl/</a>

##### CHANGES:

## [0.1.2] - 2020-09-09
### Fixed
- Re-export `Sihl.Queue.Job.t`
- Export content types under `Sihl.Web`

## [0.1.1] - 2020-09-07
### Fixed
- Don't raise exception when user login fails if it is a user error
- Remove dev tools as dev dependencies

### Added
- Storage service can remove files
- Move README.md documentation to ocamldoc based documentation

## [0.1.0] - 2020-09-03
### Fixed
- DB connection leaks caused deadlocks
- Provide all service dependencies using functors
- Move Opium & Cohttp specific stuff into the web server service implementation to allow for swappable implementation based on something like httpaf
- Inject log service to all other services by default

### Added
- Support letters 0.2.0 for SMTP emailing
- Switch to exception based service API
- HTTP Response API to respond with file `Sihl.Web.Res.file`

## [0.0.56] - 2020-08-17
### Fixed
- Stop running integration tests during OPAM release

## [0.0.55] - 2020-08-17
### Added
- Initial release of Sihl
