### PR TITLE
[new release] ca-certs (0.1.2)

### DIFF
--- a/packages/ca-certs/ca-certs.0.1.2/opam
+++ b/packages/ca-certs/ca-certs.0.1.2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Detect root CA certificates from the operating system"
+description: """
+TLS requires a set of root anchors (Certificate Authorities) to
+authenticate servers. This library exposes this list so that it can be
+registered with ocaml-tls.
+"""
+maintainer: ["Etienne Millon <me@emillon.org>"]
+authors: ["Etienne Millon <me@emillon.org>"]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs"
+doc: "https://mirage.github.io/ca-certs/doc"
+bug-reports: "https://github.com/mirage/ca-certs/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "bos"
+  "fpath"
+  "rresult"
+  "ptime"
+  "mirage-crypto"
+  "x509" {>= "0.11.0"}
+  "ocaml" {>= "4.07.0"}
+  "alcotest" {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ca-certs.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"} # the opam sandbox on macos leads to test failures (ocaml/opam#4389)
+    "@doc" {with-doc}
+  ]
+]
+tags: ["org:mirage"]
+depexts: [
+  ["ca_root_nss"] {os = "freebsd"}
+]
+x-commit-hash: "1a03e7d85fa1aabc37eb60df353db2637c44c869"
+url {
+  src:
+    "https://github.com/mirage/ca-certs/releases/download/v0.1.2/ca-certs-v0.1.2.tbz"
+  checksum: [
+    "sha256=fff2a4ae5a2daeff2d5df4d4753d9e035265e701a4b06fcaa7ba32acf3c26b81"
+    "sha512=608bfff46cf61feed6e563459652d0f6a6155b4e8172c0ae80e5e58246cbc540f30ee9759e3b5a24fbd2f8973a79f365d8bd958fa7745c65ee8e39e14310ac40"
+  ]
+}


### PR DESCRIPTION
Detect root CA certificates from the operating system

- Project page: <a href="https://github.com/mirage/ca-certs">https://github.com/mirage/ca-certs</a>
- Documentation: <a href="https://mirage.github.io/ca-certs/doc">https://mirage.github.io/ca-certs/doc</a>

##### CHANGES:

* Revise API, avoid temporary file creation on macos
