### PR TITLE
xen-devel: use on os-family = suse

### DIFF
--- a/packages/xen-evtchn-unix/xen-evtchn-unix.2.0.0/opam
+++ b/packages/xen-evtchn-unix/xen-evtchn-unix.2.0.0/opam
@@ -25,7 +25,7 @@ depexts: [
   ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xen-devel"] {os-distribution = "opensuse"}
+  ["xen-devel"] {os-family = "suse"}
   ["xenstore"] {os-distribution = "arch"}
 ]
 synopsis: "Xen event channel bindings."

--- a/packages/xen-evtchn-unix/xen-evtchn-unix.2.1.0/opam
+++ b/packages/xen-evtchn-unix/xen-evtchn-unix.2.1.0/opam
@@ -25,7 +25,7 @@ depexts: [
   ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
-  ["xen-devel"] {os-distribution = "opensuse"}
+  ["xen-devel"] {os-family = "suse"}
   ["xenstore"] {os-distribution = "arch"}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-evtchn.git"

--- a/packages/xenctrl/xenctrl.0.10.0/opam
+++ b/packages/xenctrl/xenctrl.0.10.0/opam
@@ -45,7 +45,7 @@ depexts: [
   ["xen-devel"] {os-distribution = "fedora"}
   ["xen-devel"] {os-distribution = "rhel"}
   ["xen-devel"] {os-distribution = "ol"}
-  ["xen-devel"] {os-distribution = "opensuse"}
+  ["xen-devel"] {os-family = "suse"}
   ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
   ["xen-dev"] {os-distribution = "alpine"}
 ]


### PR DESCRIPTION
this should fix the failure observed in https://github.com/ocaml/opam-repository/pull/17458 (and https://github.com/mirage/ocaml-vchan/pull/136#issuecomment-713448337)