### PR TITLE
[new release] dap (1.0.1)

### DIFF
--- a/packages/dap/dap.1.0.1/opam
+++ b/packages/dap/dap.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Debug adapter protocol"
+description: """
+The Debug Adapter Protocol defines the protocol used between an editor or IDE and a debugger or runtime.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocaml-dap"
+bug-reports: "https://github.com/hackwaly/ocaml-dap/issues"
+dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
+doc: "https://hackwaly.github.io/ocaml-dap/"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {build & >= "1.3"}
+  "yojson"
+  "ppx_here"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "lwt"
+  "lwt_ppx"
+  "lwt_react"
+  "react"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+x-commit-hash: "142477248f5b3a776972436c3b27ed5a46ef66ab"
+url {
+  src:
+    "https://github.com/hackwaly/ocaml-dap/releases/download/1.0.1/dap-1.0.1.tbz"
+  checksum: [
+    "sha256=de9cea47376d1731f27e07e1635dddcbd908ec23e62d953935acb5a0b0b705d1"
+    "sha512=0f2cbf421b0bb94f109da572256c5dd32189bb45cc0a7bcfa1995b6a79ca9bdb16ee6ea723e2347553484ca4e298388f9fba1001919cee6f88e7f0a2c4461882"
+  ]
+}


### PR DESCRIPTION
Debug adapter protocol

- Project page: <a href="https://github.com/hackwaly/ocaml-dap">https://github.com/hackwaly/ocaml-dap</a>
- Documentation: <a href="https://hackwaly.github.io/ocaml-dap/">https://hackwaly.github.io/ocaml-dap/</a>

##### CHANGES:

Initial release.

- Specification version is 1.43
