### PR TITLE
Add the wasmtime package

### DIFF
--- a/packages/libwasmtime/libwasmtime.0.0.1/opam
+++ b/packages/libwasmtime/libwasmtime.0.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+homepage: "https://github.com/LaurentMazare/ocaml-wasmtime"
+maintainer: "lmazare@gmail.com"
+bug-reports: "https://github.com/LaurentMazare/ocaml-wasmtime/issues"
+authors: [
+  "Laurent Mazare"
+]
+install: [
+  [
+    "sh"
+    "-c"
+    "test -d %{lib}%/lib/libwasmtime.a || ( tar xf wasmtime-linux.tar.xz && mv -f wasmtime-*linux*/* %{lib}%/ )"
+  ] { os = "linux" }
+  [
+    "sh"
+    "-c"
+    "test -d %{lib}%/lib/libwasmtime.a || ( tar xf wasmtime-macos.tar.xz && mv -f wasmtime-*macos*/* %{lib}%/ )"
+  ] { os = "macos" }
+]
+synopsis: "libwasmtime library package"
+description: """
+This is used by the wasmtime package to trigger the install of the
+libwasmtime library."""
+extra-source "wasmtime-linux.tar.xz" {
+  src: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.21.0/wasmtime-v0.21.0-x86_64-linux-c-api.tar.xz"
+  checksum: "md5=fa7df1c3eb44a319e3e133c1ab764c24"
+}
+extra-source "wasmtime-macos.tar.xz" {
+  src: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.21.0/wasmtime-v0.21.0-x86_64-macos-c-api.tar.xz"
+  checksum: "md5=8f4354d8f5c187a5daacd6867124d0b8"
+}

--- a/packages/libwasmtime/libwasmtime.0.0.1/opam
+++ b/packages/libwasmtime/libwasmtime.0.0.1/opam
@@ -29,3 +29,4 @@ extra-source "wasmtime-macos.tar.xz" {
   src: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.21.0/wasmtime-v0.21.0-x86_64-macos-c-api.tar.xz"
   checksum: "md5=8f4354d8f5c187a5daacd6867124d0b8"
 }
+available: [ os = "macos" | os = "linux" ]

--- a/packages/libwasmtime/libwasmtime.0.0.1/opam
+++ b/packages/libwasmtime/libwasmtime.0.0.1/opam
@@ -9,12 +9,12 @@ install: [
   [
     "sh"
     "-c"
-    "test -d %{lib}%/lib/libwasmtime.a || ( tar xf wasmtime-linux.tar.xz && mv -f wasmtime-*linux*/* %{lib}%/ )"
+    "test -d %{lib}%/libwasmtime/lib/libwasmtime.a || ( mkdir -p %{lib}%/libwasmtime && tar xf wasmtime-linux.tar.xz && mv -f wasmtime-*linux*/* %{lib}%/libwasmtime )"
   ] { os = "linux" }
   [
     "sh"
     "-c"
-    "test -d %{lib}%/lib/libwasmtime.a || ( tar xf wasmtime-macos.tar.xz && mv -f wasmtime-*macos*/* %{lib}%/ )"
+    "test -d %{lib}%/libwasmtime/lib/libwasmtime.a || ( mkdir -p %{lib}%/libwasmtime && tar xf wasmtime-macos.tar.xz && mv -f wasmtime-*macos*/* %{lib}%/libwasmtime )"
   ] { os = "macos" }
 ]
 synopsis: "libwasmtime library package"

--- a/packages/libwasmtime/libwasmtime.0.21.0+linux-x86_64/opam
+++ b/packages/libwasmtime/libwasmtime.0.21.0+linux-x86_64/opam
@@ -10,14 +10,9 @@ install: [
     "sh"
     "-c"
     "test -d %{lib}%/libwasmtime/lib/libwasmtime.a || ( mkdir -p %{lib}%/libwasmtime && tar xf wasmtime-linux.tar.xz && mv -f wasmtime-*linux*/* %{lib}%/libwasmtime )"
-  ] { os = "linux" }
-  [
-    "sh"
-    "-c"
-    "test -d %{lib}%/libwasmtime/lib/libwasmtime.a || ( mkdir -p %{lib}%/libwasmtime && tar xf wasmtime-macos.tar.xz && mv -f wasmtime-*macos*/* %{lib}%/libwasmtime )"
-  ] { os = "macos" }
+  ]
 ]
