### PR TITLE
Package apronext.1.0.2

### DIFF
--- a/packages/apronext/apronext.1.0.2/opam
+++ b/packages/apronext/apronext.1.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Ghiles Ziat <ghiles.ziat@isae-supaero.fr"
+authors: ["Ghiles Ziat <ghiles.ziat@isae-supaero.fr"]
+homepage: "https://github.com/ghilesZ/apronext"
+bug-reports: "https://github.com/ghilesZ/apronext/issues"
+dev-repo: "git+https://github.com/ghilesZ/apronext"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "dune"  {>= "2.1"}
+  "ocaml" {>= "4.08"}
+  "apron"
+]
+synopsis: "Apron extension"
+description: "An extension for the OCaml interface of the Apron library"
+url {
+  src: "https://github.com/ghilesZ/apronext/archive/1.0.2.tar.gz"
+  checksum: [
+    "md5=93a1e54a22953d299390b0d06132bec7"
+    "sha512=2228f14542cae71d624a1966619db708e20ea1711c01ab98a5dd69b2ebc51516f00d5143cf2644b67699a60400969de1c7973f846750228e5cf62b14098e01f7"
+  ]
+}


### PR DESCRIPTION
### `apronext.1.0.2`
Apron extension
An extension for the OCaml interface of the Apron library



---
* Homepage: https://github.com/ghilesZ/apronext
* Source repo: git+https://github.com/ghilesZ/apronext
* Bug tracker: https://github.com/ghilesZ/apronext/issues

---
:camel: Pull-request generated by opam-publish v2.0.2