### PR TITLE
conf-gles2: Fix FreeBSD

### DIFF
--- a/packages/conf-gles2/conf-gles2.1/opam
+++ b/packages/conf-gles2/conf-gles2.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["Mesa-libGLESv2-devel"] {os-family = "suse"}
   ["mesa-dev"] {os-family = "alpine"}
   ["mesa"] {os-family = "arch"}
-  ["mesa-devel"] {os = "freebsd"}
+  ["mesa-libs"] {os = "freebsd"}
   # OpenBSD includes it in xbase.tgz
   ["MesaLib"] {os = "netbsd"}
   # MacOS includes it by default


### PR DESCRIPTION
Fixes issue discovered in https://github.com/ocaml/opam-repository/pull/17534
cc @mseri somehow the files prefixed by `@comment` in FreshPorts are not installed by the package and I already had `mesa-libs` installed locally..