### PR TITLE
[new release] index and index-bench (1.3.0)

### DIFF
--- a/packages/index-bench/index-bench.1.3.0/opam
+++ b/packages/index-bench/index-bench.1.3.0/opam
@@ -24,6 +24,7 @@ depends: [
   "re"
   "stdlib-shims"
   "yojson"
+  "ppx_repr"
 ]
 
 synopsis: "Index benchmarking suite"

--- a/packages/index-bench/index-bench.1.3.0/opam
+++ b/packages/index-bench/index-bench.1.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.03.0"}
+  "cmdliner"
+  "dune"    {>= "2.7.0"}
+  "fmt"
+  "index"
+  "metrics"
+  "metrics-unix"
+  "ppx_deriving_yojson"
+  "re"
+  "stdlib-shims"
+  "yojson"
+]
+
+synopsis: "Index benchmarking suite"
+x-commit-hash: "aa71287be7b779a6abbc5a6b68c1351761ab7a11"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.3.0/index-1.3.0.tbz"
+  checksum: [
+    "sha256=ef47464c7d05167bbeedd0df377f3a4c4895e63806ce92209582425f206554bb"
+    "sha512=73a62471c67fcd970d774bd321ac1e5f278089d89d470d2de08dff10f1729e43f8d57ce4e08715a1e46976f70d0ec5418a0dcf48015c777f16435c5e8a38a9da"
+  ]
+}

--- a/packages/index/index.1.3.0/opam
+++ b/packages/index/index.1.3.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      [
+   "Craig Ferguson <craig@tarides.com>"
+   "Thomas Gazagnaire <thomas@tarides.com>"
+   "Ioana Cristescu <ioana@tarides.com>"
+   "Clément Pascutto <clement@tarides.com>"
+]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+doc:          "https://mirage.github.io/index/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "repr"
+  "ppx_repr"
+  "fmt"
+  "logs"
+  "mtime"   {>= "1.0.0"}
+  "cmdliner"
+  "progress"
+  "alcotest" {with-test}
+  "crowbar" {with-test & >= "0.2"}
+  "re" {with-test}
+]
+synopsis: "A platform-agnostic multi-level index for OCaml"
+description:"""
+Index is a scalable implementation of persistent indices in OCaml.
+
+It takes an arbitrary IO implementation and user-supplied content
+types and supplies a standard key-value interface for persistent
+storage. Index provides instance sharing: each OCaml
+run-time can share a common singleton instance.
+
+Index supports multiple-reader/single-writer access. Concurrent access
+is safely managed using lock files."""
+x-commit-hash: "aa71287be7b779a6abbc5a6b68c1351761ab7a11"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.3.0/index-1.3.0.tbz"
+  checksum: [
+    "sha256=ef47464c7d05167bbeedd0df377f3a4c4895e63806ce92209582425f206554bb"
+    "sha512=73a62471c67fcd970d774bd321ac1e5f278089d89d470d2de08dff10f1729e43f8d57ce4e08715a1e46976f70d0ec5418a0dcf48015c777f16435c5e8a38a9da"
+  ]
+}


### PR DESCRIPTION
A platform-agnostic multi-level index for OCaml

- Project page: <a href="https://github.com/mirage/index">https://github.com/mirage/index</a>
- Documentation: <a href="https://mirage.github.io/index/">https://mirage.github.io/index/</a>

##### CHANGES:

## Added

- Added `flush_callback` parameter to the creation of a store, to register
  a callback before a flush. This callback can be temporarily disabled by
  `~no_callback:()` to `flush`. (mirage/index#189, mirage/index#216)

- Added `Stats.merge_durations` to list the duration of the last 10 merges.
  (mirage/index#193)

- Added `is_merging` to detect if a merge is running. (mirage/index#192)

- New `IO.Header.{get,set}` functions to read and write the file headers
  atomically (mirage/index#175, mirage/index#204, @icristescu, @CraigFe, @samoht)

- Added a `throttle` configuration option to select the strategy to use
  when the cache are full and an async merge is already in progress. The
  current behavior is the (default) [`Block_writes] strategy. The new
  [`Overcommit_memory] does not block but continue to fill the cache instead.
  (mirage/index#209, @samoht)

- Add `IO.exists` obligation for IO implementations, to be used for lazy
  creation of IO instances. (mirage/index#233, @CraigFe)

- `Index.close` now takes an `~immediately:()` argument. When passed, this
  causes `close` to terminate any ongoing asynchronous merge operation, rather
  than waiting for it to finish. (mirage/index#185, mirage/index#234)

- Added `Index.Checks.cli`, which provides offline integrity checking of Index
  stores. (mirage/index#236)

## Changed

- `sync` has to be called by the read-only instance to synchronise with the
  files on disk. (mirage/index#175)

- Caching of `Index` instances is now explicit: `Index.Make` requires a cache
  implementation, and `Index.v` may be passed a cache to be used for instance
  sharing. The default behaviour is _not_ to share instances. (mirage/index#188)

## Fixed

- Added values after a clear are found by read-only instances. (mirage/index#168)
- Fix a race between `merge` and `sync` (mirage/index#203, @samoht, @CraigFe)
- Fix a potential loss of data if a crash occurs at the end of a merge (mirage/index#232)
