### PR TITLE
Package cryptokit.1.16.1

### DIFF
--- a/packages/cryptokit/cryptokit.1.16.1/opam
+++ b/packages/cryptokit/cryptokit.1.16.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A library of cryptographic primitives"
+description: """\
+Cryptokit includes block ciphers (AES, DES, 3DES), stream ciphers
+(ARCfour), public-key crypto (RSA, DH), hashes (SHA-1, SHA-256,
+SHA-3), MACs, compression, random number generation -- all presented
+with a compositional, extensible interface."""
+maintainer: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+authors: "Xavier Leroy"
+homepage: "https://github.com/xavierleroy/cryptokit"
+bug-reports: "https://github.com/xavierleroy/cryptokit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "dune-configurator"
+  "zarith" {>= "1.4"}
+  "conf-zlib"
+  "conf-gmp-powm-sec"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xavierleroy/cryptokit.git"
+url {
+  src: "https://github.com/xavierleroy/cryptokit/archive/release1161.tar.gz"
+  checksum: [
+    "md5=18591fc3f467bc33681be2cede36b8f1"
+    "sha512=28913a7c35ae951a4c464287acc511ee1bdc9d03b5928e2243c5ae5cbb8b10afe8e84d7a73ba6478ed62657d01fdb6f02472739255c33de3671c4130b659da52"
+  ]
+}


### PR DESCRIPTION
### `cryptokit.1.16.1`
A library of cryptographic primitives
Cryptokit includes block ciphers (AES, DES, 3DES), stream ciphers
(ARCfour), public-key crypto (RSA, DH), hashes (SHA-1, SHA-256,
SHA-3), MACs, compression, random number generation -- all presented
with a compositional, extensible interface.



---
* Homepage: https://github.com/xavierleroy/cryptokit
* Source repo: git+https://github.com/xavierleroy/cryptokit.git
* Bug tracker: https://github.com/xavierleroy/cryptokit/issues

---
:camel: Pull-request generated by opam-publish v2.0.2