### PR TITLE
[new release] semaphore-compat (1.0.0)

### DIFF
--- a/packages/semaphore-compat/semaphore-compat.1.0.0/opam
+++ b/packages/semaphore-compat/semaphore-compat.1.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Compatibility Semaphore module"
+description: """
+Projects that want to use the Semaphore module defined in OCaml 4.12.0 while
+staying compatible with older versions of OCaml should use this library
+instead.
+"""
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Xavier Leroy"]
+license: "LGPLv2"
+homepage: "https://github.com/mirage/semaphore-compat"
+doc: "https://mirage.github.io/semaphore-compat"
+bug-reports: "https://github.com/mirage/semaphore-compat/issues"
+depends: [
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/semaphore-compat.git"
+x-commit-hash: "603638795c20e34fb4c6d5710ec4013dcdbb2f2d"
+url {
+  src:
+    "https://github.com/mirage/semaphore-compat/releases/download/1.0.0/semaphore-compat-1.0.0.tbz"
+  checksum: [
+    "sha256=2fc9e1be5182741210f58e33ec8314ed0fdf2b8049aaf951da6b8db14057ed9b"
+    "sha512=b686b16f3d6d4d0d02df02670f0ae60dda5306d9fe7125402f26cd9b578ab8a31dfba175db4d79faa84edc337c64762400d5570be0e1c2ddc1bfc77c464bfbc1"
+  ]
+}


### PR DESCRIPTION
Compatibility Semaphore module. Releasing now rather than waiting for the 4.12 release, since this module can also be used in code that relied on the (undocumented) non-error-checking nature of glibc mutexes (in particular, this unblocks the release of `mirage/index`).

- Project page: <a href="https://github.com/mirage/semaphore-compat">https://github.com/mirage/semaphore-compat</a>
- Documentation: <a href="https://mirage.github.io/semaphore-compat">https://mirage.github.io/semaphore-compat</a>