### PR TITLE
[new release] rpclib-html, rpclib-async, rpclib, rpc, rpclib-lwt, ppx_deriving_rpc and rpclib-js (7.2.0)

### DIFF
--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.7.2.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.7.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for ocaml-rpc, a library to deal with RPCs in OCaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/ppx_deriving_rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "2.0.0"}
+  "rpclib" {= version}
+  "rresult"
+  "ppxlib" {>= "0.9.0"}
+  "base" {>= "v0.11.0"}
+  "lwt" {with-test & >= "3.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+x-commit-hash: "8bc02c451d79ead719875d0c69d7e22dd2dbf9a6"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.2.0/rpclib-v7.2.0.tbz"
+  checksum: [
+    "sha256=e9858041fc03149f7be060a9cd09b92f68aae7527efb0b15ae8da1650e02273a"
+    "sha512=903163d208ed7cfc53b6f90e51abd8d9504f488a0b8b2171244306590c9f25f7f2afee967ba077f1d340c20a97df4e33a454b83fd6413d2478412f9b03fb7434"
+  ]
+}

--- a/packages/rpc/rpc.7.2.0/opam
+++ b/packages/rpc/rpc.7.2.0/opam
@@ -17,7 +17,6 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-    ["dune" "runtest" "-p" name] {with-test}
     ["dune" "build" "@doc"] {with-doc}
 ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"

--- a/packages/rpc/rpc.7.2.0/opam
+++ b/packages/rpc/rpc.7.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - meta-package"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project" "deprecated"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "2.0.0"}
+  "rpclib" {=version}
+  "rpclib-lwt" {=version}
+  "ppx_deriving_rpc" {=version}
+  "alcotest" {with-test}
+  # "md2mld" {(with-doc | with-test) & >= "0.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc"] {with-doc}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+
+This is a dummy package installing the main library components.
+"""
+post-messages: ["DEPRECATED. This package is a virtual package and is outdated, you should consider using directly rpclib, rpclib-lwt, rpclib-async and ppx_deriving_rpc instead"]
+x-commit-hash: "8bc02c451d79ead719875d0c69d7e22dd2dbf9a6"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.2.0/rpclib-v7.2.0.tbz"
+  checksum: [
+    "sha256=e9858041fc03149f7be060a9cd09b92f68aae7527efb0b15ae8da1650e02273a"
+    "sha512=903163d208ed7cfc53b6f90e51abd8d9504f488a0b8b2171244306590c9f25f7f2afee967ba077f1d340c20a97df4e33a454b83fd6413d2478412f9b03fb7434"
+  ]
+}

--- a/packages/rpclib-async/rpclib-async.7.2.0/opam
+++ b/packages/rpclib-async/rpclib-async.7.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Async interface"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-async"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune" {>= "2.0.0"}
+  "rpclib" {=version}
+  "async" {>= "v0.9.0"}
+  "ppx_deriving_rpc" {with-test & =version}
+]
+conflicts: [
+  "core" {< "v0.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+x-commit-hash: "8bc02c451d79ead719875d0c69d7e22dd2dbf9a6"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.2.0/rpclib-v7.2.0.tbz"
+  checksum: [
+    "sha256=e9858041fc03149f7be060a9cd09b92f68aae7527efb0b15ae8da1650e02273a"
+    "sha512=903163d208ed7cfc53b6f90e51abd8d9504f488a0b8b2171244306590c9f25f7f2afee967ba077f1d340c20a97df4e33a454b83fd6413d2478412f9b03fb7434"
+  ]
+}

--- a/packages/rpclib-html/rpclib-html.7.2.0/opam
+++ b/packages/rpclib-html/rpclib-html.7.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis:
+  "A library to deal with RPCs in OCaml - html documentation generator"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-html"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "2.0.0"}
+  "rpclib" {=version}
+  "cow"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+x-commit-hash: "8bc02c451d79ead719875d0c69d7e22dd2dbf9a6"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.2.0/rpclib-v7.2.0.tbz"
+  checksum: [
+    "sha256=e9858041fc03149f7be060a9cd09b92f68aae7527efb0b15ae8da1650e02273a"
+    "sha512=903163d208ed7cfc53b6f90e51abd8d9504f488a0b8b2171244306590c9f25f7f2afee967ba077f1d340c20a97df4e33a454b83fd6413d2478412f9b03fb7434"
+  ]
+}

--- a/packages/rpclib-js/rpclib-js.7.2.0/opam
+++ b/packages/rpclib-js/rpclib-js.7.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Bindings for js_of_ocaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-js"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "2.0.0"}
+  "rpclib" {=version}
+  "js_of_ocaml" {>= "3.5.0"}
+  "js_of_ocaml-ppx" {>= "3.5.0"}
+  "lwt"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+x-commit-hash: "8bc02c451d79ead719875d0c69d7e22dd2dbf9a6"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.2.0/rpclib-v7.2.0.tbz"
+  checksum: [
+    "sha256=e9858041fc03149f7be060a9cd09b92f68aae7527efb0b15ae8da1650e02273a"
+    "sha512=903163d208ed7cfc53b6f90e51abd8d9504f488a0b8b2171244306590c9f25f7f2afee967ba077f1d340c20a97df4e33a454b83fd6413d2478412f9b03fb7434"
+  ]
+}

--- a/packages/rpclib-lwt/rpclib-lwt.7.2.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.7.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Lwt interface"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-lwt"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune" {>= "2.0.0"}
+  "rpclib" {=version}
+  "lwt" {>= "3.0.0"}
+  "alcotest-lwt" {with-test}
+  "ppx_deriving_rpc" {with-test & =version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+x-commit-hash: "8bc02c451d79ead719875d0c69d7e22dd2dbf9a6"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.2.0/rpclib-v7.2.0.tbz"
+  checksum: [
+    "sha256=e9858041fc03149f7be060a9cd09b92f68aae7527efb0b15ae8da1650e02273a"
+    "sha512=903163d208ed7cfc53b6f90e51abd8d9504f488a0b8b2171244306590c9f25f7f2afee967ba077f1d340c20a97df4e33a454b83fd6413d2478412f9b03fb7434"
+  ]
+}

--- a/packages/rpclib/rpclib.7.2.0/opam
+++ b/packages/rpclib/rpclib.7.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "alcotest" {with-test}
+  "dune" {>= "2.0.0"}
+  "base64" {>= "3.4.0"}
+  "cmdliner"
+  "rresult"
+  "xmlm"
+  "yojson" {>= "1.7.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+x-commit-hash: "8bc02c451d79ead719875d0c69d7e22dd2dbf9a6"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v7.2.0/rpclib-v7.2.0.tbz"
+  checksum: [
+    "sha256=e9858041fc03149f7be060a9cd09b92f68aae7527efb0b15ae8da1650e02273a"
+    "sha512=903163d208ed7cfc53b6f90e51abd8d9504f488a0b8b2171244306590c9f25f7f2afee967ba077f1d340c20a97df4e33a454b83fd6413d2478412f9b03fb7434"
+  ]
+}


### PR DESCRIPTION
A library to deal with RPCs in OCaml - html documentation generator

- Project page: <a href="https://github.com/mirage/ocaml-rpc">https://github.com/mirage/ocaml-rpc</a>
- Documentation: <a href="https://mirage.github.io/ocaml-rpc/rpclib">https://mirage.github.io/ocaml-rpc/rpclib</a>

##### CHANGES:

* ppx_deriving_rpc: fix a transitive dep on base to enable support for recent ppxlib
