### PR TITLE
conf-gnomecanvas: Add support for alpine and ubuntu/arch-derived distributions

### DIFF
--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -6,9 +6,11 @@ license: "LGPL-2.1-or-later"
 build: [["pkg-config" "libgnomecanvas-2.0"]]
 depexts: [
   ["libgnomecanvas2-dev"] {os-family = "debian"}
+  ["libgnomecanvas2-dev"] {os-family = "ubuntu"}
   ["libgnomecanvas-devel"] {os-family = "fedora" | os-family = "rhel"}
   ["libgnomecanvas"] {os = "macos" & os-distribution = "homebrew"}
-  ["libgnomecanvas"] {os-distribution = "arch"}
+  ["libgnomecanvas-dev"] {os-family = "alpine"}
+  ["libgnomecanvas"] {os-family = "arch"}
   ["libgnomecanvas"] {os = "freebsd"}
   ["libgnomecanvas"] {os = "openbsd"}
   ["gnome2.libgnomecanvas"] {os-distribution = "nixos"}

--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -9,7 +9,7 @@ depexts: [
   ["libgnomecanvas2-dev"] {os-family = "ubuntu"}
   ["libgnomecanvas-devel"] {os-family = "fedora" | os-family = "rhel"}
   ["libgnomecanvas"] {os = "macos" & os-distribution = "homebrew"}
-  ["libgnomecanvas-dev"] {os-family = "alpine"}
+  ["libgnomecanvas-dev@testing"] {os-family = "alpine"}
   ["libgnomecanvas"] {os-family = "arch"}
   ["libgnomecanvas"] {os = "freebsd"}
   ["libgnomecanvas"] {os = "openbsd"}


### PR DESCRIPTION
Issue detected in https://github.com/ocaml/opam-repository/pull/17670