### PR TITLE
Publish not-ocamlfind 0.07.01

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.07.01/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.07.01/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.8.0"}
+  "fmt" {>= "0.8.8"}
+  "sexplib" {>= "v0.13.0"}
+  "rresult" {>= "0.6.0"}
+  "ocamlgraph" {>= "2.0.0"}
+]
+depexts: [
+  [
+    "xdot"
+  ] {os-family = "debian"}
+]
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/0.07.01.tar.gz"
+  checksum: [
+    "sha512=1adb172b4b3340f233e4b3e7fef0ccd075d3a35bf54abe652aa174bd195fc89f5f74065a12b1587a0c0d0b493249d7ecc9330b69d59b5f8d27d86ee793bf4e0d"
+  ]
+}


### PR DESCRIPTION
* [13 Oct 2020] added a changelog

  minor fix for ocamlgraph 2.0.0 compatibility.  Since ocamlgraph
  1.8.8->2.0.0 is a breaking change, this version of not-ocamlfind
  will only work with the newer version of ocamlgraph.