### PR TITLE
Package smtlib-utils.0.2

### DIFF
--- a/packages/smtlib-utils/smtlib-utils.0.2/opam
+++ b/packages/smtlib-utils/smtlib-utils.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Parser for SMTLIB2"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-bytes"
+  "result"
+  "menhir" {build}
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "SMTLIB" "smt2" "parse" "logic" ]
+homepage: "https://github.com/c-cube/smtlib-utils/"
+bug-reports: "https://github.com/c-cube/smtlib-utils/issues"
+dev-repo: "git+https://github.com/c-cube/smtlib-utils.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/smtlib-utils/archive/v0.2.tar.gz"
+  checksum: [
+    "md5=b2d3c374531455c70eb3efe29b5f5cab"
+    "sha512=fbf60c300e632e964cf9b286467142cf2a2f62a38169a6d3c1eac3590d67d19b5032c6b68a88ff0f747295a5d1fc119cb49dd1304258dbde1d12f9eb8b9296ce"
+  ]
+}


### PR DESCRIPTION
### `smtlib-utils.0.2`
Parser for SMTLIB2



---
* Homepage: https://github.com/c-cube/smtlib-utils/
* Source repo: git+https://github.com/c-cube/smtlib-utils.git
* Bug tracker: https://github.com/c-cube/smtlib-utils/issues

---
:camel: Pull-request generated by opam-publish v2.0.0