### PR TITLE
Package vue-jsoo.0.2.1

### DIFF
--- a/packages/vue-jsoo/vue-jsoo.0.2.1/opam
+++ b/packages/vue-jsoo/vue-jsoo.0.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Binding of Vue_js"
+maintainer: ["maxime.levillain@origin-labs.com"]
+authors: ["Maxime Levillain"]
+license: "MIT"
+homepage: "https://gitlab.com/o-labs/vue-jsoo"
+doc: "https://o-labs.gitlab.io/vue-jsoo/vue-jsoo"
+bug-reports: "https://gitlab.com/o-labs/vue-jsoo/-/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "js_of_ocaml-ppx" {>= "3.1.0"}
+  "lwt"
+]
+depopts: ["js_of_ocaml-tyxml"]
+conflicts: [
+  "js_of_ocaml-tyxml" {< "3.1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/o-labs/vue-jsoo.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/18174793/repository/archive?sha=58f76f0d7b837ba648b620bbbcd8c6f2d2a8fe54"
+  checksum: [
+    "md5=df958a0a08e7c8d3acaa6b93e24c99e1"
+    "sha512=fbccf36f1f7740a2b56ef96c7db8c854a6fc1038e6fc20bd746e74fe0a4804bae79dbbe4809316c54494c8ca3b2a08116b4eb9e634f2b7ad0adb9e7d245e70d6"
+  ]
+}


### PR DESCRIPTION
### `vue-jsoo.0.2.1`
Binding of Vue_js



---
* Homepage: https://gitlab.com/o-labs/vue-jsoo
* Source repo: git+https://gitlab.com/o-labs/vue-jsoo.git
* Bug tracker: https://gitlab.com/o-labs/vue-jsoo/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.2