### PR TITLE
[new release] albatross (1.0.1)

### DIFF
--- a/packages/albatross/albatross.1.0.1/opam
+++ b/packages/albatross/albatross.1.0.1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "cstruct"
+  "logs"
+  "rresult"
+  "bos"
+  "ptime"
+  "cmdliner" {>= "1.0.0"}
+  "fmt"
+  "astring"
+  "jsonm"
+  "x509" {>= "0.11.0"}
+  "tls" {>= "0.12.2"}
+  "mirage-crypto-pk"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "0.9.0" & < "1.0.0"}
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+available: [
+  arch != "ppc64" & arch != "x86_32" & arch != "arm32"
+]
+x-commit-hash: "bd04fc05cd0deef4129b134a6726926c6cc6a46a"
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v1.0.1/albatross-v1.0.1.tbz"
+  checksum: [
+    "sha256=a6ed4443ef37d8584a2ab5788efcdb25878bdcf08b3841f4be8940b5b0c42a91"
+    "sha512=162942ee6d543976051a2578ab5ff220dd59adafd1bfa0247e0214d9de29b8d7c4571f8879e8ca81a2f6bb2b58f247787b4164c5e3a93f7dcb75d9b9b5d14e85"
+  ]
+}

--- a/packages/albatross/albatross.1.0.1/opam
+++ b/packages/albatross/albatross.1.0.1/opam
@@ -39,6 +39,7 @@ build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
 synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
 description: """
 The goal of albatross is robust deployment of [MirageOS](https://mirage.io)


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

* Use the conf-libnl3 opam package on Linux (created by @reynir, roburio/albatross#57 @hannesm)
* Avoid using sysctl.h on Linux (roburio/albatross#58 @reynir @kit-ty-kate)
