### PR TITLE
[new release] dap (1.0.1)

### DIFF
--- a/packages/dap/dap.1.0.1/opam
+++ b/packages/dap/dap.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Debug adapter protocol"
+description: """
+The Debug Adapter Protocol defines the protocol used between an editor or IDE and a debugger or runtime.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocaml-dap"
+bug-reports: "https://github.com/hackwaly/ocaml-dap/issues"
+dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
+doc: "https://hackwaly.github.io/ocaml-dap/"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {build & >= "1.3"}
+  "yojson"
+  "ppx_here"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "lwt"
+  "lwt_ppx"
+  "lwt_react"
+  "react"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+x-commit-hash: "3a94ffc82da2871b8e72c5a117cdb821dd25e0ed"
+url {
+  src:
+    "https://github.com/hackwaly/ocaml-dap/releases/download/1.0.1/dap-1.0.1.tbz"
+  checksum: [
+    "sha256=9e2971279e0af9dcbd18483b64b33746c9c4caddd1e595ab584da08121ca008c"
+    "sha512=bbf9622dd1df8f94f757d19cacd4517b7eae60f2569fcd3ee53b82d6606cc8c25813a3db58c357a986e32612f31c8b11921d3d7856f5276c7e80347b00d5070c"
+  ]
+}


### PR DESCRIPTION
Debug adapter protocol

- Project page: <a href="https://github.com/hackwaly/ocaml-dap">https://github.com/hackwaly/ocaml-dap</a>
- Documentation: <a href="https://hackwaly.github.io/ocaml-dap/">https://hackwaly.github.io/ocaml-dap/</a>

##### CHANGES:

Initial release.

- Specification version is 1.43
