### PR TITLE
graphics < 4.09: fix META file installation

### DIFF
--- a/packages/graphics/graphics.3.07+1/files/install.sh
+++ b/packages/graphics/graphics.3.07+1/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.07+1/opam
+++ b/packages/graphics/graphics.3.07+1/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.07+1"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=f6e58fde0430a780b9328f930fa23e34"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"

--- a/packages/graphics/graphics.3.07+2/files/install.sh
+++ b/packages/graphics/graphics.3.07+2/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.07+2/opam
+++ b/packages/graphics/graphics.3.07+2/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.07+2"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=1a7f3c4e05f1149a33cde0c99a825cf2"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"

--- a/packages/graphics/graphics.3.07/files/install.sh
+++ b/packages/graphics/graphics.3.07/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.07/opam
+++ b/packages/graphics/graphics.3.07/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.07"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=9eb0c8a52e8471b88e9e409a1c957e12"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"

--- a/packages/graphics/graphics.3.08.0/files/install.sh
+++ b/packages/graphics/graphics.3.08.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.08.0/opam
+++ b/packages/graphics/graphics.3.08.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.08.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=961fe5a2565659f760714aa612003e16"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.0.tar.gz"

--- a/packages/graphics/graphics.3.08.1/files/install.sh
+++ b/packages/graphics/graphics.3.08.1/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.08.1/opam
+++ b/packages/graphics/graphics.3.08.1/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.08.1"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=0d6d202f61796aa9508ac0311e57d945"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.1.tar.gz"

--- a/packages/graphics/graphics.3.08.2/files/install.sh
+++ b/packages/graphics/graphics.3.08.2/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.08.2/opam
+++ b/packages/graphics/graphics.3.08.2/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.08.2"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=2727e5311f1a49dd8d1f97a25b5919f7"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.2.tar.gz"

--- a/packages/graphics/graphics.3.08.3/files/install.sh
+++ b/packages/graphics/graphics.3.08.3/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.08.3/opam
+++ b/packages/graphics/graphics.3.08.3/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.08.3"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=b50edf3568bbaf94fa4c954dd6c19cb8"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.3.tar.gz"

--- a/packages/graphics/graphics.3.08.4/files/install.sh
+++ b/packages/graphics/graphics.3.08.4/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.08.4/opam
+++ b/packages/graphics/graphics.3.08.4/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.08.4"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=e6fef7b54d6a3369acd4a45320ba39ad"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.4.tar.gz"

--- a/packages/graphics/graphics.3.09.0/files/install.sh
+++ b/packages/graphics/graphics.3.09.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.09.0/opam
+++ b/packages/graphics/graphics.3.09.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.09.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=8d738ec6dfd11acca9d378d7a3e4f07b"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.0.tar.gz"

--- a/packages/graphics/graphics.3.09.1/files/install.sh
+++ b/packages/graphics/graphics.3.09.1/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.09.1/opam
+++ b/packages/graphics/graphics.3.09.1/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.09.1"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=69cd40daf367bb1a20087666dbf69bd7"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.1.tar.gz"

--- a/packages/graphics/graphics.3.09.2/files/install.sh
+++ b/packages/graphics/graphics.3.09.2/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.09.2/opam
+++ b/packages/graphics/graphics.3.09.2/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.09.2"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=0ce5b893ec778b7859a434771c4d1e02"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.2.tar.gz"

--- a/packages/graphics/graphics.3.09.3/files/install.sh
+++ b/packages/graphics/graphics.3.09.3/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.09.3/opam
+++ b/packages/graphics/graphics.3.09.3/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.09.3"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=86128bc99793cd2ee5fb7e135ccb83c2"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.3.tar.gz"

--- a/packages/graphics/graphics.3.10.0/files/install.sh
+++ b/packages/graphics/graphics.3.10.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.10.0/opam
+++ b/packages/graphics/graphics.3.10.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.10.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=ac0d96fd384df78a13a76c187176b31a"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.0.tar.gz"

--- a/packages/graphics/graphics.3.10.1/files/install.sh
+++ b/packages/graphics/graphics.3.10.1/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.10.1/opam
+++ b/packages/graphics/graphics.3.10.1/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.10.1"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=dc80f671a9f534fc1c71e1f0af2f466f"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.1.tar.gz"

--- a/packages/graphics/graphics.3.10.2/files/install.sh
+++ b/packages/graphics/graphics.3.10.2/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.10.2/opam
+++ b/packages/graphics/graphics.3.10.2/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.10.2"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=db69e7e01cb7736ead422c937e3bd57d"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.2.tar.gz"

