### PR TITLE
[new release] dap (1.0.1)

### DIFF
--- a/packages/dap/dap.1.0.1/opam
+++ b/packages/dap/dap.1.0.1/opam
@@ -12,7 +12,7 @@ dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
 doc: "https://hackwaly.github.io/ocaml-dap/"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {build & >= "1.3"}
+  "dune" {>= "2.7"}
   "yojson"
   "ppx_here"
   "ppx_deriving"

--- a/packages/dap/dap.1.0.1/opam
+++ b/packages/dap/dap.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Debug adapter protocol"
+description: """
+The Debug Adapter Protocol defines the protocol used between an editor or IDE and a debugger or runtime.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocaml-dap"
+bug-reports: "https://github.com/hackwaly/ocaml-dap/issues"
+dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
+doc: "https://hackwaly.github.io/ocaml-dap/"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {build & >= "1.3"}
+  "yojson"
+  "ppx_here"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "lwt"
+  "lwt_ppx"
+  "lwt_react"
+  "react"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+x-commit-hash: "b7863cada6f62ffade6dfd7bde83c78967ddde55"
+url {
+  src:
+    "https://github.com/hackwaly/ocaml-dap/releases/download/1.0.1/dap-1.0.1.tbz"
+  checksum: [
+    "sha256=2c1cb97ed697a3b3c236b3d6d42332193ed9e4f169845551d3690bfa8aa1f527"
+    "sha512=9653b7e91148b0a86c41084524dc52ac25e2062d0c39965ab6a916791e9149ca0459ad1e12a71f0670e1956e5295c08356c3bb26bf99090739763f3dbe1fcbdb"
+  ]
+}


### PR DESCRIPTION
Debug adapter protocol

- Project page: <a href="https://github.com/hackwaly/ocaml-dap">https://github.com/hackwaly/ocaml-dap</a>
- Documentation: <a href="https://hackwaly.github.io/ocaml-dap/">https://hackwaly.github.io/ocaml-dap/</a>

##### CHANGES:

Initial release.

- Specification version is 1.43
