### PR TITLE
[new release] letters (0.2.1)

### DIFF
--- a/packages/letters/letters.0.2.1/opam
+++ b/packages/letters/letters.0.2.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Client library for sending emails over SMTP"
+description: "Simple to use SMTP client implementation for OCaml"
+maintainer: ["Miko Nieminen <miko.nieminen@iki.fi>"]
+authors: ["Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/letters/"
+doc: "https://oxidizing.github.io/letters/"
+bug-reports: "https://github.com/oxidizing/letters/issues"
+depends: [
+  "ocaml" {>= "4.08.1"}
+  "dune" {>= "2.3"}
+  "mrmime" {>= "0.3.1"}
+  "colombe" {>= "0.4.0"}
+  "sendmail" {>= "0.4.0"}
+  "fmt" {>= "0.8.8"}
+  "x509" {>= "0.9.0"}
+  "ptime" {>= "0.8.5"}
+  "lwt" {>= "5.2.0"}
+  "fpath" {>= "0.7.0"}
+  "alcotest" {>= "1.1.0" & with-test}
+  "alcotest-lwt" {>= "1.1.0" & with-test}
+  "yojson" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {dev}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/letters.git"
+x-commit-hash: "707eb6ba3ba4492d0edc16058f8b5266086eb5b9"
+url {
+  src:
+    "https://github.com/oxidizing/letters/releases/download/0.2.1/letters-0.2.1.tbz"
+  checksum: [
+    "sha256=ed825c2da0d127c5edb64179e5858f2535b50e20d99c516b3d044e600676cbd5"
+    "sha512=16fd185ba0e06d8200e3fbdc7abae2a76b96e9d97b0750904f7200b3963dc9b45838576984bc74dfdc56189667c2c7eb70e9ca0343eeef9f8792d64a484a16de"
+  ]
+}


### PR DESCRIPTION
Client library for sending emails over SMTP

- Project page: <a href="https://github.com/oxidizing/letters/">https://github.com/oxidizing/letters/</a>
- Documentation: <a href="https://oxidizing.github.io/letters/">https://oxidizing.github.io/letters/</a>

##### CHANGES:

## [0.2.1] - 2020-12-07
### Fixed
- Upgrade to `colombe` version `0.4.0`, this fixes vanishing full stop issue,
  when encoded mail body contains line that stars with full stop. See
  [SMTP Transparency](https://tools.ietf.org/html/rfc821#section-4.5.2) for more
  information.
### Changed
- Improve service tests
- Improve documentation for running service tests
### Added
- Use also *mailtrap.io* in service tests

## [0.2.0] - 2020-08-25
### Added
- Support for multipart/alternative emails supporting HTML and plain text bodies
  as alternative representation for the content
- Add documentation for basic use
- Add support for detecting CA certificates automatically for peer verification
- Add support defining bundle or single CA certificate for peer verification
- Add support for selecting mechanism for CA certificates used for peer
  verification
### Changed
- Refactor configurations into separate module
- Refactor structure of tests

## [0.1.1] - 2020-07-10
### Fixed
- Add missing `public_name` stanza in library's dune file to make it properly
available
- Fix minimum required OCaml version to 4.08.1
- Relax `mrmime` and `colombe` dependency constraints

## [0.1.0] - 2020-07-07
### Added
- Support sending email over TLS protected SMTP connection
- Support sending email over SMTP with STARTTLS
- Support sending HTML or plain text body
