### PR TITLE
bibtex2html 1.99: do not compile doc

### DIFF
--- a/packages/bibtex2html/bibtex2html.1.99/opam
+++ b/packages/bibtex2html/bibtex2html.1.99/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/backtracking/bibtex2html.git"
 bug-reports: "https://github.com/backtracking/bibtex2html/issues"
 license: "GPL-2.0-only"
 build: [
-  ["./configure" "--prefix=%{prefix}%"]
+  ["./configure" "--prefix=%{prefix}%" "--enable-doc=no"]
   [make]
 ]
 depends: [


### PR DESCRIPTION
Attempt to fix https://github.com/backtracking/bibtex2html/issues/25 using the suggestion by @Armael 