### PR TITLE
4 packages from owlbarn/owl_ode at 0.4.0

### DIFF
--- a/packages/owl-ode-base/owl-ode-base.0.4.0/opam
+++ b/packages/owl-ode-base/owl-ode-base.0.4.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Owl's ODE solvers"
+description: """\
+OwlDE: ODE Integration library
+
+The base library contains pure OCaml code and supports compilation with js_of_ocaml"""
+maintainer: "owlbarn"
+authors: ["Marcello Seri" "Ta-Chu Calvin Kao"]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl_ode"
+doc: "https://owlbarn.github.io/owl_ode/owl-ode"
+bug-reports: "https://github.com/owlbarn/owl_ode/issues"
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "owl-base" {>= "0.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/owlbarn/owl_ode.git"
+url {
+  src:
+    "https://github.com/owlbarn/owl_ode/releases/download/v0.4.0/owl-ode-v0.4.0.tbz"
+  checksum: [
+    "md5=94853ee6e39e8d1f302f6e9f2e7ce72e"
+    "sha512=999ea3f02554fc5859188c07727400d3f4ebd1a46e3885f8491a4117be4ce1fad32bd1e0806b7a3a43a7f1026e9eb7fb46ed1bc11179000cdaad64681c5bfc53"
+  ]
+}

--- a/packages/owl-ode-odepack/owl-ode-odepack.0.4.0/opam
+++ b/packages/owl-ode-odepack/owl-ode-odepack.0.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Owl's ODE solvers, interface with ODEPACK"
+description: """\
+OwlDE: ODE Integration library
+
+The ODEPACK library provides bindings to ODEPACK via OCaml's
+ODEPACK library."""
+maintainer: "owlbarn"
+authors: ["Marcello Seri" "Ta-Chu Calvin Kao"]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl_ode"
+doc: "https://owlbarn.github.io/owl_ode/ode"
+bug-reports: "https://github.com/owlbarn/owl_ode/issues"
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "owl" {>= "0.9.0"}
+  "dune" {>= "2.0.0"}
+  "owl-ode" {= version}
+  "owl-plplot" {with-test}
+  "odepack"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/owlbarn/owl_ode.git"
+url {
+  src:
+    "https://github.com/owlbarn/owl_ode/releases/download/v0.4.0/owl-ode-v0.4.0.tbz"
+  checksum: [
+    "md5=94853ee6e39e8d1f302f6e9f2e7ce72e"
+    "sha512=999ea3f02554fc5859188c07727400d3f4ebd1a46e3885f8491a4117be4ce1fad32bd1e0806b7a3a43a7f1026e9eb7fb46ed1bc11179000cdaad64681c5bfc53"
+  ]
+}

--- a/packages/owl-ode-sundials/owl-ode-sundials.0.4.0/opam
+++ b/packages/owl-ode-sundials/owl-ode-sundials.0.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Owl's ODE solvers, interface with SundialsML"
+description: """\
+OwlDE: ODE Integration library
+
+The sundials library provides bindings to sundials via OCaml's
+sundialsml library."""
+maintainer: "owlbarn"
+authors: ["Marcello Seri" "Ta-Chu Calvin Kao"]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl_ode"
+doc: "https://owlbarn.github.io/owl_ode/ode"
+bug-reports: "https://github.com/owlbarn/owl_ode/issues"
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "owl" {>= "0.9.0"}
+  "dune" {>= "2.0.0"}
+  "owl-ode" {= version}
+  "owl-plplot" {with-test}
+  "sundialsml"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/owlbarn/owl_ode.git"
+url {
+  src:
+    "https://github.com/owlbarn/owl_ode/releases/download/v0.4.0/owl-ode-v0.4.0.tbz"
+  checksum: [
+    "md5=94853ee6e39e8d1f302f6e9f2e7ce72e"
+    "sha512=999ea3f02554fc5859188c07727400d3f4ebd1a46e3885f8491a4117be4ce1fad32bd1e0806b7a3a43a7f1026e9eb7fb46ed1bc11179000cdaad64681c5bfc53"
+  ]
+}

--- a/packages/owl-ode/owl-ode.0.4.0/opam
+++ b/packages/owl-ode/owl-ode.0.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Owl's ODE solvers"
+description: """\
+OwlDE: ODE Integration library
+
+The main library contains solvers using the faster BLAS/LAPACK 
+Owl interface."""
+maintainer: "owlbarn"
+authors: ["Marcello Seri" "Ta-Chu Calvin Kao"]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl_ode"
+doc: "https://owlbarn.github.io/owl_ode/owl-ode"
+bug-reports: "https://github.com/owlbarn/owl_ode/issues"
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "owl" {>= "0.9.0"}
+  "owl-ode-base" {= version}
+  "owl-plplot" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/owlbarn/owl_ode.git"
+url {
+  src:
+    "https://github.com/owlbarn/owl_ode/releases/download/v0.4.0/owl-ode-v0.4.0.tbz"
+  checksum: [
+    "md5=94853ee6e39e8d1f302f6e9f2e7ce72e"
+    "sha512=999ea3f02554fc5859188c07727400d3f4ebd1a46e3885f8491a4117be4ce1fad32bd1e0806b7a3a43a7f1026e9eb7fb46ed1bc11179000cdaad64681c5bfc53"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`owl-ode.0.4.0`: Owl's ODE solvers
-`owl-ode-base.0.4.0`: Owl's ODE solvers
-`owl-ode-odepack.0.4.0`: Owl's ODE solvers, interface with ODEPACK
-`owl-ode-sundials.0.4.0`: Owl's ODE solvers, interface with SundialsML



---
* Homepage: https://github.com/owlbarn/owl_ode
* Source repo: git+https://github.com/owlbarn/owl_ode.git
* Bug tracker: https://github.com/owlbarn/owl_ode/issues

---
:camel: Pull-request generated by opam-publish v2.0.2