### PR TITLE
Package pg_query.0.9.6

### DIFF
--- a/packages/pg_query/pg_query.0.9.6/opam
+++ b/packages/pg_query/pg_query.0.9.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Bindings to libpg_query for parsing PostgreSQL"
+description:
+  "OCaml bindings to libpg_query for parsing PostgreSQL, and a command-line tool that uses them"
+maintainer: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+authors: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+license: "MIT"
+homepage: "https://github.com/roddyyaga/pg_query-ocaml"
+doc: "https://roddyyaga.github.io/pg_query-ocaml/pg_query-ocaml/index.html"
+bug-reports: "https://github.com/roddyyaga/pg_query-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "2.0"}
+  "cmdliner"
+  "ctypes"
+  "ctypes-foreign"
+  "ppx_deriving"
+  "alcotest" {with_test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/roddyyaga/pg_query-ocaml.git"
+url {
+  src: "https://github.com/roddyyaga/pg_query-ocaml/archive/0.9.6.tar.gz"
+  checksum: [
+    "md5=00f353e31ea49a062644f5450fcdf24d"
+    "sha512=591c0c382a427ccaed222c80d0fd683c50779f8090938442de78d18cd6b858a899ed2c6c4d5382a458cfc230dd6a4008821b2bf3eb8a115991b289a092d7efd7"
+  ]
+}


### PR DESCRIPTION
### `pg_query.0.9.6`
Bindings to libpg_query for parsing PostgreSQL
OCaml bindings to libpg_query for parsing PostgreSQL, and a command-line tool that uses them



---
* Homepage: https://github.com/roddyyaga/pg_query-ocaml
* Source repo: git+https://github.com/roddyyaga/pg_query-ocaml.git
* Bug tracker: https://github.com/roddyyaga/pg_query-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2