### PR TITLE
opam admin add-constraint 'mirage-xen<6.0.0', and further conflicts

### DIFF
--- a/packages/bigstringaf/bigstringaf.0.3.0/opam
+++ b/packages/bigstringaf/bigstringaf.0.3.0/opam
@@ -33,3 +33,6 @@ url {
   src: "https://github.com/inhabitedtype/bigstringaf/archive/0.3.0.tar.gz"
   checksum: "md5=739a2006067d7432743f777d7f5afcfd"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/crc/crc.1.0.0/opam
+++ b/packages/crc/crc.1.0.0/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/xapi-project/ocaml-crc/archive/1.0.0.tar.gz"
   checksum: "md5=09051d7cd0a4dd935d379a1584777e07"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.10.0/opam
+++ b/packages/ctypes/ctypes.0.10.0/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.10.0.tar.gz"
   checksum: "md5=d165e2f434bfa4d7a0e23353e38725ff"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.10.1/opam
+++ b/packages/ctypes/ctypes.0.10.1/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.10.1.tar.gz"
   checksum: "md5=45f0eaef250b03a7885042b3077aff20"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.10.2/opam
+++ b/packages/ctypes/ctypes.0.10.2/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.10.2.tar.gz"
   checksum: "md5=4efd9c98d8dd3483981efc89d41fc16f"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.10.3/opam
+++ b/packages/ctypes/ctypes.0.10.3/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.10.3.tar.gz"
   checksum: "md5=fc8ced9282ddbda2575a5b62b7fc99e6"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.10.4/opam
+++ b/packages/ctypes/ctypes.0.10.4/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.10.4.tar.gz"
   checksum: "md5=846f9ce0638e9a2046a4771a4c47c2d8"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.10.5/opam
+++ b/packages/ctypes/ctypes.0.10.5/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.10.5.tar.gz"
   checksum: "md5=67a4e1ba7dcf2dab40ce7cc3b517dc92"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.11.0/opam
+++ b/packages/ctypes/ctypes.0.11.0/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.11.0.tar.gz"
   checksum: "md5=cc6a8f3a88a1c2d0d03a4ece9aa43360"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.11.1/opam
+++ b/packages/ctypes/ctypes.0.11.1/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.11.1.tar.gz"
   checksum: "md5=4c44181a7d19c911d57485a179ab1713"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.11.2/opam
+++ b/packages/ctypes/ctypes.0.11.2/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.11.2.tar.gz"
   checksum: "md5=72055750770278a84965bb81aec68d87"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.11.3/opam
+++ b/packages/ctypes/ctypes.0.11.3/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.11.3.tar.gz"
   checksum: "md5=cdad9a9020611ebbeb31a47f299e5e15"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.11.4/opam
+++ b/packages/ctypes/ctypes.0.11.4/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.11.4.tar.gz"
   checksum: "md5=585ce71ec3f1b0fb3d9c9cc7fd858119"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.11.5/opam
+++ b/packages/ctypes/ctypes.0.11.5/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.11.5.tar.gz"
   checksum: "md5=20aa5fe2bc8c4c507593dd25edf1e02d"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.12.0/opam
+++ b/packages/ctypes/ctypes.0.12.0/opam
@@ -60,3 +60,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.12.0.tar.gz"
   checksum: "md5=59e8b3f328ba00febabe2a957029cb94"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.12.1/opam
+++ b/packages/ctypes/ctypes.0.12.1/opam
@@ -60,3 +60,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.12.1.tar.gz"
   checksum: "md5=4dd798e84b93cd97fbd605d023a0a707"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.13.0/opam
+++ b/packages/ctypes/ctypes.0.13.0/opam
@@ -60,3 +60,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.13.0.tar.gz"
   checksum: "md5=fe066ce52fb44921314208c3e0ee6c53"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.13.1/opam
+++ b/packages/ctypes/ctypes.0.13.1/opam
@@ -60,3 +60,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.13.1.tar.gz"
   checksum: "md5=0e1b70d28b5b9adc8c4596d9f4dff5b9"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.14.0/opam
+++ b/packages/ctypes/ctypes.0.14.0/opam
@@ -60,3 +60,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.14.0.tar.gz"
   checksum: "md5=57875f5e5986ca6004c356d77a3b31b5"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.15.0/opam
+++ b/packages/ctypes/ctypes.0.15.0/opam
@@ -60,3 +60,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.15.0.tar.gz"
   checksum: "md5=cf151f2713bda6ce5e43124f5f57a6b7"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.15.1/opam
+++ b/packages/ctypes/ctypes.0.15.1/opam
@@ -56,3 +56,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.15.1.tar.gz"
   checksum: "md5=e87b2646f7597e00b8b9a1f5f8e36ee6"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.16.0/opam
+++ b/packages/ctypes/ctypes.0.16.0/opam
@@ -56,3 +56,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.16.0.tar.gz"
   checksum: "md5=31d4f2072abd74e99ed8d70f934e3718"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.17.0/opam
+++ b/packages/ctypes/ctypes.0.17.0/opam
@@ -56,3 +56,6 @@ url {
   checksum: "md5=8dbdf1684a5286433da6fac973ab0e5c"
 }
 available: false
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.17.1/opam
+++ b/packages/ctypes/ctypes.0.17.1/opam
@@ -55,3 +55,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.17.1.tar.gz"
   checksum: "md5=508ea062105518c14fd516aa2ea9db5e"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.4.0/opam
+++ b/packages/ctypes/ctypes.0.4.0/opam
@@ -52,3 +52,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.4.0.tar.gz"
   checksum: "md5=66edc3ea304db77205a228f12893543f"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.4.1/opam
+++ b/packages/ctypes/ctypes.0.4.1/opam
@@ -52,3 +52,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.4.1.tar.gz"
   checksum: "md5=08a284c379e341d57b6918611b5bc56b"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.4.2/opam
+++ b/packages/ctypes/ctypes.0.4.2/opam
@@ -53,3 +53,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.4.2.tar.gz"
   checksum: "md5=072af512312e25ebe1c9de1b5109e49e"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.5.0/opam
+++ b/packages/ctypes/ctypes.0.5.0/opam
@@ -53,3 +53,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.5.0.tar.gz"
   checksum: "md5=769ee19704664e3c34d9938101c38869"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.5.1/opam
+++ b/packages/ctypes/ctypes.0.5.1/opam
@@ -53,3 +53,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.5.1.tar.gz"
   checksum: "md5=92774c91b1dbc1b31a59a78cdb96611b"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.6.0/opam
+++ b/packages/ctypes/ctypes.0.6.0/opam
@@ -53,3 +53,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.6.0.tar.gz"
   checksum: "md5=23ca5f08ce804bb7b028b8f8f641f645"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.6.1/opam
+++ b/packages/ctypes/ctypes.0.6.1/opam
@@ -53,3 +53,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.6.1.tar.gz"
   checksum: "md5=3d542bfc1743873fc3b72bc0b567dab7"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.6.2/opam
+++ b/packages/ctypes/ctypes.0.6.2/opam
@@ -53,3 +53,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.6.2.tar.gz"
   checksum: "md5=1066e7960cb8141d358958f909364821"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.6.3/opam
+++ b/packages/ctypes/ctypes.0.6.3/opam
@@ -53,3 +53,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.6.3.tar.gz"
   checksum: "md5=e3fda6b626e239006bf4416e0ac0b383"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.7.0/opam
+++ b/packages/ctypes/ctypes.0.7.0/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.7.0.tar.gz"
   checksum: "md5=13136bfeb764764e6175b05caadccf7b"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.7.1/opam
+++ b/packages/ctypes/ctypes.0.7.1/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.7.1.tar.gz"
   checksum: "md5=9b26c192aaf1f5a4cf25e7a067738e75"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.7.2/opam
+++ b/packages/ctypes/ctypes.0.7.2/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.7.2.tar.gz"
   checksum: "md5=204d0967fd2a164dd2379bc126ff0eba"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.8.0/opam
+++ b/packages/ctypes/ctypes.0.8.0/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.8.0.tar.gz"
   checksum: "md5=9ca73b1b663b753fa9a77b65822bd119"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.8.1/opam
+++ b/packages/ctypes/ctypes.0.8.1/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.8.1.tar.gz"
   checksum: "md5=354661558f0d2798b1c4fcb3b483bfac"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.8.2/opam
+++ b/packages/ctypes/ctypes.0.8.2/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.8.2.tar.gz"
   checksum: "md5=6e5939389614afe4d6e71478aaf955ab"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.9.0/opam
+++ b/packages/ctypes/ctypes.0.9.0/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.9.0.tar.gz"
   checksum: "md5=0aa68ffa571e7c711c7b0d8c1f73a6d4"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.9.1/opam
+++ b/packages/ctypes/ctypes.0.9.1/opam
@@ -59,3 +59,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.9.1.tar.gz"
   checksum: "md5=8ddf6772802e5cb7b162c644733b0d76"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.9.2/opam
+++ b/packages/ctypes/ctypes.0.9.2/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.9.2.tar.gz"
   checksum: "md5=1918e7e240547d3bc1bcb5f351085a20"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.9.3/opam
+++ b/packages/ctypes/ctypes.0.9.3/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.9.3.tar.gz"
   checksum: "md5=d9139f1462a61f650829c271ef407790"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.9.4/opam
+++ b/packages/ctypes/ctypes.0.9.4/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.9.4.tar.gz"
   checksum: "md5=3b023d198feee3c63783591a750ef1d1"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/ctypes/ctypes.0.9.5/opam
+++ b/packages/ctypes/ctypes.0.9.5/opam
@@ -58,3 +58,6 @@ url {
   src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.9.5.tar.gz"
   checksum: "md5=fd0d441adbb2a14a1855793895b1c71e"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-block-xen/mirage-block-xen.1.7.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.1.7.0/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-block" {>= "2.0.0"}
   "ipaddr"
   "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
   "rresult"
 ]
 build: [

--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.7.0/opam
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.7.0/opam
@@ -21,11 +21,11 @@ build: [
 
 depends: [
   "dune" {>= "1.0"}
-  "mirage-xen" {>= "5.0.0"}
-  "lwt" {>="2.4.3"}
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
+  "lwt" {>= "2.4.3"}
   "astring"
   "parse-argv"
-  "ocaml" { >= "4.06.0" }
+  "ocaml" {>= "4.06.0"}
 ]
 url {
   src:

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.3.0.1/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.3.0.1/opam
@@ -9,9 +9,9 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
-  "mirage-console" {=version}
-  "mirage-console-xen-proto" {=version}
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-console" {= version}
+  "mirage-console-xen-proto" {= version}
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
   "lwt" {>= "4.0.0"}
   "io-page-xen" {>= "2.0.0"}
   "xenstore"

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.3.0.2/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.3.0.2/opam
@@ -9,9 +9,9 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
-  "mirage-console" {=version}
-  "mirage-console-xen-proto" {=version}
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-console" {= version}
+  "mirage-console-xen-proto" {= version}
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
   "lwt" {>= "4.0.0"}
   "io-page-xen" {>= "2.0.0"}
   "xenstore"

--- a/packages/mirage-console-xen/mirage-console-xen.3.0.1/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.3.0.1/opam
@@ -9,11 +9,11 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
-  "mirage-console" {=version}
-  "mirage-console-xen-proto" {=version}
+  "mirage-console" {= version}
+  "mirage-console-xen-proto" {= version}
   "xen-evtchn"
   "io-page-xen"
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-console-xen/mirage-console-xen.3.0.2/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.3.0.2/opam
@@ -9,11 +9,11 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
-  "mirage-console" {=version}
-  "mirage-console-xen-proto" {=version}
+  "mirage-console" {= version}
+  "mirage-console-xen-proto" {= version}
   "xen-evtchn"
   "io-page-xen"
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/mirage-console/mirage-console.2.0.0/opam
+++ b/packages/mirage-console/mirage-console.2.0.0/opam
@@ -17,7 +17,7 @@ depopts: ["mirage-xen"]
 conflicts: [
   "mirage-console-unix"
   "mirage-console-xen"
-  "mirage-xen" {< "1.1.0"}
+  "mirage-xen" {< "1.1.0" | >= "6.0.0"}
 ]
 dev-repo: "git://github.com/mirage/mirage-console"
 install: [make "install"]

--- a/packages/mirage-console/mirage-console.2.1.0/opam
+++ b/packages/mirage-console/mirage-console.2.1.0/opam
@@ -17,7 +17,7 @@ depopts: ["mirage-xen"]
 conflicts: [
   "mirage-console-unix"
   "mirage-console-xen"
-  "mirage-xen" {< "1.1.0"}
+  "mirage-xen" {< "1.1.0" | >= "6.0.0"}
   "mirage-xen" {> "3.3.0"}
 ]
 dev-repo: "git://github.com/mirage/mirage-console"

--- a/packages/mirage-console/mirage-console.2.1.1/opam
+++ b/packages/mirage-console/mirage-console.2.1.1/opam
@@ -18,7 +18,7 @@ depopts: ["mirage-xen"]
 conflicts: [
   "mirage-console-unix"
   "mirage-console-xen"
-  "mirage-xen" {< "1.1.0"}
+  "mirage-xen" {< "1.1.0" | >= "6.0.0"}
   "mirage-xen" {> "3.3.0"}
 ]
 dev-repo: "git://github.com/mirage/mirage-console"

--- a/packages/mirage-console/mirage-console.2.1.2/opam
+++ b/packages/mirage-console/mirage-console.2.1.2/opam
@@ -35,8 +35,8 @@ depopts: [
   "xenstore_transport"
 ]
 conflicts: [
-  "mirage-xen" {< "1.1.0"}
-  "xen-gnt"    {>= "3.0.0"}
+  "mirage-xen" {< "1.1.0" | >= "6.0.0"}
+  "xen-gnt" {>= "3.0.0"}
 ]
 synopsis: "A Mirage-compatible Console library for Xen and Unix"
 flags: light-uninstall

--- a/packages/mirage-console/mirage-console.2.1.3/opam
+++ b/packages/mirage-console/mirage-console.2.1.3/opam
@@ -36,7 +36,7 @@ depopts: [
   "xenctrl"
 ]
 conflicts: [
-  "mirage-xen" {< "1.1.0"}
+  "mirage-xen" {< "1.1.0" | >= "6.0.0"}
   "shared-memory-ring" {> "1.3.0"}
   "xenstore" {> "1.3.0"}
 ]

--- a/packages/mirage-entropy/mirage-entropy.0.4.0/opam
+++ b/packages/mirage-entropy/mirage-entropy.0.4.0/opam
@@ -27,9 +27,9 @@ depopts: [
   "mirage-xen"
 ]
 conflicts: [
-  "ocb-stubblr" {<"0.1.0"}
-  "cstruct" {<"1.4.0"}
-  "mirage-xen" {<"2.2.0"}
+  "ocb-stubblr" {< "0.1.0"}
+  "cstruct" {< "1.4.0"}
+  "mirage-xen" {< "2.2.0" | >= "6.0.0"}
 ]
 tags: [ "org:mirage"]
 available: arch = "arm" | arch = "x86_32" | arch = "x86_64" | arch = "x86_64"

--- a/packages/mirage-entropy/mirage-entropy.0.4.1/opam
+++ b/packages/mirage-entropy/mirage-entropy.0.4.1/opam
@@ -28,9 +28,9 @@ depopts: [
   "mirage-xen"
 ]
 conflicts: [
-  "ocb-stubblr" {<"0.1.0"}
-  "cstruct" {<"1.4.0"}
-  "mirage-xen" {<"2.2.0"}
+  "ocb-stubblr" {< "0.1.0"}
+  "cstruct" {< "1.4.0"}
+  "mirage-xen" {< "2.2.0" | >= "6.0.0"}
 ]
 tags: [ "org:mirage"]
 available:

--- a/packages/mirage-entropy/mirage-entropy.0.5.0/opam
+++ b/packages/mirage-entropy/mirage-entropy.0.5.0/opam
@@ -4,7 +4,6 @@ homepage:     "https://github.com/mirage/mirage-entropy"
 dev-repo:     "git+https://github.com/mirage/mirage-entropy.git"
 bug-reports:  "https://github.com/mirage/mirage-entropy/issues"
 doc:          "https://mirage.github.io/mirage-entropy/doc"
-author:       ["Hannes Mehnert" "David Kaloper" "Anil Madhavapeddy" "Dave Scott"]
 maintainer:   "david@numm.org"
 license:      "BSD2"
 
@@ -30,7 +29,7 @@ depopts: [
   "mirage-xen"
 ]
 conflicts: [
-  "mirage-xen" {<"2.2.0"}
+  "mirage-xen" {< "2.2.0" | >= "6.0.0"}
 ]
 tags: [ "org:mirage"]
 available: [
@@ -47,3 +46,4 @@ url {
 archive: "https://github.com/mirage/mirage-entropy/releases/download/v0.5.0/mirage-entropy-0.5.0.tbz"
 checksum: "395ea04f5d149422d90383fbeccb10a2"
 }
+authors: ["Hannes Mehnert" "David Kaloper" "Anil Madhavapeddy" "Dave Scott"]

--- a/packages/mirage-net-xen/mirage-net-xen.1.13.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.13.0/opam
@@ -12,18 +12,17 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune"  {>= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "mirage-net" {>= "3.0.0"}
   "io-page" {>= "1.5.0"}
   "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
   "netchannel" {= version}
   "lwt-dllist"
   "logs" {>= "0.5.0"}
 ]
-
 tags: "org:mirage"
 synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
 description: """

--- a/packages/mirage-net-xen/mirage-net-xen.1.13.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.13.1/opam
@@ -12,18 +12,17 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune"  {>= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "mirage-net" {>= "3.0.0"}
   "io-page" {>= "1.5.0"}
   "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
   "netchannel" {= version}
   "lwt-dllist"
   "logs" {>= "0.5.0"}
 ]
-
 tags: "org:mirage"
 synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
 description: """

--- a/packages/mirage-os-shim/mirage-os-shim.3.0.0/opam
+++ b/packages/mirage-os-shim/mirage-os-shim.3.0.0/opam
@@ -25,12 +25,12 @@ depopts: [
   "mirage-unix"
 ]
 conflicts: [
-  "mirage-unix" {<"3.0.0"}
-  "mirage-unix" {>="3.1.0"}
-  "mirage-xen" {<"3.0.0"}
-  "mirage-xen" {>="3.1.0"}
-  "mirage-solo5" {<"0.2.0"}
-  "mirage-solo5" {>="0.5.0"}
+  "mirage-unix" {< "3.0.0"}
+  "mirage-unix" {>= "3.1.0"}
+  "mirage-xen" {< "3.0.0" | >= "6.0.0"}
+  "mirage-xen" {>= "3.1.0"}
+  "mirage-solo5" {< "0.2.0"}
+  "mirage-solo5" {>= "0.5.0"}
 ]
 synopsis: "Portable shim for MirageOS APIs"
 description: """

--- a/packages/mirage-os-shim/mirage-os-shim.3.0.1/opam
+++ b/packages/mirage-os-shim/mirage-os-shim.3.0.1/opam
@@ -25,12 +25,12 @@ depopts: [
   "mirage-unix"
 ]
 conflicts: [
-  "mirage-unix" {<"3.0.0"}
-  "mirage-unix" {>="3.1.0"}
-  "mirage-xen" {<"3.0.0"}
-  "mirage-xen" {>="3.1.0"}
-  "mirage-solo5" {<"0.2.0"}
-  "mirage-solo5" {>="0.5.0"}
+  "mirage-unix" {< "3.0.0"}
+  "mirage-unix" {>= "3.1.0"}
+  "mirage-xen" {< "3.0.0" | >= "6.0.0"}
+  "mirage-xen" {>= "3.1.0"}
+  "mirage-solo5" {< "0.2.0"}
+  "mirage-solo5" {>= "0.5.0"}
 ]
 synopsis: "Portable shim for MirageOS APIs"
 description: """

--- a/packages/mirage-os-shim/mirage-os-shim.3.1.0/opam
+++ b/packages/mirage-os-shim/mirage-os-shim.3.1.0/opam
@@ -6,7 +6,6 @@ doc: "https://mirage.github.io/mirage-os-shim/doc"
 license: "ISC"
 dev-repo: "git+https://github.com/mirage/mirage-os-shim.git"
 bug-reports: "https://github.com/mirage/mirage-os-shim/issues"
-tags: []
 build: [
   "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
           "--with-mirage-unix" "%{mirage-unix:installed}%"
@@ -28,7 +27,7 @@ depopts: [
 conflicts: [
   "mirage-unix" {< "3.1.0"}
   "mirage-unix" {>= "4.0.0"}
-  "mirage-xen" {< "3.1.0"}
+  "mirage-xen" {< "3.1.0" | >= "6.0.0"}
   "mirage-xen" {>= "5.0.0"}
   "mirage-solo5" {< "0.5.0"}
   "mirage-solo5" {>= "0.6.1"}

--- a/packages/mirage-qubes/mirage-qubes.0.8.0/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.8.0/opam
@@ -13,16 +13,16 @@ build: [
 ]
 
 depends: [
-  "dune"  {>= "1.0"}
-  "cstruct" { >= "2.2.0" }
-  "ppx_cstruct" { < "5.1.0"}
-  "vchan-xen" { >= "5.0.0" }
+  "dune" {>= "1.0"}
+  "cstruct" {>= "2.2.0"}
+  "ppx_cstruct" {< "5.1.0"}
+  "vchan-xen" {>= "5.0.0"}
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen" { >= "5.0.0" }
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
   "lwt"
-  "logs" { >= "0.5.0" }
-  "ocaml" { >= "4.06.0" }
+  "logs" {>= "0.5.0"}
+  "ocaml" {>= "4.06.0"}
 ]
 synopsis: "Implementations of various Qubes protocols for MirageOS"
 url {

--- a/packages/mirage-qubes/mirage-qubes.0.8.1/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.8.1/opam
@@ -13,16 +13,16 @@ build: [
 ]
 
 depends: [
-  "dune"  {>= "1.0"}
-  "cstruct" { >= "2.2.0" }
+  "dune" {>= "1.0"}
+  "cstruct" {>= "2.2.0"}
   "ppx_cstruct"
-  "vchan-xen" { >= "5.0.0" }
+  "vchan-xen" {>= "5.0.0"}
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen" { >= "5.0.0" }
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
   "lwt"
-  "logs" { >= "0.5.0" }
-  "ocaml" { >= "4.06.0" }
+  "logs" {>= "0.5.0"}
+  "ocaml" {>= "4.06.0"}
 ]
 synopsis: "Implementations of various Qubes protocols for MirageOS"
 description: """

--- a/packages/mirage-qubes/mirage-qubes.0.8.2/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.8.2/opam
@@ -13,16 +13,16 @@ build: [
 ]
 
 depends: [
-  "dune"  {>= "1.0"}
-  "cstruct" { >= "2.2.0" }
+  "dune" {>= "1.0"}
+  "cstruct" {>= "2.2.0"}
   "ppx_cstruct"
-  "vchan-xen" { >= "5.0.0" }
+  "vchan-xen" {>= "5.0.0"}
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen" { >= "5.0.0" }
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
   "lwt"
-  "logs" { >= "0.5.0" }
-  "ocaml" { >= "4.06.0" }
+  "logs" {>= "0.5.0"}
+  "ocaml" {>= "4.06.0"}
 ]
 synopsis: "Implementations of various Qubes protocols for MirageOS"
 description: """

--- a/packages/mirage-qubes/mirage-qubes.0.8.3/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.8.3/opam
@@ -13,16 +13,16 @@ build: [
 ]
 
 depends: [
-  "dune"  {>= "1.0"}
-  "cstruct" { >= "2.2.0" }
+  "dune" {>= "1.0"}
+  "cstruct" {>= "2.2.0"}
   "ppx_cstruct"
-  "vchan-xen" { >= "5.0.0" }
+  "vchan-xen" {>= "5.0.0"}
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen" { >= "5.0.0" }
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
   "lwt"
-  "logs" { >= "0.5.0" }
-  "ocaml" { >= "4.06.0" }
+  "logs" {>= "0.5.0"}
+  "ocaml" {>= "4.06.0"}
 ]
 synopsis: "Implementations of various Qubes protocols for MirageOS"
 description: """

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/opam
@@ -15,7 +15,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: os = "linux"
-conflicts: [ "sexplib" { = "v0.9.0" } ]
+conflicts: [
+  "sexplib" { = "v0.9.0" }
+  "mirage-xen" {>= "6.0.0"}
+]
 synopsis: "MirageOS headers for the OCaml runtime"
 description:
   "The package contains the OCaml runtime patches and build system."

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.1/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.1/opam
@@ -16,7 +16,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: os = "linux"
-conflicts: [ "sexplib" { = "v0.9.0" } ]
+conflicts: [
+  "sexplib" { = "v0.9.0" }
+  "mirage-xen" {>= "6.0.0"}
+]
 synopsis: "MirageOS headers for the OCaml runtime"
 description:
   "The package contains the OCaml runtime patches and build system."

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/opam
@@ -16,7 +16,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: os = "linux"
-conflicts: [ "sexplib" { = "v0.9.0" } ]
+conflicts: [
+  "sexplib" { = "v0.9.0" }
+  "mirage-xen" {>= "6.0.0"}
+]
 synopsis: "MirageOS headers for the OCaml runtime"
 description:
   "The package contains the OCaml runtime patches and build system."

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.6.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.6.0/opam
@@ -16,7 +16,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: os = "linux"
-conflicts: [ "sexplib" { = "v0.9.0" } ]
+conflicts: [
+  "sexplib" { = "v0.9.0" }
+  "mirage-xen" {>= "6.0.0"}
+]
 synopsis: "MirageOS headers for the OCaml runtime"
 description:
   "The package contains the OCaml runtime patches and build system."

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/opam
@@ -17,7 +17,10 @@ depends: [
   "ocamlbuild" {build}
 ]
 available: os = "linux"
-conflicts: [ "sexplib" { = "v0.9.0" } ]
+conflicts: [
+  "sexplib" { = "v0.9.0" }
+  "mirage-xen" {>= "6.0.0"}
+]
 synopsis: "MirageOS headers for the OCaml runtime"
 description:
   "The package contains the OCaml runtime patches and build system."

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/opam
@@ -24,3 +24,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.0.4.tar.gz"
   checksum: "md5=d7fdca71808546c8caf79205f8c4e5fc"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/opam
@@ -24,3 +24,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.0.5.tar.gz"
   checksum: "md5=249e56facfe2ade94dd65866b2d97900"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.6/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.6/opam
@@ -25,3 +25,6 @@ url {
     "https://github.com/mirage/mirage-platform/releases/download/3.0.6/mirage-xen-ocaml-3.0.6.tbz"
   checksum: "md5=ead723d64c59b92c440f1f3d0d839332"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.1.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.1.0/opam
@@ -24,3 +24,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/3.1.0.tar.gz"
   checksum: "md5=939f42dd4eecb2448d03a2319c65afb2"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.2.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.2.0/opam
@@ -24,3 +24,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.2.0.tar.gz"
   checksum: "md5=ea82478dd96782965324c939e9e9bfc4"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.0/opam
@@ -15,7 +15,10 @@ substs: [
   "xen-ocaml/flags/cflags.tmp"
   "xen-ocaml/flags/libs.tmp"
   ]
-conflicts: ["ocaml-system"]
+conflicts: [
+  "ocaml-system"
+  "mirage-xen" {>= "6.0.0"}
+]
 available: os = "linux"
 build: [make "xen-ocaml-build"]
 install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.1/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.1/opam
@@ -15,7 +15,10 @@ substs: [
   "xen-ocaml/flags/cflags.tmp"
   "xen-ocaml/flags/libs.tmp"
   ]
-conflicts: ["ocaml-system"]
+conflicts: [
+  "ocaml-system"
+  "mirage-xen" {>= "6.0.0"}
+]
 available: os = "linux"
 build: [make "xen-ocaml-build"]
 install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.2/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.2/opam
@@ -15,7 +15,10 @@ substs: [
   "xen-ocaml/flags/cflags.tmp"
   "xen-ocaml/flags/libs.tmp"
   ]
-conflicts: ["ocaml-system"]
+conflicts: [
+  "ocaml-system"
+  "mirage-xen" {>= "6.0.0"}
+]
 available: os = "linux"
 build: [make "xen-ocaml-build"]
 install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.3/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.3/opam
@@ -24,3 +24,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/3.3.3.tar.gz"
   checksum: "md5=4e60e7db0dcdbf89aa86857891e9f0ee"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-posix/mirage-xen-posix.2.3.0/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.2.3.0/opam
@@ -23,3 +23,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v2.3.0.tar.gz"
   checksum: "md5=4bae08a22f8260f764646620ce83d084"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-posix/mirage-xen-posix.2.3.1/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.2.3.1/opam
@@ -23,3 +23,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v2.3.1.tar.gz"
   checksum: "md5=4d2918daafd0dc192d537f8422bf43cb"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-posix/mirage-xen-posix.2.3.3/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.2.3.3/opam
@@ -23,3 +23,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v2.3.3.tar.gz"
   checksum: "md5=5746cfe4d3d16844c5ce81a357ffd9a0"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-posix/mirage-xen-posix.2.3.4/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.2.3.4/opam
@@ -23,3 +23,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v2.3.4.tar.gz"
   checksum: "md5=00402709acf64d7405091c587a81e4eb"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-posix/mirage-xen-posix.2.6.0/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.2.6.0/opam
@@ -23,3 +23,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v2.6.0.tar.gz"
   checksum: "md5=e9d5ec80ae06b42658e48af130aea7c1"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.0.4/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.0.4/opam
@@ -23,3 +23,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.0.4.tar.gz"
   checksum: "md5=d7fdca71808546c8caf79205f8c4e5fc"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.1.0/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.1.0/opam
@@ -23,3 +23,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/3.1.0.tar.gz"
   checksum: "md5=939f42dd4eecb2448d03a2319c65afb2"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.2.0/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.2.0/opam
@@ -23,3 +23,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.2.0.tar.gz"
   checksum: "md5=ea82478dd96782965324c939e9e9bfc4"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.3.0/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.3.0/opam
@@ -28,3 +28,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.3.0.tar.gz"
   checksum: "md5=25b42ec49cdd2c4503eb994d0279ef35"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/mirage-xen-posix/mirage-xen-posix.3.3.1/opam
+++ b/packages/mirage-xen-posix/mirage-xen-posix.3.3.1/opam
@@ -28,3 +28,6 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.3.1.tar.gz"
   checksum: "md5=ef287658f37ec55bf80ff3f1d2541db5"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/netchannel/netchannel.1.13.0/opam
+++ b/packages/netchannel/netchannel.1.13.0/opam
@@ -12,7 +12,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune"  {>= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {>= "3.0.0"}
   "ppx_sexp_conv" {< "v0.15"}
   "ppx_cstruct"
@@ -20,10 +20,10 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "io-page" {>= "1.5.0"}
   "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
   "ipaddr" {>= "3.0.0"}
-  "mirage-profile" {>="0.3"}
-  "shared-memory-ring" {>="3.0.0"}
+  "mirage-profile" {>= "0.3"}
+  "shared-memory-ring" {>= "3.0.0"}
   "sexplib" {>= "113.01.00" & < "v0.15"}
   "logs" {>= "0.5.0"}
   "rresult"

--- a/packages/netchannel/netchannel.1.13.1/opam
+++ b/packages/netchannel/netchannel.1.13.1/opam
@@ -12,7 +12,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune"  {>= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {>= "3.0.0"}
   "ppx_sexp_conv"
   "ppx_cstruct"
@@ -20,10 +20,10 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "io-page" {>= "1.5.0"}
   "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
   "ipaddr" {>= "3.0.0"}
-  "mirage-profile" {>="0.3"}
-  "shared-memory-ring" {>="3.0.0"}
+  "mirage-profile" {>= "0.3"}
+  "shared-memory-ring" {>= "3.0.0"}
   "sexplib" {>= "113.01.00"}
   "logs" {>= "0.5.0"}
   "rresult"

--- a/packages/nocrypto/nocrypto.0.3.1/opam
+++ b/packages/nocrypto/nocrypto.0.3.1/opam
@@ -30,9 +30,8 @@ depopts: [
 ]
 
 conflicts: [
-  "mirage-xen" {<"2.2.0"}
+  "mirage-xen" {< "2.2.0" | >= "6.0.0"}
 ]
-
 tags: [ "org:mirage"]
 synopsis: "Small functional-style crypto library."
 description: """

--- a/packages/nocrypto/nocrypto.0.4.0/opam
+++ b/packages/nocrypto/nocrypto.0.4.0/opam
@@ -23,7 +23,8 @@ depends: [
   "type_conv"
   "sexplib" {< "113.01.00"}
   "ctypes" {>= "0.3.3" & <= "0.5.1"}
-  ("mirage-no-xen" | ("mirage-xen" "zarith-xen" "mirage-entropy-xen"))
+  ("mirage-no-xen" |
+   ("mirage-xen" {< "6.0.0"} & "zarith-xen" & "mirage-entropy-xen"))
   "ocamlbuild" {build}
 ]
 depopts: [

--- a/packages/nocrypto/nocrypto.0.5.0/opam
+++ b/packages/nocrypto/nocrypto.0.5.0/opam
@@ -30,7 +30,8 @@ depends: [
   "zarith"
   "type_conv"
   "sexplib" {< "113.01.00"}
-  ("mirage-no-xen" | ("mirage-xen" "mirage-entropy-xen" "zarith-xen"))
+  ("mirage-no-xen" |
+   ("mirage-xen" {< "6.0.0"} & "mirage-entropy-xen" & "zarith-xen"))
   "ounit" {with-test}
   "ocamlbuild" {build}
 ]

--- a/packages/nocrypto/nocrypto.0.5.1/opam
+++ b/packages/nocrypto/nocrypto.0.5.1/opam
@@ -31,7 +31,8 @@ depends: [
   "zarith"
   "type_conv"
   "sexplib" {< "113.01.00"}
-  ("mirage-no-xen" | ("mirage-xen" "mirage-entropy-xen" "zarith-xen"))
+  ("mirage-no-xen" |
+   ("mirage-xen" {< "6.0.0"} & "mirage-entropy-xen" & "zarith-xen"))
   "ounit" {with-test}
   "ocamlbuild" {build}
 ]

--- a/packages/nocrypto/nocrypto.0.5.2/opam
+++ b/packages/nocrypto/nocrypto.0.5.2/opam
@@ -27,7 +27,8 @@ depends: [
   "zarith"
   "type_conv"
   "sexplib" {< "113.01.00"}
-  ("mirage-no-xen" | ("mirage-xen" "mirage-entropy-xen" "zarith-xen"))
+  ("mirage-no-xen" |
+   ("mirage-xen" {< "6.0.0"} & "mirage-entropy-xen" & "zarith-xen"))
   "ounit" {with-test}
   "ocamlbuild" {build}
 ]

--- a/packages/nocrypto/nocrypto.0.5.3/opam
+++ b/packages/nocrypto/nocrypto.0.5.3/opam
@@ -31,7 +31,8 @@ depends: [
   "sexplib" {< "v0.11.0"}
   "ppx_deriving"
   "ppx_sexp_conv" {>= "113.33.01" & < "v0.11.0"}
-  "mirage-no-xen" | ("mirage-xen" "mirage-entropy-xen" "zarith-xen")
+  "mirage-no-xen" |
+  ("mirage-xen" {< "6.0.0"} & "mirage-entropy-xen" & "zarith-xen")
   "ounit" {with-test}
 ]
 depopts: [

--- a/packages/nocrypto/nocrypto.0.5.4-1/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-1/opam
@@ -28,7 +28,8 @@ depends: [
   "zarith"
   "lwt"
   "sexplib" {< "v0.15"}
-  "mirage-no-xen" | ("mirage-xen" & "mirage-entropy" & "zarith-xen")
+  "mirage-no-xen" |
+  ("mirage-xen" {< "6.0.0"} & "mirage-entropy" & "zarith-xen")
   "mirage-no-solo5" |
   ("mirage-solo5" & "mirage-entropy" & "zarith-freestanding")
 ]

--- a/packages/nocrypto/nocrypto.0.5.4-2/opam
+++ b/packages/nocrypto/nocrypto.0.5.4-2/opam
@@ -29,7 +29,7 @@ depends: [
   "zarith"
   "lwt"
   "sexplib" {< "v0.15"}
-  "mirage-no-xen" | ("mirage-xen" & "zarith-xen")
+  "mirage-no-xen" | ("mirage-xen" {< "6.0.0"} & "zarith-xen")
   "mirage-no-solo5" | ("mirage-solo5" & "zarith-freestanding")
 ]
 depopts: [ "mirage-entropy" ]

--- a/packages/nocrypto/nocrypto.0.5.4/opam
+++ b/packages/nocrypto/nocrypto.0.5.4/opam
@@ -23,13 +23,15 @@ depends: [
   "ppx_deriving"
   "ppx_sexp_conv" {>= "113.33.01" & < "v0.11.0"}
   "ounit" {with-test}
-  "cstruct" {>= "2.4.0" & <"3.4.0"}
+  "cstruct" {>= "2.4.0" & < "3.4.0"}
   "cstruct-lwt"
   "zarith"
   "lwt"
   "sexplib" {< "v0.11.0"}
-  "mirage-no-xen" | ("mirage-xen" "mirage-entropy" "zarith-xen")
-  "mirage-no-solo5" | ("mirage-solo5" "mirage-entropy" "zarith-freestanding")
+  "mirage-no-xen" |
+  ("mirage-xen" {< "6.0.0"} & "mirage-entropy" & "zarith-xen")
+  "mirage-no-solo5" |
+  ("mirage-solo5" & "mirage-entropy" & "zarith-freestanding")
 ]
 conflicts: [
   "topkg" {<"0.9.1"}

--- a/packages/tcpip/tcpip.2.1.0/opam
+++ b/packages/tcpip/tcpip.2.1.0/opam
@@ -37,6 +37,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {>= "3.0.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 flags: light-uninstall

--- a/packages/tcpip/tcpip.2.2.0/opam
+++ b/packages/tcpip/tcpip.2.2.0/opam
@@ -38,6 +38,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {>= "3.0.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 flags: light-uninstall

--- a/packages/tcpip/tcpip.2.2.1/opam
+++ b/packages/tcpip/tcpip.2.2.1/opam
@@ -38,6 +38,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {>= "3.0.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 flags: light-uninstall

--- a/packages/tcpip/tcpip.2.2.2/opam
+++ b/packages/tcpip/tcpip.2.2.2/opam
@@ -38,6 +38,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {>= "3.0.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 flags: light-uninstall

--- a/packages/tcpip/tcpip.2.2.3/opam
+++ b/packages/tcpip/tcpip.2.2.3/opam
@@ -37,6 +37,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {>= "3.0.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 flags: light-uninstall

--- a/packages/tcpip/tcpip.2.3.0/opam
+++ b/packages/tcpip/tcpip.2.3.0/opam
@@ -37,6 +37,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {>= "3.0.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 flags: light-uninstall

--- a/packages/tcpip/tcpip.2.3.1/opam
+++ b/packages/tcpip/tcpip.2.3.1/opam
@@ -37,6 +37,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {>= "3.0.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 flags: light-uninstall

--- a/packages/tcpip/tcpip.2.4.0/opam
+++ b/packages/tcpip/tcpip.2.4.0/opam
@@ -34,6 +34,7 @@ depends: [
 depopts: "mirage-xen"
 conflicts: [
   "lwt" {>= "3.0.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 description: """

--- a/packages/tcpip/tcpip.2.4.1/opam
+++ b/packages/tcpip/tcpip.2.4.1/opam
@@ -39,6 +39,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {>= "3.0.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 description: """

--- a/packages/tcpip/tcpip.2.4.2/opam
+++ b/packages/tcpip/tcpip.2.4.2/opam
@@ -46,6 +46,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {>= "3.0.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 description: """

--- a/packages/tcpip/tcpip.2.4.3/opam
+++ b/packages/tcpip/tcpip.2.4.3/opam
@@ -47,6 +47,7 @@ depopts: [
 ]
 conflicts: [
   "lwt" {>= "3.0.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 description: """

--- a/packages/tcpip/tcpip.2.5.0/opam
+++ b/packages/tcpip/tcpip.2.5.0/opam
@@ -52,3 +52,6 @@ url {
   src: "https://github.com/mirage/mirage-tcpip/archive/v2.5.0.tar.gz"
   checksum: "md5=b07935f47816488428995121f301d3ac"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/tcpip/tcpip.2.5.1/opam
+++ b/packages/tcpip/tcpip.2.5.1/opam
@@ -54,3 +54,6 @@ url {
   src: "https://github.com/mirage/mirage-tcpip/archive/v2.5.1.tar.gz"
   checksum: "md5=58ebf095c4563956ceac67ae16ca937c"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/tcpip/tcpip.2.6.0/opam
+++ b/packages/tcpip/tcpip.2.6.0/opam
@@ -57,3 +57,6 @@ url {
   src: "https://github.com/mirage/mirage-tcpip/archive/v2.6.0.tar.gz"
   checksum: "md5=311adb394a328fbebdecd552a572b588"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/tcpip/tcpip.2.6.1/opam
+++ b/packages/tcpip/tcpip.2.6.1/opam
@@ -57,3 +57,6 @@ url {
   src: "https://github.com/mirage/mirage-tcpip/archive/v2.6.1.tar.gz"
   checksum: "md5=128a4250716424d32c6e84f35502925a"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/tcpip/tcpip.2.7.0/opam
+++ b/packages/tcpip/tcpip.2.7.0/opam
@@ -65,8 +65,9 @@ depopts: [
   "mirage-net-unix"
 ]
 conflicts: [
-  "mirage-net-unix" { < "1.1.0" }
-  "mirage-net-unix" { >= "2.3.0" }
+  "mirage-net-unix" {< "1.1.0"}
+  "mirage-net-unix" {>= "2.3.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 description: """

--- a/packages/tcpip/tcpip.2.8.0/opam
+++ b/packages/tcpip/tcpip.2.8.0/opam
@@ -66,8 +66,9 @@ depopts: [
   "mirage-net-unix"
 ]
 conflicts: [
-  "mirage-net-unix" { < "1.1.0" }
-  "mirage-net-unix" { >= "2.3.0" }
+  "mirage-net-unix" {< "1.1.0"}
+  "mirage-net-unix" {>= "2.3.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 description: """

--- a/packages/tcpip/tcpip.2.8.1/opam
+++ b/packages/tcpip/tcpip.2.8.1/opam
@@ -66,8 +66,9 @@ depopts: [
   "mirage-net-unix"
 ]
 conflicts: [
-  "mirage-net-unix" { < "1.1.0" }
-  "mirage-net-unix" { >= "2.3.0" }
+  "mirage-net-unix" {< "1.1.0"}
+  "mirage-net-unix" {>= "2.3.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 synopsis: "Userlevel TCP/IP stack"
 description: """

--- a/packages/tcpip/tcpip.3.0.0/opam
+++ b/packages/tcpip/tcpip.3.0.0/opam
@@ -77,3 +77,6 @@ url {
   src: "https://github.com/mirage/mirage-tcpip/archive/v3.0.0.tar.gz"
   checksum: "md5=97d28f67c1388476bd57c08f6cebe11c"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/tcpip/tcpip.3.1.0/opam
+++ b/packages/tcpip/tcpip.3.1.0/opam
@@ -77,3 +77,6 @@ url {
   src: "https://github.com/mirage/mirage-tcpip/archive/v3.1.0.tar.gz"
   checksum: "md5=76c2d7f210d43e647f070a1979da9fd5"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/tcpip/tcpip.3.1.1/opam
+++ b/packages/tcpip/tcpip.3.1.1/opam
@@ -77,3 +77,6 @@ url {
   src: "https://github.com/mirage/mirage-tcpip/archive/v3.1.1.tar.gz"
   checksum: "md5=ec68e67a6313151ecfbe7398da1b38f8"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/tcpip/tcpip.3.1.2/opam
+++ b/packages/tcpip/tcpip.3.1.2/opam
@@ -77,3 +77,6 @@ url {
   src: "https://github.com/mirage/mirage-tcpip/archive/v3.1.2.tar.gz"
   checksum: "md5=2daafb7e5e220ed4f89dd0b5c642b706"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/tcpip/tcpip.3.1.3/opam
+++ b/packages/tcpip/tcpip.3.1.3/opam
@@ -77,3 +77,6 @@ url {
   src: "https://github.com/mirage/mirage-tcpip/archive/v3.1.3.tar.gz"
   checksum: "md5=c628d9545b45283876f430b4b7ac9171"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/tcpip/tcpip.3.1.4/opam
+++ b/packages/tcpip/tcpip.3.1.4/opam
@@ -77,3 +77,6 @@ url {
   src: "https://github.com/mirage/mirage-tcpip/archive/v3.1.4.tar.gz"
   checksum: "md5=ff4f4c5384d21d93541a7feafcb6f25e"
 }
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]

--- a/packages/vchan-xen/vchan-xen.5.0.0/opam
+++ b/packages/vchan-xen/vchan-xen.5.0.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune"
-  "vchan" {=version}
+  "vchan" {= version}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
   "ppx_sexp_conv" {< "v0.15"}
@@ -18,7 +18,7 @@ depends: [
   "io-page"
   "mirage-flow" {>= "2.0.0"}
   "xenstore" {>= "1.2.2"}
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-xen" {>= "5.0.0" & < "6.0.0"}
   "xenstore_transport" {>= "1.0.0"}
   "sexplib" {< "v0.15"}
   "cmdliner"


### PR DESCRIPTION
Preparation for the upcoming release of mirage-xen, which uses solo5 and ocaml-freestanding instead of minios and mirage-xen-ocaml / mirage-xen-posix (see https://github.com/mirage/mirage/issues/1159 for details):
- constrain all existing dependencies to < 6.0.0
- existing mirage-xen-ocaml & mirage-xen-posix packages conflict with mirage-xen >= 6.0.0

//cc @mato