### PR TITLE
4 packages from gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz

### DIFF
--- a/packages/ff-bench/ff-bench.0.6.1/opam
+++ b/packages/ff-bench/ff-bench.0.6.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Benchmark library for finite fields over the package ff-sig"
+description: "Benchmark library for finite fields over the package ff-sig"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-ff"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "ff-sig" {= version}
+  "core" {= "v0.13.0"}
+  "core_bench" {= "v0.13.0"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz"
+  checksum: [
+    "md5=5853a7487785160bbcf0919f13ace049"
+    "sha512=c2e4d3d495a0fe6a5e52ac668d6f7694c7b9161bd0c6fc97cb6ed714a211c397a561feac8c2ea5738182809936c5f8f6e1e64696b0e0f9b3d19e309aa62dd4de"
+  ]
+}

--- a/packages/ff-pbt/ff-pbt.0.6.1/opam
+++ b/packages/ff-pbt/ff-pbt.0.6.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis:
+  "Property based testing library for finite fields over the package ff-sig"
+description:
+  "Property based testing library for finite fields over the package ff-sig"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-ff"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "zarith" {>= "1.9.1" & < "2.0"}
+  "ff-sig" {= version}
+  "alcotest"
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz"
+  checksum: [
+    "md5=5853a7487785160bbcf0919f13ace049"
+    "sha512=c2e4d3d495a0fe6a5e52ac668d6f7694c7b9161bd0c6fc97cb6ed714a211c397a561feac8c2ea5738182809936c5f8f6e1e64696b0e0f9b3d19e309aa62dd4de"
+  ]
+}

--- a/packages/ff-sig/ff-sig.0.6.1/opam
+++ b/packages/ff-sig/ff-sig.0.6.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Minimal finite field signatures"
+description: "Minimal finite field signatures"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-ff"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "zarith" {>= "1.9.1" & < "2.0"}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz"
+  checksum: [
+    "md5=5853a7487785160bbcf0919f13ace049"
+    "sha512=c2e4d3d495a0fe6a5e52ac668d6f7694c7b9161bd0c6fc97cb6ed714a211c397a561feac8c2ea5738182809936c5f8f6e1e64696b0e0f9b3d19e309aa62dd4de"
+  ]
+}

--- a/packages/ff/ff.0.6.1/opam
+++ b/packages/ff/ff.0.6.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml implementation of Finite Field operations"
+description: "OCaml implementation of Finite Field operations"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-ff"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "zarith" {>= "1.9.1" & < "2.0"}
+  "ff-sig" {= version}
+  "alcotest" {with-test}
+  "ff-pbt" {= version & with-test}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz"
+  checksum: [
+    "md5=5853a7487785160bbcf0919f13ace049"
+    "sha512=c2e4d3d495a0fe6a5e52ac668d6f7694c7b9161bd0c6fc97cb6ed714a211c397a561feac8c2ea5738182809936c5f8f6e1e64696b0e0f9b3d19e309aa62dd4de"
+  ]
+}


### PR DESCRIPTION
There was a small issue with #17791 

This pull-request concerns:
-`ff.0.6.1`: OCaml implementation of Finite Field operations
-`ff-bench.0.6.1`: Benchmark library for finite fields over the package ff-sig
-`ff-pbt.0.6.1`: Property based testing library for finite fields over the package ff-sig
-`ff-sig.0.6.1`: Minimal finite field signatures



---
* Homepage: https://gitlab.com/dannywillems/ocaml-ff
* Source repo: git+https://gitlab.com/dannywillems/ocaml-ff.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-ff/issues

---
:camel: Pull-request generated by opam-publish v2.0.2