### PR TITLE
[new release] rusage (1.0.0)

### DIFF
--- a/packages/rusage/rusage.1.0.0/opam
+++ b/packages/rusage/rusage.1.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Bindings to the GETRUSAGE(2) syscall"
+description: "Bindings to the GETRUSAGE(2) syscall"
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Zach Shipko"]
+homepage: "https://github.com/CraigFe/ocaml-rusage"
+doc: "https://CraigFe.github.io/ocaml-rusage/"
+bug-reports: "https://github.com/CraigFe/ocaml-rusage/issues"
+depends: [
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CraigFe/ocaml-rusage.git"
+x-commit-hash: "de8d2b300344d3a57be4744a4f4d9806e90c0211"
+url {
+  src:
+    "https://github.com/CraigFe/ocaml-rusage/releases/download/1.0.0/rusage-1.0.0.tbz"
+  checksum: [
+    "sha256=3a0600d857b5828aa868e4b8e59e8504934d60dfeeabe290a14c06f0a4a8e859"
+    "sha512=518b4a039da71ac579597b1a58420b872e60614f364b88603cd1f07a153f679d52e6fb18c83e2d58bbdf749a6626733b31d92c0e0a8dadf30111c3e55e6c9859"
+  ]
+}


### PR DESCRIPTION
Bindings to the GETRUSAGE(2) syscall

- Project page: <a href="https://github.com/CraigFe/ocaml-rusage">https://github.com/CraigFe/ocaml-rusage</a>
- Documentation: <a href="https://CraigFe.github.io/rusage/">https://CraigFe.github.io/ocaml-rusage/</a>

##### CHANGES:

Initial release.
