### PR TITLE
[new release] ppx_deriving_yojson (3.6.0)

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.6.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving_yojson"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving_yojson/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving_yojson.git"
+tags: [ "syntax" "json" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
+  "result"
+  "ppx_deriving" {>= "5.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
+  "ounit" {with-test & >= "2.0.0"}
+]
+synopsis:
+  "JSON codec generator for OCaml"
+description: """
+ppx_deriving_yojson is a ppx_deriving plugin that provides
+a JSON codec generator.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving_yojson/releases/download/v3.6.0/ppx_deriving_yojson-v3.6.0.tbz"
+  checksum: [
+    "sha256=d6f66c6f76b5caa9b2f91ad61a8d8142f4e0582d9c6f39ea42b56491048358bc"
+    "sha512=63749800c57b5d56abe3fb73c2e53204b6a3847addd3b82500738efddabfd80150b6470e901d3c4fcadb1ccac416cf35245b9a8814e6e731e44df0fdf54a07ee"
+  ]
+}
+x-commit-hash: "9f2054b4aef028c9415b36e989518fd7f114e14b"


### PR DESCRIPTION
JSON codec generator for OCaml

- Project page: <a href="https://github.com/ocaml-ppx/ppx_deriving_yojson">https://github.com/ocaml-ppx/ppx_deriving_yojson</a>

##### CHANGES:

  * Update to ppx_deriving 5.0 and ppxlib
    (ocaml-ppx/ppx_deriving_yojson#121)
    Rudi Grinberg, Thierry Martinez, Kate Deplaix and Gabriel Scherer

  * Fix issues when the equality operator `(=)` is shadowed
    (ocaml-ppx/ppx_deriving_yojson#126, ocaml-ppx/ppx_deriving_yojson#128, fixes ocaml-ppx/ppx_deriving_yojson#79)
    Martin Slota, Kate Deplaix
