### PR TITLE
[new release] ppx_cstruct, cstruct-async, cstruct-sexp, cstruct-lwt, cstruct-unix and cstruct (6.0.0)

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.2.0-1/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.0-1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "result"
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "zarith"
   "ptime"
   "ounit" {with-test}

--- a/packages/asn1-combinators/asn1-combinators.0.2.2/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.2/opam
@@ -13,7 +13,7 @@ build: [ ["dune" "subst"] {pinned}
 depends: [
   "ocaml" {>="4.05.0"}
   "dune" {>= "1.2.0"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "6.0.0"}
   "zarith"
   "bigarray-compat"
   "stdlib-shims"

--- a/packages/cstruct-async/cstruct-async.6.0.0/opam
+++ b/packages/cstruct-async/cstruct-async.6.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+doc: "https://mirage.github.io/ocaml-cstruct/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0.0"}
+  "async_kernel" {>= "v0.9.0"}
+  "async_unix" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0"}
+  "cstruct" {=version}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+x-commit-hash: "8864ed511f9ef051efcf445bdc346b8847de24da"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.0/cstruct-v6.0.0.tbz"
+  checksum: [
+    "sha256=78a16d2f258cf308e9600374d8fe4ec21cf09e618acf86337663805f90642676"
+    "sha512=9f8be171ec365f04df18cb4c144c9cfb843f6a3190d01006138a7736b80b3012788b9b799d784b9a2bea480f92d635edd138ee8ac619442ca2fb666279d7c2d1"
+  ]
+}

--- a/packages/cstruct-lwt/cstruct-lwt.6.0.0/opam
+++ b/packages/cstruct-lwt/cstruct-lwt.6.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-unix"
+  "dune" {>= "2.0.0"}
+  "lwt"
+  "cstruct" {=version}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.0/cstruct-v6.0.0.tbz"
+  checksum: [
+    "sha256=78a16d2f258cf308e9600374d8fe4ec21cf09e618acf86337663805f90642676"
+    "sha512=9f8be171ec365f04df18cb4c144c9cfb843f6a3190d01006138a7736b80b3012788b9b799d784b9a2bea480f92d635edd138ee8ac619442ca2fb666279d7c2d1"
+  ]
+}
+x-commit-hash: "8864ed511f9ef051efcf445bdc346b8847de24da"

--- a/packages/cstruct-sexp/cstruct-sexp.6.0.0/opam
+++ b/packages/cstruct-sexp/cstruct-sexp.6.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Anton Kochkov" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0.0"}  
+  "sexplib"
+  "cstruct" {=version}
+  "alcotest" {with-test}
+]
+synopsis: "S-expression serialisers for C-like structures"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.
+
+This library provides Sexplib serialisers for the Cstruct.t values."""
+x-commit-hash: "8864ed511f9ef051efcf445bdc346b8847de24da"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.0/cstruct-v6.0.0.tbz"
+  checksum: [
+    "sha256=78a16d2f258cf308e9600374d8fe4ec21cf09e618acf86337663805f90642676"
+    "sha512=9f8be171ec365f04df18cb4c144c9cfb843f6a3190d01006138a7736b80b3012788b9b799d784b9a2bea480f92d635edd138ee8ac619442ca2fb666279d7c2d1"
+  ]
+}

--- a/packages/cstruct-unix/cstruct-unix.6.0.0/opam
+++ b/packages/cstruct-unix/cstruct-unix.6.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.0.0"}
+  "base-unix"
+  "cstruct" {=version}
+]
+synopsis: "Access C-like structures directly from OCaml"
+
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml. It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.
+"""
+x-commit-hash: "8864ed511f9ef051efcf445bdc346b8847de24da"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.0/cstruct-v6.0.0.tbz"
+  checksum: [
+    "sha256=78a16d2f258cf308e9600374d8fe4ec21cf09e618acf86337663805f90642676"
+    "sha512=9f8be171ec365f04df18cb4c144c9cfb843f6a3190d01006138a7736b80b3012788b9b799d784b9a2bea480f92d635edd138ee8ac619442ca2fb666279d7c2d1"
+  ]
+}

--- a/packages/cstruct/cstruct.6.0.0/opam
+++ b/packages/cstruct/cstruct.6.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Anton Kochkov" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0.0"}
+  "bigarray-compat"
+  "alcotest" {with-test}
+]
+conflicts: [ "js_of_ocaml" {<"3.5.0"} ]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+x-commit-hash: "8864ed511f9ef051efcf445bdc346b8847de24da"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.0/cstruct-v6.0.0.tbz"
+  checksum: [
+    "sha256=78a16d2f258cf308e9600374d8fe4ec21cf09e618acf86337663805f90642676"
+    "sha512=9f8be171ec365f04df18cb4c144c9cfb843f6a3190d01006138a7736b80b3012788b9b799d784b9a2bea480f92d635edd138ee8ac619442ca2fb666279d7c2d1"
+  ]
+}

