### PR TITLE
[new release] conduit-lwt-tls, conduit-mirage, conduit-tls, conduit-lwt, conduit-async-tls, conduit-async, conduit, conduit-async-ssl and conduit-lwt-ssl (3.0.0)

### DIFF
--- a/packages/conduit-async-ssl/conduit-async-ssl.3.0.0/opam
+++ b/packages/conduit-async-ssl/conduit-async-ssl.3.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" 
+  "Thomas Leonard" 
+  "Thomas Gazagnaire" 
+  "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library using Async and OpenSSL"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1"] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.07.0"}
+  "dune"          {>= "2.0.0"}
+  "core"
+  "conduit-async" {= version}
+  "async"         {>= "v0.12.0"}
+  "async_ssl"
+]
+x-commit-hash: "126ace170981b0c0bdb5d73c232099302ecf4af8"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=8b50119048e8c622b5fc09d2331ab8b9412acdd447c5d674bcc865054033cdbb"
+    "sha512=bf8e996276ca9d9393e90f718392916e3b29a56817c38d927ee87a9e81ce608b22dc3e4544fc05077e516f91511b2a96e560d9e7ab917034ba0c23cf61b10f66"
+  ]
+}

--- a/packages/conduit-async-tls/conduit-async-tls.3.0.0/opam
+++ b/packages/conduit-async-tls/conduit-async-tls.3.0.0/opam
@@ -26,6 +26,7 @@ depends: [
   "conduit-async" {= version}
   "async"         {>= "v0.12.0"}
   "conduit-tls"   {= version}
+  "mirage-crypto-rng" {>= "0.8.0"}
 ]
 x-commit-hash: "126ace170981b0c0bdb5d73c232099302ecf4af8"
 url {

--- a/packages/conduit-async-tls/conduit-async-tls.3.0.0/opam
+++ b/packages/conduit-async-tls/conduit-async-tls.3.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" 
+  "Thomas Leonard" 
+  "Thomas Gazagnaire" 
+  "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library using Async and ocaml-tls"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1"] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.07.0"}
+  "dune"          {>= "2.0.0"}
+  "core"
+  "conduit-async" {= version}
+  "async"         {>= "v0.12.0"}
+  "conduit-tls"   {= version}
+]
+x-commit-hash: "126ace170981b0c0bdb5d73c232099302ecf4af8"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=8b50119048e8c622b5fc09d2331ab8b9412acdd447c5d674bcc865054033cdbb"
+    "sha512=bf8e996276ca9d9393e90f718392916e3b29a56817c38d927ee87a9e81ce608b22dc3e4544fc05077e516f91511b2a96e560d9e7ab917034ba0c23cf61b10f66"
+  ]
+}

--- a/packages/conduit-async/conduit-async.3.0.0/opam
+++ b/packages/conduit-async/conduit-async.3.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" 
+  "Thomas Leonard" 
+  "Thomas Gazagnaire" 
+  "Rudi Grinberg"
+  "Romain Calascibetta"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Async"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1"] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.07.0"}
+  "dune"              {>= "2.0.0"}
+  "core"
+  "conduit"           {= version}
+  "async"             {>= "v0.12.0"}
+  "cstruct"
+  "base-bigarray"     {with-test}
+  "bigstringaf"       {with-test}
+  "ke"                {with-test}
+  "fmt"               {with-test}
+  "rresult"           {with-test}
+]
+x-commit-hash: "126ace170981b0c0bdb5d73c232099302ecf4af8"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=8b50119048e8c622b5fc09d2331ab8b9412acdd447c5d674bcc865054033cdbb"
+    "sha512=bf8e996276ca9d9393e90f718392916e3b29a56817c38d927ee87a9e81ce608b22dc3e4544fc05077e516f91511b2a96e560d9e7ab917034ba0c23cf61b10f66"
+  ]
+}

--- a/packages/conduit-lwt-ssl/conduit-lwt-ssl.3.0.0/opam
+++ b/packages/conduit-lwt-ssl/conduit-lwt-ssl.3.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors:[
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Romain Calascibetta"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt and OpenSSL"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1"] {with-test}
+]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.0.0"}
+  "conduit-lwt" {= version}
+  "lwt_ssl"
+]
+x-commit-hash: "126ace170981b0c0bdb5d73c232099302ecf4af8"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=8b50119048e8c622b5fc09d2331ab8b9412acdd447c5d674bcc865054033cdbb"
+    "sha512=bf8e996276ca9d9393e90f718392916e3b29a56817c38d927ee87a9e81ce608b22dc3e4544fc05077e516f91511b2a96e560d9e7ab917034ba0c23cf61b10f66"
+  ]
+}

