### PR TITLE
Package pringo.1.0

### DIFF
--- a/packages/pringo/pringo.1.0/opam
+++ b/packages/pringo/pringo.1.0/opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+synopsis: "Pseudo-random, splittable number generators"
+description:
+  "Pseudo-random number generators that support splitting and two interfaces: one stateful, one purely functional"
+maintainer: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+authors: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+license: "GPL v2 with static linking exception"
+homepage: "https://github.com/xavierleroy/pringo"
+bug-reports: "https://github.com/xavierleroy/pringo/issues"
+depends: ["ocamlfind"]
+build: make
+install: [make "install"]
+remove: [make "uninstall"]
+dev-repo: "git+https://https://github.com/xavierleroy/pringo"


### PR DESCRIPTION
### `pringo.1.0`
Pseudo-random, splittable number generators
Pseudo-random number generators that support splitting and two interfaces: one stateful, one purely functional



---
* Homepage: https://github.com/xavierleroy/pringo
* Source repo: git+https://https://github.com/xavierleroy/pringo
* Bug tracker: https://github.com/xavierleroy/pringo/issues

---
:camel: Pull-request generated by opam-publish v2.0.2