### PR TITLE
[new release] repr-bench, repr, ppx_repr and repr-fuzz (0.1.0)

### DIFF
--- a/packages/ppx_repr/ppx_repr.0.1.0/opam
+++ b/packages/ppx_repr/ppx_repr.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "PPX deriver for type representations"
+description: "PPX deriver for type representations"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "ppxlib" {>= "0.12.0" & < "0.18.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "178176e8f41ce74c485493814de3f8d1d3c0738c"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.1.0/repr-fuzz-0.1.0.tbz"
+  checksum: [
+    "sha256=b79d34a45d17c3490fadcf39259f8387435fb2b79572deab1af1bbef4977b371"
+    "sha512=269b8e43e5ebb470747fb8f9cb828239f44f307206bed1bf67b59d6ef286e62dae6f1b867c154bf94ba81af2f2374634bd737f73c7383bc314f7b18f52f73aad"
+  ]
+}

--- a/packages/repr-bench/repr-bench.0.1.0/opam
+++ b/packages/repr-bench/repr-bench.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Benchmarks for the `repr` package"
+description: "Benchmarks for the `repr` package"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "bechamel"
+  "yojson"
+  "fpath"
+  "ppx_deriving_yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "178176e8f41ce74c485493814de3f8d1d3c0738c"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.1.0/repr-fuzz-0.1.0.tbz"
+  checksum: [
+    "sha256=b79d34a45d17c3490fadcf39259f8387435fb2b79572deab1af1bbef4977b371"
+    "sha512=269b8e43e5ebb470747fb8f9cb828239f44f307206bed1bf67b59d6ef286e62dae6f1b867c154bf94ba81af2f2374634bd737f73c7383bc314f7b18f52f73aad"
+  ]
+}

--- a/packages/repr-bench/repr-bench.0.1.0/opam
+++ b/packages/repr-bench/repr-bench.0.1.0/opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/mirage/repr/issues"
 depends: [
   "dune" {>= "2.7"}
   "repr" {= version}
+  "ppx_repr" {= version}
   "bechamel"
   "yojson"
   "fpath"

--- a/packages/repr-fuzz/repr-fuzz.0.1.0/opam
+++ b/packages/repr-fuzz/repr-fuzz.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Fuzz tests for the `repr` package"
+description: "Fuzz tests for the `repr` package"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "crowbar" {= "0.2"}
+  "ppxlib" {>= "0.12.0" & < "0.18.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "178176e8f41ce74c485493814de3f8d1d3c0738c"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.1.0/repr-fuzz-0.1.0.tbz"
+  checksum: [
+    "sha256=b79d34a45d17c3490fadcf39259f8387435fb2b79572deab1af1bbef4977b371"
+    "sha512=269b8e43e5ebb470747fb8f9cb828239f44f307206bed1bf67b59d6ef286e62dae6f1b867c154bf94ba81af2f2374634bd737f73c7383bc314f7b18f52f73aad"
+  ]
+}

--- a/packages/repr/repr.0.1.0/opam
+++ b/packages/repr/repr.0.1.0/opam
@@ -23,6 +23,7 @@ depends: [
   "hex" {with-test}
   "alcotest" {>= "1.1.0" & with-test}
   "odoc" {with-doc}
+  "ppx_repr" {= version & post & with-test}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/repr/repr.0.1.0/opam
+++ b/packages/repr/repr.0.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "hex" {with-test}
   "alcotest" {>= "1.1.0" & with-test}
   "odoc" {with-doc}
-  "ppx_repr" {= version & post & with-test}
+  "ppx_repr" {= version & with-test}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/repr/repr.0.1.0/opam
+++ b/packages/repr/repr.0.1.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Dynamic type representations. Provides no stability guarantee"
+description: """
+This package defines a library of combinators for building dynamic type
+representations and a set of generic operations over representable types, used
+in the implementation of Irmin and related packages.
+
+It is not yet intended for public consumption and provides no stability
+guarantee.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.0"}
+  "uutf"
+  "jsonm" {>= "1.0.0"}
+  "base64" {>= "2.0.0"}
+  "hex" {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "178176e8f41ce74c485493814de3f8d1d3c0738c"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.1.0/repr-fuzz-0.1.0.tbz"
+  checksum: [
+    "sha256=b79d34a45d17c3490fadcf39259f8387435fb2b79572deab1af1bbef4977b371"
+    "sha512=269b8e43e5ebb470747fb8f9cb828239f44f307206bed1bf67b59d6ef286e62dae6f1b867c154bf94ba81af2f2374634bd737f73c7383bc314f7b18f52f73aad"
+  ]
+}


### PR DESCRIPTION
Dynamic type representations. Provides no stability guarantee

- Project page: <a href="https://github.com/mirage/repr">https://github.com/mirage/repr</a>

##### CHANGES:

Initial release.