-synopsis: "libwasmtime library package"
+synopsis: "The libwasmtime library package"
 description: """
 This is used by the wasmtime package to trigger the install of the
 libwasmtime library."""
@@ -25,8 +20,4 @@ extra-source "wasmtime-linux.tar.xz" {
   src: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.21.0/wasmtime-v0.21.0-x86_64-linux-c-api.tar.xz"
   checksum: "md5=fa7df1c3eb44a319e3e133c1ab764c24"
 }
-extra-source "wasmtime-macos.tar.xz" {
-  src: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.21.0/wasmtime-v0.21.0-x86_64-macos-c-api.tar.xz"
-  checksum: "md5=8f4354d8f5c187a5daacd6867124d0b8"
-}
-available: [ os = "macos" | os = "linux" ]
+available: arch = "x86_64" && os = "linux"

--- a/packages/libwasmtime/libwasmtime.0.21.0+linux-x86_64/opam
+++ b/packages/libwasmtime/libwasmtime.0.21.0+linux-x86_64/opam
@@ -20,4 +20,4 @@ extra-source "wasmtime-linux.tar.xz" {
   src: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.21.0/wasmtime-v0.21.0-x86_64-linux-c-api.tar.xz"
   checksum: "md5=fa7df1c3eb44a319e3e133c1ab764c24"
 }
-available: arch = "x86_64" && os = "linux"
+available: arch = "x86_64" & os = "linux"

--- a/packages/libwasmtime/libwasmtime.0.21.0+macos-x86_64/opam
+++ b/packages/libwasmtime/libwasmtime.0.21.0+macos-x86_64/opam
@@ -20,4 +20,4 @@ extra-source "wasmtime-macos.tar.xz" {
   src: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.21.0/wasmtime-v0.21.0-x86_64-macos-c-api.tar.xz"
   checksum: "md5=8f4354d8f5c187a5daacd6867124d0b8"
 }
-available: arch = "x86_64" && os = "macos"
+available: arch = "x86_64" & os = "macos"

--- a/packages/libwasmtime/libwasmtime.0.21.0+macos-x86_64/opam
+++ b/packages/libwasmtime/libwasmtime.0.21.0+macos-x86_64/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+homepage: "https://github.com/LaurentMazare/ocaml-wasmtime"
+maintainer: "lmazare@gmail.com"
+bug-reports: "https://github.com/LaurentMazare/ocaml-wasmtime/issues"
+authors: [
+  "Laurent Mazare"
+]
+install: [
+  [
+    "sh"
+    "-c"
+    "test -d %{lib}%/libwasmtime/lib/libwasmtime.a || ( mkdir -p %{lib}%/libwasmtime && tar xf wasmtime-macos.tar.xz && mv -f wasmtime-*macos*/* %{lib}%/libwasmtime )"
+  ]
+]
+synopsis: "The libwasmtime library package"
+description: """
+This is used by the wasmtime package to trigger the install of the
+libwasmtime library."""
+extra-source "wasmtime-macos.tar.xz" {
+  src: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.21.0/wasmtime-v0.21.0-x86_64-macos-c-api.tar.xz"
+  checksum: "md5=8f4354d8f5c187a5daacd6867124d0b8"
+}
+available: arch = "x86_64" && os = "macos"

--- a/packages/wasmtime/wasmtime.0.0.1/opam
+++ b/packages/wasmtime/wasmtime.0.0.1/opam
@@ -16,11 +16,11 @@ depends: [
   "base" {>= "v0.13.0" & < "v0.15"}
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
-  "dune" {>= "2.0.0" build}
+  "dune" {>= "2.0.0"}
   "dune-configurator"
   "libwasmtime" {= "0.0.1"}
   "ocaml" {>= "4.10"}
-  "ppx_expect" {>= "v0.13.0" & < "v0.15" with-test}
+  "ppx_expect" {>= "v0.13.0" & < "v0.15" & with-test}
   "stdio"
 ]
 

