### PR TITLE
frama-c: do not force disable GUI (fix lablgtk3 issue)

### DIFF
--- a/packages/frama-c/frama-c.21.1/opam
+++ b/packages/frama-c/frama-c.21.1/opam
@@ -86,9 +86,6 @@ tags: [
 build: [
   ["autoconf"] {pinned}
   ["./configure" "--prefix" prefix
-                 "--disable-gui" { !conf-gtksourceview:installed |
-                                   ( !conf-gnomecanvas:installed &
-                                     !lablgtk3:installed) }
                  "--mandir=%{man}%"
   ]
   [make "-j%{jobs}%"]


### PR DESCRIPTION
The Frama-C configure should be able to automatically disable the GUI when the required packages are not available, so we don't need to test them again at the opam level. Also, this avoids an issue when installing lablgtk3-specific packages (namely conf-gtksourceview3), which would force disabling the GUI unnecessarily.