### PR TITLE
7 packages from ocaml/opam at 2.1.0~beta2

### DIFF
--- a/packages/dune-release/dune-release.1.4.0/opam
+++ b/packages/dune-release/dune-release.1.4.0/opam
@@ -21,9 +21,9 @@ depends: [
   "bos"
   "cmdliner"
   "re"
-  "opam-format"
-  "opam-state"
-  "opam-core"
+  "opam-format" {< "2.1"}
+  "opam-state" {< "2.1"}
+  "opam-core" {< "2.1"}
   "rresult"
   "logs"
   "odoc"
@@ -31,7 +31,6 @@ depends: [
   "mdx" {with-test & >= "1.6.0"}
   "yojson"
 ]
-
 synopsis: "Release dune packages in opam"
 description: """
 `dune-release` is a tool to streamline the release of Dune packages in

--- a/packages/opam-bundle/opam-bundle.0.3/opam
+++ b/packages/opam-bundle/opam-bundle.0.3/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "ocamlfind"
   "cmdliner"
-  "opam-client" {<= "2.0.0~rc2" & >= "2.0.0~beta3.1"}
+  "opam-client" {>= "2.0.0~beta3.1" & <= "2.0.0~rc2"}
 ]
 synopsis: "A tool that creates stand-alone source bundles from opam packages"
 description: """

--- a/packages/opam-bundle/opam-bundle.0.4/opam
+++ b/packages/opam-bundle/opam-bundle.0.4/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {build}
   "ocamlfind" {build}
   "cmdliner" {>= "1.0.0"}
-  "opam-client" {>= "2.0.0"}
+  "opam-client" {>= "2.0.0" & < "2.1"}
 ]
 build: make
 dev-repo: "git+https://github.com/AltGr/opam-bundle"

--- a/packages/opam-client/opam-client.2.1.0~beta2/opam
+++ b/packages/opam-client/opam-client.2.1.0~beta2/opam
@@ -27,10 +27,10 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "opam-state" {= version}
   "opam-solver" {= version}
-  "extlib"
+  "extlib" {>= "1.7.3"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "1.0.0"}
   "dune" {>= "1.5.0"}
 ]
 url {

--- a/packages/opam-client/opam-client.2.1.0~beta2/opam
+++ b/packages/opam-client/opam-client.2.1.0~beta2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 development libraries (client)"
+description: """
+Actions on the opam root, switches, installations, and front-end.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-state" {= version}
+  "opam-solver" {= version}
+  "extlib"
+  "opam-repository" {= version}
+  "re" {>= "1.9.0"}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {>= "1.5.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta2.tar.gz"
+  checksum: [
+    "md5=01a30e3469c3e8ebc04f56a3330778fa"
+    "sha512=c5f00ed4d78b1863717b44e014af1f1e8c4bc9e16ca60f1ac1216d12163d9a3b19721026d0e455429067b8ce90ec646f1be39e3daf0f3710c556da65ec6cd2c0"
+  ]
+}

--- a/packages/opam-core/opam-core.2.0.0~rc/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc/opam
@@ -18,7 +18,7 @@ build: [
   [make "%{name}%.install"]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.0.7"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"

--- a/packages/opam-core/opam-core.2.1.0~beta2/opam
+++ b/packages/opam-core/opam-core.2.1.0~beta2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 development libraries (core)"
+description: """
+Small standard library extensions, and generic system interaction modules used by opam.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.9.0"}
+  "dune" {>= "1.5.0"}
+  "cppo" {build}
+]
+conflicts: "extlib-compat"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta2.tar.gz"
+  checksum: [
+    "md5=01a30e3469c3e8ebc04f56a3330778fa"
+    "sha512=c5f00ed4d78b1863717b44e014af1f1e8c4bc9e16ca60f1ac1216d12163d9a3b19721026d0e455429067b8ce90ec646f1be39e3daf0f3710c556da65ec6cd2c0"
+  ]
+}

