### PR TITLE
Package pringo.1.1

### DIFF
--- a/packages/pringo/pringo.1.1/opam
+++ b/packages/pringo/pringo.1.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Pseudo-random, splittable number generators"
+description:
+  "Pseudo-random number generators that support splitting and two interfaces: one stateful, one purely functional"
+maintainer: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+authors: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+license: "GPL v2 with static linking exception"
+homepage: "https://github.com/xavierleroy/pringo"
+bug-reports: "https://github.com/xavierleroy/pringo/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind"
+]
+build: make
+install: [make "install"]
+dev-repo: "git+https://https://github.com/xavierleroy/pringo"
+url {
+  src: "https://github.com/xavierleroy/pringo/archive/1.1.tar.gz"
+  checksum: [
+    "md5=b36b096ae1886541c52ce8bec78ade92"
+    "sha512=fb901f6ad5a2aa3c7219119431ee2fce82766a28c1ca851efe4bc933aeae0dee447480ac605570cd9e499aa9308dae1d71b072cb8d7c952be7d3665335180644"
+  ]
+}


### PR DESCRIPTION
### `pringo.1.1`
Pseudo-random, splittable number generators
Pseudo-random number generators that support splitting and two interfaces: one stateful, one purely functional



---
* Homepage: https://github.com/xavierleroy/pringo
* Source repo: git+https://https://github.com/xavierleroy/pringo
* Bug tracker: https://github.com/xavierleroy/pringo/issues

---
:camel: Pull-request generated by opam-publish v2.0.2