### PR TITLE
[new release] mirage-console-xen-proto, mirage-console-xen-backend, mirage-console-xen, mirage-console and mirage-console-unix (4.0.0)

### DIFF
--- a/packages/mirage-console-unix/mirage-console-unix.4.0.0/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.4.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "cstruct-lwt" {>= "4.0.0"}
+  "mirage-console" {=version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage consoles for Unix"
+description: """
+This implements a MirageOS console device for use with
+Unix-based targets.
+"""
+x-commit-hash: "ff6ac5a2a3213684b5ee7694751efde37cb994d7"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v4.0.0/mirage-console-v4.0.0.tbz"
+  checksum: [
+    "sha256=771bfe0430ac20c75e06269d40518a1b4dd8d9886daa05679ebfd53a4973dc86"
+    "sha512=e7fc296b352d869f30487613af6731773fe1c3aaf3f046739b39fbada189960cee998fd9d29fa4fe56e28b1a2ea3737833f318277c6304c4c953afed5d1c4d10"
+  ]
+}

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.4.0.0/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.4.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-console" {=version}
+  "mirage-console-xen-proto" {=version}
+  "mirage-xen" {>= "6.0.0"}
+  "io-page" {>= "2.0.0"}
+  "lwt" {>= "4.0.0"}
+  "xenstore"
+  "shared-memory-ring-lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console backend for Xen"
+x-commit-hash: "ff6ac5a2a3213684b5ee7694751efde37cb994d7"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v4.0.0/mirage-console-v4.0.0.tbz"
+  checksum: [
+    "sha256=771bfe0430ac20c75e06269d40518a1b4dd8d9886daa05679ebfd53a4973dc86"
+    "sha512=e7fc296b352d869f30487613af6731773fe1c3aaf3f046739b39fbada189960cee998fd9d29fa4fe56e28b1a2ea3737833f318277c6304c4c953afed5d1c4d10"
+  ]
+}

--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.4.0.0/opam
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.4.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-console" {= version}
+  "rresult"
+  "xenstore"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console protocol for Xen"
+x-commit-hash: "ff6ac5a2a3213684b5ee7694751efde37cb994d7"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v4.0.0/mirage-console-v4.0.0.tbz"
+  checksum: [
+    "sha256=771bfe0430ac20c75e06269d40518a1b4dd8d9886daa05679ebfd53a4973dc86"
+    "sha512=e7fc296b352d869f30487613af6731773fe1c3aaf3f046739b39fbada189960cee998fd9d29fa4fe56e28b1a2ea3737833f318277c6304c4c953afed5d1c4d10"
+  ]
+}

--- a/packages/mirage-console-xen/mirage-console-xen.4.0.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.4.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "io-page" {>= "2.0.0"}
+  "xenstore"
+  "shared-memory-ring"
+  "mirage-flow"
+  "mirage-console" {=version}
+  "mirage-console-xen-proto" {=version}
+  "mirage-xen" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console for Xen"
+x-commit-hash: "ff6ac5a2a3213684b5ee7694751efde37cb994d7"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v4.0.0/mirage-console-v4.0.0.tbz"
+  checksum: [
+    "sha256=771bfe0430ac20c75e06269d40518a1b4dd8d9886daa05679ebfd53a4973dc86"
+    "sha512=e7fc296b352d869f30487613af6731773fe1c3aaf3f046739b39fbada189960cee998fd9d29fa4fe56e28b1a2ea3737833f318277c6304c4c953afed5d1c4d10"
+  ]
+}

--- a/packages/mirage-console/mirage-console.4.0.0/opam
+++ b/packages/mirage-console/mirage-console.4.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementations of Mirage console devices"
+description: """
+This is a general implementation of a console device, intended
+for use in MirageOS.
+"""
+x-commit-hash: "ff6ac5a2a3213684b5ee7694751efde37cb994d7"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v4.0.0/mirage-console-v4.0.0.tbz"
+  checksum: [
+    "sha256=771bfe0430ac20c75e06269d40518a1b4dd8d9886daa05679ebfd53a4973dc86"
+    "sha512=e7fc296b352d869f30487613af6731773fe1c3aaf3f046739b39fbada189960cee998fd9d29fa4fe56e28b1a2ea3737833f318277c6304c4c953afed5d1c4d10"
+  ]
+}


### PR DESCRIPTION
Implementation of Mirage console protocol for Xen

- Project page: <a href="https://github.com/mirage/mirage-console">https://github.com/mirage/mirage-console</a>
- Documentation: <a href="https://mirage.github.io/mirage-console/">https://mirage.github.io/mirage-console/</a>

##### CHANGES:

* Adapt to mirage-xen 6.0.0 API changes (Solo5 based Xen PVH, mirage/mirage-console#85 @mato)
