### PR TITLE
[new release] emile (1.0)

### DIFF
--- a/packages/emile/emile.1.0/opam
+++ b/packages/emile/emile.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/emile"
+bug-reports:  "https://github.com/dinosaure/emile/issues"
+dev-repo:     "git+https://github.com/dinosaure/emile.git"
+doc:          "https://dinosaure.github.io/emile/"
+license:      "MIT"
+synopsis:     "Parser of email address according RFC822"
+description: """A parser of email address according RFC822, RFC2822, RFC5321 and RFC6532.
+It handles UTF-8 email addresses and encoded-word according RFC2047."""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {>= "1.0"}
+  "angstrom" {>= "0.14.0"}
+  "ipaddr"   {>= "2.7.0"}
+  "base64"   {>= "3.0.0"}
+  "pecu"
+  "uutf"
+  "alcotest" {with-test}
+]
+depopts: [ "cmdliner" ]
+x-commit-hash: "885120fa57781d56d49bf75091de4735a50d29b5"
+url {
+  src:
+    "https://github.com/dinosaure/emile/releases/download/v1.0/emile-v1.0.tbz"
+  checksum: [
+    "sha256=f0747406e650dfd62a1ed6ec188bcdaa5248c12b0b0f01d3ecb164c453d72089"
+    "sha512=989c1749686ee489f7fa87917c828045f5fe5bab833cde2ce58b5d317773a90b8dc3fdf058b3285592b77bc1fc9385163aa79d89336be7440a4a428a78cd3e31"
+  ]
+}

--- a/packages/mrmime/mrmime.0.2.0/opam
+++ b/packages/mrmime/mrmime.0.2.0/opam
@@ -25,7 +25,7 @@ depends: [
   "uutf"
   "rosetta"         {>= "0.3.0"}
   "ipaddr"
-  "emile"           {>= "0.8"}
+  "emile"           {>= "0.8" & < "1.0"}
   "base64"          {>= "3.1.0"}
   "pecu"            {>= "0.4"}
   "bigstringaf"

--- a/packages/mrmime/mrmime.0.3.0/opam
+++ b/packages/mrmime/mrmime.0.3.0/opam
@@ -25,7 +25,7 @@ depends: [
   "uutf"
   "rosetta"          {>= "0.3.0"}
   "ipaddr"
-  "emile"            {>= "0.8"}
+  "emile"            {>= "0.8" & < "1.0"}
   "base64"           {>= "3.1.0"}
   "pecu"             {>= "0.4"}
   "bigstringaf"

--- a/packages/received/received.0.2.0/opam
+++ b/packages/received/received.0.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "dune"     {>= "1.8.0"}
   "colombe"  {= version}
   "mrmime"   {>= "0.2.0"}
-  "emile"    {>= "0.8"}
+  "emile"    {>= "0.8" & < "1.0"}
   "angstrom" {>= "0.11.0"}
 ]
 url {

--- a/packages/received/received.0.3.0/opam
+++ b/packages/received/received.0.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "dune"     {>= "1.8.0"}
   "colombe"  {= version}
   "mrmime"   {>= "0.2.0"}
-  "emile"    {>= "0.8"}
+  "emile"    {>= "0.8" & < "1.0"}
   "angstrom" {>= "0.14.0"}
 ]
 url {

--- a/packages/sendmail/sendmail.0.2.0/opam
+++ b/packages/sendmail/sendmail.0.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "tls"
   "base64" {>= "3.0.0"}
   "logs"
-  "emile" {>= "0.8" & with-test}
+  "emile" {>= "0.8" & < "1.0" & with-test}
   "mrmime" {>= "0.2.0" & with-test}
   "alcotest" {with-test}
 ]

--- a/packages/sendmail/sendmail.0.3.0/opam
+++ b/packages/sendmail/sendmail.0.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "tls"
   "base64" {>= "3.0.0"}
   "logs"
-  "emile" {>= "0.8" & with-test}
+  "emile" {>= "0.8" & < "1.0" & with-test}
   "mrmime" {>= "0.2.0" & with-test}
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
Parser of email address according RFC822

- Project page: <a href="https://github.com/dinosaure/emile">https://github.com/dinosaure/emile</a>
- Documentation: <a href="https://dinosaure.github.io/emile/">https://dinosaure.github.io/emile/</a>

##### CHANGES:

- Add `to_string` functions to emit email addresses
- Better error message (**breaking-change**)