--- a/packages/conduit-lwt-tls/conduit-lwt-tls.3.0.0/opam
+++ b/packages/conduit-lwt-tls/conduit-lwt-tls.3.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors:[
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Romain Calascibetta"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt and ocaml-tls"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1"] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.07.0"}
+  "dune"              {>= "2.0.0"}
+  "conduit-lwt"       {= version}
+  "conduit-tls"       {= version}
+  "mirage-crypto-rng" {>= "0.8.0"}
+]
+x-commit-hash: "126ace170981b0c0bdb5d73c232099302ecf4af8"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=8b50119048e8c622b5fc09d2331ab8b9412acdd447c5d674bcc865054033cdbb"
+    "sha512=bf8e996276ca9d9393e90f718392916e3b29a56817c38d927ee87a9e81ce608b22dc3e4544fc05077e516f91511b2a96e560d9e7ab917034ba0c23cf61b10f66"
+  ]
+}

--- a/packages/conduit-lwt/conduit-lwt.3.0.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.3.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors:[
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Romain Calascibetta"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1"] {with-test}
+]
+
+depends: [
+  "ocaml"           {>= "4.07.0"}
+  "dune"            {>= "2.0.0"}
+  "conduit"         {= version}
+  "cstruct"
+  "lwt"
+  "base-unix"
+  "base-bigarray"   {with-test}
+  "bigstringaf"     {with-test}
+  "ke"              {with-test}
+  "fmt"             {with-test}
+  "rresult"         {with-test}
+]
+x-commit-hash: "126ace170981b0c0bdb5d73c232099302ecf4af8"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=8b50119048e8c622b5fc09d2331ab8b9412acdd447c5d674bcc865054033cdbb"
+    "sha512=bf8e996276ca9d9393e90f718392916e3b29a56817c38d927ee87a9e81ce608b22dc3e4544fc05077e516f91511b2a96e560d9e7ab917034ba0c23cf61b10f66"
+  ]
+}

--- a/packages/conduit-mirage/conduit-mirage.3.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.3.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.0.0"}
+  "conduit"     {= version}
+  "tcpip"
+  "mirage-flow"
+  "mirage-time"
+  "dns-client"  {>= "4.6.0"}
+  "ke"
+  "bigstringaf"
+]
+x-commit-hash: "126ace170981b0c0bdb5d73c232099302ecf4af8"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=8b50119048e8c622b5fc09d2331ab8b9412acdd447c5d674bcc865054033cdbb"
+    "sha512=bf8e996276ca9d9393e90f718392916e3b29a56817c38d927ee87a9e81ce608b22dc3e4544fc05077e516f91511b2a96e560d9e7ab917034ba0c23cf61b10f66"
+  ]
+}

--- a/packages/conduit-tls/conduit-tls.3.0.0/opam
+++ b/packages/conduit-tls/conduit-tls.3.0.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+  "Romain Calascibetta"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for 
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation
+"""
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "conduit"
+  "ke"
+  "tls"
+  "logs"
+  "bigstringaf"
+]
+x-commit-hash: "126ace170981b0c0bdb5d73c232099302ecf4af8"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=8b50119048e8c622b5fc09d2331ab8b9412acdd447c5d674bcc865054033cdbb"
+    "sha512=bf8e996276ca9d9393e90f718392916e3b29a56817c38d927ee87a9e81ce608b22dc3e4544fc05077e516f91511b2a96e560d9e7ab917034ba0c23cf61b10f66"
+  ]
+}

--- a/packages/conduit/conduit.3.0.0/opam
+++ b/packages/conduit/conduit.3.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Leonard"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Romain Calascibetta"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"        {>= "4.07.0"}
+  "dune"         {>= "2.0.0"}
+  "ipaddr"
+  "domain-name"
+  "stdlib-shims"
+  "alcotest"     {with-test}
+  "rresult"      {with-test}
+]
+x-commit-hash: "126ace170981b0c0bdb5d73c232099302ecf4af8"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v3.0.0/conduit-v3.0.0.tbz"
+  checksum: [
+    "sha256=8b50119048e8c622b5fc09d2331ab8b9412acdd447c5d674bcc865054033cdbb"
+    "sha512=bf8e996276ca9d9393e90f718392916e3b29a56817c38d927ee87a9e81ce608b22dc3e4544fc05077e516f91511b2a96e560d9e7ab917034ba0c23cf61b10f66"
+  ]
+}


### PR DESCRIPTION
A portable network connection establishment library using Lwt and ocaml-tls

- Project page: <a href="https://github.com/mirage/ocaml-conduit">https://github.com/mirage/ocaml-conduit</a>

##### CHANGES:

* **breaking change** - New version of `conduit`. Most of the new API has a
  description on the pull-request
  [mirage/ocaml-conduit#311](https://github.com/mirage/ocaml-conduit/pull/311). Documentation is
  updated as well with a small HOW-TO (available
  [here](https://mirage.github.io/ocaml-conduit/conduit/howto.html)) which
  describes the new API.
