### PR TITLE
[conf-gmp-powm-sec] fix test to avoid warning about undeclared function

### DIFF
--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.2/files/test.c
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.2/files/test.c
@@ -1,0 +1,26 @@
+#include <gmp.h>
+#ifndef __GMP_H__
+#error "No GMP header"
+#endif
+#if __GNU_MP_VERSION < 5
+#error "GMP >= 5 is required to support mpz_powm_sec"
+#endif
+
+void test(void) {
+  mpz_t base;
+  mpz_t exp;
+  mpz_t mod;
+  mpz_t rop;
+
+  mpz_init_set_ui(base, 2u);
+  mpz_init_set_ui(exp, 4u);
+  mpz_init_set_ui(mod, 3u);
+  mpz_init(rop);
+
+  mpz_powm_sec(rop, base, exp, mod);
+
+  mpz_clear(base);
+  mpz_clear(exp);
+  mpz_clear(mod);
+  mpz_clear(rop);
+}

--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.2/opam
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.2/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "http://gmplib.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+build: [
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos"}
+  [
+    "sh"
+    "-exc"
+    "cc -c $CFLAGS -I/opt/local/include -I/usr/local/include test.c"
+  ] {os = "macos"}
+]
+depends: ["conf-gmp"]
+synopsis:
+  "Virtual package relying on a GMP lib with constant-time modular exponentiation"
+description: """
+This package can only install if the GMP lib is installed on the system and
+corresponds to a version that has the mpz_powm_sec function."""
+authors: "Etienne Millon <etienne@cryptosense.com>"
+extra-files: ["test.c" "md5=29317f477fa828e18428660ef31064fb"]
+flags: conf


### PR DESCRIPTION
Same issue as https://github.com/ocaml/opam-repository/pull/17156 and same fix.
The raison d'être of this package is to make sure the installed `libgmp` has `mpz_powm_sec()`, so the test also checks for it for completeness.