### PR TITLE
[new release] fiat-p256 (0.2.2)

### DIFF
--- a/packages/fiat-p256/fiat-p256.0.2.2/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.2/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "Primitives for Elliptic Curve Cryptography taken from Fiat"
+description: """
+This is an implementation of the ECDH over P-256 key exchange algorithm, using
+code from Fiat (<https://github.com/mit-plv/fiat-crypto>).
+
+Cryptographic primitives should not be used in end applications, they are better
+used as part of a cryptographic library.
+"""
+maintainer: ["Etienne Millon <me@emillon.org>"]
+authors: [
+  "Etienne Millon <me@emillon.org>"
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+]
+license: "MIT"
+homepage: "https://github.com/mirage/fiat"
+doc: "https://mirage.github.io/fiat/doc"
+bug-reports: "https://github.com/mirage/fiat/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "alcotest" {with-test}
+  "asn1-combinators" {with-test}
+  "benchmark" {with-test}
+  "bigarray-compat"
+  "cstruct" {>= "3.5.0"}
+  "dune-configurator"
+  "eqaf" {>= "0.5"}
+  "hex"
+  "conf-pkg-config" {build}
+  "ppx_deriving_yojson" {with-test}
+  "rresult" {with-test}
+  "stdlib-shims" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+  "odoc" {with-doc}
+]
+depopts: ["ocaml-freestanding"]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/fiat.git"
+tags: ["org:mirage"]
+x-commit-hash: "21028c123254e8550ee00ba8bf5b09a770bc3ac8"
+url {
+  src:
+    "https://github.com/mirage/fiat/releases/download/v0.2.2/fiat-p256-v0.2.2.tbz"
+  checksum: [
+    "sha256=f32a20800cb0c0baa4f851ceaab6d10b20fd8e6d5c88f3d5d5eff923f4efc8ed"
+    "sha512=cb4243eefbe2538fbea42ba4f155218ea0da341e1571ec4b207c8e775abcbdbec39f60b906468454c2515c3b7ff8698e8861df46cb12ba67a1f7f1b5f3a2eeb0"
+  ]
+}


### PR DESCRIPTION
Primitives for Elliptic Curve Cryptography taken from Fiat

- Project page: <a href="https://github.com/mirage/fiat">https://github.com/mirage/fiat</a>
- Documentation: <a href="https://mirage.github.io/fiat/doc">https://mirage.github.io/fiat/doc</a>

##### CHANGES:

- revise MirageOS cross-compilation runes: use a Makefile, only support
  ocaml-freestanding (since mirage-xen 6.0.0 ocaml-freestanding is used)
  (mirage/fiat#59, @hannesm)
