### PR TITLE
Package mc2.0.1

### DIFF
--- a/packages/mc2/mc2.0.1/opam
+++ b/packages/mc2/mc2.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A mcsat-based SMT solver in pure OCaml"
+authors: [
+  "Simon Cruanes"
+  "Guillaume Bury"
+]
+license: "Apache"
+tags: ["sat" "smt" "mcsat"]
+homepage: "https://github.com/c-cube/mc2"
+bug-reports: "https://github.com/c-cube/mc2/issues/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "zarith" { >= "1.9" }
+  "menhir"
+  "containers" { >= "3.0" & < "4.0" }
+  "iter" { >= "1.0" }
+  "smtlib-utils" { >= "0.1" & < "0.3" }
+  "dune" { >= "1.11" }
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/mc2.git"
+url {
+  src: "https://github.com/c-cube/mc2/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=92de696251ec76fbf3eba6ee917fd80f"
+    "sha512=e88ba0cfc23186570a52172a0bd7c56053273941eaf3cda0b80fb6752e05d1b75986b01a4e4d46d9711124318e57cba1cd92d302e81d34f9f1ae8b49f39114f0"
+  ]
+}


### PR DESCRIPTION
### `mc2.0.1`
A mcsat-based SMT solver in pure OCaml



---
* Homepage: https://github.com/c-cube/mc2
* Source repo: git+https://github.com/c-cube/mc2.git
* Bug tracker: https://github.com/c-cube/mc2/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0