### PR TITLE
Package opam-depext.1.1.4

### DIFF
--- a/packages/opam-depext/opam-depext.1.1.4/opam
+++ b/packages/opam-depext/opam-depext.1.1.4/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/opam-depext"
+bug-reports: "https://github.com/ocaml/opam-depext/issues"
+depends: ["ocaml"]
+available: opam-version >= "2.0.0~beta5"
+extra-source "src_ext/cmdliner-0.9.8.tbz" {
+  src:"http://erratique.ch/software/cmdliner/releases/cmdliner-0.9.8.tbz"
+  checksum:"fc67c937447cc223722f1419fa2189da"
+}
+flags: plugin
+build: make
+dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
+synopsis: "Install OS distribution packages"
+description: """
+opam-depext is a simple program intended to facilitate the interaction between
+opam packages and the host package management system. It can query opam for the
+right external dependencies on a set of packages, depending on the host OS, and
+call the OS's package manager in the appropriate way to install them.
+"""
+url {
+  src: "https://github.com/ocaml-opam/opam-depext/releases/download/v1.1.4/opam-depext-full-1.1.4.tbz"
+  checksum: [
+    "md5=9ce9c01952da2d94008f1debd61c3969"
+    "sha512=5e7e83a613b178959ba57b77d379dc371dd1302ecbce3b8ecfe89a60ffa50fc81cfdb7adede26f191f4433fe0c9c514c8c604c58a233c8b29323595f42fdb9ab"
+  ]
+}

--- a/packages/opam-depext/opam-depext.1.1.4/opam
+++ b/packages/opam-depext/opam-depext.1.1.4/opam
@@ -12,10 +12,6 @@ homepage: "https://github.com/ocaml/opam-depext"
 bug-reports: "https://github.com/ocaml/opam-depext/issues"
 depends: ["ocaml"]
 available: opam-version >= "2.0.0~beta5"
-extra-source "src_ext/cmdliner-0.9.8.tbz" {
-  src:"http://erratique.ch/software/cmdliner/releases/cmdliner-0.9.8.tbz"
-  checksum:"fc67c937447cc223722f1419fa2189da"
-}
 flags: plugin
 build: make
 dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"


### PR DESCRIPTION
### `opam-depext.1.1.4`
install OS distribution packages
opam-depext is a simple program intended to facilitate the interaction between
OPAM packages and the host package management system. It can query OPAM for the
right external dependencies on a set of packages, depending on the host OS, and
call the OS's package manager in the appropriate way to install them.



---
* Homepage: https://github.com/ocaml/opam-depext
* Source repo: git+https://github.com/ocaml/opam-depext.git#2.0
* Bug tracker: https://github.com/ocaml/opam-depext/issues

---
:camel: Pull-request generated by opam-publish v2.0.3