### PR TITLE
dose3: Update upstream repository information

### DIFF
--- a/packages/dose3/dose3.4.3/opam
+++ b/packages/dose3/dose3.4.3/opam
@@ -11,9 +11,9 @@ authors: [
   "Olivier Rosello"
 ]
 homepage: "http://www.mancoosi.org/software/"
-bug-reports: "https://gforge.inria.fr/tracker/?group_id=4395"
+bug-reports: "https://gitlab.com/irill/dose3/-/issues"
 license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
-dev-repo: "git+https://gforge.inria.fr/git/dose/dose.git"
+dev-repo: "git+https://gitlab.com/irill/dose3.git"
 build: [
   ["./configure"]
   [make]

--- a/packages/dose3/dose3.5.0.1/opam
+++ b/packages/dose3/dose3.5.0.1/opam
@@ -11,9 +11,9 @@ authors: [
   "Olivier Rosello"
 ]
 homepage: "http://www.mancoosi.org/software/"
-bug-reports: "https://gforge.inria.fr/tracker/?group_id=4395"
+bug-reports: "https://gitlab.com/irill/dose3/-/issues"
 license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
-dev-repo: "git+https://gforge.inria.fr/git/dose/dose.git"
+dev-repo: "git+https://gitlab.com/irill/dose3.git"
 build: [
   ["./configure"]
   [make "printconf"]

--- a/packages/dose3/dose3.5.0/opam
+++ b/packages/dose3/dose3.5.0/opam
@@ -11,9 +11,9 @@ authors: [
   "Olivier Rosello"
 ]
 homepage: "http://www.mancoosi.org/software/"
-bug-reports: "https://gforge.inria.fr/tracker/?group_id=4395"
+bug-reports: "https://gitlab.com/irill/dose3/-/issues"
 license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
-dev-repo: "git+https://gforge.inria.fr/git/dose/dose.git"
+dev-repo: "git+https://gitlab.com/irill/dose3.git"
 build: [
   ["./configure"]
   [make]


### PR DESCRIPTION
More updates should be done later to change the archive as inria's gforge is closing down soon.