### PR TITLE
[new release] mirage-qubes-ipv4 and mirage-qubes (0.9.0)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "5.0.0" }
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-protocols" { >= "4.0.0" }
+  "cstruct" { >= "1.9.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+x-commit-hash: "cac912e9e8d0a07f6af4bd10c9c5fae02ff74ee4"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.9.0/mirage-qubes-v0.9.0.tbz"
+  checksum: [
+    "sha256=58c8b3c4030f3dcaaf25e176a54e6292ec3b8cdf143e3e5eeba602111d03d0b3"
+    "sha512=54624ff2b101d244d5c8ba3e99d850d6541cf4417fb5b98e961a939f6f5a5a92ba6c048be480dc35fe302a32310cad4b820e181ff1257c4950f83478894b4133"
+  ]
+}

--- a/packages/mirage-qubes/mirage-qubes.0.9.0/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.9.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "2.2.0" }
+  "ppx_cstruct"
+  "vchan-xen" { >= "6.0.0" }
+  "mirage-xen" { >= "6.0.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.08.0" }
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+x-commit-hash: "cac912e9e8d0a07f6af4bd10c9c5fae02ff74ee4"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.9.0/mirage-qubes-v0.9.0.tbz"
+  checksum: [
+    "sha256=58c8b3c4030f3dcaaf25e176a54e6292ec3b8cdf143e3e5eeba602111d03d0b3"
+    "sha512=54624ff2b101d244d5c8ba3e99d850d6541cf4417fb5b98e961a939f6f5a5a92ba6c048be480dc35fe302a32310cad4b820e181ff1257c4950f83478894b4133"
+  ]
+}


### PR DESCRIPTION
Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-qubes">https://github.com/mirage/mirage-qubes</a>
- Documentation: <a href="https://mirage.github.io/mirage-qubes">https://mirage.github.io/mirage-qubes</a>

##### CHANGES:

- adapt to mirage-xen 6.0.0 and vchan-xen 6.0.0, only metadata changes (mirage/mirage-qubes#55 @hannesm)
