### PR TITLE
[new release] cohttp-lwt-unix-nossl, cohttp-lwt-jsoo, cohttp, cohttp-…

### DIFF
--- a/packages/cohttp-async/cohttp-async.3.0.0/opam
+++ b/packages/cohttp-async/cohttp-async.3.0.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for the Async concurrency library"
+description: """
+An implementation of an HTTP client and server using the Async
+concurrency library. See the `Cohttp_async` module for information
+on how to use this.  The package also installs `cohttp-curl-async`
+and a `cohttp-server-async` binaries for quick uses of a HTTP(S)
+client and server respectively.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "async_kernel" {>= "v0.14.0"}
+  "async_unix" {>= "v0.14.0"}
+  "async" {>= "v0.14.0"}
+  "base" {>= "v0.11.0"}
+  "core" {with-test}
+  "cohttp" {=version}
+  "conduit-async" {>="3.0.0"}
+  "conduit-async-ssl"
+  "magic-mime"
+  "mirage-crypto" {with-test}
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "ounit" {with-test}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "ipaddr"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "f3a29b332df416735690cc393c988893592bc40f"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v3.0.0/cohttp-v3.0.0.tbz"
+  checksum: [
+    "sha256=fb872f437aabc9c336bb822ac18ccbce794a2614ecb9d3edafb679dcafc82ea4"
+    "sha512=a33a02f07621995aad6c7c571cab1ea715912b65a1b6ab0634d9033e786c3c61fefe08fd9783e66743eef8571ac0335136b77be830909ea1c5bbcf6617295a34"
+  ]
+}

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.3.0.0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.3.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for the Js_of_ocaml JavaScript compiler"
+description: """
+An implementation of an HTTP client for JavaScript, but using the
+CoHTTP types.  This lets you build HTTP clients that can compile
+natively (using one of the other Cohttp backends such as `cohttp-lwt-unix`)
+and also to native JavaScript via js_of_ocaml.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "cohttp" {=version}
+  "cohttp-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "js_of_ocaml" {>= "3.3.0"}
+  "js_of_ocaml-ppx" {>= "3.3.0"}
+  "js_of_ocaml-lwt" {>= "3.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "f3a29b332df416735690cc393c988893592bc40f"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v3.0.0/cohttp-v3.0.0.tbz"
+  checksum: [
+    "sha256=fb872f437aabc9c336bb822ac18ccbce794a2614ecb9d3edafb679dcafc82ea4"
+    "sha512=a33a02f07621995aad6c7c571cab1ea715912b65a1b6ab0634d9033e786c3c61fefe08fd9783e66743eef8571ac0335136b77be830909ea1c5bbcf6617295a34"
+  ]
+}

