### PR TITLE
Package smtlib-utils.0.2

### DIFF
--- a/packages/smtlib-utils/smtlib-utils.0.2/opam
+++ b/packages/smtlib-utils/smtlib-utils.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Parser for SMTLIB2"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-bytes"
+  "result"
+  "menhir" {build}
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "SMTLIB" "smt2" "parse" "logic" ]
+homepage: "https://github.com/c-cube/smtlib-utils/"
+bug-reports: "https://github.com/c-cube/smtlib-utils/issues"
+dev-repo: "git+https://github.com/c-cube/smtlib-utils.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/smtlib-utils/archive/v0.2.tar.gz"
+  checksum: [
+    "md5=c8ad8663579e1f2567dbb65b75388c9e"
+    "sha512=82dae5d3ab829e4d625bcd55c79f7dfa59a853c7549e0ba2473878c52ccd5be9f088f9099a1e62518e2e54e7a3a5a7470c7ddd539e11e159c304c368e3724d67"
+  ]
+}


### PR DESCRIPTION
### `smtlib-utils.0.2`
Parser for SMTLIB2



---
* Homepage: https://github.com/c-cube/smtlib-utils/
* Source repo: git+https://github.com/c-cube/smtlib-utils.git
* Bug tracker: https://github.com/c-cube/smtlib-utils/issues

---
:camel: Pull-request generated by opam-publish v2.0.0