### PR TITLE
Camlp5 8.00 alpha05 release

### DIFF
--- a/packages/camlp5/camlp5.8.00~alpha05/opam
+++ b/packages/camlp5/camlp5.8.00~alpha05/opam
@@ -1,0 +1,70 @@
+name: "camlp5"
+version: "8.00~alpha05"
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.02" & < "4.12.0"}
+  "conf-perl"
+  "pcre" { with-test }
+  "ounit2" { with-test }
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "world.opt"]
+]
+install: [make "install"]
+depexts: [
+  [
+    "libstring-shellquote-perl"
+    "libipc-system-simple-perl"
+  ] {os-family = "debian"}
+  [
+    "perl-string-shellquote"
+    "perl-ipc-system-simple"
+  ] {os-distribution = "alpine"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-distribution = "centos"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-family = "suse"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-family = "fedora"}
+]
+
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha05.tar.gz"
+  checksum: [
+    "sha512=48e5cac9375dd0170e32d5c138c3e28f4f839ac74783a67620e24d6152aab9e9e388af3f887b3d163c71477664198f0a2d591c2f7421ee6d719a56059af6d519"
+  ]
+}

--- a/packages/camlp5/camlp5.8.00~alpha05/opam
+++ b/packages/camlp5/camlp5.8.00~alpha05/opam
@@ -65,6 +65,6 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha05.tar.gz"
   checksum: [
-    "sha512=48e5cac9375dd0170e32d5c138c3e28f4f839ac74783a67620e24d6152aab9e9e388af3f887b3d163c71477664198f0a2d591c2f7421ee6d719a56059af6d519"
+    "sha512=9c9d6a3a90efba19e3033295c0d778b9a3fba7cf7211dad71a60246c858b356aa07b8d7186ff305298e7b322d9b9e45bbdf0d1a562736f107078c779290707ad"
   ]
 }

--- a/packages/camlp5/camlp5.8.00~alpha05/opam
+++ b/packages/camlp5/camlp5.8.00~alpha05/opam
@@ -65,6 +65,6 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha05.tar.gz"
   checksum: [
-    "sha512=9c9d6a3a90efba19e3033295c0d778b9a3fba7cf7211dad71a60246c858b356aa07b8d7186ff305298e7b322d9b9e45bbdf0d1a562736f107078c779290707ad"
+    "sha512=a70c1620152e18efce2d7d7772b2e60bdf0f1f8538d191fc732a231973988f0995b86ed4260701e8e447e7377b71e48f93c0ee627039355ffad3c8e7b694f173"
   ]
 }


### PR DESCRIPTION
Camlp5 Version 8.00-alpha05:
--------------------

* [24 Sep 2020] add support for 4.11.0 quoted-extension, viz {%foo|argle|} and
  {foo bar|argle|bar}

* [19 Sep 2020] multiple small changes

  * export more names from Reloc

  * in Q_MLast, allow Qast.Node to take a dotted name, e.g. Qast.Node
    "A.B.C" and convert it into an access-expression, so we can use
    quotations over types not in MLast.
