### PR TITLE
Temporarily fix esy: Avoid using the %{dev}% value as esy doesn't know about it

### DIFF
--- a/packages/b0/b0.0.0.0/opam
+++ b/packages/b0/b0.0.0.0/opam
@@ -17,7 +17,7 @@ depends:
 ]
 build:
 [[
-  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg=true" {dev}
 ]]
 
 synopsis: """Software construction care"""

--- a/packages/b0/b0.0.0.1/opam
+++ b/packages/b0/b0.0.0.1/opam
@@ -17,7 +17,7 @@ depends:
 ]
 build:
 [[
-  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg=true" {dev}
 ]]
 
 synopsis: """Software construction and deployment kit"""

--- a/packages/fpath/fpath.0.7.3/opam
+++ b/packages/fpath/fpath.0.7.3/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
-          "--dev-pkg" "%{dev}%" ]]
+          "--dev-pkg=true" {dev} ]]
 
 synopsis: """File system paths for OCaml"""
 description: """\

--- a/packages/mirage-solo5/mirage-solo5.0.6.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.6.0/opam
@@ -13,7 +13,7 @@ tags: [
   "org:mirage"
 ]
 build: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%" ]
+  [ "ocaml" "pkg/pkg.ml" "build" "--dev-pkg=true" {dev} ]
 ]
 depends: [
   "ocamlfind" {build}

--- a/packages/mirage-solo5/mirage-solo5.0.6.1/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.6.1/opam
@@ -13,7 +13,7 @@ tags: [
   "org:mirage"
 ]
 build: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%" ]
+  [ "ocaml" "pkg/pkg.ml" "build" "--dev-pkg=true" {dev} ]
 ]
 depends: [
   "ocamlfind" {build}

--- a/packages/notty/notty.0.2.2/opam
+++ b/packages/notty/notty.0.2.2/opam
@@ -13,7 +13,7 @@ description:
 
 
 build: [
-  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg=true" {dev}
           "--with-lwt" "%{lwt:installed}%"
 ]
 depends: [


### PR DESCRIPTION
Hopefully this should fix your issue @phated (https://github.com/ocaml/opam-repository/pull/17155#issuecomment-689251506). Could you check if this work? (I don't know if it's possible to use a special commit of opam-repository with esy)

cc @dbuenzli I'm not sure how quickly the esy issue https://github.com/esy/esy/issues/1165 is going to be fixed and released but just in case you're planning to release some other packages soon it might be worth using `=true" {dev}` instead, idk.