### PR TITLE
Relax some dependency constraints for key-parsers and zxcvbn

### DIFF
--- a/packages/key-parsers/key-parsers.0.10.1/opam
+++ b/packages/key-parsers/key-parsers.0.10.1/opam
@@ -19,8 +19,8 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "ounit" {with-test & >= "2.0.0"}
   "ppx_bin_prot" {< "v0.15"}
-  "ppx_deriving" {>= "4.0" & < "5.0"}
-  "ppx_deriving_yojson" {>= "3.0" & < "4.0"}
+  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving_yojson" {>= "3.0"}
   "result" {>= "1.2"}
   "zarith" {>= "1.4.1"}
 ]

--- a/packages/zxcvbn/zxcvbn.2.4+1/opam
+++ b/packages/zxcvbn/zxcvbn.2.4+1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.4.0"}
   "ocaml" {>= "4.04.0"}
   "ounit" {with-test}
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.0"}
 ]
 tags: ["org:cryptosense"]
 synopsis: "Bindings for the zxcvbn password strength estimation library"


### PR DESCRIPTION
I don't know why those higher bounds where there for ppx_deriving and ppx_deriving_yojson and not the other dependencies.  Additionally, the packages seem to work fine with ppx_deriving 5.

I figured this is the easiest way to get the dependencies fixed.  Let me know if I should release new versions of key-parsers and zxcvbn instead.