### PR TITLE
[new release] logs-syslog (0.3.0)

### DIFF
--- a/packages/logs-syslog/logs-syslog.0.3.0/opam
+++ b/packages/logs-syslog/logs-syslog.0.3.0/opam
@@ -9,7 +9,7 @@ license: "ISC"
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {>= "1.1.0" & build}
+  "dune" {>= "1.1.0"}
   "logs"
   "ptime"
   "syslog-message" {>= "1.0.0"}

--- a/packages/logs-syslog/logs-syslog.0.3.0/opam
+++ b/packages/logs-syslog/logs-syslog.0.3.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/hannesm/logs-syslog"
+doc: "https://hannesm.github.io/logs-syslog/doc"
+dev-repo: "git+https://github.com/hannesm/logs-syslog.git"
+bug-reports: "https://github.com/hannesm/logs-syslog/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1.0" & build}
+  "logs"
+  "ptime"
+  "syslog-message" {>= "1.0.0"}
+]
+
+depopts: [
+  "lwt"
+  "x509" "tls" "tls-mirage" "cstruct"
+  "mirage-kv"
+  "mirage-console" "mirage-clock" "mirage-stack" "ipaddr"
+]
+
+conflicts: [
+  "mirage-kv" {< "3.0.0"}
+  "mirage-console" {< "3.0.0"}
+  "mirage-clock" {< "3.0.0"}
+  "mirage-stack" {< "2.2.0"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+
+synopsis: "Logs reporter to syslog (UDP/TCP/TLS)"
+description: """
+This library provides log reporters using syslog over various transports (UDP,
+TCP, TLS) with various effectful layers: Unix, Lwt, MirageOS.  It integrates the
+[Logs](http://erratique.ch/software/logs) library, which provides logging
+infrastructure for OCaml, with the
+[syslog-message](http://verbosemo.de/syslog-message/) library, which provides
+encoding and decoding of syslog messages ([RFC
+3164](https://tools.ietf.org/html/rfc3164)).
+"""
+x-commit-hash: "187a598f99d5c23fb8c7079323f1e1f49427e602"
+url {
+  src:
+    "https://github.com/hannesm/logs-syslog/releases/download/v0.3.0/logs-syslog-v0.3.0.tbz"
+  checksum: [
+    "sha256=9ad32614bda61b3c0e4530a22fc2dc654d92ac79ea8093112e0b93e4033c135f"
+    "sha512=1e1eff5b75fcd1b45d541b22c7dc002738a3a4edc17361f77c41eed26516f6cdc5c154abf9b805f4cdf45bf3336956ba76696228a133ede872071e3a405c9996"
+  ]
+}


### PR DESCRIPTION
Logs reporter to syslog (UDP/TCP/TLS)

- Project page: <a href="https://github.com/hannesm/logs-syslog">https://github.com/hannesm/logs-syslog</a>
- Documentation: <a href="https://hannesm.github.io/logs-syslog/doc">https://hannesm.github.io/logs-syslog/doc</a>

##### CHANGES:

- support MirageOS dual IPv4 and IPv6 stack
