### PR TITLE
Package apronext.1.0.1

### DIFF
--- a/packages/apronext/apronext.1.0.1/opam
+++ b/packages/apronext/apronext.1.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Ghiles Ziat <ghiles.ziat@isae-supaero.fr"
+authors: ["Ghiles Ziat <ghiles.ziat@isae-supaero.fr"]
+homepage: "https://github.com/ghilesZ/apronext"
+bug-reports: "https://github.com/ghilesZ/apronext/issues"
+dev-repo: "git+https://github.com/ghilesZ/apronext"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "dune"  {>= "2.1"}
+  "ocaml" {>= "4.08"}
+  "apron"
+]
+synopsis: "Apron extension"
+description: "An extension for the OCaml interface of the Apron library"
+url {
+  src: "https://github.com/ghilesZ/apronext/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=5c4bdc7252d4dccb5c7e710bed7fb179"
+    "sha512=f2979caef4d96036dfadff286655110adde19473dc3df6eee39c62f859e4f826ebcd1e6f1644bd8a1ca7877bba00e4e2f0ea63329b0ace48254f9d89ffcc4646"
+  ]
+}


### PR DESCRIPTION
### `apronext.1.0.1`
Apron extension
An extension for the OCaml interface of the Apron library



---
* Homepage: https://github.com/ghilesZ/apronext
* Source repo: git+https://github.com/ghilesZ/apronext
* Bug tracker: https://github.com/ghilesZ/apronext/issues

---
:camel: Pull-request generated by opam-publish v2.0.2