### PR TITLE
Mitigate test dependency cycle (ocaml-opam/opam-depext#121) between base, dune-configurator and csexp

### DIFF
--- a/packages/csexp/csexp.1.0.0/opam
+++ b/packages/csexp/csexp.1.0.0/opam
@@ -30,7 +30,8 @@ bug-reports: "https://github.com/ocaml-dune/csexp/issues"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.04.0"}
-  "ppx_expect" {with-test & < "v0.15"}
+# "ppx_expect" {with-test & < "v0.15"}
+# Disabled because of a dependency cycle (see https://github.com/ocaml-opam/opam-depext/issues/121)
 ]
 build: [
   ["dune" "subst"] {pinned}
@@ -42,7 +43,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+#   "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/csexp/csexp.1.1.0/opam
+++ b/packages/csexp/csexp.1.1.0/opam
@@ -30,7 +30,8 @@ bug-reports: "https://github.com/ocaml-dune/csexp/issues"
 depends: [
   "dune" {>= "2.5"}
   "ocaml" {>= "4.02.3"}
-  "ppx_expect" {with-test & < "v0.15"}
+# "ppx_expect" {with-test & < "v0.15"}
+# Disabled because of a dependency cycle (https://github.com/ocaml-opam/opam-depext/issues/121)
   "result" {>= "1.5"}
 ]
 build: [
@@ -43,7 +44,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+#   "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/csexp/csexp.1.2.0/opam
+++ b/packages/csexp/csexp.1.2.0/opam
@@ -30,7 +30,8 @@ bug-reports: "https://github.com/ocaml-dune/csexp/issues"
 depends: [
   "dune" {>= "2.5"}
   "ocaml" {>= "4.02.3"}
-  "ppx_expect" {with-test}
+# "ppx_expect" {with-test}
+# Disabled because of a dependency cycle (https://github.com/ocaml-opam/opam-depext/issues/121)
   "result" {>= "1.5"}
 ]
 build: [
@@ -43,7 +44,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+#   "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/csexp/csexp.1.2.2/opam
+++ b/packages/csexp/csexp.1.2.2/opam
@@ -30,7 +30,8 @@ bug-reports: "https://github.com/ocaml-dune/csexp/issues"
 depends: [
   "dune" {>= "2.5"}
   "ocaml" {>= "4.02.3"}
-  "ppx_expect" {with-test}
+# "ppx_expect" {with-test}
+# Disabled because of a dependency cycle (see https://github.com/ocaml-opam/opam-depext/issues/121)
   "result" {>= "1.5"}
 ]
 build: [
@@ -43,7 +44,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+#   "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/csexp/csexp.1.2.3/opam
+++ b/packages/csexp/csexp.1.2.3/opam
@@ -30,7 +30,8 @@ bug-reports: "https://github.com/ocaml-dune/csexp/issues"
 depends: [
   "dune" {>= "2.5"}
   "ocaml" {>= "4.02.3"}
-  "ppx_expect" {with-test}
+# "ppx_expect" {with-test}
+# Disabled because of a dependency cycle (see https://github.com/ocaml-opam/opam-depext/issues/121)
   "result" {>= "1.5"}
 ]
 build: [
@@ -43,7 +44,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+#   "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/csexp/csexp.1.3.1/opam
+++ b/packages/csexp/csexp.1.3.1/opam
@@ -30,7 +30,8 @@ bug-reports: "https://github.com/ocaml-dune/csexp/issues"
 depends: [
   "dune" {>= "2.5"}
   "ocaml" {>= "4.02.3"}
-  "ppx_expect" {with-test}
+# "ppx_expect" {with-test}
+# Disabled because of a dependency cycle (see https://github.com/ocaml-opam/opam-depext/issues/121)
   "result" {>= "1.5"}
 ]
 build: [
@@ -43,7 +44,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+#   "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam-repository/issues/17152
Error also encountered by @emillon, @voodoos, @c-cube 

This is only a mitigation until opam 2.1 comes out and is wildly used in CIs.

@jeremiedimino @mefyl Could this be ported to csexp upstream temporarily so that it does not happen in the future until opam 2.1 comes out?