### PR TITLE
conf-cmake: Use /bin/sh instead of bash

### DIFF
--- a/packages/conf-cmake/conf-cmake.1/files/configure.sh
+++ b/packages/conf-cmake/conf-cmake.1/files/configure.sh
@@ -1,4 +1,4 @@
-#/bin/bash -ex
+#/bin/sh -ex
 
 if command -v cmake3; then
     cmake_cmd=cmake3

--- a/packages/conf-cmake/conf-cmake.1/opam
+++ b/packages/conf-cmake/conf-cmake.1/opam
@@ -4,7 +4,7 @@ authors: "Kitware, Inc. and Contributors"
 homepage: "https://cmake.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "BSD-3-Clause"
-build: ["bash" "-ex" "configure.sh"]
+build: ["sh" "-ex" "configure.sh"]
 depexts: [
   ["cmake"] {os-distribution = "homebrew" & os = "macos"}
   ["cmake"] {os-distribution = "macports" & os = "macos"}
@@ -24,5 +24,5 @@ depexts: [
 synopsis: "Virtual package relying on cmake"
 description:
   "This package can only install if cmake is installed on the system."
-extra-files: ["configure.sh" "md5=0cae8434c6b69725503c46525063c505"]
+extra-files: ["configure.sh" "md5=edf06364b88e68cda6a10dc5ab4d9207"]
 flags: conf


### PR DESCRIPTION
Should fix https://github.com/ocaml/opam-repository/issues/16780