### PR TITLE
Lens' ppx_deriving dependency is not build-only

### DIFF
--- a/packages/lens/lens.1.2.1/opam
+++ b/packages/lens/lens.1.2.1/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.10"}
-  "ppx_deriving" {build & < "5.0"}
+  "ppx_deriving" {< "5.0"}
   "ppx_tools" {build}
   "ppxfind" {build}
   "jbuilder"

--- a/packages/lens/lens.1.2.2/opam
+++ b/packages/lens/lens.1.2.2/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.10"}
-  "ppx_deriving" {build & < "5.0"}
+  "ppx_deriving" {< "5.0"}
   "ppx_tools" {build}
   "ppxfind" {build}
   "jbuilder"

--- a/packages/lens/lens.1.2.3/opam
+++ b/packages/lens/lens.1.2.3/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.1" & < "4.10"}
-  "ppx_deriving" {build & < "5.0"}
+  "ppx_deriving" {< "5.0"}
   "ppx_tools" {build}
   "ppxfind" {build}
   "dune"         { >= "1.0"}

--- a/packages/lens/lens.1.2.4/opam
+++ b/packages/lens/lens.1.2.4/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"           {>= "4.10"}
-  "ppx_deriving" {< "5.0"}
+  "ppx_deriving"    {< "5.0"}
   "ppx_tools"       {build}
   "ppxfind"         {build}
   "dune"            {>= "1.0"}


### PR DESCRIPTION
Upgrading `ppx_deriving` should recompile the lens package's ppx library, otherwise it cannot be linked into ppx executables etc. after the upgrade.

This had already been fixed for 1.2.4; this PR applies the fix for versions `1.2.1`, `1.2.2`, `1.2.3` so that OCaml versions `< 4.10.0` work correctly too.