### PR TITLE
[new release] mirage, mirage-runtime, mirage-types-lwt and mirage-types (3.9.0)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.9.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.9.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "5.0.0"}
+  "functoria-runtime"  {>= "3.0.2"}
+  "fmt"
+  "logs"
+  "lwt" {>= "4.0.0"}
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+x-commit-hash: "3d71cc923326fc6afbcebc614cc570897aeb5461"
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.9.0/mirage-v3.9.0.tbz"
+  checksum: [
+    "sha256=8a5207c01b5073dbdafe2de7b61d4e907ee989132ec56e38e793cab01381f6c3"
+    "sha512=acf7d433041e824f7252b563bd31d10aa3a087be30239d9115a875d744f2dfbccc699006e89d6b3fe0c7f16e101d0ca95b971a016bda3f38297dc36d1bc56986"
+  ]
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.9.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.9.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends:   [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-types" {= version}
+]
+
+synopsis: "Lwt module type definitions for MirageOS applications"
+description: """
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`
+"""
+post-messages: [
+ "This package will be retired in MirageOS 4.0. Please use individual signatures (mirage-net / mirage-clock / etc.) instead."
+]
+x-commit-hash: "3d71cc923326fc6afbcebc614cc570897aeb5461"
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.9.0/mirage-v3.9.0.tbz"
+  checksum: [
+    "sha256=8a5207c01b5073dbdafe2de7b61d4e907ee989132ec56e38e793cab01381f6c3"
+    "sha512=acf7d433041e824f7252b563bd31d10aa3a087be30239d9115a875d744f2dfbccc699006e89d6b3fe0c7f16e101d0ca95b971a016bda3f38297dc36d1bc56986"
+  ]
+}

--- a/packages/mirage-types/mirage-types.3.9.0/opam
+++ b/packages/mirage-types/mirage-types.3.9.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-console" {>= "3.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "mirage-fs" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+]
+synopsis: "Module type definitions for MirageOS applications"
+description: """
+Module type definitions for MirageOS applications
+"""
+post-messages: [
+  "This package will be retired in MirageOS 4.0. Please use individual signatures (mirage-net / mirage-clock / etc.) instead."
+]
+x-commit-hash: "3d71cc923326fc6afbcebc614cc570897aeb5461"
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.9.0/mirage-v3.9.0.tbz"
+  checksum: [
+    "sha256=8a5207c01b5073dbdafe2de7b61d4e907ee989132ec56e38e793cab01381f6c3"
+    "sha512=acf7d433041e824f7252b563bd31d10aa3a087be30239d9115a875d744f2dfbccc699006e89d6b3fe0c7f16e101d0ca95b971a016bda3f38297dc36d1bc56986"
+  ]
+}

--- a/packages/mirage/mirage.3.9.0/opam
+++ b/packages/mirage/mirage.3.9.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "5.0.0"}
+  "functoria"          {>= "3.1.0"}
+  "bos"
+  "astring"
+  "logs"
+  "stdlib-shims"
+  "mirage-runtime"     {=version | (>= "3.9.0" & < "3.10.0")}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+x-commit-hash: "3d71cc923326fc6afbcebc614cc570897aeb5461"
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.9.0/mirage-v3.9.0.tbz"
+  checksum: [
+    "sha256=8a5207c01b5073dbdafe2de7b61d4e907ee989132ec56e38e793cab01381f6c3"
+    "sha512=acf7d433041e824f7252b563bd31d10aa3a087be30239d9115a875d744f2dfbccc699006e89d6b3fe0c7f16e101d0ca95b971a016bda3f38297dc36d1bc56986"
+  ]
+}


### PR DESCRIPTION
CHANGES:

The Xen backend is a minimal legacy-free re-write: Solo5 (since 0.6.6) provides
the low-level glue code, and ocaml-freestanding provides the OCaml runtime. The
PV-only Mini-OS implementation has been retired.

The only supported virtualization mode is now Xen PVH (version 2 or above),
supported since Xen version 4.10 or later (and Qubes OS 4.0).

The support for the ARM32 architecture on Xen has been removed.

Security posture improvements:

With the move to a Solo5 and ocaml-freestanding base MirageOS gains several
notable improvements to security posture for unikernels on Xen:

* Stack smashing protection is enabled unconditionally for all C code.
* W^X is enforced throughout, i.e. `.text` is read-execute, `.rodata` is
  read-only, non-executable and `.data`, heap and stack are read-write and
  non-executable.
* The memory allocator used by the OCaml runtime is now dlmalloc (provided by
  ocaml-freestanding), which is a big improvement over the Mini-OS malloc, and
  incorporates features such as heap canaries.

Interface changes:

* With the rewrite of the Xen core platform stack, several Xen-specific APIs
  have changed in incompatible ways; unikernels may need to be updated. Please
  refer to the mirage-xen v6.0.0 [change
  log](https://github.com/mirage/mirage-xen/releases/tag/v6.0.0) for a list of
  interfaces that have changed along with their replacements.

Other changes:

* OCaml 4.08 is the minimum supported version.
* A dummy `dev-repo` field is emitted for the generated opam file.
* .xe files are no longer generated.
* Previous versions of MirageOS would strip boot parameters on Xen, since Qubes
  OS 3.x added arguments that could not be interpreted by our command line
  parser. Since Qubes OS 4.0 this is no longer an issue, and MirageOS no longer
  strips any boot parameters. You may need to execute
  `qvm-prefs qube-name kernelopts ''`.

Acknowledgements:

* Thanks to Roger Pau Monné, Andrew Cooper and other core Xen developers for
  help with understanding the specifics of how PVHv2 works, and how to write an
  implementation from scratch.
* Thanks to Marek Marczykowski-Górecki for help with the Qubes OS specifics, and
  for forward-porting some missing parts of PVHv2 to Qubes OS version of Xen.
* Thanks to @palainp on Github for help with testing on Qubes OS.