### PR TITLE
[new release] mrmime (0.3.1)

### DIFF
--- a/packages/mrmime/mrmime.0.3.1/opam
+++ b/packages/mrmime/mrmime.0.3.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/mrmime"
+bug-reports:  "https://github.com/mirage/mrmime/issues"
+dev-repo:     "git+https://github.com/mirage/mrmime.git"
+doc:          "https://mirage.github.io/mrmime/"
+license:      "MIT"
+synopsis:     "Mr. MIME"
+description:  """Parser and generator of mail in OCaml"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"            {>= "4.07.0"}
+  "dune"             {>= "1.2"}
+  "rresult"
+  "fmt"
+  "ke"               {>= "0.4"}
+  "unstrctrd"        {>= "0.2"}
+  "ptime"
+  "uutf"
+  "rosetta"          {>= "0.3.0"}
+  "ipaddr"
+  "emile"            {>= "1.0"}
+  "base64"           {>= "3.1.0"}
+  "pecu"             {>= "0.4"}
+  "bigstringaf"
+  "bigarray-compat"
+  "bigarray-overlap" {>= "0.2.0"}
+  "angstrom"         {>= "0.14.0"}
+  "hxd"              {with-test}
+  "alcotest"         {with-test}
+  "jsonm"            {with-test}
+]
+x-commit-hash: "35619f057149ebe00b3a64109a28edd65f157efa"
+url {
+  src:
+    "https://github.com/mirage/mrmime/releases/download/v0.3.1/mrmime-v0.3.1.tbz"
+  checksum: [
+    "sha256=6c0c054c05af7218080c3c59e08096a62e23afd15d63fe89fb683f29f330bf32"
+    "sha512=2ce67aff35d680f38af1c78efa58454b12a20c985bd248bc975e9e259a14f8a2ab04287ace88d46bc95a2b245c040deba9d4fb058ea2b103c0724467dda15414"
+  ]
+}


### PR DESCRIPTION
Mr. MIME

- Project page: <a href="https://github.com/mirage/mrmime">https://github.com/mirage/mrmime</a>
- Documentation: <a href="https://mirage.github.io/mrmime/">https://mirage.github.io/mrmime/</a>

##### CHANGES:

- Fix unstructured values (@dinosaure, mirage/mrmime#34)
- Fix `Mrmime.Hd` decoder about the separation between the header
  and the body (@dinosaure, mirage/mrmime#35)
- ocamlformat.0.15.0 pass (@dinosaure, mirage/mrmime#36)
- Use emile.1.0 (@dinosaure)
