### PR TITLE
[new release] ocaml-migrate-parsetree (2.1.0)

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.02.3" & < "4.13"}
+]
+synopsis: "Convert OCaml parsetrees between different versions"
+description: """
+Convert OCaml parsetrees between different versions
+
+This library converts parsetrees, outcometree and ast mappers between
+different OCaml versions.  High-level functions help making PPX
+rewriters independent of a compiler version.
+"""
+x-commit-hash: "4a05cf7a00d84e5f827cc9ae9c75e5dc85126085"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v2.1.0/ocaml-migrate-parsetree-v2.1.0.tbz"
+  checksum: [
+    "sha256=387b788ee4c0537f1fe02c25e05f0335af424828fc6fe940acc0db5948a5a71f"
+    "sha512=6ac80face6b77531c8d89a77d7a246bd5d43da435c355f62c03c8b8e360e1d7e339c904709fd3dbc9aa340c86ada9a69d5ebcf97cbdb7bd51bec97f831741b99"
+  ]
+}


### PR DESCRIPTION
Convert OCaml parsetrees between different versions

- Project page: <a href="https://github.com/ocaml-ppx/ocaml-migrate-parsetree">https://github.com/ocaml-ppx/ocaml-migrate-parsetree</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ocaml-migrate-parsetree/">https://ocaml-ppx.github.io/ocaml-migrate-parsetree/</a>

##### CHANGES:

- Add support for 4.12 (ocaml-ppx/ocaml-migrate-parsetree#107, @ceastlund)
