### PR TITLE
[new release] ppxlib (0.17.0)

### DIFF
--- a/packages/ppxlib/ppxlib.0.17.0/opam
+++ b/packages/ppxlib/ppxlib.0.17.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.10" }
+]
+depends: [
+  "ocaml"                   {>= "4.04.1"}
+  "dune"                    {>= "1.11"}
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "2.0.0"}
+  "ppx_derivers"            {>= "1.0"}
+  "result"
+  "sexplib0"
+  "stdlib-shims"
+  "ocamlfind"               {with-test}
+  "cinaps"                  {with-test & >= "v0.12.1"}
+  "base"                    {with-test}
+  "stdio"                   {with-test}
+]
+synopsis: "Standard library for ppx rewriters"
+description: """
+Ppxlib is the standard library for ppx rewriters and other programs
+that manipulate the in-memory reprensation of OCaml programs, a.k.a
+the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+x-commit-hash: "710a18a5a3b195d910d72ab97d6eeed536c8d7d3"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.17.0/ppxlib-0.17.0.tbz"
+  checksum: [
+    "sha256=d569dcdd01605c6e3f6b52c3fae1d99887fe1784cb18449772796553e3f5ce4f"
+    "sha512=48ceeb43d938e05d695377a41a391e9c0bc83900770bab1a396e45e0a8883d285067bb782777f827235f80452fd95015669be362d39888b2cf633e98b103bf5e"
+  ]
+}


### PR DESCRIPTION
Standard library for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Add accessors for `code_path` and `tool_name` to `Expansion_context.Base`
  (ocaml-ppx/ppxlib#173, @jberdine)
- Add `cases` methods to traversal classes in `Ast_traverse` (ocaml-ppx/ppxlib#183, @pitag-ha)
