### PR TITLE
Release np.np1.19-0.3.1, scipy.sp1.5-0.3.1, sklearn.sk0.23-0.3.1.

### DIFF
--- a/packages/np/np.np1.19-0.3.1/opam
+++ b/packages/np/np.np1.19-0.3.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Fundamental scientific computing with Numpy for OCaml"
+description: """
+These are OCaml bindings to Numpy, the fundamental package for scientific computing with Python:
+- powerful n-dimensional arrays
+- numerical computing tools
+- interoperable
+- performant
+- easy to use
+- open source.
+"""
+maintainer: ["Ronan Le Hy <ronan.lehy@gmail.com>"]
+authors: ["Ronan Le Hy"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/lehy/ocaml-sklearn"
+bug-reports: "https://github.com/lehy/ocaml-sklearn/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.07.1"}
+  "pyml" {>= "20200222"}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lehy/ocaml-sklearn.git"
+x-commit-hash: "bc83ed202843b89c48cda811bfeb0ee4e772783b"
+url {
+  src:
+    "https://github.com/lehy/ocaml-sklearn/releases/download/v0.3.1/sklearn-v0.3.1.tbz"
+  checksum: [
+    "sha256=48809d88893a3f17d79f8e5acbd28126de919b8ced6d1f6856a61fd6bfae571d"
+    "sha512=9e1d01c42aed436163b1ce50bee141f40cb5bc943d5dd16d6eb21f1b53d613933533c70f28675e418a550cf44e0cd66d47496e462132769b05dec64bf3db560c"
+  ]
+}

--- a/packages/scipy/scipy.sp1.5-0.3.1/opam
+++ b/packages/scipy/scipy.sp1.5-0.3.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "SciPy scientific computing library for OCaml"
+description: """
+These are OCaml bindings to the SciPy Python library.
+The SciPy library provides many
+user-friendly and efficient numerical routines, such as routines for
+numerical integration, interpolation, optimization, linear algebra,
+and statistics.
+"""
+maintainer: ["Ronan Le Hy <ronan.lehy@gmail.com>"]
+authors: ["Ronan Le Hy"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/lehy/ocaml-sklearn"
+bug-reports: "https://github.com/lehy/ocaml-sklearn/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.07.1"}
+  "pyml" {>= "20200222"}
+  "np" {= "np1.19-0.3.1"}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lehy/ocaml-sklearn.git"
+x-commit-hash: "bc83ed202843b89c48cda811bfeb0ee4e772783b"
+url {
+  src:
+    "https://github.com/lehy/ocaml-sklearn/releases/download/v0.3.1/sklearn-v0.3.1.tbz"
+  checksum: [
+    "sha256=48809d88893a3f17d79f8e5acbd28126de919b8ced6d1f6856a61fd6bfae571d"
+    "sha512=9e1d01c42aed436163b1ce50bee141f40cb5bc943d5dd16d6eb21f1b53d613933533c70f28675e418a550cf44e0cd66d47496e462132769b05dec64bf3db560c"
+  ]
+}

--- a/packages/sklearn/sklearn.sk0.23-0.3.1/opam
+++ b/packages/sklearn/sklearn.sk0.23-0.3.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Scikit-learn machine learning library for OCaml"
+description: """
+Scikit-learn machine learning library for OCaml
+These are bindings to Python's scikit-learn machine learning library:
+- Simple and efficient tools for predictive data analysis
+- Accessible to everybody, and reusable in various contexts
+- Built on NumPy, SciPy, and matplotlib
+- Open source, commercially usable - BSD license
+"""
+maintainer: ["Ronan Le Hy <ronan.lehy@gmail.com>"]
+authors: ["Ronan Le Hy"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/lehy/ocaml-sklearn"
+bug-reports: "https://github.com/lehy/ocaml-sklearn/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.07.1"}
+  "pyml" {>= "20200222"}
+  "np" {= "np1.19-0.3.1"}
+  "scipy" {= "sp1.5-0.3.1"}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lehy/ocaml-sklearn.git"
+x-commit-hash: "bc83ed202843b89c48cda811bfeb0ee4e772783b"
+url {
+  src:
+    "https://github.com/lehy/ocaml-sklearn/releases/download/v0.3.1/sklearn-v0.3.1.tbz"
+  checksum: [
+    "sha256=48809d88893a3f17d79f8e5acbd28126de919b8ced6d1f6856a61fd6bfae571d"
+    "sha512=9e1d01c42aed436163b1ce50bee141f40cb5bc943d5dd16d6eb21f1b53d613933533c70f28675e418a550cf44e0cd66d47496e462132769b05dec64bf3db560c"
+  ]
+}


### PR DESCRIPTION
Weird versions are on purpose. These packages depend on particular versions of
Python packages so these versions appear in the opam version strings.