### PR TITLE
Package pringo.1.0

### DIFF
--- a/packages/pringo/pringo.1.0/opam
+++ b/packages/pringo/pringo.1.0/opam
@@ -13,7 +13,6 @@ depends: [
 ]
 build: make
 install: [make "install"]
-remove: [make "uninstall"]
 dev-repo: "git+https://https://github.com/xavierleroy/pringo"
 url {
   src: "https://github.com/xavierleroy/pringo/archive/1.0.tar.gz"

--- a/packages/pringo/pringo.1.0/opam
+++ b/packages/pringo/pringo.1.0/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "Pseudo-random, splittable number generators"
+description:
+  "Pseudo-random number generators that support splitting and two interfaces: one stateful, one purely functional"
+maintainer: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+authors: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+license: "GPL v2 with static linking exception"
+homepage: "https://github.com/xavierleroy/pringo"
+bug-reports: "https://github.com/xavierleroy/pringo/issues"
+depends: ["ocamlfind"]
+build: make
+install: [make "install"]
+remove: [make "uninstall"]
+dev-repo: "git+https://https://github.com/xavierleroy/pringo"
+url {
+  src: "https://github.com/xavierleroy/pringo/archive/1.0.tar.gz"
+  checksum: [
+    "md5=7b88117f80c33440c0e74ea6c77da3a9"
+    "sha512=a97e2ec79902fe2004e700e05f185a86dfbf883958148b01593edcc084110e7e34de1cfaf7aca8783212f5eb9e6ab8e5c0c5061e6d47f8dc10085120ac18c1e4"
+  ]
+}

--- a/packages/pringo/pringo.1.0/opam
+++ b/packages/pringo/pringo.1.0/opam
@@ -7,7 +7,10 @@ authors: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
 license: "GPL v2 with static linking exception"
 homepage: "https://github.com/xavierleroy/pringo"
 bug-reports: "https://github.com/xavierleroy/pringo/issues"
-depends: ["ocamlfind"]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind"
+]
 build: make
 install: [make "install"]
 remove: [make "uninstall"]


### PR DESCRIPTION
### `pringo.1.0`
Pseudo-random, splittable number generators
Pseudo-random number generators that support splitting and two interfaces: one stateful, one purely functional



---
* Homepage: https://github.com/xavierleroy/pringo
* Source repo: git+https://https://github.com/xavierleroy/pringo
* Bug tracker: https://github.com/xavierleroy/pringo/issues

---
:camel: Pull-request generated by opam-publish v2.0.2