### PR TITLE
Preparing many releases for new Camlp5 8.x

### DIFF
--- a/packages/GT/GT.0.3.0/opam
+++ b/packages/GT/GT.0.3.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+
+name: "GT"
+synopsis: "Generic programming with extensible transformations"
+description: """
+Yet another library for generic programming. Provides syntax extensions
+both for camlp5 and PPX which allow decoration of type declarations with
+following compile-time code generation. Provides the way for creating
+plugins (compiled separately from the library) for enchancing supported
+type transformations.
+
+Strongly remids the `visitors` library from François Pottier.
+During desing of a library of these kind there many possible
+design decision and in many cases we decided to implement
+the decision opposite to the one used in `visitors`.
+"""
+version: "0.3.0"
+
+maintainer: "kakadu.hafanana@gmail.com"
+authors: ["https://github.com/dboulytchev" "https://github.com/Kakadu"]
+homepage: "https://github.com/JetBrains-Research/GT"
+bug-reports: "https://github.com/JetBrains-Research/GT/issues"
+
+depends: [
+  "ocaml"      { >= "4.07.0" }
+  "camlp5"     { >= "8" | = "8.00~alpha04" | = "8.00~alpha05" }
+  "ocamlfind"  { build }
+  "dune"       { > "2.7" & build }
+  "ocamlgraph"
+  "ppxlib"     {>= "0.9.0" & <= "0.13.0" }
+  "ocaml-migrate-parsetree" { < "2" }
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" "GT,GT-p5" "-j" jobs]
+]
+install: [make "install"]
+
+dev-repo: "git+https://github.com/JetBrains-Research/GT.git"
+url {
+  src: "https://github.com/Kakadu/GT/archive/v0.3.0.zip"
+  checksum: [
+    "sha256=58aa091948383ffa6c452b89880becae980ae32cc3a4969fe1c636e46810db69"
+    "sha512=ee878ba4c2ee16f5b77f4b4e98664d53e91b7a710b9162905b9a43118a03e9c0d7b378a13e104e16a84556bca1176026d93f11934d69eecb459b771e9340ffd7"
+  ]
+}
+

--- a/packages/GT/GT.0.3.0/opam
+++ b/packages/GT/GT.0.3.0/opam
@@ -27,7 +27,7 @@ depends: [
     # because a few features are not properly backported (and probably will never be)
   "camlp5"     { >= "8" | = "8.00~alpha04" | = "8.00~alpha05" }
   "ocamlfind"  { build }
-  "dune"       { > "2.7" & build }
+  "dune"       { > "2.7" }
   "ocamlgraph"
   "ppxlib"     {>= "0.9.0" & <= "0.13.0" }
   "ocaml-migrate-parsetree" { < "2" }
@@ -47,4 +47,3 @@ url {
     "sha512=ee878ba4c2ee16f5b77f4b4e98664d53e91b7a710b9162905b9a43118a03e9c0d7b378a13e104e16a84556bca1176026d93f11934d69eecb459b771e9340ffd7"
   ]
 }
-

