### PR TITLE
[new release] sihl-email, sihl-queue, sihl-storage and sihl (0.1.10)

### DIFF
--- a/packages/sihl-email/sihl-email.0.1.10/opam
+++ b/packages/sihl-email/sihl-email.0.1.10/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A Sihl service for sending emails using Lwt"
+description: """
+
+A Sihl service for sending emails using Lwt. Various email transports are provided that can be used in production or testing such as SMTP, Sendgrid, in-memory and console printing."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "letters" {>= "0.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "03f08e7485c50b9da92670c084d3d5e23f7733e6"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.1.10/sihl-queue-0.1.10.tbz"
+  checksum: [
+    "sha256=b264f357c2a65dbed00c3459be76cdd9b21275aeb9d0289634a2050161665211"
+    "sha512=b22fa96a3c7fa607df04848b40a0f54890f4f63c519d10ff7fcef8ccf09341731b42ff4decccb4a7e858e138a803c849ee0c5226c514938cdcded2fd80cae4cb"
+  ]
+}

--- a/packages/sihl-queue/sihl-queue.0.1.10/opam
+++ b/packages/sihl-queue/sihl-queue.0.1.10/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A Sihl service for queue jobs"
+description: """
+
+A Sihl service for putting and working jobs on queues. Various queue backends are provided."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "03f08e7485c50b9da92670c084d3d5e23f7733e6"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.1.10/sihl-queue-0.1.10.tbz"
+  checksum: [
+    "sha256=b264f357c2a65dbed00c3459be76cdd9b21275aeb9d0289634a2050161665211"
+    "sha512=b22fa96a3c7fa607df04848b40a0f54890f4f63c519d10ff7fcef8ccf09341731b42ff4decccb4a7e858e138a803c849ee0c5226c514938cdcded2fd80cae4cb"
+  ]
+}

--- a/packages/sihl-storage/sihl-storage.0.1.10/opam
+++ b/packages/sihl-storage/sihl-storage.0.1.10/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A Sihl service for storing and retrieving large files"
+description: """
+
+This service can be used to handle large binary blobs that are typically not stored in relational databases. Various storage backends are provided."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "03f08e7485c50b9da92670c084d3d5e23f7733e6"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.1.10/sihl-queue-0.1.10.tbz"
+  checksum: [
+    "sha256=b264f357c2a65dbed00c3459be76cdd9b21275aeb9d0289634a2050161665211"
+    "sha512=b22fa96a3c7fa607df04848b40a0f54890f4f63c519d10ff7fcef8ccf09341731b42ff4decccb4a7e858e138a803c849ee0c5226c514938cdcded2fd80cae4cb"
+  ]
+}

--- a/packages/sihl/sihl.0.1.10/opam
+++ b/packages/sihl/sihl.0.1.10/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "The modular functional web framework"
+description: "Build web apps fast with long-term maintainability in mind."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.3.0"}
+  "opium" {>= "0.17.1"}
+  "multipart-form-data" {>= "0.3.0"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.5.2"}
+  "conformist" {>= "0.1.0"}
+  "tsort" {>= "2.0.0"}
+  "tls" {>= "0.11.1"}
+  "ssl" {>= "0.5.9"}
+  "lwt_ssl" {>= "1.1.3"}
+  "caqti" {>= "1.2.1"}
+  "caqti-lwt" {>= "1.2.0"}
+  "tyxml" {>= "4.3.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.8"}
+  "safepass" {>= "3.0"}
+  "jwto" {>= "0.3.0"}
+  "uuidm" {>= "0.9.7"}
+  "sexplib" {>= "v0.13.0"}
+  "ppx_fields_conv" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "alcotest" {>= "1.2.0"}
+  "alcotest-lwt" {>= "1.2.0" & < "3.0.0" & with-test}
+  "cohttp-lwt-unix" {>= "2.5.1" & < "3.0.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "03f08e7485c50b9da92670c084d3d5e23f7733e6"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.1.10/sihl-queue-0.1.10.tbz"
+  checksum: [
+    "sha256=b264f357c2a65dbed00c3459be76cdd9b21275aeb9d0289634a2050161665211"
+    "sha512=b22fa96a3c7fa607df04848b40a0f54890f4f63c519d10ff7fcef8ccf09341731b42ff4decccb4a7e858e138a803c849ee0c5226c514938cdcded2fd80cae4cb"
+  ]
+}


### PR DESCRIPTION
A Sihl service for sending emails using Lwt

- Project page: <a href="https://github.com/oxidizing/sihl">https://github.com/oxidizing/sihl</a>
- Documentation: <a href="https://oxidizing.github.io/sihl/">https://oxidizing.github.io/sihl/</a>

##### CHANGES:

### Fixed
- Properly load `.env` files based on project root, can be set using `ENV_FILES_PATH`
- Add custom error types for user actions to allow overriding errors displayed to users

### Added
- Determine project rood using markers such as the .git folder
