### PR TITLE
[new release] mlbdd (0.7.1)

### DIFF
--- a/packages/mlbdd/mlbdd.0.7.1/opam
+++ b/packages/mlbdd/mlbdd.0.7.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "An OCaml library for Binary Decision Diagrams (BDDs)"
+description:
+  "The mlbdd library provides a simple, easy-to-use, easy-to-extend implementation of binary decision diagrams (BDDs) in OCaml. It is well tested and well documented. The library itself has no dependencies and is thus easy to include in applications that might, for example, be compiled with js_of_ocaml or other tools that rely on pure OCaml. It is also easier to integrate with existing projects due to its lack of dependencies.  Critically, this BDD implementation uses a garbage-collection-aware hashing scheme, so that unused nodes can be collected.  Additionally, this implementation uses complement edges to significantly improve performance over the simplest BDD implementations."
+maintainer: ["Arlen Cox <arlencox@gmail.com>"]
+authors: ["Arlen Cox <arlencox@gmail.com>"]
+license: "BSD"
+homepage: "https://github.com/arlencox/mlbdd"
+bug-reports: "https://github.com/arlencox/mlbdd/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arlencox/mlbdd.git"
+x-commit-hash: "e045847a1f82a766be9140c825e6e6cad69329ac"
+url {
+  src:
+    "https://github.com/arlencox/mlbdd/releases/download/v0.7.1/mlbdd-v0.7.1.tbz"
+  checksum: [
+    "sha256=473c038d15c01d15439e197701a6ca540d1b120f360f577122aa1b61deb65aef"
+    "sha512=4a105c483ee8b5538ab50cd82094e513b2d5b06c4f6f0d4df79aa8bb1ba47f35bebb0514d75099d94dd8396a5511b73dcf2eb329793412534ad7cdd97a9f4612"
+  ]
+}


### PR DESCRIPTION
An OCaml library for Binary Decision Diagrams (BDDs)

- Project page: <a href="https://github.com/arlencox/mlbdd">https://github.com/arlencox/mlbdd</a>

##### CHANGES:

- Fixed install
