### PR TITLE
[new release] js_of_ocaml-ocamlbuild, js_of_ocaml-compiler, js_of_ocaml-ppx, js_of_ocaml-lwt, js_of_ocaml-toplevel, js_of_ocaml-tyxml, js_of_ocaml and js_of_ocaml-ppx_deriving_json (3.8.0)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.8.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.8.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "ppx_expect" {with-test & >= "v0.12.0"}
+  "cmdliner"
+  "menhir"
+  "ppxlib" {>= "0.15.0"}
+  "yojson" # It's optional, but we want users to be able to use source-map without pain.
+]
+
+depopts: [ "ocamlfind" ]
+
+conflicts: [
+  "ocamlfind"   {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+x-commit-hash: "09d5731241917577e9c16b6a0063c23baae00df8"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.8.0/js_of_ocaml-3.8.0.tbz"
+  checksum: [
+    "sha256=9ed1424afd3eeafa5c5a031d817326edd751da58bda9a16fb4fcb1ee55f43219"
+    "sha512=e4855e242e4b0c6b396154e3d093fb5de28e4073efb1df00ee91ad52fad8530425498f4ff46631f128a9c792225f53c2046eeaea81517281cee1e3442a347578"
+  ]
+}

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.8.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.8.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "lwt" {>= "2.4.4"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+]
+depopts: [ "graphics" "lwt_log" ]
+x-commit-hash: "09d5731241917577e9c16b6a0063c23baae00df8"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.8.0/js_of_ocaml-3.8.0.tbz"
+  checksum: [
+    "sha256=9ed1424afd3eeafa5c5a031d817326edd751da58bda9a16fb4fcb1ee55f43219"
+    "sha512=e4855e242e4b0c6b396154e3d093fb5de28e4073efb1df00ee91ad52fad8530425498f4ff46631f128a9c792225f53c2046eeaea81517281cee1e3442a347578"
+  ]
+}

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.8.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.8.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.5"}
+  "ocamlbuild"
+]
+x-commit-hash: "09d5731241917577e9c16b6a0063c23baae00df8"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.8.0/js_of_ocaml-3.8.0.tbz"
+  checksum: [
+    "sha256=9ed1424afd3eeafa5c5a031d817326edd751da58bda9a16fb4fcb1ee55f43219"
+    "sha512=e4855e242e4b0c6b396154e3d093fb5de28e4073efb1df00ee91ad52fad8530425498f4ff46631f128a9c792225f53c2046eeaea81517281cee1e3442a347578"
+  ]
+}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.8.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.8.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "ppxlib" {>= "0.15.0"}
+  "js_of_ocaml" {= version}
+]
+x-commit-hash: "09d5731241917577e9c16b6a0063c23baae00df8"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.8.0/js_of_ocaml-3.8.0.tbz"
+  checksum: [
+    "sha256=9ed1424afd3eeafa5c5a031d817326edd751da58bda9a16fb4fcb1ee55f43219"
+    "sha512=e4855e242e4b0c6b396154e3d093fb5de28e4073efb1df00ee91ad52fad8530425498f4ff46631f128a9c792225f53c2046eeaea81517281cee1e3442a347578"
+  ]
+}

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.8.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.8.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "2.5"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+]
+x-commit-hash: "09d5731241917577e9c16b6a0063c23baae00df8"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.8.0/js_of_ocaml-3.8.0.tbz"
+  checksum: [
+    "sha256=9ed1424afd3eeafa5c5a031d817326edd751da58bda9a16fb4fcb1ee55f43219"
+    "sha512=e4855e242e4b0c6b396154e3d093fb5de28e4073efb1df00ee91ad52fad8530425498f4ff46631f128a9c792225f53c2046eeaea81517281cee1e3442a347578"
+  ]
+}

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.8.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.8.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "ocamlfind" {>= "1.5.1"}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= version}
+]
+x-commit-hash: "09d5731241917577e9c16b6a0063c23baae00df8"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.8.0/js_of_ocaml-3.8.0.tbz"
+  checksum: [
+    "sha256=9ed1424afd3eeafa5c5a031d817326edd751da58bda9a16fb4fcb1ee55f43219"
+    "sha512=e4855e242e4b0c6b396154e3d093fb5de28e4073efb1df00ee91ad52fad8530425498f4ff46631f128a9c792225f53c2046eeaea81517281cee1e3442a347578"
+  ]
+}

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.8.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.8.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "tyxml" {>= "4.3"}
+  "reactiveData" {>= "0.2"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+]
+x-commit-hash: "09d5731241917577e9c16b6a0063c23baae00df8"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.8.0/js_of_ocaml-3.8.0.tbz"
+  checksum: [
+    "sha256=9ed1424afd3eeafa5c5a031d817326edd751da58bda9a16fb4fcb1ee55f43219"
+    "sha512=e4855e242e4b0c6b396154e3d093fb5de28e4073efb1df00ee91ad52fad8530425498f4ff46631f128a9c792225f53c2046eeaea81517281cee1e3442a347578"
+  ]
+}

--- a/packages/js_of_ocaml/js_of_ocaml.3.8.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.8.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "ppxlib" {>= "0.15.0" }
+  "uchar"
+  "js_of_ocaml-compiler" {= version}
+]
+x-commit-hash: "09d5731241917577e9c16b6a0063c23baae00df8"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.8.0/js_of_ocaml-3.8.0.tbz"
+  checksum: [
+    "sha256=9ed1424afd3eeafa5c5a031d817326edd751da58bda9a16fb4fcb1ee55f43219"
+    "sha512=e4855e242e4b0c6b396154e3d093fb5de28e4073efb1df00ee91ad52fad8530425498f4ff46631f128a9c792225f53c2046eeaea81517281cee1e3442a347578"
+  ]
+}


### PR DESCRIPTION
Compiler from OCaml bytecode to Javascript

- Project page: <a href="http://ocsigen.github.io/js_of_ocaml">http://ocsigen.github.io/js_of_ocaml</a>

##### CHANGES:

## Features/Changes
* compiler, ppx_js, ppx_deriving_json: port PPX's to ppxlib (ocsigen/js_of_ocaml#1041)
