### PR TITLE
Package ezjs_recaptcha.0.1.1

### DIFF
--- a/packages/ezjs_recaptcha/ezjs_recaptcha.0.1.1/opam
+++ b/packages/ezjs_recaptcha/ezjs_recaptcha.0.1.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Bindings for reCAPTCHA"
+description: "Bindings for reCAPTCHA"
+maintainer: "OCamlPro <contact@ocamlpro.com>"
+authors: "OCamlPro <contact@ocamlpro.com>"
+license: "LGPL-2.1"
+homepage: "https://github.com/ocamlpro/ezjs_recaptcha"
+bug-reports: "https://github.com/ocamlpro/ezjs_recaptcha/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "2.0"}
+  "js_of_ocaml" {>= "3.6"}
+  "js_of_ocaml-ppx" {>= "3.6"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamlpro/ezjs_recaptcha.git"
+url {
+  src: "https://github.com/ocamlpro/ezjs_recaptcha/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=88dfc40c0228d9d88b3e97f9175643ee"
+    "sha512=2e080113ca6afd43e1c416062786c9c553319499c1b83a527e733f275b17b91d9e72ea9e0afd9ac4c0234d79a92ecf05b129d8936cd47fb3bf0605861d967ca2"
+  ]
+}


### PR DESCRIPTION
### `ezjs_recaptcha.0.1.1`
Bindings for reCAPTCHA
Bindings for reCAPTCHA



---
* Homepage: https://github.com/ocamlpro/ezjs_recaptcha
* Source repo: git+https://github.com/ocamlpro/ezjs_recaptcha.git
* Bug tracker: https://github.com/ocamlpro/ezjs_recaptcha/issues

---
:camel: Pull-request generated by opam-publish v2.0.2