--- a/packages/opam-devel/opam-devel.2.1.0~beta2/opam
+++ b/packages/opam-devel/opam-devel.2.1.0~beta2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 bootstrapped binary"
+description: """
+This package compiles (bootstraps) opam. For consistency and safety of the installation, the binaries are not installed into the PATH, but into lib/opam-devel, from where the user can manually install them system-wide.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+  [make "tests"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-client" {= version}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {>= "1.5.0"}
+]
+post-messages: [
+"The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/opam /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2=\"OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""
+  {success}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta2.tar.gz"
+  checksum: [
+    "md5=01a30e3469c3e8ebc04f56a3330778fa"
+    "sha512=c5f00ed4d78b1863717b44e014af1f1e8c4bc9e16ca60f1ac1216d12163d9a3b19721026d0e455429067b8ce90ec646f1be39e3daf0f3710c556da65ec6cd2c0"
+  ]
+}

--- a/packages/opam-format/opam-format.2.0.0/opam
+++ b/packages/opam-format/opam-format.2.0.0/opam
@@ -16,7 +16,7 @@ homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 depends: [

--- a/packages/opam-format/opam-format.2.0.0~rc2/opam
+++ b/packages/opam-format/opam-format.2.0.0~rc2/opam
@@ -16,7 +16,7 @@ homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 depends: [

--- a/packages/opam-format/opam-format.2.0.0~rc3/opam
+++ b/packages/opam-format/opam-format.2.0.0~rc3/opam
@@ -16,7 +16,7 @@ homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 depends: [

--- a/packages/opam-format/opam-format.2.0.1/opam
+++ b/packages/opam-format/opam-format.2.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "jbuilder" {>= "1.0+beta18"}
 ]
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"

--- a/packages/opam-format/opam-format.2.0.2/opam
+++ b/packages/opam-format/opam-format.2.0.2/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.2.1"}
 ]
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"

--- a/packages/opam-format/opam-format.2.0.3/opam
+++ b/packages/opam-format/opam-format.2.0.3/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.2.1"}
 ]
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"

--- a/packages/opam-format/opam-format.2.0.4/opam
+++ b/packages/opam-format/opam-format.2.0.4/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.2.1"}
 ]
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"

--- a/packages/opam-format/opam-format.2.0.5/opam
+++ b/packages/opam-format/opam-format.2.0.5/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.2.1"}
 ]
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"

--- a/packages/opam-format/opam-format.2.0.6/opam
+++ b/packages/opam-format/opam-format.2.0.6/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.2.1"}
 ]
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"

--- a/packages/opam-format/opam-format.2.1.0~beta2/opam
+++ b/packages/opam-format/opam-format.2.1.0~beta2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 development libraries (format)"
+description: """
+Definition of opam datastructures and its file interface.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-core" {= version}
+  "opam-file-format" {>= "2.0.0~rc2"}
+  "dune" {>= "1.5.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta2.tar.gz"
+  checksum: [
+    "md5=01a30e3469c3e8ebc04f56a3330778fa"
+    "sha512=c5f00ed4d78b1863717b44e014af1f1e8c4bc9e16ca60f1ac1216d12163d9a3b19721026d0e455429067b8ce90ec646f1be39e3daf0f3710c556da65ec6cd2c0"
+  ]
+}

--- a/packages/opam-lock/opam-lock.0.1/opam
+++ b/packages/opam-lock/opam-lock.0.1/opam
@@ -10,7 +10,7 @@ depends: [
   "jbuilder"
   "cmdliner" {>= "1.0"}
   "opam-solver" {>= "2.0.0~beta5"}
-  "opam-state" {>= "2.0.0~beta5"}
+  "opam-state" {>= "2.0.0~beta5" & < "2.1"}
 ]
 build: ["jbuilder" "build" "-p" name]
 flags: plugin

--- a/packages/opam-lock/opam-lock.0.2/opam
+++ b/packages/opam-lock/opam-lock.0.2/opam
@@ -10,7 +10,7 @@ depends: [
   "jbuilder"
   "cmdliner" {>= "1.0"}
   "opam-solver" {>= "2.0.0~beta5"}
-  "opam-state" {>= "2.0.0~beta5"}
+  "opam-state" {>= "2.0.0~beta5" & < "2.1"}
 ]
 build: ["jbuilder" "build" "-p" name]
 flags: plugin

