### PR TITLE
Package topkg-care.1.0.3

### DIFF
--- a/packages/topkg-care/topkg-care.1.0.3/opam
+++ b/packages/topkg-care/topkg-care.1.0.3/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "https://erratique.ch/software/topkg"
+doc: "https://erratique.ch/software/topkg/doc"
+license: "ISC"
+dev-repo: "git+https://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild"
+  "topkg" {= version}
+  "fmt"
+  "logs"
+  "bos" {>= "0.1.5"}
+  "cmdliner" {>= "1.0.0"}
+  "webbrowser"
+  "opam-format" {>= "2.0.0"}
+]
+build:[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pkg-name" name
+          "--dev-pkg" "%{pinned}%"
+]
+synopsis: """The transitory OCaml software packager"""
+description: """\
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser
+"""
+url {
+archive: "http://erratique.ch/software/topkg/releases/topkg-1.0.3.tbz"
+checksum: "e285f7a296d77ee7d831ba9a6bfb396f"
+}


### PR DESCRIPTION
### `topkg-care.1.0.3`
The transitory OCaml software packager
Topkg is a packager for distributing OCaml software. It provides an
API to describe the files a package installs in a given build
configuration and to specify information about the package's
distribution, creation and publication procedures.

The optional topkg-care package provides the `topkg` command line tool
which helps with various aspects of a package's life cycle: creating
and linting a distribution, releasing it on the WWW, publish its
documentation, add it to the OCaml opam repository, etc.

Topkg is distributed under the ISC license and has **no**
dependencies. This is what your packages will need as a *build*
dependency.

Topkg-care is distributed under the ISC license it depends on
[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
[webbrowser][webbrowser] and `opam-format`.

[fmt]: http://erratique.ch/software/fmt
[logs]: http://erratique.ch/software/logs
[bos]: http://erratique.ch/software/bos
[cmdliner]: http://erratique.ch/software/cmdliner
[webbrowser]: http://erratique.ch/software/webbrowser



---
* Homepage: https://erratique.ch/software/topkg
* Source repo: git+https://erratique.ch/repos/topkg.git
* Bug tracker: https://github.com/dbuenzli/topkg/issues

---
v1.0.3 2020-09-19 Zagreb
------------------------

- Fix for OCaml 4.12. The M.() notation is evil. 
  Thanks to Florian Angeletti for the fix.

---
:camel: Pull-request generated by opam-publish v2.0.2