### PR TITLE
Package fadbadml.0.1.2

### DIFF
--- a/packages/fadbadml/fadbadml.0.1.2/opam
+++ b/packages/fadbadml/fadbadml.0.1.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "FADBAD++ for OCaml"
+description:
+  "This library is an OCaml porting of FADBAD++, a software written by Ole Stauning and Claus Bendtsen."
+maintainer: ["fbidet@lix.polytechnique.fr" "ismail.lahkim.bennani@ens.fr"]
+authors: ["François Bidet" "Ismail Bennani"]
+license: "CECILL-C"
+homepage: "https://fadbadml-dev.github.io/FADBADml/"
+doc: "https://fadbadml-dev.github.io/FADBADml/doc/"
+bug-reports: "https://github.com/fadbadml-dev/FADBADml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/fadbadml-dev/FADBADml.git"
+url {
+  src: "https://github.com/fadbadml-dev/FADBADml/archive/0.1.2.tar.gz"
+  checksum: [
+    "md5=fe47c68f8176d54f1235b40f122b3ae0"
+    "sha512=310996cb0d607faa305176790d2dceccdd6fe9fb454d9e095375b6d0fa1f0aa193f22d6f1b4a54410a6d7fc7e347d77cb41713821dd869331e0c3f22db3d6f21"
+  ]
+}

--- a/packages/fadbadml/fadbadml.0.1.2/opam
+++ b/packages/fadbadml/fadbadml.0.1.2/opam
@@ -9,7 +9,10 @@ homepage: "https://fadbadml-dev.github.io/FADBADml/"
 doc: "https://fadbadml-dev.github.io/FADBADml/doc/"
 bug-reports: "https://github.com/fadbadml-dev/FADBADml/issues"
 depends: [
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
+  "qcheck" {with-test}
+  "conf-python-3" {with-test}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
### `fadbadml.0.1.2`
FADBAD++ for OCaml
This library is an OCaml porting of FADBAD++, a software written by Ole Stauning and Claus Bendtsen.



---
* Homepage: https://fadbadml-dev.github.io/FADBADml/
* Source repo: git+https://github.com/fadbadml-dev/FADBADml.git
* Bug tracker: https://github.com/fadbadml-dev/FADBADml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2