### PR TITLE
[new release] albatross (1.0.0)

### DIFF
--- a/packages/albatross/albatross.1.0.0/opam
+++ b/packages/albatross/albatross.1.0.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "cstruct"
+  "logs"
+  "rresult"
+  "bos"
+  "ptime"
+  "cmdliner" {>= "1.0.0"}
+  "fmt"
+  "astring"
+  "jsonm"
+  "x509" {>= "0.11.0"}
+  "tls" {>= "0.12.2"}
+  "mirage-crypto-pk"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "0.9.0" & < "1.0.0"}
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: [
+  ["libnl-3-dev" "libnl-route-3-dev"] {os-family = "debian"}
+  ["libnl3" "libnl3-devel"] {os-family = "centos"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+x-commit-hash: "4c619ee15cc21bc71fdc8da625b64c38cfdb81aa"
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v1.0.0/albatross-v1.0.0.tbz"
+  checksum: [
+    "sha256=d82e303ba7a577762df68b3db30131c62ca7b51a6486dabebfa749fcf057d098"
+    "sha512=731a6fe0d249a2dc0ef64750f25164670c2a46c194504acb6a4b6e65927e6bb3c9c492602265272cd0c441c80dbd862efc2d0d952d659ed2de1e080142ad427a"
+  ]
+}

--- a/packages/albatross/albatross.1.0.0/opam
+++ b/packages/albatross/albatross.1.0.0/opam
@@ -11,6 +11,7 @@ depends: [
   "dune"
   "dune-configurator"
   "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
   "lwt" {>= "3.0.0"}
   "ipaddr" {>= "4.0.0"}
   "cstruct"
@@ -37,10 +38,6 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-]
-depexts: [
-  ["libnl-3-dev" "libnl-route-3-dev"] {os-family = "debian"}
-  ["libnl3" "libnl3-devel"] {os-family = "centos"}
 ]
 synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
 description: """

--- a/packages/albatross/albatross.1.0.0/opam
+++ b/packages/albatross/albatross.1.0.0/opam
@@ -12,6 +12,7 @@ depends: [
   "dune-configurator"
   "conf-pkg-config" {build}
   "conf-libnl3" {os = "linux"}
+  "conf-linux-libc-dev" {os = "linux"}
   "lwt" {>= "3.0.0"}
   "ipaddr" {>= "4.0.0"}
   "cstruct"
@@ -56,3 +57,6 @@ url {
     "sha512=731a6fe0d249a2dc0ef64750f25164670c2a46c194504acb6a4b6e65927e6bb3c9c492602265272cd0c441c80dbd862efc2d0d952d659ed2de1e080142ad427a"
   ]
 }
+available: [
+  arch != "ppc64" & arch != "x86_32" & arch != "arm32"
+]


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

Initial release
