### PR TITLE
Revised detection for conf-capnproto

### DIFF
--- a/packages/conf-capnproto/conf-capnproto.1/opam
+++ b/packages/conf-capnproto/conf-capnproto.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: [
+  "Sandstorm Development Group, Inc."
+  "Cloudflare, Inc."
+  "other contributors"
+]
+homepage: "https://capnproto.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/capnproto/capnproto.git"
+license: "MIT"
+build: [
+  ["capnp" "--version"]
+]
+depexts: [
+  ["capnproto-dev@testing"] {os-distribution = "alpine"}
+  ["capnproto"] {os-distribution = "arch"}
+  ["capnproto" "epel-release"] {os-distribution = "centos"}
+  ["capnproto" "libcapnp-dev"] {os-family = "debian"}
+  ["capnproto"] {os-distribution = "fedora"}
+  ["capnproto"] {os-distribution = "gentoo"}
+  ["capnp"] {os-distribution = "homebrew" & os = "macos"}
+  ["capnproto"] {os-distribution = "macports" & os = "macos"}
+  ["capnproto"] {os-family = "suse"}
+  ["capnproto"] {os = "freebsd"}
+]
+synopsis: "Virtual package relying on captnproto installation"
+flags: conf


### PR DESCRIPTION
See also https://github.com/capnproto/capnp-ocaml/pull/75

`capnpc` was replaced with `capnp` when the compiler was switched from Haskell to C++ (see [the 0.2 news item](https://capnproto.org/news/2013-08-12-capnproto-0.2-no-more-haskell.html)). Ubuntu certainly, and I guess others, symlink `capnpc` to `capnp`, but the Windows binary distribution only has `capnp.exe`.

I've put this in a new package, rather than updating the `.0` package, since if this does break anything it should be clear that it was a package upgrade which did it!