### PR TITLE
2 packages from Ninjapouet/slurp at 0.1.0

### DIFF
--- a/packages/slurp-cohttp/slurp-cohttp.0.1.0/opam
+++ b/packages/slurp-cohttp/slurp-cohttp.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Cohttp definition for Slurp"
+maintainer: "Julien Blond <julien.blond@gmail.com>"
+authors: "Julien Blond <julien.blond@gmail.com>"
+license: "Apache 2.0"
+tags: ["sinatra" "route" "http" "server" "cohttp"]
+homepage: "https://github.com/Ninjapouet/slurp"
+bug-reports: "https://github.com/Ninjapouet/slurp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "slurp" {>= "0.1.0"}
+  "cohttp-lwt-unix" {>= "2.5.1"}
+  "ezcmdliner" {>= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@test/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Ninjapouet/slurp.git"
+url {
+  src: "https://github.com/Ninjapouet/slurp/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=aae341405089035829129033ec3a6aa8"
+    "sha512=59e0d546b1bf6cb867378b16809408325a74987c0fff89ce0a6cbea93c87adbe693ed48ea2371bc32fd6db4c1d38984cec81fb04a6b3e978b2bfb53bdd556756"
+  ]
+}

--- a/packages/slurp/slurp.0.1.0/opam
+++ b/packages/slurp/slurp.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Sinatra Like URL Route Processing"
+maintainer: "Julien Blond <julien.blond@gmail.com>"
+authors: "Julien Blond <julien.blond@gmail.com>"
+license: "Apache 2.0"
+tags: ["sinatra" "route" "http" "server"]
+homepage: "https://github.com/Ninjapouet/slurp"
+bug-reports: "https://github.com/Ninjapouet/slurp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.1"}
+  "fmt" {>= "0.8.8"}
+  "ezjsonm" {>= "1.1.0"}
+  "uri" {>= "3.1.0"}
+  "lwt" {>= "5.2.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "magic-mime" {>= "1.1.2"}
+  "fpath" {>= "0.7.3"}
+  "lwt_react" {>= "1.1.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@lib/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Ninjapouet/slurp.git"
+url {
+  src: "https://github.com/Ninjapouet/slurp/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=aae341405089035829129033ec3a6aa8"
+    "sha512=59e0d546b1bf6cb867378b16809408325a74987c0fff89ce0a6cbea93c87adbe693ed48ea2371bc32fd6db4c1d38984cec81fb04a6b3e978b2bfb53bdd556756"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`slurp.0.1.0`: Sinatra Like URL Route Processing
-`slurp-cohttp.0.1.0`: Cohttp definition for Slurp



---
* Homepage: https://github.com/Ninjapouet/slurp
* Source repo: git+https://github.com/Ninjapouet/slurp.git
* Bug tracker: https://github.com/Ninjapouet/slurp/issues

---
:camel: Pull-request generated by opam-publish v2.0.2