### PR TITLE
[new release] mirage-crypto-pk, mirage-crypto, mirage-crypto-rng and mirage-crypto-rng-mirage (0.8.6)

### DIFF
--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.6/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.6/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.7"}
+  "rresult" {>= "0.6.0"}
+  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding")
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+x-commit-hash: "c6299a7ec045d1bdcdb4418157aee84ca225c92a"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.6/mirage-crypto-v0.8.6.tbz"
+  checksum: [
+    "sha256=782e69011d643861575f497b00a31465ed5b23c35086698d9e31d44b137af0b9"
+    "sha512=3795a84cfdd800366288fbd2c82ba1d1e0fc4ffec80259a6a4397c70308f2e36571aa109b152db5997139532518cb015d61021d58ee43c29515b77811d424b52"
+  ]
+}

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.6/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.6/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+x-commit-hash: "c6299a7ec045d1bdcdb4418157aee84ca225c92a"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.6/mirage-crypto-v0.8.6.tbz"
+  checksum: [
+    "sha256=782e69011d643861575f497b00a31465ed5b23c35086698d9e31d44b137af0b9"
+    "sha512=3795a84cfdd800366288fbd2c82ba1d1e0fc4ffec80259a6a4397c70308f2e36571aa109b152db5997139532518cb015d61021d58ee43c29515b77811d424b52"
+  ]
+}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.6/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.6/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "mirage-crypto" {=version}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+# lwt sublibrary
+  "mtime"
+  "lwt" {>= "4.0.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+x-commit-hash: "c6299a7ec045d1bdcdb4418157aee84ca225c92a"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.6/mirage-crypto-v0.8.6.tbz"
+  checksum: [
+    "sha256=782e69011d643861575f497b00a31465ed5b23c35086698d9e31d44b137af0b9"
+    "sha512=3795a84cfdd800366288fbd2c82ba1d1e0fc4ffec80259a6a4397c70308f2e36571aa109b152db5997139532518cb015d61021d58ee43c29515b77811d424b52"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.8.6/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.6/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "eqaf" {>= "0.7"}
+]
+depopts: [
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
+hashes (MD5, SHA-1, SHA-2).
+"""
+x-commit-hash: "c6299a7ec045d1bdcdb4418157aee84ca225c92a"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.6/mirage-crypto-v0.8.6.tbz"
+  checksum: [
+    "sha256=782e69011d643861575f497b00a31465ed5b23c35086698d9e31d44b137af0b9"
+    "sha512=3795a84cfdd800366288fbd2c82ba1d1e0fc4ffec80259a6a4397c70308f2e36571aa109b152db5997139532518cb015d61021d58ee43c29515b77811d424b52"
+  ]
+}


### PR DESCRIPTION
Simple public-key cryptography for the modern age

- Project page: <a href="https://github.com/mirage/mirage-crypto">https://github.com/mirage/mirage-crypto</a>
- Documentation: <a href="https://mirage.github.io/mirage-crypto/doc">https://mirage.github.io/mirage-crypto/doc</a>

##### CHANGES:

* Detect CPU architecture from C compiler, allowing cross-compiling to Android
  and iOS (mirage/mirage-crypto#84 by @EduardoRFC)
* Upgrade to dune2, use a Makefile for building freestanding libraries, drop
  mirage-xen-posix support (solo5-based PVH exists now) mirage/mirage-crypto#86 by @hannesm
