### PR TITLE
3 packages from c-cube/ocaml-containers at 3.1

### DIFF
--- a/packages/containers-data/containers-data.3.1/opam
+++ b/packages/containers-data/containers-data.3.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A set of advanced datatypes for containers"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "containers" { = version }
+  "seq"
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  #"mdx" { with-test & >= "1.5.0" & < "2.0.0" }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "RAL" "functional" "vector" "okasaki" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.1.tar.gz"
+  checksum: [
+    "md5=18f35ec3794803f5a4f95254f313c764"
+    "sha512=090e33705ffb0f77f71f881f78b51d909778bf41afad32339acac21ddbd5f6947b4ebff754148331f9263a544a6000d7f7412d5758e1835fbe84490240b671de"
+  ]
+}

--- a/packages/containers-thread/containers-thread.3.1/opam
+++ b/packages/containers-thread/containers-thread.3.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "An extension of containers for threading"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "base-threads"
+  "dune-configurator"
+  "containers" { = version }
+  "iter" { with-test }
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "thread" "semaphore" "blocking queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.1.tar.gz"
+  checksum: [
+    "md5=18f35ec3794803f5a4f95254f313c764"
+    "sha512=090e33705ffb0f77f71f881f78b51d909778bf41afad32339acac21ddbd5f6947b4ebff754148331f9263a544a6000d7f7412d5758e1835fbe84490240b671de"
+  ]
+}

--- a/packages/containers/containers.3.1/opam
+++ b/packages/containers/containers.3.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A modular, clean and powerful extension of the OCaml standard library"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "dune-configurator"
+  "seq"
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+depopts: [
+  "base-unix"
+  "base-threads"
+]
+tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.1.tar.gz"
+  checksum: [
+    "md5=18f35ec3794803f5a4f95254f313c764"
+    "sha512=090e33705ffb0f77f71f881f78b51d909778bf41afad32339acac21ddbd5f6947b4ebff754148331f9263a544a6000d7f7412d5758e1835fbe84490240b671de"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`containers.3.1`: A modular, clean and powerful extension of the OCaml standard library
-`containers-data.3.1`: A set of advanced datatypes for containers
-`containers-thread.3.1`: An extension of containers for threading



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: git+https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0