### PR TITLE
Package promise_jsoo.0.2.0

### DIFF
--- a/packages/promise_jsoo/promise_jsoo.0.2.0/opam
+++ b/packages/promise_jsoo/promise_jsoo.0.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Js_of_ocaml bindings to JS Promises with supplemental functions"
+maintainer: ["Max Lantas <mnxndev@outlook.com>"]
+authors: ["Max Lantas <mnxndev@outlook.com>"]
+license: "MIT"
+homepage: "https://github.com/mnxn/promise_jsoo"
+bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
+  "gen_js_api"
+  "webtest" {with-test}
+  "webtest-js" {with-test}
+  "conf-npm" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mnxn/promise_jsoo.git"
+url {
+  src: "https://github.com/mnxn/promise_jsoo/archive/v0.2.0.tar.gz"
+  checksum: [
+    "md5=dc3d7930cdebdbaa5f01ffce36c9ccd4"
+    "sha512=250499b2f6db7b7708a591cb468acfd0e81774506cc24d2d3cb1387bcf033b2f4edd58ff09b10623dce70ed0e3734a947a341f238da9567138ae3112af999246"
+  ]
+}


### PR DESCRIPTION
### `promise_jsoo.0.2.0`
Js_of_ocaml bindings to JS Promises with supplemental functions



---
* Homepage: https://github.com/mnxn/promise_jsoo
* Source repo: git+https://github.com/mnxn/promise_jsoo.git
* Bug tracker: https://github.com/mnxn/promise_jsoo/issues

---
:camel: Pull-request generated by opam-publish v2.0.2