--- a/packages/dns/dns.1.0.0/opam
+++ b/packages/dns/dns.1.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "base-bytes"
   "jbuilder" {>= "1.0+beta9"}
-  "cstruct" {>= "3.0.2"}
+  "cstruct" {>= "3.0.2" & < "6.0.0"}
   "ppx_cstruct"
   "re"
   "domain-name" {<"0.3.0"}

--- a/packages/dns/dns.1.0.1/opam
+++ b/packages/dns/dns.1.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "base-bytes"
   "jbuilder" {>= "1.0+beta9"}
-  "cstruct" {>= "3.0.2"}
+  "cstruct" {>= "3.0.2" & < "6.0.0"}
   "ppx_cstruct"
   "re"
   "domain-name" {<"0.3.0"}

--- a/packages/dns/dns.1.1.0/opam
+++ b/packages/dns/dns.1.1.0/opam
@@ -32,7 +32,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
-  "cstruct" {>= "3.0.2"}
+  "cstruct" {>= "3.0.2" & < "6.0.0"}
   "ppx_cstruct"
   "re" {>= "1.7.2"}
   "domain-name" {<"0.3.0"}

--- a/packages/dns/dns.1.1.1/opam
+++ b/packages/dns/dns.1.1.1/opam
@@ -32,7 +32,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
-  "cstruct" {>= "3.0.2"}
+  "cstruct" {>= "3.0.2" & < "6.0.0"}
   "ppx_cstruct"
   "re" {>= "1.7.2"}
   "domain-name" {<"0.3.0"}

--- a/packages/dns/dns.1.1.3/opam
+++ b/packages/dns/dns.1.1.3/opam
@@ -32,7 +32,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.2"}
-  "cstruct" {>= "3.0.2"}
+  "cstruct" {>= "3.0.2" & < "6.0.0"}
   "ppx_cstruct"
   "re" {>="1.7.2"}
   "ipaddr" {>= "4.0.0"}

--- a/packages/mirage-net-unix/mirage-net-unix.2.4.1/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.2.4.1/opam
@@ -20,7 +20,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta9"}
-  "cstruct" {>= "3.0.2"}
+  "cstruct" {>= "3.0.2" & < "6.0.0"}
   "cstruct-lwt"
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}

--- a/packages/mirage-net-unix/mirage-net-unix.2.5.0/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.2.5.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/mirage/mirage-net-unix/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "cstruct" {>= "1.7.1"}
+  "cstruct" {>= "1.7.1" & < "6.0.0"}
   "cstruct-lwt"
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}

--- a/packages/ppx_cstruct/ppx_cstruct.6.0.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.6.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.0.0"}
+  "cstruct" {=version}
+  "ounit" {with-test}
+  "ppxlib" {>= "0.16.0"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {>="v0.9.0"}
+  "cstruct-sexp" {with-test}
+  "cppo" {with-test}
+  "cstruct-unix" {with-test & =version}
+  "stdlib-shims"
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+x-commit-hash: "8864ed511f9ef051efcf445bdc346b8847de24da"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.0/cstruct-v6.0.0.tbz"
+  checksum: [
+    "sha256=78a16d2f258cf308e9600374d8fe4ec21cf09e618acf86337663805f90642676"
+    "sha512=9f8be171ec365f04df18cb4c144c9cfb843f6a3190d01006138a7736b80b3012788b9b799d784b9a2bea480f92d635edd138ee8ac619442ca2fb666279d7c2d1"
+  ]
+}

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.10.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.10.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "protocol-9p" {= "0.10.0"}
   "base-bytes"
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "1.9.0" & < "6.0.0"}
   "sexplib" {> "113.00.00" & < "v0.15"}
   "result"
   "rresult"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.11.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.11.0/opam
@@ -17,7 +17,7 @@ depends: [
   "protocol-9p" {= "0.11.0"}
   "io-page-unix" {>= "2.0.0"}
   "base-bytes"
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "1.9.0" & < "6.0.0"}
   "sexplib" {> "113.00.00" & < "v0.15"}
   "prometheus"
   "result"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.11.1/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.11.1/opam
