### PR TITLE
Package opam-publish.2.0.2: update constraint

### DIFF
--- a/packages/opam-publish/opam-publish.2.0.2/opam
+++ b/packages/opam-publish/opam-publish.2.0.2/opam
@@ -21,8 +21,8 @@ depends: [
   "opam-core" {>= "2.0.0"}
   "opam-format" {>= "2.0.0"}
   "opam-state" {>= "2.0.0"}
-  "github" {>= "2.0.0" & < "4.3.0"}
-  "github-unix" {< "4.3.0"}
+  "github" {>= "4.3.2"}
+  "github-unix"
   ("ssl" {= "0.5.5"} | "tls")
 ]
 flags: plugin


### PR DESCRIPTION
"Publish" done with `ocaml-github.4.3.2`, cf #17239

### `opam-publish.2.0.2`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.0.2