### PR TITLE
[new release] mirage-nat (2.2.3)

### DIFF
--- a/packages/mirage-nat/mirage-nat.2.2.3/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+homepage: "https://github.com/mirage/mirage-nat"
+bug-reports: "https://github.com/mirage/mirage-nat/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-nat.git"
+doc: "https://mirage.github.io/mirage-nat/"
+license: "ISC"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "ipaddr"
+  "cstruct"
+  "lwt"
+  "rresult"
+  "logs"
+  "lru" {>= "0.3.0"}
+  "ppx_deriving" {>= "4.2" }
+  "dune" {>= "1.0"}
+  "tcpip" { >= "4.1.0" }
+  "ethernet" { >= "2.0.0" }
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+]
+synopsis: "Mirage-nat is a library for network address translation to be used with MirageOS"
+description: """
+Mirage-nat is a library for [network address
+translation](https://tools.ietf.org/html/rfc2663).  It is intended for use in
+[MirageOS](https://mirage.io) and makes extensive use of
+[tcpip](https://github.com/mirage/mirage-tcpip), the network stack used by
+default in MirageOS unikernels.
+"""
+x-commit-hash: "1bed6c49b7554123a99e5e56d1f0967707424bb2"
+url {
+  src:
+    "https://github.com/mirage/mirage-nat/releases/download/v2.2.3/mirage-nat-v2.2.3.tbz"
+  checksum: [
+    "sha256=aa0eb326df497b5453fab80a2fffc0ab6627f30add7c034375284282822cc933"
+    "sha512=a98cb784299645ce0f3e0c81a349f5fec621819e3324c4dab48207bebfdf1d1f8388bd52249643b0a49eeb1d83cad5a79590d489ea8d5883e41402afef60b386"
+  ]
+}


### PR DESCRIPTION
Mirage-nat is a library for network address translation to be used with MirageOS

- Project page: <a href="https://github.com/mirage/mirage-nat">https://github.com/mirage/mirage-nat</a>
- Documentation: <a href="https://mirage.github.io/mirage-nat/">https://mirage.github.io/mirage-nat/</a>

##### CHANGES:

- example: adapt to mirage 3.8 changes (mirage/mirage-nat#43 @hannesm)
- tests: depend on tcpip.unix for tcpip 6.0.0 compatibility (mirage/mirage-nat#44 @hannesm)
