### PR TITLE
[new release] monomorphic (2.0)

### DIFF
--- a/packages/monomorphic/monomorphic.2.0/opam
+++ b/packages/monomorphic/monomorphic.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "A small library used to shadow polymorphic operators (and functions) contained in the stdlib"
+maintainer: ["Kate <kit.ty.kate@disroot.org>"]
+authors: ["Kate <kit.ty.kate@disroot.org>"]
+license: "MIT"
+tags: [
+  "polymorphic" "compare" "equal" "equality" "monomorphic" "unsafe" "safe"
+]
+homepage: "https://github.com/kit-ty-kate/ocaml-monomorphic"
+bug-reports: "https://github.com/kit-ty-kate/ocaml-monomorphic/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/kit-ty-kate/ocaml-monomorphic.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/ocaml-monomorphic/releases/download/2.0/monomorphic-2.0.tbz"
+  checksum: [
+    "sha256=23fc4e79f003082de925e8a520d96573a709495645dc7a184e3527eae217a02c"
+    "sha512=9bf91b6102e8b33c7dff2a242248271ba4b1124b00fc75490864d01df0ac1e86e78824d6628394c1c99ec92684de66aae33bae315525c4ec1a123d662b7a70cb"
+  ]
+}
+x-commit-hash: "8b8c6a7049b6a91ff39951927517cab3b0af444e"


### PR DESCRIPTION
A small library used to shadow polymorphic operators (and functions) contained in the stdlib

- Project page: <a href="https://github.com/kit-ty-kate/ocaml-monomorphic">https://github.com/kit-ty-kate/ocaml-monomorphic</a>

##### CHANGES:

- Add support for the `Stdlib` module from OCaml 4.07

- Use the `Int` implementation by default instead of `None` in the `Stdlib` module.

- Remove the `MakeInfix`, `MakeCmp` modules and `TY` module type

- Monomorphise `Stdlib.List.assoc_opt` from OCaml 4.05

- Monomorphise the `Stdlib.ListLabels` and `Stdlib.Pervasives` modules properly

- Add the `Bool` and `String` modules to monomorphise the equality functions
  for `bool` and `string` respectively.

- Now requires OCaml >= 4.08 and Dune >= 2.7
