### PR TITLE
[new release] ppx_deriving_cmdliner (0.5.1)

### DIFF
--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.5.1/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.5.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Seb Mondet <seb@mondet.org>"
+authors: [
+  "Isaac Hodes <isaachodes@gmail.com>"
+  "B. Arman Aksoy <arman@aksoy.org>"
+  "Seb Mondet <seb@mondet.org>"
+  "Nick Zalutskiy <nick@const.fun>"
+  "Armaël Guéneau <armael.gueneau@ens-lyon.fr>"
+]
+homepage: "https://github.com/hammerlab/ppx_deriving_cmdliner"
+bug-reports: "https://github.com/hammerlab/ppx_deriving_cmdliner/issues"
+dev-repo: "git+https://github.com/hammerlab/ppx_deriving_cmdliner.git"
+doc: "http://hammerlab.github.io/ppx_deriving_cmdliner"
+license: "MIT"
+version: "0.5.1"
+tags: ["syntax" "cli"]
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["jbuilder" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "cmdliner" {>= "1.0.0"}
+  "result"
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "dune" {< "2.0"}
+  "ocamlfind"    {build}
+  "ppxfind"      {build}
+  "cppo"         {build}
+  "alcotest"     {with-test}
+  "ppx_import"   {with-test & >= "1.1"}
+]
+synopsis: "Cmdliner.Term.t generator"
+description: """
+ppx_deriving_cmdliner is a ppx_deriving plugin that generates
+a Cmdliner Term.t for a record type."""
+url {
+  src:
+    "https://github.com/hammerlab/ppx_deriving_cmdliner/archive/v0.5.1.tar.gz"
+  checksum: "md5=2a704e21068b021e83f261c937316ed5"
+}
+

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.5.1/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.5.1/opam
@@ -12,21 +12,20 @@ bug-reports: "https://github.com/hammerlab/ppx_deriving_cmdliner/issues"
 dev-repo: "git+https://github.com/hammerlab/ppx_deriving_cmdliner.git"
 doc: "http://hammerlab.github.io/ppx_deriving_cmdliner"
 license: "MIT"
-version: "0.5.1"
 tags: ["syntax" "cli"]
 build: [
-  ["jbuilder" "subst" "-n" name] {pinned}
-  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [
-  ["jbuilder" "runtest" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs]
 ]
 depends: [
   "ocaml" {>= "4.03"}
   "cmdliner" {>= "1.0.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}
-  "dune" {< "2.0"}
+  "dune" {>= "1.0"}
   "ocamlfind"    {build}
   "ppxfind"      {build}
   "cppo"         {build}


### PR DESCRIPTION
CHANGES:

- Add support for OCaml 4.10.0, 4.11.0, and 4.11.1. (Fix for https://github.com/hammerlab/ppx_deriving_cmdliner/issues/40)