### PR TITLE
[new release] cairo2, cairo2-pango and cairo2-gtk (0.6.2)

### DIFF
--- a/packages/cairo2-gtk/cairo2-gtk.0.6.2/opam
+++ b/packages/cairo2-gtk/cairo2-gtk.0.6.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <pierre@hauweele.net>" ]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-cairo"
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune"
+  "conf-pkg-config" {build}
+  "conf-cairo"
+  "cairo2" {= version}
+  "lablgtk"
+]
+synopsis: "Rendering Cairo on Gtk2 canvas"
+description: """
+This provides the link between Cairo and Lablgtk.
+"""
+x-commit-hash: "202674a8d0c533b689ceacdb523ca167611e1b4c"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6.2/cairo2-0.6.2.tbz"
+  checksum: [
+    "sha256=6bb3f59225662304fa161b70c6cdbd7df80ee227b1b2e97152873d72726610ae"
+    "sha512=789b65428855c3b8fb71836ee6e607870c3140a6152fb01b8ba6e7d2e2f4842a62412061a5eff99023234d305587b605d0cbbacd29456c86a52e9df6466bd302"
+  ]
+}

--- a/packages/cairo2-pango/cairo2-pango.0.6.2/opam
+++ b/packages/cairo2-pango/cairo2-pango.0.6.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <pierre@hauweele.net>" ]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-cairo"
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune"
+  "conf-pkg-config" {build}
+  "conf-cairo"
+  "cairo2" {= version}
+  "lablgtk"
+]
+synopsis: "Interface between Cairo and Pango (for Gtk2)"
+description: """
+This package provides a way to use Pango (lablgtk, Gtk2) with Cairo.
+"""
+x-commit-hash: "202674a8d0c533b689ceacdb523ca167611e1b4c"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6.2/cairo2-0.6.2.tbz"
+  checksum: [
+    "sha256=6bb3f59225662304fa161b70c6cdbd7df80ee227b1b2e97152873d72726610ae"
+    "sha512=789b65428855c3b8fb71836ee6e607870c3140a6152fb01b8ba6e7d2e2f4842a62412061a5eff99023234d305587b605d0cbbacd29456c86a52e9df6466bd302"
+  ]
+}

--- a/packages/cairo2/cairo2.0.6.2/opam
+++ b/packages/cairo2/cairo2.0.6.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <pierre@hauweele.net>" ]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-cairo"
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune"
+  "dune-configurator"
+  "conf-cairo"
+]
+depopts: [
+  "conf-freetype"
+]
+conflicts: [
+  "cairo" {= "0.4.1"}
+  "cairo" {= "0.4.2"}
+]
+post-messages: [
+  "Try to re-run the install command with PKG_CONFIG_PATH pointing a pkg-config path including libffi, e.g. if you use homebrew you can try PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig" {failure & os = "macos"}
+]
+synopsis: "Binding to Cairo, a 2D Vector Graphics Library"
+description: """
+This is a binding to Cairo, a 2D graphics library with support for
+multiple output devices. Currently supported output targets include
+the X Window System, Quartz, Win32, image buffers, PostScript, PDF,
+and SVG file output."""
+x-commit-hash: "202674a8d0c533b689ceacdb523ca167611e1b4c"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6.2/cairo2-0.6.2.tbz"
+  checksum: [
+    "sha256=6bb3f59225662304fa161b70c6cdbd7df80ee227b1b2e97152873d72726610ae"
+    "sha512=789b65428855c3b8fb71836ee6e607870c3140a6152fb01b8ba6e7d2e2f4842a62412061a5eff99023234d305587b605d0cbbacd29456c86a52e9df6466bd302"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- Fix a memory leak (Chris00/ocaml-cairo#19).
- Fix GCC warnings, in particular the “multiple definition of …” (Chris00/ocaml-cairo#23).
- Clarify the license.
- Use `dune-configurator`.