### PR TITLE
OCaml 4.10.2: tier 1 platform support fixes

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Official release 4.10.2"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-system/ocaml-system.4.10.2/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-system/ocaml-system.4.10.2/files/gen_ocaml_config.ml.in
@@ -1,0 +1,43 @@
+let () =
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
+  if Sys.ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "ERROR: The compiler found at %%s has version %%s,\n\
+        and this package requires %{_:version}%.\n\
+        You should use e.g. 'opam switch create %{_:name}%.%%s' \
+        instead."
+       ocamlc Sys.ocaml_version Sys.ocaml_version;
+     exit 1)
+  else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
+  let oc = open_out "%{_:name}%.config" in
+  Printf.fprintf oc "opam-version: \"2.0\"\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
+                     variables { path: %%S }\n"
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
+  close_out oc

--- a/packages/ocaml-system/ocaml-system.4.10.2/opam
+++ b/packages/ocaml-system/ocaml-system.4.10.2/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (system version, from outside of opam)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {post}
+  "base-unix" {post}
+  "base-threads" {post}
+  "base-bigarray" {post}
+]
+conflict-class: "ocaml-core-compiler"
+available: sys-ocaml-version = "4.10.2"
+flags: compiler
+build: ["ocaml" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"
+extra-files: ["gen_ocaml_config.ml.in" "md5=093e7bec1ec95f9e4c6a313d73c5d840"]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+32bit/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2, compiled in 32-bit mode for 64-bit Linux and OS X hosts"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+depexts: [
+  ["gcc-multilib" "g++-multilib"] {os-family = "debian"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=gcc -m32"
+    "AS=as --32"
+    "ASPP=gcc -m32 -c"
+    "--host" "i386-linux"
+    "PARTIALLD=ld -r -melf_i386"
+  ] {os = "linux"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32"
+    "AS=as -arch i386"
+    "ASPP=gcc -arch i386 -m32 -c"
+    "--host" "i386-apple-darwin13.2.0"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+afl/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Official release 4.10.2, with afl-fuzz instrumentation"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-afl"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--with-afl"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+bytecode-only/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Official release 4.10.2, without the native-code compiler"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--disable-native-compiler"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--disable-native-compiler"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+default-unsafe-string/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2, without safe strings by default"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "DEFAULT_STRING=unsafe"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "CC=cc"
+    "ASPP=cc -c"
+    "DEFAULT_STRING=unsafe"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+flambda+no-flat-float-array/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2, with flambda activated and --disable-flat-float-array"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-flambda" "--disable-flat-float-array"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--enable-flambda"
+    "--disable-flat-float-array"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+flambda/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Official release 4.10.2, with flambda activated"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--enable-flambda"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+fp+flambda/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2, with frame-pointers and flambda activated"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-frame-pointers" "--enable-flambda"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+fp/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Official release 4.10.2, with frame-pointers"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-frame-pointers"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--enable-frame-pointers"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+musl+flambda/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2, compiled with musl-gcc and with flambda activated"
+description:
+  "Requires musl-gcc to be installed (package musl on Arch Linux or musl-tools on Debian)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=musl-gcc -Os"
+    "ASPP=musl-gcc -c"
+    "--enable-flambda"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+musl+static+flambda/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2, compiled with musl-gcc -static and with flambda activated"
+description:
+  "Requires musl-gcc to be installed (package musl on Arch Linux, musl-tools on Debian, musl-dev on Alpine)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev"] {os-distribution = "alpine"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=musl-gcc" {os-distribution != "alpine"}
+    "CFLAGS=-Os"
+    "ASPP=musl-gcc -c" {os-distribution != "alpine"}
+    "--enable-flambda"
+    "LIBS=-static"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+no-flat-float-array/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Official release 4.10.2 with --disable-flat-float-array"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--disable-flat-float-array"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--disable-flat-float-array"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+spacetime/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Official release 4.10.2, with spacetime activated"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.10.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-spacetime"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+    "--enable-spacetime"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz"
+  checksum: "sha256=7aa26e0d70f36f0338df92cf5aaeb2704f3443bfe910a3d02a5dca9162f1d866"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml/ocaml.4.10.2/opam
+++ b/packages/ocaml/ocaml.4.10.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-config"
+  "ocaml-base-compiler" {= "4.10.2"} |
+  "ocaml-variants" {>= "4.10.2" & < "4.10.3~"} |
+  "ocaml-system" {>= "4.10.2" & < "4.10.3~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: CAML_LD_LIBRARY_PATH = ""
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]


### PR DESCRIPTION
This exceptional release contains fixes to restore support for three of the tier 1 platforms of the compiler: mingw64, macos/Arm64, and FreeBSD/amd64 (cc @avsm @hannesm). 

------------------

OCaml 4.10.2 (8 December 2020)
------------------------------

### Build system:

- 9938, 9939: Define __USE_MINGW_ANSI_STDIO=0 for the mingw-w64 ports to
  prevent their C99-compliant snprintf conflicting with ours.
  (David Allsopp, report by Michael Soegtrop, review by Xavier Leroy)

### Supported platforms:

- 9699, 10026: add support for iOS and macOS on ARM 64 bits
  Backported from OCaml 4.12.0
  (GitHub user @EduardoRFS, review by Xavier Leroy, Nicolás Ojeda Bär
   and Anil Madhavapeddy, additional testing by Michael Schmidt)

### Code generation and optimization

- 9752, 10026: Revised handling of calling conventions for
  external C functions.
  Provide a more precise description of the types of unboxed arguments,
  so that the ARM64 iOS/macOS calling conventions can be honored.
  Backported from OCaml 4.12.0
  (Xavier Leroy, review by Mark Shinwell and Github user @EduardoRFS)

- 9969, 9981: Added mergeable flag tqo ELF sections containing mergeable
  constants.  Fixes compatibility with the integrated assembler in clang 11.0.0.
  Backported from OCaml 4.12.0
  (Jacob Young, review by Nicolás Ojeda Bär)