### PR TITLE
Fix to compile ocaml 4.07.1 on Xcode 12

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/files/configure-xcode12.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/files/configure-xcode12.patch
@@ -1,0 +1,25 @@
+diff --git a/configure b/configure
+index 1316b3c1e..052a20876 100755
+--- a/configure
++++ b/configure
+@@ -454,8 +454,11 @@ case "$ocamlversion" in
+        *) gcc_warnings="-Wall";;
+ esac
+ 
++origcc="$cc"
++
+ case "$ccfamily" in
+   clang-*)
++    cc="$cc -Wno-implicit-function-declaration";
+     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
+     internal_cflags="$gcc_warnings";;
+   gcc-[012]-*)
+@@ -2054,7 +2057,7 @@ fi
+ 
+ cclibs="$cclibs $mathlib"
+ 
+-config CC "$cc"
++config CC "$origcc"
+ config CPP "$cpp"
+ config CFLAGS "$common_cflags $internal_cflags"
+ config CPPFLAGS "$common_cppflags $internal_cppflags"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -41,4 +41,5 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch" "configure-xcode12.patch"]
-extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"]
+               "configure-xcode12.patch" ]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -40,5 +40,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
+patches: ["fix-gcc10.patch" "configure-xcode12"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -40,5 +40,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "configure-xcode12"]
+patches: ["fix-gcc10.patch" "configure-xcode12.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -41,5 +41,7 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch" "configure-xcode12.patch"]
-extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"]
-               "configure-xcode12.patch" ]
+extra-files: [
+  ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"]
+  ["configure-xcode12.patch" "md5=0aa6e37da38842f0974c032510ab8b1e"]
+]


### PR DESCRIPTION
Following a discussion at [Discuss](https://discuss.ocaml.org/t/ocaml-4-07-1-fails-to-build-with-apple-xcode-12/6441/20), here is a PR that allows to configure and compile ocaml-4.07.1 on recent MacOS.
Note that `-Wno-implicit-function-declaration` is only used during configuration.