### PR TITLE
[new release] memtrace (0.1.1)

### DIFF
--- a/packages/memtrace/memtrace.0.1.1/opam
+++ b/packages/memtrace/memtrace.0.1.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Streaming client for Memprof"
+description: "Generates compact traces of a program's memory use."
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/janestreet/memtrace"
+bug-reports: "https://github.com/janestreet/memtrace/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/janestreet/memtrace.git"
+x-commit-hash: "17958eb6f82b99bd4ec56c9086385456cbaebec1"
+url {
+  src:
+    "https://github.com/janestreet/memtrace/releases/download/v0.1.1/memtrace-v0.1.1.tbz"
+  checksum: [
+    "sha256=58fb90ca075269bb8bf6b50e76d343481b3ffa46cdc89fa70b1d1c49a4a918bd"
+    "sha512=71723ce8b495a0e9a6f7bf2aedefb5eb80beb29c95ba3c735e095bf8e772575dc4e01e424a9c9ae5df812a90b9026223ed777e3e64f97ede9ac8e01f215e99b5"
+  ]
+}


### PR DESCRIPTION
Streaming client for Memprof

- Project page: <a href="https://github.com/janestreet/memtrace">https://github.com/janestreet/memtrace</a>

##### CHANGES:

Packaging fixes.
