### PR TITLE
Package note.0.0.1

### DIFF
--- a/packages/note/note.0.0.1/opam
+++ b/packages/note/note.0.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The note programmers"]
+homepage: "https://erratique.ch/software/note"
+doc: "https://erratique.ch/software/note/doc"
+license: "ISC"
+dev-repo: "git+https://erratique.ch/repos/note.git"
+bug-reports: "https://github.com/dbuenzli/note/issues"
+tags: [ "reactive" "declarative" "signal" "event" "frp" "org:erratique" ]
+depends:
+[
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+]
+build:
+[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{dev}%"
+]]
+
+synopsis: """Declarative events and signals for OCaml"""
+description: """\
+
+Note is an OCaml library for functional reactive programming (FRP). It
+provides support to program with time varying values: declarative
+events and signals.
+
+Note is distributed under the ISC license.
+"""
+url {
+archive: "https://erratique.ch/software/note/releases/note-0.0.1.tbz"
+checksum: "ea16940570494d6f2b779bc718685961"
+}


### PR DESCRIPTION
### `note.0.0.1`
Declarative events and signals for OCaml
Note is an OCaml library for functional reactive programming (FRP). It
provides support to program with time varying values: declarative
events and signals.

Note is distributed under the ISC license.



---
* Homepage: https://erratique.ch/software/note
* Source repo: git+https://erratique.ch/repos/note.git
* Bug tracker: https://github.com/dbuenzli/note/issues

---
v0.0.1 2020-10-08 Zagreb
------------------------

First release to support `brr`.

---
:camel: Pull-request generated by opam-publish v2.0.2