### PR TITLE
conf-libev depends on ocaml

### DIFF
--- a/packages/conf-libev/conf-libev.4-11/opam
+++ b/packages/conf-libev/conf-libev.4-11/opam
@@ -3,6 +3,9 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://software.schmorp.de/pkg/libev.html"
 authors: "Marc Lehmann"
 build: [["sh" "./build.sh"]]
+depends: [
+  "ocaml" {>= "3.11.0"}
+]
 depexts: [
   ["libev-dev"] {os-family = "debian"}
   ["libev"] {os = "macos" & os-distribution = "homebrew"}


### PR DESCRIPTION
A dependency on `ocaml` is missing in `conf-libev`.  I found this when trying to install lwt with libev support in an empty switch.

The 3.11.0 constraint on OCaml is a somewhat conservative guess.  Much older compilers would probably work as well since `discover.ml` doesn't seem to use any remotely new language features or stdlib functions.