### PR TITLE
[new release] erlang (0.0.14)

### DIFF
--- a/packages/erlang/erlang.0.0.14/opam
+++ b/packages/erlang/erlang.0.0.14/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Libraries to manipulate Erlang sources"
+description: """
+erlang is a  a set of libraries designed to facilitate manipulating
+ Standard Erlang and Core Erlang sources.
+
+ It provides a lexer/parser, a concrete AST, and a printer for Standard Erlang
+ in its current version.
+"""
+maintainer: ["Leandro Ostera <leandro@ostera.io>"]
+authors: ["Leandro Ostera <leandro@ostera.io>"]
+license: "Apache-2.0"
+homepage: "https://github.com/AbstractMachinesLab/caramel"
+bug-reports: "https://github.com/AbstractMachinesLab/caramel/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.11.1"}
+  "cmdliner"
+  "menhir"
+  "ppx_sexp_conv"
+  "sexplib"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/AbstractMachinesLab/caramel.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+run-test: ["dune" "runtest" "./erlang/tests" "-p" name]
+x-commit-hash: "27bc02d4c865d73764d3aadb2c77f0e815460e44"
+url {
+  src:
+    "https://github.com/AbstractMachinesLab/caramel/releases/download/v0.0.14/erlang-v0.0.14.tbz"
+  checksum: [
+    "sha256=5e018ee6cd932f534c19b31e83345290fbc48cb91af1cd5c57986ab485215031"
+    "sha512=bbaf181dc8f4e20d2ba56b629ee9470b581bf7731f65b2b627957a58ba40de131fcf4fe152b0bafa7b788060a15659f069042355c9713b5c8969f4f1e0e08818"
+  ]
+}


### PR DESCRIPTION
### `erlang.0.0.14`

Libraries for manipulating Standard Erlang and Core Erlang sources
and their abstract syntax trees according to the Erlang specifications.

This version provides:
* A lexer/parser written in Menhir for Standard Erlang
* ASTs for Core Erlang and Standard Erlang
* An AST helper module for constructing Standard Erlang programs
* A printer for the Standard Erlang AST (of highly volatile prettiness)
* Support to turn ASTs to S-expressions 
* `erldump`, a binary tool for reading Erlang sources and printing their
  concrete syntax trees as S-expressions.

Erlang is distributed under Apache-2.0 license. It depends on Menhir
and Cmdliner.

Erlang is developed as part of the Caramel project.

---

Source repo: https://github.com/AbstractMachinesLab/caramel
Homepage: https://caramel.abstractmachines.dev
Bug tracker:  https://github.com/AbstractMachinesLab/caramel/issues?q=is%3Aopen+is%3Aissue+label%3Alib%3Aerlang