### PR TITLE
conf-mbedtls: Fix presence test on FreeBSD

### DIFF
--- a/packages/conf-mbedtls/conf-mbedtls.1/opam
+++ b/packages/conf-mbedtls/conf-mbedtls.1/opam
@@ -6,7 +6,7 @@ homepage: "https://tls.mbed.org/"
 bug-reports: "https://github.com/ARMmbed/mbedtls/issues"
 license: "Apache-2.0"
 build: [
-  ["cc" "test.c"]
+  ["cc" "-I/usr/local/include" "test.c"]
 ]
 depexts: [
   ["mbedtls-dev"] {os-distribution = "alpine"}


### PR DESCRIPTION
Should fix https://github.com/ocaml/opam-repository/issues/16951