### PR TITLE
Package ezjs_cytoscape.0.1

### DIFF
--- a/packages/ezjs_cytoscape/ezjs_cytoscape.0.1/opam
+++ b/packages/ezjs_cytoscape/ezjs_cytoscape.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Bindings for Cytoscape"
+description: "Bindings for Cytoscape"
+maintainer: "OCamlPro <contact@ocamlpro.com>"
+authors: "OCamlPro <contact@ocamlpro.com>"
+license: "LGPL-2.1"
+homepage: "https://github.com/ocamlpro/ezjs_cytoscape"
+bug-reports: "https://github.com/ocamlpro/ezjs_cytoscape/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "2.0"}
+  "js_of_ocaml-ppx" {>= "3.6"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamlpro/ezjs_cytoscape.git"
+url {
+  src: "https://github.com/ocamlpro/ezjs_cytoscape/archive/0.1.tar.gz"
+  checksum: [
+    "md5=72d9f30def84cd807c55da0e6ebb6fb3"
+    "sha512=47e92abf3c40218923df176b601211d252fca314fdafb300355de31d5c3a2a983e6e508bc3d6c964e9130c8249a818a1c45a05370cb23beeebcf60f9c026ca52"
+  ]
+}


### PR DESCRIPTION
### `ezjs_cytoscape.0.1`
Bindings for Cytoscape
Bindings for Cytoscape



---
* Homepage: https://github.com/ocamlpro/ezjs_cytoscape
* Source repo: git+https://github.com/ocamlpro/ezjs_cytoscape.git
* Bug tracker: https://github.com/ocamlpro/ezjs_cytoscape/issues

---
:camel: Pull-request generated by opam-publish v2.0.2