### PR TITLE
Package speex.0.3.0

### DIFF
--- a/packages/speex/speex.0.3.0/opam
+++ b/packages/speex/speex.0.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-speex"
+build: [
+  ["./bootstrap"] {dev}
+  ["./configure" "--prefix" prefix] {os != "macos"}
+  [
+    "./configure"
+    "CFLAGS=-I/usr/local/include"
+    "LDFLAGS=-L/usr/local/lib"
+    "OCAMLFLAGS=-ccopt -I/usr/local/include -cclib -L/usr/local/lib"
+    "--prefix"
+    prefix
+  ] {os = "macos"}
+  [make "clean"] {dev}
+  [make]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+  "ogg"
+  "conf-libflac" {build}
+  "conf-pkg-config" {build}
+]
+bug-reports: "https://github.com/savonet/ocaml-speex/issues"
+dev-repo: "git+https://github.com/savonet/ocaml-speex.git"
+synopsis:
+  "Bindings for the speex library to decode audio files in speex format"
+url {
+  src:
+    "https://github.com/savonet/ocaml-speex/releases/download/v0.3.0/ocaml-speex-0.3.0.tar.gz"
+  checksum: [
+    "md5=dfc41813699da113c89dc02c527a37e9"
+    "sha512=5b125b3fda8b710e0c03ba9dd1a964487aeaee16814b16975cc18981dabcf43e6c3c0eee2cd590f6a0feb5f08d662f3ebcd23b18d812c4aa0de5c02fdd4deb81"
+  ]
+}


### PR DESCRIPTION
### `speex.0.3.0`
Bindings for the speex library to decode audio files in speex format



---
* Homepage: https://github.com/savonet/ocaml-speex
* Source repo: git+https://github.com/savonet/ocaml-speex.git
* Bug tracker: https://github.com/savonet/ocaml-speex/issues

---
:camel: Pull-request generated by opam-publish v2.0.2