### PR TITLE
Add ez_cmdliner.0.2.0

### DIFF
--- a/packages/ez_cmdliner/ez_cmdliner.0.2.0/opam
+++ b/packages/ez_cmdliner/ez_cmdliner.0.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis: "Easy interface to Cmdliner à la Arg.parse with sub-commands"
+description: """\
+ez_cmdliner is a simple layer on top of Cmdliner to provide an interface
+à la Arg.parse with an extension for simple sub-commands.
+"""
+authors: ["Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>"]
+maintainer: ["Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>"]
+homepage: "https://ocamlpro.github.io/ez_cmdliner"
+doc: "https://ocamlpro.github.io/ez_cmdliner/sphinx"
+bug-reports: "https://github.com/ocamlpro/ez_cmdliner/issues"
+dev-repo: "git+https://github.com/ocamlpro/ez_cmdliner.git"
+tags: "org:ocamlpro"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.6.0"}
+  "ocplib_stuff" {}
+  "ez_subst" {>= "0.1"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {with-test}
+]
+
+url {
+    src: "https://github.com/ocamlpro/ez_cmdliner/archive/v0.2.0.tar.gz"
+    checksum: [ "sha256=7ad232ba64660749cf5a54c396f05e643a3363249329f0c3b37ee72db748e0d8" ]
+}


### PR DESCRIPTION
* Add documentation generation for sub-commands in RST format
* Versioned interface (`open Ezcmd.V2`) with versioning on sub-commands and
  arguments for documentation

(notice that `drom` now publishes `opam` files without comments and name/version fields)
