### PR TITLE
[new release] dap (1.0.1)

### DIFF
--- a/packages/dap/dap.1.0.1/opam
+++ b/packages/dap/dap.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Debug adapter protocol"
+description: """
+The Debug Adapter Protocol defines the protocol used between an editor or IDE and a debugger or runtime.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocaml-dap"
+bug-reports: "https://github.com/hackwaly/ocaml-dap/issues"
+dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
+doc: "https://hackwaly.github.io/ocaml-dap/"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {build & >= "1.3"}
+  "yojson"
+  "ppx_here"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "lwt"
+  "lwt_ppx"
+  "lwt_react"
+  "react"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+x-commit-hash: "cb714757b1d572a398edd9cf0fefc6b6cb99b16e"
+url {
+  src:
+    "https://github.com/hackwaly/ocaml-dap/releases/download/1.0.1/dap-1.0.1.tbz"
+  checksum: [
+    "sha256=8c71b7033e1c43a068a9fa649f68e9615c27f00c54243bbff7b001c24bc37f92"
+    "sha512=90716ef3707276d8ff663ad0dc4858bd953afbca1352a8e90cafd35a682f5e6e218c9f72e11758d5411a6189a09fe4e96c9dabad6ef69b46fd2d098138217a87"
+  ]
+}


### PR DESCRIPTION
Debug adapter protocol

- Project page: <a href="https://github.com/hackwaly/ocaml-dap">https://github.com/hackwaly/ocaml-dap</a>
- Documentation: <a href="https://hackwaly.github.io/ocaml-dap/">https://hackwaly.github.io/ocaml-dap/</a>

##### CHANGES:

Initial release.

- Specification version is 1.43
