### PR TITLE
[new release] promise_jsoo (0.3.0)

### DIFF
--- a/packages/promise_jsoo/promise_jsoo.0.3.0/opam
+++ b/packages/promise_jsoo/promise_jsoo.0.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Js_of_ocaml bindings to JS Promises with supplemental functions"
+maintainer: ["Max Lantas <mnxndev@outlook.com>"]
+authors: ["Max Lantas <mnxndev@outlook.com>"]
+license: "MIT"
+homepage: "https://github.com/mnxn/promise_jsoo"
+bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
+  "gen_js_api"
+  "webtest" {with-test}
+  "webtest-js" {with-test}
+  "conf-npm" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mnxn/promise_jsoo.git"
+x-commit-hash: "a1fce4ea0bac1fd204a62105abf616fe1ab6fdc0"
+url {
+  src:
+    "https://github.com/mnxn/promise_jsoo/releases/download/v0.3.0/promise_jsoo-v0.3.0.tbz"
+  checksum: [
+    "sha256=41451be5efb29d60e49bebdc681e9cc8dea5be0e585b4585b7f97b145876556c"
+    "sha512=d0f1d331a4433466e4a5ffc129b0978f24baef44fcd982b9d9f76573fb0f912db0df229a513949bf3f16996baae58e294c4993796eaa3c2a09780bae9f8f5240"
+  ]
+}


### PR DESCRIPTION
Js_of_ocaml bindings to JS Promises with supplemental functions

- Project page: <a href="https://github.com/mnxn/promise_jsoo">https://github.com/mnxn/promise_jsoo</a>

##### CHANGES:

## 0.3.0

-   Fix `Promise.Array.find_map` and `Promise.List.find_map` raising
    `Assert_failure` (mnxn/promise_jsoo#1)
-   Stop calling the function once `Promise.Array.find_map` and
    `Promise.List.find_map` find a value (mnxn/promise_jsoo#1)