### PR TITLE
[new release] repr, repr-fuzz, repr-bench and ppx_repr (0.1.0)

### DIFF
--- a/packages/ppx_repr/ppx_repr.0.1.0/opam
+++ b/packages/ppx_repr/ppx_repr.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "PPX deriver for type representations"
+description: "PPX deriver for type representations"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "ppxlib" {>= "0.12.0" & < "0.18.0"}
+  "hex" {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "d8f03cd243cf92c6e4a6ec760f33e0bc23dd982e"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.1.0/repr-fuzz-0.1.0.tbz"
+  checksum: [
+    "sha256=90225eeb444ad52be83cebb8d80196a9ba2cc5f3da066390c17dadd361db7339"
+    "sha512=15396ed0599acad3be7319574d0492ed8dd4aa2b9669acfc20b3acf98a186cfceabdd186ef88bd994f409fcb885bfbb2d086330092777a7da93f282e4a02b159"
+  ]
+}

--- a/packages/repr-bench/repr-bench.0.1.0/opam
+++ b/packages/repr-bench/repr-bench.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Benchmarks for the `repr` package"
+description: "Benchmarks for the `repr` package"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "ppx_repr" {= version}
+  "bechamel"
+  "yojson"
+  "fpath"
+  "ppx_deriving_yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "d8f03cd243cf92c6e4a6ec760f33e0bc23dd982e"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.1.0/repr-fuzz-0.1.0.tbz"
+  checksum: [
+    "sha256=90225eeb444ad52be83cebb8d80196a9ba2cc5f3da066390c17dadd361db7339"
+    "sha512=15396ed0599acad3be7319574d0492ed8dd4aa2b9669acfc20b3acf98a186cfceabdd186ef88bd994f409fcb885bfbb2d086330092777a7da93f282e4a02b159"
+  ]
+}

--- a/packages/repr-fuzz/repr-fuzz.0.1.0/opam
+++ b/packages/repr-fuzz/repr-fuzz.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Fuzz tests for the `repr` package"
+description: "Fuzz tests for the `repr` package"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "crowbar" {= "0.2"}
+  "ppxlib" {>= "0.12.0" & < "0.18.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "d8f03cd243cf92c6e4a6ec760f33e0bc23dd982e"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.1.0/repr-fuzz-0.1.0.tbz"
+  checksum: [
+    "sha256=90225eeb444ad52be83cebb8d80196a9ba2cc5f3da066390c17dadd361db7339"
+    "sha512=15396ed0599acad3be7319574d0492ed8dd4aa2b9669acfc20b3acf98a186cfceabdd186ef88bd994f409fcb885bfbb2d086330092777a7da93f282e4a02b159"
+  ]
+}

--- a/packages/repr/repr.0.1.0/opam
+++ b/packages/repr/repr.0.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Dynamic type representations. Provides no stability guarantee"
+description: """
+This package defines a library of combinators for building dynamic type
+representations and a set of generic operations over representable types, used
+in the implementation of Irmin and related packages.
+
+It is not yet intended for public consumption and provides no stability
+guarantee.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.0"}
+  "uutf"
+  "jsonm" {>= "1.0.0"}
+  "base64" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "d8f03cd243cf92c6e4a6ec760f33e0bc23dd982e"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.1.0/repr-fuzz-0.1.0.tbz"
+  checksum: [
+    "sha256=90225eeb444ad52be83cebb8d80196a9ba2cc5f3da066390c17dadd361db7339"
+    "sha512=15396ed0599acad3be7319574d0492ed8dd4aa2b9669acfc20b3acf98a186cfceabdd186ef88bd994f409fcb885bfbb2d086330092777a7da93f282e4a02b159"
+  ]
+}


### PR DESCRIPTION
Dynamic type representations. Provides no stability guarantee

- Project page: <a href="https://github.com/mirage/repr">https://github.com/mirage/repr</a>

##### CHANGES:

Initial release.
