### PR TITLE
Package satyrographos.0.0.2.8

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.2.8/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.8/opam
@@ -39,6 +39,9 @@ depends: [
   "ppx_jane"
   "shexp"
 ]
+depexts: [
+  [ "diffutils" ] {with-test}
+]
 synopsis: "A package manager for SATySFi"
 description: """
 Satyrographos is a package manager for [SATySFi].

--- a/packages/satyrographos/satyrographos.0.0.2.8/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.8/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  ["dune" "subst"] {pinned}
+  ["sed" "-i.bak" "-e" "s/%%%%VERSION_NUM%%%%/%{version}%/" "bin/main.ml"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest"]
+]
+
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "dune" {>= "2.7"}
+  "fileutils"
+  "json-derivers"
+  "menhir"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ocamlgraph"
+  "opam-format" {>= "2.0" & < "2.1"}
+  "opam-state" {>= "2.0" & < "2.1"}
+  "re" {with-test}
+  "stringext" {with-test}
+  "uri" {>= "3.0.0"}
+  "uri-sexp" {>= "3.0.0"}
+  "yaml" {>= "2.0" & < "3.0"}
+  "yojson"
+
+  # Janestreet Libs
+  "core" {>= "v0.13" & < "v0.15"}
+  "ppx_jane"
+  "shexp"
+]
+synopsis: "A package manager for SATySFi"
+description: """
+Satyrographos is a package manager for [SATySFi].
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src: "https://github.com/na4zagin3/satyrographos/archive/v0.0.2.8.tar.gz"
+  checksum: [
+    "md5=37f4c1415fb0aeee89d6808b3e3eaa82"
+    "sha512=d3ecd1568702f78a33b65722a89ea6999ee832318ddb2608f758f3e09891f4fb29b79b1a01fc01e219a8742b214708e32a9ceede3eae77e24023b2db63221f45"
+  ]
+}


### PR DESCRIPTION
### `satyrographos.0.0.2.8`
A package manager for SATySFi
Satyrographos is a package manager for [SATySFi].

Satyrographos is distributed under the LGPL-3.0 license.


  [SATySFi]: https://github.com/gfngfn/SATySFi
  [Satyrographos]: https://github.com/na4zagin3/satyrographos



---
* Homepage: https://github.com/na4zagin3/satyrographos
* Source repo: git+https://github.com/na4zagin3/satyrographos.git
* Bug tracker: https://github.com/na4zagin3/satyrographos/issues

---
:camel: Pull-request generated by opam-publish v2.0.2