### PR TITLE
[new release] mirage-stack (2.2.0)

### DIFF
--- a/packages/mirage-stack/mirage-stack.2.2.0/opam
+++ b/packages/mirage-stack/mirage-stack.2.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-stack"
+doc: "https://mirage.github.io/mirage-stack/"
+bug-reports: "https://github.com/mirage/mirage-stack/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-stack.git"
+synopsis: "MirageOS signatures for network stacks"
+description: """
+mirage-stack provides a set of module types which libraries intended to be used
+as MirageOS network stacks should implement.
+"""
+x-commit-hash: "7656bb5c7bb41083f40b8c5c9594469f577470b1"
+url {
+  src:
+    "https://github.com/mirage/mirage-stack/releases/download/v2.2.0/mirage-stack-v2.2.0.tbz"
+  checksum: [
+    "sha256=003776ec66a4a673d11c30966fcc320b056b982a0858ec0f874312c9e00311e2"
+    "sha512=e588f01a14b39cb039eab06276aad948d937b4f189b6a9702a356cdde5bcefd3deb167a0fc734ff41c71b803769dc6dab9e84363ed7e84f4c8badd89381b418f"
+  ]
+}


### PR DESCRIPTION
MirageOS signatures for network stacks

- Project page: <a href="https://github.com/mirage/mirage-stack">https://github.com/mirage/mirage-stack</a>
- Documentation: <a href="https://mirage.github.io/mirage-stack/">https://mirage.github.io/mirage-stack/</a>

##### CHANGES:

* add Mirage_stack.V4V6 module type (mirage/mirage-stack#19 @hannesm)
