### PR TITLE
Package ezjs_min.0.2

### DIFF
--- a/packages/ezjs_fetch/ezjs_fetch.0.1/opam
+++ b/packages/ezjs_fetch/ezjs_fetch.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0"}
   "js_of_ocaml" {>= "3.6"}
   "js_of_ocaml-ppx" {>= "3.6"}
-  "ezjs_min" {>= "0.1"}
+  "ezjs_min" {>= "0.1" & < "0.2"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/ezjs_min/ezjs_min.0.2/opam
+++ b/packages/ezjs_min/ezjs_min.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A bunch of js_of_ocaml shortcuts"
+description: "A bunch of js_of_ocaml shortcuts"
+maintainer: "OCamlPro <contact@ocamlpro.com>"
+authors: "OCamlPro <contact@ocamlpro.com>"
+license: "LGPL-2.1"
+homepage: "https://github.com/ocamlpro/ezjs_min"
+bug-reports: "https://github.com/ocamlpro/ezjs_min/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "2.0"}
+  "js_of_ocaml-ppx"
+  "stdlib-shims" {>= "0.1"}
+]
+depopts: ["lwt"]
+conflicts: [
+  "lwt" {< "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamlpro/ezjs_min.git"
+url {
+  src: "https://github.com/ocamlpro/ezjs_min/archive/0.2.tar.gz"
+  checksum: [
+    "md5=616fa2b92e5132153a0353acf2dc757b"
+    "sha512=aa2db089193f07a394e9bcb012d838f9f63124b6116e69999c7fc40a7d03eb5436924a7f2c5cbcc30ff22eb08ba382b8037f4035e4f19a5652711595d0a97fa0"
+  ]
+}


### PR DESCRIPTION
### `ezjs_min.0.2`
A bunch of js_of_ocaml shortcuts
A bunch of js_of_ocaml shortcuts



---
* Homepage: https://github.com/ocamlpro/ezjs_min
* Source repo: git+https://github.com/ocamlpro/ezjs_min.git
* Bug tracker: https://github.com/ocamlpro/ezjs_min/issues

---
:camel: Pull-request generated by opam-publish v2.0.2