### PR TITLE
[new release] vchan-unix, vchan and vchan-xen (6.0.0)

### DIFF
--- a/packages/vchan-unix/vchan-unix.6.0.0/opam
+++ b/packages/vchan-unix/vchan-unix.6.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "vchan" {= version}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "io-page-unix"
+  "mirage-flow" {>= "2.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "xen-evtchn-unix"
+  "xen-gnt-unix"
+  "sexplib"
+  "cmdliner"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+x-commit-hash: "69de0287d4eb732b42873f10c346f8473032591f"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v6.0.0/vchan-v6.0.0.tbz"
+  checksum: [
+    "sha256=7a6cc89ff8ba7144d6cef3f36722f40deedb3cefff0f7be1b2f3b7b2a2b41747"
+    "sha512=0df7879cead12d37d7a16cc21af839fc26ba16532ced69313bb3b153f187e5f4586c8e34d59ee51265500e0f50febc1b8c01f9ba3703ddd18b6851f02f52c43a"
+  ]
+}

--- a/packages/vchan-xen/vchan-xen.6.0.0/opam
+++ b/packages/vchan-xen/vchan-xen.6.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "vchan" {=version}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "mirage-flow" {>= "2.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "mirage-xen" {>= "6.0.0"}
+  "xenstore_transport" {>= "1.0.0"}
+  "sexplib"
+  "cmdliner"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+x-commit-hash: "69de0287d4eb732b42873f10c346f8473032591f"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v6.0.0/vchan-v6.0.0.tbz"
+  checksum: [
+    "sha256=7a6cc89ff8ba7144d6cef3f36722f40deedb3cefff0f7be1b2f3b7b2a2b41747"
+    "sha512=0df7879cead12d37d7a16cc21af839fc26ba16532ced69313bb3b153f187e5f4586c8e34d59ee51265500e0f50febc1b8c01f9ba3703ddd18b6851f02f52c43a"
+  ]
+}

--- a/packages/vchan/vchan.6.0.0/opam
+++ b/packages/vchan/vchan.6.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+description: """
+This is an implementation of the Xen "libvchan" or "vchan" communication
+protocol in OCaml. It allows fast inter-domain communication using shared
+memory.
+"""
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "mirage-flow" {>= "2.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "sexplib"
+  "cmdliner"
+  "ounit" {with-test}
+  "io-page-unix" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+x-commit-hash: "69de0287d4eb732b42873f10c346f8473032591f"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v6.0.0/vchan-v6.0.0.tbz"
+  checksum: [
+    "sha256=7a6cc89ff8ba7144d6cef3f36722f40deedb3cefff0f7be1b2f3b7b2a2b41747"
+    "sha512=0df7879cead12d37d7a16cc21af839fc26ba16532ced69313bb3b153f187e5f4586c8e34d59ee51265500e0f50febc1b8c01f9ba3703ddd18b6851f02f52c43a"
+  ]
+}


### PR DESCRIPTION
Xen Vchan implementation

- Project page: <a href="https://github.com/mirage/ocaml-vchan">https://github.com/mirage/ocaml-vchan</a>
- Documentation: <a href="https://mirage.github.io/ocaml-vchan">https://mirage.github.io/ocaml-vchan</a>

##### CHANGES:

* Adapt to mirage-xen 6.0.0 API changes (Solo5 based Xen PVH, mirage/ocaml-vchan#136 @mato)
