### PR TITLE
Update lablgtk3.3.0.beta5 (still required for Windows compatibility)

### DIFF
--- a/packages/lablgtk3/lablgtk3.3.0.beta5/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta5/opam
@@ -17,11 +17,10 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
   "ocaml"     {         >= "4.05.0" & < "4.10" }
-  "dune"      {         >= "1.4.0"
-                      & != "1.7.0"
-                      & != "1.7.1"  } # Due to dune/dune#1833
+  "dune"      {         >= "1.8.0"  }
   "dune-configurator"
   "conf-gtk3" { build & >= "18"     }
+  "conf-gtksourceview3" { build     }
   "cairo2"    {         >= "0.6"    }
 ]
 


### PR DESCRIPTION
This PR does a few minor updates to lablgtk3.3.0.beta5:
- update required dune version
- make it dependent on conf-gtksourceview3 (otherwise it fails e.g. on Mac where this is not commonly installed)

The old beta5 package is still required for Windows compatibility, because newer packages have still unresolved issues with flexlink (or the system linker).