### PR TITLE
[new release] obuilder and obuilder-spec (0.1)

### DIFF
--- a/packages/obuilder-spec/obuilder-spec.0.1/opam
+++ b/packages/obuilder-spec/obuilder-spec.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Build specification format"
+description:
+  "A library for constructing, reading and writing OBuilder build specification files."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "sexplib"
+  "astring"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "dockerfile"
+  "ocaml" {>= "4.10.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.1/obuilder-spec-v0.1.tbz"
+  checksum: [
+    "sha256=07646502ecf345c8be698dee6bc40f17bbf6ef41eb8dce56d11edc27e6aa8363"
+    "sha512=03eaab4636c43e593900a047f6adaa01e4d2bda71263d0d356b79dfd55c1911c558e32fe1f6ec89370ddf9dd9c2ef91d0936fdc07ea859f65148d91a998038d5"
+  ]
+}

--- a/packages/obuilder/obuilder.0.1/opam
+++ b/packages/obuilder/obuilder.0.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Run build scripts for CI"
+description:
+  "OBuilder takes a build script (similar to a Dockerfile) and performs the steps in it in a sandboxed environment."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "lwt"
+  "astring"
+  "fmt"
+  "logs"
+  "cmdliner"
+  "tar-unix"
+  "yojson"
+  "sexplib"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "sha"
+  "sqlite3"
+  "dockerfile"
+  "obuilder-spec"
+  "ocaml" {>= "4.10.0"}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.1/obuilder-spec-v0.1.tbz"
+  checksum: [
+    "sha256=07646502ecf345c8be698dee6bc40f17bbf6ef41eb8dce56d11edc27e6aa8363"
+    "sha512=03eaab4636c43e593900a047f6adaa01e4d2bda71263d0d356b79dfd55c1911c558e32fe1f6ec89370ddf9dd9c2ef91d0936fdc07ea859f65148d91a998038d5"
+  ]
+}


### PR DESCRIPTION
Run build scripts for CI

- Project page: <a href="https://github.com/ocurrent/obuilder">https://github.com/ocurrent/obuilder</a>
- Documentation: <a href="https://ocurrent.github.io/obuilder/">https://ocurrent.github.io/obuilder/</a>

##### CHANGES:

Initial release.
