### PR TITLE
Add support for OCaml 4.10.1 on macOS/arm64

### DIFF
--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.3/files/test.c
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.3/files/test.c
@@ -1,0 +1,26 @@
+#include <gmp.h>
+#ifndef __GMP_H__
+#error "No GMP header"
+#endif
+#if __GNU_MP_VERSION < 5
+#error "GMP >= 5 is required to support mpz_powm_sec"
+#endif
+
+void test(void) {
+  mpz_t base;
+  mpz_t exp;
+  mpz_t mod;
+  mpz_t rop;
+
+  mpz_init_set_ui(base, 2u);
+  mpz_init_set_ui(exp, 4u);
+  mpz_init_set_ui(mod, 3u);
+  mpz_init(rop);
+
+  mpz_powm_sec(rop, base, exp, mod);
+
+  mpz_clear(base);
+  mpz_clear(exp);
+  mpz_clear(mod);
+  mpz_clear(rop);
+}

--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.3/opam
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.3/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "http://gmplib.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+build: [
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos"}
+  [
+    "sh"
+    "-exc"
+    "cc -c $CFLAGS -I/opt/homebrew/include -I/opt/local/include -I/usr/local/include test.c"
+  ] {os = "macos"}
+]
+depends: ["conf-gmp"]
+synopsis:
+  "Virtual package relying on a GMP lib with constant-time modular exponentiation"
+description: """
+This package can only install if the GMP lib is installed on the system and
+corresponds to a version that has the mpz_powm_sec function."""
+authors: "Etienne Millon <etienne@cryptosense.com>"
+extra-files: ["test.c" "md5=29317f477fa828e18428660ef31064fb"]
+flags: conf

--- a/packages/conf-gmp/conf-gmp.3/files/test.c
+++ b/packages/conf-gmp/conf-gmp.3/files/test.c
@@ -1,0 +1,10 @@
+#include <gmp.h>
+#ifndef __GMP_H__
+#error "No GMP header"
+#endif
+
+void test(void) {
+  mpz_t n;
+  mpz_init(n);
+  mpz_clear(n);
+}

