### PR TITLE
[new release] charrua-unix, charrua, charrua-server and charrua-client (1.3.0)

### DIFF
--- a/packages/charrua-client-lwt/charrua-client-lwt.0.12.0/opam
+++ b/packages/charrua-client-lwt/charrua-client-lwt.0.12.0/opam
@@ -19,7 +19,7 @@ depends: [
   "alcotest" {with-test}
   "cstruct-unix" {with-test}
   "charrua-core" {>= "0.12.0"}
-  "charrua-client" {>= "0.12.0"}
+  "charrua-client" {>= "0.12.0" & < "1.0.0"}
   "cstruct" {>= "3.0.2"}
   "ipaddr" {>= "3.0.0"}
   "mirage-random" {>= "1.0.0" & < "2.0.0"}

--- a/packages/charrua-client/charrua-client.1.3.0/opam
+++ b/packages/charrua-client/charrua-client.1.3.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   ["Mindy Preston"]
+authors   :   ["Mindy Preston"]
+homepage:     "https://github.com/mirage/charrua"
+bug-reports:  "https://github.com/mirage/charrua/issues"
+dev-repo:     "git+https://github.com/mirage/charrua.git"
+tags:         [ "org:mirage"]
+doc:          "https://docs.mirage.io"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>= "1.4.0"}
+  "ocaml" {>= "4.06.0"}
+  "alcotest"     {with-test}
+  "cstruct-unix" {with-test}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "charrua-server" {= version & with-test}
+  "charrua" {= version}
+  "cstruct" {>="3.0.2"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "duration"
+  "logs"
+  "fmt"
+  "lwt" {>= "4.0.0"}
+]
+synopsis: "DHCP client implementation"
+description: """
+charrua-client is a DHCP client powered by [charrua](https://github.com/mirage/charrua).
+
+The base library exposes a simple state machine in `Dhcp_client`
+for use in acquiring a DHCP lease.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.3.0/charrua-v1.3.0.tbz"
+  checksum: [
+    "sha256=b9f59f45d2eae1253de1f7b4d42f5f2d772949b55f963a04eae40086b1936afc"
+    "sha512=426868b9cc4b861fa5e48d59d03891799cd0c4cca67adc2bcb665176c2ea47c93677868fcb2d78706eedb4aabcc0582f8b3bfe9c8f3829d4a6d5a181871eadb4"
+  ]
+}

--- a/packages/charrua-server/charrua-server.1.3.0/opam
+++ b/packages/charrua-server/charrua-server.1.3.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+dev-repo: "git+https://github.com/mirage/charrua.git"
+doc: "https://mirage.github.io/charrua/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.06.0"}
+  "dune"          {>= "1.4.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "menhir"        {build}
+  "charrua"       {= version}
+  "cstruct"       {>= "3.0.1"}
+  "sexplib"
+  "ipaddr"        {>= "5.0.0"}
+  "macaddr"       {>= "4.0.0"}
+  "ipaddr-sexp"
+  "macaddr-sexp"
+  "cstruct-unix"  {with-test}
+]
+synopsis: "DHCP server"
+description: """
+Charrua-server consists of a single `Dhcp_server` module used for constructing DHCP
+servers.
+
+[dhcp](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp)
+is a Mirage DHCP unikernel server based on charrua, included as a part of the MirageOS unikernel example and starting-point repository.
+
+#### Features
+
+* `Dhcp_server` supports a stripped down ISC dhcpd.conf, so you can probably just
+  use your old `dhcpd.conf`. It also supports manual configuration building in
+  OCaml.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.3.0/charrua-v1.3.0.tbz"
+  checksum: [
+    "sha256=b9f59f45d2eae1253de1f7b4d42f5f2d772949b55f963a04eae40086b1936afc"
+    "sha512=426868b9cc4b861fa5e48d59d03891799cd0c4cca67adc2bcb665176c2ea47c93677868fcb2d78706eedb4aabcc0582f8b3bfe9c8f3829d4a6d5a181871eadb4"
+  ]
+}

--- a/packages/charrua-unix/charrua-unix.1.3.0/opam
+++ b/packages/charrua-unix/charrua-unix.1.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mirage/charrua.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "1.4.0"}
+  "ocaml" {>= "4.06.0"}
+  "lwt" {>="3.0.0"}
+  "lwt_log"
+  "charrua" {= version}
+  "charrua-server" {= version}
+  "cstruct-unix"
+  "cmdliner"
+  "rawlink" {>= "1.0"}
+  "tuntap" {>= "2.0.0"}
+  "mtime" {>="1.0.0"}
+]
+synopsis: "Unix DHCP daemon"
+description: """
+charrua-unix is an _ISC-licensed_ Unix DHCP daemon based on
+[charrua](http://www.github.com/mirage/charrua).
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.3.0/charrua-v1.3.0.tbz"
+  checksum: [
+    "sha256=b9f59f45d2eae1253de1f7b4d42f5f2d772949b55f963a04eae40086b1936afc"
+    "sha512=426868b9cc4b861fa5e48d59d03891799cd0c4cca67adc2bcb665176c2ea47c93677868fcb2d78706eedb4aabcc0582f8b3bfe9c8f3829d4a6d5a181871eadb4"
+  ]
+}

--- a/packages/charrua/charrua.1.3.0/opam
+++ b/packages/charrua/charrua.1.3.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+dev-repo: "git+https://github.com/mirage/charrua.git"
+doc: "https://mirage.github.io/charrua/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"         {>= "4.06.0"}
+  "dune"          {>= "1.4.0"}
+  "ppx_sexp_conv" {>="v0.10.0"}
+  "ppx_cstruct"
+  "cstruct"       {>= "3.0.1"}
+  "sexplib"
+  "ipaddr"        {>= "5.0.0"}
+  "macaddr"       {>= "4.0.0"}
+  "ipaddr-sexp"
+  "macaddr-sexp"
+  "ethernet"      {>= "2.2.0"}
+  "tcpip"         {>= "5.0.0"}
+  "rresult"
+]
+synopsis: "DHCP wire frame encoder and decoder"
+description: """
+Charrua consists a single modules, `Dhcp_wire` responsible for parsing and
+constructing DHCP messages
+
+You can browse the API for [charrua](http://www.github.com/mirage/charrua) at
+https://mirage.github.io/charrua/
+
+#### Features
+
+* `Dhcp_wire` provides marshalling and unmarshalling utilities for DHCP.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.3.0/charrua-v1.3.0.tbz"
+  checksum: [
+    "sha256=b9f59f45d2eae1253de1f7b4d42f5f2d772949b55f963a04eae40086b1936afc"
+    "sha512=426868b9cc4b861fa5e48d59d03891799cd0c4cca67adc2bcb665176c2ea47c93677868fcb2d78706eedb4aabcc0582f8b3bfe9c8f3829d4a6d5a181871eadb4"
+  ]
+}


### PR DESCRIPTION
CHANGES:
    
* Revise packaging: charrua-client-lwt and charrua-client-mirage are now available as charrua-client.lwt and charrua-client.mirage (mirage/charrua#110 @hannesm)
* Dhcp_ipv4 directly uses Dhcp_client_mirage (instead of an abstract module interface being passed) (mirage/charrua#110 @hannesm)
* Fix sending of client_identifier with appropriate type as sent by the client (mirage/charrua#98 @hannesm, reported in mirage/charrua#84 by @lynxis)
