### PR TITLE
3 packages from gitlab.com/dannywillems/ocaml-ff/-/archive/0.5.0/ocaml-ff-0.5.0.tar.gz

### DIFF
--- a/packages/ff-pbt/ff-pbt.0.5.0/opam
+++ b/packages/ff-pbt/ff-pbt.0.5.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis:
+  "Property based testing library for finite fields over the package ff-sig"
+description:
+  "Property based testing library for finite fields over the package ff-sig"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-ff"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "zarith" {>= "1.9.1" & < "2.0"}
+  "ff-sig" {= "0.5.0"}
+  "alcotest"
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.5.0/ocaml-ff-0.5.0.tar.gz"
+  checksum: [
+    "md5=bb169cc29473e0f41f3c57382a4b9268"
+    "sha512=a23741b42ad362320c2e554b58181941cd8a1e2d078e5c2625126be622216f2efc0d6367e6a4c6a80abd101f10602617c42e821cc4b7175f6891bf2791b0fd27"
+  ]
+}

--- a/packages/ff-sig/ff-sig.0.5.0/opam
+++ b/packages/ff-sig/ff-sig.0.5.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Minimal finite field signatures"
+description: "Minimal finite field signatures"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-ff"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "zarith" {>= "1.9.1" & < "2.0"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.5.0/ocaml-ff-0.5.0.tar.gz"
+  checksum: [
+    "md5=bb169cc29473e0f41f3c57382a4b9268"
+    "sha512=a23741b42ad362320c2e554b58181941cd8a1e2d078e5c2625126be622216f2efc0d6367e6a4c6a80abd101f10602617c42e821cc4b7175f6891bf2791b0fd27"
+  ]
+}

--- a/packages/ff/ff.0.5.0/opam
+++ b/packages/ff/ff.0.5.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml implementation of Finite Field operations"
+description: "OCaml implementation of Finite Field operations"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-ff"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "zarith" {>= "1.9.1" & < "2.0"}
+  "ff-sig" {= "0.5.0"}
+  "alcotest" {with-test}
+  "ff-pbt" {= "0.5.0" & with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.5.0/ocaml-ff-0.5.0.tar.gz"
+  checksum: [
+    "md5=bb169cc29473e0f41f3c57382a4b9268"
+    "sha512=a23741b42ad362320c2e554b58181941cd8a1e2d078e5c2625126be622216f2efc0d6367e6a4c6a80abd101f10602617c42e821cc4b7175f6891bf2791b0fd27"
+  ]
+}


### PR DESCRIPTION
Additional notes. `ff` is now splitted in `ff-sig`, `ff` and `ff-pbt`.

This pull-request concerns:
-`ff.0.5.0`: OCaml implementation of Finite Field operations
-`ff-pbt.0.5.0`: Property based testing library for finite fields over the package ff-sig
-`ff-sig.0.5.0`: Minimal finite field signatures


---
* Homepage: https://gitlab.com/dannywillems/ocaml-ff
* Source repo: git+https://gitlab.com/dannywillems/ocaml-ff.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-ff/issues

---
:camel: Pull-request generated by opam-publish v2.0.2