### PR TITLE
[new release] conduit-lwt-tls, conduit-mirage, conduit-tls, conduit-lwt, conduit-async-tls, conduit-async, conduit, conduit-async-ssl and conduit-lwt-ssl (3.0.0)

### DIFF
--- a/packages/conduit-async-ssl/conduit-async-ssl.3.0.0/opam
+++ b/packages/conduit-async-ssl/conduit-async-ssl.3.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library using Async and OpenSSL"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1"] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.07.0"}
+  "dune"          {>= "2.0.0"}
+  "core"
+  "conduit-async" {= version}
+  "async"         {>= "v0.12.0"}
+  "async_ssl"
+]
+x-commit-hash: "f5ec040e47bf878c17c247a8e18bed7a0d60d2af"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=ac41681b50107c96bcae92fc93be4faa3d4d2b6c2095e79b963c142a0f055fd8"
+    "sha512=b427c2f37908b662f98360410dcaa18b31554024ddf2480abd9195acc83f427df44428642d2b028faa15c99f4a538d15fcd89d9b8dca399ee684864633963738"
+  ]
+}

--- a/packages/conduit-async-tls/conduit-async-tls.3.0.0/opam
+++ b/packages/conduit-async-tls/conduit-async-tls.3.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library using Async and ocaml-tls"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1"] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.07.0"}
+  "dune"          {>= "2.0.0"}
+  "core"
+  "conduit-async" {= version}
+  "async"         {>= "v0.12.0"}
+  "conduit-tls"   {= version}
+]
+x-commit-hash: "f5ec040e47bf878c17c247a8e18bed7a0d60d2af"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=ac41681b50107c96bcae92fc93be4faa3d4d2b6c2095e79b963c142a0f055fd8"
+    "sha512=b427c2f37908b662f98360410dcaa18b31554024ddf2480abd9195acc83f427df44428642d2b028faa15c99f4a538d15fcd89d9b8dca399ee684864633963738"
+  ]
+}

--- a/packages/conduit-async/conduit-async.3.0.0/opam
+++ b/packages/conduit-async/conduit-async.3.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Romain Calascibetta"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Async"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1"] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.0.0"}
+  "core"
+  "conduit" {= version}
+  "async" {>= "v0.12.0"}
+  "cstruct"
+  "base-bigarray" {with-test}
+  "bigstringaf" {with-test}
+  "ke" {with-test}
+  "fmt" {with-test}
+  "rresult" {with-test}
+  "conduit-async-tls" {with-test & post}
+  "conduit-async-ssl" {with-test & post}
+]
+x-commit-hash: "f5ec040e47bf878c17c247a8e18bed7a0d60d2af"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=ac41681b50107c96bcae92fc93be4faa3d4d2b6c2095e79b963c142a0f055fd8"
+    "sha512=b427c2f37908b662f98360410dcaa18b31554024ddf2480abd9195acc83f427df44428642d2b028faa15c99f4a538d15fcd89d9b8dca399ee684864633963738"
+  ]
+}

--- a/packages/conduit-lwt-ssl/conduit-lwt-ssl.3.0.0/opam
+++ b/packages/conduit-lwt-ssl/conduit-lwt-ssl.3.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors:[
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Romain Calascibetta"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt and OpenSSL"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1"] {with-test}
+]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.0.0"}
+  "conduit-lwt" {= version}
+  "lwt_ssl"
+]
+x-commit-hash: "f5ec040e47bf878c17c247a8e18bed7a0d60d2af"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=ac41681b50107c96bcae92fc93be4faa3d4d2b6c2095e79b963c142a0f055fd8"
+    "sha512=b427c2f37908b662f98360410dcaa18b31554024ddf2480abd9195acc83f427df44428642d2b028faa15c99f4a538d15fcd89d9b8dca399ee684864633963738"
+  ]
+}

--- a/packages/conduit-lwt-tls/conduit-lwt-tls.3.0.0/opam
+++ b/packages/conduit-lwt-tls/conduit-lwt-tls.3.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors:[
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Romain Calascibetta"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt and ocaml-tls"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1"] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.07.0"}
+  "dune"              {>= "2.0.0"}
+  "conduit-lwt"       {= version}
+  "conduit-tls"       {= version}
+  "mirage-crypto-rng" {>= "0.8.0"}
+]
+x-commit-hash: "f5ec040e47bf878c17c247a8e18bed7a0d60d2af"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=ac41681b50107c96bcae92fc93be4faa3d4d2b6c2095e79b963c142a0f055fd8"
+    "sha512=b427c2f37908b662f98360410dcaa18b31554024ddf2480abd9195acc83f427df44428642d2b028faa15c99f4a538d15fcd89d9b8dca399ee684864633963738"
+  ]
+}

