### PR TITLE
Package ocsigen-i18n.3.6.0

### DIFF
--- a/packages/ocsigen-i18n/ocsigen-i18n.3.6.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.6.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis:     "I18n made easy for web sites written with eliom"
+description:  "Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file"
+maintainer:   "Jan Rochel <jan@besport.com>"
+
+homepage: "https://github.com/besport/ocsigen-i18n"
+bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
+dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+build:   [ make "build" ]
+install: [ make "bindir=%{bin}%" "install" ]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "ocamlfind" {build}
+  "tyxml" { >= "4.3.0" }
+  "ppx_tools"
+]
+authors: "Julien Sagot"
+url {
+  src: "https://github.com/besport/ocsigen-i18n/archive/3.6.0.tar.gz"
+  checksum: [
+    "md5=8bcc62f4835dedbfdd3739da7324d69c"
+    "sha512=aafcc2229d47534c72018ae44de03d546bd2e9a55367ebf8480d689c8e2e02f1c5dfe282db9d6a96b1bbbe5ac9e3d7042d591ccf73ede9f0ac38a41e9e9a4273"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-i18n.3.6.0`
I18n made easy for web sites written with eliom
Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file



---
* Homepage: https://github.com/besport/ocsigen-i18n
* Source repo: git+https://github.com/besport/ocsigen-i18n.git
* Bug tracker: https://github.com/besport/ocsigen-i18n/issues

---
:camel: Pull-request generated by opam-publish v2.0.2