### PR TITLE
Fix compilation of memtrace_viewer for local switches

### DIFF
--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
@@ -7,7 +7,8 @@ dev-repo: "git+https://github.com/janestreet/memtrace_viewer.git"
 doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/memtrace_viewer/index.html"
 license: "MIT"
 build: [
-  ["dune" "build" "--profile" "release" "--default-target" "@install" "."]
+  ["dune" "build" "--profile" "release" "--default-target" "@install" "."
+     "--root" "." "--cache-transport=direct"]
   ["cp" "_build/default/memtrace_viewer.install" "."]
 ]
 depends: [

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
@@ -7,7 +7,8 @@ dev-repo: "git+https://github.com/janestreet/memtrace_viewer.git"
 doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/memtrace_viewer/index.html"
 license: "MIT"
 build: [
-  ["dune" "build" "--profile" "release" "--default-target" "@install" "."]
+  ["dune" "build" "--profile" "release" "--default-target" "@install" "."
+     "--root" "." "--cache-transport=direct"]
   ["cp" "_build/default/memtrace_viewer.install" "."]
 ]
 depends: [


### PR DESCRIPTION
Otherwise the compilation fails in local switches with:

```
#=== ERROR while compiling memtrace_viewer.v0.14.1 ============================#
# context     2.1.0~alpha3 | macos/x86_64 | ocaml-base-compiler.4.11.1 | https://opam.ocaml.org#6089b913
# path        ~/git/irmin/_opam/.opam-switch/build/memtrace_viewer.v0.14.1
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build --profile release --default-target @install .
# exit-code   1
# env-file    ~/.opam/log/memtrace_viewer-47329-58c514.env
# output-file ~/.opam/log/memtrace_viewer-47329-58c514.out
### output ###
# Error: _build/log: Operation not permitted
```

As `dune` is trying to go up in the directory hierarchy to find the workspace root.