### PR TITLE
Package dssi.0.1.3

### DIFF
--- a/packages/alsa/alsa.0.3.0/opam
+++ b/packages/alsa/alsa.0.3.0/opam
@@ -7,6 +7,7 @@ license: "GPL-2.0"
 homepage: "https://github.com/savonet/ocaml-alsa"
 bug-reports: "https://github.com/savonet/ocaml-alsa/issues"
 depends: [
+  "conf-alsa"
   "ocaml" {>= "4.02.0"}
   "dune" {> "2.0"}
   "dune-configurator"
@@ -29,13 +30,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-alsa.git"
-depexts: [
-  ["alsa-lib-dev"] {os-distribution = "alpine"}
-  ["alsa-lib-devel"] {os-distribution = "centos"}
-  ["alsa-lib-devel"] {os-distribution = "fedora"}
-  ["alsa-lib-devel"] {os-family = "suse"}
-  ["libasound2-dev"] {os-family = "debian"}
-]
 available: [os = "linux"]
 url {
   src: "https://github.com/savonet/ocaml-alsa/archive/0.3.0.tar.gz"

--- a/packages/alsa/alsa.0.3.0/opam
+++ b/packages/alsa/alsa.0.3.0/opam
@@ -8,6 +8,7 @@ homepage: "https://github.com/savonet/ocaml-alsa"
 bug-reports: "https://github.com/savonet/ocaml-alsa/issues"
 depends: [
   "conf-alsa"
+  "conf-pkg-config"
   "ocaml" {>= "4.02.0"}
   "dune" {> "2.0"}
   "dune-configurator"

--- a/packages/conf-alsa/conf-alsa.1/opam
+++ b/packages/conf-alsa/conf-alsa.1/opam
@@ -4,6 +4,10 @@ homepage: "https://www.alsa-project.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "alsa dev team"
 license: "BSD"
+build: ["pkg-config" "--exists" "alsa"]
+depends: [
+  "conf-pkg-config" {build}
+]
 depexts: [
   ["alsa-lib"] {os-distribution = "nixos" | os-family = "arch"}
   ["alsa-lib-dev"] {os-distribution = "alpine"}

--- a/packages/conf-alsa/conf-alsa.1/opam
+++ b/packages/conf-alsa/conf-alsa.1/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://www.alsa-project.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "alsa dev team"
+license: "BSD"
+depexts: [
+  ["alsa-lib"] {os-distribution = "nixos" | os-family = "arch"}
+  ["alsa-lib-dev"] {os-distribution = "alpine"}
+  ["alsa-lib-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-distribution = "oraclelinux"}
+  ["libasound2-dev"] {os-family = "debian" | os-family = "ubuntu"}
+
+]
+available: [ os = "linux" ]
+synopsis: "Virtual package relying on alsa"
+description:
+  "This package can only install if the alsa library is installed on the system."
+flags: conf

--- a/packages/conf-dssi/conf-dssi.1/opam
+++ b/packages/conf-dssi/conf-dssi.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "http://dssi.sourceforge.net/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "dssi dev team"
+license: "BSD"
+depends: [
+  "conf-alsa" {os = "linux"}
+]
+depexts: [
+  ["dssi-dev"] {os-family = "debian" | os-distribution = "alpine"}
+  ["dssi-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}
+  ["dssi"] {os-distribution = "nixos" | os-distribution = "arch"}
+  ["drfill/liquidsoap/libdssi"] {os = "macos" & os-distribution = "homebrew"}
+]
+available: [ os = "linux" | os = "macos" ]
+synopsis: "Virtual package relying on dssi"
+description:
+  "This package installs external dependencies to build dssi."
+flags: conf

--- a/packages/conf-ladspa/conf-ladspa.1/opam
+++ b/packages/conf-ladspa/conf-ladspa.1/opam
@@ -13,5 +13,5 @@ depexts: [
 ]
 synopsis: "Virtual package relying on ladspa"
 description:
-  "This package can only install if the ladspa library is installed on the system."
+  "This package installs system-specific external dependencies to build ladspa plugins, when they exist."
 flags: conf

--- a/packages/conf-soundtouch/conf-soundtouch.1/opam
+++ b/packages/conf-soundtouch/conf-soundtouch.1/opam
@@ -4,16 +4,15 @@ homepage: "http://www.mega-nerd.com/SRC/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "soundtouch dev team"
 license: "BSD"
-build: ["sh" "-c" "pkg-config --exists soundtouch || pkg-config --exists libSoundTouch"]
+build: ["sh" "-c" "pkg-config --exists soundtouch || pkg-config --exists libSoundTouch || pkg-config --exists soundtouch-1.4"]
 depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
   ["soundtouch-dev"] {os-distribution = "alpine"}
   ["soundtouch-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}
-  ["soundtouch-devel"] {os-family = "suse"}
   ["libsoundtouch-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["soundtouch"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os = "oraclelinux"}
+  ["soundtouch"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "oraclelinux"}
   ["sound-touch"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on soundtouch"

--- a/packages/dssi/dssi.0.1.3/opam
+++ b/packages/dssi/dssi.0.1.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Bindings for the DSSI API which provides audio synthesizers"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1"
+homepage: "https://github.com/savonet/ocaml-dssi"
+bug-reports: "https://github.com/savonet/ocaml-dssi/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "dune-configurator"
+  "ladspa" {>= "0.2.0"}
+  "conf-dssi"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-dssi.git"
+url {
+  src: "https://github.com/savonet/ocaml-dssi/archive/v0.1.3.tar.gz"
+  checksum: [
+    "md5=6f6065ea71202cec0f6f163db9a67f6c"
+    "sha512=8f7db557d2edbcaaeb5e9401e50b7dba84fb59fe0817d74840e57c9a8111d24652e91262a439eacf80642847e98c2e92c90d0a20f6eb37b2faf4994023901942"
+  ]
+}

--- a/packages/ladspa/ladspa.0.2.0/opam
+++ b/packages/ladspa/ladspa.0.2.0/opam
@@ -6,6 +6,7 @@ license: "LGPL-2.1"
 homepage: "https://github.com/savonet/ocaml-ladspa"
 bug-reports: "https://github.com/savonet/ocaml-ladspa/issues"
 depends: [
+  "base-bigarray"
   "dune" {>= "2.0"}
   "dune-configurator"
   "conf-ladspa"

--- a/packages/soundtouch/soundtouch.0.1.9/opam
+++ b/packages/soundtouch/soundtouch.0.1.9/opam
@@ -31,7 +31,7 @@ dev-repo: "git+https://github.com/savonet/ocaml-soundtouch.git"
 url {
   src: "https://github.com/savonet/ocaml-soundtouch/archive/v0.1.9.tar.gz"
   checksum: [
-    "md5=4042e388af8def3e783f2c14c7ce62d0"
-    "sha512=12335fb7cb8b1bce753649104b39864c604207cdecf0b994ee5ea7ece39e5765b0a688f3fe244aa0f0e96ec899451d3c6cc9401dbb69f0b5ae84747f458ac201"
+    "md5=bb457bc6a52619c720ab8c4a565f1bf7"
+    "sha512=2e330a9218a81bff8dd1d5d8c9b1fb59d9b9adc2fcf1532d20396f8075888f948e310cef0343875e59adb9e0c5d74b38d5a55dae15e0517d3316d8e72cac15a0"
   ]
 }


### PR DESCRIPTION
### `dssi.0.1.3`
Bindings for the DSSI API which provides audio synthesizers

This PR also includes some extra changes:
* dssi relies on the alsa headers so I added `conf-alsa` and switched the latest `alsa` to it.
* There is a compat header for alsa on OSX but I don't think that it can be used to compile a working alsa library on OSX so I limited this depext to `conf-dssi` and made `conf-alsa` only available on linux systems.
* While working on it, I noticed a little glitch on `conf-soundtouch` for `oraclelinux` and tried to fix it, pushing an update to the latest release. Alas, it didn't fix it but that's still a slight enhancement (`soundtouch` has historically multiple `pkg-config` packages names, which is annoying. I added a new one to the supported list).

Let me know if anything here needs fixing. Thanks!