### PR TITLE
[new release] asn1-combinators (0.2.4)

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.2.4/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+authors: "David Kaloper Meršinjak"
+maintainer: "David Kaloper Meršinjak <dk505@cam.ac.uk>"
+homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
+doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+synopsis: "Embed typed ASN.1 grammars in OCaml"
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+depends: [
+  "ocaml" {>="4.05.0"}
+  "dune" {>= "1.2.0"}
+  "cstruct" {>= "1.6.0"}
+  "zarith"
+  "bigarray-compat"
+  "stdlib-shims"
+  "ptime"
+  "alcotest" {with-test}
+]
+description: """
+asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
+part of ASN.1, and embed the abstract syntax directly in the language. These
+abstract syntax representations can be used for parsing, serialization, or
+random testing.
+
+The only ASN.1 encodings currently supported are BER and DER.
+"""
+x-commit-hash: "5ad18c05b9ee693296a882ebef10e3fba3021591"
+url {
+  src:
+    "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.2.4/asn1-combinators-v0.2.4.tbz"
+  checksum: [
+    "sha256=39c5812538d915c4ef125f716a147cf00070740994f9b442e9e77188392f3627"
+    "sha512=49d066790794bf9adbed76d61257fdebc31a62bcb9cafc815b59df21b10b6e1805eb2ae12edff3ea63f5bd944da666545d9aa943fd284901f25693a826a1fd15"
+  ]
+}


### PR DESCRIPTION
Embed typed ASN.1 grammars in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-asn1-combinators">https://github.com/mirleft/ocaml-asn1-combinators</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-asn1-combinators/doc">https://mirleft.github.io/ocaml-asn1-combinators/doc</a>

##### CHANGES:

* OCaml 4.12 support (mirleft/ocaml-asn1-combinators#35 by @kit-ty-kate, @hannesm)
