### PR TITLE
Revert "Make opam-file-format 2.1.1 conflict with core_kernel"

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.1.1/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.1/opam
@@ -10,7 +10,6 @@ depends: [
   "dune" {>= "2.0"}
   "alcotest" {with-test}
 ]
-conflicts: ["core_kernel"]
 build: [
   ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}


### PR DESCRIPTION
Temporary reverts ocaml/opam-repository#17774 until the release of opam-file-format.2.1.2
Closes https://github.com/ocaml/opam-repository/pull/17779

cc @lefessan 