--- a/packages/wasmtime/wasmtime.0.0.1/opam
+++ b/packages/wasmtime/wasmtime.0.0.1/opam
@@ -24,7 +24,7 @@ depends: [
   "stdio"
 ]
 
-available: os = "linux" | os = "macos"
+available: arch = "x86_64" & (os = "linux" | os = "macos")
 
 synopsis: "Wasmtime bindings for OCaml"
 description: """

--- a/packages/wasmtime/wasmtime.0.0.1/opam
+++ b/packages/wasmtime/wasmtime.0.0.1/opam
@@ -35,7 +35,7 @@ runtime for WebAssembly.
 url {
   src: "https://github.com/LaurentMazare/ocaml-wasmtime/archive/v0.0.1.tar.gz"
   checksum: [
-    "md5=d8299950943013045b28d0f343fa924e"
-    "sha512=2e6e98d067991cb20265f2c1327dd6fa07cea271800a04708d0a4da94b4565769e1935dd2b3d1340084b21e42bf072ab92a389358dfb66b08040b9756184f6a7"
+    "md5=8cacadcd31e7fb34fe32d9c132509990"
+    "sha512=0ce53ab2c0bbe79682799f9e3848f25303f28539945dd546ad19409270c2f534e86269474025f818b2f13ae0888c8de3149ffbce531dda90b9088a7f43b76ed3"
   ]
 }

--- a/packages/wasmtime/wasmtime.0.0.1/opam
+++ b/packages/wasmtime/wasmtime.0.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ctypes-foreign"
   "dune" {>= "2.0.0"}
   "dune-configurator"
-  "libwasmtime" {= "0.0.1"}
+  "libwasmtime" {>= "0.21.0" & < "0.22.0"}
   "ocaml" {>= "4.10"}
   "ppx_expect" {>= "v0.13.0" & < "v0.15" & with-test}
   "stdio"

--- a/packages/wasmtime/wasmtime.0.0.1/opam
+++ b/packages/wasmtime/wasmtime.0.0.1/opam
@@ -33,9 +33,9 @@ runtime for WebAssembly.
 """
 
 url {
-  src: "https://github.com/LaurentMazare/ocaml-wasmtime/archive/v0.0.1.tar.gz"
+  src: "https://github.com/LaurentMazare/ocaml-wasmtime/archive/v0.0.1a.tar.gz"
   checksum: [
-    "md5=8cacadcd31e7fb34fe32d9c132509990"
-    "sha512=0ce53ab2c0bbe79682799f9e3848f25303f28539945dd546ad19409270c2f534e86269474025f818b2f13ae0888c8de3149ffbce531dda90b9088a7f43b76ed3"
+    "md5=fc32ece358cfa8ac5e080c129b43d8e5"
+    "sha512=7f366ddb9ea2728eb8c0d9cdbfc09734602086b48371a43509325176ff93ab4217a7ce91eda0137a0d1237671256d98eb57d5bde910d0b11536091fcd211f319"
   ]
 }

