### PR TITLE
Declare package cache in git-controlled repo file

### DIFF
--- a/repo
+++ b/repo
@@ -1,3 +1,4 @@
 opam-version: "2.0"
-browse: "https://opam.ocaml.org/pkg/"
+browse: "https://opam.ocaml.org/packages/"
 upstream: "https://github.com/ocaml/opam-repository/tree/master/"
+archive-mirrors: "https://opam.ocaml.org/cache"


### PR DESCRIPTION
The repository served over HTTP has it enabled anyway (enabled by
opam-admin), but we want clients to use the cache even when they use the
git repository directly.

NOTE: the repository scripts will need to be updated ASAP after this
is merged, to avoid a double-definition of the repository cache.