### PR TITLE
Package shapefile.0.2.0

### DIFF
--- a/packages/shapefile/shapefile.0.2.0/opam
+++ b/packages/shapefile/shapefile.0.2.0/opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+synopsis: "A small library to read ESRI shapefiles"
+maintainer: "Cyril Allignol <cyril@allignol.com>"
+authors: ["Cyril Allignol <cyril@allignol.com>"]
+homepage: "https://github.com/cyril-allignol/ocaml-shapefile"
+bug-reports: "https://github.com/cyril-allignol/ocaml-shapefile/issues"
+dev-repo: "git+https://github.com/cyril-allignol/ocaml-shapefile.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {build}
+  "ocamlfind"
+  "bitstring"
+  "menhir" {build}
+]

--- a/packages/shapefile/shapefile.0.2.0/opam
+++ b/packages/shapefile/shapefile.0.2.0/opam
@@ -12,3 +12,7 @@ depends: [
   "bitstring"
   "menhir" {build}
 ]
+url {
+  src: "https://github.com/cyril-allignol/ocaml-shapefile/archive/v0.2.0.tar.gz"
+  checksum: "md5=15ef86f56066cb304bf2a6163cdbd837"
+}


### PR DESCRIPTION
### `shapefile.0.2.0`
A small library to read ESRI shapefiles



---
* Homepage: https://github.com/cyril-allignol/ocaml-shapefile
* Source repo: git+https://github.com/cyril-allignol/ocaml-shapefile.git
* Bug tracker: https://github.com/cyril-allignol/ocaml-shapefile/issues

---
:camel: Pull-request generated by opam-publish v2.0.2