### PR TITLE
Package inferno.20201001

### DIFF
--- a/packages/inferno/inferno.20201001/opam
+++ b/packages/inferno/inferno.20201001/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/inferno"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/inferno.git"
+bug-reports: "francois.pottier@inria.fr"
+license: "MIT"
+synopsis: "A library for constraint-based Hindley-Milner type inference"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.02.3" }
+  "dune"  { >= "1.11" }
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/inferno/repository/20201001/archive.tar.gz"
+  checksum: [
+    "md5=c669a9084bcd34c8f557b87f1a3c7d85"
+    "sha512=548d1d332e8ab4e0bdd2f9b922c2389b59ed5657bf9ad57b652d1ca4fdf6bf83cebcc0ecec3475d1b1ab44c2fc5d2adbaa618ed5a7c0427dc9798f1167229e12"
+  ]
+}


### PR DESCRIPTION
### `inferno.20201001`
A library for constraint-based Hindley-Milner type inference



---
* Homepage: https://gitlab.inria.fr/fpottier/inferno
* Source repo: git+https://gitlab.inria.fr/fpottier/inferno.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.2