### PR TITLE
Package qrc.0.1.0

### DIFF
--- a/packages/qrc/qrc.0.1.0/opam
+++ b/packages/qrc/qrc.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The qrc programmers"]
+homepage: "https://erratique.ch/software/qrc"
+doc: "https://erratique.ch/software/qrc/doc"
+license: "ISC"
+dev-repo: "git+https://erratique.ch/repos/qrc.git"
+bug-reports: "https://github.com/dbuenzli/qrc/issues"
+tags: [ "qr-code" "codec" "org:erratique" ]
+depends:
+[
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+]
+depopts: ["cmdliner"]
+conflicts: [ "cmdliner" {< "1.0.4"} ]
+build:
+[[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{dev}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+]]
+
+synopsis: """QR code encoder for OCaml"""
+description: """\
+
+Qrc encodes your data into QR codes. It has built-in QR matrix
+renderers for SVG, ANSI terminal and text.
+
+Qrc is distributed under the ISC license. It has no dependencies.
+"""
+url {
+archive: "https://erratique.ch/software/qrc/releases/qrc-0.1.0.tbz"
+checksum: "60151f3126ae3c45ae9052499d4c99a1"
+}


### PR DESCRIPTION
### `qrc.0.1.0`
QR code encoder for OCaml
Qrc encodes your data into QR codes. It has built-in QR matrix
renderers for SVG, ANSI terminal and text.

Qrc is distributed under the ISC license. It has no dependencies.



---
* Homepage: https://erratique.ch/software/qrc
* Source repo: git+https://erratique.ch/repos/qrc.git
* Bug tracker: https://github.com/dbuenzli/qrc/issues

---
v0.1.0 2020-10-22 Zagreb
------------------------

First release.

---
:camel: Pull-request generated by opam-publish v2.0.2