### PR TITLE
Package monolith.20201026

### DIFF
--- a/packages/monolith/monolith.20201026/opam
+++ b/packages/monolith/monolith.20201026/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/monolith"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/monolith.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "2.0" }
+  "afl-persistent" { >= "1.3" }
+  "pprint" { >= "20200410" }
+  "seq"
+]
+synopsis: "A framework for testing a library using afl-fuzz"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/monolith/repository/20201026/archive.tar.gz"
+  checksum: [
+    "md5=940ff10c3d46c3f34324ffb05bea23d0"
+    "sha512=0aaebb5550643319acbac005afc8ef603cffa68ff16e31742da2c6f7b6bc2e41d704b810a20b7b6611ca4a46664d124e413c978dd80f7b7095857b710bb9f34c"
+  ]
+}


### PR DESCRIPTION
### `monolith.20201026`
A framework for testing a library using afl-fuzz



---
* Homepage: https://gitlab.inria.fr/fpottier/monolith
* Source repo: git+https://gitlab.inria.fr/fpottier/monolith.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.2