### PR TITLE
Package http-multipart-formdata.1.0.1

### DIFF
--- a/packages/http-multipart-formdata/http-multipart-formdata.1.0.1/opam
+++ b/packages/http-multipart-formdata/http-multipart-formdata.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Http multipart/formdata parser"
+description:
+  "OCaml implementation of RFC 7578 (Returning Values from Forms: multipart/form-data)- https://tools.ietf.org/html/rfc7578"
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem, <gbikal@gmail.com>"]
+license: "MPL-2.0"
+tags: ["http" "multipart" "formadata" "form" "web"]
+homepage: "https://github.com/lemaetech/http-mutlipart-formdata"
+bug-reports: "https://github.com/lemaetech/http-mutlipart-formdata/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "fmt" {>= "0.8.9"}
+  "reparse"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/http-mutlipart-formdata.git"
+url {
+  src:
+    "https://github.com/lemaetech/http-multipart-formdata/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=c7d373e4fb487e0834920ec630ad5015"
+    "sha512=7470e1deef694e19ce8bdb93006dee256206f145db54fc8b66ce81c6a4c7b664fadbde8e44d300000fc005a10a08e32996beec9bbdd9eb684a85c62b8fd9573a"
+  ]
+}


### PR DESCRIPTION
### `http-multipart-formdata.1.0.1`
Http multipart/formdata parser
OCaml implementation of RFC 7578 (Returning Values from Forms: multipart/form-data)- https://tools.ietf.org/html/rfc7578



---
* Homepage: https://github.com/lemaetech/http-mutlipart-formdata
* Source repo: git+https://github.com/lemaetech/http-mutlipart-formdata.git
* Bug tracker: https://github.com/lemaetech/http-mutlipart-formdata/issues

---
:camel: Pull-request generated by opam-publish v2.0.2