### PR TITLE
[new release] decoders-yojson, decoders-cbor, decoders, decoders-jsonm, decoders-ezjsonm, decoders-sexplib, decoders-bencode and decoders-msgpck (0.5.0)

### DIFF
--- a/packages/decoders-bencode/decoders-bencode.0.5.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Bencode backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Simon Cruanes <simon@imandra.ai>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders/decoders-bencode/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "decoders"
+  "bencode"
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "f9cc33ebb1d992bc2c49d79839430c0dbf07bdc3"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.5.0/decoders-v0.5.0.tbz"
+  checksum: [
+    "sha256=cf1149b47022e64413991f6733b5a63fa835c8dc1af908a19c952ff9072d6fb5"
+    "sha512=951c02059a8060ba551c1c1bd74c509c9bce8462a6e7ea3b0beb9739e54347087734038668eed09b6454f3487ae3963794223b821e1d8d86b0c986a3bfecdc30"
+  ]
+}

--- a/packages/decoders-cbor/decoders-cbor.0.5.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.0.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "CBOR backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders/decoders-cbor/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "decoders"
+  "cbor"
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "f9cc33ebb1d992bc2c49d79839430c0dbf07bdc3"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.5.0/decoders-v0.5.0.tbz"
+  checksum: [
+    "sha256=cf1149b47022e64413991f6733b5a63fa835c8dc1af908a19c952ff9072d6fb5"
+    "sha512=951c02059a8060ba551c1c1bd74c509c9bce8462a6e7ea3b0beb9739e54347087734038668eed09b6454f3487ae3963794223b821e1d8d86b0c986a3bfecdc30"
+  ]
+}

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.5.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Ezjsonm backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders/decoders-ezjsonm/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "decoders"
+  "ezjsonm" {>= "0.4.0"}
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "f9cc33ebb1d992bc2c49d79839430c0dbf07bdc3"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.5.0/decoders-v0.5.0.tbz"
+  checksum: [
+    "sha256=cf1149b47022e64413991f6733b5a63fa835c8dc1af908a19c952ff9072d6fb5"
+    "sha512=951c02059a8060ba551c1c1bd74c509c9bce8462a6e7ea3b0beb9739e54347087734038668eed09b6454f3487ae3963794223b821e1d8d86b0c986a3bfecdc30"
+  ]
+}

--- a/packages/decoders-jsonm/decoders-jsonm.0.5.0/opam
+++ b/packages/decoders-jsonm/decoders-jsonm.0.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Jsonm backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders/decoders-jsonm/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "decoders"
+  "jsonm"
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "f9cc33ebb1d992bc2c49d79839430c0dbf07bdc3"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.5.0/decoders-v0.5.0.tbz"
+  checksum: [
+    "sha256=cf1149b47022e64413991f6733b5a63fa835c8dc1af908a19c952ff9072d6fb5"
+    "sha512=951c02059a8060ba551c1c1bd74c509c9bce8462a6e7ea3b0beb9739e54347087734038668eed09b6454f3487ae3963794223b821e1d8d86b0c986a3bfecdc30"
+  ]
+}

--- a/packages/decoders-msgpck/decoders-msgpck.0.5.0/opam
+++ b/packages/decoders-msgpck/decoders-msgpck.0.5.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Msgpck backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: [
+  "Matt Bray <mattjbray@gmail.com>" "Simon Cruanes <simon@imandra.ai>"
+]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders/decoders-msgpck/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "decoders"
+  "msgpck"
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "f9cc33ebb1d992bc2c49d79839430c0dbf07bdc3"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.5.0/decoders-v0.5.0.tbz"
+  checksum: [
+    "sha256=cf1149b47022e64413991f6733b5a63fa835c8dc1af908a19c952ff9072d6fb5"
+    "sha512=951c02059a8060ba551c1c1bd74c509c9bce8462a6e7ea3b0beb9739e54347087734038668eed09b6454f3487ae3963794223b821e1d8d86b0c986a3bfecdc30"
+  ]
+}

--- a/packages/decoders-sexplib/decoders-sexplib.0.5.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.0.5.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Sexplib backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders/decoders-sexplib/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "decoders"
+  "sexplib0"
+  "sexplib"
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "f9cc33ebb1d992bc2c49d79839430c0dbf07bdc3"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.5.0/decoders-v0.5.0.tbz"
+  checksum: [
+    "sha256=cf1149b47022e64413991f6733b5a63fa835c8dc1af908a19c952ff9072d6fb5"
+    "sha512=951c02059a8060ba551c1c1bd74c509c9bce8462a6e7ea3b0beb9739e54347087734038668eed09b6454f3487ae3963794223b821e1d8d86b0c986a3bfecdc30"
+  ]
+}

--- a/packages/decoders-yojson/decoders-yojson.0.5.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Yojson backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders/decoders-yojson/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "decoders"
+  "yojson"
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "f9cc33ebb1d992bc2c49d79839430c0dbf07bdc3"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.5.0/decoders-v0.5.0.tbz"
+  checksum: [
+    "sha256=cf1149b47022e64413991f6733b5a63fa835c8dc1af908a19c952ff9072d6fb5"
+    "sha512=951c02059a8060ba551c1c1bd74c509c9bce8462a6e7ea3b0beb9739e54347087734038668eed09b6454f3487ae3963794223b821e1d8d86b0c986a3bfecdc30"
+  ]
+}

--- a/packages/decoders/decoders.0.5.0/opam
+++ b/packages/decoders/decoders.0.5.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Elm-inspired decoders for Ocaml"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders/decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "odoc" {with-doc}
+  "containers" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "f9cc33ebb1d992bc2c49d79839430c0dbf07bdc3"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.5.0/decoders-v0.5.0.tbz"
+  checksum: [
+    "sha256=cf1149b47022e64413991f6733b5a63fa835c8dc1af908a19c952ff9072d6fb5"
+    "sha512=951c02059a8060ba551c1c1bd74c509c9bce8462a6e7ea3b0beb9739e54347087734038668eed09b6454f3487ae3963794223b821e1d8d86b0c986a3bfecdc30"
+  ]
+}


### PR DESCRIPTION
Yojson backend for decoders

- Project page: <a href="https://github.com/mattjbray/ocaml-decoders">https://github.com/mattjbray/ocaml-decoders</a>
- Documentation: <a href="https://mattjbray.github.io/ocaml-decoders/decoders/decoders-yojson/">https://mattjbray.github.io/ocaml-decoders/decoders/decoders-yojson/</a>

##### CHANGES:

* Add `Decoders_msgpck` (mattjbray/ocaml-decoders#26, @c-cube)
* Add `let` operators (mattjbray/ocaml-decoders#24, @c-cube)
* Alias `Decode.map` as `<$>` (mattjbray/ocaml-decoders#21, @hamza0867)
