### PR TITLE
Fix primes package build instructions

### DIFF
--- a/packages/primes/primes.1.3.3/opam
+++ b/packages/primes/primes.1.3.3/opam
@@ -6,12 +6,11 @@ dev-repo: "git+https://github.com/KitFreddura/OCaml-Primes.git"
 homepage: "https://github.com/KitFreddura/OCaml-Primes"
 bug-reports: "https://github.com/KitFreddura/OCaml-Primes/issues/new"
 build: [
-  ["ocamlfind" "ocamlc" "-c" "-linkpkg" "-package" "zarith" "primes.mli"]
-  ["ocamlfind" "ocamlc" "-o" "primes.cma" "primes.ml" "-linkpkg" "-package" "zarith,core,gen" "-thread"]
-  ["ocamlfind" "ocamlopt" "-o" "primes.cmxa" "primes.ml" "-linkpkg" "-package" "zarith,core,gen" "-thread"]
+       ["ocamlfind" "ocamlc" "-bin-annot" "-c" "-linkpkg" "-package" "zarith" "primes.mli"]
+       ["ocamlfind" "ocamlmklib" "-o" "primes" "primes.ml" "-linkpkg" "-package" "zarith,gen"]
 ]
 install: [
-  ["ocamlfind" "install" "primes" "META" "primes.cma" "primes.cmxa" "primes.cmo" "primes.cmi" "primes.mli" "primes.o" "primes.cmx"]
+  ["ocamlfind" "install" "primes" "META" "primes.cma" "primes.cmxa" "primes.cmo" "primes.cmi" "primes.mli" "primes.o" "primes.cmx" "primes.cmti"]
 ]
 depends: [
   "ocaml" {>= "4.02"}

--- a/packages/primes/primes.1.3.3/opam
+++ b/packages/primes/primes.1.3.3/opam
@@ -6,8 +6,8 @@ dev-repo: "git+https://github.com/KitFreddura/OCaml-Primes.git"
 homepage: "https://github.com/KitFreddura/OCaml-Primes"
 bug-reports: "https://github.com/KitFreddura/OCaml-Primes/issues/new"
 build: [
-       ["ocamlfind" "ocamlc" "-bin-annot" "-c" "-linkpkg" "-package" "zarith" "primes.mli"]
-       ["ocamlfind" "ocamlmklib" "-o" "primes" "primes.ml" "-linkpkg" "-package" "zarith,gen"]
+  ["ocamlfind" "ocamlc" "-bin-annot" "-c" "-linkpkg" "-package" "zarith" "primes.mli"]
+  ["ocamlfind" "ocamlmklib" "-o" "primes" "primes.ml" "-linkpkg" "-package" "zarith,core,gen"]
 ]
 install: [
   ["ocamlfind" "install" "primes" "META" "primes.cma" "primes.cmxa" "primes.cmo" "primes.cmi" "primes.mli" "primes.o" "primes.cmx" "primes.cmti"]

--- a/packages/primes/primes.1.3.5/opam
+++ b/packages/primes/primes.1.3.5/opam
@@ -6,12 +6,11 @@ dev-repo: "git+https://github.com/KitFreddura/OCaml-Primes.git"
 homepage: "https://github.com/KitFreddura/OCaml-Primes"
 bug-reports: "https://github.com/KitFreddura/OCaml-Primes/issues/new"
 build: [
-  ["ocamlfind" "ocamlc" "-c" "-linkpkg" "-package" "zarith" "primes.mli"]
-  ["ocamlfind" "ocamlc" "-o" "primes.cma" "primes.ml" "-linkpkg" "-package" "zarith,gen" "-thread"]
-  ["ocamlfind" "ocamlopt" "-o" "primes.cmxa" "primes.ml" "-linkpkg" "-package" "zarith,gen" "-thread"]
+       ["ocamlfind" "ocamlc" "-bin-annot" "-c" "-linkpkg" "-package" "zarith" "primes.mli"]
+       ["ocamlfind" "ocamlmklib" "-o" "primes" "primes.ml" "-linkpkg" "-package" "zarith,gen"]
 ]
 install: [
-  ["ocamlfind" "install" "primes" "META" "primes.cma" "primes.cmxa" "primes.cmo" "primes.cmi" "primes.mli" "primes.o" "primes.cmx"]
+  ["ocamlfind" "install" "primes" "META" "primes.cma" "primes.cmxa" "primes.cmo" "primes.cmi" "primes.mli" "primes.o" "primes.cmx" "primes.cmti" ]
 ]
 depends: [
   "ocaml" {>= "4.02"}

--- a/packages/primes/primes.1.3.5/opam
+++ b/packages/primes/primes.1.3.5/opam
@@ -6,8 +6,8 @@ dev-repo: "git+https://github.com/KitFreddura/OCaml-Primes.git"
 homepage: "https://github.com/KitFreddura/OCaml-Primes"
 bug-reports: "https://github.com/KitFreddura/OCaml-Primes/issues/new"
 build: [
-       ["ocamlfind" "ocamlc" "-bin-annot" "-c" "-linkpkg" "-package" "zarith" "primes.mli"]
-       ["ocamlfind" "ocamlmklib" "-o" "primes" "primes.ml" "-linkpkg" "-package" "zarith,gen"]
+  ["ocamlfind" "ocamlc" "-bin-annot" "-c" "-linkpkg" "-package" "zarith" "primes.mli"]
+  ["ocamlfind" "ocamlmklib" "-o" "primes" "primes.ml" "-linkpkg" "-package" "zarith,gen"]
 ]
 install: [
   ["ocamlfind" "install" "primes" "META" "primes.cma" "primes.cmxa" "primes.cmo" "primes.cmi" "primes.mli" "primes.o" "primes.cmx" "primes.cmti" ]


### PR DESCRIPTION
While building documentation, @thomasblanc noticed that the `primes` package files are broken, the .cma/.cmxa are executable install of libraries. This PR should fix these problems.
