### PR TITLE
[new release] key-parsers (1.0.0)

### DIFF
--- a/packages/key-parsers/key-parsers.1.0.0/opam
+++ b/packages/key-parsers/key-parsers.1.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: [
+    "Cryptosense <opensource@cryptosense.com>"
+    "Nathan Rebours <nathan.p.rebours@gmail.com>"
+]
+homepage: "https://github.com/cryptosense/key-parsers"
+bug-reports: "https://github.com/cryptosense/key-parsers/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/key-parsers.git"
+doc: "https://cryptosense.github.io/key-parsers/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "asn1-combinators" {>= "0.2.0"}
+  "cstruct" {>= "1.6.0"}
+  "dune" {build}
+  "hex" {>= "1.0.0"}
+  "ocaml" {>= "4.04.1"}
+  "ounit" {with-test & >= "2.0.0"}
+  "ppx_deriving" {>= "4.0"}
+  "result" {>= "1.2"}
+  "zarith" {>= "1.4.1"}
+]
+conflicts: [
+  "ppx_driver" {= "v0.9.1"}
+]
+synopsis: "Parsers for multiple key formats"
+description: """
+This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman or
+Elliptic curve public and private keys.
+"""
+x-commit-hash: "a17d058b9a89264838d52498125d75b92d92351e"
+url {
+  src:
+    "https://github.com/cryptosense/key-parsers/releases/download/1.0.0/key-parsers-1.0.0.tbz"
+  checksum: [
+    "sha256=6e10a1e8a8ef1172a5bc2694400d84e52d21d75a36a46814a4b6cd0f936db3f4"
+    "sha512=1033269dffaf3a805e8c84dab92fe025a90cfcb6b0938dcaadeffd8c67ad7a3366759209aba3e8dc01ea725ba14cf450b06d66b7cf49cdb59c649fc650ca8b95"
+  ]
+}

--- a/packages/pkcs11/pkcs11.0.9.0/opam
+++ b/packages/pkcs11/pkcs11.0.9.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "hex" {>= "1.0.0"}
   "integers"
-  "key-parsers" {>= "0.5.0" & != "0.6.0"}
+  "key-parsers" {>= "0.5.0" & != "0.6.0" & < "1.0.0"}
   "ppx_deriving" {>= "4.0"}
   "ppx_deriving_yojson" {>= "3.0"}
   "ocamlbuild" {build}


### PR DESCRIPTION
Parsers for multiple key formats

- Project page: <a href="https://github.com/cryptosense/key-parsers">https://github.com/cryptosense/key-parsers</a>
- Documentation: <a href="https://cryptosense.github.io/key-parsers/doc">https://cryptosense.github.io/key-parsers/doc</a>

##### CHANGES:

## 1.0.0

*2020-12-03*

### Changed

- Correct spelling 'alogrithm' -> 'algorithm' in some labels

### Removed

- Remove dependency on ppx_deriving_yojson and ppx_bin_prot, and associated deprecated
  serialization values (`bin_t`, `bin_size_t`, `to_yojson`, etc).
- Remove deprecated uppercase module aliases `RSA`, `DSA`, `EC` and `DH` in `Asn1`, `Cvc`
  and `Ltpa`.