### PR TITLE
Package ocsigen-i18n.3.7.0

### DIFF
--- a/packages/ocsigen-i18n/ocsigen-i18n.3.7.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.7.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis:     "I18n made easy for web sites written with eliom"
+description:  "Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file"
+maintainer:   "Jan Rochel <jan@besport.com>"
+
+homepage: "https://github.com/besport/ocsigen-i18n"
+bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
+dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+build:   [ make "build" ]
+install: [ make "bindir=%{bin}%" "install" ]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "ocamlfind" {build}
+  "tyxml" { >= "4.3.0" }
+  "ppx_tools"
+]
+authors: "Julien Sagot"
+url {
+  src: "https://github.com/besport/ocsigen-i18n/archive/3.7.0.tar.gz"
+  checksum: [
+    "md5=6aa3be1a88f6adf3ace89fff16dffe3c"
+    "sha512=e16743070f1a15bb8850132f710aceda61102dea692da8b611c7d249602007400036c4944d7a2ff14ffdd7dfcc42504377fd8762a7fe40540051ee09b0d563c1"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-i18n.3.7.0`
I18n made easy for web sites written with eliom
Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file



---
* Homepage: https://github.com/besport/ocsigen-i18n
* Source repo: git+https://github.com/besport/ocsigen-i18n.git
* Bug tracker: https://github.com/besport/ocsigen-i18n/issues

---
:camel: Pull-request generated by opam-publish v2.0.2