### PR TITLE
Package pg_query.0.9.6

### DIFF
--- a/packages/pg_query/pg_query.0.9.6/opam
+++ b/packages/pg_query/pg_query.0.9.6/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Bindings to libpg_query for parsing PostgreSQL"
+description:
+  "OCaml bindings to libpg_query for parsing PostgreSQL, and a command-line tool that uses them"
+maintainer: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+authors: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+license: "MIT"
+homepage: "https://github.com/roddyyaga/pg_query-ocaml"
+doc: "https://roddyyaga.github.io/pg_query-ocaml/pg_query-ocaml/index.html"
+bug-reports: "https://github.com/roddyyaga/pg_query-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "2.0"}
+  "cmdliner"
+  "ctypes"
+  "ctypes-foreign"
+  "ppx_deriving"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/roddyyaga/pg_query-ocaml.git"
+url {
+  src: "https://github.com/roddyyaga/pg_query-ocaml/archive/0.9.6.tar.gz"
+  checksum: [
+    "md5=591f55317b49a01d6000ac43b77dd68e"
+    "sha512=f9284cde820d15320d9c86eb6342e9ac280967bad9655f5e5ca11d8dcac13e0aadd4c43064ebfb33364c70a166fc2b16b3d0ad82e1e30a29157cd831c04aeb8b"
+  ]
+}


### PR DESCRIPTION
### `pg_query.0.9.6`
Bindings to libpg_query for parsing PostgreSQL
OCaml bindings to libpg_query for parsing PostgreSQL, and a command-line tool that uses them



---
* Homepage: https://github.com/roddyyaga/pg_query-ocaml
* Source repo: git+https://github.com/roddyyaga/pg_query-ocaml.git
* Bug tracker: https://github.com/roddyyaga/pg_query-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2