### PR TITLE
Added an existence check to conf-gnome-icon-theme3

### DIFF
--- a/packages/conf-adwaita-icon-theme/conf-adwaita-icon-theme.1/opam
+++ b/packages/conf-adwaita-icon-theme/conf-adwaita-icon-theme.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+homepage: "https://github.com/adwaita/adwaita-icon-theme"
+bug-reports: "https://gitlab.adwaita.org/adwaita/adwaita-icon-theme/issues"
+authors: "GNU Project"
+license: ["LGPL-3.0-only" "CC-BY-SA-3.0"]
+# E.g. on Fedora the system package does not contain a .pc file.
+# Testing for this folder seems to be more portable than using system packager commands as fallback.
+build: [ "sh" "-c" "pkg-config --short-errors --print-errors adwaita-icon-theme || [ -d /usr/share/icons/Adwaita ]"]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  # The list of supported os-family names can be derived from the opam sources
+  #   https://github.com/ocaml/opam/blob/6aefe95e60084e63d01b1c7c028b6b77de1f839f/src/state/opamSysInteract.ml#L84-L123
+  # The package name for many Linux/BSD/macOS/cygwin/msys platforms can be searched here
+  #   https://repology.org specifically https://repology.org/project/adwaita-icon-theme/versions
+  #   Not listed above but supported by opam are suse, oraclelinix, ol, rhel
+  [ "adwaita-icon-theme" "adwaita-icon-theme-dev" ] {os-family = "alpine"}
+  [ "adwaita-icon-theme" ] {os-family = "amzn"}
+  [ "adwaita-icon-theme" ] {os-family = "arch"}
+  [ "adwaita-icon-theme" ] {os-family = "archlinux"}
+  [ "adwaita-icon-theme" ] {os-family = "centos"}
+  [ "adwaita-icon-theme" ] {os-family = "debian"}
+  [ "adwaita-icon-theme" ] {os-family = "fedora"}
+  [ "x11-themes/adwaita-icon-theme" ] {os-family = "gentoo"}
+  [ "adwaita-icon-theme" ] {os-family = "homebrew"}
+  [ "adwaita-icon-theme" ] {os-family = "macports"}
+  [ "adwaita-icon-theme" ] {os-family = "mageia"}
+  [ "adwaita-icon-theme" ] {os-family = "opensuse"}
+  [ "x11/gnome/adwaita-icon-theme" ] {os-family = "bsd"}
+]
+synopsis: "Virtual package relying on adwaita-icon-theme"
+description:
+  "This package can only install if the adwaita-icon-theme package is installed on the system."
+flags: conf

--- a/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
+++ b/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
@@ -3,6 +3,8 @@ homepage: "https://github.com/GNOME/adwaita-icon-theme"
 bug-reports: "https://gitlab.gnome.org/GNOME/adwaita-icon-theme/issues"
 authors: "GNU Project"
 license: ["LGPL-3.0-only" "CC-BY-SA-3.0"]
