### PR TITLE
tldr.0.3.0: Add missing dependencies

### DIFF
--- a/packages/tldr/tldr.0.3.0/opam
+++ b/packages/tldr/tldr.0.3.0/opam
@@ -11,6 +11,8 @@ depends: [
   "lwt_ssl"
   "ANSITerminal"
   "angstrom" {>= "0.14.0"}
+  "stdio"
+  "cmdliner"
 ]
 conflicts: [
   "ssl" {= "0.5.6"}


### PR DESCRIPTION
Fixes issue detected in https://github.com/ocaml/opam-repository/pull/17316