### PR TITLE
Package clap.0.1.0

### DIFF
--- a/packages/clap/clap.0.1.0/opam
+++ b/packages/clap/clap.0.1.0/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+maintainer: "Romain Bardou"
+authors: [ "Romain Bardou" ]
+homepage: "https://github.com/rbardou/clap"
+bug-reports: "https://github.com/rbardou/clap/issues"
+dev-repo: "git+https://github.com/rbardou/clap/issues.git"
+license: "MIT"
+build: [ ["dune" "build" "-p" name "-j" jobs] ]
+synopsis: "Command-Line Argument Parsing, imperative style with a consumption mechanism"
+url {
+  src: "https://github.com/rbardou/clap/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=96ad1856987596d725c1d49ae80b14ff"
+    "sha512=5a27d11364ef11d14b4d0b34998f8c9499a056cbb6ff82f8bf01683ceb227aef69709ea5c81ca53cbedfe15485a3c48a49b337645110836d62e343b50cad86ff"
+  ]
+}


### PR DESCRIPTION
### `clap.0.1.0`
Command-Line Argument Parsing, imperative style with a consumption mechanism



---
* Homepage: https://github.com/rbardou/clap
* Source repo: git+https://github.com/rbardou/clap/issues.git
* Bug tracker: https://github.com/rbardou/clap/issues

---
:camel: Pull-request generated by opam-publish v2.0.2