### PR TITLE
Package ladspa.0.2.0

### DIFF
--- a/packages/conf-ladspa/conf-ladspa.1/opam
+++ b/packages/conf-ladspa/conf-ladspa.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://www.ladspa.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "ladspa dev team"
+license: "BSD"
+depexts: [
+  ["ladspa-dev"] {os-distribution = "alpine"}
+  ["ladspa-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}
+  ["ladspa-sdk"] {os-family = "debian"}
+  ["drfill/liquidsoap/ladspa_header"]
+    {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on ladspa"
+description:
+  "This package can only install if the ladspa library is installed on the system."
+flags: conf

--- a/packages/dssi/dssi.0.1.1/opam
+++ b/packages/dssi/dssi.0.1.1/opam
@@ -8,7 +8,11 @@ build: [
   [make]
 ]
 remove: [["ocamlfind" "remove" "dssi"]]
-depends: ["ocaml" "ocamlfind" "ladspa"]
+depends: [
+  "ocaml"
+  "ocamlfind"
+  "ladspa" {< "0.2.0"}
+]
 x-ci-accept-failures: ["debian-unstable"]
 depexts: [
   ["dssi-dev" "ladspa-sdk"] {os-family = "debian"}

--- a/packages/dssi/dssi.0.1.2/opam
+++ b/packages/dssi/dssi.0.1.2/opam
@@ -10,7 +10,11 @@ install: [
   [make "install"]
 ]
 remove: ["ocamlfind" "remove" "dssi"]
-depends: ["ocaml" "ocamlfind" "ladspa"]
+depends: [
+  "ocaml"
+  "ocamlfind"
+  "ladspa" {< "0.2.0"}
+]
 depexts: [
   ["dssi-dev"] {os-family = "debian"}
   ["dssi-devel"] {os-distribution = "centos"}

--- a/packages/ladspa/ladspa.0.2.0/opam
+++ b/packages/ladspa/ladspa.0.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Bindings for the LADSPA API which provides audio effects"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1"
+homepage: "https://github.com/savonet/ocaml-ladspa"
+bug-reports: "https://github.com/savonet/ocaml-ladspa/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-configurator"
+  "conf-ladspa"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-ladspa.git"
+url {
+  src: "https://github.com/savonet/ocaml-ladspa/archive/v0.2.0.tar.gz"
+  checksum: [
+    "md5=3b5aaa67f910c8783d7879b3ff5490c7"
+    "sha512=d01c731b852d864c3d843e1e5b4e9b5a6b39a0b56252e45c8bb5ee196d2843b6c4f86382e4b537ac550ea4c46d729b3080dcb2b1305f6bec1ecfac204c781948"
+  ]
+}

--- a/packages/liquidsoap/liquidsoap.1.4.0/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.0/opam
@@ -106,6 +106,7 @@ conflicts: [
   "gstreamer" {< "0.3.0"}
   "inotify" {< "1.0"}
   "ladspa" {< "0.1.4"}
+  "ladspa" {>= "0.2.0"}
   "lame" {< "0.3.2"}
   "lastfm" {< "0.3.0"}
   "lo" {< "0.1.2"}

--- a/packages/liquidsoap/liquidsoap.1.4.1-1/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1-1/opam
@@ -117,6 +117,7 @@ conflicts: [
   "gstreamer" {< "0.3.0"}
   "inotify" {< "1.0"}
   "ladspa" {< "0.1.4"}
+  "ladspa" {>= "0.2.0"}
   "lame" {< "0.3.2"}
   "lastfm" {< "0.3.0"}
   "lo" {< "0.1.2"}

--- a/packages/liquidsoap/liquidsoap.1.4.1-2/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1-2/opam
@@ -120,6 +120,7 @@ conflicts: [
   "gstreamer" {< "0.3.0"}
   "inotify" {< "1.0"}
   "ladspa" {< "0.1.4"}
+  "ladspa" {>= "0.2.0"}
   "lame" {< "0.3.2"}
   "lastfm" {< "0.3.0"}
   "lo" {< "0.1.2"}

--- a/packages/liquidsoap/liquidsoap.1.4.1/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1/opam
@@ -106,6 +106,7 @@ conflicts: [
   "gstreamer" {< "0.3.0"}
   "inotify" {< "1.0"}
   "ladspa" {< "0.1.4"}
+  "ladspa" {>= "0.2.0"}
   "lame" {< "0.3.2"}
   "lastfm" {< "0.3.0"}
   "lo" {< "0.1.2"}

--- a/packages/liquidsoap/liquidsoap.1.4.2/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.2/opam
@@ -117,6 +117,7 @@ conflicts: [
   "gstreamer" {< "0.3.0"}
   "inotify" {< "1.0"}
   "ladspa" {< "0.1.4"}
+  "ladspa" {>= "0.2.0"}
   "lame" {< "0.3.2"}
   "lame" {>= "0.3.4"}
   "lastfm" {< "0.3.0"}

--- a/packages/liquidsoap/liquidsoap.1.4.3/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.3/opam
@@ -117,6 +117,7 @@ conflicts: [
   "gstreamer" {< "0.3.0"}
   "inotify" {< "1.0"}
   "ladspa" {< "0.1.4"}
+  "ladspa" {>= "0.2.0"}
   "lame" {< "0.3.2"}
   "lastfm" {< "0.3.0"}
   "lo" {< "0.1.2"}


### PR DESCRIPTION
### `ladspa.0.2.0`
Bindings for the LADSPA API which provides audio effects



---
* Homepage: https://github.com/savonet/ocaml-ladspa
* Source repo: git+https://github.com/savonet/ocaml-ladspa.git
* Bug tracker: https://github.com/savonet/ocaml-ladspa/issues

---
:camel: Pull-request generated by opam-publish v2.0.2