### PR TITLE
[new release] mirage-protocols (5.0.0)

### DIFF
--- a/packages/mirage-protocols/mirage-protocols.5.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.5.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "fmt"
+  "duration"
+  "lwt" {>= "4.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "macaddr" {>= "4.0.0"}
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to
+be used as MirageOS network implementations should implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v5.0.0/mirage-protocols-v5.0.0.tbz"
+  checksum: [
+    "sha256=730d5323cf4741282211d0e00e9fcf40643d8754db65f5bf8f140b0cfbfba6ad"
+    "sha512=22b9c6a6c005e679ecbdad896faf606661c78efd3369e2fbc8b5c6199fe5beaeaa4a56fe8f06c9694b2e26ba52878c8e759328cadbb45ac7deef299e4c3cafd3"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- Retire ipv4_config type and DHCP_CLIENT module type (mirage/mirage-protocols#27 @hannesm)
- Revise IP.mtu (used to be of type t -> int, now t -> dst:ipaddr -> int) to
  support dual stack (mirage/mirage-protocols#27 @hannesm)
- Revise ICMP.write, now has ?src:ipaddr (mirage/mirage-protocols#27 @hannesm)
- Revise UDP.write. now has ?src:ipaddr (mirage/mirage-protocols#27 @hannesm)

as far as I know #17302 and #17325 were sufficient for reverse dependencies, but we'll figure out what CI says (NB #17705 is compatible with this mirage-protocols release AFAICT)