### PR TITLE
ocaml-base-compiler 4.11*, ocaml-variants 4.11*: do not pass CC=cc on FreeBSD

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.0/opam
@@ -19,8 +19,8 @@ build: [
     "./configure"
     "--prefix=%{prefix}%"
     "-C"
-    "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
-    "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
   ]
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.1/opam
@@ -19,8 +19,8 @@ build: [
     "./configure"
     "--prefix=%{prefix}%"
     "-C"
-    "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
-    "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
   ]
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+afl/opam
@@ -16,14 +16,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--with-afl"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+bytecode-only/opam
@@ -16,14 +16,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--disable-native-compiler"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--disable-native-compiler"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
 ]
 install: [make "install"]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+default-unsafe-string/opam
@@ -21,7 +21,7 @@ build: [
     "--prefix=%{prefix}%"
     "--disable-force-safe-string"
     "DEFAULT_STRING=unsafe"
-  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  ] {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
@@ -29,7 +29,7 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
     "DEFAULT_STRING=unsafe"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+flambda+no-flat-float-array/opam
@@ -18,7 +18,7 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"
                  "--enable-flambda" "--disable-flat-float-array"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
@@ -26,7 +26,7 @@ build: [
     "ASPP=cc -c"
     "--enable-flambda"
     "--disable-flat-float-array"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+flambda/opam
@@ -16,14 +16,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--enable-flambda"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+fp+flambda/opam
@@ -18,7 +18,7 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"
                  "--enable-frame-pointers" "--enable-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
@@ -26,7 +26,7 @@ build: [
     "ASPP=cc -c"
     "--enable-frame-pointers"
     "--enable-flambda"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+fp/opam
@@ -16,14 +16,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-frame-pointers"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--enable-frame-pointers"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+no-flat-float-array/opam
@@ -17,14 +17,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--disable-flat-float-array"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--disable-flat-float-array"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+spacetime/opam
@@ -16,14 +16,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-spacetime"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--enable-spacetime"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+BER/opam
@@ -13,9 +13,9 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "-prefix" "%{prefix}%"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   ["./configure" "-prefix" "%{prefix}%" "CC=cc" "ASPP=cc -c"]
-    {os = "openbsd" | os = "freebsd" | os = "macos"}
+    {os = "openbsd" | os = "macos"}
   [make "world.opt"]
   [make "-C" "ber-metaocaml-111" "all"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+afl/opam
@@ -16,14 +16,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--with-afl"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+bytecode-only/opam
@@ -16,14 +16,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--disable-native-compiler"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--disable-native-compiler"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
 ]
 install: [make "install"]

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+default-unsafe-string/opam
@@ -21,7 +21,7 @@ build: [
     "--prefix=%{prefix}%"
     "--disable-force-safe-string"
     "DEFAULT_STRING=unsafe"
-  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  ] {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
@@ -29,7 +29,7 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
     "DEFAULT_STRING=unsafe"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+flambda+no-flat-float-array/opam
@@ -18,7 +18,7 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"
                  "--enable-flambda" "--disable-flat-float-array"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
@@ -26,7 +26,7 @@ build: [
     "ASPP=cc -c"
     "--enable-flambda"
     "--disable-flat-float-array"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+flambda/opam
@@ -16,14 +16,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--enable-flambda"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+fp+flambda/opam
@@ -18,7 +18,7 @@ setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"
                  "--enable-frame-pointers" "--enable-flambda"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
@@ -26,7 +26,7 @@ build: [
     "ASPP=cc -c"
     "--enable-frame-pointers"
     "--enable-flambda"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+fp/opam
@@ -16,14 +16,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-frame-pointers"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--enable-frame-pointers"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+no-flat-float-array/opam
@@ -17,14 +17,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--disable-flat-float-array"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--disable-flat-float-array"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+spacetime/opam
@@ -16,14 +16,14 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-spacetime"]
-    {os != "openbsd" & os != "freebsd" & os != "macos"}
+    {os != "openbsd" & os != "macos"}
   [
     "./configure"
     "--prefix=%{prefix}%"
     "CC=cc"
     "ASPP=cc -c"
     "--enable-spacetime"
-  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ] {os = "openbsd" | os = "macos"}
   [make "-j%{jobs}%" {os != "cygwin"} "world"]
   [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
 ]


### PR DESCRIPTION
As done earlier (in #16575) and mentioned in
https://github.com/ocaml/opam-repository/pull/16568#commitcomment-39656969
this is no longer necessary since https://github.com/ocaml/ocaml/pull/9437 -
which was part of 4.11.0.

NB: I'm not a big fan of modifying existing packages, but imho this is sane
and safe in this case, and looking at #16575 it seemed to be fine with
maintainers back then.

I did not touch:
- 32bit
- flambda+musl
- flambda+musl+static

Since I don't understand how they are supposed to work in the first place.
Eventually it'd make sense to restrict them to supported platforms via
(available = [ os = "linux" & os-distribution = ... ])?

//cc @Octachron @kit-ty-kate @avsm -- AFAICT the 4.12 release is fine in this respect. Thanks.