### PR TITLE
[new release] clangml.4.3.0 and dependencies

### DIFF
--- a/packages/clangml/clangml.4.3.0/opam
+++ b/packages/clangml/clangml.4.3.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Clang API"
+description: """
+clangml provides bindings to call the Clang API from OCaml.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://memcad.gitlabpages.inria.fr/clangml/"
+doc: "https://memcad.gitlabpages.inria.fr/clangml/doc/clangml/index.html"
+bug-reports: "https://gitlab.inria.fr/memcad/clangml/issues"
+depends: [
+  "conf-libclang"
+  "conf-ncurses"
+  "conf-zlib"
+  "dune" {>= "1.11.0"}
+  "stdcompat" {>= "13"}
+  "ocaml" {>= "4.08.0" & < "4.12.0"}
+  "ocamlfind" {build & >= "1.8.0"}
+  "ocamlcodoc" {with-test & >= "1.0.1"}
+  "pattern" {with-test & >= "0.2.0"}
+  "metapp" {>= "0.3.0"}
+  "metaquot" {>= "0.3.0"}
+  "refl" {>= "0.3.0"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
+url {
+  src: "https://gitlab.inria.fr/memcad/clangml/-/archive/v4.3.0/clangml-v4.3.0.tar.gz"
+  checksum: "sha512=7868e961ad68fdf86eae0b91cc55fde61f88e4f8fb4d095b3bcbd6dca62b4be818342d4f23f78ce693b8d064c81d4e3ecc3cb0224e7159f3906d987d5427d550"
+}

--- a/packages/clangml/clangml.4.3.0/opam
+++ b/packages/clangml/clangml.4.3.0/opam
@@ -32,5 +32,5 @@ build: [
     "@doc" {with-doc}]]
 url {
   src: "https://gitlab.inria.fr/memcad/clangml/-/archive/v4.3.0/clangml-v4.3.0.tar.gz"
-  checksum: "sha512=7868e961ad68fdf86eae0b91cc55fde61f88e4f8fb4d095b3bcbd6dca62b4be818342d4f23f78ce693b8d064c81d4e3ecc3cb0224e7159f3906d987d5427d550"
+  checksum: "sha512=0f3f1d4f858c9b2752ecc651b0bde378df1a8a675e4c2d8788324a32b4fe4f218e7ed156418cf4cd7e787f3e66bc52876254a3ad7fcf8e0c08d0c176c2eae67b"
 }

--- a/packages/clangml/clangml.4.3.0/opam
+++ b/packages/clangml/clangml.4.3.0/opam
@@ -25,6 +25,11 @@ depends: [
   "odoc" {with-doc & >= "1.5.1"}
 ]
 dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%"]
+  ["dune" "build" "-p" name "-j" jobs "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}]]
 url {
   src: "https://gitlab.inria.fr/memcad/clangml/-/archive/v4.3.0/clangml-v4.3.0.tar.gz"
   checksum: "sha512=7868e961ad68fdf86eae0b91cc55fde61f88e4f8fb4d095b3bcbd6dca62b4be818342d4f23f78ce693b8d064c81d4e3ecc3cb0224e7159f3906d987d5427d550"

--- a/packages/metapp/metapp.0.3.0/opam
+++ b/packages/metapp/metapp.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+version: "0.3.0"
+synopsis: "Meta-preprocessor for OCaml"
+description: """
+Meta-preprocessor for OCaml: extends the language with [%meta ... ]
+construction where ... stands for OCaml code evaluated at
+compile-time.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/metapp"
+doc: "https://github.com/thierry-martinez/metapp"
+bug-reports: "https://github.com/thierry-martinez/metapp"
+depends: [
+  "ocaml" {>= "4.08.0" & < "4.12.0"}
+  "stdcompat" {>= "12"}
+  "ppxlib" {>= "0.16.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "dune" {>= "1.11.0"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry-martinez/metapp.git"
+url {
+  src: "https://github.com/thierry-martinez/metapp/archive/v0.3.0.tar.gz"
+  checksum: "sha512=16b962aefdb1460e33ba1b90ecc8bc337e85e82f4b130af76d902fd723bb9b6067bfe5ae1c819581525755365b343725442645987f91361fb020f5860bf3288d"
+}

--- a/packages/metaquot/metaquot.0.2.0/opam
+++ b/packages/metaquot/metaquot.0.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml-migrate-parsetree" {>= "1.7.3" & < "2.0.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}
-  "metapp" {>= "0.2.0"}
+  "metapp" {>= "0.2.0" & < "0.3.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/metaquot/metaquot.0.3.0/opam
+++ b/packages/metaquot/metaquot.0.3.0/opam
@@ -35,5 +35,5 @@ build: [
 dev-repo: "git+https://github.com/thierry-martinez/metaquot.git"
 url {
   src: "https://github.com/thierry-martinez/metaquot/archive/v0.3.0.tar.gz"
-  checksum: "sha512=0483a9e96303dd779db9d22976a909ec2a3adeed8172abee25f9951c13f25c33d1d42e1e6b57c715567515f3bbb7d8bcf49d3ce4cbd9e254ff2b1d02b16da6e3"
+  checksum: "sha512=907f4b4c12e9d8f6772f9872a0549cced6f6daa3ec6c4b13042b89bceecc21eeb8c708b4d27af4a55e6c0d1cbb90e4841b566367593bed781172f4110c88e75c"
 }

--- a/packages/metaquot/metaquot.0.3.0/opam
+++ b/packages/metaquot/metaquot.0.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "OCaml syntax extension for quoting code"
+description: """
+metaquot allows to quote OCaml code.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/metaquot"
+doc: "https://github.com/thierry-martinez/metaquot"
+bug-reports: "https://github.com/thierry-martinez/metaquot"
+depends: [
+  "ocaml" {>= "4.08.0" & < "4.12.0"}
+  "stdcompat" {>= "12"}
+  "ppxlib" {>= "0.16.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "dune" {>= "1.11.0"}
+  "metapp" {>= "0.3.0"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry-martinez/metaquot.git"
+url {
+  src: "https://github.com/thierry-martinez/metaquot/archive/v0.3.0.tar.gz"
+  checksum: "sha512=0483a9e96303dd779db9d22976a909ec2a3adeed8172abee25f9951c13f25c33d1d42e1e6b57c715567515f3bbb7d8bcf49d3ce4cbd9e254ff2b1d02b16da6e3"
+}

--- a/packages/pattern/pattern.0.2.0/opam
+++ b/packages/pattern/pattern.0.2.0/opam
@@ -21,9 +21,9 @@ the list of differences between a pattern and a value.
 depends: [
   "ocaml" {>= "4.03.0" & < "4.12.0"}
   "dune" {>= "1.10.0"}
-  "metapp" {>= "0.1.0"}
-  "metaquot" {>= "0.1.0"}
-  "refl" {>= "0.1.0"}
+  "metapp" {>= "0.1.0" & < "0.3.0"}
+  "metaquot" {>= "0.1.0" & < "0.3.0"}
+  "refl" {>= "0.1.0" & < "0.3.0"}
   "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "stdcompat" {>= "10"}
 ]

--- a/packages/pattern/pattern.0.3.0/opam
+++ b/packages/pattern/pattern.0.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+bug-reports: "https://github.com/thierry-martinez/pattern"
+homepage: "https://github.com/thierry-martinez/pattern"
+doc: "https://github.com/thierry-martinez/pattern"
+license: "BSD-2-Clause"
+version: "0.3.0"
+dev-repo: "git+https://github.com/thierry-martinez/pattern.git"
+synopsis: "Run-time patterns that explain match failures"
+description: """
+pattern is a PPX extension that generates functions from patterns
+that explain match failures by returning the common context and
+the list of differences between a pattern and a value.
+"""
+depends: [
+  "ocaml" {>= "4.08.0" & < "4.12.0"}
+  "dune" {>= "1.10.0"}
+  "metapp" {>= "0.3.0"}
+  "metaquot" {>= "0.3.0"}
+  "refl" {>= "0.3.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "stdcompat" {>= "10"}
+]
+url {
+  src: "https://github.com/thierry-martinez/pattern/archive/v0.3.0.tar.gz"
+  checksum: "sha512=a0933881039dc6b5da43b1dcc512f3877a6446469b0a09537e2b357bba9767e442ab9081d49be1841ac3da0595d661774d1a3543d8cdb1c57bfda3dc0983f4ef"
+}

--- a/packages/refl/refl.0.1.0/opam
+++ b/packages/refl/refl.0.1.0/opam
@@ -14,9 +14,9 @@ depends: [
   "dune" {>= "1.11.0"}
   "stdcompat" {>= "14"}
   "fix" {>= "20200131"}
-  "metapp" {>= "0.2.0"}
-  "metaquot" {>= "0.2.0"}
-  "traverse" {>= "0.2.0"}
+  "metapp" {>= "0.2.0" & < "0.3.0"}
+  "metaquot" {>= "0.2.0" & < "0.3.0"}
+  "traverse" {>= "0.2.0" & < "0.3.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/refl/refl.0.2.0/opam
+++ b/packages/refl/refl.0.2.0/opam
@@ -14,9 +14,9 @@ depends: [
   "dune" {>= "1.11.0"}
   "stdcompat" {>= "14"}
   "fix" {>= "20200131"}
-  "metapp" {>= "0.2.0"}
-  "metaquot" {>= "0.2.0"}
-  "traverse" {>= "0.2.0"}
+  "metapp" {>= "0.2.0" & < "0.3.0"}
+  "metaquot" {>= "0.2.0" & < "0.3.0"}
+  "traverse" {>= "0.2.0" & < "0.3.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/refl/refl.0.3.0/opam
+++ b/packages/refl/refl.0.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "PPX deriver for reflection"
+description: """
+PPX deriver for reflection
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/refl"
+doc: "https://github.com/thierry-martinez/refl"
+bug-reports: "https://github.com/thierry-martinez/refl"
+depends: [
+  "ocaml" {>= "4.03.0" & < "4.12.0"}
+  "dune" {>= "1.11.0"}
+  "stdcompat" {>= "14"}
+  "fix" {>= "20200131"}
+  "metapp" {>= "0.2.0"}
+  "metaquot" {>= "0.2.0"}
+  "traverse" {>= "0.2.0"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry-martinez/refl"
+url {
+  src: "https://github.com/thierry-martinez/refl/archive/v0.3.0.tar.gz"
+  checksum: "sha512=90d605f48e8442e68b7ab6e9697070229775b7840f7519d310d7408ac6988e60558d1b6da153dc318ca2b104e824b41a566835d1a6dec17741f6b7cd34dfe3aa"
+}

--- a/packages/refl/refl.0.3.0/opam
+++ b/packages/refl/refl.0.3.0/opam
@@ -14,9 +14,9 @@ depends: [
   "dune" {>= "1.11.0"}
   "stdcompat" {>= "14"}
   "fix" {>= "20200131"}
-  "metapp" {>= "0.2.0"}
-  "metaquot" {>= "0.2.0"}
-  "traverse" {>= "0.2.0"}
+  "metapp" {>= "0.3.0"}
+  "metaquot" {>= "0.3.0"}
+  "traverse" {>= "0.3.0"}
   "odoc" {with-doc & >= "1.5.1"}
 ]
 build: [

--- a/packages/traverse/traverse.0.2.0/opam
+++ b/packages/traverse/traverse.0.2.0/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.12.0"}
   "dune" {>= "1.10.0"}
   "stdcompat" {>= "14"}
-  "metapp" {>= "0.2.0"}
-  "metaquot" {>= "0.2.0"}
+  "metapp" {>= "0.2.0" & < "0.3.0"}
+  "metaquot" {>= "0.2.0" & < "0.3.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/traverse/traverse.0.3.0/opam
+++ b/packages/traverse/traverse.0.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Traversable data structures with applicative functors"
+description: """
+Definition of applicative functors with instances for traversable
+    data structures"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/traverse"
+doc: "https://github.com/thierry-martinez/traverse"
+bug-reports: "https://github.com/thierry-martinez/traverse"
+depends: [
+  "ocaml" {>= "4.03.0" & < "4.12.0"}
+  "dune" {>= "1.10.0"}
+  "stdcompat" {>= "14"}
+  "metapp" {>= "0.3.0"}
+  "metaquot" {>= "0.3.0"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry-martinez/traverse"
+url {
+  src: "https://github.com/thierry-martinez/traverse/archive/v0.3.0.tar.gz"
+  checksum: "sha512=a29798bf912dc2c2ddce06aafc63f88fce4bf5dd35884c2e2c7b7caa1b2d8e95122e6f6d3b675965145853f530fad856740201f2f349561a15e78591a56e10fe"
+}


### PR DESCRIPTION
This PR contains the new release of clangml.4.3.0 and its dependencies:
- metapp.0.3.0
- metaquot.0.3.0
- traverse 0.3.0
- refl.0.3.0
- pattern 0.3.0