### PR TITLE
stdlib-shims: require dune >= 2.8 when using OCaml >= 4.12

### DIFF
--- a/packages/stdlib-shims/stdlib-shims.0.1.0/opam
+++ b/packages/stdlib-shims/stdlib-shims.0.1.0/opam
@@ -8,9 +8,9 @@ bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
 tags: ["stdlib" "compatibility" "org:ocaml"]
 license: ["typeof OCaml system"]
 depends: [
-  "ocaml" {>="4.02.3"}
+  "ocaml" {>= "4.02.3"}
   "dune"
- ("dune" {>= "2.7.0"} | "dune" & "ocaml" {<"4.12.0~~"})
+ ("dune" {>= "2.8.0"} | "ocaml" {< "4.12.0~~"})
 ]
 build: [ "dune" "build" "-p" name "-j" jobs ]
 synopsis: "Backport some of the new stdlib features to older compiler"


### PR DESCRIPTION
This is required for https://github.com/ocurrent/opam-repo-ci/pull/21
https://github.com/ocaml/dune/pull/3793 should hopefully get merged in dune 2.8

cc @rgrinberg 