### PR TITLE
Package flac.0.2.0

### DIFF
--- a/packages/flac/flac.0.2.0/opam
+++ b/packages/flac/flac.0.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-flac"
+build: [
+  ["./bootstrap"] {dev}
+  ["./configure" "--prefix" prefix] {os != "macos"}
+  [
+    "./configure"
+    "CFLAGS=-I/usr/local/include"
+    "LDFLAGS=-L/usr/local/lib"
+    "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib"
+    "--prefix"
+    prefix
+  ] {os = "macos"}
+  [make "clean"] {dev}
+  [make]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "ocamlfind" {build}
+  "ogg"
+]
+depexts: [
+  ["flac-dev"] {os-distribution = "alpine"}
+  ["flac"] {os-distribution = "arch"}
+  ["flac-devel"] {os-distribution = "centos"}
+  ["flac-devel"] {os-distribution = "fedora"}
+  ["flac-devel"] {os-family = "suse"}
+  ["libflac-dev"] {os-family = "debian"}
+  ["flac"] {os-distribution = "nixos"}
+  ["flac"] {os = "macos" & os-distribution = "homebrew"}
+  ["flac"] {os = "freebsd"}
+]
+bug-reports: "https://github.com/savonet/ocaml-flac/issues"
+dev-repo: "git+https://github.com/savonet/ocaml-flac.git"
+synopsis:
+  "Interface for the Free Lossless Audio Codec otherwise known as FLAC"
+url {
+  src:
+    "https://github.com/savonet/ocaml-flac/releases/download/v0.2.0/ocaml-flac-0.2.0.tar.gz"
+  checksum: [
+    "md5=72acb898a4e313b3e73e5c04b0664d8e"
+    "sha512=27b3e8e9a08b241b89e7d06ce816916518b213c81a79cf2e087a0236eac0df9c05e53254959c2a2ad7860cb6972a0e274e2cb18a19f86b7f2fe26bf4e9e789c5"
+  ]
+}


### PR DESCRIPTION
### `flac.0.2.0`
Interface for the Free Lossless Audio Codec otherwise known as FLAC



---
* Homepage: https://github.com/savonet/ocaml-flac
* Source repo: git+https://github.com/savonet/ocaml-flac.git
* Bug tracker: https://github.com/savonet/ocaml-flac/issues

---
:camel: Pull-request generated by opam-publish v2.0.2