### PR TITLE
Package brr.0.0.1

### DIFF
--- a/packages/brr/brr.0.0.1/opam
+++ b/packages/brr/brr.0.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The brr programmers"]
+homepage: "https://erratique.ch/software/brr"
+doc: "https://erratique.ch/software/brr/doc"
+license: ["ISC" "BSD3"]
+dev-repo: "git+https://erratique.ch/repos/brr.git"
+bug-reports: "https://github.com/dbuenzli/brr/issues"
+tags: ["reactive" "declarative" "frp" "front-end" "browser"
+       "org:erratique"]
+depends:
+[
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "js_of_ocaml-compiler" {>= "3.7.1"}
+  "js_of_ocaml-toplevel" {>= "3.7.1"}
+  "note"
+]
+build:
+[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{dev}%"
+]]
+
+synopsis: """Browser programming toolkit for OCaml"""
+description: """\
+
+Brr is a toolkit for programming browsers in OCaml with the
+[`js_of_ocaml`][jsoo] compiler. It provides:
+
+* Interfaces to a selection of browser APIs.
+* Note based reactive support (optional and experimental).
+* An OCaml console developer tool for live interaction 
+  with programs running in web pages.
+* A JavaScript FFI for idiomatic OCaml programming.
+
+Brr is distributed under the ISC license. It depends on [Note][note]
+and on the `js_of_ocaml` compiler and runtime – but not on its
+libraries or syntax extension.
+
+[note]: https://erratique.ch/software/note
+[jsoo]: https://ocsigen.org/js_of_ocaml
+"""
+url {
+archive: "https://erratique.ch/software/brr/releases/brr-0.0.1.tbz"
+checksum: "e647233a49af156b42872316eff44c8c"
+}


### PR DESCRIPTION
### `brr.0.0.1`
Browser programming toolkit for OCaml
Brr is a toolkit for programming browsers in OCaml with the
[`js_of_ocaml`][jsoo] compiler. It provides:

* Interfaces to a selection of browser APIs.
* Note based reactive support (optional and experimental).
* An OCaml console developer tool for live interaction 
  with programs running in web pages.
* A JavaScript FFI for idiomatic OCaml programming.

Brr is distributed under the ISC license. It depends on [Note][note]
and on the `js_of_ocaml` compiler and runtime – but not on its
libraries or syntax extension.

[note]: https://erratique.ch/software/note
[jsoo]: https://ocsigen.org/js_of_ocaml



---
* Homepage: https://erratique.ch/software/brr
* Source repo: git+https://erratique.ch/repos/brr.git
* Bug tracker: https://github.com/dbuenzli/brr/issues

---
v0.0.1 2020-10-14 Zagreb
------------------------

First release. 

---
:camel: Pull-request generated by opam-publish v2.0.2