### PR TITLE
Add conf-tzdata

### DIFF
--- a/packages/conf-tzdata/conf-tzdata.1/opam
+++ b/packages/conf-tzdata/conf-tzdata.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: "Etienne Millon <me@emillon.org>"
+homepage: "https://www.iana.org/time-zones"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "public domain"
+build: ["test" "-d" "/usr/share/zoneinfo"]
+depexts: [
+  ["tzdata"] {os-family = "debian"}
+  ["tzdata"] {os-distribution = "alpine"}
+  ["tzdata"] {os-family = "fedora"}
+  ["timezone"] {os-family = "suse"}
+]
+synopsis: "Virtual package relying on tzdata"
+description:
+  "This package can only install if a time zone database is available at /usr/share/zoneinfo."
+flags: conf


### PR DESCRIPTION
This new conf package refers to the time zone database. These files are necessary at run time when using for example [the timezone package](https://github.com/janestreet/timezone).

The path is hardcoded in the build step but the test can be extended if necessary.