### PR TITLE
mirage-solo5 0.6.3

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.6.3/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.6.3/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.0.0"}
+  "bheap" {>= "2.0.0"}
+  "ocaml" {>= "4.06.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "ocaml-freestanding" {>= "0.4.5"}
+  "metrics"
+  "mirage-runtime" {>= "3.7.0"}
+  "duration"
+  ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"})
+]
+conflicts: [
+  "io-page" {< "2.0.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+x-commit-hash: "0243e470092c75825ffbd2f8588a92761faeeeee"
+url {
+  src:
+    "https://github.com/mirage/mirage-solo5/releases/download/v0.6.3/mirage-solo5-v0.6.3.tbz"
+  checksum: [
+    "sha256=09aa28b855d9765050c5d41cd76417b540a0381be96ab5bd06d2d9f6cad2a24f"
+    "sha512=c9b7ff959d2c1888da38522b168fef1176589fabaa38b716cba468886573b8886eec718078eddbddf93db17328446e104997e695a5f954ffe99c54b090141c51"
+  ]
+}


### PR DESCRIPTION
Mainly update to bheap >= 2.0.0 API, plus a few other changes.

/cc @hannesm