### PR TITLE
2 packages from Ninjapouet/slurp at 0.1.0

### DIFF
--- a/packages/slurp-cohttp/slurp-cohttp.0.1.0/opam
+++ b/packages/slurp-cohttp/slurp-cohttp.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Cohttp definition for Slurp"
+maintainer: "Julien Blond <julien.blond@gmail.com>"
+authors: "Julien Blond <julien.blond@gmail.com>"
+license: "Apache 2.0"
+tags: ["sinatra" "route" "http" "server" "cohttp"]
+homepage: "https://github.com/Ninjapouet/slurp"
+bug-reports: "https://github.com/Ninjapouet/slurp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "slurp" {>= "0.1.0"}
+  "cohttp-lwt-unix" {>= "2.5.1"}
+  "ezcmdliner" {>= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@test/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Ninjapouet/slurp.git"
+url {
+  src: "https://github.com/Ninjapouet/slurp/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=40b51c156a42c8eb4062bea99754e843"
+    "sha512=57771b0b7fd124c784462195ef1cc1e1fd3ba27005310461cea2147bc3792b6493968407749b7ad368aaee2653008b0c266755218d8971da76b6fc74f3863aaa"
+  ]
+}

--- a/packages/slurp/slurp.0.1.0/opam
+++ b/packages/slurp/slurp.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Sinatra Like URL Route Processing"
+maintainer: "Julien Blond <julien.blond@gmail.com>"
+authors: "Julien Blond <julien.blond@gmail.com>"
+license: "Apache 2.0"
+tags: ["sinatra" "route" "http" "server"]
+homepage: "https://github.com/Ninjapouet/slurp"
+bug-reports: "https://github.com/Ninjapouet/slurp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "fmt" {>= "0.8.8"}
+  "ezjsonm" {>= "1.1.0"}
+  "uri" {>= "3.1.0"}
+  "lwt" {>= "5.2.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "fpath" {>= "0.7.3"}
+  "lwt_react" {>= "1.1.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@lib/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Ninjapouet/slurp.git"
+url {
+  src: "https://github.com/Ninjapouet/slurp/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=40b51c156a42c8eb4062bea99754e843"
+    "sha512=57771b0b7fd124c784462195ef1cc1e1fd3ba27005310461cea2147bc3792b6493968407749b7ad368aaee2653008b0c266755218d8971da76b6fc74f3863aaa"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`slurp.0.1.0`: Sinatra Like URL Route Processing
-`slurp-cohttp.0.1.0`: Cohttp definition for Slurp



---
* Homepage: https://github.com/Ninjapouet/slurp
* Source repo: git+https://github.com/Ninjapouet/slurp.git
* Bug tracker: https://github.com/Ninjapouet/slurp/issues

---
:camel: Pull-request generated by opam-publish v2.0.2