### PR TITLE
Package ogg.0.6.0

### DIFF
--- a/packages/ogg/ogg.0.6.0/opam
+++ b/packages/ogg/ogg.0.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Interface for Ogg Bitstream Library, otherwise known as libogg"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/savonet/ocaml-ogg"
+bug-reports: "https://github.com/savonet/ocaml-ogg/issues"
+depends: [
+  "dune" {> "2.0"}
+  "dune-configurator"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-ogg.git"
+depexts: [
+  ["libogg-dev"] {os-distribution = "alpine"}
+  ["libogg"] {os-distribution = "arch"}
+  ["libogg-dev"] {os-family = "debian"}
+  ["libogg-devel"] {os-distribution = "centos"}
+  ["libogg-devel"] {os-distribution = "fedora"}
+  ["libogg-devel"] {os-family = "suse"}
+  ["libogg"] {os-distribution = "nixos"}
+  ["libogg"] {os = "macos" & os-distribution = "homebrew"}
+]
+url {
+  src: "https://github.com/savonet/ocaml-ogg/archive/v0.6.0.tar.gz"
+  checksum: [
+    "md5=41816e9ecf5f686084700c185b3bc703"
+    "sha512=da20db2c9edccac9a73aa1672a7474dc9e4414a74ebb9c241afe29380c0775a638dcd2c83674ef988757cf8befa617938dcf57b36d184b801e3991cca51a8fea"
+  ]
+}


### PR DESCRIPTION
### `ogg.0.6.0`
Interface for Ogg Bitstream Library, otherwise known as libogg



---
* Homepage: https://github.com/savonet/ocaml-ogg
* Source repo: git+https://github.com/savonet/ocaml-ogg.git
* Bug tracker: https://github.com/savonet/ocaml-ogg/issues

---
:camel: Pull-request generated by opam-publish v2.0.2