### PR TITLE
[new release] mirage-block-xen (2.0.0)

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.2.0.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.2.0.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott" "Thomas Leonard"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-block-xen"
+doc: "https://mirage.github.io/mirage-block-xen/"
+bug-reports: "https://github.com/mirage/mirage-block-xen/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "logs"
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_cstruct" {build & >= "3.6.0"}
+  "shared-memory-ring"
+  "shared-memory-ring-lwt"
+  "mirage-block" {>= "2.0.0"}
+  "io-page" {>= "2.0.0"}
+  "mirage-xen" {>= "6.0.0"}
+  "xenstore"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block-xen.git"
+synopsis: "MirageOS block driver for Xen that implements the blkfront/back protocol"
+description: """
+This library allows a Mirage OCaml application to
+
+  1. read and write blocks from any Xen "backend" (server)
+  2. service block requests from any Xen "frontend" (client)
+
+This library can be used in both kernelspace (on Xen)
+or in userspace (using libraries that come with Xen).
+
+This library depends on the
+[shared-memory-ring](https://github.com/mirage/shared-memory-ring)
+library which enables high-throughput, low-latency data
+transfers over shared memory on both x86 and ARM architectures,
+using the standard Xen RPC and event channel semantics.
+"""
+x-commit-hash: "cf6d97c1f48a73baeedc57136028191db36d892f"
+url {
+  src:
+    "https://github.com/mirage/mirage-block-xen/releases/download/v2.0.0/mirage-block-xen-v2.0.0.tbz"
+  checksum: [
+    "sha256=794cb14f62a6bd595948f6d1bc923430f5f2ebccc14e4d9cfabf92d17fe3ec0f"
+    "sha512=b8269a283be5c46e6aa3b0d7df8ac5cc0cfe2e06f66428e5fb8d735f2b0581ccd1a01899c0874dc660bd5a4f9145b3543705e051c683bc77cf22e63b7844d71f"
+  ]
+}


### PR DESCRIPTION
MirageOS block driver for Xen that implements the blkfront/back protocol

- Project page: <a href="https://github.com/mirage/mirage-block-xen">https://github.com/mirage/mirage-block-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-xen/">https://mirage.github.io/mirage-block-xen/</a>

##### CHANGES:

* Adapt to mirage-xen 6.0.0 API changes (Solo5 based Xen PVH, mirage/mirage-block-xen#87 @mato)
