### PR TITLE
2 packages from Ninjapouet/ezcmdliner at 0.1.1

### DIFF
--- a/packages/ezcmdliner-ppx/ezcmdliner-ppx.0.1.1/opam
+++ b/packages/ezcmdliner-ppx/ezcmdliner-ppx.0.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Derivates cmdliner terms from type definitions"
+description:
+  "This PPX gives to your program a nice CLI using simple type annotations"
+maintainer: "Julien Blond <julien.blond@gmail.com>"
+authors: "Julien Blond <julien.blond@gmail.com>"
+license: "Apache 2.0"
+homepage: "https://github.com/Ninjapouet/ezcmdliner"
+bug-reports: "https://github.com/Ninjapouet/ezcmdliner/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "ppxlib" {>= "0.14.0"}
+  "fmt" {>= "0.8.8"}
+  "cmdliner" {>= "1.0.4"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Ninjapouet/ezcmdliner.git"
+url {
+  src: "https://github.com/Ninjapouet/ezcmdliner/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=34d248c53e83e2125639f5624b7a40f1"
+    "sha512=6d4ecf55a235c0448db1cd311f0f6350a716469a5592259b5e75f8c9da17e6ec3f063653159d0dd465b841ab46bc746f6752a5c70b13614c76f6ba3ba7e7825f"
+  ]
+}

--- a/packages/ezcmdliner/ezcmdliner.0.1.1/opam
+++ b/packages/ezcmdliner/ezcmdliner.0.1.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "An easy interface to cmdliner"
+description:
+  "It simplifies the binary command line definition and composition"
+maintainer: "Julien Blond <julien.blond@gmail.com>"
+authors: "Julien Blond <julien.blond@gmail.com>"
+license: "Apache 2.0"
+homepage: "https://github.com/Ninjapouet/ezcmdliner"
+bug-reports: "https://github.com/Ninjapouet/ezcmdliner/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "cmdliner" {>= "1.0.4"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Ninjapouet/ezcmdliner.git"
+url {
+  src: "https://github.com/Ninjapouet/ezcmdliner/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=34d248c53e83e2125639f5624b7a40f1"
+    "sha512=6d4ecf55a235c0448db1cd311f0f6350a716469a5592259b5e75f8c9da17e6ec3f063653159d0dd465b841ab46bc746f6752a5c70b13614c76f6ba3ba7e7825f"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ezcmdliner.0.1.1`: An easy interface to cmdliner
-`ezcmdliner-ppx.0.1.1`: Derivates cmdliner terms from type definitions



---
* Homepage: https://github.com/Ninjapouet/ezcmdliner
* Source repo: git+https://github.com/Ninjapouet/ezcmdliner.git
* Bug tracker: https://github.com/Ninjapouet/ezcmdliner/issues

---
:camel: Pull-request generated by opam-publish v2.0.2