### PR TITLE
[new release] ocaml-protoc-plugin (4.1.0)

### DIFF
--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.1.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Issuu"
+authors: "Anders Fugmann <af@issuu.com>"
+license: "APACHE 2.0"
+homepage: "https://github.com/issuu/ocaml-protoc-plugin"
+dev-repo: "git+https://github.com/issuu/ocaml-protoc-plugin"
+bug-reports: "https://github.com/issuu/ocaml-protoc-plugin/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "conf-protoc" {>= "1.0.0"}
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.06.0"}
+  "ppx_expect" {with-test}
+  "ppx_inline_test" {with-test}
+  "ppx_deriving" {with-test}
+]
+
+
+synopsis: "Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file"
+
+description: """ The plugin generates ocaml type definitions,
+serialization and deserialization functions from a protobuf file.
+The types generated aims to create ocaml idiomatic types;
+- messages are mapped into modules
+- oneof constructs are mapped to polymorphic variants
+- enums are mapped to adt's
+- map types are mapped to assoc lists
+- all integer types are mapped to int by default (exact mapping is also possible)
+- all floating point types are mapped to float.
+- packages are mapped to nested modules
+"""
+x-commit-hash: "a2b517ace784e8c900b72689efbe7408fee7b5d6"
+url {
+  src:
+    "https://github.com/issuu/ocaml-protoc-plugin/releases/download/4.1.0/ocaml-protoc-plugin-4.1.0.tbz"
+  checksum: [
+    "sha256=04964e0aa77238241970dff0de6c740d1296e20dc8637d63a4fa2ff417360c10"
+    "sha512=28ec3c9755852e2cb9e821c5d32646cb9bb1679c817ced5b74f7a12a045f9938b9a7fbe93051bf85fe8702d609eb12868e1845033121a0cb58acb0a4b7e3388a"
+  ]
+}


### PR DESCRIPTION
Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file

- Project page: <a href="https://github.com/issuu/ocaml-protoc-plugin">https://github.com/issuu/ocaml-protoc-plugin</a>

##### CHANGES:

- [x] Fix bug with Proto2 default integer arguments for Int32 and
      Int64 types
- [x] Add function to construct messages with default values