--- a/packages/graphics/graphics.3.11.0/files/install.sh
+++ b/packages/graphics/graphics.3.11.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.11.0/opam
+++ b/packages/graphics/graphics.3.11.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.11.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=83f5a2b8be7e314379d26c4d51b9d32c"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.0.tar.gz"

--- a/packages/graphics/graphics.3.11.1/files/install.sh
+++ b/packages/graphics/graphics.3.11.1/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.11.1/opam
+++ b/packages/graphics/graphics.3.11.1/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.11.1"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=55f6343ff2de3907060679f0f31ec910"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.1.tar.gz"

--- a/packages/graphics/graphics.3.11.2/files/install.sh
+++ b/packages/graphics/graphics.3.11.2/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.11.2/opam
+++ b/packages/graphics/graphics.3.11.2/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.11.2"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=4703dbfd3b8aec0cabec32086a4e90dd"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.2.tar.gz"

--- a/packages/graphics/graphics.3.12.0/files/install.sh
+++ b/packages/graphics/graphics.3.12.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.12.0/opam
+++ b/packages/graphics/graphics.3.12.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.12.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=b1ca11d3ca48378167c67d197e8e6991"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.0.tar.gz"

--- a/packages/graphics/graphics.3.12.1/files/install.sh
+++ b/packages/graphics/graphics.3.12.1/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.3.12.1/opam
+++ b/packages/graphics/graphics.3.12.1/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "3.12.1"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=767c34b30a819f997086c71315a657d2"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1.tar.gz"

--- a/packages/graphics/graphics.4.00.0/files/install.sh
+++ b/packages/graphics/graphics.4.00.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.00.0/opam
+++ b/packages/graphics/graphics.4.00.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.00.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=54cd1e08d3a25fe63c4306da64cddf63"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.0.tar.gz"

--- a/packages/graphics/graphics.4.00.1/files/install.sh
+++ b/packages/graphics/graphics.4.00.1/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.00.1/opam
+++ b/packages/graphics/graphics.4.00.1/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.00.1"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=04e7e003625ce06386922aec2eafdd19"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"

--- a/packages/graphics/graphics.4.01.0/files/install.sh
+++ b/packages/graphics/graphics.4.01.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.01.0/opam
+++ b/packages/graphics/graphics.4.01.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.01.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=1974c4336a8f9c6157905c053b221eaf"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"

--- a/packages/graphics/graphics.4.02.0/files/install.sh
+++ b/packages/graphics/graphics.4.02.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.02.0/opam
+++ b/packages/graphics/graphics.4.02.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.02.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=8943881cd051666e6c307087643d4ada"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz"

--- a/packages/graphics/graphics.4.02.1/files/install.sh
+++ b/packages/graphics/graphics.4.02.1/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.02.1/opam
+++ b/packages/graphics/graphics.4.02.1/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.02.1"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=5c02a61527a7c0c40a98e5a7ae427ba0"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"

--- a/packages/graphics/graphics.4.02.2/files/install.sh
+++ b/packages/graphics/graphics.4.02.2/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.02.2/opam
+++ b/packages/graphics/graphics.4.02.2/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.02.2"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=77bc9f43ef46792d12f2a65f54b70e11"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.2.tar.gz"

--- a/packages/graphics/graphics.4.02.3/files/install.sh
+++ b/packages/graphics/graphics.4.02.3/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.02.3/opam
+++ b/packages/graphics/graphics.4.02.3/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.02.3"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=c74f9b314f88d8582643240aa453ee06"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"

--- a/packages/graphics/graphics.4.03.0/files/install.sh
+++ b/packages/graphics/graphics.4.03.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.03.0/opam
+++ b/packages/graphics/graphics.4.03.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.03.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=791555f7f4432e51c8290ff66733dfb2"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"

--- a/packages/graphics/graphics.4.04.0/files/install.sh
+++ b/packages/graphics/graphics.4.04.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.04.0/opam
+++ b/packages/graphics/graphics.4.04.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.04.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=95713ee345737b9da7718c292e6d6ef8"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"

--- a/packages/graphics/graphics.4.04.1/files/install.sh
+++ b/packages/graphics/graphics.4.04.1/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.04.1/opam
+++ b/packages/graphics/graphics.4.04.1/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.04.1"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=63a55d5f69cc6cc078e7ed72801dee3d"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"

--- a/packages/graphics/graphics.4.04.2/files/install.sh
+++ b/packages/graphics/graphics.4.04.2/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.04.2/opam
+++ b/packages/graphics/graphics.4.04.2/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.04.2"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=2c3de0f5eb1b86bba95718f8b001da99"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.04.2.tar.gz"

