### PR TITLE
Package ezjs_ace.0.1.1

### DIFF
--- a/packages/ezjs_ace/ezjs_ace.0.1.1/opam
+++ b/packages/ezjs_ace/ezjs_ace.0.1.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Bindings for the Ace editor"
+description: "Bindings for the Ace editor"
+maintainer: "OCamlPro <contact@ocamlpro.com>"
+authors: "OCamlPro <contact@ocamlpro.com>"
+license: "LGPL-2.1"
+homepage: "https://github.com/ocamlpro/ezjs_ace"
+bug-reports: "https://github.com/ocamlpro/ezjs_ace/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "2.0"}
+  "js_of_ocaml" {>= "3.6"}
+  "js_of_ocaml-ppx" {>= "3.6"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamlpro/ezjs_ace.git"
+url {
+  src: "https://github.com/ocamlpro/ezjs_ace/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=d082fae5e5d56c6b31d80641144b1161"
+    "sha512=9ceafdbddadba31b0363a99d8a4617aac30791cf514558b376746c2569510643676e48f0f81d31ac964b895ff05325d22342897d6ccf791087e22963080405ec"
+  ]
+}


### PR DESCRIPTION
### `ezjs_ace.0.1.1`
Bindings for the Ace editor
Bindings for the Ace editor



---
* Homepage: https://github.com/ocamlpro/ezjs_ace
* Source repo: git+https://github.com/ocamlpro/ezjs_ace.git
* Bug tracker: https://github.com/ocamlpro/ezjs_ace/issues

---
:camel: Pull-request generated by opam-publish v2.0.2