### PR TITLE
Package clap.0.1.0

### DIFF
--- a/packages/clap/clap.0.1.0/opam
+++ b/packages/clap/clap.0.1.0/opam
@@ -5,6 +5,11 @@ homepage: "https://github.com/rbardou/clap"
 bug-reports: "https://github.com/rbardou/clap/issues"
 dev-repo: "git+https://github.com/rbardou/clap.git"
 license: "MIT"
+
+depends: [
+   "ocaml" {>= "4.02"}
+   "dune"
+]
 build: [ ["dune" "build" "-p" name "-j" jobs] ]
 synopsis: "Command-Line Argument Parsing, imperative style with a consumption mechanism"
 url {

--- a/packages/clap/clap.0.1.0/opam
+++ b/packages/clap/clap.0.1.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/rbardou/clap.git"
 license: "MIT"
 
 depends: [
-   "ocaml" {>= "4.02"}
+   "ocaml" {>= "4.07"}
    "dune"
 ]
 build: [ ["dune" "build" "-p" name "-j" jobs] ]

--- a/packages/clap/clap.0.1.0/opam
+++ b/packages/clap/clap.0.1.0/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+maintainer: "Romain Bardou"
+authors: [ "Romain Bardou" ]
+homepage: "https://github.com/rbardou/clap"
+bug-reports: "https://github.com/rbardou/clap/issues"
+dev-repo: "git+https://github.com/rbardou/clap.git"
+license: "MIT"
+build: [ ["dune" "build" "-p" name "-j" jobs] ]
+synopsis: "Command-Line Argument Parsing, imperative style with a consumption mechanism"
+url {
+  src: "https://github.com/rbardou/clap/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=ee8785806255ea0e95d8a74649b8a582"
+    "sha512=3b5ebacc498b621187c171c538b711f2b786b87d5fa3bc4d6f652a9783d12a54aa8fdf1c1cf3fcef6bded62c0ae9403286d8aa81a53542f0e02d532db6b20710"
+  ]
+}


### PR DESCRIPTION
### `clap.0.1.0`
Command-Line Argument Parsing, imperative style with a consumption mechanism



---
* Homepage: https://github.com/rbardou/clap
* Source repo: git+https://github.com/rbardou/clap.git
* Bug tracker: https://github.com/rbardou/clap/issues

---
:camel: Pull-request generated by opam-publish v2.0.2