### PR TITLE
coqide cannot be installed anymore due to upgrade of conf-gnome-icon-…

### DIFF
--- a/packages/coqide/coqide.8.12.0-1/files/coqide.install
+++ b/packages/coqide/coqide.8.12.0-1/files/coqide.install
@@ -1,0 +1,9 @@
+bin: [
+  "bin/coqide"
+]
+share_root: [
+  "ide/coq.lang" {"coq/coq.lang"}
+  "ide/coq-ssreflect.lang" {"coq/coq-ssreflect.lang"}
+  "ide/coq.png" {"coq/coq.png"}
+  "ide/coq_style.xml" {"coq/coq_style.xml"}
+]

--- a/packages/coqide/coqide.8.12.0-1/opam
+++ b/packages/coqide/coqide.8.12.0-1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "conf-findutils" {build}
   "lablgtk3-sourceview3"
-  "conf-gnome-icon-theme3"
+  "conf-adwaita-icon-theme"
 ]
 build: [
   [

--- a/packages/coqide/coqide.8.12.0/opam
+++ b/packages/coqide/coqide.8.12.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "conf-findutils" {build}
   "lablgtk3-sourceview3"
-  "conf-gnome-icon-theme3"
+  "conf-adwaita-icon-theme"
 ]
 build: [
   [


### PR DESCRIPTION
…theme3

Message from spam during the installation: "The package 'conf-gnome-icon-theme3' is deprecated. Please use 'conf-adwaita-icon-theme' instead!"