### PR TITLE
Package ogg.0.6.1

### DIFF
--- a/packages/conf-libogg/conf-libogg.1/opam
+++ b/packages/conf-libogg/conf-libogg.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://xiph.org/ogg/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "Xiph.Org Foundation"
+license: "BSD"
+build: ["pkg-config" "--exists" "ogg"]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["libogg-dev"] {os-distribution = "alpine"}
+  ["libogg"] {os-distribution = "arch"}
+  ["libogg-dev"] {os-family = "debian"}
+  ["libogg-devel"] {os-distribution = "centos"}
+  ["libogg-devel"] {os-distribution = "fedora"}
+  ["libogg-devel"] {os-family = "suse"}
+  ["libogg"] {os-distribution = "nixos"}
+  ["libogg"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on libogg"
+description:
+  "This package can only install if the ogg library is installed on the system."
+flags: conf

--- a/packages/conf-libogg/conf-libogg.1/opam
+++ b/packages/conf-libogg/conf-libogg.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["libogg-devel"] {os-distribution = "fedora"}
   ["libogg-devel"] {os-family = "suse"}
   ["libogg"] {os-distribution = "nixos"}
+  ["libogg"] {os-family = "bsd"}
   ["libogg"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on libogg"

--- a/packages/ogg/ogg.0.6.1/opam
+++ b/packages/ogg/ogg.0.6.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Romain Beauxis <toots@rastageeks.org>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+homepage: "https://github.com/savonet/ocaml-ogg"
+bug-reports: "https://github.com/savonet/ocaml-ogg/issues"
+synopsis: "Bindings to libogg"
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+  "conf-pkg-config"
+  "conf-libogg"
+]
+build: [
+  ["./bootstrap"] {dev}
+  ["./configure" "--prefix" prefix]
+  [make "clean"] {dev}
+  [make]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/savonet/ocaml-ogg.git"
+url {
+  src:
+    "https://github.com/savonet/ocaml-ogg/releases/download/v0.6.1/ocaml-ogg-0.6.1.tar.gz"
+  checksum: [
+    "md5=4e08372bc5d0693a7ab2289e789e812d"
+    "sha512=e4edb0f8b595d1e7997f2a639dfff0767eb7d0f8df914e421ebbf7ac6fd5dfa607de3e73c3708745749241341735926d3566490134a97179e992f1ad9aa24af2"
+  ]
+}


### PR DESCRIPTION
### `ogg.0.6.1`
Bindings to libogg



---
* Homepage: https://github.com/savonet/ocaml-ogg
* Source repo: git+https://github.com/savonet/ocaml-ogg.git
* Bug tracker: https://github.com/savonet/ocaml-ogg/issues

---
:camel: Pull-request generated by opam-publish v2.0.2