### PR TITLE
[new release] mirage-net-unix (2.8.0)

### DIFF
--- a/packages/mirage-net-unix/mirage-net-unix.2.8.0/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.2.8.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "David Scott" "Thomas Gazagnaire" "Hannes Mehnert"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/mirage-net-unix"
+doc: "https://mirage.github.io/mirage-net-unix/"
+bug-reports: "https://github.com/mirage/mirage-net-unix/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "1.7.1"}
+  "cstruct-lwt"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "tuntap" {>= "1.8.0"}
+  "alcotest" {with-test}
+  "logs"
+  "macaddr"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-net-unix.git"
+synopsis: "Unix implementation of the Mirage_net_lwt interface"
+description: """
+This interface exposes raw Ethernet frames using `ocaml-tuntap`,
+suitable for use with an OCaml network stack such as the one
+found at <https://github.com/mirage/mirage-tcpip>.
+"""
+x-commit-hash: "6d9201bc1b80f991e1aad8c0016a52cbbd6016d5"
+url {
+  src:
+    "https://github.com/mirage/mirage-net-unix/releases/download/v2.8.0/mirage-net-unix-v2.8.0.tbz"
+  checksum: [
+    "sha256=9ee3d44ffdc2ccfaf9083338f12fcfc8507aaa1db49d337c6dfc942df975180c"
+    "sha512=2f05db95d477e9e13fbec9718dadd1f0c4575c156580cfc41d9fcc4534fcfabf218315565677312962ab4f5129efcf632af1022a1862ed92f46592dba02ed3a6"
+  ]
+}


### PR DESCRIPTION
Unix implementation of the Mirage_net_lwt interface

- Project page: <a href="https://github.com/mirage/mirage-net-unix">https://github.com/mirage/mirage-net-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-unix/">https://mirage.github.io/mirage-net-unix/</a>

##### CHANGES:

* Netif.listen: do not catch out of memory exception (mirage/mirage-net-unix#49 @hannesm)
