### PR TITLE
[new release] ocaml-protoc-plugin (4.1.0)

### DIFF
--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.1.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Issuu"
+authors: "Anders Fugmann <af@issuu.com>"
+license: "APACHE 2.0"
+homepage: "https://github.com/issuu/ocaml-protoc-plugin"
+dev-repo: "git+https://github.com/issuu/ocaml-protoc-plugin"
+bug-reports: "https://github.com/issuu/ocaml-protoc-plugin/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "conf-protoc" {>= "1.0.0"}
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.06.0"}
+  "ppx_expect" {with-test}
+  "ppx_inline_test" {with-test}
+  "ppx_deriving" {with-test}
+]
+
+
+synopsis: "Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file"
+
+description: """ The plugin generates ocaml type definitions,
+serialization and deserialization functions from a protobuf file.
+The types generated aims to create ocaml idiomatic types;
+- messages are mapped into modules
+- oneof constructs are mapped to polymorphic variants
+- enums are mapped to adt's
+- map types are mapped to assoc lists
+- all integer types are mapped to int by default (exact mapping is also possible)
+- all floating point types are mapped to float.
+- packages are mapped to nested modules
+"""
+x-commit-hash: "bfe136cf6b97351b54f2ab2597cb43d7690fc6bd"
+url {
+  src:
+    "https://github.com/issuu/ocaml-protoc-plugin/releases/download/4.1.0/ocaml-protoc-plugin-4.1.0.tbz"
+  checksum: [
+    "sha256=2e02e070c3bc18c5b2c804012d6db8c9451fb4b23a7a4256aab3e9fe96aaf862"
+    "sha512=4fe3a392f897a531eebf22c15a55623512ac0d9795da68188c367ab1f216d6b936ad22064be7179d04f204a22324ede772c7c4678a3fe3b2ca760aecb5e87999"
+  ]
+}


### PR DESCRIPTION
Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file

- Project page: <a href="https://github.com/issuu/ocaml-protoc-plugin">https://github.com/issuu/ocaml-protoc-plugin</a>

##### CHANGES:

- [x] Fix bug with Proto2 default integer arguments for Int32 and
      Int64 types
- [x] Add function to construct messages with default values
- [x] Add missing includes for google well known types
