### PR TITLE
[new release] links, links-mysql, links-postgresql, and links-sqlite3 (v0.9.2)

### DIFF
--- a/packages/links-mysql/links-mysql.0.9.2/opam
+++ b/packages/links-mysql/links-mysql.0.9.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "James Cheney <jcheney@inf.ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "MySQL database driver for the Links Programming Language"
+description: "MySQL database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-2"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.10.0"}
+  "conf-mysql"
+  "mysql"
+  "links"
+]
+x-commit-hash: "92ec7bf8eed1ca4ce8f1de513974467088f90e56"
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.2/links-0.9.2.tbz"
+  checksum: [
+    "sha256=db5956df65964faed32d53fb37e33f31d432773643ae7aaee76e348a07af67e6"
+    "sha512=935c29ab40d23e9409062af3ab9b7214f74dcb147f84b328f48bcf8011ad6f58ed6c9224e0dba1521c9ea004a34e0a61ecfda869bf4cc8ac2e5e93bfafe27fcb"
+  ]
+}

--- a/packages/links-postgresql/links-postgresql.0.9.2/opam
+++ b/packages/links-postgresql/links-postgresql.0.9.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Simon Fowler <simon.fowler@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "Postgresql database driver for the Links Programming Language"
+description: "Postgresql database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-2"
+
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.10.0"}
+  "postgresql"
+  "links"
+]
+x-commit-hash: "92ec7bf8eed1ca4ce8f1de513974467088f90e56"
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.2/links-0.9.2.tbz"
+  checksum: [
+    "sha256=db5956df65964faed32d53fb37e33f31d432773643ae7aaee76e348a07af67e6"
+    "sha512=935c29ab40d23e9409062af3ab9b7214f74dcb147f84b328f48bcf8011ad6f58ed6c9224e0dba1521c9ea004a34e0a61ecfda869bf4cc8ac2e5e93bfafe27fcb"
+  ]
+}

--- a/packages/links-sqlite3/links-sqlite3.0.9.2/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jan Stolarek <jan.stolarek@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "SQLite database driver for the Links Programming Language"
+description: "SQLite database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-2"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.10.0"}
+  "sqlite3"
+  "links"
+]
+x-commit-hash: "92ec7bf8eed1ca4ce8f1de513974467088f90e56"
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.2/links-0.9.2.tbz"
+  checksum: [
+    "sha256=db5956df65964faed32d53fb37e33f31d432773643ae7aaee76e348a07af67e6"
+    "sha512=935c29ab40d23e9409062af3ab9b7214f74dcb147f84b328f48bcf8011ad6f58ed6c9224e0dba1521c9ea004a34e0a61ecfda869bf4cc8ac2e5e93bfafe27fcb"
+  ]
+}

--- a/packages/links/links.0.9.2/opam
+++ b/packages/links/links.0.9.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Simon Fowler <simon.fowler@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "The Links Programming Language"
+description: "Links is a functional programming language designed to make web programming easier."
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-2"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "exec" "preinstall/preinstall.exe" "--" "-libdir" _:lib ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.10.0"}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.3"}
+  "base64"
+  "linenoise"
+  "ANSITerminal"
+  "lwt" {>= "3.1.0"}
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit-lwt-unix"
+  "uri"
+  "websocket"
+  "websocket-lwt-unix"
+  "safepass"
+  "result"
+  "ocamlfind"
+  "menhir"
+  "ppx_sexp_conv"
+]
+x-commit-hash: "92ec7bf8eed1ca4ce8f1de513974467088f90e56"
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.2/links-0.9.2.tbz"
+  checksum: [
+    "sha256=db5956df65964faed32d53fb37e33f31d432773643ae7aaee76e348a07af67e6"
+    "sha512=935c29ab40d23e9409062af3ab9b7214f74dcb147f84b328f48bcf8011ad6f58ed6c9224e0dba1521c9ea004a34e0a61ecfda869bf4cc8ac2e5e93bfafe27fcb"
+  ]
+}


### PR DESCRIPTION
This updates the Links-related packages to 0.9.2.

# Changes

This minor release contains various bug fixes, improvements, and a **breaking**
change.

## Breaking change: Trailing semicolons are no longer permitted
The surface syntax of Links has been changed.  Up until now it was possible to
end a block with a semicolon.  A trailing semicolon was interpreted as
implicitly ending the block with a `()` expression.  The rationale for this
change is to make the Links syntax more consistent, i.e. now all blocks must end
with an explicit expression.  To sum up, previously both of the following were
allowed

```links
fun foo(x) {
  bar(y);
  baz(x);
}
fun foo'(x) {
  bar(y);
  baz(x)
}
```

Now the first form is no longer accepted. Instead you have to drop the semicolon
and either end the block with an explicit `()` or wrap the last expression in an
`ignore` application.

```links
fun foo(x) {
  bar(y);
  baz(x);
  ()
}

fun foo(x) {
  bar(y);
  ignore(baz(x))
}
```

A third option is to simply drop the trailing semicolon, though, this only works
as intended if the type of the last expression is `()`.


## SML-style function definitions

Links now supports "switch functions", a new syntax for defining functions in
terms of match clauses directly, similar to SML. This allows writing the
following function
```links
fun ack(_,_) switch {
  case (0, n) -> n + 1
  case (m, 0) -> ack(m - 1, 1)
  case (m, n) -> ack(m - 1, ack(m, n - 1))
}
```
instead of the following, more verbose version:

```links
fun ack(a, b) {
  switch(a, b) {
    case (0, n) -> n + 1
    case (m, 0) -> ack(m - 1, 1)
    case (m, n) -> ack(m - 1, ack(m, n - 1))
  }
}
```

Switch functions can also be anonymous, allowing function like the following:
```links
fun(_, _) switch {
  case (0, n) -> 0
  case (m, n) -> m + n
}
```
Note: currently switch function syntax is only supported for uncurried functions.
As switch functions have experimental status they are disabled by default. To
enable them you must set the option `switch_functions=true` in a
configuration file.
## Require OCaml 4.08

The minimum required OCaml version has been raised to 4.08.


## Miscellaneous

- Fixed a bug breaking the TODO list example (#812)
- Checkboxes and radio groups in form elements are now handled correctly (#903)
- Links supports MySQL databases again! (#858)
- Fixed a bug where the effect of `orderby` was inconsistent between database
  drivers w.r.t. reversing the order of results (#858)
- Relational lenses can now be used with MySQL and Sqlite3 databases, too (#897)
- Remove setting `use_keys_in_shredding`, behaving as if it was always true (#892)
- Remove setting `query`, behaving as if it was off
  (i.e., `query` behaves like `query flat`) (#892)
- Fixed a bug where regular expressions in nested queries did not work correctly
  (#852)
- Implemented support for negative patterns in let bindings (#811)
