### PR TITLE
[new release] mirage-clock-freestanding, mirage-clock and mirage-clock-unix (3.1.0)

### DIFF
--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.3.1.0/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.3.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Paravirtual implementation of the MirageOS Clock interface"
+description: """
+This 'freestanding' implementation of the MirageOS CLOCK interface
+is designed to be linked against an embedded runtime that provides
+a concrete implementation of the clock source. Example implementations
+include the [Solo5](https://github.com/solo5/solo5) backend of
+MirageOS.
+"""
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "mirage-clock" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git://github.com/mirage/mirage-clock"
+x-commit-hash: "987d197802f80778b7b3daa642caee0c27a1ce43"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v3.1.0/mirage-clock-v3.1.0.tbz"
+  checksum: [
+    "sha256=b602556cda4f9819cd01c54791d6fe01cd9d9721d4051d7703bcaa89d5010a33"
+    "sha512=a1dbac3ae5671e02d77ebe5b9d8c53d787c0fcce59ec74a5d5ebd5ed28919d838ef6ab1c00ee18e0c261f7bafcb86de34548f1271129838b77654ee1a82ca4ff"
+  ]
+}

--- a/packages/mirage-clock-unix/mirage-clock-unix.3.1.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.3.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Unix-based implementation for the MirageOS Clock interface"
+description: """
+The Unix implementation of the MirageOS Clock interface uses
+`gettimeofday` or `clock_gettime`, depending on
+which OS is in use (see [clock_stubs.c](https://github.com/mirage/mirage-clock/blob/master/unix/clock_stubs.c)).
+"""
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "dune-configurator"
+  "mirage-clock" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+x-commit-hash: "987d197802f80778b7b3daa642caee0c27a1ce43"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v3.1.0/mirage-clock-v3.1.0.tbz"
+  checksum: [
+    "sha256=b602556cda4f9819cd01c54791d6fe01cd9d9721d4051d7703bcaa89d5010a33"
+    "sha512=a1dbac3ae5671e02d77ebe5b9d8c53d787c0fcce59ec74a5d5ebd5ed28919d838ef6ab1c00ee18e0c261f7bafcb86de34548f1271129838b77654ee1a82ca4ff"
+  ]
+}

--- a/packages/mirage-clock/mirage-clock.3.1.0/opam
+++ b/packages/mirage-clock/mirage-clock.3.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Libraries and module types for portable clocks"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirage.io) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements an `MCLOCK` module that represents a monotonic timesource
+since an arbitrary point, and `PCLOCK` which counts time since the Unix
+epoch.
+"""
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+x-commit-hash: "987d197802f80778b7b3daa642caee0c27a1ce43"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v3.1.0/mirage-clock-v3.1.0.tbz"
+  checksum: [
+    "sha256=b602556cda4f9819cd01c54791d6fe01cd9d9721d4051d7703bcaa89d5010a33"
+    "sha512=a1dbac3ae5671e02d77ebe5b9d8c53d787c0fcce59ec74a5d5ebd5ed28919d838ef6ab1c00ee18e0c261f7bafcb86de34548f1271129838b77654ee1a82ca4ff"
+  ]
+}


### PR DESCRIPTION
Paravirtual implementation of the MirageOS Clock interface

- Project page: <a href="https://github.com/mirage/mirage-clock">https://github.com/mirage/mirage-clock</a>

##### CHANGES:

* Use implicit executable dependency for discover.exe
  into the dune file (mirage/mirage-clock#46 @TheLortex)
* Fix cross-compilation on Android (mirage/mirage-clock#45 @EduardoRFS)
