### PR TITLE
Package embedded_ocaml_templates.0.5.1

### DIFF
--- a/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.5.1/opam
+++ b/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.5.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "EML is a simple templating language that lets you generate text with plain OCaml"
+description: """
+Inspired by EJS templates, it does currently implements all of its functionnality. 
+I plan to implement everything eventually, especially if someone actually want to use this.
+Please contact me if you find this interesting but there is a missing feature that you need !
+"""
+maintainer: "Emile Trotignon emile.trotignon@gmail.com"
+authors: "Emile Trotignon emile.trotignon@gmail.com"
+license: "MIT"
+homepage: "https://github.com/EmileTrotignon/embedded_ocaml_templates"
+bug-reports: "https://github.com/EmileTrotignon/embedded_ocaml_templates/issues"
+dev-repo: "git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git"
+depends: [ 
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.5.0"} 
+    "sedlex" { >= "2.0" }
+    "core" {>= "v0.12"}
+    "uutf" 
+    "menhir" 
+    "ppxlib"
+    "ppx_deriving"
+    "containers"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/EmileTrotignon/embedded_ocaml_templates/archive/0.5.1.tar.gz"
+  checksum: [
+    "md5=540b7c3b5c7d5c21755556272b6ff5d7"
+    "sha512=0756d0a9a4ed247580b3e8818c8e5c53075ffe5604fe139ab30267309ab620fcfca5b0187427dc4bb27ec1ab6c538cc50fb139b5279de4a1774592f5d5af20d1"
+  ]
+}


### PR DESCRIPTION
### `embedded_ocaml_templates.0.5.1`
EML is a simple templating language that lets you generate text with plain OCaml
Inspired by EJS templates, it does currently implements all of its functionnality. 
I plan to implement everything eventually, especially if someone actually want to use this.
Please contact me if you find this interesting but there is a missing feature that you need !



---
* Homepage: https://github.com/EmileTrotignon/embedded_ocaml_templates
* Source repo: git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git
* Bug tracker: https://github.com/EmileTrotignon/embedded_ocaml_templates/issues

---
:camel: Pull-request generated by opam-publish v2.0.2