### PR TITLE
2 packages from project-everest/hacl-star at 0.2.2

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.2.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `hacl-star` package, of
+which `hacl-star-raw` is a dependency."""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ctypes"
+  "ctypes-foreign"
+]
+build: [
+  ["sh" "-exc" "cd raw && ./configure"]
+  [make "-C" "raw"]
+]
+install: [make "-C" "raw" "install-hacl-star-raw"]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.2.2/hacl-star.0.2.2.tar.gz"
+  checksum: [
+    "md5=bf3bb86bf6dc622182795f03aad9247c"
+    "sha512=b5bba6c7c2d1e995a2795d339829ed7bcf77e03a0b8737c6e9d29e4638dd756db1eb13ad8a39b38246bfba5171125cdd1b6c0d36c0ec66c347acd7b85f381190"
+  ]
+}

--- a/packages/hacl-star/hacl-star.0.2.2/opam
+++ b/packages/hacl-star/hacl-star.0.2.2/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "OCaml API for EverCrypt/HACL*"
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.2"}
+  "hacl-star-raw" {= version}
+  "zarith"
+  "cppo" {build}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.2.2/hacl-star.0.2.2.tar.gz"
+  checksum: [
+    "md5=bf3bb86bf6dc622182795f03aad9247c"
+    "sha512=b5bba6c7c2d1e995a2795d339829ed7bcf77e03a0b8737c6e9d29e4638dd756db1eb13ad8a39b38246bfba5171125cdd1b6c0d36c0ec66c347acd7b85f381190"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`hacl-star.0.2.2`: OCaml API for EverCrypt/HACL*
-`hacl-star-raw.0.2.2`: Auto-generated low-level OCaml bindings for EverCrypt/HACL*



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.2