### PR TITLE
[new release] arp (2.3.1)

### DIFF
--- a/packages/arp/arp.2.3.1/opam
+++ b/packages/arp/arp.2.3.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/arp"
+doc: "https://mirage.github.io/arp/"
+dev-repo: "git+https://github.com/mirage/arp.git"
+bug-reports: "https://github.com/mirage/arp/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "2.2.0"}
+  "ipaddr" {>= "4.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "logs"
+  "mirage-time" {>= "2.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "lwt"
+  "duration"
+  "mirage-profile" {>= "0.9"}
+  "mirage-random" {with-test & >= "2.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "alcotest" {with-test}
+  "ethernet" {with-test & >= "2.0.0"}
+  "fmt" {with-test}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-random" {with-test & >= "2.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Address Resolution Protocol purely in OCaml"
+description: """
+ARP is an implementation of the address resolution protocol (RFC826) purely in
+OCaml.  It handles IPv4 protocol addresses and Ethernet hardware addresses only.
+"""
+url {
+  src:
+    "https://github.com/mirage/arp/releases/download/v2.3.1/arp-v2.3.1.tbz"
+  checksum: [
+    "sha256=77cc562959a97695030d91180f1977ee52334e22da01e3d013e0fc3d971bf5db"
+    "sha512=d3c229ead968d50da9ce3dd7c5a5cbec936c98cbcee89fd1be1f2da5827493509e1572b6b94c682e225689dd25b318a9dd09c8e8b1a7ac82da60cf96005b8918"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Fix opam file to include mirage-profile dependency (mirage/arp#21 @hannesm)