### PR TITLE
Package binaryen.0.4.0

### DIFF
--- a/packages/binaryen/binaryen.0.4.0/opam
+++ b/packages/binaryen/binaryen.0.4.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.09"}
+  "dune" {>= "2.7.1"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.4.0/binaryen-archive-v0.4.0.tar.gz"
+  checksum: [
+    "md5=707a45c3e7ede218c378c4d799a186d6"
+    "sha512=beeaecc743c9ec31ef9c75b47e9141e53cd1122ee929ee11bb7ae7f3f2315dc1b544bac9e49539e8640742e2e1f7e4d11bf88e0c7ce0cd0d03ba33eb82a4d770"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.4.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
Changes in this Release
- Upgrade Binaryen to v95
- Add Windows support
- Vendor prebuilt Binaryen for Windows, MacOS, and Linux

---
:camel: Pull-request generated by opam-publish v2.0.2