### PR TITLE
[new release] ppxlib (0.18.0)

### DIFF
--- a/packages/clim-ppx/clim-ppx.0.3.0/opam
+++ b/packages/clim-ppx/clim-ppx.0.3.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/Ninjapouet/clim/issues"
 depends: [
   "dune" {>= "2.7"}
   "clim" {= "0.3.0"}
-  "ppxlib" {>= "0.14.0"}
+  "ppxlib" {>= "0.14.0" & < "0.18.0"}
   "fmt" {>= "0.8.8"}
   "cmdliner" {>= "1.0.4"}
   "odoc" {with-doc}

--- a/packages/hardcaml/hardcaml.v0.14.0/opam
+++ b/packages/hardcaml/hardcaml.v0.14.0/opam
@@ -17,7 +17,7 @@ depends: [
   "stdio"            {>= "v0.14" & < "v0.15"}
   "topological_sort" {>= "v0.14" & < "v0.15"}
   "dune"             {>= "2.0.0"}
-  "ppxlib"           {>= "0.11.0"}
+  "ppxlib"           {>= "0.11.0" & < "0.18.0"}
   "zarith"           {>= "1.5"}
 ]
 synopsis: "RTL Hardware Design in OCaml"

--- a/packages/metapp/metapp.0.3.0/opam
+++ b/packages/metapp/metapp.0.3.0/opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0" & < "4.12.0"}
   "stdcompat" {>= "12"}
-  "ppxlib" {>= "0.16.0"}
+  "ppxlib" {>= "0.16.0" & < "0.18.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}
   "odoc" {with-doc & >= "1.5.1"}

--- a/packages/metaquot/metaquot.0.3.0/opam
+++ b/packages/metaquot/metaquot.0.3.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/thierry-martinez/metaquot"
 depends: [
   "ocaml" {>= "4.08.0" & < "4.12.0"}
   "stdcompat" {>= "12"}
-  "ppxlib" {>= "0.16.0"}
+  "ppxlib" {>= "0.16.0" & < "0.18.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}
   "metapp" {>= "0.3.0"}

--- a/packages/mlt_parser/mlt_parser.v0.14.0/opam
+++ b/packages/mlt_parser/mlt_parser.v0.14.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_expect"  {>= "v0.14" & < "v0.15"}
   "ppx_jane"    {>= "v0.14" & < "v0.15"}
   "dune"        {>= "2.0.0"}
-  "ppxlib"      {>= "0.11.0"}
+  "ppxlib"      {>= "0.11.0" & < "0.18.0"}
 ]
 synopsis: "Parsing of top-expect files"
 description: "

--- a/packages/ppx_bitstring/ppx_bitstring.4.0.0/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.4.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "bitstring" {>= "4.0.0"}
   "ocaml" {with-test & >= "4.08.0"}
-  "ppxlib" {build & >= "0.16.0"}
+  "ppxlib" {build & >= "0.16.0" & < "0.18.0"}
   "ounit" {with-test}
 ]
 build: [

--- a/packages/ppx_const/ppx_const.2.0/opam
+++ b/packages/ppx_const/ppx_const.2.0/opam
@@ -16,7 +16,7 @@ bug-reports: "https://github.com/mcclure/ppx_const/issues"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.04.0"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.18.0"}
   "ounit2" {with-test}
   "ppx_getenv" {with-test & >= "2.0"}
   "odoc" {with-doc}

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.13.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.13.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"          {>= "v0.13" & < "v0.14"}
   "ppx_sexp_conv" {>= "v0.13" & < "v0.14"}
   "dune"          {>= "1.5.1"}
-  "ppxlib"        {>= "0.9.0"}
+  "ppxlib"        {>= "0.9.0" & < "0.18.0"}
 ]
 synopsis: "Printf-style format-strings for user-defined string conversion"
 description: "

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.14.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.14.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"          {>= "v0.14" & < "v0.15"}
   "ppx_sexp_conv" {>= "v0.14" & < "v0.15"}
   "dune"          {>= "2.0.0"}
-  "ppxlib"        {>= "0.11.0"}
+  "ppxlib"        {>= "0.11.0" & < "0.18.0"}
 ]
 synopsis: "Printf-style format-strings for user-defined string conversion"
 description: "

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.7.2.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.7.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "rpclib" {= version}
   "rresult"
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.18.0"}
   "base" {>= "v0.11.0"}
   "lwt" {with-test & >= "3.0.0"}
   "alcotest" {with-test}

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.0.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "rpclib" {= version}
   "rresult"
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.18.0"}
   "lwt" {with-test & >= "3.0.0"}
   "alcotest" {with-test}
 ]

--- a/packages/ppx_expect/ppx_expect.v0.14.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.14.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_inline_test" {>= "v0.14" & < "v0.15"}
   "stdio"           {>= "v0.14" & < "v0.15"}
   "dune"            {>= "2.0.0"}
-  "ppxlib"          {>= "0.11.0"}
+  "ppxlib"          {>= "0.11.0" & < "0.18.0"}
   "re"              {>= "1.8.0"}
 ]
 synopsis: "Cram like framework for OCaml"

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.14.1/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.14.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base"      {>= "v0.14" & < "v0.15"}
   "fieldslib" {>= "v0.14" & < "v0.15"}
   "dune"      {>= "2.0.0"}
-  "ppxlib"    {>= "0.14.0"}
+  "ppxlib"    {>= "0.14.0" & < "0.18.0"}
 ]
 synopsis: "Generation of accessor and iteration functions for ocaml records"
 description: "

