### PR TITLE
[new release] tcpip (6.0.0)

### DIFF
--- a/packages/git-mirage/git-mirage.2.0.0/opam
+++ b/packages/git-mirage/git-mirage.2.0.0/opam
@@ -30,7 +30,7 @@ depends: [
   "nocrypto"         {with-test & >= "0.5.4"}
   "tls"              {with-test}
   "io-page"          {with-test & >= "1.6.1" & <  "2.0.0"}
-  "tcpip"            {with-test & >= "3.3.0"}
+  "tcpip"            {with-test & >= "3.3.0" & < "6.0.0"}
   "mirage-stack-lwt" {with-test & >= "1.3.0"}
   "mirage-time-unix"
 ]

--- a/packages/git-mirage/git-mirage.2.1.0/opam
+++ b/packages/git-mirage/git-mirage.2.1.0/opam
@@ -30,7 +30,7 @@ depends: [
   "nocrypto"         {with-test & >= "0.5.4"}
   "tls"              {with-test}
   "io-page"          {with-test & >= "1.6.1"}
-  "tcpip"            {with-test & >= "3.3.0"}
+  "tcpip"            {with-test & >= "3.3.0" & < "6.0.0"}
   "io-page-unix"     {with-test}
   "mirage-stack-lwt" {with-test & >= "1.3.0"}
   "mirage-time-unix"

--- a/packages/git-mirage/git-mirage.2.1.1/opam
+++ b/packages/git-mirage/git-mirage.2.1.1/opam
@@ -29,7 +29,7 @@ depends: [
   "nocrypto"         {with-test & >= "0.5.4"}
   "tls"              {with-test}
   "io-page"          {with-test & >= "1.6.1"}
-  "tcpip"            {with-test & >= "3.3.0"}
+  "tcpip"            {with-test & >= "3.3.0" & < "6.0.0"}
   "io-page-unix"     {with-test}
   "mirage-stack-lwt" {with-test & >= "1.3.0"}
   "mirage-random-test" {with-test}

--- a/packages/git-mirage/git-mirage.2.1.2/opam
+++ b/packages/git-mirage/git-mirage.2.1.2/opam
@@ -30,7 +30,7 @@ depends: [
   "nocrypto"         {with-test & >= "0.5.4"}
   "tls"              {with-test}
   "io-page"          {with-test & >= "1.6.1"}
-  "tcpip"            {with-test & >= "3.3.0"}
+  "tcpip"            {with-test & >= "3.3.0" & < "6.0.0"}
   "io-page-unix"     {with-test}
   "mirage-stack" {with-test & >= "2.0.0"}
   "mirage-random-test" {with-test}

--- a/packages/git-mirage/git-mirage.2.1.3/opam
+++ b/packages/git-mirage/git-mirage.2.1.3/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-crypto-rng" {with-test & >= "0.5.4"}
   "tls"               {with-test}
   "io-page"           {with-test & >= "1.6.1"}
-  "tcpip"             {with-test & >= "3.3.0"}
+  "tcpip"             {with-test & >= "3.3.0" & < "6.0.0"}
   "io-page-unix"      {with-test}
   "mirage-stack"      {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/mirage-nat/mirage-nat.1.1.0/opam
+++ b/packages/mirage-nat/mirage-nat.1.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lru" {< "0.3.0"}
   "ppx_deriving" {build & >= "4.2" }
   "dune" {>= "1.0"}
-  "tcpip" { >= "3.7.0" }
+  "tcpip" { >= "3.7.0" & < "4.0.0"}
   "ethernet" { >= "2.0.0" }
   "arp"
   "alcotest" {with-test}

--- a/packages/mirage-nat/mirage-nat.1.2.0/opam
+++ b/packages/mirage-nat/mirage-nat.1.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "lru" {>= "0.3.0"}
   "ppx_deriving" {build & >= "4.2" }
   "dune" {>= "1.0"}
-  "tcpip" { >= "3.7.2" }
+  "tcpip" { >= "3.7.2" & < "4.0.0" }
   "ethernet" { >= "2.0.0" }
   "arp"
   "alcotest" {with-test}

--- a/packages/mirage-nat/mirage-nat.2.1.0/opam
+++ b/packages/mirage-nat/mirage-nat.2.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "lru" {>= "0.3.0"}
   "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
-  "tcpip" { >= "4.1.0" }
+  "tcpip" { >= "4.1.0" & < "6.0.0" }
   "ethernet" { >= "2.0.0" }
   "stdlib-shims"
   "alcotest" {with-test}

--- a/packages/mirage-nat/mirage-nat.2.2.0/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.0/opam
@@ -23,7 +23,7 @@ depends: [
   "lru" {>= "0.3.0"}
   "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
-  "tcpip" { >= "4.1.0" }
+  "tcpip" { >= "4.1.0" & < "6.0.0"}
   "ethernet" { >= "2.0.0" }
   "stdlib-shims"
   "alcotest" {with-test}

--- a/packages/mirage-nat/mirage-nat.2.2.1/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.1/opam
@@ -23,7 +23,7 @@ depends: [
   "lru" {>= "0.3.0"}
   "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
-  "tcpip" { >= "4.1.0" }
+  "tcpip" { >= "4.1.0" & < "6.0.0"}
   "ethernet" { >= "2.0.0" }
   "stdlib-shims"
   "alcotest" {with-test}

--- a/packages/mirage-nat/mirage-nat.2.2.2/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.2/opam
@@ -22,7 +22,7 @@ depends: [
   "lru" {>= "0.3.0"}
   "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
-  "tcpip" { >= "4.1.0" }
+  "tcpip" { >= "4.1.0" & < "6.0.0"}
   "ethernet" { >= "2.0.0" }
   "stdlib-shims"
   "alcotest" {with-test}

--- a/packages/tcpip/tcpip.6.0.0/opam
+++ b/packages/tcpip/tcpip.6.0.0/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [ "mirage-xen" {< "6.0.0"} ]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ocaml" {>= "4.06.0"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {>= "3.2.0"}
+  "cstruct-lwt"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-protocols" {>= "5.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv"
+  "ethernet" {>= "2.0.0"}
+  "mirage-flow" {with-test & >= "2.0.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "alcotest" {with-test & >="0.7.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "arp" {with-test & >= "2.3.0"}
+  "ipaddr-cstruct" {with-test}
+  "lru" {>= "0.3.0"}
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+x-commit-hash: "ca66fb27c52f4fbbc19562ff60595b6eceeaeaef"
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v6.0.0/tcpip-v6.0.0.tbz"
+  checksum: [
+    "sha256=1a2dbb275dcc84c0c97f876730fc130c7a023b579ce18a73fb83eff025d27971"
+    "sha512=a579972e298956fb71525e27f41125dcc574d198b386088d20ffb1f531fdcc8b170a39e8b7d944c56ab86dc2ecc1e2e94dc211dae1f728253900b94efb8d6132"
+  ]
+}

--- a/packages/tcpip/tcpip.6.0.0/opam
+++ b/packages/tcpip/tcpip.6.0.0/opam
@@ -15,7 +15,7 @@ tags: ["org:mirage"]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" "1"] {with-test}
 ]
 conflicts: [ "mirage-xen" {< "6.0.0"} ]
 depends: [


### PR DESCRIPTION
OCaml TCP/IP networking stack, used in MirageOS

- Project page: <a href="https://github.com/mirage/mirage-tcpip">https://github.com/mirage/mirage-tcpip</a>
- Documentation: <a href="https://mirage.github.io/mirage-tcpip/">https://mirage.github.io/mirage-tcpip/</a>

##### CHANGES:

* Dual IPv4 and IPv6 socket and direct stack support, now requires
  mirage-stack 2.2.0 and mirage-protocols 5.0.0 (mirage/mirage-tcpip#433 @hannesm)
* The above change also unified arguments passed to connect functions which
  are API-breaking changes
* IPv6 waits for timeout after sending neighbour advertisement (for duplicate
  address detection)
* Remove Xen cross-compilation runes, with mirage-xen 6.0.0 they're provided
  by mirage-xen (mirage/mirage-tcpip#434 @hannesm)
* Move to dune 2.7.0 (and bisect instrumentation if desired) (mirage/mirage-tcpip#436 @hannesm)