--- a/packages/wasmtime/wasmtime.0.0.1/opam
+++ b/packages/wasmtime/wasmtime.0.0.1/opam
@@ -33,9 +33,9 @@ runtime for WebAssembly.
 """
 
 url {
-  src: "https://github.com/LaurentMazare/ocaml-wasmtime/archive/v0.0.1a.tar.gz"
+  src: "https://github.com/LaurentMazare/ocaml-wasmtime/archive/v0.0.1b.tar.gz"
   checksum: [
-    "md5=fc32ece358cfa8ac5e080c129b43d8e5"
-    "sha512=7f366ddb9ea2728eb8c0d9cdbfc09734602086b48371a43509325176ff93ab4217a7ce91eda0137a0d1237671256d98eb57d5bde910d0b11536091fcd211f319"
+    "md5=7056aff1755eca0aac746e2d1744fc91"
+    "sha512=e8b7b9d66af89a69ffda67e99be59d483140b84601ededa06c411c7c1151e723efd95cd93cd159cc5efed0f5da36117c175ca7d2e7bfb8bdd6a25678fc757302"
   ]
 }

--- a/packages/wasmtime/wasmtime.0.0.1/opam
+++ b/packages/wasmtime/wasmtime.0.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "base" {>= "v0.13.0" & < "v0.15"}
   "ctypes" {>= "0.5"}
   "ctypes-foreign"
-  "dune" {>= "2.0.0"}
+  "dune" {>= "2.7.0"}
   "dune-configurator"
   "libwasmtime" {>= "0.21.0" & < "0.22.0"}
   "ocaml" {>= "4.10"}

--- a/packages/wasmtime/wasmtime.0.0.1/opam
+++ b/packages/wasmtime/wasmtime.0.0.1/opam
@@ -33,9 +33,9 @@ runtime for WebAssembly.
 """
 
 url {
-  src: "https://github.com/LaurentMazare/ocaml-wasmtime/archive/v0.0.1b.tar.gz"
+  src: "https://github.com/LaurentMazare/ocaml-wasmtime/archive/v0.0.1c.tar.gz"
   checksum: [
-    "md5=7056aff1755eca0aac746e2d1744fc91"
-    "sha512=e8b7b9d66af89a69ffda67e99be59d483140b84601ededa06c411c7c1151e723efd95cd93cd159cc5efed0f5da36117c175ca7d2e7bfb8bdd6a25678fc757302"
+    "md5=430db93c83b112f1adedef0f230d1986"
+    "sha512=c578e0b346ba981f4dadac9a35b9e271843880fea88826c83687c5651d6f0b5fda00d5ceb4c019dd961e0a748a05f39be633cbf8eda3ab6c7204e2f5ca82d11e"
   ]
 }

--- a/packages/wasmtime/wasmtime.0.0.1/opam
+++ b/packages/wasmtime/wasmtime.0.0.1/opam
@@ -9,7 +9,7 @@ authors:      [ "Laurent Mazare" ]
 build: [["dune" "build" "-p" name "-j" jobs]]
 
 run-test: [
-  ["dune" "runtest" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] { os-distribution != "alpine" }
 ]
 
 depends: [

--- a/packages/wasmtime/wasmtime.0.0.1/opam
+++ b/packages/wasmtime/wasmtime.0.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name:         "wasmtime"
+bug-reports:  "https://github.com/LaurentMazare/ocaml-wasmtime/issues"
+homepage:     "https://github.com/LaurentMazare/ocaml-wasmtime"
+dev-repo:     "git+https://github.com/LaurentMazare/ocaml-wasmtime.git"
+maintainer:   "Laurent Mazare <lmazare@gmail.com>"
+authors:      [ "Laurent Mazare" ]
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+
+depends: [
+  "base" {>= "v0.13.0" & < "v0.15"}
+  "ctypes" {>= "0.5"}
+  "ctypes-foreign"
+  "dune" {>= "2.0.0" build}
+  "dune-configurator"
+  "libwasmtime" {= "0.0.1"}
+  "ocaml" {>= "4.10"}
+  "ppx_expect" {>= "v0.13.0" & < "v0.15" with-test}
+  "stdio"
+]
+
+available: os = "linux" | os = "macos"
+
+synopsis: "Wasmtime bindings for OCaml"
+description: """
+Bindings for Wasmtime, a small and efficient
+runtime for WebAssembly.
+"""
+
+url {
+  src: "https://github.com/LaurentMazare/ocaml-wasmtime/archive/v0.0.1.tar.gz"
+  checksum: [
+    "md5=d8299950943013045b28d0f343fa924e"
+    "sha512=2e6e98d067991cb20265f2c1327dd6fa07cea271800a04708d0a4da94b4565769e1935dd2b3d1340084b21e42bf072ab92a389358dfb66b08040b9756184f6a7"
+  ]
+}


### PR DESCRIPTION
This PR adds two new packages:
- wasmtime: a package wrapping the [wasmtime c library](https://github.com/bytecodealliance/wasmtime) so that it can be used from OCaml. This makes it possible to run wasm files, including system calls via wasi, callbacks, etc.
- libwasmtime: this ships the c library (as it is not included in distributions at the moment).