### PR TITLE
Package fadbadml.0.1.1

### DIFF
--- a/packages/fadbadml/fadbadml.0.1.1/opam
+++ b/packages/fadbadml/fadbadml.0.1.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "FADBAD++ for OCaml"
+maintainer: [
+  "francois-bidet <fbidet@lix.polytechnique.fr>"
+  "ismailbennani <ismail.lahkim.bennani@ens.fr>"
+]
+authors: [
+  "francois-bidet <fbidet@lix.polytechnique.fr>"
+  "ismailbennani <ismail.lahkim.bennani@ens.fr>"
+]
+license: "CeCILL-C"
+homepage: "https://github.com/fadbadml-dev/FADBADml"
+bug-reports: "https://github.com/fadbadml-dev/FADBADml/issues"
+depends: [
+  "ocaml" { >= "4.08" }
+  "ocamlfind" {build}
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make "lib"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/fadbadml-dev/FADBADml"
+url {
+  src: "https://github.com/fadbadml-dev/FADBADml/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=74d6e7fe0a97e898a0c98346f7eae461"
+    "sha512=1e69eb664c3db88973b3eea96e2b260dbd333f2b94f71cf07a6bb92816c4cc9b740b8046016d41c230d0a065b34684989004de1788c820f0b77fd11c5682470d"
+  ]
+}


### PR DESCRIPTION
### `fadbadml.0.1.1`
FADBAD++ for OCaml



---
* Homepage: https://github.com/fadbadml-dev/FADBADml
* Source repo: git+https://github.com/fadbadml-dev/FADBADml
* Bug tracker: https://github.com/fadbadml-dev/FADBADml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2