### PR TITLE
Package embedded_ocaml_templates.0.5

### DIFF
--- a/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.5/opam
+++ b/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.5/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "EML is a simple templating language that lets you generate text with plain OCaml"
+description: """
+Inspired by EJS templates, it does currently implements all of its functionnality. 
+I plan to implement everything eventually, especially if someone actually want to use this.
+Please contact me if you find this interesting but there is a missing feature that you need !
+"""
+maintainer: "Emile Trotignon emile.trotignon@gmail.com"
+authors: "Emile Trotignon emile.trotignon@gmail.com"
+license: "MIT"
+homepage: "https://github.com/EmileTrotignon/embedded_ocaml_templates"
+bug-reports: "https://github.com/EmileTrotignon/embedded_ocaml_templates/issues"
+dev-repo: "git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git"
+depends: [ 
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.5.0"} 
+    "sedlex" { >= "2.0" }
+    "core" {>= "v0.12"}
+    "uutf" 
+    "menhir" 
+    "ppxlib"
+    "ppx_deriving"
+    "containers"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/EmileTrotignon/embedded_ocaml_templates/archive/0.5.tar.gz"
+  checksum: [
+    "md5=26460887be02f4d285c6a36dfcf303a4"
+    "sha512=5278de26aefdf3f3476528e2b73182732d93a4e3b7ed17d0e16e8dd67ed502a021fb450c6e6d140d3563053566925bcd1c9322067565111e5feba5d7e1853142"
+  ]
+}


### PR DESCRIPTION
### `embedded_ocaml_templates.0.5`
EML is a simple templating language that lets you generate text with plain OCaml
Inspired by EJS templates, it does currently implements all of its functionnality. 
I plan to implement everything eventually, especially if someone actually want to use this.
Please contact me if you find this interesting but there is a missing feature that you need !

Now supports whitespace slurping and printf-syntax for types other than string.

---
* Homepage: https://github.com/EmileTrotignon/embedded_ocaml_templates
* Source repo: git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git
* Bug tracker: https://github.com/EmileTrotignon/embedded_ocaml_templates/issues

---
:camel: Pull-request generated by opam-publish v2.0.2