### PR TITLE
Fix ocaml-variants with ocaml-option-bytecode-only enabled

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.12.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+trunk/opam
@@ -47,7 +47,7 @@ build: [
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"] {!ocaml-option-bytecode-only:installed}
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
@@ -46,7 +46,7 @@ build: [
     "LIBS=-static" {ocaml-option-static:installed}
   ]
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"] {!ocaml-option-bytecode-only:installed}
 ]
 install: [make "install"]
 url {


### PR DESCRIPTION
Current error otherwise:
```
#=== ERROR while compiling ocaml-variants.4.12.0+trunk ========================#
# context              2.1.0~beta3 | linux/x86_64 |  | file:///home/opam/opam-repository
# path                 ~/.opam/4.12.0+trunk/.opam-switch/build/ocaml-variants.4.12.0+trunk
# command              /usr/bin/make -j47 world.opt
# exit-code            2
# env-file             ~/.opam/log/ocaml-variants-7-9fcb43.env
# output-file          ~/.opam/log/ocaml-variants-7-9fcb43.out
### output ###
# Makefile:920: *** The native-code compiler is not supported on this platform.  Stop.
```