### PR TITLE
2 packages from project-everest/hacl-star at 0.3.0

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `hacl-star` package, of
+which `hacl-star-raw` is a dependency."""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ctypes"
+  "ctypes-foreign"
+]
+available: os-family != "bsd"
+build: [
+  ["sh" "-exc" "cd raw && ./configure"]
+  [make "-C" "raw"]
+]
+install: [make "-C" "raw" "install-hacl-star-raw"]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.3.0/hacl-star.0.3.0.tar.gz"
+  checksum: [
+    "md5=d96f706ad7cc24b0b4bd048a8acf872e"
+    "sha512=909b2cc9cfd7d37959768d441fe248eaf09c82072d82a25927fa3a5fb1582602d1196604d8fcc663531b7cd5fc1554129f1dc069b8ba147c5c4c4d8139573485"
+  ]
+}

--- a/packages/hacl-star/hacl-star.0.3.0/opam
+++ b/packages/hacl-star/hacl-star.0.3.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "OCaml API for EverCrypt/HACL*"
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.2"}
+  "hacl-star-raw" {= version}
+  "zarith"
+  "cppo" {build}
+]
+available: os-family != "bsd"
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.3.0/hacl-star.0.3.0.tar.gz"
+  checksum: [
+    "md5=d96f706ad7cc24b0b4bd048a8acf872e"
+    "sha512=909b2cc9cfd7d37959768d441fe248eaf09c82072d82a25927fa3a5fb1582602d1196604d8fcc663531b7cd5fc1554129f1dc069b8ba147c5c4c4d8139573485"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`hacl-star.0.3.0`: OCaml API for EverCrypt/HACL*
-`hacl-star-raw.0.3.0`: Auto-generated low-level OCaml bindings for EverCrypt/HACL*



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.2