### PR TITLE
[new release] dap (1.0.0)

### DIFF
--- a/packages/dap/dap.1.0.0/opam
+++ b/packages/dap/dap.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Debug adapter protocol"
+description: """
+The Debug Adapter Protocol defines the protocol used between an editor or IDE and a debugger or runtime.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocaml-dap"
+bug-reports: "https://github.com/hackwaly/ocaml-dap/issues"
+dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
+doc: "https://hackwaly.github.io/ocaml-dap/"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {build & >= "1.3"}
+  "yojson"
+  "ppx_here"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "lwt"
+  "lwt_ppx"
+  "lwt_react"
+  "react"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+x-commit-hash: "ddf64b746f6e9fe22abcc10e260660c2b3dad51f"
+url {
+  src:
+    "https://github.com/hackwaly/ocaml-dap/releases/download/1.0.0/dap-1.0.0.tbz"
+  checksum: [
+    "sha256=7a670242ed251d8eb51b1690739577aa2e8dce6b6308ecdf51ec2c933c4d2910"
+    "sha512=be6e75212e1f6c1275b260802229f76fb2cc5d5eb2aa07ac9d2e21510b5dc9897e93bd126663d157a6a695c5b34e042978d41c975c4e1b7fc444577e30f9b1d0"
+  ]
+}

--- a/packages/dap/dap.1.0.0/opam
+++ b/packages/dap/dap.1.0.0/opam
@@ -12,7 +12,7 @@ dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
 doc: "https://hackwaly.github.io/ocaml-dap/"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {build & >= "1.3"}
+  "dune" {>= "2.7"}
   "yojson"
   "ppx_here"
   "ppx_deriving"


### PR DESCRIPTION
Debug adapter protocol

- Project page: <a href="https://github.com/hackwaly/ocaml-dap">https://github.com/hackwaly/ocaml-dap</a>
- Documentation: <a href="https://hackwaly.github.io/ocaml-dap/">https://hackwaly.github.io/ocaml-dap/</a>

##### CHANGES:

Initial release.

- Specification version is 1.43
