### PR TITLE
[new release] nottui, nottui-pretty, lwd, nottui-lwt and tyxml-lwd (0.1)

### DIFF
--- a/packages/lwd/lwd.0.1/opam
+++ b/packages/lwd/lwd.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Lightweight reactive documents"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "seq"
+  "ocaml" {>= "4.03"}
+  "qtest" {with-test}
+  "qcheck" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+x-commit-hash: "0e35464eee6fafcd1502fcc0bf0b12f82911406b"
+url {
+  src: "https://github.com/let-def/lwd/releases/download/v0.1/lwd-v0.1.tbz"
+  checksum: [
+    "sha256=547fca47767744595b80fdf30e4d0e2748333bb1994a0a9061f620be7ed76c49"
+    "sha512=472a97a9904f09c09368a85f0b1a6b8812586e8d46cb8602e33d9cf2ca8fc005ab7f81a9494c3a508c1c5104f71e0c8552505ab55941a69a2ca950e0717e45f1"
+  ]
+}

--- a/packages/nottui-lwt/nottui-lwt.0.1/opam
+++ b/packages/nottui-lwt/nottui-lwt.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Run Nottui UIs in Lwt"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "notty"
+  "lwt"
+  "nottui"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+x-commit-hash: "0e35464eee6fafcd1502fcc0bf0b12f82911406b"
+url {
+  src: "https://github.com/let-def/lwd/releases/download/v0.1/lwd-v0.1.tbz"
+  checksum: [
+    "sha256=547fca47767744595b80fdf30e4d0e2748333bb1994a0a9061f620be7ed76c49"
+    "sha512=472a97a9904f09c09368a85f0b1a6b8812586e8d46cb8602e33d9cf2ca8fc005ab7f81a9494c3a508c1c5104f71e0c8552505ab55941a69a2ca950e0717e45f1"
+  ]
+}

--- a/packages/nottui-pretty/nottui-pretty.0.1/opam
+++ b/packages/nottui-pretty/nottui-pretty.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A pretty-printer based on PPrint rendering UIs"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "notty"
+  "nottui"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+x-commit-hash: "0e35464eee6fafcd1502fcc0bf0b12f82911406b"
+url {
+  src: "https://github.com/let-def/lwd/releases/download/v0.1/lwd-v0.1.tbz"
+  checksum: [
+    "sha256=547fca47767744595b80fdf30e4d0e2748333bb1994a0a9061f620be7ed76c49"
+    "sha512=472a97a9904f09c09368a85f0b1a6b8812586e8d46cb8602e33d9cf2ca8fc005ab7f81a9494c3a508c1c5104f71e0c8552505ab55941a69a2ca950e0717e45f1"
+  ]
+}

--- a/packages/nottui/nottui.0.1/opam
+++ b/packages/nottui/nottui.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "UI toolkit for the terminal built on top of Notty and Lwd"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "lwd"
+  "notty"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+x-commit-hash: "0e35464eee6fafcd1502fcc0bf0b12f82911406b"
+url {
+  src: "https://github.com/let-def/lwd/releases/download/v0.1/lwd-v0.1.tbz"
+  checksum: [
+    "sha256=547fca47767744595b80fdf30e4d0e2748333bb1994a0a9061f620be7ed76c49"
+    "sha512=472a97a9904f09c09368a85f0b1a6b8812586e8d46cb8602e33d9cf2ca8fc005ab7f81a9494c3a508c1c5104f71e0c8552505ab55941a69a2ca950e0717e45f1"
+  ]
+}

--- a/packages/tyxml-lwd/tyxml-lwd.0.1/opam
+++ b/packages/tyxml-lwd/tyxml-lwd.0.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Hello"
+description: "Make reactive webpages in Js_of_ocaml using Tyxml and Lwd"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: ["dune" "lwd" "tyxml" "js_of_ocaml" "js_of_ocaml-ppx"]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+x-commit-hash: "0e35464eee6fafcd1502fcc0bf0b12f82911406b"
+url {
+  src: "https://github.com/let-def/lwd/releases/download/v0.1/lwd-v0.1.tbz"
+  checksum: [
+    "sha256=547fca47767744595b80fdf30e4d0e2748333bb1994a0a9061f620be7ed76c49"
+    "sha512=472a97a9904f09c09368a85f0b1a6b8812586e8d46cb8602e33d9cf2ca8fc005ab7f81a9494c3a508c1c5104f71e0c8552505ab55941a69a2ca950e0717e45f1"
+  ]
+}


### PR DESCRIPTION
UI toolkit for the terminal built on top of Notty

- Project page: <a href="https://github.com/let-def/lwd">https://github.com/let-def/lwd</a>
- Documentation: <a href="https://let-def.github.io/lwd/doc">https://let-def.github.io/lwd/doc</a>

##### CHANGES:                                       
                                                                           
Preview release, the API is not yet stabilized.                            
Most features are there, except support for overlays (menu, dialog windows,
popup, ...) in Nottui.                                                     
                                                                           
Libraries included in this release:                                        
- Lwd, the definition of reactive documents                                
- Nottui, reactive terminal interfaces using Notty & Lwd                   
- Nottui-lwt, an asynchronous mainloop for Nottui                          
- Tyxml-lwd, strongly-typed reactive webpages in Jsoo using Tyxml & Lwd    
                                                                           

