### PR TITLE
Release Camlp5 Version 8.00-alpha06

### DIFF
--- a/packages/camlp5/camlp5.8.00~alpha06/opam
+++ b/packages/camlp5/camlp5.8.00~alpha06/opam
@@ -73,6 +73,6 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha06.tar.gz"
   checksum: [
-    "sha512=f07eabe0a9c2a1908bade41309169710351fc5e764e266f4a6261fcd6df31fbe5bee41d5c4107431a8805a15d3671e847f37d9ea765ed8da2d8f1aef8225050c"
+    "sha512=c7bf823ea4a468f51e8d3cd2c6312b2866ed675d999fb7a94679dcb1f6df3a23a5fd705540d63ae99631f3f9e0db105f2bba2f46f1124b1d44912b80d1aa6c77"
   ]
 }

--- a/packages/camlp5/camlp5.8.00~alpha06/opam
+++ b/packages/camlp5/camlp5.8.00~alpha06/opam
@@ -1,0 +1,78 @@
+name: "camlp5"
+version: "8.00~alpha06"
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.02" & < "4.12.0"}
+  "conf-perl"
+  "pcre" { with-test }
+  "ounit2" { with-test }
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "world.opt"]
+]
+install: [make "install"]
+depexts: [
+  [
+    "libstring-shellquote-perl"
+    "libipc-system-simple-perl"
+  ] {os-family = "debian"}
+  [
+    "perl-string-shellquote"
+    "perl-ipc-system-simple"
+  ] {os-distribution = "alpine"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-distribution = "centos"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-family = "suse"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-family = "fedora"}
+  [
+    "perl-string-shellquote"
+    "perl-ipc-system-simple"
+  ] {os-family = "arch"}
+]
+
+post-messages:
+  "To use mkcamlp5 and mkcamlp5.opt properly you will require Perl module which contains 'IPC/System/Simple.pm'. We currently don't know the right way to specify this dependecy on BSD and MacOS systems. You can use https://github.com/camlp5/camlp5/issues/66 for discussion."
+    { os = "macos" | os = "freebsd" | os = "openbsd" }
+
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/rel8.00+alpha06.tar.gz"
+  checksum: [
+    "sha512=f07eabe0a9c2a1908bade41309169710351fc5e764e266f4a6261fcd6df31fbe5bee41d5c4107431a8805a15d3671e847f37d9ea765ed8da2d8f1aef8225050c"
+  ]
+}


### PR DESCRIPTION
* [01 Oct 2020] multiple small changes

  * export "pa_macro_gram.cmo" as the findlib package "camlp5.macro_gram": this provides IFDEF support in grammars.

  * in Q_ast, add "stri" as a valid antiquotation for str_item.  And add tests.

  * factored out base of Q_ast, so we can use it in PPX derivers that
    generate quotations for other types than Camlp5's AST