### PR TITLE
[new release] netchannel and mirage-net-xen (2.0.0)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.2.0.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "6.0.0"}
+  "netchannel" {= version}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+x-commit-hash: "d517b5ddb84ee7954e1a28b21535a8688da6287d"
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.0.0/mirage-net-xen-v2.0.0.tbz"
+  checksum: [
+    "sha256=ec3906ef1804ef6a9e36b91f4ae73ce4849e9e0d1d36a80fe66b5f905fab93ad"
+    "sha512=ead53a07c482f95932c1f35f642f646b19e9415722418cce90e9d2336b77e58b0014b84a68e882721195aba758eed62cbc491bdf604e031507fd512b5c14806e"
+  ]
+}

--- a/packages/netchannel/netchannel.2.0.0/opam
+++ b/packages/netchannel/netchannel.2.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "3.0.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "6.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-profile" {>="0.3"}
+  "shared-memory-ring" {>="3.0.0"}
+  "sexplib" {>= "113.01.00"}
+  "logs" {>= "0.5.0"}
+  "rresult"
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+
+Note: the `Netif` module is the public API.
+The `Netchannel` API is still under development.
+"""
+x-commit-hash: "d517b5ddb84ee7954e1a28b21535a8688da6287d"
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.0.0/mirage-net-xen-v2.0.0.tbz"
+  checksum: [
+    "sha256=ec3906ef1804ef6a9e36b91f4ae73ce4849e9e0d1d36a80fe66b5f905fab93ad"
+    "sha512=ead53a07c482f95932c1f35f642f646b19e9415722418cce90e9d2336b77e58b0014b84a68e882721195aba758eed62cbc491bdf604e031507fd512b5c14806e"
+  ]
+}


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* Adapt to mirage-xen 6.0.0 API changes (Solo5 based Xen PVH, mirage/mirage-net-xen#99 @mato)
