### PR TITLE
Package cryptoverif.2.04

### DIFF
--- a/packages/cryptoverif/cryptoverif.2.04/opam
+++ b/packages/cryptoverif/cryptoverif.2.04/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "CryptoVerif: Cryptographic protocol verifier in the computational model"
+description: """
+CryptoVerif is an automatic protocol prover sound in the computational model. It can prove
+
+  - secrecy;
+  - correspondences, which include in particular authentication;
+  - indistinguishability between two games.
+
+It provides a generic mechanism for specifying the security assumptions on cryptographic primitives, which can handle in particular symmetric encryption, message authentication codes, public-key encryption, signatures, hash functions.
+
+The generated proofs are proofs by sequences of games, as used by cryptographers. These proofs are valid for a number of sessions polynomial in the security parameter, in the presence of an active adversary. CryptoVerif can also evaluate the probability of success of an attack against the protocol as a function of the probability of breaking each cryptographic primitive and of the number of sessions (exact security).
+
+This software is under development; please use it at your own risk. Comments and bug reports welcome. 
+"""
+maintainer: "Bruno Blanchet <Bruno.Blanchet@inria.fr>"
+authors: "Bruno Blanchet <Bruno.Blanchet@inria.fr> and David Cadé <David.Cade@normalesup.org>"
+license: "CECILL-B"
+homepage: "https://cryptoverif.inria.fr"
+bug-reports: "Bruno.Blanchet@inria.fr"
+depends: [ "ocaml" { >= "4.03" } "ocamlfind" { post } "cryptokit" { post } "conf-m4" { post } ]
+build: [
+       [ "./build" "byte" { !ocaml:native } ] 
+]
+install: [ "./build" "install" "%{prefix}%" ]
+url {
+  src: "http://cryptoverif.inria.fr/cryptoverif2.04.tar.gz"
+  checksum: [
+    "md5=f08d6ff61416ad6caa068ebecf1694d5"
+    "sha512=eecbc4c2ce8bfe603cc16a85ee2ac0f53a8b7b15c07712e2cd9f4428a6cd18f5904d2fd3043fc273fce7bbc3b188f8c50db9040b164f7e2f85c1911475755a5c"
+  ]
+}


### PR DESCRIPTION
### `cryptoverif.2.04`
CryptoVerif: Cryptographic protocol verifier in the computational model
CryptoVerif is an automatic protocol prover sound in the computational model. It can prove

  - secrecy;
  - correspondences, which include in particular authentication;
  - indistinguishability between two games.

It provides a generic mechanism for specifying the security assumptions on cryptographic primitives, which can handle in particular symmetric encryption, message authentication codes, public-key encryption, signatures, hash functions.

The generated proofs are proofs by sequences of games, as used by cryptographers. These proofs are valid for a number of sessions polynomial in the security parameter, in the presence of an active adversary. CryptoVerif can also evaluate the probability of success of an attack against the protocol as a function of the probability of breaking each cryptographic primitive and of the number of sessions (exact security).

This software is under development; please use it at your own risk. Comments and bug reports welcome.



---
* Homepage: https://cryptoverif.inria.fr
* Bug tracker: Bruno.Blanchet@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.2