### PR TITLE
Package cryptokit.1.16

### DIFF
--- a/packages/cryptokit/cryptokit.1.16/opam
+++ b/packages/cryptokit/cryptokit.1.16/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A library of cryptographic primitives"
+description: """\
+Cryptokit includes block ciphers (AES, DES, 3DES), stream ciphers
+(ARCfour), public-key crypto (RSA, DH), hashes (SHA-1, SHA-256,
+SHA-3), MACs, compression, random number generation -- all presented
+with a compositional, extensible interface."""
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: "Xavier Leroy"
+homepage: "https://github.com/xavierleroy/cryptokit"
+bug-reports: "https://github.com/xavierleroy/cryptokit/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.0"}
+  "dune-configurator"
+  "zarith" {>= "1.4"}
+  "conf-zlib"
+  "conf-gmp-powm-sec"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xavierleroy/cryptokit.git"
+url {
+  src: "https://github.com/xavierleroy/cryptokit/archive/release116.tar.gz"
+  checksum: [
+    "md5=1f34029aa06e20774b76498e8c9d610b"
+    "sha512=f9d453154f094c5b3649487bf2928e17a92c51d252673f47f1c339e176ca94d14f0bb67f9c1ef7debbb34e971017d7d367248999e3a49e743c6f491f8327147f"
+  ]
+}


### PR DESCRIPTION
### `cryptokit.1.16`
A library of cryptographic primitives
Cryptokit includes block ciphers (AES, DES, 3DES), stream ciphers
(ARCfour), public-key crypto (RSA, DH), hashes (SHA-1, SHA-256,
SHA-3), MACs, compression, random number generation -- all presented
with a compositional, extensible interface.



---
* Homepage: https://github.com/xavierleroy/cryptokit
* Source repo: git+https://github.com/xavierleroy/cryptokit.git
* Bug tracker: https://github.com/xavierleroy/cryptokit/issues

---
:camel: Pull-request generated by opam-publish v2.0.2