### PR TITLE
Package mad.0.5.0

### DIFF
--- a/packages/mad/mad.0.5.0/opam
+++ b/packages/mad/mad.0.5.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Mad decoding library"
+description:
+  "Bindings for the mad library which provides functions for encoding wave audio files into mp3"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-mad"
+bug-reports: "https://github.com/savonet/ocaml-mad/issues"
+depends: [
+  "dune" {> "2.0"}
+  "dune-configurator"
+]
+conflicts: [
+  "liquidsoap" {< "1.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-mad.git"
+depexts: [
+  ["libmad-dev"] {os-distribution = "alpine"}
+  ["libmad"] {os-distribution = "archlinux"}
+  ["libmad-devel"] {os-distribution = "centos"}
+  ["libmad-devel"] {os-distribution = "fedora"}
+  ["libmad-devel"] {os-family = "suse"}
+  ["libmad0-dev"] {os-family = "debian"}
+  ["libmad"] {os-distribution = "nixos"}
+  ["mad"] {os = "macos" & os-distribution = "homebrew"}
+]
+url {
+  src: "https://github.com/savonet/ocaml-mad/archive/v0.5.0.tar.gz"
+  checksum: [
+    "md5=7918a0b2b590fad0b6cfbc20bc3ed801"
+    "sha512=284e2be07f73d5d26378341194c34c28498aceb26d26dd3fd685016e19baba59943c8b4df08eb4be715430a92265a856cd594209ee9d7aed5d10b29b63857dff"
+  ]
+}

--- a/packages/mad/mad.0.5.0/opam
+++ b/packages/mad/mad.0.5.0/opam
@@ -11,9 +11,6 @@ depends: [
   "dune" {> "2.0"}
   "dune-configurator"
 ]
-conflicts: [
-  "liquidsoap" {< "1.5.0"}
-]
 build: [
   ["dune" "subst"] {pinned}
   [


### PR DESCRIPTION
### `mad.0.5.0`
Mad decoding library
Bindings for the mad library which provides functions for encoding wave audio files into mp3



---
* Homepage: https://github.com/savonet/ocaml-mad
* Source repo: git+https://github.com/savonet/ocaml-mad.git
* Bug tracker: https://github.com/savonet/ocaml-mad/issues

---
:camel: Pull-request generated by opam-publish v2.0.2