### PR TITLE
Removes the build of error messages by menhir for release build

### DIFF
--- a/packages/acgtk/acgtk.1.5.2/opam
+++ b/packages/acgtk/acgtk.1.5.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "sylvain.pogodalla@inria.fr"
+
+build: [
+  ["dune" "subst"] {pinned}
+# remove the -p to also build the local libraries: conflict with the
+# fact that some libraries are also part of the acgtkLib package
+#  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "--profile=release" "-j" jobs]
+]
+
+install: ["dune" "install"]
+
+depends: [
+  "ocaml" { >= "4.05.0" }
+  "dune" { >= "1.0" }
+  "menhir"
+  "ANSITerminal"
+  "fmt"
+  "logs"
+  "mtime"
+  "cmdliner"
+  "conf-freetype"
+  "conf-pkg-config"
+  "conf-cairo"
+  "cairo2"
+  "yojson"
+  "easy-format"
+]
+
+dev-repo: "git+https://gitlab.inria.fr/ACG/dev/ACGtk.git"
+
+homepage: "http://acg.loria.fr/"
+license: "CeCILL-1.0+"
+authors: ["Sylvain Pogodalla"]
+bug-reports: "sylvain.pogodalla@inria.fr"
+
+synopsis: "Abstract Categorial Grammar development toolkit"
+
+description: "This toolkit provides a compiler and an interpreter for Abstract Categorial Grammars (ACGs). Grammars can be compiled and then used by the interpreter to parse (if the grammar is at most second-order) or to generate terms. See http://acg.loria.fr for more details and bibliographic references."
+
+url {
+     src: "http://acg.loria.fr/software/acg-1.5.2-20201204.tar.gz"
+     checksum: "md5=db893b834152aaa29690477099d8dc17"
+}

--- a/packages/acgtk/acgtk.1.5.2/opam
+++ b/packages/acgtk/acgtk.1.5.2/opam
@@ -13,7 +13,7 @@ install: ["dune" "install"]
 
 depends: [
   "ocaml" { >= "4.05.0" }
-  "dune" { >= "1.0" }
+  "dune" { >= "1.4" }
   "menhir"
   "ANSITerminal"
   "fmt"

--- a/packages/memtrace/memtrace.0.1.1/opam
+++ b/packages/memtrace/memtrace.0.1.1/opam
@@ -25,6 +25,9 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/janestreet/memtrace.git"
+available: [
+  arch != "x86_32" & arch != "arm32"
+]
 x-commit-hash: "17958eb6f82b99bd4ec56c9086385456cbaebec1"
 url {
   src:

--- a/packages/memtrace/memtrace.0.1.2/opam
+++ b/packages/memtrace/memtrace.0.1.2/opam
@@ -25,6 +25,9 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/janestreet/memtrace.git"
+available: [
+  arch != "x86_32" & arch != "arm32"
+]
 x-commit-hash: "43cc9dfe04cbb9c087dd999a7a1d18a729e58cec"
 url {
   src:

--- a/packages/memtrace/memtrace.0.1/opam
+++ b/packages/memtrace/memtrace.0.1/opam
@@ -26,6 +26,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/janestreet/memtrace.git"
 doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/memtrace/index.html"
+available: [
+  arch != "x86_32" & arch != "arm32"
+]
 x-commit-hash: "bb09c9e802c230c2518d72578c3cc2b917dff6fb"
 url {
   src:


### PR DESCRIPTION
Removes the build of error messages by menhir for release build (so acgtk should still compile when menhir changes the way it generates messages) and makes a bit of code cleaning.