### PR TITLE
[new release] clangml.4.3.0

### DIFF
--- a/packages/clangml/clangml.4.3.0/opam
+++ b/packages/clangml/clangml.4.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Clang API"
+description: """
+clangml provides bindings to call the Clang API from OCaml.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://memcad.gitlabpages.inria.fr/clangml/"
+doc: "https://memcad.gitlabpages.inria.fr/clangml/doc/clangml/index.html"
+bug-reports: "https://gitlab.inria.fr/memcad/clangml/issues"
+depends: [
+  "conf-libclang"
+  "conf-ncurses"
+  "conf-zlib"
+  "dune" {>= "1.11.0"}
+  "stdcompat" {>= "13"}
+  "ocaml" {>= "4.08.0" & < "4.12.0"}
+  "ocamlfind" {build & >= "1.8.0"}
+  "ocamlcodoc" {with-test & >= "1.0.1"}
+  "pattern" {with-test & >= "0.2.0"}
+  "metapp" {>= "0.3.0"}
+  "metaquot" {>= "0.3.0"}
+  "refl" {>= "0.3.0"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%"]
+  ["dune" "build" "-p" name "-j" jobs "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}]]
+url {
+  src: "https://gitlab.inria.fr/memcad/clangml/-/archive/v4.3.0/clangml-v4.3.0.tar.gz"
+  checksum: "sha512=0f3f1d4f858c9b2752ecc651b0bde378df1a8a675e4c2d8788324a32b4fe4f218e7ed156418cf4cd7e787f3e66bc52876254a3ad7fcf8e0c08d0c176c2eae67b"
+}


### PR DESCRIPTION
This PR publishes the new release clangml.4.3.0:

- Port to ppxlib 0.16 / ocaml-migrate-parsetree 2.0.0

- Support for Clang/LLVM 11.0.0

- New module `Clang.Cursor`, exposing the signature
  `Hashtbl.HashedType with type t = cxcursor`
  and `Clang.Cursor.Hashtbl`.

- New function `Clang.Decl.annotate_access_specifier`, to enumerate
  class fields with their access specifiers.

- Fix segmentation fault when parsing the redeclaration of a function decl
  without prototype when the previous declarations has some parameters.
  (reported by Kihong Heo)

- New field `has_written_prototype` in `function_decl` to distinguish
  between function declarations where the prototype is actually provided
  and declarations where the prototype is inherited.
