### PR TITLE
ocaml-systemd.1.2: correct bug-reports site

### DIFF
--- a/packages/ocaml-systemd/ocaml-systemd.1.2/opam
+++ b/packages/ocaml-systemd/ocaml-systemd.1.2/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "Juergen Hoetzel <juergen@archlinux.org>"
 authors: "Juergen Hoetzel <juergen@archlinux.org>"
 homepage: "https://github.com/juergenhoetzel/ocaml-systemd/"
-bug-reports:  "https://github.com/mirage/mirage/issues/"
+bug-reports:  "https://github.com/juergenhoetzel/ocaml-systemd/issues"
 dev-repo: "git+https://github.com/juergenhoetzel/ocaml-systemd.git"
 license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
 build: [


### PR DESCRIPTION
Direct people to the correct issue tracker and not mirage/mirage's issue tracker. Been merged upstream in https://github.com/juergenhoetzel/ocaml-systemd/pull/7