### PR TITLE
[new release] mirage, mirage-runtime, mirage-types-lwt and mirage-types (3.8.1)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.8.1/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.8.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "5.0.0"}
+  "functoria-runtime"  {>= "3.0.2"}
+  "fmt"
+  "logs"
+  "lwt" {>= "4.0.0"}
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+x-commit-hash: "83de3a2c60af99c2141f301c05f2ecfbc397becc"
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.8.1/mirage-v3.8.1.tbz"
+  checksum: [
+    "sha256=9c83030028b482bdb7e14bb4c4ff9d061a5aa18bcbafa873cb62c940806ba9eb"
+    "sha512=7ae6f25a5778738b0acdea59090f8791f0319c3c70a9067cc5762239ba4c75cec8a334b5447da6ed892a9ffa289f313f38df5b0c6089a7298efec0b693799312"
+  ]
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.8.1/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.8.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends:   [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-types" {= version}
+]
+
+synopsis: "Lwt module type definitions for MirageOS applications"
+description: """
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`
+"""
+post-messages: [
+ "This package will be retired in MirageOS 4.0. Please use individual signatures (mirage-net / mirage-clock / etc.) instead."
+]
+x-commit-hash: "83de3a2c60af99c2141f301c05f2ecfbc397becc"
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.8.1/mirage-v3.8.1.tbz"
+  checksum: [
+    "sha256=9c83030028b482bdb7e14bb4c4ff9d061a5aa18bcbafa873cb62c940806ba9eb"
+    "sha512=7ae6f25a5778738b0acdea59090f8791f0319c3c70a9067cc5762239ba4c75cec8a334b5447da6ed892a9ffa289f313f38df5b0c6089a7298efec0b693799312"
+  ]
+}

--- a/packages/mirage-types/mirage-types.3.8.1/opam
+++ b/packages/mirage-types/mirage-types.3.8.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-console" {>= "3.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "mirage-fs" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+]
+synopsis: "Module type definitions for MirageOS applications"
+description: """
+Module type definitions for MirageOS applications
+"""
+post-messages: [
+  "This package will be retired in MirageOS 4.0. Please use individual signatures (mirage-net / mirage-clock / etc.) instead."
+]
+x-commit-hash: "83de3a2c60af99c2141f301c05f2ecfbc397becc"
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.8.1/mirage-v3.8.1.tbz"
+  checksum: [
+    "sha256=9c83030028b482bdb7e14bb4c4ff9d061a5aa18bcbafa873cb62c940806ba9eb"
+    "sha512=7ae6f25a5778738b0acdea59090f8791f0319c3c70a9067cc5762239ba4c75cec8a334b5447da6ed892a9ffa289f313f38df5b0c6089a7298efec0b693799312"
+  ]
+}

--- a/packages/mirage/mirage.3.8.1/opam
+++ b/packages/mirage/mirage.3.8.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "5.0.0"}
+  "functoria"          {>= "3.1.0"}
+  "bos"
+  "astring"
+  "logs"
+  "stdlib-shims"
+  "mirage-runtime"     {=version | (>= "3.8.0" & < "3.9.0")}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+x-commit-hash: "83de3a2c60af99c2141f301c05f2ecfbc397becc"
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.8.1/mirage-v3.8.1.tbz"
+  checksum: [
+    "sha256=9c83030028b482bdb7e14bb4c4ff9d061a5aa18bcbafa873cb62c940806ba9eb"
+    "sha512=7ae6f25a5778738b0acdea59090f8791f0319c3c70a9067cc5762239ba4c75cec8a334b5447da6ed892a9ffa289f313f38df5b0c6089a7298efec0b693799312"
+  ]
+}


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

* OCaml runtime parameters (OCAMLPARAM) are exposed as boot and configure
  arguments. This allows e.g. to switch to the best-fit garbage collection
  strategy (mirage/mirage#1180 @hannesm)
