### PR TITLE
ppx_deriving_rpc: fix compatibility with recent ppxlib

### DIFF
--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.7.1.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.7.1.0/opam
@@ -12,6 +12,7 @@ depends: [
   "rpclib" {= version}
   "rresult"
   "ppxlib" {>= "0.9.0" & < "0.15.0"}
+  "base" {>= "v0.11.0"}
   "lwt" {with-test & >= "3.0.0"}
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
There was a transitive dependency on base

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>