### PR TITLE
Fix revdeps for the next release of lwt_ppx (switch to ppxlib)

### DIFF
--- a/packages/eliom/eliom.6.10.1/opam
+++ b/packages/eliom/eliom.6.10.1/opam
@@ -22,6 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.5.1"}
   "lwt_log"
   "lwt_ppx"
+  "ppx_tools_versioned"
   "tyxml" {>= "4.3.0" & < "4.4.0"}
   "ocsigenserver" {>= "2.10"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.11.0/opam
+++ b/packages/eliom/eliom.6.11.0/opam
@@ -22,6 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.5.1"}
   "lwt_log"
   "lwt_ppx"
+  "ppx_tools_versioned"
   "tyxml" {>= "4.4.0" & < "5.0.0"}
   "ocsigenserver" {>= "2.10"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.12.0/opam
+++ b/packages/eliom/eliom.6.12.0/opam
@@ -22,6 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.5.1"}
   "lwt_log"
   "lwt_ppx"
+  "ppx_tools_versioned"
   "tyxml" {>= "4.4.0" & < "5.0.0"}
   "ocsigenserver" {>= "2.10"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.12.1/opam
+++ b/packages/eliom/eliom.6.12.1/opam
@@ -22,6 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.5.1"}
   "lwt_log"
   "lwt_ppx"
+  "ppx_tools_versioned"
   "tyxml" {>= "4.4.0" & < "5.0.0"}
   "ocsigenserver" {>= "2.10"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.12.4/opam
+++ b/packages/eliom/eliom.6.12.4/opam
@@ -22,6 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.5.1"}
   "lwt_log"
   "lwt_ppx"
+  "ppx_tools_versioned"
   "tyxml" {>= "4.4.0" & < "5.0.0"}
   "ocsigenserver" {>= "2.10"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.8.0/opam
+++ b/packages/eliom/eliom.6.8.0/opam
@@ -21,6 +21,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.3" & < "3.5.0"}
   "lwt_log"
   "lwt_ppx"
+  "ppx_tools_versioned"
   "tyxml" {>= "4.3.0" & < "4.4.0"}
   "ocsigenserver" {>= "2.10"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.8.1/opam
+++ b/packages/eliom/eliom.6.8.1/opam
@@ -21,6 +21,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.3" & < "3.5"}
   "lwt_log"
   "lwt_ppx"
+  "ppx_tools_versioned"
   "tyxml" {>= "4.3.0" & < "4.4.0"}
   "ocsigenserver" {>= "2.10"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.9.1/opam
+++ b/packages/eliom/eliom.6.9.1/opam
@@ -21,6 +21,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.3" & < "3.5"}
   "lwt_log"
   "lwt_ppx"
+  "ppx_tools_versioned"
   "tyxml" {>= "4.3.0" & < "4.4.0"}
   "ocsigenserver" {>= "2.10"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.9.2/opam
+++ b/packages/eliom/eliom.6.9.2/opam
@@ -22,6 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.3"}
   "lwt_log"
   "lwt_ppx"
+  "ppx_tools_versioned"
   "tyxml" {>= "4.3.0" & < "4.4.0"}
   "ocsigenserver" {>= "2.10"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.9.3/opam
+++ b/packages/eliom/eliom.6.9.3/opam
@@ -22,6 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.3"}
   "lwt_log"
   "lwt_ppx"
+  "ppx_tools_versioned"
   "tyxml" {>= "4.3.0" & < "4.4.0"}
   "ocsigenserver" {>= "2.10"}
   "ipaddr" {>= "2.1"}

--- a/packages/gdbprofiler/gdbprofiler.0.3/opam
+++ b/packages/gdbprofiler/gdbprofiler.0.3/opam
@@ -19,6 +19,7 @@ depends: [
   "lwt_log"
   "containers" {>= "0.20" & < "3.0"}
   "yojson"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 synopsis: "gdbprofiler, a profiler for native OCaml and other executables"
 description:


### PR DESCRIPTION
cc @aantron @raphael-proust, you'll be happy to hear that apart from the minor failures on these packages everything ran smoothly with the new lwt_ppx (using ppxlib), no regression detected :tada: