### PR TITLE
Package doi2bib.0.1.4

### DIFF
--- a/packages/doi2bib/doi2bib.0.1.4/opam
+++ b/packages/doi2bib/doi2bib.0.1.4/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+  ["dune" "build" "-p" name "-j" jobs "@install"]
 ]
 dev-repo: "git+https://github.com/mseri/doi2bib.git"
 url {

--- a/packages/doi2bib/doi2bib.0.1.4/opam
+++ b/packages/doi2bib/doi2bib.0.1.4/opam
@@ -12,7 +12,7 @@ depends: [
   "clap" {>= "0.1.0"}
   "ezxmlm" {>= "1.1.0"}
   "lwt_ppx" {>= "2.0.0"}
-  ("tls" | "lwt_ssl")
+  "tls"
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/doi2bib/doi2bib.0.1.4/opam
+++ b/packages/doi2bib/doi2bib.0.1.4/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Little CLI tool to get bibtex entries out of doi or arxiv ids"
+maintainer: "marcello.seri@gmail.com"
+authors: "Marcello Seri"
+license: "MIT"
+homepage: "https://github.com/mseri/doi2bib"
+bug-reports: "https://github.com/mseri/doi2bib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "astring" {>= "0.8.0"}
+  "cohttp-lwt-unix" {>= "2.5.0"}
+  "clap" {>= "0.1.0"}
+  "ezxmlm" {>= "1.1.0"}
+  "lwt_ppx" {>= "2.0.0"}
+  ("tls" | "lwt_ssl")
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
+dev-repo: "git+https://github.com/mseri/doi2bib.git"
+url {
+  src:
+    "https://github.com/mseri/doi2bib/releases/download/0.1.4/doi2bib-0.1.4.tbz"
+  checksum: [
+    "md5=4e31c4107d9880028f662e865f4b0327"
+    "sha512=2801adbdae561506af46b2f800ce5a180a35c7a585d3d8a83bd79766c86b42964797626be481a7662b617fab41b02316c9a15873e96ae077dbf7c0665193b0a6"
+  ]
+}

--- a/packages/doi2bib/doi2bib.0.1.4/opam
+++ b/packages/doi2bib/doi2bib.0.1.4/opam
@@ -6,6 +6,7 @@ license: "MIT"
 homepage: "https://github.com/mseri/doi2bib"
 bug-reports: "https://github.com/mseri/doi2bib/issues"
 depends: [
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
   "astring" {>= "0.8.0"}
   "cohttp-lwt-unix" {>= "2.5.0"}


### PR DESCRIPTION
### `doi2bib.0.1.4`
Little CLI tool to get bibtex entries out of doi or arxiv ids



---
* Homepage: https://github.com/mseri/doi2bib
* Source repo: git+https://github.com/mseri/doi2bib.git
* Bug tracker: https://github.com/mseri/doi2bib/issues

---
:camel: Pull-request generated by opam-publish v2.0.2