### PR TITLE
2 packages from Gbury/mSAT at 0.8.3

### DIFF
--- a/packages/msat-bin/msat-bin.0.8.3/opam
+++ b/packages/msat-bin/msat-bin.0.8.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "SAT solver binary based on the msat library"
+license: "Apache"
+maintainer: ["guillaume.bury@gmail.com" "simon.cruanes.2007@m4x.org"]
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  #["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.1" }
+  "msat" { = version }
+  "containers" { >= "2.8.1" & < "4.0" }
+  "camlzip"
+]
+tags: [ "sat" ]
+homepage: "https://github.com/Gbury/mSAT"
+dev-repo: "git+https://github.com/Gbury/mSAT.git"
+bug-reports: "https://github.com/Gbury/mSAT/issues/"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+url {
+  src: "https://github.com/Gbury/mSAT/archive/v0.8.3.tar.gz"
+  checksum: [
+    "md5=d13411fc725e3b53343f7c389560fbdf"
+    "sha512=8ecc179e61a695c69bba5014f10e8c80b4366bec365ffe7e3274ab3d7510388f91c792ce5e7950f50f44fb556a4b66aa3cc19a745a57eac1dd09c12a0081916b"
+  ]
+}

--- a/packages/msat/msat.0.8.3/opam
+++ b/packages/msat/msat.0.8.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Library containing a SAT solver that can be parametrized by a theory"
+license: "Apache"
+maintainer: ["guillaume.bury@gmail.com" "simon.cruanes.2007@m4x.org"]
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.1" }
+  "iter" { >= "1.2" }
+  "containers" {with-test & >= "2.8.1" & < "4.0" }
+  "mdx" {with-test}
+]
+tags: [ "sat" "smt" "cdcl" "functor" ]
+homepage: "https://github.com/Gbury/mSAT"
+dev-repo: "git+https://github.com/Gbury/mSAT.git"
+bug-reports: "https://github.com/Gbury/mSAT/issues/"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+url {
+  src: "https://github.com/Gbury/mSAT/archive/v0.8.3.tar.gz"
+  checksum: [
+    "md5=d13411fc725e3b53343f7c389560fbdf"
+    "sha512=8ecc179e61a695c69bba5014f10e8c80b4366bec365ffe7e3274ab3d7510388f91c792ce5e7950f50f44fb556a4b66aa3cc19a745a57eac1dd09c12a0081916b"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`msat.0.8.3`: Library containing a SAT solver that can be parametrized by a theory
-`msat-bin.0.8.3`: SAT solver binary based on the msat library



---
* Homepage: https://github.com/Gbury/mSAT
* Source repo: git+https://github.com/Gbury/mSAT.git
* Bug tracker: https://github.com/Gbury/mSAT/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0