### PR TITLE
Package ezjs_extension.0.1

### DIFF
--- a/packages/ezjs_extension/ezjs_extension.0.1/opam
+++ b/packages/ezjs_extension/ezjs_extension.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Binding for Chrome and Firefox extension API"
+maintainer: "OCamlPro <contact@ocamlpro.com>"
+authors: "Maxime Levillain <maxime.levillain@ocamlpro.com>"
+license: "LGPL-2.1"
+homepage: "https://github.com/ocamlpro/ezjs_extension"
+bug-reports: "https://github.com/ocamlpro/ezjs_extension/issues"
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "2.0"}
+  "ezjs_min" {>= "0.2"}
+]
+depopts: ["lwt"]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamlpro/ezjs_extension.git"
+url {
+  src: "https://github.com/ocamlpro/ezjs_extension/archive/0.1.tar.gz"
+  checksum: [
+    "md5=0d1dc7175a620eb50c07f2bbe0531533"
+    "sha512=5742b4e64398533c95291fe7c9b5ed3e264214dee7522fec1a0074766afd40e633aa1ceea16cbc6923ab80d737a15c13b50b96d4ddf8fad8ec74c30816877c9a"
+  ]
+}


### PR DESCRIPTION
### `ezjs_extension.0.1`
Binding for Chrome and Firefox extension API



---
* Homepage: https://github.com/ocamlpro/ezjs_extension
* Source repo: git+https://github.com/ocamlpro/ezjs_extension.git
* Bug tracker: https://github.com/ocamlpro/ezjs_extension/issues

---
:camel: Pull-request generated by opam-publish v2.0.2