### PR TITLE
[new release] memtrace (0.1.2)

### DIFF
--- a/packages/memtrace/memtrace.0.1.2/opam
+++ b/packages/memtrace/memtrace.0.1.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Streaming client for Memprof"
+description: "Generates compact traces of a program's memory use."
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/janestreet/memtrace"
+bug-reports: "https://github.com/janestreet/memtrace/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/janestreet/memtrace.git"
+x-commit-hash: "43cc9dfe04cbb9c087dd999a7a1d18a729e58cec"
+url {
+  src:
+    "https://github.com/janestreet/memtrace/releases/download/v0.1.2/memtrace-v0.1.2.tbz"
+  checksum: [
+    "sha256=1dc76b4bd375460c026d5a602149a1c3ea401644df38480e7b5919387b18bf83"
+    "sha512=5726ce796611bae1e24fa4b51d88dc5115cb5b2cdd36e63c4696d38d51178ace93e79a73671e04d35f3fdd1d29efb4f958a9792dca832e37ad89d82b5ee2dd6f"
+  ]
+}


### PR DESCRIPTION
Streaming client for Memprof

- Project page: <a href="https://github.com/janestreet/memtrace">https://github.com/janestreet/memtrace</a>

##### CHANGES:

More packaging fixes.
