### PR TITLE
Package gmp.6.2.1

### DIFF
--- a/packages/gmp/gmp.6.2.0/opam
+++ b/packages/gmp/gmp.6.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Lucas Pluvinage <lucas@tarides.com>"
+license:      ["LGPL-3.0-only" "LGPL-2.0-only"]
+authors: "Torbjörn Granlund and contributors"
+homepage: "https://github.com/TheLortex/ocaml-gmp"
+bug-reports: "https://github.com/TheLortex/ocaml-gmp/issues"
+dev-repo: "git+https://github.com/TheLortex/ocaml-gmp.git"
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" {with-test} ]
+]
+depends: [
+  "ocaml" {>="4.05.0"}
+  "dune" {>="2.6"}
+]
+synopsis: "The GNU Multiple Precision Arithmetic Library"
+description: """Dune packaging of the GMP library, suitable for 
+cross-compilation."""
+extra-source "src/gmp-6.2.0.tar.xz" {
+  src: "https://gmplib.org/download/gmp/gmp-6.2.0.tar.xz"
+  checksum: "md5=a325e3f09e6d91e62101e59f9bda3ec1"
+}
+url {
+  src: "https://github.com/TheLortex/ocaml-gmp/archive/6.2.0.tar.gz"
+  checksum: [
+    "md5=ae4b966da7353cc96c70ea19cd1456a1"
+    "sha512=449aa2afb57c9efc8b0e0ae3f52080429e4ee5fbebba2ff42b350b07d8f11bf1e074f1c3fc2408c43b82eddd24dc9cf9179430719f5fec8601e9dfbaca6c717e"
+  ]
+}

