### PR TITLE
Package ezjs_cleave.0.1.1

### DIFF
--- a/packages/ezjs_cleave/ezjs_cleave.0.1.1/opam
+++ b/packages/ezjs_cleave/ezjs_cleave.0.1.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Bindings for Cleave"
+description: "Bindings for Cleave"
+maintainer: "OCamlPro <contact@ocamlpro.com>"
+authors: "OCamlPro <contact@ocamlpro.com>"
+license: "LGPL-2.1"
+homepage: "https://github.com/ocamlpro/ezjs_cleave"
+bug-reports: "https://github.com/ocamlpro/ezjs_cleave/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "2.0"}
+  "js_of_ocaml" {>= "3.6"}
+  "js_of_ocaml-ppx" {>= "3.6"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamlpro/ezjs_cleave.git"
+url {
+  src: "https://github.com/ocamlpro/ezjs_cleave/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=1e5eff7c65e8b6a37ebf8f6c83d0e712"
+    "sha512=22fa31da83fa62dfde4a6c9709d9a69f40edc67ea053350b7ca9029d907fac50a01dfb0e56427c9813742af9a53795a22487599a095c47f2827092aa56564b38"
+  ]
+}


### PR DESCRIPTION
### `ezjs_cleave.0.1.1`
Bindings for Cleave
Bindings for Cleave



---
* Homepage: https://github.com/ocamlpro/ezjs_cleave
* Source repo: git+https://github.com/ocamlpro/ezjs_cleave.git
* Bug tracker: https://github.com/ocamlpro/ezjs_cleave/issues

---
:camel: Pull-request generated by opam-publish v2.0.2