### PR TITLE
Package ocaml_db_model.0.1

### DIFF
--- a/packages/ocaml_db_model/ocaml_db_model.0.1/opam
+++ b/packages/ocaml_db_model/ocaml_db_model.0.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "An Ocaml library and utility for creating modules out of thin air that describe database tables and types, with functions for running queries and commands. Aka database modelling"
+description:
+  "In the style of ODB for C++ or JOOQ for Java, this project aims to get off the ground rudimentary support for the creation of code (Ocaml modules) that otherwise would have to be tediously hand written, and maintained to track changes, such as to field names and types, in a live database. The output modules can serve as inputs to other client projects. This project supports mysql. For postgresql support see the ocaml_pgsql_model project"
+maintainer: ["papatangonyc@gmail.com"]
+authors: ["papatangonyc@gmail.com"]
+license: "GPLv3"
+homepage: "https://github.com/pat227/ocaml-db-model.git"
+bug-reports: "https://github.com/pat227/ocaml-db-model.git/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08.1"}
+  "bignum" {>= "v0.14.0"}
+  "core" {>= "v0.14.0"}
+  "fieldslib" {>= "v0.14.0"}
+  "mysql" {>= "1.2.4"}
+  "ppx_deriving" {>= "4.5"}
+  "ppx_deriving_yojson" {>= "3.5.2"}
+  "ppx_fields_conv" {>= "v0.14.0"}
+  "pcre" {>= "7.2.3"}
+  "uint" {>= "2.0.1"}
+  "yojson" {>= "1.7.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pat227/ocaml-db-model.git.git"
+url {
+  src: "https://github.com/pat227/ocaml-db-model/archive/0.1.tar.gz"
+  checksum: [
+    "md5=bc28476bd5ec043480ffe16283e18f51"
+    "sha512=5ff9718fb40620141a8f211183cde1873c4070a269ce9990b4c7ec45095126d5faf1e014920d7639639222b763590513395b633d72d8cdc7b8912c266dc2b052"
+  ]
+}


### PR DESCRIPTION
### `ocaml_db_model.0.1`
An Ocaml library and utility for creating modules out of thin air that describe database tables and types, with functions for running queries and commands. Aka database modelling
In the style of ODB for C++ or JOOQ for Java, this project aims to get off the ground rudimentary support for the creation of code (Ocaml modules) that otherwise would have to be tediously hand written, and maintained to track changes, such as to field names and types, in a live database. The output modules can serve as inputs to other client projects. This project supports mysql. For postgresql support see the ocaml_pgsql_model project



---
* Homepage: https://github.com/pat227/ocaml-db-model.git
* Source repo: git+https://github.com/pat227/ocaml-db-model.git.git
* Bug tracker: https://github.com/pat227/ocaml-db-model.git/issues

---
:camel: Pull-request generated by opam-publish v2.0.2