### PR TITLE
[new release] tls-mirage and tls (0.12.6)

### DIFF
--- a/packages/tls-mirage/tls-mirage.0.12.6/opam
+++ b/packages/tls-mirage/tls-mirage.0.12.6/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "tls" {= version}
+  "x509" {>= "0.10.0"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "hacl_x25519" {>= "0.1.1"}
+  "fiat-p256" {>= "0.2.1"}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"
+description: """
+Tls-mirage provides an effectful FLOW module to be used in the MirageOS
+ecosystem.
+"""
+x-commit-hash: "37cb029647486b9ce48482d6fded8277763c2821"
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.12.6/tls-v0.12.6.tbz"
+  checksum: [
+    "sha256=89f56f08fded86663fbd45e6c520b2da97ff30f2a1f0cc51c5c52c6813126291"
+    "sha512=4d534d15636d8b2c6e4a36a63a90dde89592a749e2972657277bd5e3184356d42e2c6a185c72efa1c1faa4bd89667dc81130288ab2f83828fe60c023933f5e51"
+  ]
+}

--- a/packages/tls/tls.0.12.6/opam
+++ b/packages/tls/tls.0.12.6/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_cstruct" {>= "3.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "cstruct-sexp"
+  "sexplib"
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-pk"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "x509" {>= "0.11.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt"
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "ounit" {with-test & >= "2.2.0"}
+  "lwt" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "hacl_x25519"
+  "fiat-p256"
+  "hkdf"
+  "logs"
+  "alcotest" {with-test}
+]
+
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+x-commit-hash: "37cb029647486b9ce48482d6fded8277763c2821"
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.12.6/tls-v0.12.6.tbz"
+  checksum: [
+    "sha256=89f56f08fded86663fbd45e6c520b2da97ff30f2a1f0cc51c5c52c6813126291"
+    "sha512=4d534d15636d8b2c6e4a36a63a90dde89592a749e2972657277bd5e3184356d42e2c6a185c72efa1c1faa4bd89667dc81130288ab2f83828fe60c023933f5e51"
+  ]
+}


### PR DESCRIPTION
Transport Layer Security purely in OCaml, MirageOS layer

- Project page: <a href="https://github.com/mirleft/ocaml-tls">https://github.com/mirleft/ocaml-tls</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-tls/doc">https://mirleft.github.io/ocaml-tls/doc</a>

##### CHANGES:

* OCaml 4.12 support (mirleft/ocaml-tls#421 @kit-ty-kate)
