### PR TITLE
Package soundtouch.0.1.9

### DIFF
--- a/packages/conf-soundtouch/conf-soundtouch.1/opam
+++ b/packages/conf-soundtouch/conf-soundtouch.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "http://www.mega-nerd.com/SRC/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "soundtouch dev team"
+license: "BSD"
+build: ["sh" "-c" "pkg-config --exists soundtouch || pkg-config --exists libSoundTouch"]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["soundtouch-dev"] {os-distribution = "alpine"}
+  ["soundtouch-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}
+  ["soundtouch-devel"] {os-family = "suse"}
+  ["libsoundtouch-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["soundtouch"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os = "oraclelinux"}
+  ["sound-touch"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on soundtouch"
+description:
+  "This package can only install if the soundtouch library is installed on the system."
+flags: conf

--- a/packages/soundtouch/soundtouch.0.1.9/opam
+++ b/packages/soundtouch/soundtouch.0.1.9/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/savonet/ocaml-soundtouch"
 bug-reports: "https://github.com/savonet/ocaml-soundtouch/issues"
 depends: [
   "ocaml"
-  "dune" {> "2.0"}
+  "dune" {>= "2.0"}
   "dune-configurator"
   "conf-soundtouch"
   "conf-pkg-config"

--- a/packages/soundtouch/soundtouch.0.1.9/opam
+++ b/packages/soundtouch/soundtouch.0.1.9/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings for the soundtouch library which provides functions for changing pitch and timestretching audio data"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1"
+homepage: "https://github.com/savonet/ocaml-soundtouch"
+bug-reports: "https://github.com/savonet/ocaml-soundtouch/issues"
+depends: [
+  "ocaml"
+  "dune" {> "2.0"}
+  "dune-configurator"
+  "conf-soundtouch"
+  "conf-pkg-config"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-soundtouch.git"
+url {
+  src: "https://github.com/savonet/ocaml-soundtouch/archive/v0.1.9.tar.gz"
+  checksum: [
+    "md5=4042e388af8def3e783f2c14c7ce62d0"
+    "sha512=12335fb7cb8b1bce753649104b39864c604207cdecf0b994ee5ea7ece39e5765b0a688f3fe244aa0f0e96ec899451d3c6cc9401dbb69f0b5ae84747f458ac201"
+  ]
+}


### PR DESCRIPTION
### `soundtouch.0.1.9`
Bindings for the soundtouch library which provides functions for changing pitch and timestretching audio data



---
* Homepage: https://github.com/savonet/ocaml-soundtouch
* Source repo: git+https://github.com/savonet/ocaml-soundtouch.git
* Bug tracker: https://github.com/savonet/ocaml-soundtouch/issues

---
:camel: Pull-request generated by opam-publish v2.0.2