### PR TITLE
[new release] ocamlformat (0.16.0)

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.16.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.16.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-team@fb.com>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.06" & < "4.13"}
+  "ocaml" {with-test & < "4.12"}
+  "ocaml-version"
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune-build-info"
+  "fix"
+  "fpath"
+  "menhir"
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "ppxlib" {>= "0.18.0"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+x-commit-hash: "101d2306f5b0b23bbc25e1155c1ffd51a0bbf61e"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.16.0/ocamlformat-0.16.0.tbz"
+  checksum: [
+    "sha256=b912c62b9b298a97016da09fc669c7fa9738ad4657a24d0260920205f9de92ef"
+    "sha512=318e2d84dfa38a4495084786464e07a56f1aff1aa6c5df126ec763c4be0934729d018a289a78c48c5751c9e8fa2d64e98996fb46a464fd6f8b9a2fd1367459c3"
+  ]
+}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### Removed

  + Remove the 'escape-chars' option, deprecated since 0.14.0 (ocaml-ppx/ocamlformat#1462, @gpetiot)

  + Remove the 'escape-strings' option, deprecated since 0.14.0 (ocaml-ppx/ocamlformat#1463, @gpetiot)

  + Remove the 'doc-comments-val' option, deprecated since 0.14.2 (ocaml-ppx/ocamlformat#1461, @gpetiot)

  + Removed options are now listed in the commandline manual (new REMOVED OPTIONS section) (ocaml-ppx/ocamlformat#1469, @Julow)

#### Changes

  + Set 'indicate-multiline-delimiters=no' on default profile (ocaml-ppx/ocamlformat#1452, @gpetiot)

  + Option 'let-open' is now deprecated, concrete syntax will always be preserved starting from OCamlFormat v0.17.0, corresponding to the current 'let-open=preserve' behavior. (ocaml-ppx/ocamlformat#1467, @gpetiot)

  + Warnings printed by ocamlformat itself now use the 4.12 style with symbolic names (ocaml-ppx/ocamlformat#1511, ocaml-ppx/ocamlformat#1518, @emillon)

  + Remove extension from executable name in error messages. On Windows, this means that messages now start with "ocamlformat: ..." instead of "ocamlformat.exe: ..." (ocaml-ppx/ocamlformat#1531, @emillon)

  + Using tokens instead of string manipulation when inspecting the original source (ocaml-ppx/ocamlformat#1526, ocaml-ppx/ocamlformat#1533, ocaml-ppx/ocamlformat#1541 @hhugo) (ocaml-ppx/ocamlformat#1532, @gpetiot)

#### Bug fixes

  + Allow a break after `if%ext` with `if-then-else=keyword-first` (ocaml-ppx/ocamlformat#1419, ocaml-ppx/ocamlformat#1543, @gpetiot)

  + Fix parentheses around infix applications having attributes (ocaml-ppx/ocamlformat#1464, @gpetiot)

  + Fix parentheses around the index arg of a non-sugared index operation (ocaml-ppx/ocamlformat#1465, @gpetiot)

  + Preserve comment position around `match` and `try` keywords (ocaml-ppx/ocamlformat#1458, @gpetiot)

  + Add missing break in module statement (ocaml-ppx/ocamlformat#1431, @gpetiot)

  + Indent attributes attached to included modules better (ocaml-ppx/ocamlformat#1468, @gpetiot)

  + Clean up `ocamlformat.el` for submission to MELPA (ocaml-ppx/ocamlformat#1476, ocaml-ppx/ocamlformat#1495, @bcc32)
    - Added missing package metadata to `ocamlformat.el` (ocaml-ppx/ocamlformat#1474, @bcc32)
    - Fix `ocamlformat.el` buffer replacement for MacOS Emacs (ocaml-ppx/ocamlformat#1481, @juxd)

  + Add missing parentheses around a pattern matching that is the left-hand part of a sequence when an attribute is attached (ocaml-ppx/ocamlformat#1483, @gpetiot)

  + Add missing parentheses around infix operator used to build a function (ocaml-ppx/ocamlformat#1486, @gpetiot)

  + Fix comments around desugared expression (ocaml-ppx/ocamlformat#1487, @gpetiot)

  + Fix invalid fragment delimiters of format-invalid-files recovery mode (ocaml-ppx/ocamlformat#1485, @hhugo)

  + Fix misalignment of cases in docked `function` match (ocaml-ppx/ocamlformat#1498, @gpetiot)

  + Preserve short-form extensions for structure item extensions (ocaml-ppx/ocamlformat#1502, @gpetiot)
    For example `open%ext M` will not get rewritten to `[%%ext open M]`.

  + Do not change the spaces within the code spans in docstrings (ocaml-ppx/ocamlformat#1499, @gpetiot)

  + Comments of type constrained label in record pattern have to be relocated in 4.12 (ocaml-ppx/ocamlformat#1517, @gpetiot)

  + Preserve functor syntax for OCaml 4.12 (ocaml-ppx/ocamlformat#1514, @gpetiot)

  + Fix inconsistencies of the closing parentheses with indicate-multiline-delimiters (ocaml-ppx/ocamlformat#1377, ocaml-ppx/ocamlformat#1540, @gpetiot)

  + Fix position of comments around list constructor (::) (ocaml-ppx/ocamlformat#1524, @gpetiot)

  + Fix comments position in extensions (ocaml-ppx/ocamlformat#1525, @gpetiot)

  + Fix formatting of field override with constraint (ocaml-ppx/ocamlformat#1544, @gpetiot)

#### New features
