### PR TITLE
Revert "Declare package cache in git-controlled repo file"

### DIFF
--- a/repo
+++ b/repo
@@ -1,4 +1,3 @@
 opam-version: "2.0"
-browse: "https://opam.ocaml.org/packages/"
+browse: "https://opam.ocaml.org/pkg/"
 upstream: "https://github.com/ocaml/opam-repository/tree/master/"
-archive-mirrors: "https://opam.ocaml.org/cache"


### PR DESCRIPTION
Reverts ocaml/opam-repository#17355 until we clarify the behaviour and its consequences. @AltGr please make whatever change necessary in the other repo