### PR TITLE
ppx_rapper.0.9.2: add missing core dependency

### DIFF
--- a/packages/ppx_rapper/ppx_rapper.0.9.2/opam
+++ b/packages/ppx_rapper/ppx_rapper.0.9.2/opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/roddyyaga/ppx_rapper/issues"
 depends: [
   "ocaml" {>= "4.07"}
   "dune" {>= "2.0.1"}
+  "core"
   "pg_query"
   "ppxlib"
 ]


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/17427 revdeps

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>