### PR TITLE
[new release] ocaml-r (0.4.0)

### DIFF
--- a/packages/ocaml-r/ocaml-r.0.4.0/opam
+++ b/packages/ocaml-r/ocaml-r.0.4.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Objective Caml bindings for the R interpreter"
+description: """
+
+OCaml-R is a library that can be used to construct R values in memory,
+convert them to OCaml values, and build clean wrappers to R
+functions. It provide a simple means to develop bindings to any R
+package."""
+maintainer: ["philippe.veber@gmail.com"]
+authors: ["Guillaume Yzyquel" "Maxence Guesdon" "Philippe Veber"]
+license: "GPL3"
+tags: ["R" "statistics"]
+homepage: "https://github.com/pveber/ocaml-r/"
+doc: "https://pveber.github.io/ocaml-r/ocaml-r/index.html"
+bug-reports: "https://github.com/pveber/ocaml-r/issues"
+depends: [
+  "base" {build & >= "v0.14"}
+  "conf-r" {build}
+  "conf-r-mathlib" {build}
+  "dune" {>= "2.5"}
+  "stdio" {>= "v0.14" & build}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pveber/ocaml-r.git"
+x-commit-hash: "888680d5ecc2eb3d4aeb87c52cf48a0990a038d5"
+url {
+  src:
+    "https://github.com/pveber/ocaml-r/releases/download/v0.4.0/ocaml-r-v0.4.0.tbz"
+  checksum: [
+    "sha256=12629a334c28908343a590785e69e086ddf899bb8a0e61b31a9b2e4e36ce3baa"
+    "sha512=b39d8a286652f4d7bdcae37f44d9d1844e0de41491dfb44ac7443fabdfb4e0d14467b9a4f612bac1ca8252d0f0075654925f4e491792a60cdb045added7b7c59"
+  ]
+}

--- a/packages/ocaml-r/ocaml-r.0.4.0/opam
+++ b/packages/ocaml-r/ocaml-r.0.4.0/opam
@@ -19,6 +19,7 @@ depends: [
   "conf-r-mathlib" {build}
   "dune" {>= "2.5"}
   "stdio" {>= "v0.14" & build}
+  "alcotest" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/ocaml-r/ocaml-r.0.4.0/opam
+++ b/packages/ocaml-r/ocaml-r.0.4.0/opam
@@ -14,6 +14,7 @@ homepage: "https://github.com/pveber/ocaml-r/"
 doc: "https://pveber.github.io/ocaml-r/ocaml-r/index.html"
 bug-reports: "https://github.com/pveber/ocaml-r/issues"
 depends: [
+  "ocaml" {>= "4.08"}
   "base" {build & >= "v0.14"}
   "conf-r" {build}
   "conf-r-mathlib" {build}


### PR DESCRIPTION
Objective Caml bindings for the R interpreter

- Project page: <a href="https://github.com/pveber/ocaml-r/">https://github.com/pveber/ocaml-r/</a>
- Documentation: <a href="https://pveber.github.io/ocaml-r/ocaml-r/index.html">https://pveber.github.io/ocaml-r/ocaml-r/index.html</a>

##### CHANGES:

ocaml-r-0.4.0 2020-10-15
------------------------

This version implements a massive API refactoring, which generalizes
and amplifies the design experimented in version 0.2.0. Each R
datatype is represented as an abstract type of a dedicated module. The
`t` type of the module is a bare SEXP (or at rather a custom block
wrapping a bare SEXP). S3 inheritance is represented by module (type)
inclusion.

- addition of an (alco)test suite
- (typed) matrices for logical, character and int types
- row and column access for data.frame and matrix
- access to factor values
- safer interface for list and data.frame components
- modular interface for statistical tests

ocaml-r-0.3.1 2020-07-29
------------------------

- replaced configurator by dune.configurator
- fixed compilation warnings

ocaml-r-0.3.0 2020-05-07
------------------------

- base: added readRDS, saveRDS, cbind, rbind
- graphics: abline
- stats: ecdf
- fixed compilation bug

ocaml-r-0.2.0 2019-06-07
------------------------

- experimented modular (instead of object) interfaces
- a few more wrappers in base, stats and graphics
- improved stub generation
- API documentation

ocaml-r-0.1.1 2018-11-18
------------------------

jbuilder-to-dune transition

ocaml-r-0.1.0 2018-06-06
------------------------

First formal release