--- a/packages/ppx_getenv/ppx_getenv.2.0/opam
+++ b/packages/ppx_getenv/ppx_getenv.2.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ocaml-ppx/ppx_getenv/issues"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.04.0"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" < "0.18.0"}
   "ounit2" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/ppx_irmin/ppx_irmin.2.2.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.2.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "1.8.0"}
   "ocaml" {>= "4.06.0"}
   "ocaml-syntax-shims"
-  "ppxlib" {>= "0.12.0"}
+  "ppxlib" {>= "0.12.0" & < "0.18.0"}
   "irmin" {with-test & >= "2.0.0"}
 ]
 

--- a/packages/ppx_optcomp/ppx_optcomp.v0.13.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.13.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"   {>= "v0.13" & < "v0.14"}
   "stdio"  {>= "v0.13" & < "v0.14"}
   "dune"   {>= "1.5.1"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.18.0"}
 ]
 synopsis: "Optional compilation for OCaml"
 description: "

--- a/packages/ppx_optcomp/ppx_optcomp.v0.14.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.14.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"   {>= "v0.14" & < "v0.15"}
   "stdio"  {>= "v0.14" & < "v0.15"}
   "dune"   {>= "2.0.0"}
-  "ppxlib" {>= "0.11.0"}
+  "ppxlib" {>= "0.11.0" & < "0.18.0"}
 ]
 synopsis: "Optional compilation for OCaml"
 description: "

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.3/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.3/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.04"}
   "base" {>= "v0.14.0" }
   "dune" {>= "1.2"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.18.0"}
   "ppx_sexp_conv" {with-test}
   "sexplib" {with-test}
   "alcotest" {with-test & >= "0.8.0"}

--- a/packages/ppx_python/ppx_python.v0.13.0/opam
+++ b/packages/ppx_python/ppx_python.v0.13.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"     {>= "v0.13" & < "v0.14"}
   "ppx_base" {>= "v0.13" & < "v0.14"}
   "dune"     {>= "1.5.1"}
-  "ppxlib"   {>= "0.9.0"}
+  "ppxlib"   {>= "0.9.0" & < "0.18.0"}
   "pyml"     {>= "20190626"}
 ]
 synopsis: "[@@deriving] plugin to generate Python conversion functions"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.1/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base"     {>= "v0.14" & < "v0.15"}
   "sexplib0" {>= "v0.14" & < "v0.15"}
   "dune"     {>= "2.0.0"}
-  "ppxlib"   {>= "0.15.0"}
+  "ppxlib"   {>= "0.15.0" & < "0.18.0"}
 ]
 synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
 description: "

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.13.0/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.13.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_here"      {>= "v0.13" & < "v0.14"}
   "ppx_sexp_conv" {>= "v0.13" & < "v0.14"}
   "dune"          {>= "1.5.1"}
-  "ppxlib"        {>= "0.9.0"}
+  "ppxlib"        {>= "0.9.0" & < "0.18.0"}
 ]
 synopsis: "A ppx rewriter for easy construction of s-expressions"
 description: "

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.14.0/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.14.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_here"      {>= "v0.14" & < "v0.15"}
   "ppx_sexp_conv" {>= "v0.14" & < "v0.15"}
   "dune"          {>= "2.0.0"}
-  "ppxlib"        {>= "0.11.0"}
+  "ppxlib"        {>= "0.11.0" & < "0.18.0"}
 ]
 synopsis: "A ppx rewriter for easy construction of s-expressions"
 description: "

--- a/packages/ppx_yojson/ppx_yojson.1.0.0/opam
+++ b/packages/ppx_yojson/ppx_yojson.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "1.9.3"}
   "ocaml" {>= "4.04.2"}
   "ounit" {with-test & >= "2.0.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.3.0" & < "0.18.0"}
   "ppx_deriving" {with-test}
   "yojson" {>= "1.6.0" & with-test}
 ]

--- a/packages/ppxlib/ppxlib.0.18.0/opam
+++ b/packages/ppxlib/ppxlib.0.18.0/opam
@@ -14,7 +14,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.10" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1"}
+  "ocaml"                   {>= "4.04.1" & < "4.12"}
   "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "2.0.0"}

--- a/packages/ppxlib/ppxlib.0.18.0/opam
+++ b/packages/ppxlib/ppxlib.0.18.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.10" }
+]
+depends: [
+  "ocaml"                   {>= "4.04.1"}
+  "dune"                    {>= "1.11"}
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "2.0.0"}
+  "ppx_derivers"            {>= "1.0"}
+  "sexplib0"
+  "stdlib-shims"
+  "ocamlfind"               {with-test}
+  "cinaps"                  {with-test & >= "v0.12.1"}
+  "base"                    {with-test}
+  "stdio"                   {with-test}
+]
+synopsis: "Standard library for ppx rewriters"
+description: """
+Ppxlib is the standard library for ppx rewriters and other programs
+that manipulate the in-memory reprensation of OCaml programs, a.k.a
+the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+x-commit-hash: "8b4221588f6ec5e60d750d74ce037e2975e9d044"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.18.0/ppxlib-0.18.0.tbz"
+  checksum: [
+    "sha256=9d483c36467ae061c70df7166ed1465eadcc3442aefa760fb5c5439bf8047dc3"
+    "sha512=b1a9faff8f190f78600fe33762a32362eae457a09dbcb35b58eb897dc7915d1c228df818a3e698a8cca19d40a2ec422a860620d3468dfa1feeee78eb0b2e8445"
+  ]
+}


### PR DESCRIPTION
Standard library for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Bump ppxlib's AST to 4.11 (ocaml-ppx/ppxlib#180, @NathanReb)
