### PR TITLE
Switch 4.11.2 and 4.13.0 dev packages to use hidden-version

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+afl/opam
@@ -6,10 +6,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta"
+  "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [ compiler hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+flambda/opam
@@ -6,10 +6,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta"
+  "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [ compiler hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+fp/opam
@@ -6,10 +6,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta"
+  "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [ compiler hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--enable-frame-pointers" ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+trunk/opam
@@ -6,10 +6,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta"
+  "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [ compiler hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+trunk+afl/opam
@@ -6,10 +6,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta"
+  "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [ compiler hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+trunk+flambda/opam
@@ -6,10 +6,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta"
+  "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [ compiler hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+trunk+fp+flambda/opam
@@ -6,10 +6,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta"
+  "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [ compiler hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+trunk+fp/opam
@@ -6,10 +6,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta"
+  "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [ compiler hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+trunk+nnp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+trunk+nnp/opam
@@ -6,10 +6,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta"
+  "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [ compiler hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+trunk+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+trunk+no-flat-float-array/opam
@@ -6,10 +6,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta"
+  "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [ compiler hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+trunk/opam
@@ -6,10 +6,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta"
+  "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [ compiler hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [


### PR DESCRIPTION
This PR "simply" applies the `hidden-version` opam 2.1 flag and only requires the `ocaml-beta` package for opam 2.0.

It's mildly useful at the moment in testing, as it eliminates messages about ocaml-beta and also allows a check to ensure that 4.12 alpha switches aren't upgraded to 4.13 trunk switches...