### PR TITLE
[new release] ppx_factory (0.2.0)

### DIFF
--- a/packages/ppx_factory/ppx_factory.0.2.0/opam
+++ b/packages/ppx_factory/ppx_factory.0.2.0/opam
@@ -17,7 +17,7 @@ run-test: [
 ]
 depends: [
   "dune" {>= "1.1"}
-  "ocaml" {>= "4.07.0" & < "4.11.0"}
+  "ocaml" {>= "4.07.0" & < "4.12.0"}
   "ounit" {with-test & >= "2.0.0"}
   "ppxlib" {>= "0.14.0"}
   "ppx_deriving" {with-test}

--- a/packages/ppx_factory/ppx_factory.0.2.0/opam
+++ b/packages/ppx_factory/ppx_factory.0.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: [
+    "Cryptosense <opensource@cryptosense.com>"
+    "Nathan Rebours <nathan.p.rebours@gmail.com>"
+]
+homepage: "https://github.com/cryptosense/ppx_factory"
+bug-reports: "https://github.com/cryptosense/ppx_factory/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/ppx_factory.git"
+doc: "https://cryptosense.github.io/ppx_factory/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "1.1"}
+  "ocaml" {>= "4.07.0" & < "4.11.0"}
+  "ounit" {with-test & >= "2.0.0"}
+  "ppxlib" {>= "0.14.0"}
+  "ppx_deriving" {with-test}
+]
+tags: ["org:cryptosense"]
+synopsis: "PPX to derive factories and default values"
+description: """
+ppx_factory is a ppx deriver that builds factory method from record and variant type
+definitions.
+
+Factory methods allow you to build test values by only supplying the parts that are relevant
+to your tests.
+"""
+x-commit-hash: "d7cad104e64e700540a2195459ae484dc099ccf3"
+url {
+  src:
+    "https://github.com/cryptosense/ppx_factory/releases/download/0.2.0/ppx_factory-0.2.0.tbz"
+  checksum: [
+    "sha256=23a90da63c9ab5078b0582805bbdaabf440cd8a8ac32abd1ad16d2dbac27b891"
+    "sha512=5d1e9f14d7cecc6617a9bc4d4438648230e05c167b7fd7f88449d94d5ab237561c0fc1f62fd628a6af0d77094c7f167d18910676e20ce3659a5383c38f2d4806"
+  ]
+}


### PR DESCRIPTION
PPX to derive factories and default values

- Project page: <a href="https://github.com/cryptosense/ppx_factory">https://github.com/cryptosense/ppx_factory</a>
- Documentation: <a href="https://cryptosense.github.io/ppx_factory/doc">https://cryptosense.github.io/ppx_factory/doc</a>

##### CHANGES:

All notable changes to this project will be documented in this file.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## Unreleased

_No unreleased changes at the moment_

## 0.2.0 - 2020-11-09

### Changed

- Make compatible with (only) ppxlib >= 0.14 (@NathanReb
  [cryptosense/ppx_factory#24](https://github.com/cryptosense/ppx_factory/pull/20))

## 0.1.1 - 2020-05-29

### Added

- Add support for OCaml 4.09 and 4.10

## 0.1.0 - 2019-08-07

### Fixes

- Raise an error when used with an abstract type, except when invoked from `ocamldep` (@NathanReb
  [cryptosense/ppx_factory#20](https://github.com/cryptosense/ppx_factory/pull/20))

## 0.0.0 - 2019-03-07

### Added

- Initial release
