### PR TITLE
[new release] mirage-solo5 (0.6.4)

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.6.4/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.6.4/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.6.0"}
+  "bheap" {>= "2.0.0"}
+  "ocaml" {>= "4.06.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "ocaml-freestanding" {>= "0.4.5"}
+  "metrics"
+  "mirage-runtime" {>= "3.7.0"}
+  "duration"
+  ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"})
+]
+conflicts: [
+  "io-page" {< "2.0.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+x-commit-hash: "7cf24bcc58c7082738618c1bbc4d1d4586f1f7e0"
+url {
+  src:
+    "https://github.com/mirage/mirage-solo5/releases/download/v0.6.4/mirage-solo5-v0.6.4.tbz"
+  checksum: [
+    "sha256=a90c9e417bdd9e13821c47f224df70ac7d8cdfd6a7b0a13b73314fee1cf8e352"
+    "sha512=d3e5bdbf052aa9345fd3d3b9d469a7943401cfcbdf83fcb8c16736d5c381f740aa4caeea59fe3805d7e9b2f2f55e0a45eb3ddd345b26dacd76104985bbb443b5"
+  ]
+}


### PR DESCRIPTION
Solo5 core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-solo5">https://github.com/mirage/mirage-solo5</a>

##### CHANGES:

* Synchronise interfaces with those of the newly-released mirage-xen:
    * Provide a new OS.Memory statistics interface.
    * Mark existing OS.MM interfaces as deprecated.
    * Use a Makefile to build `libmirage-solo5_bindings.a`.
    * Time: minor syntactic chagnes, remove unused `min_timeout`.
    * (@hannesm / @mato, mirage/mirage-solo5#72)
* Remove superfluous conditional compilation for no longer supported OCaml versions (@hannesm, mirage/mirage-solo5#70).
