### PR TITLE
Package lua-ml.0.9.2

### DIFF
--- a/packages/lua-ml/lua-ml.0.9.2/opam
+++ b/packages/lua-ml/lua-ml.0.9.2/opam
@@ -7,6 +7,7 @@ authors: [
 license: "Two-clause BSD"
 homepage: "https://github.com/lindig/lua-ml"
 bug-reports: "https://github.com/lindig/lua-ml/issues"
+dev-repo: "git+https://github.com/lindig/lua-ml.git"
 depends: [
   "ocaml" {>= "4.07"}
   "ocamlbuild"

--- a/packages/lua-ml/lua-ml.0.9.2/opam
+++ b/packages/lua-ml/lua-ml.0.9.2/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "An embeddable Lua 2.5 interpreter implemented in OCaml"
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: [
+  "Norman Ramsey <nr@cs.tufts.edu>" "Christian Lindig <lindig@gmail.com>"
+]
+license: "Two-clause BSD"
+homepage: "https://github.com/lindig/lua-ml"
+bug-reports: "https://github.com/lindig/lua-ml/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "ocamlbuild"
+  "ocamlfind"
+]
+build: [make "lib"]
+url {
+  src: "https://github.com/lindig/lua-ml/archive/0.9.2.tar.gz"
+  checksum: [
+    "md5=22fd2043f8f40100d9bcb8b0a8e6594b"
+    "sha512=0719252c753a81301ff2de1b4de7a60a136afe2d73fc75c332529fed7f0975d44b85cbd2cad1762f8f9985110108b85a8e935222c7cbf430993fbafc2253d6fa"
+  ]
+}


### PR DESCRIPTION
### `lua-ml.0.9.2`
An embeddable Lua 2.5 interpreter implemented in OCaml



---
* Homepage: https://github.com/lindig/lua-ml
* Bug tracker: https://github.com/lindig/lua-ml/issues

---
:camel: Pull-request generated by opam-publish v2.0.2