### PR TITLE
key-parsers is not compatible with cstruct 6.0.0

### DIFF
--- a/packages/key-parsers/key-parsers.0.10.0/opam
+++ b/packages/key-parsers/key-parsers.0.10.0/opam
@@ -20,7 +20,7 @@ depends: [
   "zarith" {>= "1.4.1"}
   "result" {>= "1.2"}
   "ppx_bin_prot" {< "v0.15"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "6.0.0"}
 ]
 conflicts: [
   "ppx_driver" {= "v0.9.1"}

--- a/packages/key-parsers/key-parsers.0.10.1/opam
+++ b/packages/key-parsers/key-parsers.0.10.1/opam
@@ -13,7 +13,7 @@ run-test: [
 ]
 depends: [
   "asn1-combinators" {>= "0.2.0"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "6.0.0"}
   "dune"
   "hex" {>= "1.0.0"}
   "ocaml" {>= "4.04.1"}

--- a/packages/key-parsers/key-parsers.0.9.2/opam
+++ b/packages/key-parsers/key-parsers.0.9.2/opam
@@ -19,7 +19,7 @@ depends: [
   "result" {>= "1.2"}
   "topkg" {build}
   "ppx_bin_prot" {< "v0.15"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "6.0.0"}
 ]
 conflicts: [
   "ppx_driver" {= "v0.9.1"}


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/17299

cc @eXenon