### PR TITLE
Package pg_query.0.9.6

### DIFF
--- a/packages/pg_query/pg_query.0.9.6/opam
+++ b/packages/pg_query/pg_query.0.9.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Bindings to libpg_query for parsing PostgreSQL"
+description:
+  "OCaml bindings to libpg_query for parsing PostgreSQL, and a command-line tool that uses them"
+maintainer: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+authors: ["Roddy MacSween <github@roddymacsween.co.uk>"]
+license: "MIT"
+homepage: "https://github.com/roddyyaga/pg_query-ocaml"
+doc: "https://roddyyaga.github.io/pg_query-ocaml/pg_query-ocaml/index.html"
+bug-reports: "https://github.com/roddyyaga/pg_query-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "2.0"}
+  "cmdliner"
+  "ctypes"
+  "ctypes-foreign"
+  "ppx_deriving"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/roddyyaga/pg_query-ocaml.git"
+url {
+  src: "https://github.com/roddyyaga/pg_query-ocaml/archive/0.9.6.tar.gz"
+  checksum: [
+    "md5=fe2494f9230c587b0ef13f6722e56967"
+    "sha512=db0e3370591cf3133594abc0c9e6609f163d478ad2e1d6a62e97d0e3bf4e64935b7b6d7fddc5ace95b1d2de458822c08c7e8d8aa8b328a36e919380c4fa74d37"
+  ]
+}


### PR DESCRIPTION
### `pg_query.0.9.6`
Bindings to libpg_query for parsing PostgreSQL
OCaml bindings to libpg_query for parsing PostgreSQL, and a command-line tool that uses them



---
* Homepage: https://github.com/roddyyaga/pg_query-ocaml
* Source repo: git+https://github.com/roddyyaga/pg_query-ocaml.git
* Bug tracker: https://github.com/roddyyaga/pg_query-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2