### PR TITLE
Package yices2_bindings.0.2

### DIFF
--- a/packages/yices2_bindings/yices2_bindings.0.2/opam
+++ b/packages/yices2_bindings/yices2_bindings.0.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Ocaml bindings for yices2"
+description: "Ocaml bindings for yices2"
+maintainer: "Stephane Graham-Lengrand <stephane.graham-lengrand@csl.sri.com>"
+authors: "Stephane Graham-Lengrand <stephane.graham-lengrand@csl.sri.com>"
+license: "GPLv3"
+homepage: "https://github.com/SRI-CSL/yices2_ocaml_bindings"
+bug-reports: "https://github.com/SRI-CSL/yices2_ocaml_bindings/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "containers"  {>= "3.0.0"}
+  "ctypes"
+  "ctypes-foreign"
+  "ppx_deriving"
+  "ppx_optcomp"
+  "sexplib"
+  "sexplib0"
+  "zarith"
+  "ctypes-zarith" {>= "0.2.0"}
+#  "ctypes-of-clang"
+]
+build: [
+  make
+]
+install: [
+  make "install"
+]
+url {
+  src: "https://github.com/SRI-CSL/yices2_ocaml_bindings/archive/0.2.tar.gz"
+  checksum: [
+    "md5=ff7ffd8b5e9f3aa2ba2d374c8c4c20e6"
+    "sha512=617def9703ab0b97f95fed86c7e5947b576d9662d7255687499fce58b90f3ba0e110e2c6e46d5aab32bc9d692ff6c0ab4987878dabe185f73e3ac5bfef364aa6"
+  ]
+}


### PR DESCRIPTION
### `yices2_bindings.0.2`
Ocaml bindings for yices2
Ocaml bindings for yices2



---
* Homepage: https://github.com/SRI-CSL/yices2_ocaml_bindings
* Bug tracker: https://github.com/SRI-CSL/yices2_ocaml_bindings/issues

---
:camel: Pull-request generated by opam-publish v2.0.2