### PR TITLE
[new release] dap (1.0.2)

### DIFF
--- a/packages/dap/dap.1.0.2/opam
+++ b/packages/dap/dap.1.0.2/opam
@@ -12,7 +12,7 @@ dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
 doc: "https://hackwaly.github.io/ocaml-dap/"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {build & >= "1.3"}
+  "dune" {>= "2.7"}
   "yojson"
   "ppx_here"
   "ppx_deriving"

--- a/packages/dap/dap.1.0.2/opam
+++ b/packages/dap/dap.1.0.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Debug adapter protocol"
+description: """
+The Debug Adapter Protocol defines the protocol used between an editor or IDE and a debugger or runtime.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocaml-dap"
+bug-reports: "https://github.com/hackwaly/ocaml-dap/issues"
+dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
+doc: "https://hackwaly.github.io/ocaml-dap/"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {build & >= "1.3"}
+  "yojson"
+  "ppx_here"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "lwt"
+  "lwt_ppx"
+  "lwt_react"
+  "react"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+x-commit-hash: "fa86f14213aaecd03bed9dd5c9d891075b0371d7"
+url {
+  src:
+    "https://github.com/hackwaly/ocaml-dap/releases/download/1.0.2/dap-1.0.2.tbz"
+  checksum: [
+    "sha256=5e14788efb74983486d34a0376669543837e4df32e9a267a5472a9c94b7b743f"
+    "sha512=1e075d34cbd290fda63bed2deade9972decc05553c68682b9e82891819129e1070e39f8f12f37deaa7a586fc259cc603d586effe227db123eacb94eced770a97"
+  ]
+}


### PR DESCRIPTION
Debug adapter protocol

- Project page: <a href="https://github.com/hackwaly/ocaml-dap">https://github.com/hackwaly/ocaml-dap</a>
- Documentation: <a href="https://hackwaly.github.io/ocaml-dap/">https://hackwaly.github.io/ocaml-dap/</a>

##### CHANGES:

### Fixed

- Fix `breakpoints : Breakpoint.t` should be `breakpoints : Breakpoint.t list`
- Fix `Env.t = Empty_dict.t` shuld be `Env.t = String_opt_dict.t`
