### PR TITLE
Add conf-libnl3 virtual package

### DIFF
--- a/packages/conf-libnl3/conf-libnl3.1/opam
+++ b/packages/conf-libnl3/conf-libnl3.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+authors: ["Thomas Graf"]
+homepage: "https://www.infradead.org/~tgr/libnl/"
+license: "LGPL-2.1"
+build: [
+  ["pkg-config" "libnl-3.0"]
+  ["pkg-config" "libnl-route-3.0"]
+]
+depends: ["conf-pkg-config"]
+depexts: [
+  ["libnl-3-dev" "libnl-route-3-dev"] {os-family = "debian"}
+  ["libnl3" "libnl3-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
+  ["libnl3-devel"] {os-family = "suse"}
+  ["libnl"] {os-family = "arch"}
+  ["libnl3-dev"] {os-distribution = "alpine"}
+]
+available: [ os = "linux" ]
+synopsis: "Virtual package relying on a libnl system installation"
+description:
+  "This package can only install if libnl is installed on the system."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-libnl3/conf-libnl3.1/opam
+++ b/packages/conf-libnl3/conf-libnl3.1/opam
@@ -10,10 +10,11 @@ build: [
 depends: ["conf-pkg-config"]
 depexts: [
   ["libnl-3-dev" "libnl-route-3-dev"] {os-family = "debian"}
+  ["libnl-3-dev" "libnl-route-3-dev"] {os-family = "ubuntu"}
   ["libnl3" "libnl3-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
   ["libnl3-devel"] {os-family = "suse"}
   ["libnl"] {os-family = "arch"}
-  ["libnl3-dev"] {os-distribution = "alpine"}
+  ["libnl3-dev"] {os-family = "alpine"}
 ]
 available: [ os = "linux" ]
 synopsis: "Virtual package relying on a libnl system installation"


### PR DESCRIPTION
In debian the libnl libraries are packaged in a handful of different packages while on centos family they seem to be all packaged in one package. This depends on both libnl-3 and libnl-route-3 since that's what we need in #17742. 