### PR TITLE
[new release] ca-certs (0.1.3)

### DIFF
--- a/packages/ca-certs/ca-certs.0.1.3/opam
+++ b/packages/ca-certs/ca-certs.0.1.3/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Detect root CA certificates from the operating system"
+description: """
+TLS requires a set of root anchors (Certificate Authorities) to
+authenticate servers. This library exposes this list so that it can be
+registered with ocaml-tls.
+"""
+maintainer: ["Etienne Millon <me@emillon.org>"]
+authors: [
+  "Etienne Millon <me@emillon.org>, Hannes Mehnert <hannes@mehnert.org>"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs"
+doc: "https://mirage.github.io/ca-certs/doc"
+bug-reports: "https://github.com/mirage/ca-certs/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "astring"
+  "bos"
+  "fpath"
+  "rresult"
+  "ptime"
+  "logs"
+  "mirage-crypto"
+  "x509" {>= "0.11.0"}
+  "ocaml" {>= "4.07.0"}
+  "alcotest" {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ca-certs.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"} # the opam sandbox on macos leads to test failures (ocaml/opam#4389)
+    "@doc" {with-doc}
+  ]
+]
+tags: ["org:mirage"]
+depexts: [
+  ["ca_root_nss"] {os = "freebsd"}
+]
+x-commit-hash: "00491224306525c50e020831e7385c10ba3287c1"
+url {
+  src:
+    "https://github.com/mirage/ca-certs/releases/download/v0.1.3/ca-certs-v0.1.3.tbz"
+  checksum: [
+    "sha256=f60bf04e45482c39601f51212ed2aa8662c5fc415d34f0a2e91c59716587ef4a"
+    "sha512=c67ae9f71e9bdd10fecf92df6f794c6f62e5270b584cef14bb2134a6b1452535f8399d8dbf644d02da6b27798477411cc0324f490ec3ab0819fba61f1e5a22a5"
+  ]
+}


### PR DESCRIPTION
Detect root CA certificates from the operating system

- Project page: <a href="https://github.com/mirage/ca-certs">https://github.com/mirage/ca-certs</a>
- Documentation: <a href="https://mirage.github.io/ca-certs/doc">https://mirage.github.io/ca-certs/doc</a>

##### CHANGES:

* Allow some certificates to fail decoding (mirage/ca-certs#11, reported by @mattpallissard
  in mirleft/ocaml-x509mirage/ca-certs#137)