--- a/packages/opam-package-upgrade/opam-package-upgrade.0.1/opam
+++ b/packages/opam-package-upgrade/opam-package-upgrade.0.1/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/AltGr/opam-package-upgrade.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml"
-  "opam-client" {>= "2.0.0~beta3.1"}
+  "opam-client" {>= "2.0.0~beta3.1" & < "2.1"}
   "cmdliner"
   "jbuilder"
 ]

--- a/packages/opam-package-upgrade/opam-package-upgrade.0.2/opam
+++ b/packages/opam-package-upgrade/opam-package-upgrade.0.2/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/AltGr/opam-package-upgrade/issues"
 tags: "org:ocamlpro"
 flags: plugin
 depends: [
-  "opam-client" {>= "2.0.1"}
+  "opam-client" {>= "2.0.1" & < "2.1"}
   "cmdliner"
   "dune"
 ]

--- a/packages/opam-publish/opam-publish.2.0.0/opam
+++ b/packages/opam-publish/opam-publish.2.0.0/opam
@@ -11,9 +11,9 @@ homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "opam-core" {build & >= "2.0.0"}
-  "opam-format" {build & >= "2.0.0"}
-  "opam-state" {build & >= "2.0.0"}
+  "opam-core" {build & >= "2.0.0" & < "2.1"}
+  "opam-format" {build & >= "2.0.0" & < "2.1"}
+  "opam-state" {build & >= "2.0.0" & < "2.1"}
   "jbuilder" {>= "1.0+beta19"}
   "cmdliner" {build}
   ("ssl" | "tls")

--- a/packages/opam-publish/opam-publish.2.0.0~beta/opam
+++ b/packages/opam-publish/opam-publish.2.0.0~beta/opam
@@ -12,9 +12,9 @@ dev-repo: "git+https://github.com/ocaml/opam-publish.git"
 build: [ "jbuilder" "build" "-p" name ]
 depends: [
   "ocaml"
-  "opam-core" {build & >= "2.0.0~beta5"}
-  "opam-format" {build & >= "2.0.0~beta5"}
-  "opam-state" {build & >= "2.0.0~beta5"}
+  "opam-core" {build & >= "2.0.0~beta5" & < "2.1"}
+  "opam-format" {build & >= "2.0.0~beta5" & < "2.1"}
+  "opam-state" {build & >= "2.0.0~beta5" & < "2.1"}
   "jbuilder" {>= "1.0+beta19"}
   "cmdliner" {build}
   ("ssl" | "tls")

--- a/packages/opam-publish/opam-publish.2.0.1/opam
+++ b/packages/opam-publish/opam-publish.2.0.1/opam
@@ -11,9 +11,9 @@ homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "opam-core" {build & >= "2.0.0"}
-  "opam-format" {build & >= "2.0.0"}
-  "opam-state" {build & >= "2.0.0"}
+  "opam-core" {build & >= "2.0.0" & < "2.1"}
+  "opam-format" {build & >= "2.0.0" & < "2.1"}
+  "opam-state" {build & >= "2.0.0" & < "2.1"}
   "jbuilder" {>= "1.0+beta19"}
   "cmdliner" {build}
   "lwt_ssl"

--- a/packages/opam-repository/opam-repository.2.0.0/opam
+++ b/packages/opam-repository/opam-repository.2.0.0/opam
@@ -16,7 +16,7 @@ homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 depends: [

--- a/packages/opam-repository/opam-repository.2.0.0~rc2/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~rc2/opam
@@ -16,7 +16,7 @@ homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 depends: [

--- a/packages/opam-repository/opam-repository.2.0.0~rc3/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~rc3/opam
@@ -16,7 +16,7 @@ homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 depends: [

--- a/packages/opam-repository/opam-repository.2.0.1/opam
+++ b/packages/opam-repository/opam-repository.2.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "jbuilder" {>= "1.0+beta17"}
 ]
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"

--- a/packages/opam-repository/opam-repository.2.0.2/opam
+++ b/packages/opam-repository/opam-repository.2.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.2.1"}
 ]
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"

--- a/packages/opam-repository/opam-repository.2.0.3/opam
+++ b/packages/opam-repository/opam-repository.2.0.3/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.2.1"}
 ]
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"

--- a/packages/opam-repository/opam-repository.2.0.4/opam
+++ b/packages/opam-repository/opam-repository.2.0.4/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.2.1"}
 ]
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"

