### PR TITLE
Changed GTK icon theme to adwaita in all GTK3 based CoqIDE packages

### DIFF
--- a/packages/coqide/coqide.8.10.0/opam
+++ b/packages/coqide/coqide.8.10.0/opam
@@ -11,7 +11,7 @@ depends: [
   "coq" {= version}
   "lablgtk3-sourceview3" {!= "3.0.beta7"}
   "conf-findutils" {build}
-  "conf-gnome-icon-theme3"
+  "conf-adwaita-icon-theme"
 ]
 build: [
   [

--- a/packages/coqide/coqide.8.10.1/opam
+++ b/packages/coqide/coqide.8.10.1/opam
@@ -16,7 +16,7 @@ depends: [
   "coq" {= version}
   "lablgtk3-sourceview3" {!= "3.0.beta7"}
   "conf-findutils" {build}
-  "conf-gnome-icon-theme3"
+  "conf-adwaita-icon-theme"
 ]
 build: [
   [

--- a/packages/coqide/coqide.8.10.2/opam
+++ b/packages/coqide/coqide.8.10.2/opam
@@ -16,7 +16,7 @@ depends: [
   "coq" {= version}
   "lablgtk3-sourceview3" {!= "3.0.beta7"}
   "conf-findutils" {build}
-  "conf-gnome-icon-theme3"
+  "conf-adwaita-icon-theme"
 ]
 build: [
   [

--- a/packages/coqide/coqide.8.11.0/opam
+++ b/packages/coqide/coqide.8.11.0/opam
@@ -16,7 +16,7 @@ depends: [
   "coq" {= version}
   "lablgtk3-sourceview3" {!= "3.0.beta7"}
   "conf-findutils" {build}
-  "conf-gnome-icon-theme3"
+  "conf-adwaita-icon-theme"
 ]
 build: [
   [

--- a/packages/coqide/coqide.8.11.1/opam
+++ b/packages/coqide/coqide.8.11.1/opam
@@ -16,7 +16,7 @@ depends: [
   "coq" {= version}
   "lablgtk3-sourceview3" {!= "3.0.beta7"}
   "conf-findutils" {build}
-  "conf-gnome-icon-theme3"
+  "conf-adwaita-icon-theme"
 ]
 build: [
   [

--- a/packages/coqide/coqide.8.11.2/opam
+++ b/packages/coqide/coqide.8.11.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "conf-findutils" {build}
   "lablgtk3-sourceview3" {!= "3.0.beta7"}
-  "conf-gnome-icon-theme3"
+  "conf-adwaita-icon-theme"
 ]
 build: [
   [

--- a/packages/coqide/coqide.8.12.0/opam
+++ b/packages/coqide/coqide.8.12.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "conf-findutils" {build}
   "lablgtk3-sourceview3"
-  "conf-gnome-icon-theme3"
+  "conf-adwaita-icon-theme"
 ]
 build: [
   [


### PR DESCRIPTION
This is a follow up on my PR #17279 which replaces the dependency from the now deprecated conf-gnome-icon-theme3 to conf-adwaita-icon-theme for all versions of CoqIDE based on GTK3.

Note: on Mac CoqIDE does no longer build since #17279 because the hack to install the adwaita icon theme in conf-gnome-icon-theme3 on Mac has been removed with #17279.

See also (https://github.com/coq/coq/issues/13229).