### PR TITLE
[new release] ca-certs-nss (3.57)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.57/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.57/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "X.509 trust anchors extracted from Mozilla's NSS"
+description: """
+Trust anchors extracted from Mozilla's NSS certdata.txt package,
+to be used in MirageOS unikernels.
+"""
+maintainer: ["Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs-nss"
+doc: "https://mirage.github.io/ca-certs-nss/doc"
+bug-reports: "https://github.com/mirage/ca-certs-nss/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "rresult"
+  "mirage-crypto"
+  "mirage-clock"
+  "x509" {>= "0.11.0"}
+  "ocaml" {>= "4.07.0"}
+  "logs" {build}
+  "fmt" {build}
+  "hex" {build}
+  "bos" {build}
+  "astring" {build}
+  "cmdliner" {build}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ca-certs-nss.git"
+tags: ["org:mirage"]
+x-commit-hash: "12962017a11e27fdd2508a101d0e108f5ab63833"
+url {
+  src:
+    "https://github.com/mirage/ca-certs-nss/releases/download/v3.57/ca-certs-nss-v3.57.tbz"
+  checksum: [
+    "sha256=32f788541ec68398d1f365ecc85c25dc3f1c7239ce1cc5f15ccc1ef0cd52011e"
+    "sha512=f23edfe257d2e27c1af666a2d15bd4e3a52ff9d1798fef3e83ea5c6aecfe1a6eb666f32292effdfbab61585ca701a988cc9b697d63dd19e26c0238e308b30877"
+  ]
+}


### PR DESCRIPTION
X.509 trust anchors extracted from Mozilla's NSS

- Project page: <a href="https://github.com/mirage/ca-certs-nss">https://github.com/mirage/ca-certs-nss</a>
- Documentation: <a href="https://mirage.github.io/ca-certs-nss/doc">https://mirage.github.io/ca-certs-nss/doc</a>

##### CHANGES:

* Initial public release (version numbers meet NSS releases)
