### PR TITLE
Luv 0.5.6: binding to libuv

### DIFF
--- a/packages/luv/luv.0.5.6/opam
+++ b/packages/luv/luv.0.5.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+
+synopsis: "Binding to libuv: cross-platform asynchronous I/O"
+
+version: "0.5.6"
+license: "MIT"
+homepage: "https://github.com/aantron/luv"
+doc: "https://aantron.github.io/luv"
+bug-reports: "https://github.com/aantron/luv/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/luv.git"
+
+depends: [
+  "base-unix" {build}
+  "ctypes" {>= "0.13.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.02.0"}
+  "result"
+
+  "alcotest" {with-test & >= "0.8.1"}
+  "base-unix" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Luv is a binding to libuv, the cross-platform C library that does
+asynchronous I/O in Node.js and runs its main loop.
+
+Besides asynchronous I/O, libuv also supports multiprocessing and
+multithreading. Multiple event loops can be run in different threads. libuv also
+exposes a lot of other functionality, amounting to a full OS API, and an
+alternative to the standard module Unix."
+
+url {
+  src: "https://github.com/aantron/luv/releases/download/0.5.6/luv-0.5.6.tar.gz"
+  checksum: "md5=fb78fd1b179f5c9585e79b5a1c5ff644"
+}


### PR DESCRIPTION
[Changelog](https://github.com/aantron/luv/releases/tag/0.5.6):

> - Upgrade libuv to [1.40.0](https://github.com/libuv/libuv/releases/tag/v1.40.0) (aantron/luv#81).
> - Expose [`uv_timer_get_due_in`](http://docs.libuv.org/en/v1.x/timer.html#c.uv_timer_get_due_in) as [`Luv.Timer.get_due_in`](https://aantron.github.io/luv/luv/Luv/Timer/index.html#val-get_due_in) (aantron/luv#81).
> - Expose [`UV_UDP_MMSG_FREE`](http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_flags) as [`` `MMSG_FREE ``](https://aantron.github.io/luv/luv/Luv/UDP/Recv_flag/index.html#type-t.MMSG_FREE) (aantron/luv#81).

cc @ulrikstrid 