--- a/packages/conf-gmp/conf-gmp.3/opam
+++ b/packages/conf-gmp/conf-gmp.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "nbraud"
+homepage: "http://gmplib.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+build: [
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos"}
+  [
+    "sh"
+    "-exc"
+    "cc -c $CFLAGS -I/opt/homebrew/include -I/opt/local/include -I/usr/local/include test.c"
+  ] {os = "macos"}
+]
+depexts: [
+  ["libgmp-dev"] {os-family = "debian"}
+  ["gmp"] {os = "macos" & os-distribution = "homebrew"}
+  ["gmp"] {os-distribution = "macports" & os = "macos"}
+  ["gmp" "gmp-devel"] {os-distribution = "centos"}
+  ["gmp" "gmp-devel"] {os-distribution = "fedora"}
+  ["gmp" "gmp-devel"] {os-distribution = "ol"}
+  ["gmp"] {os = "openbsd"}
+  ["gmp"] {os = "freebsd"}
+  ["gmp-dev"] {os-distribution = "alpine"}
+  ["gmp-devel"] {os-family = "suse"}
+]
+synopsis: "Virtual package relying on a GMP lib system installation"
+description:
+  "This package can only install if the GMP lib is installed on the system."
+authors: "nbraud"
+extra-files: ["test.c" "md5=2fd2970c293c36222a6d299ec155823f"]
+flags: conf

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
@@ -41,3 +41,4 @@ extra-source "ocaml-3.07-patch1.diffs" {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch1.diffs"
   checksum: "md5=50e158dee599e00a4b9b93041ea9d21f"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
@@ -41,3 +41,4 @@ extra-source "ocaml-3.07-patch2.diffs" {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch2.diffs"
   checksum: "md5=f91d1f1e531f77011bd554817dbbc12a"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
@@ -36,3 +36,4 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
   checksum: "md5=2dd038055f5e1350078ad81270411b78"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
@@ -35,3 +35,4 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.0.tar.gz"
   checksum: "md5=c6ef478362295c150101cdd2efcd38e0"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
@@ -35,3 +35,4 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.1.tar.gz"
   checksum: "md5=8a32dd665d0d8fc08a027e1b8f68a001"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
@@ -35,3 +35,4 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.2.tar.gz"
   checksum: "md5=b79358a09884f5e679433cce284de43e"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
@@ -35,3 +35,4 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.3.tar.gz"
   checksum: "md5=b1fc455aca6980e02e8cce8a3cbb4c81"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
@@ -35,3 +35,4 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.4.tar.gz"
   checksum: "md5=105d192896bf945b660c4fb1ee486f57"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
@@ -35,3 +35,4 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.0.tar.gz"
   checksum: "md5=5445b3fba28291fe789797d10cef3431"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
@@ -35,3 +35,4 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.1.tar.gz"
   checksum: "md5=c73f4b093e27ba5bf13d62923f89befc"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
@@ -35,3 +35,4 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.2.tar.gz"
   checksum: "md5=dc4a298cfa8c65fe4e506a06fe514ccd"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
@@ -35,3 +35,4 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.3.tar.gz"
   checksum: "md5=11a91651007f70a2cb4d5ecfe20fab89"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
@@ -36,3 +36,4 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.0.tar.gz"
   checksum: "md5=5ec0b860730925f738d91ca96d692406"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
@@ -35,3 +35,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.1.tar.gz"
   checksum: "md5=04fbe476b7f633a910429106e02d9948"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
@@ -35,3 +35,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.2.tar.gz"
   checksum: "md5=52c795592c90ecb15c2c4754f04eeff4"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
@@ -35,3 +35,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.0.tar.gz"
   checksum: "md5=be152066bdf09761ddf1c31291e5cb90"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
@@ -35,3 +35,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.1.tar.gz"
   checksum: "md5=069aa55d40e548280f92af693f6c625a"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
@@ -40,3 +40,4 @@ extra-source "3.11.2_binutils.patch" {
   src: "http://www.ocamlpro.com/patches/3.11.2_binutils.patch"
   checksum: "md5=041f12c823520d687a7bbbce10cd57e3"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
@@ -40,3 +40,4 @@ extra-source "file_download.php?file_id=418&type=bug" {
   src: "http://caml.inria.fr/mantis/file_download.php?file_id=418&type=bug"
   checksum: "md5=8c664a0a346424ea2ec6fc6f713170c6"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
@@ -35,3 +35,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1.tar.gz"
   checksum: "md5=814a047085f0f901ab7d8e3a4b7a9e65"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
@@ -27,3 +27,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.0.tar.gz"
   checksum: "md5=fa11560a45793bd9fa45c1295a6f4a91"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
@@ -33,3 +33,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
     "https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   checksum: "md5=faccda3b3ab092fa9ac7d5d4d8beb004"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
@@ -45,3 +45,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
     "https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   checksum: "md5=faccda3b3ab092fa9ac7d5d4d8beb004"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=91a4a258611302bc57f4d9fadb7fc14d"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=d40cd243f53876ba0b7e181ac16836a9"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c59d1ac3de4c892f4aa74d8d1112de00"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.0/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.1/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
@@ -49,3 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -49,3 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
@@ -44,3 +44,4 @@ extra-files: [
   ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"]
   ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
@@ -44,3 +44,4 @@ extra-files: [
   ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"]
   ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.1/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.0/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.1/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Official release 4.10.2"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.0/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.1/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-system/ocaml-system.4.10.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.10.2/files/gen_ocaml_config.ml.in
@@ -1,0 +1,43 @@
+let () =
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
+  if Sys.ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "ERROR: The compiler found at %%s has version %%s,\n\
+        and this package requires %{_:version}%.\n\
+        You should use e.g. 'opam switch create %{_:name}%.%%s' \
+        instead."
+       ocamlc Sys.ocaml_version Sys.ocaml_version;
+     exit 1)
+  else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
+  let oc = open_out "%{_:name}%.config" in
+  Printf.fprintf oc "opam-version: \"2.0\"\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
+                     variables { path: %%S }\n"
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
+  close_out oc

--- a/packages/ocaml-system/ocaml-system.4.10.2/opam
+++ b/packages/ocaml-system/ocaml-system.4.10.2/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (system version, from outside of opam)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {post}
+  "base-unix" {post}
+  "base-threads" {post}
+  "base-bigarray" {post}
+]
+conflict-class: "ocaml-core-compiler"
+available: sys-ocaml-version = "4.10.2"
+flags: compiler
+build: ["ocaml" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"
+extra-files: ["gen_ocaml_config.ml.in" "md5=093e7bec1ec95f9e4c6a313d73c5d840"]

--- a/packages/ocaml-variants/ocaml-variants.3.09.1+metaocaml/opam
+++ b/packages/ocaml-variants/ocaml-variants.3.09.1+metaocaml/opam
@@ -34,3 +34,4 @@ url {
     "https://github.com/metaocaml/metaocaml-archive/blob/master/MetaOCaml_309_alpha_030.tar.gz?raw=true"
   checksum: "md5=28fca7ec424a1fd9fcdcf89fa2929f2a"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.00.0+debug-runtime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.0+debug-runtime/opam
@@ -39,3 +39,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.0.tar.gz"
   checksum: "md5=fa11560a45793bd9fa45c1295a6f4a91"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.00.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.0+fp/opam
@@ -32,3 +32,4 @@ extra-source "omit-frame-pointer-4.00.0.patch" {
   src: "http://www.ocamlpro.com/files/omit-frame-pointer-4.00.0.patch"
   checksum: "md5=681ebe15d8fab3374a32e945cd75ac73"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+BER/opam
@@ -37,3 +37,4 @@ url {
   src: "https://github.com/metaocaml/ber-metaocaml/archive/ber-N100.tar.gz"
   checksum: "md5=5bfe2ec41fdfb2d467f56d47e2f70b94"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+PIC/opam
@@ -37,3 +37,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
   checksum: "md5=91124a8eb12a57f1e56c02fe3db0f9e7"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+annot/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+annot/opam
@@ -33,3 +33,4 @@ extra-source "ocaml-annot-4.00.1.patch" {
     "https://bitbucket.org/camlspotter/spotinstall/raw/26c014770721e44be11f364f09b149cff54a047f/ocaml-annot-4.00.1.patch"
   checksum: "md5=4171df269228f085bb93f96adb25ba9a"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+debug-runtime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+debug-runtime/opam
@@ -45,3 +45,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
     "https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   checksum: "md5=a8c6dd8e547a7b766138f7ca3eb1cbfd"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+french/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+french/opam
@@ -32,3 +32,4 @@ extra-source "ocaml-4.00.1.fr.patch" {
   src: "http://www.ocamlpro.com/contribs/ocaml-french/ocaml-4.00.1.fr.patch"
   checksum: "md5=0f9583bdb3b8f4e5d3ca34a1aebc7980"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-unix/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-unix/opam
@@ -36,3 +36,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
   checksum: "md5=91124a8eb12a57f1e56c02fe3db0f9e7"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-xen/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-xen/opam
@@ -36,3 +36,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
   checksum: "md5=91124a8eb12a57f1e56c02fe3db0f9e7"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+open-types/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+open-types/opam
@@ -27,3 +27,4 @@ url {
   src: "https://github.com/lpw25/ocaml/archive/4.00.1+open_types.tar.gz"
   checksum: "md5=58813a434956cf4b07e4a5d0d7ea906d"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+raspberrypi/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+raspberrypi/opam
@@ -33,3 +33,4 @@ extra-source "dc0776f55108a20dad5a9c06188545dc08dbf462.patch" {
     "https://github.com/avsm/ocaml/commit/dc0776f55108a20dad5a9c06188545dc08dbf462.patch"
   checksum: "md5=84843356ceefd4b6dde7a7b74d48a769"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+short-types/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+short-types/opam
@@ -27,3 +27,4 @@ url {
   src: "https://github.com/avsm/ocaml/archive/4.00.1+short-types.tar.gz"
   checksum: "md5=586fadd27d0a46426c59984f4236056d"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+32bit/opam
@@ -49,3 +49,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
     "https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   checksum: "md5=a8c6dd8e547a7b766138f7ca3eb1cbfd"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+BER/opam
@@ -44,3 +44,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
     "https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   checksum: "md5=faccda3b3ab092fa9ac7d5d4d8beb004"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+PIC/opam
@@ -43,3 +43,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
     "https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   checksum: "md5=a8c6dd8e547a7b766138f7ca3eb1cbfd"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+armv6-freebsd/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+armv6-freebsd/opam
@@ -38,3 +38,4 @@ extra-source "freebsd10-armv6-natdynlink.patch" {
     "https://github.com/andrewray/mirage-fpga/releases/download/v0.1/freebsd10-armv6-natdynlink.patch"
   checksum: "md5=44062e1512c4ad6152845ce309034273"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+fp/opam
@@ -51,3 +51,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
     "https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   checksum: "md5=a8c6dd8e547a7b766138f7ca3eb1cbfd"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+lsb/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+lsb/opam
@@ -67,3 +67,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
   checksum: "md5=04dfdd7da189462a4f10ec6530359cef"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+musl+static/opam
@@ -50,3 +50,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
   checksum: "md5=04dfdd7da189462a4f10ec6530359cef"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+musl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+musl/opam
@@ -41,3 +41,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
   checksum: "md5=04dfdd7da189462a4f10ec6530359cef"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+open-types/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+open-types/opam
@@ -33,3 +33,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
     "https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   checksum: "md5=a8c6dd8e547a7b766138f7ca3eb1cbfd"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+profile/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+profile/opam
@@ -48,3 +48,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
     "https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   checksum: "md5=a8c6dd8e547a7b766138f7ca3eb1cbfd"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+PIC/opam
@@ -39,3 +39,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=91a4a258611302bc57f4d9fadb7fc14d"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+improved-errors/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+improved-errors/opam
@@ -37,3 +37,4 @@ extra-source "improved-error.patch" {
     "https://gist.githubusercontent.com/andrewray/1928825fea090e50c0de/raw/e121b5cd176cdf6b882bc402276235b1c0a71b69/improved-error.patch"
   checksum: "md5=047e4294cf4a00448985cabb7b75fba6"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+rc1/opam
@@ -39,3 +39,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0+rc1.tar.gz"
   checksum: "md5=a18e89606d032a6442f68fc640541ab6"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+trunk/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=91a4a258611302bc57f4d9fadb7fc14d"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+32bit/opam
@@ -59,3 +59,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+BER/opam
@@ -36,3 +36,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+PIC/opam
@@ -39,3 +39,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+fp/opam
@@ -47,3 +47,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits-ber/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits-ber/opam
@@ -37,3 +37,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits/opam
@@ -35,3 +35,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+musl+static/opam
@@ -51,3 +51,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+musl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+musl/opam
@@ -42,3 +42,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.2+improved-errors/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.2+improved-errors/opam
@@ -40,3 +40,4 @@ url {
     "https://github.com/charguer/ocaml/archive/4.02.2+improved-errors.tar.gz"
   checksum: "md5=93eba0d8e6df7152952040fc1f5d736f"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.2+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.2+rc1/opam
@@ -39,3 +39,4 @@ url {
   src: "http://github.com/ocaml/ocaml/tarball/4.02.2+rc1"
   checksum: "md5=5444ee57d65d457d3524d293a51f3ae8"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+32bit/opam
@@ -60,3 +60,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+PIC/opam
@@ -39,3 +39,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-1/opam
@@ -44,3 +44,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-master/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-master/opam
@@ -41,3 +41,4 @@ install: [make "install"]
 url {
   src: "https://github.com/bloomberg/ocaml/archive/master.zip"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+bytecode-only/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+curried-constr/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+curried-constr/opam
@@ -108,3 +108,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+fp/opam
@@ -47,3 +47,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+musl+static/opam
@@ -51,3 +51,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+musl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+musl/opam
@@ -42,3 +42,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+32bit/opam
@@ -59,3 +59,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1-no-debug/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1-no-debug/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2-no-debug/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2-no-debug/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+fPIC/opam
@@ -38,3 +38,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+fp+flambda/opam
@@ -48,3 +48,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+fp/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+statistical-memprof/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+32bit/opam
@@ -59,3 +59,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+BER/opam
@@ -37,3 +37,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+afl/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta1+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta1/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta2+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta2/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+bytecode-only/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+copatterns/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+copatterns/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+fPIC/opam
@@ -38,3 +38,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+fp+flambda/opam
@@ -48,3 +48,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+fp/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+safe-string/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+spacetime/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+trunk+forced_lto/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+trunk+forced_lto/opam
@@ -45,3 +45,4 @@ url {
   src: "https://github.com/chambart/ocaml-1/archive/lto.tar.gz"
   checksum: "md5=0bc3ded0fed30966a457c47f973e814e"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+32bit/opam
@@ -59,3 +59,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c59d1ac3de4c892f4aa74d8d1112de00"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+bytecode-only/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c59d1ac3de4c892f4aa74d8d1112de00"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+fPIC/opam
@@ -38,3 +38,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c59d1ac3de4c892f4aa74d8d1112de00"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c59d1ac3de4c892f4aa74d8d1112de00"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+fp+flambda/opam
@@ -48,3 +48,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c59d1ac3de4c892f4aa74d8d1112de00"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+fp/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c59d1ac3de4c892f4aa74d8d1112de00"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+safe-string/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c59d1ac3de4c892f4aa74d8d1112de00"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+spacetime/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c59d1ac3de4c892f4aa74d8d1112de00"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+32bit/opam
@@ -59,3 +59,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+bytecode-only/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+fPIC/opam
@@ -38,3 +38,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+fp+flambda/opam
@@ -48,3 +48,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+fp/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+safe-string/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+spacetime/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+statistical-memprof/opam
@@ -44,3 +44,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+32bit/opam
@@ -59,3 +59,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+afl/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta1+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta1/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta2+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta2/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta3/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+bytecode-only/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+lto/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+lto/opam
@@ -42,3 +42,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+musl+flambda/opam
@@ -44,3 +44,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+musl+static+flambda/opam
@@ -53,3 +53,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+rc1+flambda/opam
@@ -39,3 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.05.0+rc1.tar.gz"
   checksum: "md5=83868514b06c3583cfe33f8ca4e8eb89"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+rc1/opam
@@ -38,3 +38,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.05.0+rc1.tar.gz"
   checksum: "md5=83868514b06c3583cfe33f8ca4e8eb89"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+safe-string/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+spacetime/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+statistical-memprof/opam
@@ -29,3 +29,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+afl/opam
@@ -39,3 +39,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+flambda/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+fp+flambda/opam
@@ -47,3 +47,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+fp/opam
@@ -45,3 +45,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+trunk+safe-string/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+trunk/opam
@@ -39,3 +39,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+32bit/opam
@@ -59,3 +59,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+afl/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+afl/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+default-unsafe-string/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+force-safe-string/opam
@@ -39,3 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
   checksum: "md5=150d27e8c053e1f2794be668895fcf1f"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp+flambda/opam
@@ -48,3 +48,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+afl/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+default-unsafe-string/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+force-safe-string/opam
@@ -39,3 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta2.tar.gz"
   checksum: "md5=d3beca2a7d12c42c6b2585557ba59c4a"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp+flambda/opam
@@ -48,3 +48,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+bytecode-only/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+default-unsafe-string/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+flambda+no-flat-float-array/opam
@@ -49,3 +49,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+force-safe-string/opam
@@ -39,3 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0.tar.gz"
   checksum: "md5=4f3906e581181c5435078ffe3e485e3f"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+fp+flambda/opam
@@ -48,3 +48,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+fp/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+musl+flambda/opam
@@ -44,3 +44,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+musl+static+flambda/opam
@@ -53,3 +53,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+no-flat-float-array/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+afl/opam
@@ -38,3 +38,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
   checksum: "md5=4789f3147cbe82656459fea0f1b0b1a9"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+default-unsafe-string/opam
@@ -45,3 +45,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
   checksum: "md5=4789f3147cbe82656459fea0f1b0b1a9"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+flambda/opam
@@ -39,3 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
   checksum: "md5=4789f3147cbe82656459fea0f1b0b1a9"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+force-safe-string/opam
@@ -39,3 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
   checksum: "md5=4789f3147cbe82656459fea0f1b0b1a9"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+fp+flambda/opam
@@ -46,3 +46,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
   checksum: "md5=4789f3147cbe82656459fea0f1b0b1a9"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+fp/opam
@@ -44,3 +44,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
   checksum: "md5=4789f3147cbe82656459fea0f1b0b1a9"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1/opam
@@ -38,3 +38,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
   checksum: "md5=4789f3147cbe82656459fea0f1b0b1a9"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+spacetime/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+statistical-memprof/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+32bit/opam
@@ -59,3 +59,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+afl/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+bytecode-only/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+default-unsafe-string/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+flambda/opam
@@ -41,3 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+force-safe-string/opam
@@ -39,3 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
   checksum: "md5=d02eb67b828de22c3f97d94b3c46acba"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+fp+flambda/opam
@@ -49,3 +49,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+fp/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+lto/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+lto/opam
@@ -44,3 +44,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+musl+flambda/opam
@@ -44,3 +44,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
@@ -53,3 +53,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+no-flat-float-array/opam
@@ -46,3 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+no-naked-pointers+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+no-naked-pointers+flambda/opam
@@ -49,3 +49,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+afl/opam
@@ -38,3 +38,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc1.tar.gz"
   checksum: "md5=7a8d77a43528224fa589e962604bd184"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+default-unsafe-string/opam
@@ -45,3 +45,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc1.tar.gz"
   checksum: "md5=7a8d77a43528224fa589e962604bd184"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+flambda/opam
@@ -39,3 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc1.tar.gz"
   checksum: "md5=7a8d77a43528224fa589e962604bd184"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+force-safe-string/opam
@@ -39,3 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc1.tar.gz"
   checksum: "md5=7a8d77a43528224fa589e962604bd184"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+fp+flambda/opam
@@ -47,3 +47,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc1.tar.gz"
   checksum: "md5=7a8d77a43528224fa589e962604bd184"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+fp/opam
@@ -44,3 +44,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc1.tar.gz"
   checksum: "md5=7a8d77a43528224fa589e962604bd184"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1/opam
@@ -38,3 +38,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc1.tar.gz"
   checksum: "md5=7a8d77a43528224fa589e962604bd184"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+afl/opam
@@ -39,3 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc2.tar.gz"
   checksum: "md5=8befb315cd6d4dbfad130061b5a34a66"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+default-unsafe-string/opam
@@ -45,3 +45,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc2.tar.gz"
   checksum: "md5=8befb315cd6d4dbfad130061b5a34a66"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+flambda/opam
@@ -39,3 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc2.tar.gz"
   checksum: "md5=8befb315cd6d4dbfad130061b5a34a66"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+force-safe-string/opam
@@ -39,3 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc2.tar.gz"
   checksum: "md5=8befb315cd6d4dbfad130061b5a34a66"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+fp+flambda/opam
@@ -47,3 +47,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc2.tar.gz"
   checksum: "md5=8befb315cd6d4dbfad130061b5a34a66"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+fp/opam
@@ -44,3 +44,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc2.tar.gz"
   checksum: "md5=8befb315cd6d4dbfad130061b5a34a66"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2/opam
@@ -38,3 +38,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc2.tar.gz"
   checksum: "md5=8befb315cd6d4dbfad130061b5a34a66"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+statistical-memprof/opam
@@ -43,3 +43,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+termux/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+termux/opam
@@ -43,3 +43,4 @@ extra-source "ocaml-4.06.1+termux.patch" {
   src: "https://ygrek.org/files/ocaml-4.06.1+termux.patch"
   checksum: "md5=ad51572a1aec13802e133c0a8e94ed8a"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+afl/opam
@@ -39,3 +39,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+flambda/opam
@@ -40,3 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+force-safe-string/opam
@@ -38,3 +38,4 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.tar.gz"
 }
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+fp+flambda/opam
@@ -47,3 +47,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk+fp/opam
@@ -45,3 +45,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+trunk/opam
@@ -39,3 +39,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
@@ -68,3 +68,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
@@ -49,3 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
@@ -49,3 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
@@ -55,3 +55,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
@@ -50,3 +50,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
@@ -48,3 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
@@ -57,3 +57,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
@@ -55,3 +55,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
@@ -49,3 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
@@ -50,3 +50,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
@@ -55,3 +55,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
@@ -58,3 +58,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
@@ -50,3 +50,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
@@ -48,3 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
@@ -57,3 +57,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
@@ -55,3 +55,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
@@ -56,3 +56,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
@@ -54,3 +54,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
@@ -48,3 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
@@ -49,3 +49,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
@@ -56,3 +56,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
@@ -53,3 +53,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
@@ -54,3 +54,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
@@ -48,3 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
@@ -49,3 +49,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
@@ -56,3 +56,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
@@ -53,3 +53,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
@@ -50,3 +50,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+afl/opam
@@ -48,3 +48,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+default-unsafe-string/opam
@@ -56,3 +56,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+flambda/opam
@@ -49,3 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp+flambda/opam
@@ -56,3 +56,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk+fp/opam
@@ -54,3 +54,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+trunk/opam
@@ -48,3 +48,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
@@ -68,3 +68,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
@@ -46,3 +46,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
@@ -49,3 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
@@ -50,3 +50,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
@@ -56,3 +56,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
@@ -58,3 +58,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
@@ -50,3 +50,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
@@ -51,3 +51,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
@@ -58,3 +58,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
@@ -55,3 +55,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
@@ -55,3 +55,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
@@ -64,3 +64,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
@@ -56,3 +56,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
@@ -68,3 +68,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
@@ -49,3 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
@@ -56,3 +56,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
@@ -58,3 +58,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
@@ -50,3 +50,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
@@ -51,3 +51,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
@@ -58,3 +58,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
@@ -55,3 +55,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
@@ -49,3 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
@@ -50,3 +50,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
@@ -49,3 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+32bit/opam
@@ -52,3 +52,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
@@ -41,3 +41,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
@@ -45,3 +45,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
@@ -40,3 +40,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
@@ -45,3 +45,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
@@ -43,3 +43,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
@@ -39,3 +39,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
@@ -41,3 +41,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
@@ -45,3 +45,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
@@ -40,3 +40,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
@@ -45,3 +45,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
@@ -43,3 +43,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
@@ -39,3 +39,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
@@ -40,3 +40,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
@@ -45,3 +45,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
@@ -40,3 +40,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
@@ -45,3 +45,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
@@ -43,3 +43,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
@@ -39,3 +39,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+bytecode-only/opam
@@ -42,3 +42,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+default-unsafe-string/opam
@@ -44,3 +44,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+flambda+no-flat-float-array/opam
@@ -46,3 +46,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+flambda/opam
@@ -43,3 +43,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+force-safe-string/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+fp+flambda/opam
@@ -46,3 +46,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+fp/opam
@@ -43,3 +43,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
@@ -54,3 +54,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+no-flat-float-array/opam
@@ -44,3 +44,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+afl/opam
@@ -39,3 +39,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+default-unsafe-string/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+flambda/opam
@@ -38,3 +38,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp+flambda/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1/opam
@@ -37,3 +37,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+default-unsafe-string/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+spacetime/opam
@@ -43,3 +43,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+32bit/opam
@@ -55,3 +55,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+bytecode-only/opam
@@ -42,3 +42,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+default-unsafe-string/opam
@@ -44,3 +44,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+flambda+no-flat-float-array/opam
@@ -46,3 +46,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+flambda/opam
@@ -43,3 +43,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+force-safe-string/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+fp+flambda/opam
@@ -46,3 +46,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+fp/opam
@@ -43,3 +43,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+flambda/opam
@@ -51,3 +51,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
@@ -54,3 +54,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+no-flat-float-array/opam
@@ -44,3 +44,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+afl/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+default-unsafe-string/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+force-safe-string/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+afl/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+default-unsafe-string/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+force-safe-string/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+afl/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+default-unsafe-string/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+force-safe-string/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+spacetime/opam
@@ -43,3 +43,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+trunk+afl/opam
@@ -39,3 +39,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+trunk+default-unsafe-string/opam
@@ -44,3 +44,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+trunk+flambda/opam
@@ -39,3 +39,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+trunk+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+trunk+force-safe-string/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+trunk+fp+flambda/opam
@@ -48,3 +48,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+trunk+fp/opam
@@ -46,3 +46,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+trunk/opam
@@ -38,3 +38,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+32bit/opam
@@ -53,3 +53,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+afl/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+default-unsafe-string/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+default-unsafe-string/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+bytecode-only/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+default-unsafe-string/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+flambda+no-flat-float-array/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+flambda/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+force-safe-string/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+fp+flambda/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+fp/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+flambda/opam
@@ -48,3 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
@@ -51,3 +51,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+no-flat-float-array/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+spacetime/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+32bit/opam
@@ -53,3 +53,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+afl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+afl+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+afl/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+bytecode-only/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+default-unsafe-string/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+flambda+no-flat-float-array/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+flambda/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+force-safe-string/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+fp+flambda/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+fp/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+musl+flambda/opam
@@ -48,3 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+musl+static+flambda/opam
@@ -51,3 +51,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+no-flat-float-array/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+spacetime/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+afl/opam
@@ -37,3 +37,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+default-unsafe-string/opam
@@ -46,3 +46,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+flambda/opam
@@ -37,3 +37,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+fp+flambda/opam
@@ -46,3 +46,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+fp/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk/opam
@@ -36,3 +36,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+32bit/opam
@@ -53,3 +53,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+afl/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+bytecode-only/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+default-unsafe-string/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+flambda+no-flat-float-array/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+flambda/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+fp+flambda/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+fp/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+musl+flambda/opam
@@ -48,3 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+musl+static+flambda/opam
@@ -51,3 +51,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+nnpcheck/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+nnpcheck/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+no-flat-float-array/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+spacetime/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+32bit/opam
@@ -53,3 +53,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+afl/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+bytecode-only/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+default-unsafe-string/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+flambda+no-flat-float-array/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+flambda/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+fp+flambda/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+fp/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+musl+flambda/opam
@@ -48,3 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+musl+static+flambda/opam
@@ -51,3 +51,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+no-flat-float-array/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+afl/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+flambda/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+fp+flambda/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+fp/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1/opam
@@ -39,3 +39,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+spacetime/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+32bit/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2, compiled in 32-bit mode for 64-bit Linux and OS X hosts"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+depexts: [
+  ["gcc-multilib" "g++-multilib"] {os-family = "debian"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=gcc -m32"
+    "AS=as --32"
+    "ASPP=gcc -m32 -c"
+    "--host" "i386-linux"
+    "PARTIALLD=ld -r -melf_i386"
+  ] {os = "linux"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32"
+    "AS=as -arch i386"
+    "ASPP=gcc -arch i386 -m32 -c"
+    "--host" "i386-apple-darwin13.2.0"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+afl/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Official release 4.10.2, with afl-fuzz instrumentation"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-afl"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--with-afl"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+bytecode-only/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Official release 4.10.2, without the native-code compiler"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--disable-native-compiler"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--disable-native-compiler"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+default-unsafe-string/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2, without safe strings by default"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "DEFAULT_STRING=unsafe"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "CC=cc"
+    "ASPP=cc -c"
+    "DEFAULT_STRING=unsafe"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+flambda+no-flat-float-array/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2, with flambda activated and --disable-flat-float-array"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-flambda" "--disable-flat-float-array"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--enable-flambda"
+    "--disable-flat-float-array"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+flambda/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Official release 4.10.2, with flambda activated"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--enable-flambda"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+fp+flambda/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2, with frame-pointers and flambda activated"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-frame-pointers" "--enable-flambda"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+fp/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Official release 4.10.2, with frame-pointers"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-frame-pointers"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--enable-frame-pointers"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+musl+flambda/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2, compiled with musl-gcc and with flambda activated"
+description:
+  "Requires musl-gcc to be installed (package musl on Arch Linux or musl-tools on Debian)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=musl-gcc -Os"
+    "ASPP=musl-gcc -c"
+    "--enable-flambda"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+musl+static+flambda/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2, compiled with musl-gcc -static and with flambda activated"
+description:
+  "Requires musl-gcc to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=musl-gcc" {os-distribution != "alpine"}
+    "CFLAGS=-Os"
+    "ASPP=musl-gcc -c" {os-distribution != "alpine"}
+    "--enable-flambda"
+    "LIBS=-static"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+no-flat-float-array/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2 with --disable-flat-float-array"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--disable-flat-float-array"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--disable-flat-float-array"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+spacetime/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Official release 4.10.2, with spacetime activated"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-spacetime"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--enable-spacetime"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+32bit/opam
@@ -53,3 +53,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+afl/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+afl/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+flambda/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp+flambda/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+afl/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+flambda/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+fp+flambda/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+fp/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3/opam
@@ -39,3 +39,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+bytecode-only/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+default-unsafe-string/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+flambda+no-flat-float-array/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+flambda/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+fp+flambda/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+fp/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+musl+flambda/opam
@@ -48,3 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+musl+static+flambda/opam
@@ -51,3 +51,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+no-flat-float-array/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+afl/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+flambda/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+fp+flambda/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+fp/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1/opam
@@ -39,3 +39,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+afl/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+flambda/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+fp+flambda/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+fp/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2/opam
@@ -39,3 +39,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+spacetime/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+32bit/opam
@@ -53,3 +53,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+BER/opam
@@ -36,3 +36,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+afl/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+bytecode-only/opam
@@ -40,3 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+default-unsafe-string/opam
@@ -47,3 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+flambda+no-flat-float-array/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+flambda/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+fp+flambda/opam
@@ -44,3 +44,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+fp/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+musl+flambda/opam
@@ -48,3 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+musl+static+flambda/opam
@@ -51,3 +51,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+no-flat-float-array/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+spacetime/opam
@@ -41,3 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+afl/opam
@@ -37,3 +37,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+flambda/opam
@@ -37,3 +37,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+fp/opam
@@ -37,3 +37,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+trunk/opam
@@ -36,3 +36,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml/ocaml.4.10.2/opam
+++ b/packages/ocaml/ocaml.4.10.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-config"
+  "ocaml-base-compiler" {= "4.10.2"} |
+  "ocaml-variants" {>= "4.10.2" & < "4.10.3~"} |
+  "ocaml-system" {>= "4.10.2" & < "4.10.3~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: CAML_LD_LIBRARY_PATH = ""
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]

--- a/packages/zarith/zarith.1.11/opam
+++ b/packages/zarith/zarith.1.11/opam
@@ -18,7 +18,7 @@ build: [
   [
     "sh"
     "-exc"
-    "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"
+    "LDFLAGS=\"$LDFLAGS -L/opt/homebrew/lib -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/homebrew/include -I/opt/local/include -I/usr/local/include\" ./configure"
   ] {os = "macos"}
   [make]
 ]


### PR DESCRIPTION
This adds the backported compiler from https://github.com/ocaml/ocaml/pull/10026 as a ocaml-variants.4.10.1+macos-arm64 package.

The PR also adds constraints to all the other OCaml base-compiler and variants packages pre-4.12 to restrict them from being selected on macos/arm64, so that the default compiler will be 4.10.1 (and 4.12.0~alpha1 if the beta repository is active).

Still testing this, just got my M1 delivered...