--- a/packages/graphics/graphics.4.05.0/files/install.sh
+++ b/packages/graphics/graphics.4.05.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.05.0/opam
+++ b/packages/graphics/graphics.4.05.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.05.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=398c8af98e1dfbf0d79f77064c9e9c3e"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.05.0.tar.gz"

--- a/packages/graphics/graphics.4.06.0/files/install.sh
+++ b/packages/graphics/graphics.4.06.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.06.0/opam
+++ b/packages/graphics/graphics.4.06.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.06.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=b7926af7a2d12f22444e75806fc7e4e9"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0.tar.gz"

--- a/packages/graphics/graphics.4.06.1/files/install.sh
+++ b/packages/graphics/graphics.4.06.1/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.06.1/opam
+++ b/packages/graphics/graphics.4.06.1/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.06.1"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=3eda975bdab4a82a6fe8311fa2df031a"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"

--- a/packages/graphics/graphics.4.07.0/files/install.sh
+++ b/packages/graphics/graphics.4.07.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.07.0/opam
+++ b/packages/graphics/graphics.4.07.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.07.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=317bad0da80f02a9993e6bd70d3328b1"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz"

--- a/packages/graphics/graphics.4.07.1/files/install.sh
+++ b/packages/graphics/graphics.4.07.1/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.07.1/opam
+++ b/packages/graphics/graphics.4.07.1/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.07.1"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=2f8f3f6c0a50ab148492b6c50d19c1eb"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz"

--- a/packages/graphics/graphics.4.08.0/files/install.sh
+++ b/packages/graphics/graphics.4.08.0/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.08.0/opam
+++ b/packages/graphics/graphics.4.08.0/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.08.0"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=69304ee69d8d2b4646fb50d01565c1c1"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz"

--- a/packages/graphics/graphics.4.08.1/files/install.sh
+++ b/packages/graphics/graphics.4.08.1/files/install.sh
@@ -79,11 +79,10 @@ if test "$1" = 'build' ; then
   # Build the library
   $6 -C otherlibs/graph CAMLC=ocamlc CAMLOPT=ocamlopt MKLIB=ocamlmklib all $7
 
-  # System compilers must always have META installed; this package is a depopt
-  # of ocamlfind, so it will be reinstalled if this package is added.
-  if $2 ; then
-    echo 'lib: ["META"]' >> graphics.install
+  if ! $2 ; then
+    echo 'directory = "^"' >> META
   fi
+  echo 'lib: ["META"]' >> graphics.install
 elif test -e otherlibs/graph/graphics.cmi ; then
   # $2 = 'true' or 'false' (ocaml:preinstalled)
   # $3 = value of make

