### PR TITLE
[new release] mirage-qubes-ipv4 and mirage-qubes (0.9.1)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.1/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "5.0.0" }
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-protocols" { >= "4.0.0" }
+  "cstruct" { >= "1.9.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.9.1/mirage-qubes-v0.9.1.tbz"
+  checksum: [
+    "sha256=dca185c7ee3cfc019fbe72a254b3a2a2f7b86a659b74b9e7c214cb16ff6f10a4"
+    "sha512=4925136237bdfe0d846a8055f94546e8020eaa53151f658456823f51fbc0e76b72b6f6d74eb3a88fb31c4ff7d1cf6d33ed31471b0caa6f33f8b09c5caee473cb"
+  ]
+}

--- a/packages/mirage-qubes/mirage-qubes.0.9.1/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.9.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "2.2.0" }
+  "ppx_cstruct"
+  "vchan-xen" { >= "6.0.0" }
+  "mirage-xen" { >= "6.0.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.08.0" }
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.9.1/mirage-qubes-v0.9.1.tbz"
+  checksum: [
+    "sha256=dca185c7ee3cfc019fbe72a254b3a2a2f7b86a659b74b9e7c214cb16ff6f10a4"
+    "sha512=4925136237bdfe0d846a8055f94546e8020eaa53151f658456823f51fbc0e76b72b6f6d74eb3a88fb31c4ff7d1cf6d33ed31471b0caa6f33f8b09c5caee473cb"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- RExec: being future compatible, and negotiate protocol version 2 (mirage/mirage-qubes#56 mirage/mirage-qubes#57 @reynir)
- Remove Utils module (mirage/mirage-qubes#58 @hannesm)
- RExec: close connection with peer on unknown messages, instead of raising an exception (mirage/mirage-qubes#61 @reynir)