### PR TITLE
[new release] ppx_deriving (5.3)

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.5.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {build}
+  "ppx_derivers"
+  "ppxlib" {>= "0.18.0"}
+  "result"
+  "ounit2" {with-test}
+]
+synopsis: "Type-driven code generation for OCaml"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v5.3/ppx_deriving-v5.3.tbz"
+  checksum: [
+    "sha256=b9a75ed5786ac12cb77b38f7fcc3dae72b4d1d663eebb7c5c24756bcbed42dea"
+    "sha512=077038afa8e05a495a467ee24996f5d1b2db9a35ae73c231356d919dab0fa0863928ea15931e671c188783a24e73b12f1ffab305a4e13d71b97f40877e5dcfec"
+  ]
+}
+x-commit-hash: "acb48690d73d15c6bf999087ed251334ecd1cb33"


### PR DESCRIPTION
Type-driven code generation for OCaml

- Project page: <a href="https://github.com/ocaml-ppx/ppx_deriving">https://github.com/ocaml-ppx/ppx_deriving</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_deriving/">https://ocaml-ppx.github.io/ppx_deriving/</a>

##### CHANGES:

* Update to ppxlib 0.18.0 ocaml-ppx/ppx_deriving#239
  (Kate Deplaix)

* Remove unused dependencies (ocaml-migrate-parsetree and ocamlfind/findlib) ocaml-ppx/ppx_deriving#241
  (Kate Deplaix)

* Upgrade testsuite from ounit to ounit2 ocaml-ppx/ppx_deriving#241
  (Kate Deplaix)
