### PR TITLE
[new release] pecu (0.5)

### DIFF
--- a/packages/mrmime/mrmime.0.1.0/opam
+++ b/packages/mrmime/mrmime.0.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "uutf"
   "rosetta"
   "base64" {>= "3.1.0"}
-  "pecu" {>= "0.3"}
+  "pecu" {>= "0.3" & < "0.5"}
   "rresult"
   "fmt"
   "hxd" {with-test}

--- a/packages/mrmime/mrmime.0.2.0/opam
+++ b/packages/mrmime/mrmime.0.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ipaddr"
   "emile"           {>= "0.8" & < "1.0"}
   "base64"          {>= "3.1.0"}
-  "pecu"            {>= "0.4"}
+  "pecu"            {= "0.4"}
   "bigstringaf"
   "bigarray-compat"
   "bigarray-overlap"

--- a/packages/mrmime/mrmime.0.3.0/opam
+++ b/packages/mrmime/mrmime.0.3.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ipaddr"
   "emile"            {>= "0.8" & < "1.0"}
   "base64"           {>= "3.1.0"}
-  "pecu"             {>= "0.4"}
+  "pecu"             {= "0.4"}
   "bigstringaf"
   "bigarray-compat"
   "bigarray-overlap" {>= "0.2.0"}

--- a/packages/mrmime/mrmime.0.3.1/opam
+++ b/packages/mrmime/mrmime.0.3.1/opam
@@ -27,7 +27,7 @@ depends: [
   "ipaddr"
   "emile"            {>= "1.0"}
   "base64"           {>= "3.1.0"}
-  "pecu"             {>= "0.4"}
+  "pecu"             {= "0.4"}
   "bigstringaf"
   "bigarray-compat"
   "bigarray-overlap" {>= "0.2.0"}

--- a/packages/pecu/pecu.0.5/opam
+++ b/packages/pecu/pecu.0.5/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/pecu"
+bug-reports:  "https://github.com/mirage/pecu/issues"
+dev-repo:     "git+https://github.com/mirage/pecu.git"
+doc:          "https://mirage.github.io/pecu/"
+license:      "MIT"
+synopsis:     "Encoder/Decoder of Quoted-Printable (RFC2045 & RFC2047)"
+description:  """A non-blocking encoder/decoder of Quoted-Printable according to
+RFC2045 and RFC2047 (about encoded-word). Useful to translate contents of emails."""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "fmt" {with-test}
+  "alcotest" {with-test}
+]
+x-commit-hash: "c4d01536a303f2051d831b8714fc972724a04191"
+url {
+  src: "https://github.com/mirage/pecu/releases/download/v0.5/pecu-v0.5.tbz"
+  checksum: [
+    "sha256=713753cd6ba3f4609a26d94576484e83ffef7de5f2208a2993576a1b22f0e0e7"
+    "sha512=99d9b26ff194d810585b74b0ea77cee4f081427078a2574f0e7effa01d11ea30b72446e82e958a809f5ced33c25c382129eade2ef525cb941ddb4a53309acef0"
+  ]
+}


### PR DESCRIPTION
Encoder/Decoder of Quoted-Printable (RFC2045 & RFC2047)

- Project page: <a href="https://github.com/mirage/pecu">https://github.com/mirage/pecu</a>
- Documentation: <a href="https://mirage.github.io/pecu/">https://mirage.github.io/pecu/</a>

##### CHANGES:

* **breaking changes** The encoder flush
  at any emission of `\r\n`. It can break
  some assumptions about the behavior of
  `Pecu.encode`.
* Add empty .ocamlformat file
