### PR TITLE
[new release] ocamlgraph_gtk and ocamlgraph (2.0.0)

### DIFF
--- a/packages/dose3/dose3.5.0.1/opam
+++ b/packages/dose3/dose3.5.0.1/opam
@@ -26,7 +26,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "ocamlgraph" {>= "1.8.6"}
+  "ocamlgraph" {>= "1.8.6" & <= "1.8.8"}
   "cudf" {>= "0.7"}
   "conf-perl" {build}
   ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})

--- a/packages/dose3/dose3.5.0.1/opam
+++ b/packages/dose3/dose3.5.0.1/opam
@@ -26,7 +26,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "ocamlgraph" {>= "1.8.6" & <= "1.8.8"}
+  "ocamlgraph" {>= "1.8.6" & < "2.0.0"}
   "cudf" {>= "0.7"}
   "conf-perl" {build}
   ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})

--- a/packages/llvmgraph/llvmgraph.0.2/opam
+++ b/packages/llvmgraph/llvmgraph.0.2/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
   "llvm" {>= "3.6"}
-  "ocamlgraph" {>= "1.8.5"}
+  "ocamlgraph" {>= "1.8.5" & <= "1.8.8"}
   "ocamlbuild" {build}
   "conf-clang" {with-test}
 ]

--- a/packages/llvmgraph/llvmgraph.0.2/opam
+++ b/packages/llvmgraph/llvmgraph.0.2/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
   "llvm" {>= "3.6"}
-  "ocamlgraph" {>= "1.8.5" & <= "1.8.8"}
+  "ocamlgraph" {>= "1.8.5" & < "2.0.0"}
   "ocamlbuild" {build}
   "conf-clang" {with-test}
 ]

--- a/packages/not-ocamlfind/not-ocamlfind.0.07/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.07/opam
@@ -13,7 +13,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "sexplib" {>= "v0.13.0"}
   "rresult" {>= "0.6.0"}
