### PR TITLE
[new release] spin (0.7.0)

### DIFF
--- a/packages/spin/spin.0.7.0/opam
+++ b/packages/spin/spin.0.7.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "A project generator for Reason and OCaml"
+description: """
+A project generator for Reason and OCaml
+"""
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/tmattio/spin"
+doc: "https://tmattio.github.io/spin/"
+bug-reports: "https://github.com/tmattio/spin/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7" & >= "2.7"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "crunch" {build}
+  "base"
+  "fmt"
+  "fpath"
+  "cmdliner"
+  "logs"
+  "sexplib"
+  "lwt" {>= "5.3.0"}
+  "jingoo"
+  "inquire" {>= "0.2.1"}
+]
+dev-repo: "git+https://github.com/tmattio/spin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@test/runtest" {with-test}
+    "@test_bin/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "b259fd10d62536a9f993f793ef8735303ec3c16f"
+url {
+  src:
+    "https://github.com/tmattio/spin/releases/download/0.7.0/spin-0.7.0.tbz"
+  checksum: [
+    "sha256=d151cf6aee92c3b6f2d596b11b5d1ac2c75d554b681aa736b6293981344d062c"
+    "sha512=e80ec9d40eecace6684308960ea224b81ce6e2fc8e81201c99702d13b3d888b7f2de9379777c94719bf679ee6ed10e3a83668064bba36cf1121f1f6628539046"
+  ]
+}

--- a/packages/spin/spin.0.7.0/opam
+++ b/packages/spin/spin.0.7.0/opam
@@ -36,8 +36,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@test/runtest" {with-test}
-    "@test_bin/runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
A project generator for Reason and OCaml

- Project page: <a href="https://github.com/tmattio/spin">https://github.com/tmattio/spin</a>
- Documentation: <a href="https://tmattio.github.io/spin/">https://tmattio.github.io/spin/</a>

##### CHANGES:

## Added

- Added a new `spa` template to generate Single-Page-Application with Js_of_ocaml
- Dune's `--root` argument in templates' Makefiles to better compose generated projects
- The templates CI/CD is now caching Opam dependencies to improve build time
- The templates are now installing locked dependencies by default during CI/CD
- The Makefile of the templates include a small inlined python script to open the documentation with the default browser with the command `servedoc`

## Changed

- Removed the `bs-react` template from the official templates. The template now lives in [tmattio/spin-rescript](https://github.com/tmattio/spin-rescript).
- Removed dependency on Reason and use the generated project's Reason to convert `.ml` files to `.re`.

## Fixed

- Fixed NPM release by vendoring a Chamomille-free version of Inquire
- Remove wrong release flags from all templates
