### PR TITLE
Package soupault.2.1.0

### DIFF
--- a/packages/soupault/soupault.2.1.0/opam
+++ b/packages/soupault/soupault.2.1.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Static website generator based on HTML rewriting"
+description: """\
+A website generator that works with page element tree rather than text
+and allows you to manipulate pages and retrieve metadata from
+existing HTML using arbitrary CSS selectors.
+
+Built-in functionality includes setting page title, generating ToC and footnotes,
+inserting files/HTML snippets or output of external programs into pages etc.
+
+Metadata extracted from pages can be rendered using Jingoo templates or exported to JSON
+and processed with an external script.
+
+Extensible with Lua (2.5) plugins. Can also be used as an HTML processor for existing pages."""
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: "Daniil Baturin <daniil+soupault@baturin.org>"
+license: "MIT"
+homepage: "https://soupault.neocities.org"
+bug-reports: "https://github.com/dmbaturin/soupault/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0.0"}
+  "lambdasoup" {>= "0.7.2"}
+  "markup" {>= "1.0.0"}
+  "toml"
+  "fileutils"
+  "logs"
+  "fmt"
+  "re"
+  "ezjsonm"
+  "containers"
+  "stringext"
+  "calendar"
+  "spelll"
+  "jingoo"
+  "tsort" {>= "2.0.0"}
+  "lua-ml" {>= "0.9.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/dmbaturin/soupault"
+url {
+  src: "https://github.com/dmbaturin/soupault/archive/2.1.0.tar.gz"
+  checksum: [
+    "md5=505f3e59d757e1a7898d80b5cafa40e8"
+    "sha512=c2d88537db3c920f6cc8dceee67f9dd4c0a74e44855ee12e3f715f2f7839cbe195dda57f7627043d432ab17a7a2829b88eaca8a24c7afc373617003ddee547aa"
+  ]
+}


### PR DESCRIPTION
### `soupault.2.1.0`
Static website generator based on HTML rewriting
A website generator that works with page element tree rather than text
and allows you to manipulate pages and retrieve metadata from
existing HTML using arbitrary CSS selectors.

Built-in functionality includes setting page title, generating ToC and footnotes,
inserting files/HTML snippets or output of external programs into pages etc.

Metadata extracted from pages can be rendered using Jingoo templates or exported to JSON
and processed with an external script.

Extensible with Lua (2.5) plugins. Can also be used as an HTML processor for existing pages.



---
* Homepage: https://soupault.neocities.org
* Source repo: git+https://github.com/dmbaturin/soupault
* Bug tracker: https://github.com/dmbaturin/soupault/issues

---
:camel: Pull-request generated by opam-publish v2.0.2