### PR TITLE
ocaml-freestanding 0.6.3

### DIFF
--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.3/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-freestanding"
+bug-reports: "https://github.com/mirage/ocaml-freestanding/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-freestanding.git"
+build: [make]
+install: [make "install" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "ocamlfind" {build}
+  "ocaml-src" {build}
+  ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")
+  "ocaml" {>= "4.08.0" & < "4.12.0"}
+]
+substs: [
+  "flags/cflags.tmp"
+  "flags/libs.tmp"
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+synopsis: "Freestanding OCaml runtime"
+description:
+  "This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer."
+url {
+  src: "https://github.com/mirage/ocaml-freestanding/archive/v0.6.3.tar.gz"
+  checksum: "sha512=80707b6f633935a849b511d34a1edbaa94656b7cc0d36b6298269f880f0f5eb9219468a5c30924af77bc1cdff4a8e46efbfc3b6791a34df8449be2eaa7d38170"
+}


### PR DESCRIPTION
* nolibc: dlmalloc: Improve security posture and robustness by always
enabling assertions, initialising magic value for heap canaries using
monotonic time and enabling FOOTERs. (#87, @mato)