--- a/packages/cohttp-lwt-unix-nossl/cohttp-lwt-unix-nossl.3.0.0/opam
+++ b/packages/cohttp-lwt-unix-nossl/cohttp-lwt-unix-nossl.3.0.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for Unix and Windows using Lwt"
+description: """
+An implementation of an HTTP client and server using the Lwt
+concurrency library. See the `Cohttp_lwt_unix` module for information
+on how to use this.  The package also installs `cohttp-curl-lwt`
+and a `cohttp-server-lwt` binaries for quick uses of a HTTP(S)
+client and server respectively.
+
+Although the name implies that this only works under Unix, it
+should also be fine under Windows too."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "conduit-lwt" {>= "3.0.0"}
+  "ca-certs"
+  "cmdliner"
+  "magic-mime"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "cohttp-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "base-unix"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "f3a29b332df416735690cc393c988893592bc40f"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v3.0.0/cohttp-v3.0.0.tbz"
+  checksum: [
+    "sha256=fb872f437aabc9c336bb822ac18ccbce794a2614ecb9d3edafb679dcafc82ea4"
+    "sha512=a33a02f07621995aad6c7c571cab1ea715912b65a1b6ab0634d9033e786c3c61fefe08fd9783e66743eef8571ac0335136b77be830909ea1c5bbcf6617295a34"
+  ]
+}

--- a/packages/cohttp-lwt-unix-ssl/cohttp-lwt-unix-ssl.3.0.0/opam
+++ b/packages/cohttp-lwt-unix-ssl/cohttp-lwt-unix-ssl.3.0.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for Unix and Windows using Lwt"
+description: """
+An implementation of an HTTP client and server using the Lwt
+concurrency library. See the `Cohttp_lwt_unix` module for information
+on how to use this.  The package also installs `cohttp-curl-lwt`
+and a `cohttp-server-lwt` binaries for quick uses of a HTTP(S)
+client and server respectively.
+
+Although the name implies that this only works under Unix, it
+should also be fine under Windows too."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "conduit-lwt" {>= "3.0.0"}
+  "conduit-lwt-ssl"
+  "ca-certs"
+  "cmdliner"
+  "magic-mime"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "cohttp-lwt" {=version}
+  "cohttp-lwt-unix-nossl" {=version}
+  "lwt" {>= "3.0.0"}
+  "base-unix"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "f3a29b332df416735690cc393c988893592bc40f"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v3.0.0/cohttp-v3.0.0.tbz"
+  checksum: [
+    "sha256=fb872f437aabc9c336bb822ac18ccbce794a2614ecb9d3edafb679dcafc82ea4"
+    "sha512=a33a02f07621995aad6c7c571cab1ea715912b65a1b6ab0634d9033e786c3c61fefe08fd9783e66743eef8571ac0335136b77be830909ea1c5bbcf6617295a34"
+  ]
+}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.3.0.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.3.0.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for Unix and Windows using Lwt"
+description: """
+An implementation of an HTTP client and server using the Lwt
+concurrency library. See the `Cohttp_lwt_unix` module for information
+on how to use this.  The package also installs `cohttp-curl-lwt`
+and a `cohttp-server-lwt` binaries for quick uses of a HTTP(S)
+client and server respectively.
+
+Although the name implies that this only works under Unix, it
+should also be fine under Windows too."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "conduit-lwt" {>= "3.0.0"}
+  "conduit-lwt-tls"
+  "ca-certs"
+  "cmdliner"
+  "magic-mime"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "cohttp-lwt" {=version}
+  "cohttp-lwt-unix-nossl" {=version}
+  "lwt" {>= "3.0.0"}
+  "base-unix"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "f3a29b332df416735690cc393c988893592bc40f"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v3.0.0/cohttp-v3.0.0.tbz"
+  checksum: [
+    "sha256=fb872f437aabc9c336bb822ac18ccbce794a2614ecb9d3edafb679dcafc82ea4"
+    "sha512=a33a02f07621995aad6c7c571cab1ea715912b65a1b6ab0634d9033e786c3c61fefe08fd9783e66743eef8571ac0335136b77be830909ea1c5bbcf6617295a34"
+  ]
+}

--- a/packages/cohttp-lwt/cohttp-lwt.3.0.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.3.0.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation using the Lwt concurrency library"
+description: """
+This is a portable implementation of HTTP that uses the Lwt
+concurrency library to multiplex IO.  It implements as much of the
+logic in an OS-independent way as possible, so that more specialised
+modules can be tailored for different targets.  For example, you
+can install `cohttp-lwt-unix` or `cohttp-lwt-jsoo` for a Unix or
+JavaScript backend, or `cohttp-mirage` for the MirageOS unikernel
+version of the library. All of these implementations share the same
+IO logic from this module."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "cohttp" {=version}
+  "lwt" {>= "2.5.0"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "f3a29b332df416735690cc393c988893592bc40f"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v3.0.0/cohttp-v3.0.0.tbz"
+  checksum: [
+    "sha256=fb872f437aabc9c336bb822ac18ccbce794a2614ecb9d3edafb679dcafc82ea4"
+    "sha512=a33a02f07621995aad6c7c571cab1ea715912b65a1b6ab0634d9033e786c3c61fefe08fd9783e66743eef8571ac0335136b77be830909ea1c5bbcf6617295a34"
+  ]
+}

