### PR TITLE
Make opam-file-format 2.1.1 conflict with core_kernel

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.1.1/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.1/opam
@@ -10,6 +10,7 @@ depends: [
   "dune" {>= "2.0"}
   "alcotest" {with-test}
 ]
+conflicts: ["core_kernel"]
 build: [
   ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}


### PR DESCRIPTION
See Issue ocaml/opam-file-format#33 for the reproducible example.

Closes https://github.com/ocaml/opam-repository/issues/17680.