### PR TITLE
add ez_opam_file.0.1.0 compatibility package for opam-file-format

### DIFF
--- a/packages/ez_opam_file/ez_opam_file.0.1.0/opam
+++ b/packages/ez_opam_file/ez_opam_file.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:
+  "Package ez_opam_file is a simple compatibility layer on top of opam-file-format"
+description: """\
+This package provides a minimal compatibility layer on top of opam-file-format
+to support both version 2.1.0 and version 2.1.1.
+"""
+authors: ["Fabrice Le Fessant <fabrice.le_fessant@origin-labs.com>"]
+maintainer: ["Fabrice Le Fessant <fabrice.le_fessant@origin-labs.com>"]
+homepage: "https://ocamlpro.github.io/ez_opam_file"
+doc: "https://ocamlpro.github.io/ez_opam_file/sphinx"
+bug-reports: "https://github.com/ocamlpro/ez_opam_file/issues"
+dev-repo: "git+https://github.com/ocamlpro/ez_opam_file.git"
+tags: "org:ocamlpro"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.6.0"}
+  "opam-file-format" {>= "2.0"}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {with-test}
+]
+
+url {
+    src: "https://github.com/ocamlpro/ez_opam_file/archive/v0.1.0.tar.gz"
+    checksum: [ "sha256=f744176b0545ac4eb306a0518fd770b22a1c0f7863886a6748198fcdc0e6bef5" ]
+}


### PR DESCRIPTION
opam-file-format 2.1.1 is incompatible with previous versions. This package provides a (minimal, for now) compatibility layer that allows `drom` and `opam-bin` to be installed with any version of opam-file-format.