### PR TITLE
[new release] stdint (0.7.0)

### DIFF
--- a/packages/stdint/stdint.0.7.0/opam
+++ b/packages/stdint/stdint.0.7.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: ["Markus W. Weissmann <markus.weissmann@in.tum.de>"]
+authors: [
+  "Andre Nathan <andre@digirati.com.br>"
+  "Jeff Shaw <shawjef3@msu.edu>"
+  "Markus W. Weissmann <markus.weissmann@in.tum.de>"
+  "Florian Pichlmeier <florian.pichlmeier@mytum.de>"
+]
+bug-reports: "https://github.com/andrenth/ocaml-stdint/issues"
+homepage: "https://github.com/andrenth/ocaml-stdint"
+doc: "https://andrenth.github.io/ocaml-stdint/"
+license: "MIT"
+dev-repo: "git+https://github.com/andrenth/ocaml-stdint.git"
+synopsis: "Signed and unsigned integer types having specified widths"
+description: """
+The stdint library provides signed and unsigned integer types of various fixed
+widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
+
+This interface is similar to Int32 and Int64 from the base library but provides
+more functions and constants like arithmetic and bit-wise operations, constants
+like maximum and minimum values, infix operators conversion to and from every
+other integer type (including int, float and nativeint), parsing from and
+conversion to readable strings (binary, octal, decimal, hexademical), conversion
+to and from buffers in both big endian and little endian byte order."""
+depends: [
+  "ocaml" {>= "4.03"}
+  "qcheck" {test}
+  "dune" {>= "1.10"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "f3eb95c3807249e1fb8ca635bdaa1ef98f7249da"
+url {
+  src:
+    "https://github.com/andrenth/ocaml-stdint/releases/download/0.7.0/stdint-0.7.0.tbz"
+  checksum: [
+    "sha256=4fcc66aef58e2b96e7af3bbca9d910aa239e045ba5fb2400aaef67d0041252dc"
+    "sha512=9b05b6cf691320b718dd2118b1e3f96a2997e42e6c99a34b470b060c82fc16c50d57c6ee392d1b62bdb8df73094657eea56050da3e74745a4afb0f150a60a584"
+  ]
+}

--- a/packages/stdint/stdint.0.7.0/opam
+++ b/packages/stdint/stdint.0.7.0/opam
@@ -24,7 +24,7 @@ conversion to readable strings (binary, octal, decimal, hexademical), conversion
 to and from buffers in both big endian and little endian byte order."""
 depends: [
   "ocaml" {>= "4.03"}
-  "qcheck" {test}
+  "odoc" {with-doc}
   "dune" {>= "1.10"}
 ]
 build: [


### PR DESCRIPTION
Signed and unsigned integer types having specified widths

- Project page: <a href="https://github.com/andrenth/ocaml-stdint">https://github.com/andrenth/ocaml-stdint</a>
- Documentation: <a href="https://andrenth.github.io/ocaml-stdint/">https://andrenth.github.io/ocaml-stdint/</a>

##### CHANGES:

## Fixes:

* Correct conversion from uint24 to other ints (andrenth/ocaml-stdint#39, @rixed)
* Fix conversion from all ints to uint24 and int24 (andrenth/ocaml-stdint#41, @rixed)
* Fix int24 failing to recover from casts (andrenth/ocaml-stdint#43, @rixed)
* Fix sign extensions (andrenth/ocaml-stdint#49, @rixed)
* `Long_val` returns `intnat`, previously `long` was used (andrenth/ocaml-stdint#53, @dra27)
* Reduce size of marshalled custom values on 4.08+ (andrenth/ocaml-stdint#54, @dra27)
* Store 128-bit ints as structs to prevent unaligned access (andrenth/ocaml-stdint#55, @dra27)

## New features:

* Add `of_substring` (andrenth/ocaml-stdint#49, @darlentar)
