### PR TITLE
2 packages from c-cube/tiny_httpd at 0.7

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.7/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.7/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" { >= "4.03.0" }
   "odoc" {with-doc}
   "qtest" { >= "2.9" & with-test}
-  "qcheck" {with-test}
+  "qcheck" {>= "0.9" & with-test}
 ]
 tags: [ "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver" ]
 homepage: "https://github.com/c-cube/tiny_httpd/"

--- a/packages/tiny_httpd/tiny_httpd.0.7/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.7/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Minimal HTTP server using good old threads"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" } # for now, since qtest needs old dune
+  "base-threads"
+  "ocaml" { >= "4.03.0" }
+  "odoc" {with-doc}
+  "qtest" { >= "2.9" & with-test}
+  "qcheck" {with-test}
+]
+tags: [ "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+post-messages: "tiny http server, with blocking IOs. Also ships with a `http_of_dir` program."
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/0.7.tar.gz"
+  checksum: [
+    "md5=eaa23afea2f49c451875bfd57a4eb481"
+    "sha512=951d6f4b7ce9e4afece01a184d6900e0d5f0159b8727f4596744b01cb5e3d9a5ea0c0a02143e48af0f3c3ae56f6bebbf1963095ebcc49dbedc57aa9bdd1e4ab2"
+  ]
+}

--- a/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.7/opam
+++ b/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Interface to camlzip for tiny_httpd"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "camlzip"
+  "tiny_httpd" { = version }
+  "ocaml" { >= "4.03.0" }
+  "odoc" {with-doc}
+]
+tags: [ "http" "thread" "server" "gzip" "camlzip" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/0.7.tar.gz"
+  checksum: [
+    "md5=eaa23afea2f49c451875bfd57a4eb481"
+    "sha512=951d6f4b7ce9e4afece01a184d6900e0d5f0159b8727f4596744b01cb5e3d9a5ea0c0a02143e48af0f3c3ae56f6bebbf1963095ebcc49dbedc57aa9bdd1e4ab2"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`tiny_httpd.0.7`: Minimal HTTP server using good old threads
-`tiny_httpd_camlzip.0.7`: Interface to camlzip for tiny_httpd



---
* Homepage: https://github.com/c-cube/tiny_httpd/
* Source repo: git+https://github.com/c-cube/tiny_httpd.git
* Bug tracker: https://github.com/c-cube/tiny_httpd/issues

---
:camel: Pull-request generated by opam-publish v2.0.0