### PR TITLE
[new release] http-cookie (2.0.0)

### DIFF
--- a/packages/http-cookie/http-cookie.2.0.0/opam
+++ b/packages/http-cookie/http-cookie.2.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "HTTP cookie library for OCaml"
+description: "OCaml library to manipulate HTTP cookie. Adheres to RFC 6265."
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/http-cookie"
+bug-reports: "https://github.com/lemaetech/http-cookie/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/http-cookie.git"
+x-commit-hash: "49f2e87b367e02e70e8421d6801d4a313d4bef0e"
+url {
+  src:
+    "https://github.com/lemaetech/http-cookie/releases/download/v2.0.0/http-cookie-v2.0.0.tbz"
+  checksum: [
+    "sha256=e64d180d358435357f902ecc6b583f8f16e104639285ef598240ed386461fb31"
+    "sha512=399ce242432553f24925137ac0b4cf5ba7f5ef3f756e0ba3b059233e52116f6738a625479f038b63b5646f1aa0b99b13a5894a49e52e08c94ee41fb541870e90"
+  ]
+}


### PR DESCRIPTION
HTTP cookie library for OCaml

- Project page: <a href="https://github.com/lemaetech/http-cookie">https://github.com/lemaetech/http-cookie</a>

##### CHANGES:

- Rewrite library by removing almost all ppx and external libraries
- Rename package to `http-cookie` from `cookies`.
- Make the `Http_cookie` the topmost module.
- Change code formatting to `janestreet`
- Document API, generate docs and host it.
