### PR TITLE
[new release] asn1-combinators (0.2.3)

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.2.3/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+authors: "David Kaloper Meršinjak"
+maintainer: "David Kaloper Meršinjak <dk505@cam.ac.uk>"
+homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
+doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+synopsis: "Embed typed ASN.1 grammars in OCaml"
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+depends: [
+  "ocaml" {>="4.05.0"}
+  "dune" {>= "1.2.0"}
+  "cstruct" {>= "1.6.0"}
+  "zarith"
+  "bigarray-compat"
+  "stdlib-shims"
+  "ptime"
+  "alcotest" {with-test}
+]
+description: """
+asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
+part of ASN.1, and embed the abstract syntax directly in the language. These
+abstract syntax representations can be used for parsing, serialization, or
+random testing.
+
+The only ASN.1 encodings currently supported are BER and DER.
+"""
+x-commit-hash: "c32e3df61cac98a8276b54e19d28beb460a1631e"
+url {
+  src:
+    "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.2.3/asn1-combinators-v0.2.3.tbz"
+  checksum: [
+    "sha256=d9b4e3917e8f7c3a51ad2220053772c7c4ac1d490ff0ee1689a216770283e3fc"
+    "sha512=ea7ecf8e86f5364ed44399a22d08f155db4ad57b2d691f1604091ff3720ddbe65dae63912dbf4e73b2d1ca5e7933661c79e8ea919bf78f458cd576acf01e0f8b"
+  ]
+}


### PR DESCRIPTION
Embed typed ASN.1 grammars in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-asn1-combinators">https://github.com/mirleft/ocaml-asn1-combinators</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-asn1-combinators/doc">https://mirleft.github.io/ocaml-asn1-combinators/doc</a>

##### CHANGES:

* adapt to cstruct 6.0.0 API changes (mirleft/ocaml-asn1-combinators#34 by @dinosaure)
