### PR TITLE
Package opam-depext.1.1.5

### DIFF
--- a/packages/opam-depext/opam-depext.1.1.5/opam
+++ b/packages/opam-depext/opam-depext.1.1.5/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/ocaml/opam-depext"
+bug-reports: "https://github.com/ocaml/opam-depext/issues"
+depends: ["ocaml"]
+available: opam-version >= "2.0.0~beta5"
+flags: plugin
+build: make
+dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
+synopsis: "install OS distribution packages"
+description: """
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can query OPAM for the
+right external dependencies on a set of packages, depending on the host OS, and
+call the OS's package manager in the appropriate way to install them.
+"""
+url {
+  src:
+    "https://github.com/ocaml-opam/opam-depext/releases/download/v1.1.5/opam-depext-full-v1.1.5.tbz"
+  checksum: [
+    "md5=e05aa8bf3f794bbbb293eb2d4d5b1233"
+    "sha512=661bdb43867904ffd9c20390b5679eccd4d3dbcd0e5d1252561f0b24aac3cf1d80d2cf72cadf04e25d480eb3c79d3dda5874c88075971d42445f1c956c0fad9c"
+  ]
+}


### PR DESCRIPTION
### `opam-depext.1.1.5`
install OS distribution packages
opam-depext is a simple program intended to facilitate the interaction between
OPAM packages and the host package management system. It can query OPAM for the
right external dependencies on a set of packages, depending on the host OS, and
call the OS's package manager in the appropriate way to install them.



---
* Homepage: https://github.com/ocaml/opam-depext
* Source repo: git+https://github.com/ocaml/opam-depext.git#2.0
* Bug tracker: https://github.com/ocaml/opam-depext/issues

---
:camel: Pull-request generated by opam-publish v2.0.3