### PR TITLE
[new release] bitv (1.4)

### DIFF
--- a/packages/bitv/bitv.1.4/opam
+++ b/packages/bitv/bitv.1.4/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "filliatr@lri.fr"
+authors: "Jean-Christophe Filliâtre"
+license: "LGPL v2"
+synopsis: "A bit vector library for OCaml"
+description: "A bit vector library for OCaml"
+homepage: "https://github.com/backtracking/bitv"
+bug-reports: "https://github.com/backtracking/bitv/issues"
+doc: "https://backtracking.github.io/bitv"
+depends: [
+  "ocaml"
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/backtracking/bitv.git"
+x-commit-hash: "410cc10f28df8eaa767a8419b2df1fd233f279e5"
+url {
+  src:
+    "https://github.com/backtracking/bitv/releases/download/1.4/bitv-1.4.tbz"
+  checksum: [
+    "sha256=d81167614a0ea2c3e371562bdc5abfbced9801bbe75f5af82cc7793639c5bbd6"
+    "sha512=82c0da34c2155ec5640a4b96844d25c34675daab5ee535fa612c3c9fbd7fa2bda9a2a12ec53947f9205b8f40686da3ff3b77e52ce8b1ff3ea75321fa35f6cf65"
+  ]
+}


### PR DESCRIPTION
A bit vector library for OCaml

- Project page: <a href="https://github.com/backtracking/bitv">https://github.com/backtracking/bitv</a>
- Documentation: <a href="https://backtracking.github.io/bitv">https://backtracking.github.io/bitv</a>

##### CHANGES:

- switch to dune build system, and opam 2.0
  - add to/of_bytes for machine-independant serialisation
  - fix binary serialisation when vector is larger than 2^32
