### PR TITLE
[new release] ocamlformat (0.15.1)

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.15.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.15.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06" & < "4.12"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune" {>= "2.2.0"}
+  "fix"
+  "fpath"
+  "menhir"
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "ppxlib" {>= "0.18.0"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+x-commit-hash: "7027acfed5b8e6e492801f297766b0c803a13086"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.15.1/ocamlformat-0.15.1.tbz"
+  checksum: [
+    "sha256=2a61513d10889d975eaa721b577f37b454ecfec0e08257c027f3e9928882cef4"
+    "sha512=3e03e06f5aabf9c80d7edb0ad908f708a99e371538e25674401170fa5a9836e1c463a1b055b2901ce32854928897b969834d854b7a92c2e18a8d1044ba93e842"
+  ]
+}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### Internal

  + Use ppxlib instead of ocaml-migrate-parsetree 1.x. (ocaml-ppx/ocamlformat#1482, @emillon)
    * No functional changes are expected.
    * Cherry picked commits: 219dc1e3a4614041e1bc5428d003c0af4e, 9e453b0ef87124e33827ee2423289deef8, 7ad1e575ffa4ce3022c71daba39954d3b9, eb49db6772a9adabe611982000465d0ad7, dc79052a085950cd88fdef0843f665a029, c06c544e21bd65b726cde8fee0f78a6248, ce94d2fa50ff276b5782070375a0b30ba1
