### PR TITLE
OCaml 4.12.0: second alpha release

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Second alpha release of OCaml 4.12.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml#4.12"
+depends: [
+  "ocaml" {= "4.12.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler hidden-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.12.0-alpha2.tar.gz"
+  checksum: "sha256=45e8ecf8708ebe2412161ace3836be4f6b96579bedc0043c6c404db97b35d263"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
@@ -24,8 +24,7 @@ build: [
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}
   ]
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"}]
 ]
 install: [make "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+synopsis: "Second alpha release of OCaml 4.12.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml#4.12"
+depends: [
+  "ocaml" {= "4.12.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta" {opam-version < "2.1"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler hidden-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--enable-spacetime" {ocaml-option-spacetime:installed}
+    "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+  ]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.12.0-alpha2.tar.gz"
+  checksum: "sha256=45e8ecf8708ebe2412161ace3836be4f6b96579bedc0043c6c404db97b35d263"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+  "ocaml-option-spacetime"
+  "ocaml-option-nnp"
+]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
@@ -45,8 +45,7 @@ build: [
     "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
     "LIBS=-static" {ocaml-option-static:installed}
   ]
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" {os != "cygwin"}]
 ]
 install: [make "install"]
 url {


### PR DESCRIPTION
This PR contains the `ocaml-base-compiler` and `ocaml-variants` package for the second alpha release of OCaml 4.12.0 .

The changes compared to the first alpha are the following:

--------
Items marked with + contain additional bug fixes. 
## New and updated bug fixes

- (+) 9500, 9727, 9866, 9870, 9873: Injectivity annotations
  One can now mark type parameters as injective, which is useful for
  abstract types:
    module Vec : sig type !'a t end = struct type 'a t = 'a array end
  On non-abstract types, this can be used to check the injectivity of
  parameters. Since all parameters of record and sum types are by definition
  injective, this only makes sense for type abbreviations:
    type !'a t = 'a list
  Note that this change required making the regularity check stricter.
  (Jacques Garrigue, review by Jeremy Yallop and Leo White)

- 2195: Improve error message in bytecode stack trace printing and load
  debug information during bytecode startup if OCAMLRUNPARAM=b=2.
  (David Allsopp, review by Gabriel Scherer and Xavier Leroy)

- 10050: update {PUSH,}OFFSETCLOSURE* bytecode instructions to match new
  representation for closures
  (Nathanaël Courant, review by Xavier Leroy)

- 10035: Make sure that flambda respects atomicity in the Atomic module.
  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)

- 8796: On Windows, make Unix.utimes use FILE_FLAG_BACKUP_SEMANTICS flag
  to allow it to work with directories.
  (Daniil Baturin, review by Damien Doligez)

- 10008: Improve error message for aliases to the current compilation unit.
  (Leo White, review by Gabriel Scherer)

- 9938, 9939: Define __USE_MINGW_ANSI_STDIO=0 for the mingw-w64 ports to
  prevent their C99-compliant snprintf conflicting with ours.
  (David Allsopp, report by Michael Soegtrop, review by Xavier Leroy)

- 7813, 9955: make sure the major GC cycle doesn't get stuck in Idle state
  (Damien Doligez, report by Anders Fugmann, review by Jacques-Henri Jourdan)

- 9991: Fix reproducibility for `-no-alias-deps`
  (Leo White, review by Gabriel Scherer and Florian Angeletti)

- 9998: Use Sys.opaque_identity in CamlinternalLazy.force
  This removes extra warning 59 messages when compiling afl-instrumented
  code with flambda -O3.
  (Vincent Laviron, report by Louis Gesbert, review by Gabriel Scherer and
   Pierre Chambart)

- 9999: fix -dsource printing of the pattern (`A as x | (`B as x)).
  (Gabriel Scherer, report by Anton Bachin, review by Florian Angeletti)

- 9970, 10010: fix the declaration scope of extensible-datatype constructors.
  A regression that dates back to 4.08 makes extensible-datatype constructors
  with inline records very fragile, for example:
    type 'a t += X of {x : 'a}
  (Gabriel Scherer, review by Thomas Refis and Leo White,
   report by Nicolás Ojeda Bär)

## Removed features

* 9811: remove propagation from previous branches
  Type information inferred from previous branches was propagated in
  non-principal mode. Revert this for better compatibility with
  -principal mode.
  For the time being, infringing code should result in a principality warning.
  (Jacques Garrigue, review by Thomas Refis and Gabriel Scherer)

