### PR TITLE
Add dependencies and bounds to memtrace_viewer

### DIFF
--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
@@ -30,8 +30,10 @@ depends: [
   "logs" {>= "0.7.0"}
   "magic-mime" {>= "1.1.2"}
   "memtrace" {>= "0.1.1"}
+  "ocaml-migrate-parsetree" {>= "0.4" & < "2.0.0"}
   "octavius" {>= "1.2.2"}
-  "ppxlib" {>= "0.15.0"}
+  "ppxlib" {>= "0.15.0" & < "0.18.0"}
+  "ppx_tools_versioned" {>= "5.4.0"}
   "spawn" {>= "v0.13.0"}
   "tyxml" {>= "4.4.0"}
   "uri" {>= "3.1.0"}

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
@@ -30,8 +30,10 @@ depends: [
   "logs" {>= "0.7.0"}
   "magic-mime" {>= "1.1.2"}
   "memtrace" {>= "0.1.1"}
+  "ocaml-migrate-parsetree" {>= "0.4" & < "2.0.0"}
   "octavius" {>= "1.2.2"}
-  "ppxlib" {>= "0.15.0"}
+  "ppxlib" {>= "0.15.0" & < "0.18.0"}
+  "ppx_tools_versioned" {>= "5.4.0"}
   "spawn" {>= "v0.13.0"}
   "tyxml" {>= "4.4.0"}
   "uri" {>= "3.1.0"}


### PR DESCRIPTION
memtrace_viewer doesn't currently install in a fresh opam switch. I installed some versions of packages manually and then it built successfully. This PR adds those packages as dependencies and bounds in the opam files for memtrace_viewer.