--- a/packages/conduit-lwt/conduit-lwt.3.0.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.3.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors:[
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Romain Calascibetta"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1"] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.0.0"}
+  "conduit" {= version}
+  "cstruct"
+  "lwt"
+  "base-unix"
+  "base-bigarray" {with-test}
+  "bigstringaf" {with-test}
+  "ke" {with-test}
+  "fmt" {with-test}
+  "rresult" {with-test}
+  "conduit-lwt-tls" {with-test & post}
+  "conduit-lwt-ssl" {with-test & post}
+]
+x-commit-hash: "f5ec040e47bf878c17c247a8e18bed7a0d60d2af"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=ac41681b50107c96bcae92fc93be4faa3d4d2b6c2095e79b963c142a0f055fd8"
+    "sha512=b427c2f37908b662f98360410dcaa18b31554024ddf2480abd9195acc83f427df44428642d2b028faa15c99f4a538d15fcd89d9b8dca399ee684864633963738"
+  ]
+}

--- a/packages/conduit-mirage/conduit-mirage.3.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.3.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.0.0"}
+  "conduit" {= version}
+  "tcpip"
+  "mirage-flow"
+  "mirage-time"
+  "dns-client" {>= "4.6.0"}
+  "ke"
+  "bigstringaf"
+]
+x-commit-hash: "f5ec040e47bf878c17c247a8e18bed7a0d60d2af"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=ac41681b50107c96bcae92fc93be4faa3d4d2b6c2095e79b963c142a0f055fd8"
+    "sha512=b427c2f37908b662f98360410dcaa18b31554024ddf2480abd9195acc83f427df44428642d2b028faa15c99f4a538d15fcd89d9b8dca399ee684864633963738"
+  ]
+}

--- a/packages/conduit-tls/conduit-tls.3.0.0/opam
+++ b/packages/conduit-tls/conduit-tls.3.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+  "Romain Calascibetta"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "An ocaml-tls for conduit"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "conduit" {= version}
+  "ke"
+  "tls"
+  "logs"
+  "bigstringaf"
+]
+x-commit-hash: "f5ec040e47bf878c17c247a8e18bed7a0d60d2af"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=ac41681b50107c96bcae92fc93be4faa3d4d2b6c2095e79b963c142a0f055fd8"
+    "sha512=b427c2f37908b662f98360410dcaa18b31554024ddf2480abd9195acc83f427df44428642d2b028faa15c99f4a538d15fcd89d9b8dca399ee684864633963738"
+  ]
+}

--- a/packages/conduit/conduit.3.0.0/opam
+++ b/packages/conduit/conduit.3.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Romain Calascibetta"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"        {>= "4.07.0"}
+  "dune"         {>= "2.0.0"}
+  "ipaddr"
+  "domain-name"
+  "stdlib-shims"
+  "alcotest"     {with-test}
+  "rresult"      {with-test}
+]
+x-commit-hash: "f5ec040e47bf878c17c247a8e18bed7a0d60d2af"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=ac41681b50107c96bcae92fc93be4faa3d4d2b6c2095e79b963c142a0f055fd8"
+    "sha512=b427c2f37908b662f98360410dcaa18b31554024ddf2480abd9195acc83f427df44428642d2b028faa15c99f4a538d15fcd89d9b8dca399ee684864633963738"
+  ]
+}


### PR DESCRIPTION
A portable network connection establishment library using Lwt

- Project page: <a href="https://github.com/mirage/ocaml-conduit">https://github.com/mirage/ocaml-conduit</a>

##### CHANGES:

* **breaking change** - New version of `conduit`. Most of the new API has a
  description on the pull-request
  [mirage/ocaml-conduit#311](https://github.com/mirage/ocaml-conduit/pull/311). Documentation is
  updated as well with a small HOW-TO (available
  [here](https://mirage.github.io/ocaml-conduit/conduit/howto.html)) which
  describes the new API. An other document exists to understand the goal
  of Conduit [here](https://mirage.github.io/ocaml-conduit/conduit/readme.html).
