### PR TITLE
Enlarge OCaml compatibility of bigarray-compat (4.02.3)

### DIFF
--- a/packages/bigarray-compat/bigarray-compat.1.0.0/opam
+++ b/packages/bigarray-compat/bigarray-compat.1.0.0/opam
@@ -6,7 +6,7 @@ license: "ISC"
 homepage: "https://github.com/mirage/bigarray-compat"
 bug-reports: "https://github.com/mirage/bigarray-compat/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.02.3"}
   "dune" {>= "1.0"}
 ]
 build: [


### PR DESCRIPTION
I think it's fine for `bigarray-compat` to support OCaml 4.02.3 (`dune.1.0.0` seems works for OCaml 4.02.3).