### PR TITLE
Package faad.0.5.0

### DIFF
--- a/packages/faad/faad.0.5.0/opam
+++ b/packages/faad/faad.0.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings for the faad library which provides functions for decoding AAC audio files"
+maintainer: ["Romain Beauxis <toots@rastageeks.org>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-faad"
+bug-reports: "https://github.com/savonet/ocaml-faad/issues"
+depends: [
+  "dune" {> "2.0"}
+  "dune-configurator"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-faad.git"
+depexts: [
+  ["faad2-dev"] {os-distribution = "alpine"}
+  ["faad2"] {os-distribution = "arch"}
+  ["faad2-devel"] {os-distribution = "centos"}
+  ["faad2-devel"] {os-distribution = "fedora"}
+  ["faad2-devel"] {os-family = "suse"}
+  ["libfaad-dev"] {os-family = "debian"}
+  ["faad2"] {os = "macos" & os-distribution = "homebrew"}
+]
+url {
+  src: "https://github.com/savonet/ocaml-faad/archive/v0.5.0.tar.gz"
+  checksum: [
+    "md5=3ce604faf3981cb4433688b205cb8758"
+    "sha512=0983cdf7552f03f021ca20e86ed6ebc67419db8900dd0e3fc316c18af83851259d91b8829092a2e1e307638ce31d6c3ee4810889f43632070122ee24e7971874"
+  ]
+}


### PR DESCRIPTION
### `faad.0.5.0`
Bindings for the faad library which provides functions for decoding AAC audio files



---
* Homepage: https://github.com/savonet/ocaml-faad
* Source repo: git+https://github.com/savonet/ocaml-faad.git
* Bug tracker: https://github.com/savonet/ocaml-faad/issues

---
:camel: Pull-request generated by opam-publish v2.0.2