### PR TITLE
Package duppy.0.9.0

### DIFF
--- a/packages/duppy/duppy.0.9.0/opam
+++ b/packages/duppy/duppy.0.9.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Library providing monadic threads"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["Romain Beauxis <toots@rastageeks.org>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-duppy"
+bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
+depends: [
+  "dune" {> "2.0"}
+  "pcre"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
+url {
+  src: "https://github.com/savonet/ocaml-duppy/archive/v0.9.0.tar.gz"
+  checksum: [
+    "md5=c86cab5bf72fb0f4522606b40e1b8b39"
+    "sha512=f847e1ad9ff36f6107d4518296ba794085e8897539c4fb7ba98d3709708bd069b0467465a939bf6738966192219d9bc64eee9db40c55be8195df24390570eb3f"
+  ]
+}


### PR DESCRIPTION
### `duppy.0.9.0`
Library providing monadic threads



---
* Homepage: https://github.com/savonet/ocaml-duppy
* Source repo: git+https://github.com/savonet/ocaml-duppy.git
* Bug tracker: https://github.com/savonet/ocaml-duppy/issues

---
:camel: Pull-request generated by opam-publish v2.0.2