### PR TITLE
[new release] dap (1.0.1)

### DIFF
--- a/packages/dap/dap.1.0.1/opam
+++ b/packages/dap/dap.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Debug adapter protocol"
+description: """
+The Debug Adapter Protocol defines the protocol used between an editor or IDE and a debugger or runtime.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocaml-dap"
+bug-reports: "https://github.com/hackwaly/ocaml-dap/issues"
+dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
+doc: "https://hackwaly.github.io/ocaml-dap/"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {build & >= "1.3"}
+  "yojson"
+  "ppx_here"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "lwt"
+  "lwt_ppx"
+  "lwt_react"
+  "react"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+x-commit-hash: "8409f83ae0b5adcc521f5a83bd84706b2eecc805"
+url {
+  src:
+    "https://github.com/hackwaly/ocaml-dap/releases/download/1.0.1/dap-1.0.1.tbz"
+  checksum: [
+    "sha256=697b7739fbe25143777622c549544dc57b83b3d8a2de20ed45b16edacf956bb7"
+    "sha512=315f9249535a54b370d59fc844c28e5a9286badfdcaa8c9643e630d453af73f0224c52dbb9d353ed75ed02ceb4e1b55c0579d84eb8c07e5bd5bb4289a62a475f"
+  ]
+}


### PR DESCRIPTION
Debug adapter protocol

- Project page: <a href="https://github.com/hackwaly/ocaml-dap">https://github.com/hackwaly/ocaml-dap</a>
- Documentation: <a href="https://hackwaly.github.io/ocaml-dap/">https://hackwaly.github.io/ocaml-dap/</a>

##### CHANGES:

Initial release.

- Specification version is 1.43
