### PR TITLE
introduces ppx_bap, a ppx rewriter for BAP needs

### DIFF
--- a/packages/ppx_bap/ppx_bap.v0.14.0/opam
+++ b/packages/ppx_bap/ppx_bap.v0.14.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "ivg@cmu.edu"
+authors: ["Carnegie Mellon University BAP Team"]
+homepage: "https://github.com/BinaryAnalysisPlatform/ppx_bap"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/ppx_bap/issues"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/ppx_bap.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"               {>= "4.08.0"}
+  "base_quickcheck"     {>= "v0.14" & < "v0.15"}
+  "ppx_assert"          {>= "v0.14" & < "v0.15"}
+  "ppx_bench"           {>= "v0.14" & < "v0.15"}
+  "ppx_bin_prot"        {>= "v0.14" & < "v0.15"}
+  "ppx_cold"            {>= "v0.14" & < "v0.15"}
+  "ppx_compare"         {>= "v0.14" & < "v0.15"}
+  "ppx_enumerate"       {>= "v0.14" & < "v0.15"}
+  "ppx_fields_conv"     {>= "v0.14" & < "v0.15"}
+  "ppx_hash"            {>= "v0.14" & < "v0.15"}
+  "ppx_here"            {>= "v0.14" & < "v0.15"}
+  "ppx_optcomp"         {>= "v0.14" & < "v0.15"}
+  "ppx_sexp_conv"       {>= "v0.14" & < "v0.15"}
+  "ppx_sexp_value"      {>= "v0.14" & < "v0.15"}
+  "ppx_variants_conv"   {>= "v0.14" & < "v0.15"}
+  "dune"                {>= "2.0.0"}
+  "ppxlib"              {>= "0.15.0"}
+]
+synopsis: "The set of ppx rewriters for BAP"
+description: "
+ppx_bap is the set of blessed ppx rewriters used in BAP projects.
+It fills the same role as ppx_base or ppx_jane (from which it is derived),
+but doesn't impose any style requirements and has only the minimal necessary
+set of rewriters."
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/ppx_bap/archive/v0.14.tar.gz"
+  checksum: "md5=cf2ae08b613776661094b9dccdf5e796"
+}


### PR DESCRIPTION
This package is merely a copy of the ppx_jane with an amended set of
ppx rewriters, namely with the ppx_js_style removed, which makes it
impossible to use ppx_jane (and ppx_base) especially when the code is
generated, e.g., when the `findlib.dynload` library is used together
with ocamlfind, which requires the inclusion of a generated code that
triggers a fatal warning in ppx_js_style. We provided [a fix][1] for
that, which was ignored. Another example, is code generated by various
protocol compilers, namely piqi-ocaml, for which we also provided a
[fix][2] that got merged but was never released. In other words,
ppx_js_style is applying itself to the code that neither belongs to
Jane Street nor even to a user of the ppx_jane rewriter.

We have [been asking Jane Street][5] to remove ppx_js_style for a long
time but we were just ignored (no replies in 5 months). Therefore we
decided to create our own package with the set of ppx rewriters that
we use in BAP (which also solves another issue associated with
[ppx_jane][4]).

Once this package is merged we can move BAP to the newest versions of
OCaml, up to 4.11.1, see [the PR to BAP][5].

[1]: https://github.com/ocaml/ocamlfind/pull/9
[2]: https://github.com/alavrik/piqi-ocaml/pull/15
[3]: https://github.com/janestreet/ppx_jane/issues/5
[4]: https://github.com/janestreet/ppx_jane/issues/6
[5]: https://github.com/BinaryAnalysisPlatform/bap/pull/1116