### PR TITLE
[new release] plist-xml and plist-xml-lwt (0.3.0)

### DIFF
--- a/packages/plist-xml-lwt/plist-xml-lwt.0.3.0/opam
+++ b/packages/plist-xml-lwt/plist-xml-lwt.0.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Reading of plist files in the XML format with Lwt"
+description: "Reading of plist files in the XML format with Lwt."
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "MIT"
+homepage: "https://github.com/alan-j-hu/ocaml-plist-xml"
+doc: "https://alan-j-hu.github.io/ocaml-plist-xml/"
+bug-reports: "https://github.com/alan-j-hu/ocaml-plist-xml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "plist-xml" {= "0.3.0"}
+  "lwt" {>= "5.0" & < "6.0"}
+  "markup-lwt" {>= "0.5" & < "0.6"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/ocaml-plist-xml.git"
+x-commit-hash: "cf538a2c0013f85091e903a5365d6f5a7811bb76"
+url {
+  src:
+    "https://github.com/alan-j-hu/ocaml-plist-xml/releases/download/0.3.0/plist-xml-lwt-0.3.0.tbz"
+  checksum: [
+    "sha256=f1bef673f1145a2d9f4d8e51a61563cd3630ae5352d79610369ead307aa5f4d5"
+    "sha512=75eb172941fff651fd59daff9c7aeece5dd6e90b34ad1d07b8034b6c290112dde1baec3d3971b1e34702ca4873407ff854fdc7c87467bd0d8f7e08451a60cd67"
+  ]
+}

--- a/packages/plist-xml/plist-xml.0.3.0/opam
+++ b/packages/plist-xml/plist-xml.0.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Reading and writing of plist files in the XML format in pure OCaml"
+description: """
+Reading and writing of plist files in the XML format in pure OCaml.
+
+Implementation of https://www.apple.com/DTDs/PropertyList-1.0.dtd."""
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "MIT"
+homepage: "https://github.com/alan-j-hu/ocaml-plist-xml"
+doc: "https://alan-j-hu.github.io/ocaml-plist-xml/"
+bug-reports: "https://github.com/alan-j-hu/ocaml-plist-xml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "base64" {>= "3.4" & < "4.0"}
+  "ISO8601" {>= "0.2.6" & < "0.3"}
+  "markup" {>= "0.8" & < "2.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/ocaml-plist-xml.git"
+x-commit-hash: "cf538a2c0013f85091e903a5365d6f5a7811bb76"
+url {
+  src:
+    "https://github.com/alan-j-hu/ocaml-plist-xml/releases/download/0.3.0/plist-xml-lwt-0.3.0.tbz"
+  checksum: [
+    "sha256=f1bef673f1145a2d9f4d8e51a61563cd3630ae5352d79610369ead307aa5f4d5"
+    "sha512=75eb172941fff651fd59daff9c7aeece5dd6e90b34ad1d07b8034b6c290112dde1baec3d3971b1e34702ca4873407ff854fdc7c87467bd0d8f7e08451a60cd67"
+  ]
+}


### PR DESCRIPTION
Reading and writing of plist files in the XML format in pure OCaml

- Project page: <a href="https://github.com/alan-j-hu/ocaml-plist-xml">https://github.com/alan-j-hu/ocaml-plist-xml</a>
- Documentation: <a href="https://alan-j-hu.github.io/ocaml-plist-xml/">https://alan-j-hu.github.io/ocaml-plist-xml/</a>

##### CHANGES:

- `plist_of_stream_exn` now takes a `(Markup.signal, s) Markup.stream` instead
  of a `(Markup.content_signal, s) Markup.stream`, as the
  `Markup.content_signal` type was removed from Markup.ml in version 1.0.0-1.
