### PR TITLE
tcpip < 5.0.1: Disable all the tests (fixed in tcpip.5.0.1)

### DIFF
--- a/packages/tcpip/tcpip.4.0.0/opam
+++ b/packages/tcpip/tcpip.4.0.0/opam
@@ -15,7 +15,7 @@ tags: ["org:mirage"]
 build: [
   ["dune" "subst"] {pinned}
   ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs]
-  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "runtest" "-p" name "-j" "1"] {with-test}
 ]
 
 depopts: ["mirage-xen-ocaml"]
@@ -33,7 +33,7 @@ depends: [
   "mirage-protocols" {>= "4.0.0" & < "5.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "4.0.0"}
-  "ipaddr" {with-test & < "5.0.0"}
+#  "ipaddr" {with-test & < "5.0.0"}
   "macaddr" {>="4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
@@ -44,13 +44,13 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "2.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
-  "alcotest" {with-test & >="0.7.0"}
-  "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "3.0.0"}
-  "mirage-random-test" {with-test & >= "0.1.0"}
-  "arp-mirage" {with-test & >= "2.0.0"}
+#  "mirage-flow" {with-test & >= "2.0.0"}
+#  "mirage-vnetif" {with-test & >= "0.5.0"}
+#  "alcotest" {with-test & >="0.7.0"}
+#  "pcap-format" {with-test}
+#  "mirage-clock-unix" {with-test & >= "3.0.0"}
+#  "mirage-random-test" {with-test & >= "0.1.0"}
+#  "arp-mirage" {with-test & >= "2.0.0"}
   "lru" {>= "0.3.0"}
 ]
 synopsis: "OCaml TCP/IP networking stack, used in MirageOS"

--- a/packages/tcpip/tcpip.4.1.0/opam
+++ b/packages/tcpip/tcpip.4.1.0/opam
@@ -15,7 +15,7 @@ tags: ["org:mirage"]
 build: [
   ["dune" "subst"] {pinned}
   ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs]
-  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "runtest" "-p" name "-j" "1"] {with-test}
 ]
 
 depopts: ["mirage-xen-ocaml"]
@@ -33,7 +33,7 @@ depends: [
   "mirage-protocols" {>= "4.0.0" & < "5.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "4.0.0"}
-  "ipaddr" {with-test & < "5.0.0"}
+#  "ipaddr" {with-test & < "5.0.0"}
   "macaddr" {>="4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
@@ -44,13 +44,13 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "2.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
-  "alcotest" {with-test & >="0.7.0"}
-  "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "3.0.0"}
-  "mirage-random-test" {with-test & >= "0.1.0"}
-  "arp-mirage" {with-test & >= "2.0.0"}
+#  "mirage-flow" {with-test & >= "2.0.0"}
+#  "mirage-vnetif" {with-test & >= "0.5.0"}
+#  "alcotest" {with-test & >="0.7.0"}
+#  "pcap-format" {with-test}
+#  "mirage-clock-unix" {with-test & >= "3.0.0"}
+#  "mirage-random-test" {with-test & >= "0.1.0"}
+#  "arp-mirage" {with-test & >= "2.0.0"}
   "lru" {>= "0.3.0"}
 ]
 synopsis: "OCaml TCP/IP networking stack, used in MirageOS"

--- a/packages/tcpip/tcpip.5.0.0/opam
+++ b/packages/tcpip/tcpip.5.0.0/opam
@@ -15,7 +15,7 @@ tags: ["org:mirage"]
 build: [
   ["dune" "subst"] {pinned}
   ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs]
-  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "runtest" "-p" name "-j" "1"] {with-test}
 ]
 
 depopts: ["mirage-xen-ocaml"]
@@ -43,13 +43,13 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "2.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
-  "alcotest" {with-test & >="0.7.0"}
-  "pcap-format" {with-test}
-  "mirage-clock-unix" {with-test & >= "3.0.0"}
-  "mirage-random-test" {with-test & >= "0.1.0"}
-  "arp-mirage" {with-test & >= "2.0.0"}
+#  "mirage-flow" {with-test & >= "2.0.0"}
+#  "mirage-vnetif" {with-test & >= "0.5.0"}
+#  "alcotest" {with-test & >="0.7.0"}
+#  "pcap-format" {with-test}
+#  "mirage-clock-unix" {with-test & >= "3.0.0"}
+#  "mirage-random-test" {with-test & >= "0.1.0"}
+#  "arp-mirage" {with-test & >= "2.0.0"}
   "lru" {>= "0.3.0"}
 ]
 synopsis: "OCaml TCP/IP networking stack, used in MirageOS"


### PR DESCRIPTION
Hopefully this fixes the issue. If not I'll disable the tests entirely