### PR TITLE
[new release] textmate-language (0.2.0)

### DIFF
--- a/packages/textmate-language/textmate-language.0.2.0/opam
+++ b/packages/textmate-language/textmate-language.0.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Tokenizing source code with TextMate grammars"
+description: """
+
+Tokenizing source code with TextMate grammars."""
+maintainer: ["Alan Hu <hu.ala@northeastern.edu>"]
+authors: ["Alan Hu <hu.ala@northeastern.edu>"]
+license: "MIT"
+homepage: "https://github.com/alan-j-hu/ocaml-textmate-language"
+doc: "https://alan-j-hu.github.io/ocaml-textmate-language/"
+bug-reports: "https://github.com/alan-j-hu/ocaml-textmate-language/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "oniguruma" {< "0.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/ocaml-textmate-language.git"
+x-commit-hash: "330797da0aabbee89b9a506a2cc665eb81e879ad"
+url {
+  src:
+    "https://github.com/alan-j-hu/ocaml-textmate-language/releases/download/0.2.0/textmate-language-0.2.0.tbz"
+  checksum: [
+    "sha256=b12f669a697492839ee3192e8d625012418e9af331c5d3e3c2341bb85baf41fb"
+    "sha512=8514417a3a871e15105ac400bed60386b40a6acc52e8ab090f9d9881c2200e6ab78b975826ef2206ca3c47222d95f2d86a9c60a2bdbb19e458005174909550e2"
+  ]
+}


### PR DESCRIPTION
Tokenizing source code with TextMate grammars

- Project page: <a href="https://github.com/alan-j-hu/ocaml-textmate-language">https://github.com/alan-j-hu/ocaml-textmate-language</a>
- Documentation: <a href="https://alan-j-hu.github.io/ocaml-textmate-language/">https://alan-j-hu.github.io/ocaml-textmate-language/</a>

##### CHANGES:

- Switch from PCRE to Oniguruma.
- Substitute captures from `begin` pattern for backreferences in `end` and
  `while` patterns.