@@ -17,7 +17,7 @@ depends: [
   "protocol-9p" {= "0.11.1"}
   "io-page-unix" {>= "2.0.0"}
   "base-bytes"
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "1.9.0" & < "6.0.0"}
   "sexplib" {> "113.00.00" & < "v0.15"}
   "prometheus"
   "result"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.11.2/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.11.2/opam
@@ -17,8 +17,8 @@ depends: [
   "protocol-9p" {= "0.11.2"}
   "io-page-unix" {>= "2.0.0"}
   "base-bytes"
-  "cstruct" {>= "3.0.0"}
-  "cstruct-lwt" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "6.0.0"}
+  "cstruct-lwt" {>= "3.0.0" & < "6.0.0"}
   "sexplib" {> "113.00.00" & < "v0.15"}
   "prometheus"
   "result"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.12.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.12.0/opam
@@ -16,8 +16,8 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "protocol-9p" {= "0.12.0"}
   "base-bytes"
-  "cstruct" {>= "3.0.0"}
-  "cstruct-lwt" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "6.0.0"}
+  "cstruct-lwt" {>= "3.0.0" & < "6.0.0"}
   "sexplib" {> "113.00.00" & < "v0.15"}
   "prometheus"
   "result"

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.12.1/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.12.1/opam
@@ -16,8 +16,8 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "protocol-9p" {="0.12.1"}
   "base-bytes"
-  "cstruct" {>= "3.0.0"}
-  "cstruct-lwt" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "6.0.0"}
+  "cstruct-lwt" {>= "3.0.0" & < "6.0.0"}
   "sexplib" {> "113.00.00" & < "v0.15"}
   "prometheus"
   "result"

--- a/packages/protocol-9p-unix/protocol-9p-unix.1.0.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.1.0.0/opam
@@ -10,8 +10,8 @@ depends: [
   "dune" {>= "1.0"}
   "protocol-9p" {>="1.0.0" & <"2.0.0"}
   "base-bytes"
-  "cstruct" {>= "3.0.0"}
-  "cstruct-lwt" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "6.0.0"}
+  "cstruct-lwt" {>= "3.0.0" & < "6.0.0"}
   "sexplib" {> "113.00.00" & < "v0.15"}
   "prometheus"
   "rresult"

--- a/packages/protocol-9p-unix/protocol-9p-unix.1.0.1/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.1.0.1/opam
@@ -10,8 +10,8 @@ depends: [
   "dune" {>= "1.0"}
   "protocol-9p" {>="1.0.1" & <"2.0.0"}
   "base-bytes"
-  "cstruct" {>= "3.0.0"}
-  "cstruct-lwt" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "6.0.0"}
+  "cstruct-lwt" {>= "3.0.0" & < "6.0.0"}
   "sexplib" {> "113.00.00" & < "v0.15"}
   "prometheus"
   "rresult"

--- a/packages/protocol-9p-unix/protocol-9p-unix.2.0.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.2.0.0/opam
@@ -10,8 +10,8 @@ depends: [
   "dune" {>= "1.0"}
   "protocol-9p" {>="2.0.0"}
   "base-bytes"
-  "cstruct" {>= "3.0.0"}
-  "cstruct-lwt" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "6.0.0"}
+  "cstruct-lwt" {>= "3.0.0" & < "6.0.0"}
   "sexplib" {> "113.00.00" & <"v0.12.0"}
   "prometheus"
   "rresult"

