### PR TITLE
[new release] mlbdd (0.7.2)

### DIFF
--- a/packages/mlbdd/mlbdd.0.7.2/opam
+++ b/packages/mlbdd/mlbdd.0.7.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "An OCaml library for Binary Decision Diagrams (BDDs)"
+description:
+  "The mlbdd library provides a simple, easy-to-use, easy-to-extend implementation of binary decision diagrams (BDDs) in OCaml. It is well tested and well documented. The library itself has no dependencies and is thus easy to include in applications that might, for example, be compiled with js_of_ocaml or other tools that rely on pure OCaml. It is also easier to integrate with existing projects due to its lack of dependencies.  Critically, this BDD implementation uses a garbage-collection-aware hashing scheme, so that unused nodes can be collected.  Additionally, this implementation uses complement edges to significantly improve performance over the simplest BDD implementations."
+maintainer: ["Arlen Cox <arlencox@gmail.com>"]
+authors: ["Arlen Cox <arlencox@gmail.com>"]
+license: "BSD"
+homepage: "https://github.com/arlencox/mlbdd"
+bug-reports: "https://github.com/arlencox/mlbdd/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ounit2" {with-test}
+  "ocaml" {>= "4.04.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arlencox/mlbdd.git"
+x-commit-hash: "ec4c5ec840056d46a482bf3a1326a8eac1015088"
+url {
+  src:
+    "https://github.com/arlencox/mlbdd/releases/download/v0.7.2/mlbdd-v0.7.2.tbz"
+  checksum: [
+    "sha256=26e07017d63c9e05ae83f1b4f4b31f2f74914623eeb867e12238e3bbebb072f7"
+    "sha512=39ac26e8350b4f030237dcf39c3236483d6528bb12d77bc3ce23efede39a4b9d7eab74f9bdcd2ac59e56db056d70422fbcd506b272a7a2c896ef8be3d747d635"
+  ]
+}


### PR DESCRIPTION
An OCaml library for Binary Decision Diagrams (BDDs)

- Project page: <a href="https://github.com/arlencox/mlbdd">https://github.com/arlencox/mlbdd</a>

##### CHANGES:

- Fixed install