--- a/packages/GT/GT.0.3.0/opam
+++ b/packages/GT/GT.0.3.0/opam
@@ -22,7 +22,9 @@ homepage: "https://github.com/JetBrains-Research/GT"
 bug-reports: "https://github.com/JetBrains-Research/GT/issues"
 
 depends: [
-  "ocaml"      { >= "4.07.0" }
+  "ocaml"      { >= "4.10.0" }    
+    # 4.10 is required only because camlp5 has a few glitches in old compilers 
+    # because a few features are not properly backported (and probably will never be)
   "camlp5"     { >= "8" | = "8.00~alpha04" | = "8.00~alpha05" }
   "ocamlfind"  { build }
   "dune"       { > "2.7" & build }

--- a/packages/logger-p5/logger-p5.0.4.5/opam
+++ b/packages/logger-p5/logger-p5.0.4.5/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+
+synopsis: "Camlp5 syntax extension for logging"
+description: """
+A simple camlp5 syntax extension that allows syntax
+   REPR(expr)
+which translates to a pair
+   ("string with expression 'expr'", expr)
+
+Useful for logging and pretty-printing
+"""
+
+maintainer: "kakadu.hafanana@gmail.com"
+authors: "https://github.com/dboulytchev"
+homepage: "https://github.com/dboulytchev/logger"
+bug-reports: "https://github.com/dboulytchev/logger/issues"
+
+depends: [
+  "ocaml" { >= "4.07.0" }
+  "ocamlfind" {build}
+  "camlp5" { >= "8" | = "8.00~alpha04"  | = "8.00~alpha05" }
+]
+build: [
+  [make "-f" "Makefile.ob"]
+]
+install: [make "-f" "Makefile.ob" "PREFIX=%{prefix}%" "install"]
+
+dev-repo: "git+https://github.com/dboulytchev/logger.git"
+url {
+  src: "https://github.com/dboulytchev/logger/archive/0.4.5.zip"
+  checksum: "md5=cf67fa77095b0d2ed42c688bfdc5ae50"
+}

--- a/packages/noCanren/noCanren.0.2.0/opam
+++ b/packages/noCanren/noCanren.0.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+
+name: "noCanren"
+version: "0.2.0"
+synopsis: "Translator from subset of OCaml to OCanren"
+maintainer: [ "Kakadu@pm.me" "lozov.peter@gmail.com" ]
+authors: ["https://github.com/Lozov-Petr" "https://github.com/Kakadu" "https://github.com/dboulytchev"]
+homepage: "https://github.com/Lozov-Petr/noCanren"
+bug-reports: "https://github.com/Lozov-Petr/noCanren/issues"
+
+depends: [
+  "ocaml"      {= "4.10.1" }
+  "ocamlfind"  { build }
+  "ocamlbuild" { build }
+  "ppx_tools"  { build }
+  "GT"         { build }
+]
+build: [
+  [make]
+  # [make "test"] {with-test} # tests require OCanren package which isn't opamized yet
+]
+install: [make "PREFIX=%{prefix}%" "install"]
+
+dev-repo: "git+https://github.com/Lozov-Petr/noCanren.git"
+
+url {
+  src: "https://github.com/Kakadu/noCanren/archive/0.2.0.tar.gz"
+  checksum: [
+    "sha256=605cee95fee9505259cd93cb8a2ced5d321e58b74018572e4afa4c50fcbe67c0"
+    "sha512=86c0672b49d808f252a7995d0c65e1a0af58f6e613eac372e3dfc99504bf012de3ddd8c3075f7337238f5a16045309d3a94dec43e24ada12e578952fc7e1ecfa"
+  ]
+}
+

--- a/packages/ostap/ostap.0.5/opam
+++ b/packages/ostap/ostap.0.5/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Parser-combinator library"
+authors: "dboulytchev@gmail.com"
+maintainer: "Kakadu@pm.me"
+version:  "0.5"
+homepage: "https://github.com/dboulytchev/ostap"
+bug-reports: "https://github.com/Kakadu/ostap/issues"
+dev-repo:    "git+https://github.com/Kakadu/ostap.git"
+
+build: [
+  [make]
+  [make "test"] { with-test }
+]
+
+install: [make "PREFIX=%{prefix}%" "install"]
+
+depends: [
+  "ocamlbuild" { build }
+  "ocamlfind"  { build }
+  "camlp5"     { >= "8" | = "8.00~alpha04" | = "8.00~alpha05"  }
+  "re"
+  "GT"
+]
+
+url {
+  src: "https://github.com/Kakadu/ostap/archive/0.5-memoCPS.tar.gz"
+  checksum: [
+    "sha256=b7c8499f46c6d376b2127ba4c926560d0bf6ac3a81aeb8c3fed95956e86f51be"
+  ]
+}
+


### PR DESCRIPTION
continuous-integration/travis-ci/pr fails on Mac because of camlp5+perl issues there

Errors are not releveant
1) Camlp5 gives stack overflow during compilation of itself
2) Camlp5 has PERL issues on Mac

Please, review.