### PR TITLE
[new release] emile (1.1)

### DIFF
--- a/packages/emile/emile.1.1/opam
+++ b/packages/emile/emile.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/emile"
+bug-reports:  "https://github.com/dinosaure/emile/issues"
+dev-repo:     "git+https://github.com/dinosaure/emile.git"
+doc:          "https://dinosaure.github.io/emile/"
+license:      "MIT"
+synopsis:     "Parser of email address according RFC822"
+description: """A parser of email address according RFC822, RFC2822, RFC5321 and RFC6532.
+It handles UTF-8 email addresses and encoded-word according RFC2047."""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {>= "1.0"}
+  "angstrom" {>= "0.14.0"}
+  "ipaddr"   {>= "2.7.0"}
+  "base64"   {>= "3.0.0"}
+  "pecu"
+  "uutf"
+  "alcotest" {with-test}
+]
+depopts: [ "cmdliner" ]
+x-commit-hash: "8281eb5bee3063968972010a3b306b4e23066d8a"
+url {
+  src:
+    "https://github.com/dinosaure/emile/releases/download/v1.1/emile-v1.1.tbz"
+  checksum: [
+    "sha256=1759253996b53b84ff1a2b76ff30c3614bc61cb02ff8a500480be4a96a202164"
+    "sha512=b53df652cd9c585d2720cf1ad6b877a11e3779b4edda08d6b965557721d46538cd10dd8a7a3a6316dc6a3785ae66167785529619e31f40e7dfde01faaf692c7f"
+  ]
+}


### PR DESCRIPTION
Parser of email address according RFC822

- Project page: <a href="https://github.com/dinosaure/emile">https://github.com/dinosaure/emile</a>
- Documentation: <a href="https://dinosaure.github.io/emile/">https://dinosaure.github.io/emile/</a>

##### CHANGES:

- Add some tests to check the behavior of the pretty-printer (@dinosaure, dinosaure/emile#14)
- Fix the implementation of the quoted-string (@dinosaure, dinosaure/emile#14)
- Fix internal list pretty-printer (discovered by @hannes, @dinosaure, dinosaure/emile#14)
