### PR TITLE
[new release] doi2bib (0.2.1)

### DIFF
--- a/packages/doi2bib/doi2bib.0.2.1/opam
+++ b/packages/doi2bib/doi2bib.0.2.1/opam
@@ -13,7 +13,6 @@ depends: [
   "clap" {>= "0.1.0"}
   "ezxmlm" {>= "1.1.0"}
   "tls" {>= "0.12.0"}
-  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/doi2bib/doi2bib.0.2.1/opam
+++ b/packages/doi2bib/doi2bib.0.2.1/opam
@@ -25,8 +25,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
-    "@doc" {with-doc}
   ]
 ]
 dev-repo: "git+https://github.com/mseri/doi2bib.git"

--- a/packages/doi2bib/doi2bib.0.2.1/opam
+++ b/packages/doi2bib/doi2bib.0.2.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Little CLI tool to get bibtex entries out of doi or arxiv ids"
+maintainer: ["marcello.seri@gmail.com"]
+authors: ["Marcello Seri"]
+license: "MIT"
+homepage: "https://github.com/mseri/doi2bib"
+bug-reports: "https://github.com/mseri/doi2bib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "astring" {>= "0.8.0"}
+  "cohttp-lwt-unix" {>= "2.5.0"}
+  "clap" {>= "0.1.0"}
+  "ezxmlm" {>= "1.1.0"}
+  "tls" {>= "0.12.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mseri/doi2bib.git"
+x-commit-hash: "fc5106ce971346c80d99bd66e329b8ad41adbd80"
+url {
+  src:
+    "https://github.com/mseri/doi2bib/releases/download/0.2.1/doi2bib-0.2.1.tbz"
+  checksum: [
+    "sha256=dc56c36f0d942b5e216158f168919cf1473afe6a789fc6d3f1e7e549131ae352"
+    "sha512=c9a9ff7feca35c69a6922600d9beb2541fcfc584c87ea4cbfcd5c7b7aed8aa29e4228687891b9e6c464b4cde17fc3ff1b57849625320d5d597394361322ec5b8"
+  ]
+}


### PR DESCRIPTION
Little CLI tool to get bibtex entries out of doi or arxiv ids

- Project page: <a href="https://github.com/mseri/doi2bib">https://github.com/mseri/doi2bib</a>

##### CHANGES:

- Support for PubMed IDs (courtesy of @jubnzv)
- Improved error messages and error codes
