### PR TITLE
[new release] conf-openblas (0.2.1)

### DIFF
--- a/packages/conf-openblas/conf-openblas.0.2.1/files/test.c
+++ b/packages/conf-openblas/conf-openblas.0.2.1/files/test.c
@@ -1,0 +1,11 @@
+#include <cblas.h>
+#include <lapacke.h>
+
+int main(int argc, char **argv)
+{
+  int N = 3;
+  double X[] = { 1, 2, 3 };
+  int INCX = 1;
+	double res = cblas_dnrm2(N, X, INCX);
+  return 0;
+}

--- a/packages/conf-openblas/conf-openblas.0.2.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+homepage: "https://github.com/xianyi/OpenBLAS"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "BSD-3-Clause"
+build: [
+  ["sh" "-exc" "cc $CFLAGS -I/usr/include/openblas test.c -lopenblas"]
+    {os-distribution = "fedora" | os-distribution = "centos" | os-family = "suse"}
+  [
+    "sh"
+    "-exc"
+    "cc $CFLAGS -I/usr/local/opt/openblas/include test.c -L/usr/local/opt/openblas/lib -lopenblas"
+  ] {os = "macos" & os-distribution = "homebrew"}
+  ["sh" "-exc" "cc $CFLAGS test.c -lcblas"]
+    {os-distribution = "arch"}
+  ["sh" "-exc" "cc $CFLAGS -I/usr/local/include -L/usr/local/lib test.c -lopenblas"]
+    {os = "freebsd"}
+  ["sh" "-exc" "x86_64-w64-mingw32-gcc $CFLAGS test.c -lopenblas"]
+    {os = "win32" & os-distribution = "cygwinports"}
+  ["sh" "-exc" "cc $CFLAGS test.c -lopenblas"]
+    {os-distribution != "fedora" & os-distribution != "centos" & os-family != "suse" & os != "macos" & os-distribution != "arch" & os != "freebsd" & os != "win32"}
+]
+depexts: [
+  ["libc-dev" "openblas-dev"] {os-distribution = "alpine"}
+  ["epel-release" "openblas-devel"] {os-distribution = "centos"}
+  ["libopenblas-dev" "liblapacke-dev"] {os-family = "debian"}
+  ["openblas-devel"] {os-distribution = "fedora"}
+  ["openblas-devel"] {os-family = "suse"}
+  ["openblas" "lapacke" "cblas"] {os-distribution = "arch"}
+  ["openblas"] {os = "macos" & os-distribution = "homebrew"}
+  ["openblas"] {os = "freebsd"}
+]
+synopsis: "Virtual package to install OpenBLAS and LAPACKE"
+description:
+  "The package prepares OpenBLAS (CBLAS) and LAPACKE backend for Owl (OCaml numerical library). It can only be installed if OpenBLAS and LAPACKE are installed on the system."
+extra-files: ["test.c" "md5=dcf8ee02542457dde43e1e4917897416"]
+flags: conf


### PR DESCRIPTION
fixes installation on Windows for `os = "win32" & os-distribution = "cygwinports"`
