### PR TITLE
[new release] github-jsoo, github-unix and github (4.3.2)

### DIFF
--- a/packages/github-jsoo/github-jsoo.4.3.2/opam
+++ b/packages/github-jsoo/github-jsoo.4.3.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 JavaScript library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/v3/)
+(JSON). This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "github" {= version}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt-jsoo" {>= "0.99.0"}
+  "js_of_ocaml-lwt" {>= "3.4.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.3.2/github-unix-4.3.2.tbz"
+  checksum: [
+    "sha256=b6304dce6ec33503e225ade600af194e1fc3976624ea83f546c7ab27ec8cfeb7"
+    "sha512=754f0a2bce5a2cb3b2355530708e3dab1d8a32401fa2a300b5eba37bf37e63d75d21d42595e7cd60b9a20beba054dd3b45675d51201a4aa8812ce5db400ab758"
+  ]
+}

--- a/packages/github-unix/github-unix.4.3.2/opam
+++ b/packages/github-unix/github-unix.4.3.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 Unix library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/v3/)
+(JSON).  This package installs the Unix (Lwt) version."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "github" {= version}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt-unix" {>= "0.99.0"}
+  "stringext"
+  "cmdliner" {>= "0.9.8"}
+  "base-unix"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.3.2/github-unix-4.3.2.tbz"
+  checksum: [
+    "sha256=b6304dce6ec33503e225ade600af194e1fc3976624ea83f546c7ab27ec8cfeb7"
+    "sha512=754f0a2bce5a2cb3b2355530708e3dab1d8a32401fa2a300b5eba37bf37e63d75d21d42595e7cd60b9a20beba054dd3b45675d51201a4aa8812ce5db400ab758"
+  ]
+}

--- a/packages/github/github.4.3.2/opam
+++ b/packages/github/github.4.3.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 OCaml library"
+description: """
+This library provides an OCaml interface to the
+[GitHub APIv3](https://docs.github.com/v3/) (JSON).
+
+It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
+JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "0.99.0"}
+  "cohttp-lwt" {>= "0.99"}
+  "lwt" {>= "2.4.4"}
+  "atdgen" {>= "2.0.0"}
+  "yojson" {>= "1.6.0"}
+  "stringext"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.3.2/github-unix-4.3.2.tbz"
+  checksum: [
+    "sha256=b6304dce6ec33503e225ade600af194e1fc3976624ea83f546c7ab27ec8cfeb7"
+    "sha512=754f0a2bce5a2cb3b2355530708e3dab1d8a32401fa2a300b5eba37bf37e63d75d21d42595e7cd60b9a20beba054dd3b45675d51201a4aa8812ce5db400ab758"
+  ]
+}


### PR DESCRIPTION
GitHub APIv3 JavaScript library

- Project page: <a href="https://github.com/mirage/ocaml-github">https://github.com/mirage/ocaml-github</a>
- Documentation: <a href="https://mirage.github.io/ocaml-github/">https://mirage.github.io/ocaml-github/</a>

##### CHANGES:

- Fix authentication on POST/PATCH/PUT requests. (mirage/ocaml-github#242 @Aaylor)
- Add support for statistics endpoint. (mirage/ocaml-github#240 @tmcgilchrist)
- Add support for listing organization's repository. (mirage/ocaml-github#239 @tmcgilchrist)
- Remove the dependency `lambda-term`, which was only used to read password, for
  the package `github-unix`. (mirage/ocaml-github#238 @emillon)
- Add the field `committer` in the datatype `git_commit`. (mirage/ocaml-github#235 @Aaylor)
