### PR TITLE
Memtrace viewer (with dependencies)

### DIFF
--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
@@ -7,13 +7,8 @@ dev-repo: "git+https://github.com/janestreet/memtrace_viewer.git"
 doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/memtrace_viewer/index.html"
 license: "MIT"
 build: [
-  [make]
-]
-install: [
-  [make "install"]
-]
-remove: [
-  [make "uninstall"]
+  ["dune" "build" "--profile" "release" "--default-target" "@install" "."]
+  ["cp" "_build/default/memtrace_viewer.install" "."]
 ]
 depends: [
   "ocaml" {>= "4.11.0"}
@@ -21,6 +16,7 @@ depends: [
   "astring" {>= "0.8.5"}
   "base64" {>= "3.4.0"}
   "cryptokit" {>= "1.14"}
+  "cstruct" {>= "5.2.0"}
   "ctypes" {>= "0.17.1"}
   "ctypes-foreign" {>= "0.4.0"}
   "domain-name" {>= "0.3.0"}
@@ -47,10 +43,7 @@ top allocators in a table or flame graph. To help find space leaks,
 events can be filtered by lifetime, showing only allocations of
 objects that are still live at peak memory usage.
 "
-conflicts: [
-  "memtrace_viewer"
-]
 url {
   src: "https://github.com/janestreet/memtrace_viewer_with_deps/archive/v0.14.0.tar.gz"
-  checksum: "md5=80896624ed4f848b66b6e7e2a29cb33d"
+  checksum: "md5=0e4c01e80b13dc3184ee2bb10b41884a"
 }

--- a/packages/memtrace_viewer_with_deps/memtrace_viewer_with_deps.v0.14.0/opam
+++ b/packages/memtrace_viewer_with_deps/memtrace_viewer_with_deps.v0.14.0/opam
@@ -17,6 +17,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.11.0"}
+  "conf-libssl"
   "astring" {>= "0.8.5"}
   "base64" {>= "3.4.0"}
   "cryptokit" {>= "1.14"}

--- a/packages/memtrace_viewer_with_deps/memtrace_viewer_with_deps.v0.14.0/opam
+++ b/packages/memtrace_viewer_with_deps/memtrace_viewer_with_deps.v0.14.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/memtrace_viewer"
+bug-reports: "https://github.com/janestreet/memtrace_viewer/issues"
+dev-repo: "git+https://github.com/janestreet/memtrace_viewer.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/memtrace_viewer/index.html"
+license: "MIT"
+build: [
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  [make "uninstall"]
+]
+depends: [
+  "ocaml"
+  "astring" {>= "0.8.5"}
+  "base64" {>= "3.4.0"}
+  "cryptokit" {>= "1.14"}
+  "ctypes" {>= "0.17.1"}
+  "ctypes-foreign" {>= "0.4.0"}
+  "domain-name" {>= "0.3.0"}
+  "dune" {>= "2.7.1"}
+  "dune-configurator" {>= "2.7.1"}
+  "fmt" {>= "0.8.8"}
+  "js_of_ocaml" {>= "3.7.0"}
+  "js_of_ocaml-ppx" {>= "3.7.0"}
+  "jsonm" {>= "1.0.1"}
+  "lambdasoup" {>= "0.7.1"}
+  "logs" {>= "0.7.0"}
+  "magic-mime" {>= "1.1.2"}
+  "memtrace" {>= "0.1.1"}
+  "octavius" {>= "1.2.2"}
+  "ppxlib" {>= "0.15.0"}
+  "spawn" {>= "v0.13.0"}
+  "tyxml" {>= "4.4.0"}
+  "uri" {>= "3.1.0"}
+]
+synopsis: "Interactive memory profiler based on Memtrace"
+description: "\
+Processes traces produced by the Memtrace library and displays the
+top allocators in a table or flame graph. To help find space leaks,
+events can be filtered by lifetime, showing only allocations of
+objects that are still live at peak memory usage.
+"
+conflicts: [
+  "memtrace_viewer"
+]
+url {
+  src: "https://github.com/janestreet/memtrace_viewer_with_deps/archive/v0.14.0.tar.gz"
+  checksum: "md5=80896624ed4f848b66b6e7e2a29cb33d"
+}

--- a/packages/memtrace_viewer_with_deps/memtrace_viewer_with_deps.v0.14.0/opam
+++ b/packages/memtrace_viewer_with_deps/memtrace_viewer_with_deps.v0.14.0/opam
@@ -16,7 +16,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.11.0"}
   "astring" {>= "0.8.5"}
   "base64" {>= "3.4.0"}
   "cryptokit" {>= "1.14"}


### PR DESCRIPTION
This pull request releases `memtrace_viewer`.

Something perhaps noteworthy about this package is that
it vendors most of its dependencies (in particular to other
Jane Street packages). It is unconventional, but since releasing
this package implied a number of yet unpublished changes
to the packages, vendoring them allows us to publish the
memtrace viewer significantly earlier.