### PR TITLE
[new release] mirage-net-macosx (1.9.0)

### DIFF
--- a/packages/mirage-net-macosx/mirage-net-macosx.1.9.0/opam
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.9.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:  "Anil Madhavapeddy <anil@recoil.org>"
+authors:     "Anil Madhavapeddy <anil@recoil.org>"
+homepage:    "https://github.com/mirage/mirage-net-macosx"
+bug-reports: "https://github.com/mirage/mirage-net-macosx/issues"
+dev-repo:    "git+https://github.com/mirage/mirage-net-macosx.git"
+doc:         "https://mirage.github.io/mirage-net-macosx/"
+
+license: "ISC"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "1.4.0"}
+  "macaddr"
+  "sexplib"
+  "logs"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "vmnet" {>= "1.5.1"}
+]
+tags: "org:mirage"
+
+synopsis: "MacOS implementation of the Mirage_net_lwt interface"
+description: """
+This interface exposes raw Ethernet frames using the
+[Vmnet](https://github.com/mirage/ocaml-vmnet) framework that
+is available on MacOS X Yosemite onwards.  It is suitable for
+use with an OCaml network stack such as the one found at
+<https://github.com/mirage/mirage-tcpip>.
+"""
+x-commit-hash: "8d98e77f3020686b388fe2d582cb79eeebae6a13"
+url {
+  src:
+    "https://github.com/mirage/mirage-net-macosx/releases/download/v1.9.0/mirage-net-macosx-v1.9.0.tbz"
+  checksum: [
+    "sha256=931d4ed0f7fbb9481e6f4907cbb9475b0deee2fa4f2e118ef4e2513749f335e3"
+    "sha512=117a36f2d5910c27ea6f534c7cb9416f7468193e5846383cd3aaf9c8da78937ff6b7ab1d9d2fd1526ee67dc3f77277a2a28f162427a7dac6542789c572a6f4c5"
+  ]
+}


### PR DESCRIPTION
MacOS implementation of the Mirage_net_lwt interface

- Project page: <a href="https://github.com/mirage/mirage-net-macosx">https://github.com/mirage/mirage-net-macosx</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-macosx/">https://mirage.github.io/mirage-net-macosx/</a>

##### CHANGES:

- Netif.listen: do not catch out of memory exception (mirage/mirage-net-macosx#38 mirage/mirage-net-macosx#39 @hannesm)
