### PR TITLE
Fix #17385: group env value for ASPP

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.11.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+BER/opam
@@ -14,7 +14,7 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" "%{prefix}%"]
     {os != "openbsd" & os != "freebsd" & os != "macos"}
-  ["./configure" "-prefix" "%{prefix}%" "CC=cc" "-aspp" "cc -c"]
+  ["./configure" "-prefix" "%{prefix}%" "CC=cc" "ASPP=cc -c"]
     {os = "openbsd" | os = "freebsd" | os = "macos"}
   [make "world.opt"]
   [make "-C" "ber-metaocaml-111" "all"]


### PR DESCRIPTION
Tested and successfully built BER MetaOCaml on my environment with the remote url on my local repo as @yallop adviced!

My system supports the following clang compiler. If we need to add some additional logic for various cases let me know. 

```shell
> cc --version                                                 
Apple clang version 12.0.0 (clang-1200.0.32.21)
```
