### PR TITLE
4 packages from c-cube/qcheck at 0.16

### DIFF
--- a/packages/qcheck-alcotest/qcheck-alcotest.0.16/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.16/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+synopsis: "Alcotest backend for qcheck"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "quickcheck"
+  "qcheck"
+  "alcotest"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "alcotest"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.16.tar.gz"
+  checksum: [
+    "md5=5f90fcc32c3b3fbaa6c949746756b208"
+    "sha512=eb9f08cdad479399347ae7771f610d58622d45af79ae9e46d3267da7d3c197cb9d1ea57fafa6af5f1fcd0e360282f72c183dd0f6ba47329536c5523661eb40e8"
+  ]
+}

--- a/packages/qcheck-core/qcheck-core.0.16/opam
+++ b/packages/qcheck-core/qcheck-core.0.16/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+synopsis: "Core qcheck library"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.16.tar.gz"
+  checksum: [
+    "md5=5f90fcc32c3b3fbaa6c949746756b208"
+    "sha512=eb9f08cdad479399347ae7771f610d58622d45af79ae9e46d3267da7d3c197cb9d1ea57fafa6af5f1fcd0e360282f72c183dd0f6ba47329536c5523661eb40e8"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.16/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.16/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://c-cube.github.io/qcheck/"]
+synopsis: "OUnit backend for qcheck"
+tags: [
+  "qcheck"
+  "quickcheck"
+  "ounit"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "ounit2"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.16.tar.gz"
+  checksum: [
+    "md5=5f90fcc32c3b3fbaa6c949746756b208"
+    "sha512=eb9f08cdad479399347ae7771f610d58622d45af79ae9e46d3267da7d3c197cb9d1ea57fafa6af5f1fcd0e360282f72c183dd0f6ba47329536c5523661eb40e8"
+  ]
+}

--- a/packages/qcheck/qcheck.0.16/opam
+++ b/packages/qcheck/qcheck.0.16/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Compatibility package for qcheck"
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "qcheck-ounit" { = version }
+  "odoc" {with-doc}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.16.tar.gz"
+  checksum: [
+    "md5=5f90fcc32c3b3fbaa6c949746756b208"
+    "sha512=eb9f08cdad479399347ae7771f610d58622d45af79ae9e46d3267da7d3c197cb9d1ea57fafa6af5f1fcd0e360282f72c183dd0f6ba47329536c5523661eb40e8"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`qcheck.0.16`: Compatibility package for qcheck
-`qcheck-alcotest.0.16`: Alcotest backend for qcheck
-`qcheck-core.0.16`: Core qcheck library
-`qcheck-ounit.0.16`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.0.0