### PR TITLE
2 packages from Ninjapouet/slurp at 0.1.0

### DIFF
--- a/packages/slurp-cohttp/slurp-cohttp.0.1.0/opam
+++ b/packages/slurp-cohttp/slurp-cohttp.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Cohttp definition for Slurp"
+maintainer: "Julien Blond <julien.blond@gmail.com>"
+authors: "Julien Blond <julien.blond@gmail.com>"
+license: "Apache 2.0"
+tags: ["sinatra" "route" "http" "server" "cohttp"]
+homepage: "https://github.com/Ninjapouet/slurp"
+bug-reports: "https://github.com/Ninjapouet/slurp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "slurp" {>= "0.1.0"}
+  "cohttp-lwt-unix" {>= "2.5.1"}
+  "ezcmdliner" {>= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@test/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Ninjapouet/slurp.git"
+url {
+  src: "https://github.com/Ninjapouet/slurp/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=63a214e604cb29848f2cc0ddf12e7ff6"
+    "sha512=fe9b4ea24da842c3aae9233f64c6c0d72fbe88e49fa766a600da624359b3a881995206e3756158321f17648301805796648e0f681b737295a1ec99ed4f1e9467"
+  ]
+}

--- a/packages/slurp/slurp.0.1.0/opam
+++ b/packages/slurp/slurp.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Sinatra Like URL Route Processing"
+maintainer: "Julien Blond <julien.blond@gmail.com>"
+authors: "Julien Blond <julien.blond@gmail.com>"
+license: "Apache 2.0"
+tags: ["sinatra" "route" "http" "server"]
+homepage: "https://github.com/Ninjapouet/slurp"
+bug-reports: "https://github.com/Ninjapouet/slurp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.1"}
+  "fmt" {>= "0.8.8"}
+  "ezjsonm" {>= "1.1.0"}
+  "uri" {>= "3.1.0"}
+  "lwt" {>= "5.2.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "magic-mime" {>= "1.1.2"}
+  "fpath" {>= "0.7.3"}
+  "lwt_react" {>= "1.1.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@lib/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Ninjapouet/slurp.git"
+url {
+  src: "https://github.com/Ninjapouet/slurp/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=63a214e604cb29848f2cc0ddf12e7ff6"
+    "sha512=fe9b4ea24da842c3aae9233f64c6c0d72fbe88e49fa766a600da624359b3a881995206e3756158321f17648301805796648e0f681b737295a1ec99ed4f1e9467"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`slurp.0.1.0`: Sinatra Like URL Route Processing
-`slurp-cohttp.0.1.0`: Cohttp definition for Slurp



---
* Homepage: https://github.com/Ninjapouet/slurp
* Source repo: git+https://github.com/Ninjapouet/slurp.git
* Bug tracker: https://github.com/Ninjapouet/slurp/issues

---
:camel: Pull-request generated by opam-publish v2.0.2