--- a/packages/cohttp-mirage/cohttp-mirage.3.0.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.3.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+synopsis: "CoHTTP implementation for the MirageOS unikernel"
+description: """
+This HTTP implementation uses the Cohttp portable implementaiton
+along with the Lwt threading library in order to provide a
+`Cohttp_mirage` functor that can be used in MirageOS unikernels
+to build very small and efficient HTTP clients and servers
+without having a hard dependency on an underlying operating
+system.
+
+Please see <https://mirage.io> for a self-hosted explanation
+and instructions on how to use this library."""
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+  "conduit" {>= "2.0.2"}
+  "conduit-mirage" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp" {=version}
+  "cohttp-lwt" {=version}
+  "astring"
+  "magic-mime"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "f3a29b332df416735690cc393c988893592bc40f"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v3.0.0/cohttp-v3.0.0.tbz"
+  checksum: [
+    "sha256=fb872f437aabc9c336bb822ac18ccbce794a2614ecb9d3edafb679dcafc82ea4"
+    "sha512=a33a02f07621995aad6c7c571cab1ea715912b65a1b6ab0634d9033e786c3c61fefe08fd9783e66743eef8571ac0335136b77be830909ea1c5bbcf6617295a34"
+  ]
+}

--- a/packages/cohttp-top/cohttp-top.3.0.0/opam
+++ b/packages/cohttp-top/cohttp-top.3.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP toplevel pretty printers for HTTP types"
+description: """
+This library installs toplevel prettyprinters for CoHTTP
+types such as the `Request`, `Response` and `Types` modules.
+Once this library has been loaded, you can directly see the
+values of those types in toplevels such as `utop` or `ocaml`."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "cohttp" {=version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "f3a29b332df416735690cc393c988893592bc40f"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v3.0.0/cohttp-v3.0.0.tbz"
+  checksum: [
+    "sha256=fb872f437aabc9c336bb822ac18ccbce794a2614ecb9d3edafb679dcafc82ea4"
+    "sha512=a33a02f07621995aad6c7c571cab1ea715912b65a1b6ab0634d9033e786c3c61fefe08fd9783e66743eef8571ac0335136b77be830909ea1c5bbcf6617295a34"
+  ]
+}

--- a/packages/cohttp/cohttp.3.0.0/opam
+++ b/packages/cohttp/cohttp.3.0.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries.
+
+See the cohttp-async, cohttp-lwt, cohttp-lwt-unix, cohttp-lwt-jsoo and
+cohttp-mirage libraries for concrete implementations for particular
+targets.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "re" {>= "1.9.0"}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "fieldslib"
+  "sexplib0"
+  "ppx_fields_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "ppx_compare" {>= "v0.13.0"}
+  "stdlib-shims"
+  "stringext"
+  "base64" {>= "3.1.0"}
+  "stdlib-shims"
+  "fmt" {with-test}
+  "jsonm" {build}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "f3a29b332df416735690cc393c988893592bc40f"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v3.0.0/cohttp-v3.0.0.tbz"
+  checksum: [
+    "sha256=fb872f437aabc9c336bb822ac18ccbce794a2614ecb9d3edafb679dcafc82ea4"
+    "sha512=a33a02f07621995aad6c7c571cab1ea715912b65a1b6ab0634d9033e786c3c61fefe08fd9783e66743eef8571ac0335136b77be830909ea1c5bbcf6617295a34"
+  ]
+}


### PR DESCRIPTION
…lwt, cohttp-lwt-unix, cohttp-lwt-unix-ssl, cohttp-top, cohttp-async and cohttp-mirage (3.0.0)

CHANGES:

- cohttp: update HTTP codes (@emillon mirage/ocaml-cohttp#711)
- cohttp: add Uti.t to uri scheme (@brendanlong mirage/ocaml-cohttp#707)
- cohttp: fix chunked encoding of empty body (@mefyl mirage/ocaml-cohttp#715)
- cohttp-async: fix body not being uploaded with unchunked Async.Pipe (@mefyl mirage/ocaml-cohttp#706)
- cohttp-{async, lwt}: fix suprising behaviours of Body.is_empty (@anuragsoni mirage/ocaml-cohttp#714 mirage/ocaml-cohttp#712 mirage/ocaml-cohttp#713)
- port to conduit 3.0.0: minor breaking changes on the server API, an explicit distinction
  between cohttp-lwt-unix (using tls), cohttp-lwt-notls and cohttp-lwt-ssl (using lwt_ssl),
  and includes ssl in cohttp-async (@dinosaure mirage/ocaml-cohttp#692)
- cohttp-lwt-jsoo: **breaking** rename Cohttp_lwt_xhr to Cohttp_lwt_jsoo for consistency (@mseri mirage/ocaml-cohttp#717)
- refactoring of tests (@mseri mirage/ocaml-cohttp#709, @dinosaure mirage/ocaml-cohttp#692)
- update documentation (@dinosaure mirage/ocaml-cohttp#716, @mseri mirage/ocaml-cohttp#720)
- cohttp: fix transfer-encoding ordering in headers (@mseri mirage/ocaml-cohttp#721)
- lower-level support for long-running cohttp-async connections (@brendanlong mirage/ocaml-cohttp#704)
- fix deadlock in logging (@dinosaure mirage/ocaml-cohttp#722)
- add of_form and to_form functions to body (@seliopou mirage/ocaml-cohttp#440, @mseri mirage/ocaml-cohttp#723)
- cohttp-lwt: partly inline read_response, fix body stream leak (@madroach @dinosaure mirage/ocaml-cohttp#696)
- improve media type parsing (@seliopou mirage/ocaml-cohttp#542, @dinosaure mirage/ocaml-cohttp#725)
- add comparison functions for Request.t and Response.t via ppx_compare (@msaffer-js @dinosaure mirage/ocaml-cohttp#686)

EDIT: @dinosaure added a nice account of the breaking changes on the upstream repo. I am reporting it here.

 **breaking changes**, the API to launch a server was updated and types used by the client were updated too. A clean-recompilation of your project should be enough for users of the client part - however, if you deeply use Conduit, you should look the release of Conduit 3.0.0 (documentation & howto) to be aware about the new usage of this library.

- [Release of Conduit 3.0.0](https://github.com/mirage/ocaml-conduit/releases/tag/v3.0.0)
- [HOW-TO use Conduit 3.0.0](https://mirage.github.io/ocaml-conduit/conduit/howto.html)
- [Documentation of Conduit 3.0.0](https://mirage.github.io/ocaml-conduit/conduit/Conduit/module-type-S/index.html)

About the server-side part of Cohttp, we broke the API according to Conduit 3.0.0. The user must update the way to launch a Cohttp server. The technical update is about the `~mode` argument which disappears to let 3 arguments: `cfg`, `service` and `protocol`.

This allow users to choose which kind of service they want (a TLS service or a simple TCP service). Such values are provided by Conduit 3.0.0. For example, if you want to launch a simple HTTP (no secure) service, you can use:

- `Conduit_{async,lwt}.TCP.service`
- `Conduit_{async,lwt}.TCP.protocol`

The encryption layer can be provided by `Conduit_{async,lwt}_{tls,ssl}.TCP` module (`tls` means an usage of `ocaml-tls`, `ssl` means a usage of OpenSSL). Then, the `cfg` value depends on the `service` value. For example, for `Conduit_lwt.TCP.service`, `cfg = Conduit_lwt.TCP.configuration`. In this way, the user is able to launch a HTTP server with:

```ocaml
let cfg =
  { Conduit_lwt.TCP.sockaddr= Unix.ADDR_INET (Unix.inet_addr_loopback, 8080)
  ; capacity= 40 }
let run cohttp_config =
  Cohttp_lwt_unix.Server.create cfg Conduit_lwt.TCP.protocol Conduit_lwt.TCP.service
    cohttp_config
```

Of course, [the documentation](https://mirage.github.io/ocaml-cohttp/cohttp-lwt-unix-nossl/Cohttp_lwt_unix_nossl/Server/index.html) was updated according this new interface. More details can be found into Conduit 3.0.0 too about encryption services.

Finally, an other **breaking change** is about the TLS stack used by `cohttp-lwt-unix` on the client side. In **anyway**, `cohttp-lwt-unix` uses `ocaml-tls` to handle TLS. To explicitely use OpenSSL, users will need to depend ong `cohttp-lwt-unix-ssl` instead. If they do not want to use the encryption layer, they now need to use `cohttp-lwt-unix-nossl`.

See also the porting notes posted on the companion breakages PR: https://github.com/ocaml/opam-repository/pull/17577#issuecomment-723053705