-  "ocamlgraph" {= "1.8.8"}
+  "ocamlgraph" {>= "1.8.8" & < "2.0.0"}
 ]
 depexts: [
   [

--- a/packages/not-ocamlfind/not-ocamlfind.0.07/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.07/opam
@@ -13,7 +13,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "sexplib" {>= "v0.13.0"}
   "rresult" {>= "0.6.0"}
-  "ocamlgraph" {>= "1.8.8"}
+  "ocamlgraph" {= "1.8.8"}
 ]
 depexts: [
   [

--- a/packages/ocamlgraph/ocamlgraph.2.0.0/opam
+++ b/packages/ocamlgraph/ocamlgraph.2.0.0/opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/backtracking/ocamlgraph/issues/new"
 depends: [
   "ocaml" {>= "4.03.0"}
   "stdlib-shims"
-  "dune" {>= "2.0"}
+  "dune" {>= "2.0" & !with-test | >= "2.8"}
   "graphics" {with-test}
 ]
 build: [

--- a/packages/ocamlgraph/ocamlgraph.2.0.0/opam
+++ b/packages/ocamlgraph/ocamlgraph.2.0.0/opam
@@ -20,6 +20,7 @@ depends: [
   "ocaml"
   "stdlib-shims"
   "dune" {>= "2.0"}
+  "graphics" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/ocamlgraph/ocamlgraph.2.0.0/opam
+++ b/packages/ocamlgraph/ocamlgraph.2.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "A generic graph library for OCaml"
+description: "Provides both graph data structures and graph algorithms"
+maintainer: ["filliatr@lri.fr"]
+authors: ["Sylvain Conchon" "Jean-Christophe Filliâtre" "Julien Signoles"]
+license: "LGPL-2.1-only"
+tags: [
+  "graph"
+  "library"
+  "algorithms"
+  "directed graph"
+  "vertice"
+  "edge"
+  "persistent"
+  "imperative"
+]
+homepage: "https://github.com/backtracking/ocamlgraph/"
+bug-reports: "https://github.com/backtracking/ocamlgraph/issues/new"
+depends: [
+  "ocaml"
+  "stdlib-shims"
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
+x-commit-hash: "f97d342db06ccdbc11354303b5f225ae433f7ef3"
+url {
+  src:
+    "https://github.com/backtracking/ocamlgraph/releases/download/2.0.0/ocamlgraph-2.0.0.tbz"
+  checksum: [
+    "sha256=20fe267797de5322088a4dfb52389b2ea051787952a8a4f6ed70fcb697482609"
+    "sha512=c4973ac03bdff52d1c8a1ed01c81e0fbe2f76486995e57ff4e4a11bcc7b1793556139d52a81ff14ee8c8de52f1b40e4bd359e60a2ae626cc630ebe8bccefb3f1"
+  ]
+}

--- a/packages/ocamlgraph/ocamlgraph.2.0.0/opam
+++ b/packages/ocamlgraph/ocamlgraph.2.0.0/opam
@@ -17,7 +17,7 @@ tags: [
 homepage: "https://github.com/backtracking/ocamlgraph/"
 bug-reports: "https://github.com/backtracking/ocamlgraph/issues/new"
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.03.0"}
   "stdlib-shims"
   "dune" {>= "2.0"}
   "graphics" {with-test}

--- a/packages/ocamlgraph_gtk/ocamlgraph_gtk.2.0.0/opam
+++ b/packages/ocamlgraph_gtk/ocamlgraph_gtk.2.0.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Displaying graphs using OCamlGraph and GTK"
+description: "Displaying graphs using OCamlGraph and GTK"
+maintainer: ["filliatr@lri.fr"]
+authors: ["Sylvain Conchon" "Jean-Christophe Filliâtre" "Julien Signoles"]
+license: "LGPL-2.1-only"
+tags: [
+  "graph"
+  "library"
+  "algorithms"
+  "directed graph"
+  "vertice"
+  "edge"
+  "persistent"
+  "imperative"
+]
+homepage: "https://github.com/backtracking/ocamlgraph/"
+bug-reports: "https://github.com/backtracking/ocamlgraph/issues/new"
+depends: [
+  "ocaml"
+  "stdlib-shims"
+  "lablgtk"
+  "conf-gnomecanvas"
+  "ocamlgraph"
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
+x-commit-hash: "f97d342db06ccdbc11354303b5f225ae433f7ef3"
+url {
+  src:
+    "https://github.com/backtracking/ocamlgraph/releases/download/2.0.0/ocamlgraph-2.0.0.tbz"
+  checksum: [
+    "sha256=20fe267797de5322088a4dfb52389b2ea051787952a8a4f6ed70fcb697482609"
+    "sha512=c4973ac03bdff52d1c8a1ed01c81e0fbe2f76486995e57ff4e4a11bcc7b1793556139d52a81ff14ee8c8de52f1b40e4bd359e60a2ae626cc630ebe8bccefb3f1"
+  ]
+}

--- a/packages/ocamlgraph_gtk/ocamlgraph_gtk.2.0.0/opam
+++ b/packages/ocamlgraph_gtk/ocamlgraph_gtk.2.0.0/opam
@@ -23,6 +23,7 @@ depends: [
   "conf-gnomecanvas"
   "ocamlgraph"
   "dune" {>= "2.0"}
+  "graphics" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/ocamlgraph_gtk/ocamlgraph_gtk.2.0.0/opam
+++ b/packages/ocamlgraph_gtk/ocamlgraph_gtk.2.0.0/opam
@@ -17,7 +17,7 @@ tags: [
 homepage: "https://github.com/backtracking/ocamlgraph/"
 bug-reports: "https://github.com/backtracking/ocamlgraph/issues/new"
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.03.0"}
   "stdlib-shims"
   "lablgtk"
   "conf-gnomecanvas"

--- a/packages/ocamlgraph_gtk/ocamlgraph_gtk.2.0.0/opam
+++ b/packages/ocamlgraph_gtk/ocamlgraph_gtk.2.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lablgtk"
   "conf-gnomecanvas"
   "ocamlgraph"
-  "dune" {>= "2.0"}
+  "dune" {>= "2.0" & !with-test | >= "2.8"}
   "graphics" {with-test}
 ]
 build: [

--- a/packages/opam-lib/opam-lib.1.3.1/opam
+++ b/packages/opam-lib/opam-lib.1.3.1/opam
@@ -20,7 +20,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "ocamlgraph" {<= "1.8.8"}
+  "ocamlgraph" {< "2.0.0"}
   "cmdliner"
   "dose3" {>= "5.0"}
   "cudf"

--- a/packages/opam-lib/opam-lib.1.3.1/opam
+++ b/packages/opam-lib/opam-lib.1.3.1/opam
@@ -20,7 +20,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "ocamlgraph"
+  "ocamlgraph" {<= "1.8.8"}
   "cmdliner"
   "dose3" {>= "5.0"}
   "cudf"

--- a/packages/why3/why3.1.2.1/opam
+++ b/packages/why3/why3.1.2.1/opam
@@ -49,7 +49,7 @@ depends: [
 depopts: [
   "zarith"
   "camlzip"
-  "ocamlgraph"
+  "ocamlgraph" {< "1.8.8"}
 ]
 
 conflicts: [


### PR DESCRIPTION
CHANGES:

- port to dune and opam 2.0
  - :exclamation: opam package now split into two packages: ocamlgraph and ocamlgraph_gtk
  - [WeakTopological] fixed incorrect use of generic hash tables
    (backtracking/ocamlgraph#99, Tomáš Dacík)
  - [Oper] fixed transitive_reduction (backtracking/ocamlgraph#91)
  - fix incorrect uses of polymorphic equality (Steffen Smolka, Boris Yakobowski)
  - [Coloring] fixed generation of OCamlDoc documentation
    (contributed by Earnestly)
  - :exclamation: [Coloring] functions now fail if the graph is directed
  - :exclamation: [Coloring] now uses a single, global exception [NoColoring]
  - [Coloring] new function two_color to 2-color a graph (or fail)
  - :exclamation: [Fixpoint] Take initial labeling of nodes into account (Johannes Kloos)