### PR TITLE
[new release] sihl-email, sihl-queue, sihl-storage and sihl (0.1.6)

### DIFF
--- a/packages/sihl-email/sihl-email.0.1.6/opam
+++ b/packages/sihl-email/sihl-email.0.1.6/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A Sihl service for sending emails using Lwt"
+description: """
+
+A Sihl service for sending emails using Lwt. Various email transports are provided that can be used in production or testing such as SMTP, Sendgrid, in-memory and console printing."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7" & >= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "letters" {>= "0.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "d5bd270250a1392c36b4e001d927031e7e973081"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.1.6/sihl-queue-0.1.6.tbz"
+  checksum: [
+    "sha256=574c73c97ea0bc57144853b28df6125855a040ef0378f3bf180b4331dde93f9d"
+    "sha512=92c474ed3b6609395799f77259fc424af37dcad53095773ca2f2cdd4757a1607a5b53b6594cd7b6ddabeb40ebba67bb9544ff0f31dc228c87cfe015afa520aaa"
+  ]
+}

--- a/packages/sihl-email/sihl-email.0.1.6/opam
+++ b/packages/sihl-email/sihl-email.0.1.6/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/oxidizing/sihl"
 doc: "https://oxidizing.github.io/sihl/"
 bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
-  "dune" {>= "2.7" & >= "2.7"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "sihl" {= version}
   "letters" {>= "0.2.0"}

--- a/packages/sihl-queue/sihl-queue.0.1.6/opam
+++ b/packages/sihl-queue/sihl-queue.0.1.6/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/oxidizing/sihl"
 doc: "https://oxidizing.github.io/sihl/"
 bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
-  "dune" {>= "2.7" & >= "2.7"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "sihl" {= version}
   "odoc" {with-doc}

--- a/packages/sihl-queue/sihl-queue.0.1.6/opam
+++ b/packages/sihl-queue/sihl-queue.0.1.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A Sihl service for queue jobs"
+description: """
+
+A Sihl service for putting and working jobs on queues. Various queue backends are provided."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7" & >= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "d5bd270250a1392c36b4e001d927031e7e973081"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.1.6/sihl-queue-0.1.6.tbz"
+  checksum: [
+    "sha256=574c73c97ea0bc57144853b28df6125855a040ef0378f3bf180b4331dde93f9d"
+    "sha512=92c474ed3b6609395799f77259fc424af37dcad53095773ca2f2cdd4757a1607a5b53b6594cd7b6ddabeb40ebba67bb9544ff0f31dc228c87cfe015afa520aaa"
+  ]
+}

--- a/packages/sihl-storage/sihl-storage.0.1.6/opam
+++ b/packages/sihl-storage/sihl-storage.0.1.6/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/oxidizing/sihl"
 doc: "https://oxidizing.github.io/sihl/"
 bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
