### PR TITLE
Package order-i3-xfce.0.1

### DIFF
--- a/packages/order-i3-xfce/order-i3-xfce.0.1/opam
+++ b/packages/order-i3-xfce/order-i3-xfce.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Order-i3-xfce is a small utility that allow you to keep a synchronized order between i3 tabs and the xfce pannel window buttons plugin"
+maintainer: "Emile Trotignon emile.trotignon@gmail.com"
+authors: "Emile Trotignon emile.trotignon@gmail.com"
+license: "MIT"
+homepage: "https://github.com/EmileTrotignon/order-i3-xfce"
+bug-reports: "https://github.com/EmileTrotignon/order-i3-xfce/issues"
+dev-repo: "git+https://github.com/EmileTrotignon/order-i3-xfce.git"
+depends: [ 
+    "ocaml" {>= "4.07.0"}
+    "dune" {>= "2.5.0"} 
+    "lwt"
+    "lwt_ppx"
+    "i3ipc"
+    ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/EmileTrotignon/order-i3-xfce/archive/0.1.tar.gz"
+  checksum: [
+    "md5=892fd4e85bf98089df82287377cfd9c6"
+    "sha512=3f6b5a76adc5e4c96eeda6ef57a327071bd940124106bbb80719ff3bc220823da6049fb2aad4e6e34ac9e01948ebd252dda875898f5104814760062948bcf53b"
+  ]
+}

--- a/packages/order-i3-xfce/order-i3-xfce.0.1/opam
+++ b/packages/order-i3-xfce/order-i3-xfce.0.1/opam
@@ -7,8 +7,8 @@ homepage: "https://github.com/EmileTrotignon/order-i3-xfce"
 bug-reports: "https://github.com/EmileTrotignon/order-i3-xfce/issues"
 dev-repo: "git+https://github.com/EmileTrotignon/order-i3-xfce.git"
 depends: [ 
-    "ocaml" {>= "4.07.0"}
-    "dune" {>= "2.5.0"} 
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.7.0"} 
     "lwt"
     "lwt_ppx"
     "i3ipc"


### PR DESCRIPTION
### `order-i3-xfce.0.1`
Order-i3-xfce is a small utility that allow you to keep a synchronized order between i3 tabs and the xfce pannel window buttons plugin



---
* Homepage: https://github.com/EmileTrotignon/order-i3-xfce
* Source repo: git+https://github.com/EmileTrotignon/order-i3-xfce.git
* Bug tracker: https://github.com/EmileTrotignon/order-i3-xfce/issues

---
:camel: Pull-request generated by opam-publish v2.0.2