### PR TITLE
camlp5 7.10 should exclude ocaml 4.09.1

### DIFF
--- a/packages/camlp5/camlp5.7.10/opam
+++ b/packages/camlp5/camlp5.7.10/opam
@@ -30,7 +30,7 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 doc: "https://camlp5.github.io/doc/html"
 
 depends: [
-  "ocaml"       { >= "4.02" & < "4.10.0" }
+  "ocaml"       { >= "4.02" & < "4.10.0" & != "4.09.1" }
 ]
 
 build: [


### PR DESCRIPTION
this (old) camlp5 version doesn't support ocaml 4.09.1.  Per request by Kakadu@

# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# On branch opam-publish-camlp5-7.10-patch
# Changes to be committed:
#	modified:   packages/camlp5/camlp5.7.10/opam
#