### PR TITLE
Package num.1.4

### DIFF
--- a/packages/num/num.1.4/opam
+++ b/packages/num/num.1.4/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis:
+  "The legacy Num library for arbitrary-precision integer and rational arithmetic"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: ["Valérie Ménissier-Morain" "Pierre Weis" "Xavier Leroy"]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/num/"
+bug-reports: "https://github.com/ocaml/num/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "ocamlfind" {build & >= "1.7.3"}
+]
+conflicts: ["base-num"]
+build: make
+install: [
+  make
+  "install" {!ocaml:preinstalled}
+  "findlib-install" {ocaml:preinstalled}
+]
+dev-repo: "git+https://github.com/ocaml/num.git"
+url {
+  src: "https://github.com/ocaml/num/archive/v1.4.tar.gz"
+  checksum: [
+    "md5=cda2b727e116a0b6a9c03902cc4b2415"
+    "sha512=0cc9be8ad95704bb683b4bf6698bada1ee9a40dc05924b72adc7b969685c33eeb68ccf174cc09f6a228c48c18fe94af06f28bebc086a24973a066da620db8e6f"
+  ]
+}


### PR DESCRIPTION
### `num.1.4`
The legacy Num library for arbitrary-precision integer and rational arithmetic



---
* Homepage: https://github.com/ocaml/num/
* Source repo: git+https://github.com/ocaml/num.git
* Bug tracker: https://github.com/ocaml/num/issues

---
Release 1.4 (2020-11-09)

- Pull request #20: fix bug caused by unsafe string/bytes conversions,
  and remove all uses of `Bytes.unsafe_of_string`



---
:camel: Pull-request generated by opam-publish v2.0.2