### PR TITLE
Package ezjs_blockies.0.1.1

### DIFF
--- a/packages/ezjs_blockies/ezjs_blockies.0.1.1/opam
+++ b/packages/ezjs_blockies/ezjs_blockies.0.1.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Bindings for Blockies"
+description: "Bindings for Blockies"
+maintainer: "OCamlPro <contact@ocamlpro.com>"
+authors: "OCamlPro <contact@ocamlpro.com>"
+license: "LGPL-2.1"
+homepage: "https://github.com/ocamlpro/ezjs_blockies"
+bug-reports: "https://github.com/ocamlpro/ezjs_blockies/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "2.0"}
+  "js_of_ocaml" {>= "3.6"}
+  "js_of_ocaml-ppx" {>= "3.6"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamlpro/ezjs_blockies.git"
+url {
+  src: "https://github.com/ocamlpro/ezjs_blockies/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=be36e2c03f75dc6bb70f687e69fc1dd5"
+    "sha512=307b5e88b6121b78b85cbb96ff80b918b570b9eac42aaef1f84ac44e0b9dd85215e139de48ccfb68cf08d600cb321cf52f009ea1cad1b541230f6b8c3e4b5480"
+  ]
+}


### PR DESCRIPTION
### `ezjs_blockies.0.1.1`
Bindings for Blockies
Bindings for Blockies



---
* Homepage: https://github.com/ocamlpro/ezjs_blockies
* Source repo: git+https://github.com/ocamlpro/ezjs_blockies.git
* Bug tracker: https://github.com/ocamlpro/ezjs_blockies/issues

---
:camel: Pull-request generated by opam-publish v2.0.2