--- a/packages/gmp/gmp.6.2.0/opam
+++ b/packages/gmp/gmp.6.2.0/opam
@@ -10,8 +10,9 @@ build: [
  [ "dune" "runtest" {with-test} ]
 ]
 depends: [
-  "ocaml" {>="4.05.0"}
+  "ocaml" {>="4.02.0"}
   "dune" {>="2.6"}
+  "conf-m4"
 ]
 synopsis: "The GNU Multiple Precision Arithmetic Library"
 description: """Dune packaging of the GMP library, suitable for 

--- a/packages/gmp/gmp.6.2.0/opam
+++ b/packages/gmp/gmp.6.2.0/opam
@@ -24,7 +24,7 @@ extra-source "src/gmp-6.2.0.tar.xz" {
 url {
   src: "https://github.com/TheLortex/ocaml-gmp/archive/6.2.0.tar.gz"
   checksum: [
-    "md5=fe47f933ec2f5dabdbbd00a22ed0ae76"
-    "sha512=c1d46c8f93b1f68c585c0c8580a5df9e6647dcb16824038bbb894a44961b9b1a5982a5181f203f11e3c2b994919ef01b40b7bb04446e4b1c1711c005754342e0"
+    "md5=0c1e01c3cfad52ac021f05e974ed443c"
+    "sha512=454f198c712475086c283deebf65de07a0412d1d189d0dedfbb1cbc9fe05a9a09a089b1248eb0aaaf458f34f607bbc93bef9648672b460fa5281c2c64fa73a22"
   ]
 }

--- a/packages/gmp/gmp.6.2.0/opam
+++ b/packages/gmp/gmp.6.2.0/opam
@@ -1,17 +1,17 @@
 opam-version: "2.0"
 maintainer: "Lucas Pluvinage <lucas@tarides.com>"
-license:      ["LGPL-3.0-only" "LGPL-2.0-only"]
+license: ["LGPL-3.0-only" "LGPL-2.0-only"]
 authors: "Torbjörn Granlund and contributors"
 homepage: "https://github.com/mirage/ocaml-gmp"
 bug-reports: "https://github.com/mirage/ocaml-gmp/issues"
 dev-repo: "git+https://github.com/mirage/ocaml-gmp.git"
 build: [
  [ "dune" "build" "-p" name "-j" jobs ]
- [ "dune" "runtest" {with-test} ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 depends: [
-  "ocaml" {>="4.02.0"}
-  "dune" {>="2.6"}
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.6"}
   "conf-m4"
 ]
 synopsis: "The GNU Multiple Precision Arithmetic Library"

--- a/packages/gmp/gmp.6.2.0/opam
+++ b/packages/gmp/gmp.6.2.0/opam
@@ -24,7 +24,7 @@ extra-source "src/gmp-6.2.0.tar.xz" {
 url {
   src: "https://github.com/TheLortex/ocaml-gmp/archive/6.2.0.tar.gz"
   checksum: [
-    "md5=ae4b966da7353cc96c70ea19cd1456a1"
-    "sha512=449aa2afb57c9efc8b0e0ae3f52080429e4ee5fbebba2ff42b350b07d8f11bf1e074f1c3fc2408c43b82eddd24dc9cf9179430719f5fec8601e9dfbaca6c717e"
+    "md5=fe47f933ec2f5dabdbbd00a22ed0ae76"
+    "sha512=c1d46c8f93b1f68c585c0c8580a5df9e6647dcb16824038bbb894a44961b9b1a5982a5181f203f11e3c2b994919ef01b40b7bb04446e4b1c1711c005754342e0"
   ]
 }

--- a/packages/gmp/gmp.6.2.0/opam
+++ b/packages/gmp/gmp.6.2.0/opam
@@ -2,9 +2,9 @@ opam-version: "2.0"
 maintainer: "Lucas Pluvinage <lucas@tarides.com>"
 license:      ["LGPL-3.0-only" "LGPL-2.0-only"]
 authors: "Torbjörn Granlund and contributors"
-homepage: "https://github.com/TheLortex/ocaml-gmp"
-bug-reports: "https://github.com/TheLortex/ocaml-gmp/issues"
-dev-repo: "git+https://github.com/TheLortex/ocaml-gmp.git"
+homepage: "https://github.com/mirage/ocaml-gmp"
+bug-reports: "https://github.com/mirage/ocaml-gmp/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-gmp.git"
 build: [
  [ "dune" "build" "-p" name "-j" jobs ]
  [ "dune" "runtest" {with-test} ]
@@ -22,9 +22,9 @@ extra-source "src/gmp-6.2.0.tar.xz" {
   checksum: "md5=a325e3f09e6d91e62101e59f9bda3ec1"
 }
 url {
-  src: "https://github.com/TheLortex/ocaml-gmp/archive/6.2.0.tar.gz"
+  src: "https://github.com/mirage/ocaml-gmp/archive/6.2.0.tar.gz"
   checksum: [
-    "md5=0c1e01c3cfad52ac021f05e974ed443c"
-    "sha512=454f198c712475086c283deebf65de07a0412d1d189d0dedfbb1cbc9fe05a9a09a089b1248eb0aaaf458f34f607bbc93bef9648672b460fa5281c2c64fa73a22"
+    "md5=ec2df5d87bab85df5297e3371c468758"
+    "sha512=28c34ff4e3274ed17097b6f39ed32af24c82a9eee116fe7eb4091f4ed7fb14a8287ce3625fb3a4d667bd538c214427a8586c6b1f18c26fac1bd128885a156fa5"
   ]
 }

--- a/packages/gmp/gmp.6.2.1/opam
+++ b/packages/gmp/gmp.6.2.1/opam
@@ -5,6 +5,7 @@ authors: "Torbjörn Granlund and contributors"
 homepage: "https://github.com/mirage/ocaml-gmp"
 bug-reports: "https://github.com/mirage/ocaml-gmp/issues"
 dev-repo: "git+https://github.com/mirage/ocaml-gmp.git"
+substs: [ "src/build.sh" ]
 build: [
  [ "dune" "build" "-p" name "-j" jobs ]
  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
@@ -17,14 +18,10 @@ depends: [
 synopsis: "The GNU Multiple Precision Arithmetic Library"
 description: """Dune packaging of the GMP library, suitable for 
 cross-compilation."""
-extra-source "src/gmp-6.2.0.tar.xz" {
-  src: "https://gmplib.org/download/gmp/gmp-6.2.0.tar.xz"
-  checksum: "md5=a325e3f09e6d91e62101e59f9bda3ec1"
-}
 url {
-  src: "https://github.com/mirage/ocaml-gmp/archive/6.2.0.tar.gz"
+  src: "https://github.com/mirage/ocaml-gmp/archive/6.2.1.tar.gz"
   checksum: [
-    "md5=ec2df5d87bab85df5297e3371c468758"
-    "sha512=28c34ff4e3274ed17097b6f39ed32af24c82a9eee116fe7eb4091f4ed7fb14a8287ce3625fb3a4d667bd538c214427a8586c6b1f18c26fac1bd128885a156fa5"
+    "md5=318d6fc389ab3c71ce98dcfc9bf888da"
+    "sha512=f90f2463e15574b3c431fad4993ccfd80323cb8b21e85c8b2c2a7b8d7f6440ba1bf2361006f492175c08c7750f139bfb41dc5b68dfde0da205d6f98416fd4dc6"
   ]
 }


### PR DESCRIPTION
### `gmp.6.2.1
The GNU Multiple Precision Arithmetic Library
Dune packaging of the GMP library, suitable for 
cross-compilation.



---
* Homepage: https://github.com/TheLortex/ocaml-gmp
* Source repo: git+https://github.com/TheLortex/ocaml-gmp.git
* Bug tracker: https://github.com/TheLortex/ocaml-gmp/issues

---
:camel: Pull-request generated by opam-publish v2.0.2