### PR TITLE
Package apronext.1.0

### DIFF
--- a/packages/apronext/apronext.1.0/opam
+++ b/packages/apronext/apronext.1.0/opam
@@ -12,7 +12,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs]
 ]
 depends: [
-  "dune" {build}
+  "dune" {>= "2.1"}
   "ocaml" {>= "4.08"}
   "apron"
 ]

--- a/packages/apronext/apronext.1.0/opam
+++ b/packages/apronext/apronext.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Ghiles Ziat <ghiles.ziat@isae-supaero.fr"
+authors: ["Ghiles Ziat <ghiles.ziat@isae-supaero.fr"]
+homepage: "https://github.com/ghilesZ/apronext"
+bug-reports: "https://github.com/ghilesZ/apronext/issues"
+dev-repo: "git+https://github.com/ghilesZ/apronext"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.08"}
+  "apron"
+]
+synopsis: "Apron extension"
+description: "An extension for the OCaml interface of the Apron library"
+url {
+  src: "https://github.com/ghilesZ/apronext/archive/v1.0.tar.gz"
+  checksum: [
+    "md5=38b26e09339b51de160fccde1d7b6212"
+    "sha512=e447085143d5112c774985fec6058a05120660097bb5f30f91420b694d966c318475089eef3380415fe1f7789deae7f923c3d7459d0becdab7eb8e4e909d2704"
+  ]
+}


### PR DESCRIPTION
### `apronext.1.0`
Apron extension
An extension for the OCaml interface of the Apron library



---
* Homepage: https://github.com/ghilesZ/apronext
* Source repo: git+https://github.com/ghilesZ/apronext
* Bug tracker: https://github.com/ghilesZ/apronext/issues

---
:camel: Pull-request generated by opam-publish v2.0.2