### PR TITLE
conf-blas fails to install on Manjaro linux

### DIFF
--- a/packages/conf-openblas/conf-openblas.0.2.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.1/opam
@@ -13,13 +13,13 @@ build: [
     "cc $CFLAGS -I/usr/local/opt/openblas/include test.c -L/usr/local/opt/openblas/lib -lopenblas"
   ] {os = "macos" & os-distribution = "homebrew"}
   ["sh" "-exc" "cc $CFLAGS test.c -lcblas"]
-    {os-distribution = "arch"}
+    {os-family = "arch"}
   ["sh" "-exc" "cc $CFLAGS -I/usr/local/include -L/usr/local/lib test.c -lopenblas"]
     {os = "freebsd"}
   ["sh" "-exc" "x86_64-w64-mingw32-gcc $CFLAGS test.c -lopenblas"]
     {os = "win32" & os-distribution = "cygwinports"}
   ["sh" "-exc" "cc $CFLAGS test.c -lopenblas"]
-    {os-distribution != "fedora" & os-distribution != "centos" & os-family != "suse" & os != "macos" & os-distribution != "arch" & os != "freebsd" & os != "win32"}
+    {os-distribution != "fedora" & os-distribution != "centos" & os-family != "suse" & os != "macos" & os-family != "arch" & os != "freebsd" & os != "win32"}
 ]
 depexts: [
   ["libc-dev" "openblas-dev"] {os-distribution = "alpine"}


### PR DESCRIPTION
Seems like a repeat of https://github.com/ocaml/opam-repository/issues/12989

`opam config list` shows:
```
opam-version      2.0.7             # The currently running opam version
os                linux             # Inferred from system
os-distribution   manjaro           # Inferred from system
os-family         arch              # Inferred from system
os-version        20.2              # Inferred from system
```
I suspect `os-family` may be a more appropriate fix.