### PR TITLE
Package apronext.1.0.1

### DIFF
--- a/packages/apronext/apronext.1.0.1/opam
+++ b/packages/apronext/apronext.1.0.1/opam
@@ -19,9 +19,9 @@ depends: [
 synopsis: "Apron extension"
 description: "An extension for the OCaml interface of the Apron library"
 url {
-  src: "https://github.com/ghilesZ/apronext/archive/v1.0.1.tar.gz"
+  src: "https://github.com/ghilesZ/apronext/archive/1.0.2.tar.gz"
   checksum: [
-    "md5=5c4bdc7252d4dccb5c7e710bed7fb179"
-    "sha512=f2979caef4d96036dfadff286655110adde19473dc3df6eee39c62f859e4f826ebcd1e6f1644bd8a1ca7877bba00e4e2f0ea63329b0ace48254f9d89ffcc4646"
+    "md5=08a7ec1011ea74662b6fde63860c3b38"
+    "sha512=3b5dc6735b90bed59b8eaa9d5a4fb0bf0117bd61744467e89fd9a03f80bc538ebe7672e78adbf3d5223130470aba76abbc22a41d422b6bfe69ff55e34aeae14a"
   ]
 }


### PR DESCRIPTION
### `apronext.1.0.1`
Apron extension
An extension for the OCaml interface of the Apron library



---
* Homepage: https://github.com/ghilesZ/apronext
* Source repo: git+https://github.com/ghilesZ/apronext
* Bug tracker: https://github.com/ghilesZ/apronext/issues

---
:camel: Pull-request generated by opam-publish v2.0.2