### PR TITLE
Bisect_ppx 2.5.0: coverage for OCaml and Reason

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.2.5.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.5.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+
+synopsis: "Code coverage for OCaml"
+version: "2.5.0"
+license: "MIT"
+homepage: "https://github.com/aantron/bisect_ppx"
+doc: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+
+dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+
+depends: [
+  "base-unix"
+  "cmdliner" {>= "1.0.0"}
+  "dune" {>= "2.7.0"}
+  "ocaml" {>= "4.02.0"}
+  "ocaml-migrate-parsetree" {>= "1.7.0" & < "2.0.0"}
+  "ppx_tools_versioned" {>= "5.4.0"}
+
+  "ocamlfind" {with-test}
+  "ounit2" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+url {
+  src: "https://github.com/aantron/bisect_ppx/archive/2.5.0.tar.gz"
+  checksum: "md5=2eaf2f24c5d91ff975050db37d8a4cd2"
+}


### PR DESCRIPTION
[Changelog](https://github.com/aantron/bisect_ppx/releases/tag/2.5.0):

> Additions
>
> - Support Dune's [`--instrument-with`](https://github.com/aantron/bisect_ppx#Dune) integration, introduced in Dune 2.7.0 (aantron/bisect_ppx#331, Pau Ruiz Safont).
>
> Bugs fixed
>
> - `runtime.unix_open is not a function` in js_of_ocaml integration, occurring since Dune 2.7.0 (aantron/bisect_ppx#334).
> - Don't assume that `(&&)` is always applied to two arguments (aantron/bisect_ppx#333, reported Vladimir Keleshev).
> - esy sandbox directory specified in environment variable `cur__target_dir` might not exist (aantron/bisect_ppx#328, reported David Sancho).
> - Reporter: don't crash on symlink cycles (aantron/bisect_ppx#324, reported Rudi Grinberg).
