### PR TITLE
[new release] progress (0.1.1)

### DIFF
--- a/packages/progress/progress.0.1.1/opam
+++ b/packages/progress/progress.0.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "User-definable progress bars"
+description: """
+A progress bar library for OCaml, featuring a DSL for declaratively specifying
+progress bar formats. Supports rendering multiple progress bars simultaneously."""
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Craig Ferguson <me@craigfe.io>"]
+homepage: "https://github.com/CraigFe/progress"
+doc: "https://CraigFe.github.io/progress/"
+bug-reports: "https://github.com/CraigFe/progress/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "mtime"
+  "terminal_size"
+  "alcotest" {>= "1.1.0" & with-test}
+  "astring" {with-test}
+  "fmt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CraigFe/progress.git"
+x-commit-hash: "ec2ca20cfab6b81e99c123d541d71c70567153c5"
+url {
+  src:
+    "https://github.com/CraigFe/progress/releases/download/0.1.1/progress-0.1.1.tbz"
+  checksum: [
+    "sha256=90c6bec19d014a4c6b0b67006f08bdfcf36981d2176769bebe0ccd75d6785a32"
+    "sha512=76a8a8f5979c1d6ba47d28e8c8fc6fa2c4f27073f77749b98f98eaf9c101fdc0f9f76e6463ea8dbea5dbbc69a105908be26c605c8c56ddc1a1a5ccc48db87a5a"
+  ]
+}


### PR DESCRIPTION
User-definable progress bars

- Project page: <a href="https://github.com/CraigFe/progress">https://github.com/CraigFe/progress</a>
- Documentation: <a href="https://CraigFe.github.io/progress/">https://CraigFe.github.io/progress/</a>

##### CHANGES:

- Rename `Progress.with_display` to `Progress.with_reporters`. (CraigFe/progress#3, @CraigFe)

- Change the default display mode of progress bars to `ASCII` rather than
  `UTF8`. (CraigFe/progress#2, @CraigFe)

- Change `Segment.box_dynamic` to take a function rather than a reference. (CraigFe/progress#1,
  @CraigFe)

- Fix a bug causing multi-line layouts to occasionally not adapt to terminal
  size changes. (CraigFe/progress#1, @CraigFe)