+build: [["pkg-config" "--short-errors" "--print-errors" "adwaita-icon-theme"]]
+depends: ["conf-pkg-config" {build}]
 depexts: [
   ["gnome-icon-theme"] {os-family = "debian"}
   ["gnome-icon-theme"] {os-family = "fedora" | os-family = "rhel"}

--- a/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
+++ b/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 depexts: [
   ["gnome-icon-theme"] {os-family = "debian"}
-  ["gnome-icon-theme"] {os-family = "fedora" | os-family = "rhel"}
+  ["gnome-icon-theme-devel"] {os-family = "fedora" | os-family = "rhel"}
   ["gnome-icon-theme"] {os = "macos" & os-distribution = "homebrew"}
   ["adwaita-icon-theme"] {os = "macos" & os-distribution = "macports"}
   ["gnome-icon-theme"] {os-family = "suse"}

--- a/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
+++ b/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
@@ -4,14 +4,10 @@ bug-reports: "https://gitlab.gnome.org/GNOME/adwaita-icon-theme/issues"
 authors: "GNU Project"
 license: ["LGPL-3.0-only" "CC-BY-SA-3.0"]
 build: ["pkg-config" "--short-errors" "--print-errors" "gnome-icon-theme"]
-depends: [
-  "conf-pkg-config" {build}
-]
+depends: "conf-pkg-config" {build}
 depexts: [
   ["gnome-icon-theme"] {os-family = "debian"}
   ["gnome-icon-theme-devel"] {os-family = "fedora" | os-family = "rhel"}
-  ["gnome-icon-theme"] {os = "macos" & os-distribution = "homebrew"}
-  ["adwaita-icon-theme"] {os = "macos" & os-distribution = "macports"}
   ["gnome-icon-theme"] {os-family = "suse"}
   ["gnome-icon-theme"] {os-distribution = "arch"}
   ["gnome-icon-theme"] {os-distribution = "alpine"}
@@ -23,4 +19,6 @@ depexts: [
 synopsis: "Virtual package relying on gnome-icon-theme"
 description:
   "This package can only install if the gnome-icon-theme package is installed on the system."
+post-messages:
+  "The package 'conf-gnome-icon-theme3' is deprecated. Please use 'conf-adwaita-icon-theme' instead!"
 flags: conf

--- a/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
+++ b/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
@@ -11,12 +11,14 @@ depexts: [
   ["gnome-icon-theme"] {os-family = "debian"}
   ["gnome-icon-theme"] {os-family = "fedora" | os-family = "rhel"}
   ["gnome-icon-theme"] {os = "macos" & os-distribution = "homebrew"}
+  ["adwaita-icon-theme"] {os = "macos" & os-distribution = "macports"}
   ["gnome-icon-theme"] {os-family = "suse"}
   ["gnome-icon-theme"] {os-distribution = "arch"}
   ["gnome-icon-theme"] {os-distribution = "alpine"}
   ["gnome-icon-theme"] {os-distribution = "nixos"}
   ["gnome-icon-theme"] {os-distribution = "ol"}
   ["gnome-icon-theme"] {os-distribution = "gentoo"}
+  ["gnome-icon-theme"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on gnome-icon-theme"
 description:

--- a/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
+++ b/packages/conf-gnome-icon-theme3/conf-gnome-icon-theme3.0/opam
@@ -3,19 +3,20 @@ homepage: "https://github.com/GNOME/adwaita-icon-theme"
 bug-reports: "https://gitlab.gnome.org/GNOME/adwaita-icon-theme/issues"
 authors: "GNU Project"
 license: ["LGPL-3.0-only" "CC-BY-SA-3.0"]
-build: [["pkg-config" "--short-errors" "--print-errors" "adwaita-icon-theme"]]
-depends: ["conf-pkg-config" {build}]
+build: ["pkg-config" "--short-errors" "--print-errors" "gnome-icon-theme"]
+depends: [
+  "conf-pkg-config" {build}
+]
 depexts: [
   ["gnome-icon-theme"] {os-family = "debian"}
   ["gnome-icon-theme"] {os-family = "fedora" | os-family = "rhel"}
   ["gnome-icon-theme"] {os = "macos" & os-distribution = "homebrew"}
-  ["adwaita-icon-theme"] {os = "macos" & os-distribution = "macports"}
   ["gnome-icon-theme"] {os-family = "suse"}
   ["gnome-icon-theme"] {os-distribution = "arch"}
   ["gnome-icon-theme"] {os-distribution = "alpine"}
   ["gnome-icon-theme"] {os-distribution = "nixos"}
   ["gnome-icon-theme"] {os-distribution = "ol"}
-  ["adwaita-icon-theme"] {os-distribution = "gentoo"}
+  ["gnome-icon-theme"] {os-distribution = "gentoo"}
 ]
 synopsis: "Virtual package relying on gnome-icon-theme"
 description:


### PR DESCRIPTION
The PR adds a check if the gnome icon theme is actually installed, so that the package fails in case it is not installed (as is usually advertised for a conf package). As is the package has just depext dependencies but happily continues in case the icon theme is not installed.