--- a/packages/opam-repository/opam-repository.2.0.5/opam
+++ b/packages/opam-repository/opam-repository.2.0.5/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.2.1"}
 ]
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"

--- a/packages/opam-repository/opam-repository.2.0.6/opam
+++ b/packages/opam-repository/opam-repository.2.0.6/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.2.1"}
 ]
 build: [
-  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["env" "CI=" "./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/opam.git"

--- a/packages/opam-repository/opam-repository.2.1.0~beta2/opam
+++ b/packages/opam-repository/opam-repository.2.1.0~beta2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 development libraries (repository)"
+description: """
+This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "dune" {>= "1.5.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta2.tar.gz"
+  checksum: [
+    "md5=01a30e3469c3e8ebc04f56a3330778fa"
+    "sha512=c5f00ed4d78b1863717b44e014af1f1e8c4bc9e16ca60f1ac1216d12163d9a3b19721026d0e455429067b8ce90ec646f1be39e3daf0f3710c556da65ec6cd2c0"
+  ]
+}

--- a/packages/opam-solver/opam-solver.2.1.0~beta2/opam
+++ b/packages/opam-solver/opam-solver.2.1.0~beta2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 development libraries (solver)"
+description: """
+Solver and Cudf interaction. This library is based on the Cudf and Dose libraries, and handles calls to the external solver from opam.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "mccs" {>= "1.1+9"}
+  "dose3" {>= "5"}
+  "cudf" {>= "0.7"}
+  "dune" {>= "1.5.0"}
+]
+depopts: [
+  "z3"
+  "opam-0install-cudf"
+]
+conflicts: [
+  "z3" {< "4.8.4"}
+  "opam-0install-cudf" {< "0.3"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta2.tar.gz"
+  checksum: [
+    "md5=01a30e3469c3e8ebc04f56a3330778fa"
+    "sha512=c5f00ed4d78b1863717b44e014af1f1e8c4bc9e16ca60f1ac1216d12163d9a3b19721026d0e455429067b8ce90ec646f1be39e3daf0f3710c556da65ec6cd2c0"
+  ]
+}

--- a/packages/opam-state/opam-state.2.1.0~beta2/opam
+++ b/packages/opam-state/opam-state.2.1.0~beta2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 development libraries (state)"
+description: """
+Handling of the ~/.opam hierarchy, repository and switch states.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-repository" {= version}
+  "dune" {>= "1.5.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta2.tar.gz"
+  checksum: [
+    "md5=01a30e3469c3e8ebc04f56a3330778fa"
+    "sha512=c5f00ed4d78b1863717b44e014af1f1e8c4bc9e16ca60f1ac1216d12163d9a3b19721026d0e455429067b8ce90ec646f1be39e3daf0f3710c556da65ec6cd2c0"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`opam-client.2.1.0~beta2`: opam 2.1 development libraries (client)
-`opam-core.2.1.0~beta2`: opam 2.1 development libraries (core)
-`opam-devel.2.1.0~beta2`: opam 2.1 bootstrapped binary
-`opam-format.2.1.0~beta2`: opam 2.1 development libraries (format)
-`opam-repository.2.1.0~beta2`: opam 2.1 development libraries (repository)
-`opam-solver.2.1.0~beta2`: opam 2.1 development libraries (solver)
-`opam-state.2.1.0~beta2`: opam 2.1 development libraries (state)



---
* Source repo: git+https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---
:camel: Pull-request generated by opam-publish v2.0.3