### PR TITLE
Fix OCaml < 4.08.0 for XCode 12

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "$s/^/LC_ALL=C /" "ocamldoc/remove_DEBUG"]
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals.c"]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "s/struct sigaltstack/stack_t/" "asmrun/signals_asm.c"]
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
   [make "world" "opt" "opt.opt"]
 ]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
   [make "world" "opt" "opt.opt"]
 ]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.0/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.3.09.1+metaocaml/opam
+++ b/packages/ocaml-variants/ocaml-variants.3.09.1+metaocaml/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.00.0+debug-runtime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.0+debug-runtime/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.00.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.0+fp/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
   [make "world" "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+BER/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-no-tk"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-no-tk" "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+PIC/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-cc"
     "cc -fPIC"

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+annot/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+annot/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
   [make "world" "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+debug-runtime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+debug-runtime/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+french/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+french/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
   [make "world" "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-unix/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-unix/opam
@@ -17,6 +17,13 @@ setenv: [
   [MIRAGE_NET = "direct"]
 ]
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-xen/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-xen/opam
@@ -14,6 +14,13 @@ setenv: [
   [MIRAGE_NET = "direct"]
 ]
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+open-types/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+open-types/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
   [make "world" "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+raspberrypi/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+raspberrypi/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
   [make "world" "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+short-types/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+short-types/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
   [make "world" "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+32bit/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+BER/opam
@@ -13,6 +13,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" "%{prefix}%"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" "%{prefix}%" "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+PIC/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+armv6-freebsd/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+armv6-freebsd/opam
@@ -13,6 +13,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+fp/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+lsb/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+lsb/opam
@@ -19,6 +19,13 @@ setenv: [
   [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
 ]
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sed" "-i" "-e" "s/lcurses/lncurses/" "configure"]
   [
     "sed"

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+musl+static/opam
@@ -20,6 +20,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+musl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+musl/opam
@@ -15,6 +15,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+open-types/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+open-types/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
   [make "world" "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+profile/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+profile/opam
@@ -15,6 +15,13 @@ setenv: [
   [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
 ]
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+PIC/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-cc"
     "cc -fPIC"

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+improved-errors/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+improved-errors/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" "%{prefix}%"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" "%{prefix}%" "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+rc1/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+trunk/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+32bit/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+BER/opam
@@ -13,6 +13,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" "%{prefix}%"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" "%{prefix}%" "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+PIC/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-cc"
     "cc -fPIC"

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+fp/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits-ber/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits-ber/opam
@@ -14,6 +14,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" "%{prefix}%"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" "%{prefix}%" "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits/opam
@@ -13,6 +13,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" "%{prefix}%"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" "%{prefix}%" "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+musl+static/opam
@@ -20,6 +20,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+musl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+musl/opam
@@ -15,6 +15,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.02.2+improved-errors/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.2+improved-errors/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.02.2+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.2+rc1/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+32bit/opam
@@ -14,6 +14,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+PIC/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-cc"
     "cc -fPIC"

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-1/opam
@@ -16,6 +16,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-master/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-master/opam
@@ -16,6 +16,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+bytecode-only/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+curried-constr/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+curried-constr/opam
@@ -79,6 +79,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+fp/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+musl+static/opam
@@ -20,6 +20,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+musl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+musl/opam
@@ -15,6 +15,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+32bit/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1-no-debug/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1-no-debug/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2-no-debug/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2-no-debug/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+fPIC/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-cc"
     "cc -fPIC"

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+statistical-memprof/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+32bit/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+BER/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" "%{prefix}%"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" "%{prefix}%" "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta1+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta2+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta2/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+bytecode-only/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
   ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+copatterns/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+copatterns/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+fPIC/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-cc"
     "cc -fPIC"

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+spacetime/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+trunk+forced_lto/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+trunk+forced_lto/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "sh"
     "-exc"
     "echo \"* : lto = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+32bit/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+bytecode-only/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
   ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+fPIC/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-cc"
     "cc -fPIC"

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+spacetime/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+32bit/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+bytecode-only/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
   ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+fPIC/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-cc"
     "cc -fPIC"

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+spacetime/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+statistical-memprof/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "--statmemprof"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+32bit/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta1+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta2+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta2/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta3/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+bytecode-only/opam
@@ -11,8 +11,16 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
+    "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+lto/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+lto/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda" "-lto"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+musl+flambda/opam
@@ -15,6 +15,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+musl+static+flambda/opam
@@ -20,6 +20,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+rc1+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+rc1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+spacetime/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+statistical-memprof/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "--statmemprof"]
   [make "world"]
   [make "world.opt"]

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+trunk/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+32bit/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+default-unsafe-string/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+force-safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+default-unsafe-string/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+force-safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+bytecode-only/opam
@@ -11,8 +11,16 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
+    "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+default-unsafe-string/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+flambda+no-flat-float-array/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+force-safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+musl+flambda/opam
@@ -15,6 +15,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+musl+static+flambda/opam
@@ -20,6 +20,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+no-flat-float-array/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+default-unsafe-string/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+force-safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+spacetime/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+statistical-memprof/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "--statmemprof"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+32bit/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+bytecode-only/opam
@@ -11,8 +11,16 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
+    "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+default-unsafe-string/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+force-safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+fp+flambda/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+lto/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+lto/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda" "-lto"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+musl+flambda/opam
@@ -15,6 +15,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
@@ -20,6 +20,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+no-flat-float-array/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+no-naked-pointers+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+no-naked-pointers+flambda/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+default-unsafe-string/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+force-safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+fp+flambda/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+afl/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+default-unsafe-string/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+force-safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+fp+flambda/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+statistical-memprof/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "--statmemprof"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+termux/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+termux/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["sh" "./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+force-safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
@@ -11,8 +11,16 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
+    "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" "%{prefix}%"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   ["./configure" "-prefix" "%{prefix}%" "-cc" "cc" "-aspp" "cc -c"]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
@@ -11,8 +11,16 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
+    "./configure" "-prefix" prefix "-with-debug-runtime" "-no-native-compiler"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
   [
     "./configure"
     "-prefix"

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
@@ -14,6 +14,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
@@ -19,6 +19,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-afl-instrument"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-flambda"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
@@ -12,6 +12,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-force-safe-string"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
@@ -13,6 +13,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
@@ -12,6 +12,13 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
+  [
     "./configure"
     "-prefix"
     prefix

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-spacetime"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
@@ -11,6 +11,13 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  [
+    "sed"
+    "-ib"
+    "-e"
+    "s/opts=\"\"/opts=\"-Wno-implicit-function-declaration\"/"
+    "config/auto-aux/hasgot"
+  ] {os = "macos"}
   ["./configure" "-prefix" prefix "-with-debug-runtime" "--statmemprof"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
   [


### PR DESCRIPTION
As requested in https://github.com/ocaml/opam-repository/pull/17341#issuecomment-705623176 🙂

This PR patches `config/auto-aux/hasgot` in all pre-autoconf versions of OCaml to pass `-Wno-implicit-function-declaration` when building on macOS. Apparently prior to GCC 5, `-Wno-implicit-function-declaration` didn't exist - I don't know what the story would have been for clang back then, but I imagine it's quite difficult to be sat at a Mac running that old a version of GCC.