### PR TITLE
Fix tezos compatibility with uri 4.0

### DIFF
--- a/packages/tezos-base/tezos-base.7.4/opam
+++ b/packages/tezos-base/tezos-base.7.4/opam
@@ -14,7 +14,6 @@ depends: [
   "ptime" { >= "0.8.4" }
   "ezjsonm" { >= "0.5.0" }
   "ipaddr" { >= "4.0.0" & < "5.0.0" }
-  "re" { >= "1.7.2" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-clic/tezos-clic.7.4/files/with-re.patch
+++ b/packages/tezos-clic/tezos-clic.7.4/files/with-re.patch
@@ -1,0 +1,18 @@
+commit 2d04838fcff65c494316562bd415ec98e4a82703
+Author: Pierre Boutillier <pierre.boutillier@nomadic-labs.com>
+Date:   Fri Oct 16 18:05:19 2020 +0200
+
+    Opam: clic requires re
+
+diff --git a/src/lib_clic/dune b/src/lib_clic/dune
+index 421a42c891..22f96d5f10 100644
+--- a/src/lib_clic/dune
++++ b/src/lib_clic/dune
+@@ -5,6 +5,7 @@
+                    -open Tezos_error_monad))
+  (libraries tezos-stdlib
+             lwt
++            re
+             tezos-error-monad))
+ 
+ (rule

--- a/packages/tezos-clic/tezos-clic.7.4/opam
+++ b/packages/tezos-clic/tezos-clic.7.4/opam
@@ -11,6 +11,7 @@ depends: [
   "tezos-stdlib-unix" { = version }
   "re" { >= "1.7.2" }
 ]
+patches: [ "with-re.patch" ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["mv" "src/lib_clic/%{name}%.install" "./"]
@@ -25,3 +26,6 @@ url {
     "sha512=c6d927a821faec5c09864a8945be37e9e7d0b1b6b6ee02c11fccd1fd0b81dcf04ec8c591adc89aefdbf5603192e6e1fb41bbaff097c935130362fbaf9069667a"
   ]
 }
+extra-files: [
+  [ "with-re.patch" "sha256=96ca06d5e11337ce9cac4cde13d05965f698946223a592e0c03c3abd4461ca3f" ]
+]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.4/files/with-re.patch
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.4/files/with-re.patch
@@ -1,0 +1,30 @@
+commit 11a5454ad16e0fa7c9ce74905609fbed9db18e1b
+Author: Pierre Boutillier <pierre.boutillier@nomadic-labs.com>
+Date:   Fri Oct 16 17:35:04 2020 +0200
+
+    Build: tezos-stdlib-unix needs Re
+
+diff --git a/src/lib_stdlib_unix/dune b/src/lib_stdlib_unix/dune
+index 4539125cf5..bbfbd85a28 100644
+--- a/src/lib_stdlib_unix/dune
++++ b/src/lib_stdlib_unix/dune
+@@ -11,6 +11,7 @@
+             tezos-stdlib
+             lwt.unix
+             ipaddr.unix
++            re
+             ptime
+             ptime.clock.os
+             mtime
+diff --git a/src/lib_stdlib_unix/tezos-stdlib-unix.opam b/src/lib_stdlib_unix/tezos-stdlib-unix.opam
+index 9ecebc4440..30b5d93df1 100644
+--- a/src/lib_stdlib_unix/tezos-stdlib-unix.opam
++++ b/src/lib_stdlib_unix/tezos-stdlib-unix.opam
+@@ -13,6 +13,7 @@ depends: [
+   "tezos-error-monad"
+   "tezos-event-logging"
+   "tezos-stdlib"
++  "re"
+   "lwt" { >= "3.0.0" }
+   "ptime" { >= "0.8.4" }
+   "mtime" { >= "1.0.0" }

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.4/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.4/opam
@@ -16,7 +16,9 @@ depends: [
   "mtime" { >= "1.0.0" }
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
+  "re" { >= "1.7.2" }
 ]
+patches: [ "with-re.patch" ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["mv" "src/lib_stdlib_unix/%{name}%.install" "./"]
@@ -31,3 +33,6 @@ url {
     "sha512=c6d927a821faec5c09864a8945be37e9e7d0b1b6b6ee02c11fccd1fd0b81dcf04ec8c591adc89aefdbf5603192e6e1fb41bbaff097c935130362fbaf9069667a"
   ]
 }
+extra-files: [
+  [ "with-re.patch" "sha256=0d784d64fa2aa4059aa72dbbce8b064bab908a15a04322272130d2c361c039ac" ]
+]


### PR DESCRIPTION
Uri 4.0 dropped (well separate into a new package) its dependency to re. 

That revealed that, in 2 places in tezos, re is used without being explicitly declared in the `dune` files which now led build failure. These patches fix that.