### PR TITLE
[new release] ppx_deriving (5.0)

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.5.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.0/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.07.0"}
   "dune" {>= "1.6.3"}
   "cppo" {build}
   "ocamlfind"

--- a/packages/ppx_deriving/ppx_deriving.5.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {build}
+  "ocamlfind"
+  "ocaml-migrate-parsetree"
+  "ppx_derivers"
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
+  "result"
+  "ounit" {with-test}
+]
+synopsis: "Type-driven code generation for OCaml"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v5.0/ppx_deriving-v5.0.tbz"
+  checksum: [
+    "sha256=838782b8ea0c2c684a93617e44f1c0f606805bc470730be80c6efb7689cd7f3a"
+    "sha512=0ef22b1a463d8395fd31568bffc59081cd6bf0435ad74d466e5d453b7a6b76d13b9726aa377c1b6733aa9e631f659819d3284791023fd20d9af5eba4f62532c1"
+  ]
+}
+x-commit-hash: "82b9ac968aa5ad3860d47f70531f45498e6121cf"

--- a/packages/ppx_deriving/ppx_deriving.5.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.6.3"}
   "cppo" {build}
   "ocamlfind"
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"
   "ppxlib" {>= "0.9.0" & < "0.14.0"}
   "result"


### PR DESCRIPTION
Type-driven code generation for OCaml

- Project page: <a href="https://github.com/ocaml-ppx/ppx_deriving">https://github.com/ocaml-ppx/ppx_deriving</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_deriving/">https://ocaml-ppx.github.io/ppx_deriving/</a>

##### CHANGES:

* Migrate to ppxlib ocaml-ppx/ppx_deriving#206, ocaml-ppx/ppx_deriving#210
  (Anton Kochkov, Gabriel Scherer, Thierry Martinez)
