### PR TITLE
[new release] mirage, mirage-runtime, mirage-types-lwt and mirage-types (3.10.0)

### DIFF
--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.8.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.8.0/opam
@@ -22,7 +22,7 @@ depends: [
   "arp-mirage" {with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
   "io-page-unix" {with-test}
-  "tcpip" {>= "5.0.0" & with-test}
+  "tcpip" {>= "5.0.0" & < "6.0.0" & with-test}
   "mirage-vnetif" {with-test}
   "dune" {>= "2.0"}
 ]

--- a/packages/mirage-runtime/mirage-runtime.3.10.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.10.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "5.0.0"}
+  "functoria-runtime"  {>= "3.0.2"}
+  "fmt"
+  "logs"
+  "lwt" {>= "4.0.0"}
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.10.0/mirage-v3.10.0.tbz"
+  checksum: [
+    "sha256=0292be8b5cbb3f92ba4773ac4caca452b330e32b6c2bbf33df5bd3b85019d806"
+    "sha512=ebf4ef1bfa54dbd9cae5505c51953ddd694430588b6841e60506829e2cfad7177be53ee1e707b7f63151599f3eab189e35d6026cca6a315045338c1e77c20c3a"
+  ]
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.10.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.10.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends:   [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-types" {= version}
+]
+
+synopsis: "Lwt module type definitions for MirageOS applications"
+description: """
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`
+"""
+post-messages: [
+ "This package will be retired in MirageOS 4.0. Please use individual signatures (mirage-net / mirage-clock / etc.) instead."
+]
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.10.0/mirage-v3.10.0.tbz"
+  checksum: [
+    "sha256=0292be8b5cbb3f92ba4773ac4caca452b330e32b6c2bbf33df5bd3b85019d806"
+    "sha512=ebf4ef1bfa54dbd9cae5505c51953ddd694430588b6841e60506829e2cfad7177be53ee1e707b7f63151599f3eab189e35d6026cca6a315045338c1e77c20c3a"
+  ]
+}

--- a/packages/mirage-types/mirage-types.3.10.0/opam
+++ b/packages/mirage-types/mirage-types.3.10.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-console" {>= "3.0.0"}
+  "mirage-protocols" {>= "5.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "mirage-fs" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+]
+synopsis: "Module type definitions for MirageOS applications"
+description: """
+Module type definitions for MirageOS applications
+"""
+post-messages: [
+  "This package will be retired in MirageOS 4.0. Please use individual signatures (mirage-net / mirage-clock / etc.) instead."
+]
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.10.0/mirage-v3.10.0.tbz"
+  checksum: [
+    "sha256=0292be8b5cbb3f92ba4773ac4caca452b330e32b6c2bbf33df5bd3b85019d806"
+    "sha512=ebf4ef1bfa54dbd9cae5505c51953ddd694430588b6841e60506829e2cfad7177be53ee1e707b7f63151599f3eab189e35d6026cca6a315045338c1e77c20c3a"
+  ]
+}

--- a/packages/mirage/mirage.3.10.0/opam
+++ b/packages/mirage/mirage.3.10.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "5.0.0"}
+  "functoria"          {>= "3.1.0"}
+  "bos"
+  "astring"
+  "logs"
+  "stdlib-shims"
+  "mirage-runtime"     {=version | (>= "3.10.0" & < "3.11.0")}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.10.0/mirage-v3.10.0.tbz"
+  checksum: [
+    "sha256=0292be8b5cbb3f92ba4773ac4caca452b330e32b6c2bbf33df5bd3b85019d806"
+    "sha512=ebf4ef1bfa54dbd9cae5505c51953ddd694430588b6841e60506829e2cfad7177be53ee1e707b7f63151599f3eab189e35d6026cca6a315045338c1e77c20c3a"
+  ]
+}


### PR DESCRIPTION
CHANGES:

IPv6 and dual (IPv4 and IPv6) stack support mirage/mirage#1187

Since a long time, IPv6 code was around in our TCP/IP stack (thanks to @nojb
who developed it in 2014). Some months ago, @hannesm and @MagnusS got excited
to use it. After we managed to fix some bugs and add some test cases, and
writing more code to setup IPv6-only and dual stacks, we are eager to share
this support for MirageOS in a released version. We expect there to be bugs
lingering around, but duplicate address detection (neighbour solicitation and
advertisements) has been implemented, and (unless
"--accept-router-advertisement=false") router advertisements are decoded and
used to configure the IPv6 part of the stack. Configuring a static IPv6 address
is also possible (with "--ipv6=2001::42/64").

While at it, we unified the boot arguments between the different targets:
namely, on Unix (when using the socket stack), you can now pass
"--ipv4=127.0.0.1/24" to the same effect as the direct stack: only listen
on 127.0.0.1 (the subnet mask is ignored for the Unix socket stack).

A dual stack unikernel has "--ipv4-only=BOOL" and "--ipv6-only=BOOL" parameters,
so a unikernel binary could support both Internet Protocol versions, while the
operator can decide which protocol version to use.

Please also note that the default IPv4 network configuration no longer uses
10.0.0.1 as default gateway (since there was no way to unset the default
gateway mirage/mirage#1147).

For unikernel developers, there are some API changes in the Mirage module
- New "v4v6" types for IP protocols and stacks
- The ipv6_config record was adjusted in the same fashion as the ipv4_config
  type: it is now a record of a network (V6.Prefix.t) and gateway (V6.t option)

Some parts of the Mirage_key module were unified as well:
- Arp.ip_address is available (for a dual Ipaddr.t)
- Arg.ipv6_address replaces Arg.ipv6 (for an Ipaddr.V6.t)
- Arg.ipv6 replaces Arg.ipv6_prefix (for a Ipaddr.V6.Prefix.t)
- V6.network and V6.gateway are available, mirroring the V4 submodule

If you're ready to experiment with the dual stack, here's a diff for our basic
network example (from mirage-skeleton/device-usage/network) replacing IPv4
with a dual stack:

```
diff --git a/device-usage/network/config.ml b/device-usage/network/config.ml