### PR TITLE
[new release] ppx_deriving (5.2)

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.5.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {build}
+  "ocamlfind"
+  "ppx_derivers"
+  "ppxlib" {>= "0.20.0"}
+  "result"
+  "ounit2" {with-test}
+]
+synopsis: "Type-driven code generation for OCaml"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v5.2/ppx_deriving-v5.2.tbz"
+  checksum: [
+    "sha256=1c2d2626824ca350c365bf6c8bc3a23c8045c3995c170f2bc500e53baeda2ee6"
+    "sha512=03ce8b3a0d8ed56b6c078212ac54862d99e4296c0e31cc982f9e632bae973a955207cfa968dbcd9d88aa444addda557556f549ef926ae7196534f9b7c007cf10"
+  ]
+}
+x-commit-hash: "b5c1c30692819393b3a6f9f5ffccf16b59594b4a"

--- a/packages/ppx_deriving/ppx_deriving.5.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.2/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.07.0"} # TODO: change back to OCaml >= 4.05 when stdlib-shims 0.2.0 is released (same for ppx_deriving 5.0 and 5.1)
   "dune" {>= "1.6.3"}
   "cppo" {build}
   "ocamlfind"


### PR DESCRIPTION
Type-driven code generation for OCaml

- Project page: https://github.com/ocaml-ppx/ppx_deriving
- Documentation: https://ocaml-ppx.github.io/ppx_deriving/

CHANGES:

* Update to ppxlib 0.20.0
  ocaml-ppx/ppx_deriving#237 ocaml-ppx/ppx_deriving#239 ocaml-ppx/ppx_deriving#243 ocaml-ppx/ppx_deriving#245
  (Kate Deplaix, Jérémie Dimino, Thierry Martinez, Gabriel Scherer)

* Upgrade testsuite from ounit to ounit2
  ocaml-ppx/ppx_deriving#241
  (Kate Deplaix)

* (almost) use the set of standard flags from dune
  ocaml-ppx/ppx_deriving#246
  (Kate Deplaix)