### PR TITLE
[new release] mirage-bootvar-xen (0.8.0)

### DIFF
--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.8.0/opam
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.0.8.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Handle boot-time arguments for Xen platform"
+description: """
+Simple library for reading MirageOS unikernel boot parameters from Xen.
+
+To send boot parameters to the unikernel you can either add them as options in the "extra=" field in the .xl-file.
+"""
+
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-bootvar-xen"
+bug-reports: "https://github.com/mirage/mirage-bootvar-xen/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-bootvar-xen.git"
+doc: "https://mirage.github.io/mirage-bootvar-xen/"
+license: "ISC"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {>= "1.0"}
+  "mirage-xen" {>= "6.0.0"}
+  "lwt" {>="2.4.3"}
+  "parse-argv"
+  "ocaml" { >= "4.08.0" }
+]
+x-commit-hash: "442664c9acc551030a23d32d3e11bf4212c65a91"
+url {
+  src:
+    "https://github.com/mirage/mirage-bootvar-xen/releases/download/v0.8.0/mirage-bootvar-xen-v0.8.0.tbz"
+  checksum: [
+    "sha256=9b6580c3d92a157e783d938eda5a56b60527fc920e996ad7d6e3d984e303685a"
+    "sha512=40efe198c53952efa01d3d510d86250e157c296efa2ca82e9c548bd4800b6f2939f2b95b4cb4b9709b1fa99ff43b563b1c26f205543aa5cddc521c92df7987c9"
+  ]
+}


### PR DESCRIPTION
Handle boot-time arguments for Xen platform

- Project page: <a href="https://github.com/mirage/mirage-bootvar-xen">https://github.com/mirage/mirage-bootvar-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-bootvar-xen/">https://mirage.github.io/mirage-bootvar-xen/</a>

##### CHANGES:

* Adapt to mirage-xen 6.0.0 changes (Solo5 based Xen PVH, mirage/mirage-bootvar-xen#45 @mato)
