### PR TITLE
[new release] mlbdd (0.7)

### DIFF
--- a/packages/mlbdd/mlbdd.0.7/opam
+++ b/packages/mlbdd/mlbdd.0.7/opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/arlencox/mlbdd"
 bug-reports: "https://github.com/arlencox/mlbdd/issues"
 depends: [
   "dune" {>= "2.7"}
+  "ounit2" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/mlbdd/mlbdd.0.7/opam
+++ b/packages/mlbdd/mlbdd.0.7/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "An OCaml library for Binary Decision Diagrams (BDDs)"
+description:
+  "The mlbdd library provides a simple, easy-to-use, easy-to-extend implementation of binary decision diagrams (BDDs) in OCaml. It is well tested and well documented. The library itself has no dependencies and is thus easy to include in applications that might, for example, be compiled with js_of_ocaml or other tools that rely on pure OCaml. It is also easier to integrate with existing projects due to its lack of dependencies.  Critically, this BDD implementation uses a garbage-collection-aware hashing scheme, so that unused nodes can be collected.  Additionally, this implementation uses complement edges to significantly improve performance over the simplest BDD implementations."
+maintainer: ["Arlen Cox <arlencox@gmail.com>"]
+authors: ["Arlen Cox <arlencox@gmail.com>"]
+license: "BSD"
+homepage: "https://github.com/arlencox/mlbdd"
+bug-reports: "https://github.com/arlencox/mlbdd/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arlencox/mlbdd.git"
+x-commit-hash: "ec56ddc244ba2fa60194dd012b82b962400fc701"
+url {
+  src:
+    "https://github.com/arlencox/mlbdd/releases/download/v0.7/mlbdd-v0.7.tbz"
+  checksum: [
+    "sha256=347f34d97e6f15e48f6a70e5d781be0c2bf794c650f83e6b90efcd6532659fd3"
+    "sha512=66830368752bff62eee18af448a5639ec0cfdd5b16f105b98894302894e34f7bb50c2944b48593ed94d22dae03c202555d131406e38384e0d604d5594c71b54d"
+  ]
+}


### PR DESCRIPTION
An OCaml library for Binary Decision Diagrams (BDDs)

- Project page: <a href="https://github.com/arlencox/mlbdd">https://github.com/arlencox/mlbdd</a>

##### CHANGES:

- Switched build from Makefile to Dune
  - Cleaned up project structure
  - Added caching for support computation (thanks @JoanThibault)
