### PR TITLE
[new release] ppx_deriving (5.2)

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.5.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {build}
+  "ocamlfind"
+  "ocaml-migrate-parsetree"
+  "ppx_derivers"
+  "ppxlib" {>= "0.16.0" & < "0.18.0"}
+  "result"
+  "ounit" {with-test}
+]
+synopsis: "Type-driven code generation for OCaml"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v5.2/ppx_deriving-v5.2.tbz"
+  checksum: [
+    "sha256=8c1bc32f46274e7063c9b0b411b5a4a3c35a740a987362f636c37a105cf7d350"
+    "sha512=96aed1cb52a7f5aec901c265e4c971ab9783444ba9a4c742290f5ec70134050b3ce66946a4418b9d2e87c72bd44b8e0aeabb27a8c5e1e84e2ccebb34c2e88274"
+  ]
+}
+x-commit-hash: "57bcd4ef70dc6091f3b3de6ffaf5d6234dfd41e8"


### PR DESCRIPTION
Type-driven code generation for OCaml

- Project page: <a href="https://github.com/ocaml-ppx/ppx_deriving">https://github.com/ocaml-ppx/ppx_deriving</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_deriving/">https://ocaml-ppx.github.io/ppx_deriving/</a>

##### CHANGES:

* Update to ppxlib 0.16.0 ocaml-ppx/ppx_deriving#237
  (Thierry Martinez, Gabriel Scherer, Kate Deplaix)
