### PR TITLE
Package satyrographos.0.0.2.7

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.2.7/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.7/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  ["dune" "subst"] {pinned}
+  ["sed" "-i.bak" "-e" "s/%%%%VERSION_NUM%%%%/%{version}%/" "bin/main.ml"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest"]
+]
+
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "dune" {>= "2"}
+  "fileutils"
+  "json-derivers"
+  "ppx_deriving"
+  "ocamlgraph"
+  "opam-format" {>= "2.0" & < "2.1"}
+  "opam-state" {>= "2.0" & < "2.1"}
+  "re" {with-test}
+  "stringext" {with-test}
+  "uri" {>= "3.0.0"}
+  "uri-sexp" {>= "3.0.0"}
+  "yojson"
+
+  # Janestreet Libs
+  "core" {>= "v0.13" & < "v0.15"}
+  "ppx_jane"
+  "shexp"
+]
+synopsis: "A package manager for SATySFi"
+description: """
+Satyrographos is a package manager for [SATySFi].
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src: "https://github.com/na4zagin3/satyrographos/archive/v0.0.2.7.tar.gz"
+  checksum: [
+    "md5=5fb76f07c93bcc0aba92ddc497d1e4c5"
+    "sha512=4f9f155f31925efe4e03cb1a285bf9ddb52e8efd99fef104d8102ad0a675137a0fcf0b9a08076035ae37f7eb960e5467ad31eb11e33672bbd15a50b2193fdc7f"
+  ]
+}

--- a/packages/satyrographos/satyrographos.0.0.2.7/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.7/opam
@@ -18,7 +18,7 @@ run-test: [
 
 depends: [
   "ocaml" {>= "4.09.0"}
-  "dune" {>= "2"}
+  "dune" {>= "2.7"}
   "fileutils"
   "json-derivers"
   "ppx_deriving"


### PR DESCRIPTION
### `satyrographos.0.0.2.7`
A package manager for SATySFi
Satyrographos is a package manager for [SATySFi].

Satyrographos is distributed under the LGPL-3.0 license.


  [SATySFi]: https://github.com/gfngfn/SATySFi
  [Satyrographos]: https://github.com/na4zagin3/satyrographos



---
* Homepage: https://github.com/na4zagin3/satyrographos
* Source repo: git+https://github.com/na4zagin3/satyrographos.git
* Bug tracker: https://github.com/na4zagin3/satyrographos/issues

---
:camel: Pull-request generated by opam-publish v2.0.2