### PR TITLE
2 packages from Ninjapouet/ezcmdliner at 0.1.0

### DIFF
--- a/packages/ezcmdliner-ppx/ezcmdliner-ppx.0.1.0/opam
+++ b/packages/ezcmdliner-ppx/ezcmdliner-ppx.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Derivates cmdliner terms from type definitions"
+description:
+  "This PPX gives to your program a nice CLI using simple type annotations"
+maintainer: ["Julien Blond <julien.blond@gmail.com>"]
+authors: ["Julien Blond <julien.blond@gmail.com>"]
+license: "Apache 2.0"
+homepage: "https://github.com/Ninjapouet/ezcmdliner"
+bug-reports: "https://github.com/Ninjapouet/ezcmdliner/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "ppxlib" {>= "0.9.0"}
+  "fmt" {>= "0.8.8"}
+  "cmdliner" {>= "1.0.4"}
+  "ppx_deriving" {>= "4.4.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Ninjapouet/ezcmdliner.git"
+url {
+  src: "https://github.com/Ninjapouet/ezcmdliner/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=46549f6678baf3ea699154d835e13a42"
+    "sha512=2264e56527601cfc37572a5fef6b8feb4c844d5a0323d28f55df92c6189e24854f8af812c792e549e5216c776e8cfaf9447380e5db46cb48d865b59292c84c71"
+  ]
+}

--- a/packages/ezcmdliner/ezcmdliner.0.1.0/opam
+++ b/packages/ezcmdliner/ezcmdliner.0.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "An easy interface to cmdliner"
+description:
+  "It simplifies the binary command line definition and composition"
+maintainer: ["Julien Blond <julien.blond@gmail.com>"]
+authors: ["Julien Blond <julien.blond@gmail.com>"]
+license: "Apache 2.0"
+homepage: "https://github.com/Ninjapouet/ezcmdliner"
+bug-reports: "https://github.com/Ninjapouet/ezcmdliner/issues"
+depends: [
+  "dune" {>= "2.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Ninjapouet/ezcmdliner.git"
+url {
+  src: "https://github.com/Ninjapouet/ezcmdliner/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=46549f6678baf3ea699154d835e13a42"
+    "sha512=2264e56527601cfc37572a5fef6b8feb4c844d5a0323d28f55df92c6189e24854f8af812c792e549e5216c776e8cfaf9447380e5db46cb48d865b59292c84c71"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ezcmdliner.0.1.0`: An easy interface to cmdliner
-`ezcmdliner-ppx.0.1.0`: Derivates cmdliner terms from type definitions



---
* Homepage: https://github.com/Ninjapouet/ezcmdliner
* Source repo: git+https://github.com/Ninjapouet/ezcmdliner.git
* Bug tracker: https://github.com/Ninjapouet/ezcmdliner/issues

---
:camel: Pull-request generated by opam-publish v2.0.2