--- a/packages/graphics/graphics.4.08.1/opam
+++ b/packages/graphics/graphics.4.08.1/opam
@@ -19,13 +19,14 @@ install: [
 depends: [
   "conf-libX11"
   "ocaml" {= "4.08.1"}
+  "ocamlfind"
 ]
 synopsis: "The OCaml graphics library"
 description:
   "Ensures that the OCaml graphics library is available, building it if needed."
 extra-files: [
   ["META" "md5=0acdebd9c25190fccb4646fca4296e0e"]
-  ["install.sh" "md5=bcdb668c9cbc2e5b58aef6e185a9a845"]
+  ["install.sh" "md5=aea58f6edbd1c17a091d666ba7dc0e19"]
   ["graphics.install" "md5=e9c9a65968f17cbee6407fe06ab7beff"]]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.08.1.tar.gz"

--- a/packages/ocamlfind/ocamlfind.1.3.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.1/opam
@@ -59,4 +59,3 @@ url {
   checksum: "md5=e632bad87f1c7be9414a6b754232ba01"
   mirrors: "http://download2.camlcity.org/download/findlib-1.3.1.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.3.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.2/opam
@@ -59,4 +59,3 @@ url {
   checksum: "md5=672e3a644015dda74daf89b7fcdec904"
   mirrors: "http://download2.camlcity.org/download/findlib-1.3.2.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.3.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.3.3/opam
@@ -62,4 +62,3 @@ url {
   checksum: "md5=a4c22ad5e0d38367a73cf58a25fcbebd"
   mirrors: "http://download2.camlcity.org/download/findlib-1.3.3.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.4.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.0/opam
@@ -60,4 +60,3 @@ url {
     "http://pkgs.fedoraproject.org/lookaside/extras/ocaml-findlib/findlib-1.4.tar.gz/5d1f8238c53964fdd14387b87b48b5d9/findlib-1.4.tar.gz"
   checksum: "md5=5d1f8238c53964fdd14387b87b48b5d9"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.4.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.4.1/opam
@@ -60,4 +60,3 @@ url {
   checksum: "md5=5d258142e9a7db98bb3553dbca739af8"
   mirrors: "http://download2.camlcity.org/download/findlib-1.4.1.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.5.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.1/opam
@@ -63,4 +63,3 @@ url {
   checksum: "md5=6bf0d0da66104bc8bdcb3018bd13a202"
   mirrors: "http://download2.camlcity.org/download/findlib-1.5.1.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.5.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.2/opam
@@ -62,4 +62,3 @@ url {
   checksum: "md5=b4939ea55f83e132794df17f8d176de9"
   mirrors: "http://download2.camlcity.org/download/findlib-1.5.2.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.5.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.3/opam
@@ -62,4 +62,3 @@ url {
   checksum: "md5=687b9dfee7d9d380d2eabe62bab67f09"
   mirrors: "http://download2.camlcity.org/download/findlib-1.5.3.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.5.4/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.4/opam
@@ -63,4 +63,3 @@ url {
   checksum: "md5=e18f7fa25b109a40412dd60858ecf6d5"
   mirrors: "http://download2.camlcity.org/download/findlib-1.5.4.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.5.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.5/opam
@@ -62,4 +62,3 @@ url {
   checksum: "md5=703eae112f9e912507c3a2f8d8c48498"
   mirrors: "http://download2.camlcity.org/download/findlib-1.5.5.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.5.6/opam
+++ b/packages/ocamlfind/ocamlfind.1.5.6/opam
@@ -62,4 +62,3 @@ url {
   checksum: "md5=91585dd5459cb69bfd9a0689bf222403"
   mirrors: "http://download2.camlcity.org/download/findlib-1.5.6.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.6.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.1/opam
@@ -62,4 +62,3 @@ url {
   checksum: "md5=50a900451dbaa67c6985a09c905f94a7"
   mirrors: "http://download2.camlcity.org/download/findlib-1.6.1.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.6.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.6.2/opam
@@ -69,4 +69,3 @@ url {
   mirrors:
     "http://gazagnaire.org/packages/ocamlfind.1.6.2/findlib-1.6.2.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.7.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.1/opam
@@ -67,4 +67,3 @@ url {
   src: "http://download.camlcity.org/download/findlib-1.7.1.tar.gz"
   checksum: "md5=108717618e724295d8a01c21ba3f7311"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.7.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.2/opam
@@ -67,4 +67,3 @@ url {
   checksum: "md5=b2ced422ea53192bd046faa7bcbcd4a3"
   mirrors: "http://download2.camlcity.org/download/findlib-1.7.2.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.7.3-1/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.3-1/opam
@@ -72,4 +72,3 @@ url {
   checksum: "md5=7d57451218359f7b7dfc969e3684a6da"
   mirrors: "http://download2.camlcity.org/download/findlib-1.7.3.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.7.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.7.3/opam
@@ -70,4 +70,3 @@ url {
   checksum: "md5=7d57451218359f7b7dfc969e3684a6da"
   mirrors: "http://download2.camlcity.org/download/findlib-1.7.3.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.8.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.8.0/opam
@@ -66,4 +66,3 @@ url {
   checksum: "md5=a710c559667672077a93d34eb6a42e5b"
   mirrors: "http://download2.camlcity.org/download/findlib-1.8.0.tar.gz"
 }
-depopts: ["graphics"]

--- a/packages/ocamlfind/ocamlfind.1.8.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.8.1/opam
@@ -47,4 +47,3 @@ url {
   checksum: "md5=18ca650982c15536616dea0e422cbd8c"
   mirrors: "http://download2.camlcity.org/download/findlib-1.8.1.tar.gz"
 }
-depopts: ["graphics"]


### PR DESCRIPTION
Fix issue detected in https://github.com/ocaml/opam-repository/pull/17344.

Currently the graphics package for OCaml < 4.09 does not always install a `META` file. Instead `ocamlfind` is used to install it. However this behaviour is surprising.

To fix the issue, I modified the `install.sh` script so that:
* when the graphics library is already preinstalled: the package already depends on ocamlfind which installs the META file in that case.
* when it is not preinstalled: the graphics package installs the `META` file with a link to the right `directory` pointing where it is installed (in `lib/ocaml` or in `lib/graphics`)

cc @dra27 

(I'll close this draft around midnight to avoid CI explosion with datakit-ci)