### PR TITLE
Promise 1.1.2: native version of a JS promise binding

### DIFF
--- a/packages/promise/promise.1.1.2/opam
+++ b/packages/promise/promise.1.1.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+
+synopsis: "Native implementation of a JS promise binding"
+
+version: "1.1.2"
+license: "MIT"
+homepage: "https://github.com/aantron/promise"
+doc: "https://github.com/aantron/promise"
+bug-reports: "https://github.com/aantron/promise/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/promise.git"
+
+depends: [
+  "dune"
+  "ocaml"
+  "reason" {build & >= "3.3.2"}
+  "result"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "exec" "test/test_main.exe" "-p" name "-j" jobs] {with-test}
+]
+
+url {
+  src: "https://github.com/aantron/promise/archive/1.1.2.tar.gz"
+  checksum: "md5=e9e47a94c20799f9eec483569e7990b6"
+}


### PR DESCRIPTION
[Changelog](https://github.com/aantron/promise/releases/tag/1.1.2):

> - `allOk([])` should resolve to `Ok([])` (aantron/promise#62, reported Misha Bergal).