--- a/packages/protocol-9p-unix/protocol-9p-unix.2.0.1/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.2.0.1/opam
@@ -10,8 +10,8 @@ depends: [
   "dune" {>= "1.0"}
   "protocol-9p" {>="1.0.1"}
   "base-bytes"
-  "cstruct" {>= "3.0.0"}
-  "cstruct-lwt" {>= "3.0.0"}
+  "cstruct" {>= "3.0.0" & < "6.0.0"}
+  "cstruct-lwt" {>= "3.0.0" & < "6.0.0"}
   "sexplib" {> "113.00.00" & < "v0.15"}
   "prometheus"
   "rresult"

--- a/packages/protocol-9p/protocol-9p.2.0.1/opam
+++ b/packages/protocol-9p/protocol-9p.2.0.1/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.0"}
   "base-bytes"
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib" {> "113.00.00" & < "v0.15"}
   "rresult"

--- a/packages/tls/tls.0.10.2/opam
+++ b/packages/tls/tls.0.10.2/opam
@@ -26,7 +26,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.15"}
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib" {< "v0.15"}
   "nocrypto" {>= "0.5.4"}

--- a/packages/tls/tls.0.10.3/opam
+++ b/packages/tls/tls.0.10.3/opam
@@ -26,7 +26,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.15"}
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib" {< "v0.15"}
   "nocrypto" {>= "0.5.4"}

--- a/packages/tls/tls.0.10.4/opam
+++ b/packages/tls/tls.0.10.4/opam
@@ -26,7 +26,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.15"}
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib" {< "v0.15"}
   "nocrypto" {>= "0.5.4"}

--- a/packages/tls/tls.0.10.5/opam
+++ b/packages/tls/tls.0.10.5/opam
@@ -26,7 +26,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.15"}
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib" {< "v0.15"}
   "nocrypto" {>= "0.5.4"}

--- a/packages/tls/tls.0.10.6/opam
+++ b/packages/tls/tls.0.10.6/opam
@@ -26,7 +26,7 @@ depends: [
   "ppx_sexp_conv" {< "v0.15"}
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib" {< "v0.15"}
   "nocrypto" {>= "0.5.4"}

--- a/packages/tls/tls.0.11.0/opam
+++ b/packages/tls/tls.0.11.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.0"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
   "ppx_cstruct" {>= "3.0.0"}
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib" {< "v0.15"}
   "mirage-crypto" {< "0.8.1"}

--- a/packages/tls/tls.0.11.1/opam
+++ b/packages/tls/tls.0.11.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.0"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
   "ppx_cstruct" {>= "3.0.0"}
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib" {< "v0.15"}
   "mirage-crypto" {< "0.8.1"}

--- a/packages/tls/tls.0.12.0/opam
+++ b/packages/tls/tls.0.12.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.0"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
   "ppx_cstruct" {>= "3.0.0"}
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib" {< "v0.15"}
   "mirage-crypto" {< "0.8.1"}

--- a/packages/tls/tls.0.12.1/opam
+++ b/packages/tls/tls.0.12.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "ppx_cstruct" {>= "3.0.0"}
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib"
   "mirage-crypto" {< "0.8.1"}

--- a/packages/tls/tls.0.12.2/opam
+++ b/packages/tls/tls.0.12.2/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "ppx_cstruct" {>= "3.0.0"}
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib"
   "mirage-crypto" {< "0.8.1"}

--- a/packages/tls/tls.0.12.3/opam
+++ b/packages/tls/tls.0.12.3/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "ppx_cstruct" {>= "3.0.0"}
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib"
   "mirage-crypto" {>= "0.8.1"}

--- a/packages/tls/tls.0.12.4/opam
+++ b/packages/tls/tls.0.12.4/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "ppx_cstruct" {>= "3.0.0"}
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
   "sexplib"
   "mirage-crypto" {>= "0.8.1"}

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.12.0/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.12.0/opam
@@ -7,7 +7,7 @@ doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "cstruct"
+  "cstruct" {< "6.0.0"}
   "lwt" {>= "3.2.0"}
   "mirage-block" {< "2.0.0"}
   "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.9.1/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.9.1/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder"
-  "cstruct"
+  "cstruct" {< "6.0.0"}
   "lwt" {>= "2.4.3" & <= "3.1.0"}
   "mirage-block" {< "2.0.0"}
   "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.9.2/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.9.2/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "jbuilder"
-  "cstruct"
+  "cstruct" {< "6.0.0"}
   "lwt" {>= "2.4.3" & <= "3.1.0"}
   "mirage-block" {< "2.0.0"}
   "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}


### PR DESCRIPTION
Access C-like structures directly from OCaml

- Project page: <a href="https://github.com/mirage/ocaml-cstruct">https://github.com/mirage/ocaml-cstruct</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cstruct/">https://mirage.github.io/ocaml-cstruct/</a>

##### CHANGES:

**breaking changes**
- Add the function `Cstruct.length`, `Cstruct.len` will
  be deprecated to next release (@dinosaure, @hannesm, @avsm, mirage/ocaml-cstruct#279)
- `Cstruct.to_string` requires 2 optional arguments `?off` and `?len`
  (@hannesm, @cfcs, @talex5, @dinosaure, mirage/ocaml-cstruct#262)

- Use `ppxlib` instead `ppx_tools_versioned`
  (@pveber, @avsm, @dinosaure, mirage/ocaml-cstruct#280)
- Delete the support of old version of OCaml (< 4.07.0) for `ppx_cstruct`
  (@avsm, @dinosaure, mirage/ocaml-cstruct#280)
- Add useful functions to be able to parse some contents
  with `Cstruct.t` like the `astring` library (mirage/ocaml-cstruct#227,
  @dinosaure, @avsm, @samoht, @hannesm).
- Improve the interface of `Cstruct.t` with capabilities
  (@hannesm, @cfcs, @talex5, @dinosaure, mirage/ocaml-cstruct#262)
