### PR TITLE
Add post-message when installing Camlp5 on MacOS and BSD

### DIFF
--- a/packages/camlp5/camlp5.8.00~alpha01/opam
+++ b/packages/camlp5/camlp5.8.00~alpha01/opam
@@ -45,6 +45,11 @@ build: [
   [make "world.opt"]
 ]
 install: [make "install"]
+
+post-messages:
+  "To use mkcamlp5 and mkcamlp5.opt properly you will require Perl module which contains 'IPC/System/Simple.pm'. We currently don't know the right way to specify this dependecy on BSD and MacOS systems. You can use https://github.com/camlp5/camlp5/issues/66 for discussion."
+    { os = "macos" | os = "freebsd" | os = "openbsd" }
+
 url {
   src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha01.tar.gz"
   checksum: [

--- a/packages/camlp5/camlp5.8.00~alpha02/opam
+++ b/packages/camlp5/camlp5.8.00~alpha02/opam
@@ -37,6 +37,11 @@ install: [make "install"]
 depexts:
   ["libstring-shellquote-perl" "libipc-system-simple-perl"]
     {os-family = "debian"}
+
+post-messages:
+  "To use mkcamlp5 and mkcamlp5.opt properly you will require Perl module which contains 'IPC/System/Simple.pm'. We currently don't know the right way to specify this dependecy on BSD and MacOS systems. You can use https://github.com/camlp5/camlp5/issues/66 for discussion."
+    { os = "macos" | os = "freebsd" | os = "openbsd" }
+
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha02.tar.gz"

--- a/packages/camlp5/camlp5.8.00~alpha03/opam
+++ b/packages/camlp5/camlp5.8.00~alpha03/opam
@@ -57,6 +57,10 @@ depexts: [
   ] {os-family = "fedora"}
 ]
 
+post-messages:
+  "To use mkcamlp5 and mkcamlp5.opt properly you will require Perl module which contains 'IPC/System/Simple.pm'. We currently don't know the right way to specify this dependecy on BSD and MacOS systems. You can use https://github.com/camlp5/camlp5/issues/66 for discussion."
+    { os = "macos" | os = "freebsd" | os = "openbsd" }
+
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha03.tar.gz"

--- a/packages/camlp5/camlp5.8.00~alpha04/opam
+++ b/packages/camlp5/camlp5.8.00~alpha04/opam
@@ -61,6 +61,10 @@ depexts: [
   ] {os-family = "fedora"}
 ]
 
+post-messages:
+  "To use mkcamlp5 and mkcamlp5.opt properly you will require Perl module which contains 'IPC/System/Simple.pm'. We currently don't know the right way to specify this dependecy on BSD and MacOS systems. You can use https://github.com/camlp5/camlp5/issues/66 for discussion."
+    { os = "macos" | os = "freebsd" | os = "openbsd" }
+
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha04.tar.gz"

--- a/packages/camlp5/camlp5.8.00~alpha05/opam
+++ b/packages/camlp5/camlp5.8.00~alpha05/opam
@@ -61,6 +61,10 @@ depexts: [
   ] {os-family = "fedora"}
 ]
 
+post-messages:
+  "To use mkcamlp5 and mkcamlp5.opt properly you will require Perl module which contains 'IPC/System/Simple.pm'. We currently don't know the right way to specify this dependecy on BSD and MacOS systems. You can use https://github.com/camlp5/camlp5/issues/66 for discussion."
+    { os = "macos" | os = "freebsd" | os = "openbsd" }
+
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha05.tar.gz"


### PR DESCRIPTION
This is a split of PR https://github.com/ocaml/opam-repository/pull/17285 to speedup CI

Ready to review.