### PR TITLE
Package binaryen.0.3.0

### DIFF
--- a/packages/binaryen/binaryen.0.3.0/opam
+++ b/packages/binaryen/binaryen.0.3.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {= "2.6.1"}
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs "--no-buffer"]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.3.0/binaryen-archive-v0.3.0.tar.gz"
+  checksum: [
+    "md5=357870883104f04fafe1f045b6e93382"
+    "sha512=408d5562805b79762a44a88d150efcde5661d409ce3d731b64875cb3665499f876bbde6b28078f33011b64a231eac263f9ab4baee1885772f1dae483e188de54"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.3.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
Changes in this Release
- Implemented Dune Virtual Interfaces to support native & JS bindings
- Added JS bindings to binaryen.js
- Added  constant for unlimited memory
- Automated opam publish workflow

---
:camel: Pull-request generated by opam-publish v2.0.2