### PR TITLE
[new release] ocaml-lsp-server, lsp and jsonrpc (1.2.0)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.2.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "yojson"
+  "stdlib-shims"
+  "ppx_yojson_conv_lib"
+  "result" {>= "1.5"}
+  "ocaml" {>= "4.06" & < "4.12"}
+  "dune" {>= "2.5.0"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "45ebc4ee009f1588eaf5d5a2d0e5137be937501e"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.2.0/jsonrpc-1.2.0.tbz"
+  checksum: [
+    "sha256=e4e56590b9af02160e5af7733763897d7cfe3f9b876692af4d4184ab0fce4bcb"
+    "sha512=724d5190a678ca8a3f3c13915cbfcf8d3cce8efa43e0dde130b14c45065b6ccd22507951e79977bcecf361c7928f271d312b87642bb2c52f33669c3e952a7e1b"
+  ]
+}

--- a/packages/jsonrpc/jsonrpc.1.2.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.2.0/opam
@@ -17,6 +17,7 @@ bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
   "yojson"
   "stdlib-shims"
+  "ocaml-syntax-shims"
   "ppx_yojson_conv_lib"
   "result" {>= "1.5"}
   "ocaml" {>= "4.06" & < "4.12"}
@@ -24,7 +25,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["ocaml" "unix.cma" "unvendor.ml"]
   [
     "dune"

--- a/packages/lsp/lsp.1.2.0/opam
+++ b/packages/lsp/lsp.1.2.0/opam
@@ -31,7 +31,7 @@ depends: [
   "cinaps" {with-test}
   "ppx_expect" {with-test & >= "v0.14.0"}
   "ocaml" {>= "4.06" & < "4.12"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.5"}
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [

--- a/packages/lsp/lsp.1.2.0/opam
+++ b/packages/lsp/lsp.1.2.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "stdlib-shims"
+  "jsonrpc"
+  "yojson"
+  "ppx_yojson_conv_lib"
+  "ocaml-syntax-shims"
+  "cppo"
+  "uutf"
+  "csexp"
+  "menhir" {with-test}
+  "cinaps" {with-test}
+  "ppx_expect" {with-test & >= "v0.14.0"}
+  "ocaml" {>= "4.06" & < "4.12"}
+  "dune" {>= "2.0"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "45ebc4ee009f1588eaf5d5a2d0e5137be937501e"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.2.0/jsonrpc-1.2.0.tbz"
+  checksum: [
+    "sha256=e4e56590b9af02160e5af7733763897d7cfe3f9b876692af4d4184ab0fce4bcb"
+    "sha512=724d5190a678ca8a3f3c13915cbfcf8d3cce8efa43e0dde130b14c45065b6ccd22507951e79977bcecf361c7928f271d312b87642bb2c52f33669c3e952a7e1b"
+  ]
+}

--- a/packages/lsp/lsp.1.2.0/opam
+++ b/packages/lsp/lsp.1.2.0/opam
@@ -20,7 +20,7 @@ homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
   "stdlib-shims"
-  "jsonrpc"
+  "jsonrpc" {= version}
   "yojson"
   "ppx_yojson_conv_lib"
   "ocaml-syntax-shims"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.2.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.2.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "yojson"
+  "stdlib-shims"
+  "ppx_yojson_conv_lib"
+  "dune-build-info"
+  "dot-merlin-reader"
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "ocamlformat" {with-test}
+  "ocamlfind" {>= "1.5.2"}
+  "ocaml" {>= "4.06" & < "4.12"}
+  "dune" {>= "2.5.0"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "ocaml-lsp-server.install"
+    "--release"
+  ]
+]
+x-commit-hash: "45ebc4ee009f1588eaf5d5a2d0e5137be937501e"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.2.0/jsonrpc-1.2.0.tbz"
+  checksum: [
+    "sha256=e4e56590b9af02160e5af7733763897d7cfe3f9b876692af4d4184ab0fce4bcb"
+    "sha512=724d5190a678ca8a3f3c13915cbfcf8d3cce8efa43e0dde130b14c45065b6ccd22507951e79977bcecf361c7928f271d312b87642bb2c52f33669c3e952a7e1b"
+  ]
+}


### PR DESCRIPTION
LSP Server for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Features

- Add keyword completion

- Add go to declaration functionality to jump to a value's specification in a
  .mli file (ocaml/ocaml-lsp#294)

## Fixes

- ocaml/ocaml-lsp#245: correctly use mutexes on OpenBSD (ocaml/ocaml-lsp#264)

- ocaml/ocaml-lsp#268: Do not use vendored libraries when building the lsp package (ocaml/ocaml-lsp#260)

- ocaml/ocaml-lsp#271: Clear diagnostics when files are closed

- Disable non-prefix completion. There's no reliably way to trigger it and it
  can be slow.
