### PR TITLE
pa_ppx Version 0.03

### DIFF
--- a/packages/pa_ppx/pa_ppx.0.03/opam
+++ b/packages/pa_ppx/pa_ppx.0.03/opam
@@ -1,0 +1,87 @@
+version: "0.03"
+synopsis: "PPX Rewriters for Ocaml, written using Camlp5"
+description:
+"""
+This is a collection of PPX rewriters, re-implementing those based on ppxlib
+and other libraries, but instead based on Camlp5.  Included is also a collection
+of support libraries for writing new PPX rewriters.  Included are:
+
+pa_assert: ppx_assert
+pa_ppx.deriving, pa_ppx.deriving_plugins (enum, eq, fold, iter, make, map, ord, sexp, show, yojson):
+  ppx_deriving, plugins, ppx_sexp_conv, ppx_deriving_yojson
+pa_ppx.expect_test: ppx_expect_test
+pa_ppx.here: ppx_here
+pa_ppx.import: ppx_import
+pa_ppx.inline_test: ppx_inline_test
+
+pa_ppx.undo_deriving: pa_ppx.deriving expands [@@deriving ...] into code; this rewriter undoes that.
+pa_ppx.unmatched_vala: expands to match-cases (support library for camlp5-based PPX rewriters)
+pa_ppx.hashrecons: support for writing AST rewriters that automatically fills in hash-consing boilerplate
+pa_dock: implements doc-comment extraction for camlp5 preprocessors
+
+Many of the reimplementations in fact offer significant enhanced
+function, described in the pa_ppx documentation.  In addition, there
+is an extensive test-suite, much of it slightly modified versions of
+the tests for the respective PPX rewriters.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/chetmurthy/pa_ppx"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/chetmurthy/pa_ppx/issues"
+dev-repo: "git+https://github.com/chetmurthy/pa_ppx.git"
+doc: "https://github.com/chetmurthy/pa_ppx/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "4.12.0" }
+  "camlp5"      { >= "8.00~alpha03" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "yojson" { >= "1.7.0" }
+  "ounit2" { >= "2.2.3" }
+  "bos" { >= "0.2.0" }
+  "ppx_deriving_protobuf" { >= "2.7" }
+  "uint" { >= "2.0.1" }
+  "ppx_import" { with-test & >= "1.7.1" }
+  "ppx_deriving_yojson" { with-test & >= "3.5.2" }
+  "ppx_here" { with-test & >= "v0.13.0" }
+  "ppx_sexp_conv" { with-test & >= "v0.13.0" }
+  "expect_test_helpers" { with-test & >= "v0.13.0" }
+]
+depexts: [
+  [
+    "libstring-shellquote-perl"
+    "libipc-system-simple-perl"
+  ] {os-family = "debian"}
+  [
+    "perl-string-shellquote"
+    "perl-ipc-system-simple"
+  ] {os-distribution = "alpine"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-distribution = "centos"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-family = "suse"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-family = "fedora"}
+]
+
+build: [
+  [make "get-generated"]
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/chetmurthy/pa_ppx/archive/0.03.tar.gz"
+  checksum: [
+    "sha512=2d6fa0611658b248dfa61024f13f4377aef2658deebd0c6f35f38416814004fcd5c995eebc955c627535be230632e17836b7c0510d7aa6a434d1694bb6fd6457"
+  ]
+}

--- a/packages/pa_ppx/pa_ppx.0.03/opam
+++ b/packages/pa_ppx/pa_ppx.0.03/opam
@@ -71,7 +71,10 @@ depexts: [
     "perl-String-ShellQuote"
     "perl-IPC-System-Simple"
   ] {os-family = "fedora"}
-  ["perl5"] {os-family = "osx"}
+  [
+    "p5.30-string-shellquote"
+    "p5.30-ipc-system-simple"
+  ] {os = "macos" & os-distribution = "macports"}
 ]
 
 build: [

--- a/packages/pa_ppx/pa_ppx.0.03/opam
+++ b/packages/pa_ppx/pa_ppx.0.03/opam
@@ -71,6 +71,7 @@ depexts: [
     "perl-String-ShellQuote"
     "perl-IPC-System-Simple"
   ] {os-family = "fedora"}
+  ["perl"] {os-family = "macos"}
 ]
 
 build: [

--- a/packages/pa_ppx/pa_ppx.0.03/opam
+++ b/packages/pa_ppx/pa_ppx.0.03/opam
@@ -71,7 +71,7 @@ depexts: [
     "perl-String-ShellQuote"
     "perl-IPC-System-Simple"
   ] {os-family = "fedora"}
-  ["perl"] {os-family = "macos"}
+  ["perl5"] {os-family = "osx"}
 ]
 
 build: [


### PR DESCRIPTION
* [27 Sep 2020] added TRIP-TEST-ALL to generate and save
  generated-files (and run tests) for all supported ocaml versions.

* [24 Sep 2020] new way of selecting generated-src versions.
  hopefully this will make pa_ppx immune to "new camlp5 release, we
  can't build" problems.

  pa_ppx.import now support "mli-only" and "redeclare" options:

  "-pa_import-mli-only": to ensure that only MLI files are consulting during import
  (e.g. to pull in OCaml AST from an older OCaml version, and avoid
  doing so from the stdlib)

  "-pa_import-redeclare": to import types and *not* add the type-equation that
  binds them to the existing type.  For instance, to combine with
  mli-only (since there isn't any existing type that matches).

  cache files as they're read in pa_import, so we don't need to reread them.

  the [%%import ...] item-extension (for str-items and sig-items) now takes a
  [@add ...] attribute, viz.

  [%%import: MLast.expr
    [@add type loc = [%import: MLast.loc]
          and type_var = [%import: MLast.type_var]
          and 'a vala = [%import: 'a Ploc.vala]
    ]
  ]

  This says to import the entire typedecl-group in which MLast.expr is
  declared, and to add to that the types MLast.type_var and Ploc.vala,
  all in a single grouped typedef (which will be recursive, if the
  initial typedef is).  The "@add" attribute payload is a str-item, so
  it can itself have a payload that is an item-extension ("[%%import
  ...]") in order to import-and-add entire typedecl groups, thus:

  [%%import: MLast.expr
    [@add [%%import: MLast.loc]]
    [@add [%%import: MLast.type_var]]
    [@add [%%import: 'a Ploc.vala]]
    [@with Ploc.vala := vala]
  ] [@@deriving show]

  The "@with" directive applies to all types imported.  If we wanted
  to apply it to one of the types in "@add" directives (say, for
  "MLast.type_var"), we'd just put it in that "%%import" attribute in
  the normal way.

* [12 Sep 2020] added a bunch of support for matching & substitution over types,
  to support pa_ppx_migrate (which is now in a separate project).

  also add generated files for camlp5 8.00~alpha04

* [22 Aug 2020] cleanup opam file, bump version for compat with camlp5 8.00~alpha03.

  Change versioning process.
