### PR TITLE
[new release] ppx_blob (0.7.1)

### DIFF
--- a/packages/ppx_blob/ppx_blob.0.7.1/opam
+++ b/packages/ppx_blob/ppx_blob.0.7.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml"
   "dune"
-  "ocaml-migrate-parsetree" {>= "1.7.0"}
+  "ocaml-migrate-parsetree" {>= "1.7.0" & < "2.0.0"}
   "alcotest" {with-test}
 ]
 synopsis: "Include a file as a string at compile time"

--- a/packages/ppx_blob/ppx_blob.0.7.1/opam
+++ b/packages/ppx_blob/ppx_blob.0.7.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+authors: "John Whitington"
+maintainer: "contact@coherentgraphics.co.uk"
+homepage: "https://github.com/johnwhitington/ppx_blob"
+dev-repo: "git+https://github.com/johnwhitington/ppx_blob.git"
+bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
+doc: "https://johnwhitington.github.io/ppx_blob/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune"
+  "ocaml-migrate-parsetree" {>= "1.7.0"}
+  "alcotest" {with-test}
+]
+synopsis: "Include a file as a string at compile time"
+description:
+  "ppx_blob allows you to include a binary blob from a file as a string. Writing `[%blob \"filename\"]` will replace the string with the contents of the file at compile time. This allows the inclusion of arbitary, possibly compressed, data, without the need to respect OCaml's lexical conventions."
+x-commit-hash: "a893581c6cbe4484511ee71cdf065af6ddadb96d"
+url {
+  src:
+    "https://github.com/johnwhitington/ppx_blob/releases/download/0.7.1/ppx_blob-0.7.1.tbz"
+  checksum: [
+    "sha256=1434847560cd17ecc2971dc52d1dd847e8261b91a6f2082f755cd5696236c154"
+    "sha512=846a94447c4ccae106bf88062fe15574e82c6a20707f33756cfb6c35439d7807e4558d4bc522bdaf8695816d1d660933841f9c124f4a26225b0ef4bd498cdc48"
+  ]
+}


### PR DESCRIPTION
Include a file as a string at compile time

- Project page: <a href="https://github.com/johnwhitington/ppx_blob">https://github.com/johnwhitington/ppx_blob</a>
- Documentation: <a href="https://johnwhitington.github.io/ppx_blob/">https://johnwhitington.github.io/ppx_blob/</a>

##### CHANGES:

Use `Ast_411` from ocaml-migrate-parsetree for compatibility with new OCaml syntax (johnwhitington/ppx_blob#19).
