### PR TITLE
[new release] uri-re, uri-sexp and uri (3.2.0)

### DIFF
--- a/packages/uri-re/uri-re.3.2.0/opam
+++ b/packages/uri-re/uri-re.3.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "re" {>= "1.9.0"}
+  "stringext" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+x-commit-hash: "8897ba50caa0b15c846218c20f62f42f940f29c0"
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v3.2.0/uri-v3.2.0.tbz"
+  checksum: [
+    "sha256=1654f9ad6e543c1b9eada518b29f0cafb13c1e098fdfc3e18b06878f460f8fda"
+    "sha512=aa07a33470a655dfa43273b03648980eddd3157541e96f0f6f8f392c4ab4cf4bd9f1a0445d046bd60d0bbce99caaac0bec8a8e16b41b2f15da6d1a0b84669947"
+  ]
+}

--- a/packages/uri-sexp/uri-sexp.3.2.0/opam
+++ b/packages/uri-sexp/uri-sexp.3.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+ocaml-uri with sexp support
+"""
+depends: [
+  "uri" {= version}
+  "dune" {>= "1.2.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "sexplib0"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+x-commit-hash: "8897ba50caa0b15c846218c20f62f42f940f29c0"
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v3.2.0/uri-v3.2.0.tbz"
+  checksum: [
+    "sha256=1654f9ad6e543c1b9eada518b29f0cafb13c1e098fdfc3e18b06878f460f8fda"
+    "sha512=aa07a33470a655dfa43273b03648980eddd3157541e96f0f6f8f392c4ab4cf4bd9f1a0445d046bd60d0bbce99caaac0bec8a8e16b41b2f15da6d1a0b84669947"
+  ]
+}

--- a/packages/uri/uri.3.2.0/opam
+++ b/packages/uri/uri.3.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "stringext" {>= "1.4.0"}
+  "angstrom" {>= "0.14.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+x-commit-hash: "8897ba50caa0b15c846218c20f62f42f940f29c0"
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v3.2.0/uri-v3.2.0.tbz"
+  checksum: [
+    "sha256=1654f9ad6e543c1b9eada518b29f0cafb13c1e098fdfc3e18b06878f460f8fda"
+    "sha512=aa07a33470a655dfa43273b03648980eddd3157541e96f0f6f8f392c4ab4cf4bd9f1a0445d046bd60d0bbce99caaac0bec8a8e16b41b2f15da6d1a0b84669947"
+  ]
+}


### PR DESCRIPTION
An RFC3986 URI/URL parsing library

- Project page: <a href="https://github.com/mirage/ocaml-uri">https://github.com/mirage/ocaml-uri</a>
- Documentation: <a href="https://mirage.github.io/ocaml-uri/">https://mirage.github.io/ocaml-uri/</a>

##### CHANGES:

* sexp: use the sexplib v0.13 ppx directives (@avsm, mirage/ocaml-uri#143).
* rework the URI parser with `angstrom` (@anmonteiro, review @avsm & @dinosaure, mirage/ocaml-uri#142).
* add simple fuzzer tests between `angstrom` parser and _legacy_ parser (with `re.posix`, mirage/ocaml-uri#142)
* add support of modifying pct encoding (with a custom one) (@orbitz, review @anmonteiro, @tmcgilchrist, @avsm & @dinosaure, mirage/ocaml-uri#147)
* allow the selection of generic set of safe characters (with `Generic`) (@madroach, review @dinosaure, mirage/ocaml-uri#141)
