### PR TITLE
package Frama-C plugin MetAcsl

### DIFF
--- a/packages/conf-swi-prolog/conf-swi-prolog.1/opam
+++ b/packages/conf-swi-prolog/conf-swi-prolog.1/opam
@@ -1,0 +1,15 @@
+opam-version: "2.0"
+maintainer: "virgile.prevosto@m4x.org"
+homepage: "https://www.swi-prolog.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "BSD-2-Clause"
+build: ["swipl" "--version"]
+depexts: [
+  ["swi-prolog"] {os-family = "debian" }
+  ["emacs-nox"] {os-distribution = "arch"}
+]
+synopsis: "Virtual package to install the swi-prolog interpreter"
+description:
+  "This package will install a system swi-prolog if invoked via `opam depext`"
+authors: "virgile.prevosto@m4x.org"
+flags: conf

--- a/packages/conf-swi-prolog/conf-swi-prolog.1/opam
+++ b/packages/conf-swi-prolog/conf-swi-prolog.1/opam
@@ -5,8 +5,18 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "BSD-2-Clause"
 build: ["swipl" "--version"]
 depexts: [
-  ["swi-prolog"] {os-family = "debian" }
-  ["emacs-nox"] {os-distribution = "arch"}
+  ["swi-prolog"] {os-family = "debian"}
+  ["swi-prolog"] {os-family = "ubuntu"}
+  ["swi-prolog"] {os-family = "arch"}
+  ["swi-prolog"] {os-family = "gentoo"}
+  ["swi-prolog"] {os-family = "mageia"}
+  ["pl"] {os-family = "fedora" | os-family = "centos" | os-family = "rhel" | os-family = "amzn" | os-family = "ol"}
+  ["swipl"] {os-family = "suse"}
+  ["swi-pl"] {os = "freebsd"}
+  ["swi-prolog"] {os = "openbsd"}
+  ["swi-prolog"] {os = "netbsd"}
+  ["swi-prolog"] {os = "macos" & os-family = "homebrew"}
+  ["swi-prolog"] {os = "macos" & os-family = "macports"}
 ]
 synopsis: "Virtual package to install the swi-prolog interpreter"
 description:

--- a/packages/frama-c-metacsl/frama-c-metacsl.0.1/opam
+++ b/packages/frama-c-metacsl/frama-c-metacsl.0.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+name: "frama-c-metacsl"
+synopsis: "MetACSL plugin of Frama-C for writing pervasives properties"
+version: "0.1"
+description:"""
+MetACSL let users write properties that need to be checked at particular
+contexts (e.g. each time a location is written to inside a given set
+of functions). It will then generate all the corresponding ACSL
+annotations, leaving it to analysis plug-ins (e.g. WP) to prove the
+resulting clauses.
+"""
+maintainer: "virgile.prevosto@cea.fr"
+authors: [
+  "Virgile Robles"
+]
+homepage: "https://frama-c.com/"
+license: "LGPL-2.1-only"
+dev-repo: "git+https://git.frama-c.com/pub/meta.git"
+bug-reports: "https://git.frama-c.com/pub/meta/-/issues"
+tags: [
+  "program verification"
+  "formal specification"
+  "ACSL"
+  "MetACSL"
+]
+
+url {
+  src: "https://git.frama-c.com/pub/meta/uploads/deea5fb23305cdfa62976bec2cbce45c/frama-c-metacsl-0.1.tar.gz"
+  checksum: ["md5=74e2a596816520793abc8c1266057520"
+             "sha256=95c35a9a21591aeb46a6955e7a7104b8cd359f907d35e9d1a1e38c2ed29aa5fb"
+             "sha512=10f317e32afc606390681a7e8091f48cb8141b75947c9f40e7203a30a1b6effe7038a8939f283ef8d69650c4e285865cafae75d3e6992fcc45942e56fcafd699"]
+}
+
+build: [
+  ["autoconf"] {pinned}
+  ["./configure"]
+  [make "-j%{jobs}%"]
+]
+
+install: [
+  [make "install"]
+]
+
+depends: [
+  "ocaml" { >= "4.05.0" & ( < "4.08.0~" | >= "4.08.1" ) }
+  "frama-c" { >= "22.0" & < "23.0" }
+  "why3" { >= "1.3.1" }
+]
+
+depopts: [ "conf-swi-prolog" ]
+
+messages: [ "Note that if you wish to use the deduction features of MetAcsl, you must install the conf-swi-prolog package (and swi-prolog itself)" {!conf-swi-prolog:installed} ]

--- a/packages/frama-c-metacsl/frama-c-metacsl.0.1/opam
+++ b/packages/frama-c-metacsl/frama-c-metacsl.0.1/opam
@@ -1,7 +1,5 @@
 opam-version: "2.0"
-name: "frama-c-metacsl"
 synopsis: "MetACSL plugin of Frama-C for writing pervasives properties"
-version: "0.1"
 description:"""
 MetACSL let users write properties that need to be checked at particular
 contexts (e.g. each time a location is written to inside a given set
@@ -32,7 +30,7 @@ url {
 }
 
 build: [
-  ["autoconf"] {pinned}
+  ["autoconf"] {dev}
   ["./configure"]
   [make "-j%{jobs}%"]
 ]


### PR DESCRIPTION
This actually creates two packages:

- frama-c-metacsl for the brand new [MetAcsl](https://www.frama-c.com/fc-plugins/metacsl.html) package of Frama-C
- conf-swi-prolog, as MetAcsl optionally uses the SWI-prolog interpreter.