### PR TITLE
Mark memtrace as incompatible with `arm32` and `x86_32`

### DIFF
--- a/packages/memtrace/memtrace.0.1.1/opam
+++ b/packages/memtrace/memtrace.0.1.1/opam
@@ -25,6 +25,9 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/janestreet/memtrace.git"
+available: [
+  arch != "x86_32" & arch != "arm32"
+]
 x-commit-hash: "17958eb6f82b99bd4ec56c9086385456cbaebec1"
 url {
   src:

--- a/packages/memtrace/memtrace.0.1.2/opam
+++ b/packages/memtrace/memtrace.0.1.2/opam
@@ -25,6 +25,9 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/janestreet/memtrace.git"
+available: [
+  arch != "x86_32" & arch != "arm32"
+]
 x-commit-hash: "43cc9dfe04cbb9c087dd999a7a1d18a729e58cec"
 url {
   src:

--- a/packages/memtrace/memtrace.0.1/opam
+++ b/packages/memtrace/memtrace.0.1/opam
@@ -26,6 +26,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/janestreet/memtrace.git"
 doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/memtrace/index.html"
+available: [
+  arch != "x86_32" & arch != "arm32"
+]
 x-commit-hash: "bb09c9e802c230c2518d72578c3cc2b917dff6fb"
 url {
   src:


### PR DESCRIPTION
See https://github.com/janestreet/memtrace/issues/7.

This should fix the build problem shown at https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/741d81be6463c185927ec3db3a465db4a43bb887.

/cc @stedolan 