### PR TITLE
ocamlgraph_gtk: add constraint towards ocamlgraph

### DIFF
--- a/packages/ocamlgraph_gtk/ocamlgraph_gtk.2.0.0/opam
+++ b/packages/ocamlgraph_gtk/ocamlgraph_gtk.2.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "stdlib-shims"
   "lablgtk"
   "conf-gnomecanvas"
-  "ocamlgraph"
+  "ocamlgraph" {>= "2.0.0"}
   "dune" {>= "2.0" & !with-test | >= "2.8"}
   "graphics" {with-test}
 ]


### PR DESCRIPTION
I just tried installing `ocamlgraph_gtk.2.0.0` while having `ocamlgraph.1.8.8` installed, and it fails during compilation with:

```
# File "dgraph/dGraphMake.ml", line 27, characters 5-9:
# 27 | open XDot
#           ^^^^
# Error: Unbound module XDot
```

This is not surprising, considering the package has been split since version 2.0.0, but I think the constraint should be added to avoid compilation failures. @backtracking, could you please confirm if my reasoning is correct? Other than that, everything seems to work fine.

In case it's relevant, I'm using OCaml 4.08.1.