### PR TITLE
[new release] ppx_deriving_yojson (3.6.0)

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.6.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving_yojson"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving_yojson/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving_yojson.git"
+tags: [ "syntax" "json" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
+  "result"
+  "ppx_deriving" {>= "5.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
+  "ounit" {with-test & >= "2.0.0"}
+]
+synopsis:
+  "JSON codec generator for OCaml"
+description: """
+ppx_deriving_yojson is a ppx_deriving plugin that provides
+a JSON codec generator.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving_yojson/releases/download/v3.6.0/ppx_deriving_yojson-v3.6.0.tbz"
+  checksum: [
+    "sha256=4573f0c0fac1830fc999f5cf7be6dbc01a48ec53ba2307a2d8b050021368f6e8"
+    "sha512=81f2f04afee171b9a231a2b413ef1c747e818b80be36f3090fc359e45d98cae0f22f94997da1e3e830036c0457235f517639f34e30618ca7e5c3e8eaa4fe8bf8"
+  ]
+}
+x-commit-hash: "f8186833bb6ee1fa7733dc3df63ea44a85a13a60"


### PR DESCRIPTION
JSON codec generator for OCaml

- Project page: <a href="https://github.com/ocaml-ppx/ppx_deriving_yojson">https://github.com/ocaml-ppx/ppx_deriving_yojson</a>

##### CHANGES:

  * Update to ppx_deriving 5.0 and ppxlib
    (ocaml-ppx/ppx_deriving_yojson#121)
    Rudi Grinberg, Thierry Martinez, Kate Deplaix and Gabriel Scherer

  * Fix issues when the equality operator `(=)` is shadowed
    (ocaml-ppx/ppx_deriving_yojson#126, ocaml-ppx/ppx_deriving_yojson#128, fixes ocaml-ppx/ppx_deriving_yojson#79)
    Martin Slota, Kate Deplaix
