### PR TITLE
[new release] imagelib (ocaml-imagelib_20200929)

### DIFF
--- a/packages/imagelib/imagelib.ocaml-imagelib_20200929/opam
+++ b/packages/imagelib/imagelib.ocaml-imagelib_20200929/opam
@@ -1,0 +1,59 @@
+synopsis: "Library implementing parsing of image formats such as PNG, BMP, PPM"
+description:
+"""
+The imagelib library implements image formats such as PNG, BMP, and PPM in
+OCaml, relying on only one external dependency: 'decompress'.
+
+Unix-dependent functionality such as reading or writing to files in the
+filesystem are packaged separately in the 'imagelib-unix' OPAM package.
+
+Supported image formats:
+ - PNG (full implementation of RFC 2083),
+ - PPM, PGM, PBM, ... (fully supported),
+ - BMP (read-only)
+ - JPG (only image size natively, conversion to PNG otherwise),
+ - GIF (only image size natively, conversion to PNG otherwise),
+ - XCF (only image size natively, conversion to PNG otherwise),
+ - Utility functions for handling unimplemented formats are available in
+   the 'imagelib-unix' OPAM package. See that package description for more info.
+
+As imagelib only requires 'decompress', it can be used together with
+js_of_ocaml to compile projects to Javascript, or from MirageOS unikernels.
+"""
+opam-version: "2.0"
+maintainer: "rodolphe.lepigre@inria.fr"
+bug-reports: "https://github.com/rlepigre/imagelib/issues"
+homepage: "https://github.com/rlepigre/imagelib"
+dev-repo: "git+https://github.com/rlepigre/imagelib.git"
+authors: [
+  "Rodolphe Lepigre <rodolphe.lepigre@inria.fr>"
+]
+license: "GPLv3"
+doc: "https://rlepigre.github.io/ocaml-imagelib"
+
+depends: [
+  "ocaml"        { >= "4.07.0" }
+  "base-unix"
+  "dune"         { >= "2.3.0"  }
+  "decompress"   { >= "1.2.0" }
+  "stdlib-shims"
+  "alcotest"     { with-test }
+]
+
+depopts: [
+  "crowbar"        { with-test }
+  "afl-persistent" { with-test }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs "@runtest" {with-test} ]
+]
+x-commit-hash: "3d27098d5885100c130074d98f4e6973480d1f94"
+url {
+  src:
+    "https://github.com/rlepigre/imagelib/releases/download/ocaml-imagelib_20200929/imagelib-ocaml-imagelib_20200929.tbz"
+  checksum: [
+    "sha256=63621aa83f527cce1ac631dc30df5ed3298f6e34c935d19ad24bb7033d2570cc"
+    "sha512=2336943440ceaba73b3fc4d6064a8715c9a2a21ef18e387ae8e3505c0361846e92724646013b182f9d073219443a6897ce8951efcedf5aa4879b3076187b83a2"
+  ]
+}


### PR DESCRIPTION
Library implementing parsing of image formats such as PNG, BMP, PPM

- Project page: <a href="https://github.com/rlepigre/imagelib">https://github.com/rlepigre/imagelib</a>
- Documentation: <a href="https://rlepigre.github.io/ocaml-imagelib">https://rlepigre.github.io/ocaml-imagelib</a>

##### CHANGES:

- Port to dune 2.0