-  "dune" {>= "2.7" & >= "2.7"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "sihl" {= version}
   "odoc" {with-doc}

--- a/packages/sihl-storage/sihl-storage.0.1.6/opam
+++ b/packages/sihl-storage/sihl-storage.0.1.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A Sihl service for storing and retrieving large files"
+description: """
+
+This service can be used to handle large binary blobs that are typically not stored in relational databases. Various storage backends are provided."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7" & >= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "d5bd270250a1392c36b4e001d927031e7e973081"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.1.6/sihl-queue-0.1.6.tbz"
+  checksum: [
+    "sha256=574c73c97ea0bc57144853b28df6125855a040ef0378f3bf180b4331dde93f9d"
+    "sha512=92c474ed3b6609395799f77259fc424af37dcad53095773ca2f2cdd4757a1607a5b53b6594cd7b6ddabeb40ebba67bb9544ff0f31dc228c87cfe015afa520aaa"
+  ]
+}

--- a/packages/sihl/sihl.0.1.6/opam
+++ b/packages/sihl/sihl.0.1.6/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/oxidizing/sihl"
 doc: "https://oxidizing.github.io/sihl/"
 bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
-  "dune" {>= "2.7" & >= "2.7"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "lwt" {>= "5.3.0"}
   "opium" {>= "0.17.1"}

--- a/packages/sihl/sihl.0.1.6/opam
+++ b/packages/sihl/sihl.0.1.6/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "The modular functional web framework"
+description: "Build web apps fast with long-term maintainability in mind."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7" & >= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.3.0"}
+  "opium" {>= "0.17.1"}
+  "multipart-form-data" {>= "0.3.0"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.5.2"}
+  "conformist" {>= "0.1.0"}
+  "tsort" {>= "2.0.0"}
+  "tls" {>= "0.11.1"}
+  "ssl" {>= "0.5.9"}
+  "lwt_ssl" {>= "1.1.3"}
+  "caqti" {>= "1.2.1"}
+  "caqti-lwt" {>= "1.2.0"}
+  "tyxml" {>= "4.3.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.8"}
+  "safepass" {>= "3.0"}
+  "jwto" {>= "0.3.0"}
+  "uuidm" {>= "0.9.7"}
+  "sexplib" {>= "v0.13.0"}
+  "ppx_fields_conv" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "alcotest" {>= "1.2.0"}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "cohttp-lwt-unix" {>= "2.5.1" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "d5bd270250a1392c36b4e001d927031e7e973081"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.1.6/sihl-queue-0.1.6.tbz"
+  checksum: [
+    "sha256=574c73c97ea0bc57144853b28df6125855a040ef0378f3bf180b4331dde93f9d"
+    "sha512=92c474ed3b6609395799f77259fc424af37dcad53095773ca2f2cdd4757a1607a5b53b6594cd7b6ddabeb40ebba67bb9544ff0f31dc228c87cfe015afa520aaa"
+  ]
+}


### PR DESCRIPTION
A Sihl service for sending emails using Lwt

- Project page: <a href="https://github.com/oxidizing/sihl">https://github.com/oxidizing/sihl</a>
- Documentation: <a href="https://oxidizing.github.io/sihl/">https://oxidizing.github.io/sihl/</a>

##### CHANGES:

## [0.1.6] - 2020-10-31
### Fixed
- `Database.Service` and `Repository.Service` are assumed to have just one implementation, so they are referenced directly in service implementations instead of passing them as functor arguments
- Extract `Random.Service` from utils as standalone top level service
- Merge utils into one `utils.ml` file
#### HTTP API
- `Sihl.Http.Response` and `Sihl.Http.Request` have consistent API
- `Sihl.Middleware` contains all provided middlewares
- Implement multi-part form data parsing

## [0.1.5] - 2020-10-14
### Fixed
- Remove seed service since the same functionality
- Simplify app abstraction, instead of `with_` use service APIs directly
- Extract storage service as `sihl-storage` opam package
- Extract email service as `sihl-email` opam package
- Extract queue service as `sihl-queue` opam package
- Move configuration and logging into core, neither of the are implemented as services
- Replace `pcre` with `re` as regex library to get rid of a system dependency on pcre
- Split up `Sihl.Data` into `Sihl.Migration`, `Sihl.Repository` and `Sihl.Database`
- Move module signatures from `Foo.Service.Sig` to `Foo.Sig`, the services might live in a third party opam package, but the signatures are staying in `sihl`
- Move `Sihl.App` to `Sihl.Core.App` and simplify app API
- Move log service, config service and cmd service into core (they don't have to be provided to other services through functors)
- Simplify Sihl app creation and service configuration

## [0.1.4] - 2020-09-24
### Fixed
- Remove `reason` and `tyxml-jsx` as dependency as they are not used anymore

### Added
- Various combinators for `Sihl.Seed.t` including constructor and field accessors

## [0.1.3] - 2020-09-14
### Added
- Seed Service with commands `seedlist` and `seedrun <name>`

### Fixed
- Lifecycle API: A service now has two additional functions `start` and `stop`, which are used in the lifecycle definition
- Database service query functions `query`, `atomic` and `with_connection` can now be nested

## [0.1.2] - 2020-09-09
### Fixed
- Re-export `Sihl.Queue.Job.t`
- Export content types under `Sihl.Web`

## [0.1.1] - 2020-09-07
### Fixed
- Don't raise exception when user login fails if it is a user error
- Remove dev tools as dev dependencies

### Added
- Storage service can remove files
- Move README.md documentation to ocamldoc based documentation

## [0.1.0] - 2020-09-03
### Fixed
- DB connection leaks caused deadlocks
- Provide all service dependencies using functors
- Move Opium & Cohttp specific stuff into the web server service implementation to allow for swappable implementation based on something like httpaf
- Inject log service to all other services by default

### Added
- Support letters 0.2.0 for SMTP emailing
- Switch to exception based service API
- HTTP Response API to respond with file `Sihl.Web.Res.file`

## [0.0.56] - 2020-08-17
### Fixed
- Stop running integration tests during OPAM release

## [0.0.55] - 2020-08-17
### Added
- Initial release of Sihl
