### PR TITLE
[new release] prom (0.3)

### DIFF
--- a/packages/prom/prom.0.3/opam
+++ b/packages/prom/prom.0.3/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-prometheus"
+bug-reports: "https://github.com/vbmithr/ocaml-prometheus/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-prometheus"
+doc: "https://vbmithr.github.io/ocaml-prometheus/doc"
+build: [ "dune" "build" "-j" jobs "-p" name ]
+run-test: [ "dune" "runtest" "-j" jobs "-p" name ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.11.4"}
+  "fmt" {>= "0.8.8"}
+  "ptime" {>= "0.8.5"}
+  "containers" {>= "3.0"}
+  "alcotest" {with-test & >= "1.0.1"}
+]
+synopsis: "Types and pretty printer for Prometheus text-based exposition format"
+description: """Prometheus is an open-source systems
+monitoring and alerting toolkit originally built at SoundCloud."""
+x-commit-hash: "cad4a608fcd56a5c784a7408b16dad5b9809ab09"
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-prometheus/releases/download/0.3/prom-0.3.tbz"
+  checksum: [
+    "sha256=ab2790fed9bf4cd5e8410a498cf92538975c7cb86959db560138296791579b2b"
+    "sha512=d28689793eb7d146a854d7d1cb692ffcadd6f8170f05b6f8c6ee7b14250d999ffa186f55b20f78eb01df26471f7cd7961566ee685f4a6be40d666e73fae3df9a"
+  ]
+}


### PR DESCRIPTION
Types and pretty printer for Prometheus text-based exposition format

- Project page: <a href="https://github.com/vbmithr/ocaml-prometheus">https://github.com/vbmithr/ocaml-prometheus</a>
- Documentation: <a href="https://vbmithr.github.io/ocaml-prometheus/doc">https://vbmithr.github.io/ocaml-prometheus/doc</a>

##### CHANGES:

- containers > 3.0 compatibility
- Add Prom_cfg, module to generate prometheus autoconfiguration files
