### PR TITLE
[new release] reparse and reparse-unix (2.0.0)

### DIFF
--- a/packages/reparse-unix/reparse-unix.2.0.0/opam
+++ b/packages/reparse-unix/reparse-unix.2.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Provides support for parsing files as source of input for reparse library "
+description:
+  "Provides support for parsing files as source of input for reparse library "
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "reparse" {= "2.0.0"}
+  "base-unix"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+x-commit-hash: "f2d0ad0cc6696f92e58a9bba36d806e66476cdea"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v2.0.0/reparse-unix-v2.0.0.tbz"
+  checksum: [
+    "sha256=00222696d786575af17e759ee603461b8f9090dfe57c1fe308797db1c737dc0d"
+    "sha512=6d7df511e495664fe5b3f0ba7b71e3f9ff738b9e98b76f203e82aa3f5e1d0880d5230c1b7a462e934cd25b97e16c6dcb8081a23d72b79ffd7dcaddeddf78cc10"
+  ]
+}

--- a/packages/reparse/reparse.2.0.0/opam
+++ b/packages/reparse/reparse.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Recursive descent parsing library for ocaml"
+description:
+  "Monadic, recursive descent based, parser construction library for ocaml. Comprehensively documented and tested."
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+x-commit-hash: "f2d0ad0cc6696f92e58a9bba36d806e66476cdea"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v2.0.0/reparse-unix-v2.0.0.tbz"
+  checksum: [
+    "sha256=00222696d786575af17e759ee603461b8f9090dfe57c1fe308797db1c737dc0d"
+    "sha512=6d7df511e495664fe5b3f0ba7b71e3f9ff738b9e98b76f203e82aa3f5e1d0880d5230c1b7a462e934cd25b97e16c6dcb8081a23d72b79ffd7dcaddeddf78cc10"
+  ]
+}


### PR DESCRIPTION
Recursive descent parsing library for ocaml

- Project page: <a href="https://github.com/lemaetech/reparse">https://github.com/lemaetech/reparse</a>

##### CHANGES:

- Rewrite the whole package to use exceptions rather than `result` type
- Adds many more parsing combinators
- Adds comprehensive unit tests
- Adds comprehensive documentation, host documentation and add links in repo home page
- Adds abstraction for input source
- Provides unix file source and string input source
- Adds separate package `reparse-unix` for unix file input
- Adds calc.ml and json.ml in examples.
