### PR TITLE
Package apronext.1.0

### DIFF
--- a/packages/apronext/apronext.1.0/opam
+++ b/packages/apronext/apronext.1.0/opam
@@ -12,16 +12,16 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs]
 ]
 depends: [
-  "dune" {>= "2.1"}
+  "dune"  {>= "2.1"}
   "ocaml" {>= "4.08"}
   "apron"
 ]
 synopsis: "Apron extension"
 description: "An extension for the OCaml interface of the Apron library"
 url {
-  src: "https://github.com/ghilesZ/apronext/archive/v1.0.tar.gz"
+  src: "https://github.com/ghilesZ/apronext/archive/v1.0.1.tar.gz"
   checksum: [
-    "md5=38b26e09339b51de160fccde1d7b6212"
-    "sha512=e447085143d5112c774985fec6058a05120660097bb5f30f91420b694d966c318475089eef3380415fe1f7789deae7f923c3d7459d0becdab7eb8e4e909d2704"
+    "md5=959863bffbc2b600aff73e1487b00b1a"
+    "sha512=7bb5bfb37241f0b1de83e18d9b64838d93bd1b18d10e84ebef014fae33c03b402a24cd73b10d6d48a8eeb0833ada6ca661b88f4e568c13e08c0a6b57e5f8a709"
   ]
 }


### PR DESCRIPTION
### `apronext.1.0`
Apron extension
An extension for the OCaml interface of the Apron library



---
* Homepage: https://github.com/ghilesZ/apronext
* Source repo: git+https://github.com/ghilesZ/apronext
* Bug tracker: https://github.com/ghilesZ/apronext/issues

---
:camel: Pull-request generated by opam-publish v2.0.2