### PR TITLE
Package lwt-exit.1.0

### DIFF
--- a/packages/lwt-exit/lwt-exit.1.0/opam
+++ b/packages/lwt-exit/lwt-exit.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/lwt-exit"
+bug-reports: "https://gitlab.com/nomadic-labs/lwt-exit/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/lwt-exit.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "2.0" }
+  "base-unix"
+  "lwt"
+  "ptime"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Lwt-exit: an oppinionated clean-exit and signal-handling library for Lwt programs"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/lwt-exit/-/archive/1.0/lwt-exit-1.0.tar.gz"
+  checksum: [
+    "md5=f8f1c83d88d8955e055e0ccca11a3072"
+    "sha512=0ba5ef4495d402f5364af3f84e5378b04c9a1c5296a7f8bb84a0246a0bded1d5f4e3ab8e601056d7f96580eec78179d117fbd56670058460d0ae2e0990883ac2"
+  ]
+}

--- a/packages/lwt-exit/lwt-exit.1.0/opam
+++ b/packages/lwt-exit/lwt-exit.1.0/opam
@@ -16,7 +16,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-synopsis: "Lwt-exit: an oppinionated clean-exit and signal-handling library for Lwt programs"
+synopsis: "An opinionated clean-exit and signal-handling library for Lwt programs"
 url {
   src:
     "https://gitlab.com/nomadic-labs/lwt-exit/-/archive/1.0/lwt-exit-1.0.tar.gz"


### PR DESCRIPTION
### `lwt-exit.1.0`
Lwt-exit: an oppinionated clean-exit and signal-handling library for Lwt programs



---
* Homepage: https://gitlab.com/nomadic-labs/lwt-exit
* Source repo: git+https://gitlab.com/nomadic-labs/lwt-exit.git
* Bug tracker: https://gitlab.com/nomadic-labs/lwt-exit/issues

---
:camel: Pull-request generated by opam-publish v2.0.2