### PR TITLE
[new release] reparse and reparse-unix (2.0.0)

### DIFF
--- a/packages/reparse-unix/reparse-unix.2.0.0/opam
+++ b/packages/reparse-unix/reparse-unix.2.0.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/lemaetech/reparse/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.10.0"}
-  "reparse" {= "2.0.0"}
+  "reparse" {= version}
   "base-unix"
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/packages/reparse-unix/reparse-unix.2.0.0/opam
+++ b/packages/reparse-unix/reparse-unix.2.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Provides support for parsing files as source of input for reparse library "
+description:
+  "Provides support for parsing files as source of input for reparse library "
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "reparse" {= "2.0.0"}
+  "base-unix"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+x-commit-hash: "ded9e38316b5bba51d02a003cfc9df18190f2d16"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v2.0.0/reparse-unix-v2.0.0.tbz"
+  checksum: [
+    "sha256=93cee3d9f8842e85af5cb772f2586dccf1821f29959ee7f8effde1081cf650e7"
+    "sha512=69ee814e31af9a660a860b7768587a88e6fec4c918c05f237b3f665d67991a29cc8d8c2d55848b1cc38e75b712303cf225b66990cb80dbafce569e7e7b2166dd"
+  ]
+}

--- a/packages/reparse/reparse.2.0.0/opam
+++ b/packages/reparse/reparse.2.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Recursive descent parsing library for ocaml"
+description:
+  "Monadic, recursive descent based, parser construction library for ocaml. Comprehensively documented and tested."
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+x-commit-hash: "ded9e38316b5bba51d02a003cfc9df18190f2d16"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v2.0.0/reparse-unix-v2.0.0.tbz"
+  checksum: [
+    "sha256=93cee3d9f8842e85af5cb772f2586dccf1821f29959ee7f8effde1081cf650e7"
+    "sha512=69ee814e31af9a660a860b7768587a88e6fec4c918c05f237b3f665d67991a29cc8d8c2d55848b1cc38e75b712303cf225b66990cb80dbafce569e7e7b2166dd"
+  ]
+}


### PR DESCRIPTION
Recursive descent parsing library for ocaml

- Project page: <a href="https://github.com/lemaetech/reparse">https://github.com/lemaetech/reparse</a>

##### CHANGES:

- Rewrite the whole package to use exceptions rather than `result` type
- Adds many more parsing combinators
- Adds comprehensive unit tests
- Adds comprehensive documentation, host documentation and add links in repo home page
- Adds abstraction for input source
- Provides unix file source and string input source
- Adds separate package `reparse-unix` for unix file input
- Adds calc.ml and json.ml in examples.
