### PR TITLE
torch.0.1 is not compatible with imagelib >= 20200929 (API change)

### DIFF
--- a/packages/torch/torch.0.1/opam
+++ b/packages/torch/torch.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
   "dune-configurator"
-  "imagelib"
+  "imagelib" {< "20200929"}
   "libtorch" {< "1.1.0"}
   "npy"
   "ocaml" {>= "4.06"}


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/17314