### PR TITLE
BAP 2.2.0 release

### DIFF
--- a/packages/bap-abi/bap-abi.2.2.0/opam
+++ b/packages/bap-abi/bap-abi.2.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "bap-abi"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-abi"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-abi"]
+         ["ocamlfind" "remove" "bap-abi"]
+         ["bapbundle" "remove" "abi.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+]
+synopsis: "BAP ABI integration subsystem"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-abi/bap-abi.2.2.0/opam
+++ b/packages/bap-abi/bap-abi.2.2.0/opam
@@ -18,8 +18,9 @@ remove: [["ocamlfind" "remove" "bap-plugin-abi"]
          ]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
-  "cmdliner"
 ]
 synopsis: "BAP ABI integration subsystem"
 

--- a/packages/bap-abi/bap-abi.2.2.0/opam
+++ b/packages/bap-abi/bap-abi.2.2.0/opam
@@ -19,7 +19,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-abi"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
 ]
 synopsis: "BAP ABI integration subsystem"

--- a/packages/bap-analyze/bap-analyze.2.2.0/opam
+++ b/packages/bap-analyze/bap-analyze.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-analyze"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-analyze"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-analyze"]
+         ["bapbundle" "remove" "analyze.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "linenoise" {>= "1.1.0" & < "2.0.0"}
+]
+synopsis: "Implements the analyze command"
+description: """
+Analyses the knowledge base. Loads the knowledge base and executes the
+specified commands or run the REPL if no commands or script files were
+specified.
+"""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-analyze/bap-analyze.2.2.0/opam
+++ b/packages/bap-analyze/bap-analyze.2.2.0/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-analyze"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "monads"  {= "2.2.0"}
   "bap-knowledge" {= "2.2.0"}

--- a/packages/bap-analyze/bap-analyze.2.2.0/opam
+++ b/packages/bap-analyze/bap-analyze.2.2.0/opam
@@ -17,7 +17,14 @@ remove: [["ocamlfind" "remove" "bap-plugin-analyze"]
          ]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
+  "monads"  {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
   "linenoise" {>= "1.1.0" & < "2.0.0"}
 ]
 synopsis: "Implements the analyze command"

--- a/packages/bap-api/bap-api.2.2.0/opam
+++ b/packages/bap-api/bap-api.2.2.0/opam
@@ -19,8 +19,11 @@ remove: [["ocamlfind" "remove" "bap-plugin-api"]
          ]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
-  "cmdliner"
+  "regular" {= "2.2.0"}
+  "fileutils"
 ]
 synopsis: "A pass that adds parameters to subroutines based on known API"
 

--- a/packages/bap-api/bap-api.2.2.0/opam
+++ b/packages/bap-api/bap-api.2.2.0/opam
@@ -20,7 +20,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-api"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "regular" {= "2.2.0"}
   "fileutils"

--- a/packages/bap-api/bap-api.2.2.0/opam
+++ b/packages/bap-api/bap-api.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "bap-api"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-api"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-api"]
+         ["ocamlfind" "remove" "bap-api"]
+         ["bapbundle" "remove" "api.plugin"]
+         ["rm" "-rf" "%{prefix}%/share/bap-api/c"]
+         ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+]
+synopsis: "A pass that adds parameters to subroutines based on known API"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-arm/bap-arm.2.2.0/opam
+++ b/packages/bap-arm/bap-arm.2.2.0/opam
@@ -24,7 +24,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "ogre" {= "2.2.0"}
   "regular" {= "2.2.0"}
   "bitvec" {= "2.2.0"}

--- a/packages/bap-arm/bap-arm.2.2.0/opam
+++ b/packages/bap-arm/bap-arm.2.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+name: "bap-arm"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-arm"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-arm"]
+        ["ocamlfind" "remove" "bap-plugin-arm"]
+        ["bapbundle"   "remove" "arm.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "bitvec-order" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "bap-abi" {= "2.2.0"}
+  "bap-api" {= "2.2.0"}
+  "bap-c" {= "2.2.0"}
+]
+synopsis: "BAP ARM lifter and disassembler"
+description: """
+Provides semantics for ARM instructions, disassembler, and partial
+support for the gnueabi ABI"""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-arm/bap-arm.2.2.0/opam
+++ b/packages/bap-arm/bap-arm.2.2.0/opam
@@ -24,7 +24,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "ogre" {= "2.2.0"}
   "regular" {= "2.2.0"}
   "bitvec" {= "2.2.0"}

--- a/packages/bap-beagle-strings/bap-beagle-strings.2.2.0/opam
+++ b/packages/bap-beagle-strings/bap-beagle-strings.2.2.0/opam
@@ -16,6 +16,8 @@ remove: [["ocamlfind" "remove" "bap-plugin_strings"]
          ["bapbundle" "remove" "strings.plugin"]]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "regular" {= "2.2.0"}
   "bap-strings" {= "2.2.0"}

--- a/packages/bap-beagle-strings/bap-beagle-strings.2.2.0/opam
+++ b/packages/bap-beagle-strings/bap-beagle-strings.2.2.0/opam
@@ -17,7 +17,7 @@ remove: [["ocamlfind" "remove" "bap-plugin_strings"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "regular" {= "2.2.0"}
   "bap-strings" {= "2.2.0"}

--- a/packages/bap-beagle-strings/bap-beagle-strings.2.2.0/opam
+++ b/packages/bap-beagle-strings/bap-beagle-strings.2.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "bap-beagle-strings"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-strings"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin_strings"]
+         ["bapbundle" "remove" "strings.plugin"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "bap-strings" {= "2.2.0"}
+  "bap-beagle" {= "2.2.0"}
+]
+synopsis: "Finds strings of characters using microexecution"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-beagle/bap-beagle.2.2.0/opam
+++ b/packages/bap-beagle/bap-beagle.2.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name: "bap-beagle"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-beagle"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-beagle"]
+         ["ocamlfind" "remove" "bap-beagle-prey"]
+         ["bapbundle" "remove" "beagle.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+  "bap-microx" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "bap-strings" {= "2.2.0"}
+]
+synopsis: "BAP obfuscated string solver"
+description: """
+Like strings on steroids - finds strings encoded in binaries,
+even if they are not truly static."""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-beagle/bap-beagle.2.2.0/opam
+++ b/packages/bap-beagle/bap-beagle.2.2.0/opam
@@ -18,11 +18,16 @@ remove: [["ocamlfind" "remove" "bap-plugin-beagle"]
          ]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "monads"  {= "2.2.0"}
   "cmdliner"
   "bap-microx" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}
   "bap-strings" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
 ]
 synopsis: "BAP obfuscated string solver"
 description: """

--- a/packages/bap-beagle/bap-beagle.2.2.0/opam
+++ b/packages/bap-beagle/bap-beagle.2.2.0/opam
@@ -19,7 +19,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-beagle"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "regular" {= "2.2.0"}
   "monads"  {= "2.2.0"}

--- a/packages/bap-bil/bap-bil.2.2.0/opam
+++ b/packages/bap-bil/bap-bil.2.2.0/opam
@@ -16,8 +16,11 @@ remove: [["ocamlfind" "remove" "bap-plugin-bil"]
          ["bapbundle" "remove" "bil.plugin"]]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
   "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
   "bap-future" {= "2.2.0"}
   "monads" {= "2.2.0"}
   "bitvec" {= "2.2.0"}

--- a/packages/bap-bil/bap-bil.2.2.0/opam
+++ b/packages/bap-bil/bap-bil.2.2.0/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-bil"]
          ["bapbundle" "remove" "bil.plugin"]]
 depends: [
   "ocaml" {>= "4.08.0" }
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-future" {= "2.2.0"}
   "monads" {= "2.2.0"}

--- a/packages/bap-bil/bap-bil.2.2.0/opam
+++ b/packages/bap-bil/bap-bil.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-bil"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bil"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-bil"]
+         ["bapbundle" "remove" "bil.plugin"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "ppx_bap" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "bitvec-order" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+]
+synopsis: "Controls the BIL transformation pipeline"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-bil/bap-bil.2.2.0/opam
+++ b/packages/bap-bil/bap-bil.2.2.0/opam
@@ -17,7 +17,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-bil"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-core-theory" {= "2.2.0"}
   "bap-knowledge" {= "2.2.0"}

--- a/packages/bap-build/bap-build.2.2.0/opam
+++ b/packages/bap-build/bap-build.2.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocamlbuild"
   "ocamlfind"
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
 ]
 synopsis: "BAP build automation tools"
 

--- a/packages/bap-build/bap-build.2.2.0/opam
+++ b/packages/bap-build/bap-build.2.2.0/opam
@@ -26,7 +26,7 @@ depends: [
   "oasis" {build & >= "0.4.7"}
   "ocamlbuild"
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
 ]
 synopsis: "BAP build automation tools"
 

--- a/packages/bap-build/bap-build.2.2.0/opam
+++ b/packages/bap-build/bap-build.2.2.0/opam
@@ -25,6 +25,7 @@ depends: [
   "ocaml" {>= "4.08.0" }
   "oasis" {build & >= "0.4.7"}
   "ocamlbuild"
+  "ocamlfind"
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "ppx_bap" {= "v0.14"}
 ]

--- a/packages/bap-build/bap-build.2.2.0/opam
+++ b/packages/bap-build/bap-build.2.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-build"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-build"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap-build"]
+  ["rm" "-f" "%{bin}%/bapbuild"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "ocamlbuild"
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+]
+synopsis: "BAP build automation tools"
+
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-bundle/bap-bundle.2.2.0/opam
+++ b/packages/bap-bundle/bap-bundle.2.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "uri"
   "camlzip"
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "fileutils"
 ]
 synopsis: "BAP bundler"

--- a/packages/bap-bundle/bap-bundle.2.2.0/opam
+++ b/packages/bap-bundle/bap-bundle.2.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "uri"
   "camlzip"
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "fileutils"
 ]
 synopsis: "BAP bundler"

--- a/packages/bap-bundle/bap-bundle.2.2.0/opam
+++ b/packages/bap-bundle/bap-bundle.2.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-bundle"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bundle"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-bundle"]
+         ["rm" "-f" "%{bin}%/bapbundle"]
+         ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "uri"
+  "camlzip"
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+  "fileutils"
+]
+synopsis: "BAP bundler"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.2.2.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.2.2.0/opam
@@ -19,7 +19,7 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-byteweight" {= "2.2.0"}
   "cmdliner"

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.2.2.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.2.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "bap-byteweight-frontend"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-byteweight-frontend"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-byteweight" {= "2.2.0"}
+  "cmdliner"
+  "ocurl"
+  "fileutils"
+  "re"
+]
+synopsis: "BAP Toolkit for training and controlling Byteweight algorithm"
+description: """
+A command line interface to the byteweight system that can train,
+test, download, and upload binary signatures."""
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.2.2.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.2.2.0/opam
@@ -18,11 +18,14 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-byteweight" {= "2.2.0"}
   "cmdliner"
   "ocurl"
   "fileutils"
+  "ocamlfind"
   "re"
 ]
 synopsis: "BAP Toolkit for training and controlling Byteweight algorithm"

--- a/packages/bap-byteweight/bap-byteweight.2.2.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.2.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name: "bap-byteweight"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-byteweight"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-byteweight"]
+        ["ocamlfind" "remove" "bap-plugin-byteweight"]
+        [ "bapbundle" "remove" "byteweight.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-signatures" {= "2.2.0"}
+]
+synopsis: "BAP facility for indentifying code entry points"
+description: """
+Provides a library and a plugin that uses the Byteweigh algorithm for
+finding entry points (function strats) in stripped code."""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-byteweight/bap-byteweight.2.2.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.2.2.0/opam
@@ -25,8 +25,13 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-signatures" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "camlzip"
+  "uri"
 ]
 synopsis: "BAP facility for indentifying code entry points"
 description: """

--- a/packages/bap-byteweight/bap-byteweight.2.2.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.2.2.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-signatures" {= "2.2.0"}
   "regular" {= "2.2.0"}

--- a/packages/bap-c/bap-c.2.2.0/opam
+++ b/packages/bap-c/bap-c.2.2.0/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "bap-c"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-api" {= "2.2.0"}
 ]

--- a/packages/bap-c/bap-c.2.2.0/opam
+++ b/packages/bap-c/bap-c.2.2.0/opam
@@ -15,6 +15,8 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-c"]]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-api" {= "2.2.0"}
 ]

--- a/packages/bap-c/bap-c.2.2.0/opam
+++ b/packages/bap-c/bap-c.2.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+name: "bap-c"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-c"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-c"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-api" {= "2.2.0"}
+]
+synopsis: "A C language support library for BAP"
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-cache/bap-cache.2.2.0/opam
+++ b/packages/bap-cache/bap-cache.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-cache"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-cache"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-cache"]
+        [ "bapbundle" "remove" "cache.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+]
+synopsis: "BAP caching service"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-cache/bap-cache.2.2.0/opam
+++ b/packages/bap-cache/bap-cache.2.2.0/opam
@@ -23,7 +23,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "regular" {= "2.2.0"}
   "bap-main" {= "2.2.0"}

--- a/packages/bap-cache/bap-cache.2.2.0/opam
+++ b/packages/bap-cache/bap-cache.2.2.0/opam
@@ -22,8 +22,14 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
-  "cmdliner"
+  "regular" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "mmap"
+  "fileutils"
+  "uuidm"
 ]
 synopsis: "BAP caching service"
 

--- a/packages/bap-callgraph-collator/bap-callgraph-collator.2.2.0/opam
+++ b/packages/bap-callgraph-collator/bap-callgraph-collator.2.2.0/opam
@@ -19,10 +19,11 @@ remove: [["ocamlfind" "remove" "bap-plugin-callgraph_collator"]
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-main" {= "2.2.0"}
   "graphlib" {= "2.2.0"}
-  "core_kernel" {>= "v0.14" & < "v0.15"}
   "re"
 ]
 synopsis: "Collates programs based on their callgraphs"

--- a/packages/bap-callgraph-collator/bap-callgraph-collator.2.2.0/opam
+++ b/packages/bap-callgraph-collator/bap-callgraph-collator.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-callgraph-collator"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-callgraph-collator"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-callgraph_collator"]
+         ["bapbundle" "remove" "callgraph_collator.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "graphlib" {= "2.2.0"}
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "re"
+]
+synopsis: "Collates programs based on their callgraphs"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-callgraph-collator/bap-callgraph-collator.2.2.0/opam
+++ b/packages/bap-callgraph-collator/bap-callgraph-collator.2.2.0/opam
@@ -20,7 +20,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-callgraph_collator"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-main" {= "2.2.0"}
   "graphlib" {= "2.2.0"}

--- a/packages/bap-callsites/bap-callsites.2.2.0/opam
+++ b/packages/bap-callsites/bap-callsites.2.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-callsites"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-callsites"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-callsites"]
+        [ "bapbundle" "remove" "callsites.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+]
+synopsis: "Inject data definition terms at callsites"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-constant-tracker/bap-constant-tracker.2.2.0/opam
+++ b/packages/bap-constant-tracker/bap-constant-tracker.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "bap-constant-tracker"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-constant-tracker"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-constant_tracker"]
+         ["bapbundle" "remove" "constant_tracker.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+]
+synopsis: "Constant Tracking Analysis based on Primus"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-core-theory/bap-core-theory.2.2.0/opam
+++ b/packages/bap-core-theory/bap-core-theory.2.2.0/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "bap-core-theory"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "oasis" {build & >= "0.4.7"}
   "bap-knowledge" {= "2.2.0"}
   "bitvec" {= "2.2.0"}

--- a/packages/bap-core-theory/bap-core-theory.2.2.0/opam
+++ b/packages/bap-core-theory/bap-core-theory.2.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name: "bap-core-theory"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-core-theory"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-core-theory"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-knowledge" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "bitvec-binprot" {= "2.2.0"}
+  "bitvec-order" {= "2.2.0"}
+  "bitvec-sexp" {= "2.2.0"}
+]
+synopsis: "BAP Semantics Representation"
+description: """
+The Core Theory is an intermediate language that is designed to
+express the semantics of computer programs. It focuses on programs
+that are represented in binary machine code and is capable of an
+accurate representation of the architectural and micro-architectural
+details of the program behavior.
+"""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-core-theory/bap-core-theory.2.2.0/opam
+++ b/packages/bap-core-theory/bap-core-theory.2.2.0/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "bap-core-theory"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
   "bap-knowledge" {= "2.2.0"}
   "bitvec" {= "2.2.0"}

--- a/packages/bap-cxxfilt/bap-cxxfilt.2.2.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-cxxfilt"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-cxxfilt"
+                 "--cxxfilt-paths=%{conf-binutils:cxxfilts}%"
+                 ]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-cxxfilt"]
+        ["bapbundle" "remove" "cxxfilt.plugin"]
+]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-demangle" {= "2.2.0"}
+  "conf-binutils" {= "0.3"}
+]
+synopsis: "A demangler that relies on a c++filt utility"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-demangle/bap-demangle.2.2.0/opam
+++ b/packages/bap-demangle/bap-demangle.2.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name: "bap-demangle"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-demangle"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-demangle"]
+        ["ocamlfind" "remove" "bap-plugin-demangle"]
+        ["bapbundle"   "remove" "demangle.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+]
+synopsis: "Library for name demangling"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-disassemble/bap-disassemble.2.2.0/opam
+++ b/packages/bap-disassemble/bap-disassemble.2.2.0/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-disassemble"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-knowledge" {= "2.2.0"}
   "bap-core-theory" {= "2.2.0"}

--- a/packages/bap-disassemble/bap-disassemble.2.2.0/opam
+++ b/packages/bap-disassemble/bap-disassemble.2.2.0/opam
@@ -17,7 +17,16 @@ remove: [["ocamlfind" "remove" "bap-plugin-disassemble"]
          ]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+  "bap-plugins" {= "2.2.0"}
+  "bap-bundle" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
 ]
 synopsis: "Implements the disassemble command"
 description: """

--- a/packages/bap-disassemble/bap-disassemble.2.2.0/opam
+++ b/packages/bap-disassemble/bap-disassemble.2.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-disassemble"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-disassemble"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-disassemble"]
+         ["bapbundle" "remove" "disassemble.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+]
+synopsis: "Implements the disassemble command"
+description: """
+Disassembles and analyzes the input file. This is the default
+command of the bap frontend which is assumed when no other command
+was specified.
+"""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-dump-symbols/bap-dump-symbols.2.2.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.2.2.0/opam
@@ -21,8 +21,11 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
-  "cmdliner"
+  "graphlib" {= "2.2.0"}
+  "regular" {= "2.2.0"}
 ]
 synopsis: "BAP plugin that dumps symbols information from a binary"
 

--- a/packages/bap-dump-symbols/bap-dump-symbols.2.2.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.2.2.0/opam
@@ -22,7 +22,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "graphlib" {= "2.2.0"}
   "regular" {= "2.2.0"}

--- a/packages/bap-dump-symbols/bap-dump-symbols.2.2.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.2.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-dump-symbols"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-dump-symbols"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-dump_symbols"]
+        ["bapbundle" "remove" "dump_symbols.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+]
+synopsis: "BAP plugin that dumps symbols information from a binary"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-dwarf/bap-dwarf.2.2.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.2.2.0/opam
@@ -15,7 +15,10 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-dwarf"]]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
+  "regular" {= "2.2.0"}
 ]
 synopsis: "BAP DWARF parsing library"
 flags: light-uninstall

--- a/packages/bap-dwarf/bap-dwarf.2.2.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.2.2.0/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "bap-dwarf"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "regular" {= "2.2.0"}
 ]

--- a/packages/bap-dwarf/bap-dwarf.2.2.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.2.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "bap-dwarf"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-dwarf"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-dwarf"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+]
+synopsis: "BAP DWARF parsing library"
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-elementary/bap-elementary.2.2.0/opam
+++ b/packages/bap-elementary/bap-elementary.2.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "bap-elementary"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-elementary"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-elementary"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+]
+synopsis: "BAP floating point approximations of elementary functions"
+description:
+"""
+Library provides few primitives for approximations of floating
+point operations via table methods.
+"""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-elf/bap-elf.2.2.0/opam
+++ b/packages/bap-elf/bap-elf.2.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "regular" {= "2.2.0"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-dwarf" {= "2.2.0"}
   "bitstring" {>= "3.0.0" & < "4.0.0"}

--- a/packages/bap-elf/bap-elf.2.2.0/opam
+++ b/packages/bap-elf/bap-elf.2.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "bap-elf"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-elf-loader"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-elf"]
+        ["ocamlfind" "remove" "bap-plugin-elf_loader"]
+        ["bapbundle" "remove" "elf_loader.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-dwarf" {= "2.2.0"}
+  "bitstring" {>= "3.0.0" & < "4.0.0"}
+]
+synopsis: "BAP ELF parser and loader written in native OCaml"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-elf/bap-elf.2.2.0/opam
+++ b/packages/bap-elf/bap-elf.2.2.0/opam
@@ -22,6 +22,9 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "regular" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-dwarf" {= "2.2.0"}
   "bitstring" {>= "3.0.0" & < "4.0.0"}

--- a/packages/bap-frontc/bap-frontc.2.2.0/opam
+++ b/packages/bap-frontc/bap-frontc.2.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "bap-frontc"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-frontc-parser"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
+        ["bapbundle" "remove" "frontc_parser.plugin"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-c" {= "2.2.0"}
+  "FrontC"
+]
+synopsis: "A C language frontend for based on FrontC library"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-frontend/bap-frontend.2.2.0/opam
+++ b/packages/bap-frontend/bap-frontend.2.2.0/opam
@@ -25,10 +25,15 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "2.2.0"}
-  "cmdliner"
-  "parsexp" {>= "v0.14" & < "v0.15"}
+  "bap-main" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "ocamlfind"
 ]
 synopsis: "BAP frontend"
 description: "The command-line interface to the Binary Analysis Platform."

--- a/packages/bap-frontend/bap-frontend.2.2.0/opam
+++ b/packages/bap-frontend/bap-frontend.2.2.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "2.2.0"}
   "bap-main" {= "2.2.0"}

--- a/packages/bap-frontend/bap-frontend.2.2.0/opam
+++ b/packages/bap-frontend/bap-frontend.2.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name: "bap-frontend"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-frontend"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["rm" "-f" "%{bin}%/bap"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+  "parsexp" {>= "v0.14" & < "v0.15"}
+]
+synopsis: "BAP frontend"
+description: "The command-line interface to the Binary Analysis Platform."
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.2.2.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.2.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "bap-fsi-benchmark"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-fsi-benchmark"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-ida" {= "2.2.0"}
+  "bap-byteweight-frontend" {= "2.2.0"}
+  "cmdliner"
+  "fileutils"
+  "re"
+]
+synopsis: "BAP function start identification benchmark game"
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-future/bap-future.2.2.0/opam
+++ b/packages/bap-future/bap-future.2.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "bap-future"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-future"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-future"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "oasis" {build & >= "0.4.7"}
+  "monads" {= "2.2.0"}
+]
+synopsis: "A library for asynchronous values"
+description: """
+A library for reasoning about state based dynamic systems. This can
+be seen as a common denominator between Lwt and Async libraries."""
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-glibc-runtime/bap-glibc-runtime.2.2.0/opam
+++ b/packages/bap-glibc-runtime/bap-glibc-runtime.2.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name: "bap-glibc-runtime"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-glibc-runtime"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-glibc_runtime"]
+         ["bapbundle" "remove" "glibc_runtime.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "bap-abi" {= "2.2.0"}
+  "bap-c" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+]
+synopsis: "Detects the presence of glibc runtime"
+description: """
+Enables ad-hoc support for glibc runtime code. In particular it
+detects the locations of main and __libc_start_main
+functions (and adds the latter if it is absent)
+"""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-ida-plugin/bap-ida-plugin.2.2.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.2.2.0/opam
@@ -19,8 +19,10 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap" {= "2.2.0"}
-  "cmdliner"
+  "regular" {= "2.2.0"}
 ]
 synopsis: "Plugins for IDA and BAP integration"
 

--- a/packages/bap-ida-plugin/bap-ida-plugin.2.2.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.2.2.0/opam
@@ -20,7 +20,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap" {= "2.2.0"}
   "regular" {= "2.2.0"}
 ]

--- a/packages/bap-ida-plugin/bap-ida-plugin.2.2.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "bap-ida-plugin"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-emit-ida-script"]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-emit_ida_script"]
+        ["bapbundle" "remove" "emit_ida_script.plugin"]
+
+]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap" {= "2.2.0"}
+  "cmdliner"
+]
+synopsis: "Plugins for IDA and BAP integration"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-ida-python/bap-ida-python.2.2.0/files/bap.cfg.in
+++ b/packages/bap-ida-python/bap-ida-python.2.2.0/files/bap.cfg.in
@@ -1,0 +1,2 @@
+.default
+bap_executable_path    %{bap:bin}%/bap

--- a/packages/bap-ida-python/bap-ida-python.2.2.0/opam
+++ b/packages/bap-ida-python/bap-ida-python.2.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+name: "bap-ida-python"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-ida-python/"
+license: "MIT"
+substs: [
+    "bap.cfg"
+]
+install: [
+    ["mkdir" "-p" "%{prefix}%/share/%{name}%/"]
+    ["cp" "-v"  "plugins/plugin_loader_bap.py" "%{prefix}%/share/%{name}%/"]
+    ["cp" "-rv" "plugins/bap" "%{prefix}%/share/%{name}%/"]
+    ["cp" "-v"  "bap.cfg" "%{prefix}%/share/%{name}%/"]
+]
+remove: [
+    ["rm" "-rf" "%{prefix}%/share/%{name}%/"]
+]
+depends: [
+  "ocaml" {>= "4.07.0" & < "4.10.0"}
+  "bap" {= version}
+  "conf-ida"
+]
+synopsis: "A BAP - IDA Pro integration library"
+flags: light-uninstall
+extra-files: ["bap.cfg.in" "md5=aec3a830555380469b523da74daef069"]
+url {
+   src: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/archive/v2.2.0.tar.gz"
+   checksum: "md5=e97a494b80c5695f8b488e1e4b14c087"
+}
+
+
+post-messages: [
+  "In order to install bap-ida-python plugin:
+   rm -rf %{conf-ida:path}%/plugins/bap/
+   cp %{prefix}%/share/%{name}%/plugin_loader_bap.py %{conf-ida:path}%/plugins/
+   cp -r %{prefix}%/share/%{name}%/bap %{conf-ida:path}%/plugins/
+   cp %{prefix}%/share/%{name}%/bap.cfg %{conf-ida:path}%/cfg/
+ "
+]

--- a/packages/bap-ida/bap-ida.2.2.0/opam
+++ b/packages/bap-ida/bap-ida.2.2.0/opam
@@ -25,7 +25,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "conf-ida"
   "oasis" {build & >= "0.4.7"}
   "fileutils"

--- a/packages/bap-ida/bap-ida.2.2.0/opam
+++ b/packages/bap-ida/bap-ida.2.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name: "bap-ida"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+     "--prefix=%{prefix}%"
+     "--enable-ida"
+     "--ida-path=%{conf-ida:path}%"
+     "--ida-headless=%{conf-ida:headless}%"
+]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+        ["ocamlfind" "remove" "bap-ida"]
+        ["ocamlfind" "remove" "bap-plugin-ida"]
+        ["bapbundle" "remove" "ida.plugin"]
+]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "conf-ida"
+  "bap-ida-python" {= "2.2.0"}
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "oasis" {build & >= "0.4.7"}
+  "fileutils"
+  "re"
+  "bap-ida-plugin" {= "2.2.0"}
+]
+synopsis: "An IDA Pro integration library"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-ida/bap-ida.2.2.0/opam
+++ b/packages/bap-ida/bap-ida.2.2.0/opam
@@ -24,13 +24,18 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.08.0" }
-  "conf-ida"
-  "bap-ida-python" {= "2.2.0"}
   "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
+  "conf-ida"
   "oasis" {build & >= "0.4.7"}
   "fileutils"
+  "mmap"
   "re"
+  "bap-ida-python" {= "2.2.0"}
   "bap-ida-plugin" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
 ]
 synopsis: "An IDA Pro integration library"
 

--- a/packages/bap-knowledge/bap-knowledge.2.2.0/opam
+++ b/packages/bap-knowledge/bap-knowledge.2.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-knowledge"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-knowledge"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "knowledge"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "monads" {= "2.2.0"}
+]
+synopsis: "Knowledge Representation Library"
+description: """
+The library provides facilities for storing, accumulating, and
+computing knowledge. The knowledge could be represented indirectly,
+in the Knowledge Base, or directly as knowledge values. The
+library focuses on representing knowledge that is partial and
+provides mechanisms for knowledge accumulation and
+refinement. The knowledge representation library leverages the
+powerful type system of the OCaml language to facilitate
+development of complex knowledge representation and reasoning systems.
+"""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-knowledge/bap-knowledge.2.2.0/opam
+++ b/packages/bap-knowledge/bap-knowledge.2.2.0/opam
@@ -15,6 +15,8 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "knowledge"]]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "oasis" {build & >= "0.4.7"}
   "monads" {= "2.2.0"}
 ]

--- a/packages/bap-knowledge/bap-knowledge.2.2.0/opam
+++ b/packages/bap-knowledge/bap-knowledge.2.2.0/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "knowledge"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
   "monads" {= "2.2.0"}
 ]

--- a/packages/bap-llvm/bap-llvm.2.2.0/files/detect.travis
+++ b/packages/bap-llvm/bap-llvm.2.2.0/files/detect.travis
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cat > bap-llvm.config <<EOF
+ travis : ${TRAVIS:-false}
+EOF

--- a/packages/bap-llvm/bap-llvm.2.2.0/opam
+++ b/packages/bap-llvm/bap-llvm.2.2.0/opam
@@ -29,8 +29,10 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
-  "cmdliner"
+  "mmap"
   "conf-env-travis"
   "conf-bap-llvm" {= "2.2.0"}
   "ogre" {= "2.2.0"}

--- a/packages/bap-llvm/bap-llvm.2.2.0/opam
+++ b/packages/bap-llvm/bap-llvm.2.2.0/opam
@@ -30,7 +30,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "mmap"
   "conf-env-travis"

--- a/packages/bap-llvm/bap-llvm.2.2.0/opam
+++ b/packages/bap-llvm/bap-llvm.2.2.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+name: "bap-llvm"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+  "--prefix=%{prefix}%"
+  "--with-cxx=`which clang++`"
+  "--with-llvm-version=%{conf-bap-llvm:package-version}%"
+  "--with-llvm-config=%{conf-bap-llvm:config}%"
+  "--enable-llvm"]
+  [make]
+  ]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap-plugin-llvm"]
+  ["ocamlfind" "remove" "bap-llvm"]
+  ["bapbundle" "remove" "llvm.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+  "conf-env-travis"
+  "conf-bap-llvm" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+]
+depexts: [
+  ["clang" "libncurses5-dev"] {os-distribution = "ubuntu"}
+  ["clang"] {os-distribution = "debian"}
+  ["clang" "libxml2-dev"] {os-distribution = "alpine"}
+  ["clang"] {os-distribution = "fedora"}
+]
+synopsis: "BAP LLVM backend"
+description:
+  "Provides a loader and a disassembler, based on LLVM-MC library."
+extra-files: ["detect.travis" "md5=00e7b28719062d550dcd7813becf7396"]
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-llvm/bap-llvm.2.2.0/opam
+++ b/packages/bap-llvm/bap-llvm.2.2.0/opam
@@ -34,7 +34,7 @@ depends: [
   "bap-std" {= "2.2.0"}
   "mmap"
   "conf-env-travis"
-  "conf-bap-llvm" {= "2.2.0"}
+  "conf-bap-llvm"
   "ogre" {= "2.2.0"}
   "monads" {= "2.2.0"}
 ]

--- a/packages/bap-main/bap-main.2.2.0/opam
+++ b/packages/bap-main/bap-main.2.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "bap-main"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-main"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-main"] ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "base"
+  "stdio"
+  "cmdliner"
+  "bap-build" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
+  "bap-plugins" {= "2.2.0"}
+  "bap-recipe" {= "2.2.0"}
+]
+synopsis: "Build BAP Main Framework Configuration Library"
+description:
+"""
+This library is an entry point to BAP and serves the two goals:
+- embedding BAP in other applications;
+- extending BAP with the user code.
+"""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-mc/bap-mc.2.2.0/opam
+++ b/packages/bap-mc/bap-mc.2.2.0/opam
@@ -28,7 +28,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
   "bap-core-theory" {= "2.2.0"}
   "bap-knowledge" {= "2.2.0"}

--- a/packages/bap-mc/bap-mc.2.2.0/opam
+++ b/packages/bap-mc/bap-mc.2.2.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+name: "bap-mc"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-mc"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap-plugin-mc"]
+  ["bapbundle" "remove" "mc.plugin"]
+  ["rm" "-f" "%{bin}%/bap-mc"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+  "oasis" {build & >= "0.4.7"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-plugins" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+]
+synopsis: "BAP machine instruction playground"
+description: "A BAP version of llvm-mc tool."
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-mc/bap-mc.2.2.0/opam
+++ b/packages/bap-mc/bap-mc.2.2.0/opam
@@ -28,7 +28,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "oasis" {build & >= "0.4.7"}
   "bap-core-theory" {= "2.2.0"}
   "bap-knowledge" {= "2.2.0"}

--- a/packages/bap-microx/bap-microx.2.2.0/opam
+++ b/packages/bap-microx/bap-microx.2.2.0/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "bap-microx"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "monads" {= "2.2.0"}
 ]

--- a/packages/bap-microx/bap-microx.2.2.0/opam
+++ b/packages/bap-microx/bap-microx.2.2.0/opam
@@ -15,7 +15,10 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-microx"]]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
+  "monads" {= "2.2.0"}
 ]
 synopsis: "A micro execution framework"
 flags: light-uninstall

--- a/packages/bap-microx/bap-microx.2.2.0/opam
+++ b/packages/bap-microx/bap-microx.2.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "bap-microx"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-microx"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-microx"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+]
+synopsis: "A micro execution framework"
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-mips/bap-mips.2.2.0/opam
+++ b/packages/bap-mips/bap-mips.2.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+name: "bap-mips"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-mips"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-mips"]
+         ["bapbundle" "remove" "mips.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+  "zarith"
+  "bap-abi" {= "2.2.0"}
+  "bap-api" {= "2.2.0"}
+  "bap-c" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+]
+synopsis: "BAP MIPS lifter"
+description: "Provides lifter for MIPS and MIPS32 architectures"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-mips/bap-mips.2.2.0/opam
+++ b/packages/bap-mips/bap-mips.2.2.0/opam
@@ -20,7 +20,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-mips"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "zarith"
   "bap-abi" {= "2.2.0"}
   "bap-api" {= "2.2.0"}

--- a/packages/bap-mips/bap-mips.2.2.0/opam
+++ b/packages/bap-mips/bap-mips.2.2.0/opam
@@ -20,7 +20,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-mips"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "zarith"
   "bap-abi" {= "2.2.0"}
   "bap-api" {= "2.2.0"}

--- a/packages/bap-objdump/bap-objdump.2.2.0/opam
+++ b/packages/bap-objdump/bap-objdump.2.2.0/opam
@@ -21,7 +21,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "re"
   "conf-binutils" {= "0.3"}
   "bap-core-theory" {= "2.2.0"}

--- a/packages/bap-objdump/bap-objdump.2.2.0/opam
+++ b/packages/bap-objdump/bap-objdump.2.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+name: "bap-objdump"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-objdump"
+                 "--objdump-paths=%{conf-binutils:objdumps}%"
+                 ]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
+	 ["bapbundle" "remove" "objdump.plugin"]
+]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+  "re"
+  "conf-binutils" {= "0.3"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-relation" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "bitvec-order" {= "2.2.0"}
+  "bitvec-sexp" {= "2.2.0"}
+]
+synopsis: "Extract symbols from binary, using binutils objdump"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-objdump/bap-objdump.2.2.0/opam
+++ b/packages/bap-objdump/bap-objdump.2.2.0/opam
@@ -21,7 +21,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "re"
   "conf-binutils" {= "0.3"}
   "bap-core-theory" {= "2.2.0"}

--- a/packages/bap-optimization/bap-optimization.2.2.0/opam
+++ b/packages/bap-optimization/bap-optimization.2.2.0/opam
@@ -16,8 +16,11 @@ remove: [["ocamlfind" "remove" "bap-plugin-optimization"]
          ["bapbundle" "remove" "optimization.plugin"]]
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
-  "cmdliner"
+  "regular" {= "2.2.0"}
+  "graphlib" {= "2.2.0"}
 ]
 synopsis: "A BAP plugin that removes dead IR code"
 description: """

--- a/packages/bap-optimization/bap-optimization.2.2.0/opam
+++ b/packages/bap-optimization/bap-optimization.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-optimization"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-optimization"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-optimization"]
+         ["bapbundle" "remove" "optimization.plugin"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+]
+synopsis: "A BAP plugin that removes dead IR code"
+description: """
+A pass that conservatively removes dead code in the generated IR. The
+removed dead code is usually produced by a lifter, though it might be
+possible that a binary indeed contains a dead code. The algorithm
+doesn't remove variables that are stored in memory, only registers are
+considered."""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-optimization/bap-optimization.2.2.0/opam
+++ b/packages/bap-optimization/bap-optimization.2.2.0/opam
@@ -17,7 +17,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-optimization"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "regular" {= "2.2.0"}
   "graphlib" {= "2.2.0"}

--- a/packages/bap-phoenix/bap-phoenix.2.2.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.2.2.0/opam
@@ -26,10 +26,14 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "2.2.0"}
   "cmdliner"
   "text-tags" {= "2.2.0"}
+  "graphlib" {= "2.2.0"}
+  "regular" {= "2.2.0"}
   "ocamlgraph"
   "ezjsonm"
 ]

--- a/packages/bap-phoenix/bap-phoenix.2.2.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.2.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+name: "bap-phoenix"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-phoenix"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-phoenix"]
+        ["bapbundle" "remove" "phoenix.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+  "text-tags" {= "2.2.0"}
+  "ocamlgraph"
+  "ezjsonm"
+]
+synopsis: "BAP plugin that dumps information in a phoenix decompiler format"
+description: "Useful for visualization and project exploration"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-phoenix/bap-phoenix.2.2.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.2.2.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "2.2.0"}
   "cmdliner"

--- a/packages/bap-piqi/bap-piqi.2.2.0/opam
+++ b/packages/bap-piqi/bap-piqi.2.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+name: "bap-piqi"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-piqi-printers" ]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-piqi_printers"]
+        [ "ocamlfind" "remove" "bap-piqi"]
+        [ "bapbundle" "remove" "piqi_printers.plugin"]
+        [ "rm" "-f" "%{prefix}%/share/bap/exp.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap/ir.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap/stmt.piqi"]
+        [ "rm" "-f" "%{prefix}%/share/bap/type.piqi"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+  "piqi" {>= "0.7.4"}
+]
+synopsis: "BAP plugin for serialization based on piqi library"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-plugins/bap-plugins.2.2.0/opam
+++ b/packages/bap-plugins/bap-plugins.2.2.0/opam
@@ -17,8 +17,10 @@ remove: [["ocamlfind" "remove" "bap-plugins"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "cmdliner"
+  "ppx_bap" {= "v0.14"}
   "fileutils"
+  "uri"
+  "ocamlfind"
   "bap-bundle" {= "2.2.0"}
   "bap-future" {= "2.2.0"}
 ]

--- a/packages/bap-plugins/bap-plugins.2.2.0/opam
+++ b/packages/bap-plugins/bap-plugins.2.2.0/opam
@@ -17,7 +17,7 @@ remove: [["ocamlfind" "remove" "bap-plugins"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "fileutils"
   "uri"
   "ocamlfind"

--- a/packages/bap-plugins/bap-plugins.2.2.0/opam
+++ b/packages/bap-plugins/bap-plugins.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "bap-plugins"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-plugins"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugins"]
+         ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "cmdliner"
+  "fileutils"
+  "bap-bundle" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
+]
+synopsis: "BAP plugins support library"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-powerpc/bap-powerpc.2.2.0/opam
+++ b/packages/bap-powerpc/bap-powerpc.2.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+name: "bap-powerpc"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-powerpc"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-powerpc"]
+         ["bapbundle" "remove" "powerpc.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
+  "zarith"
+  "bap-abi" {= "2.2.0"}
+  "bap-api" {= "2.2.0"}
+  "bap-c" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+]
+synopsis: "BAP PowerPC lifter"
+description: "Provides support for PPC and PPC64 architectures."
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-powerpc/bap-powerpc.2.2.0/opam
+++ b/packages/bap-powerpc/bap-powerpc.2.2.0/opam
@@ -20,7 +20,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-powerpc"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "zarith"
   "bap-abi" {= "2.2.0"}

--- a/packages/bap-powerpc/bap-powerpc.2.2.0/opam
+++ b/packages/bap-powerpc/bap-powerpc.2.2.0/opam
@@ -20,7 +20,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-powerpc"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "zarith"
   "bap-abi" {= "2.2.0"}

--- a/packages/bap-primus-dictionary/bap-primus-dictionary.2.2.0/opam
+++ b/packages/bap-primus-dictionary/bap-primus-dictionary.2.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-primus-dictionary"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-dictionary"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_dictionary"]
+        ["bapbundle" "remove" "primus_dictionary.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+]
+synopsis: "BAP Primus Lisp library that provides dictionaries"
+description: """
+Provides a key-value storage for Primus Lisp programs.  Dictionaries
+are represented with symbols and it is a responsibility of user to
+prevent name clashing between different dictionaries."""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-exploring-scheduler/bap-primus-exploring-scheduler.2.2.0/opam
+++ b/packages/bap-primus-exploring-scheduler/bap-primus-exploring-scheduler.2.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-primus-exploring-scheduler"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-exploring"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-primus_exploring_scheduler"]
+         ["bapbundle" "remove" "primus_exploring_scheduler.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
+]
+synopsis: "Evaluates all machines, prioritizing the least visited"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-greedy-scheduler/bap-primus-greedy-scheduler.2.2.0/opam
+++ b/packages/bap-primus-greedy-scheduler/bap-primus-greedy-scheduler.2.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "bap-primus-greedy-scheduler"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-greedy"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-primus_greedy_scheduler"]
+         ["bapbundle" "remove" "primus_greedy_scheduler.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+]
+synopsis: "Evaluates all machines in the DFS order"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-limit/bap-primus-limit.2.2.0/opam
+++ b/packages/bap-primus-limit/bap-primus-limit.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "bap-primus-limit"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-limit"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-primus-limit"]
+         ["bapbundle" "remove" "primus_limit.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+]
+synopsis: "Ensures termination by limiting Primus machines"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-lisp/bap-primus-lisp.2.2.0/opam
+++ b/packages/bap-primus-lisp/bap-primus-lisp.2.2.0/opam
@@ -22,8 +22,15 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+
 ]
 synopsis: "BAP Primus Lisp Runtime"
 description: """

--- a/packages/bap-primus-lisp/bap-primus-lisp.2.2.0/opam
+++ b/packages/bap-primus-lisp/bap-primus-lisp.2.2.0/opam
@@ -23,7 +23,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}
   "monads" {= "2.2.0"}

--- a/packages/bap-primus-lisp/bap-primus-lisp.2.2.0/opam
+++ b/packages/bap-primus-lisp/bap-primus-lisp.2.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "bap-primus-lisp"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-lisp"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_lisp"]
+        ["bapbundle" "remove" "primus_lisp.plugin"]
+        ["rm" "-rf" "%{prefix}%/share/primus/site-lisp"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+]
+synopsis: "BAP Primus Lisp Runtime"
+description: """
+The default (and the only one so far) Primus Lisp runtime. The plugin
+provides Lisp primitives for manipulation program state, loads user
+specified libraries, and integrates Primus Lisp with BAP universe."""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-loader/bap-primus-loader.2.2.0/opam
+++ b/packages/bap-primus-loader/bap-primus-loader.2.2.0/opam
@@ -20,7 +20,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-primus_loader"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}
   "ogre" {= "2.2.0"}

--- a/packages/bap-primus-loader/bap-primus-loader.2.2.0/opam
+++ b/packages/bap-primus-loader/bap-primus-loader.2.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "bap-primus-loader"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-loader"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-primus_loader"]
+         ["bapbundle" "remove" "primus_loader.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+]
+synopsis: "Generic program loader for Primus"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-loader/bap-primus-loader.2.2.0/opam
+++ b/packages/bap-primus-loader/bap-primus-loader.2.2.0/opam
@@ -19,6 +19,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-primus_loader"]
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}
   "ogre" {= "2.2.0"}

--- a/packages/bap-primus-mark-visited/bap-primus-mark-visited.2.2.0/opam
+++ b/packages/bap-primus-mark-visited/bap-primus-mark-visited.2.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "bap-primus-mark-visited"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-mark-visited"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [ ["ocamlfind" "remove" "bap-plugin-primus_mark_visited"]
+          ["bapbundle" "remove" "primus_mark_visited.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "bap-primus-track-visited" {= "2.2.0"}
+]
+synopsis: "Registers the bap:mark-visited component"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-powerpc/bap-primus-powerpc.2.2.0/opam
+++ b/packages/bap-primus-powerpc/bap-primus-powerpc.2.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "bap-primus-powerpc"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-powerpc"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-primus_powerpc"]
+         ["bapbundle" "remove" "primus_powerpc.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+]
+synopsis: "Performs the PowerPC target specific setup"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-print/bap-primus-print.2.2.0/opam
+++ b/packages/bap-primus-print/bap-primus-print.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-primus-print"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-print"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-primus_print"]
+         ["bapbundle" "remove" "primus_print.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+  "bare" {= "2.2.0"}
+]
+synopsis: "Prints Primus states and observations"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-print/bap-primus-print.2.2.0/opam
+++ b/packages/bap-primus-print/bap-primus-print.2.2.0/opam
@@ -20,7 +20,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-primus_print"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}
   "bap-future" {= "2.2.0"}

--- a/packages/bap-primus-print/bap-primus-print.2.2.0/opam
+++ b/packages/bap-primus-print/bap-primus-print.2.2.0/opam
@@ -19,6 +19,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-primus_print"]
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}
   "bap-future" {= "2.2.0"}

--- a/packages/bap-primus-promiscuous/bap-primus-promiscuous.2.2.0/opam
+++ b/packages/bap-primus-promiscuous/bap-primus-promiscuous.2.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "bap-primus-promiscuous"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-promiscuous"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-primus_promiscuous"]
+         ["bapbundle" "remove" "primus_promiscuous.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+]
+synopsis: "Enables the promiscuous mode of execution"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-propagate-taint/bap-primus-propagate-taint.2.2.0/opam
+++ b/packages/bap-primus-propagate-taint/bap-primus-propagate-taint.2.2.0/opam
@@ -22,7 +22,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "monads" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}

--- a/packages/bap-primus-propagate-taint/bap-primus-propagate-taint.2.2.0/opam
+++ b/packages/bap-primus-propagate-taint/bap-primus-propagate-taint.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-primus-propagate-taint"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+   "--enable-primus-propagate-taint"
+  ]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+  ["ocamlfind" "remove" "bap-plugin-primus_propagate_taint"]
+  ["bapbundle" "remove" "primus_propagate_taint.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "bap-taint" {= "2.2.0"}
+]
+synopsis: "A compatibility layer between different taint analysis frameworks"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-propagate-taint/bap-primus-propagate-taint.2.2.0/opam
+++ b/packages/bap-primus-propagate-taint/bap-primus-propagate-taint.2.2.0/opam
@@ -21,7 +21,10 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
+  "monads" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}
   "bap-taint" {= "2.2.0"}
 ]

--- a/packages/bap-primus-random/bap-primus-random.2.2.0/opam
+++ b/packages/bap-primus-random/bap-primus-random.2.2.0/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-primus_random"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "zarith"
   "bap-std" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}

--- a/packages/bap-primus-random/bap-primus-random.2.2.0/opam
+++ b/packages/bap-primus-random/bap-primus-random.2.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "bap-primus-random"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-random"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-primus_random"]
+         ["bapbundle" "remove" "primus_random.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+  "zarith"
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "bitvec-sexp" {= "2.2.0"}
+]
+synopsis: "Provides components for Primus state randomization"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-random/bap-primus-random.2.2.0/opam
+++ b/packages/bap-primus-random/bap-primus-random.2.2.0/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-primus_random"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "zarith"
   "bap-std" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}

--- a/packages/bap-primus-region/bap-primus-region.2.2.0/opam
+++ b/packages/bap-primus-region/bap-primus-region.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-primus-region"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-region"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_region"]
+        ["bapbundle" "remove" "primus_region.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+]
+synopsis:
+  "Provides a set of operations to store and manipulate interval trees"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-round-robin-scheduler/bap-primus-round-robin-scheduler.2.2.0/opam
+++ b/packages/bap-primus-round-robin-scheduler/bap-primus-round-robin-scheduler.2.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-primus-round-robin-scheduler"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-round-robin"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-primus_round_robin_scheduler"]
+         ["bapbundle" "remove" "primus_round_robin_scheduler.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+]
+synopsis: "Evaluates all machines in the BFS order"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-support/bap-primus-support.2.2.0/opam
+++ b/packages/bap-primus-support/bap-primus-support.2.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+name: "bap-primus-support"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+
+depends: [
+  "bap-primus-exploring-scheduler" {= "2.2.0"}
+  "bap-primus-greedy-scheduler" {= "2.2.0"}
+  "bap-primus-limit" {= "2.2.0"}
+  "bap-primus-loader" {= "2.2.0"}
+  "bap-primus-mark-visited" {= "2.2.0"}
+  "bap-primus-print" {= "2.2.0"}
+  "bap-primus-promiscuous" {= "2.2.0"}
+  "bap-primus-round-robin-scheduler" {= "2.2.0"}
+  "bap-primus-wandering-scheduler" {= "2.2.0"}
+]
+synopsis: "Provides supporting components for Primus"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.2.2.0/opam
+++ b/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.2.2.0/opam
@@ -19,12 +19,13 @@ remove: [["ocamlfind" "remove" "bap-plugin-primus_symbolic_executor"]
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-main" {= "2.2.0"}
   "bap-std" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}
   "bap-primus-track-visited" {= "2.2.0"}
   "bitvec" {= "2.2.0"}
-  "core_kernel" {>= "v0.14" & < "v0.15"}
   "monads" {= "2.2.0"}
   "ppx_bap" {= "v0.14"}
   "regular" {= "2.2.0"}

--- a/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.2.2.0/opam
+++ b/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.2.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+name: "bap-primus-symbolic-executor"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-symbolic-executor"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-primus_symbolic_executor"]
+         ["bapbundle" "remove" "primus_symbolic_executor.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-main" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "bap-primus-track-visited" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "monads" {= "2.2.0"}
+  "ppx_bap" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "zarith"
+  "z3"
+]
+synopsis: "Primus Symbolic Executor"
+description: """
+Provides the bap:symbolic-executor Primus system that uses an SMT solver (z3) to compute
+inputs for as many paths as possible. It also includes the symbolic-computer
+component that computes symbolic formulas for each value that depends on input
+and provides Primus Lisp primitives to create symbolic values and symbolic memories,
+as well as to specify additional constraints and post asserts that are dispatched to
+the SMT solver.
+"""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.2.2.0/opam
+++ b/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.2.2.0/opam
@@ -26,7 +26,7 @@ depends: [
   "bitvec" {= "2.2.0"}
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "monads" {= "2.2.0"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "regular" {= "2.2.0"}
   "zarith"
   "z3"

--- a/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.2.2.0/opam
+++ b/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.2.2.0/opam
@@ -20,14 +20,14 @@ remove: [["ocamlfind" "remove" "bap-plugin-primus_symbolic_executor"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-main" {= "2.2.0"}
   "bap-std" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}
   "bap-primus-track-visited" {= "2.2.0"}
   "bitvec" {= "2.2.0"}
   "monads" {= "2.2.0"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "regular" {= "2.2.0"}
   "zarith"
   "z3"

--- a/packages/bap-primus-systems/bap-primus-systems.2.2.0/opam
+++ b/packages/bap-primus-systems/bap-primus-systems.2.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name: "bap-primus-systems"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-systems"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_systems"]
+        ["bapbundle" "remove" "primus_systems.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+]
+synopsis: "Loads Primus systems and registers them in the system repository"
+description: """
+The plugin installs, parses, and loads Primus systems.
+Primus System is a particular composition of components, i.e.
+a system is a Primus application that could be run.
+"""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-taint/bap-primus-taint.2.2.0/opam
+++ b/packages/bap-primus-taint/bap-primus-taint.2.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "bap-primus-taint"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-taint" ]
+  [make]
+]
+install: [[make "install"]]
+remove: [
+  ["ocamlfind" "remove" "bap-plugin-primus_taint"]
+  ["bapbundle" "remove" "primus_taint.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "bap-taint" {= "2.2.0"}
+]
+synopsis: "A taint analysis control interface"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-test/bap-primus-test.2.2.0/opam
+++ b/packages/bap-primus-test/bap-primus-test.2.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+name: "bap-primus-test"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-test"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_test"]
+        ["bapbundle" "remove" "primus_test.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+]
+synopsis: "BAP Primus Testing and Program Verification module"
+description: """
+With Primus Test Framework program analysis could be implemented as a
+set of simple tests written in Primus Lisp language. The framework
+provides an unified incident reporting facility for generalized
+problem reporting. The framework comes with a couple of analysis on
+board as a showcase.
+
+Memcheck - a memory checker that detects vioalations of memory
+management discipline, such as use-after-free, double free, and
+corrupted free.
+
+Check Returned Value - verifies that a program is addressing all
+possible outcomes of certain API calls, e.g., checks return values,
+error codes, etc."""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-track-visited/bap-primus-track-visited.2.2.0/opam
+++ b/packages/bap-primus-track-visited/bap-primus-track-visited.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "bap-primus-track-visited"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-track-visited"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [ ["ocamlfind" "remove" "bap-primus_track_visited"] ]
+
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+]
+synopsis: "Tracks basic blocks visited by Primus"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-wandering-scheduler/bap-primus-wandering-scheduler.2.2.0/opam
+++ b/packages/bap-primus-wandering-scheduler/bap-primus-wandering-scheduler.2.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-primus-wandering-scheduler"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-wandering"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-primus_wandering_scheduler"]
+         ["bapbundle" "remove" "primus_wandering_scheduler.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+]
+synopsis: "Evaluates all machines while"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus-x86/bap-primus-x86.2.2.0/opam
+++ b/packages/bap-primus-x86/bap-primus-x86.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-primus-x86"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus-x86"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-primus_x86"]
+        ["bapbundle" "remove" "primus_x86.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "bap-x86" {= "2.2.0"}
+]
+synopsis: "The x86 CPU support package for BAP Primus CPU emulator"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus/bap-primus.2.2.0/opam
+++ b/packages/bap-primus/bap-primus.2.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+name: "bap-primus"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-primus"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-primus"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-abi" {= "2.2.0"}
+  "bap-c" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
+  "bap-strings" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+  "uuidm"
+  "graphlib" {= "2.2.0"}
+  "parsexp" {>= "v0.14" & < "v0.15"}
+]
+synopsis: "The BAP Microexecution Framework"
+description: """
+BAP Primus is a Microexecutuin Framework. The Microexecution technique
+was pioneered by Patrice Godefroid from Microsoft Research. The idea
+is to execute a binary from any point, using random inputs for
+undefined values.
+
+The idea of Primus is very similiar. A program is lifted into the
+Intermediate Representation, that is interpreted using the Primus
+interpreter. The Framework allows users to customize the interpreter
+by implementing different machine components."""
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-primus/bap-primus.2.2.0/opam
+++ b/packages/bap-primus/bap-primus.2.2.0/opam
@@ -18,6 +18,8 @@ remove: [["ocamlfind" "remove" "bap-primus"]]
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-abi" {= "2.2.0"}
   "bap-c" {= "2.2.0"}

--- a/packages/bap-primus/bap-primus.2.2.0/opam
+++ b/packages/bap-primus/bap-primus.2.2.0/opam
@@ -19,7 +19,7 @@ remove: [["ocamlfind" "remove" "bap-primus"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-abi" {= "2.2.0"}
   "bap-c" {= "2.2.0"}

--- a/packages/bap-print/bap-print.2.2.0/opam
+++ b/packages/bap-print/bap-print.2.2.0/opam
@@ -23,7 +23,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-demangle" {= "2.2.0"}
   "text-tags" {= "2.2.0"}

--- a/packages/bap-print/bap-print.2.2.0/opam
+++ b/packages/bap-print/bap-print.2.2.0/opam
@@ -22,9 +22,17 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-demangle" {= "2.2.0"}
   "text-tags" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "graphlib" {= "2.2.0"}
+  "re"
+  "ogre" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
 ]
 synopsis: "Print plugin - print project in various formats"
 

--- a/packages/bap-print/bap-print.2.2.0/opam
+++ b/packages/bap-print/bap-print.2.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "bap-print"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-print"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-print"]
+        ["bapbundle" "remove" "print.plugin"]
+
+        ]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-demangle" {= "2.2.0"}
+  "text-tags" {= "2.2.0"}
+]
+synopsis: "Print plugin - print project in various formats"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-radare2/bap-radare2.2.2.0/opam
+++ b/packages/bap-radare2/bap-radare2.2.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "conf-radare2"
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "ocaml" {>= "4.08.0" }
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "re"
   "yojson"
   "zarith"

--- a/packages/bap-radare2/bap-radare2.2.2.0/opam
+++ b/packages/bap-radare2/bap-radare2.2.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "conf-radare2"
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "ocaml" {>= "4.08.0" }
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "re"
   "yojson"
   "zarith"

--- a/packages/bap-radare2/bap-radare2.2.2.0/opam
+++ b/packages/bap-radare2/bap-radare2.2.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+name: "bap-radare2"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-radare2"
+                 ]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-radare2"]
+	 ["bapbundle" "remove" "radare2.plugin"]
+]
+depends: [
+  "conf-radare2"
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ocaml" {>= "4.08.0" }
+  "ppx_bap" {= "2.2.0"}
+  "re"
+  "yojson"
+  "zarith"
+  "bap-abi" {= "2.2.0"}
+  "bap-arm" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-relation" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+]
+synopsis: "Extract symbols from binary using radare2"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-raw/bap-raw.2.2.0/opam
+++ b/packages/bap-raw/bap-raw.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "bap-raw"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-raw"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-raw"]
+         ["bapbundle" "remove" "raw.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+]
+synopsis: "Provides a loader for raw binaries"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-raw/bap-raw.2.2.0/opam
+++ b/packages/bap-raw/bap-raw.2.2.0/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-raw"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-main" {= "2.2.0"}
 ]

--- a/packages/bap-raw/bap-raw.2.2.0/opam
+++ b/packages/bap-raw/bap-raw.2.2.0/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-raw"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-main" {= "2.2.0"}
 ]

--- a/packages/bap-recipe-command/bap-recipe-command.2.2.0/opam
+++ b/packages/bap-recipe-command/bap-recipe-command.2.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name: "bap-recipe-command"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-recipe-command"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-recipe_command"]
+          ["bapbundle" "remove" "recipe_command.plugin"]
+         ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "base"
+  "stdio"
+  "parsexp"
+  "fileutils"
+  "camlzip"
+  "uuidm"
+  "bap-std" {= "2.2.0"}
+  "bap-recipe" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+]
+synopsis: "Provides commands to manipulate the recipe subsystem"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-recipe/bap-recipe.2.2.0/opam
+++ b/packages/bap-recipe/bap-recipe.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-recipe"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-recipe"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-recipe"]
+         ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "base"
+  "stdio"
+  "parsexp"
+  "fileutils"
+  "camlzip"
+  "uuidm"
+  "stdlib-shims"
+]
+synopsis: "Stores command line parameters and resources in a single file"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-relation/bap-relation.2.2.0/opam
+++ b/packages/bap-relation/bap-relation.2.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "bap-relation"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-relation"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-relation"]]
+depends: [
+  "ocaml" {>= "4.08.0" & < "4.12.0"}
+  "oasis" {build & >= "0.4.7"}
+  "base" {>= "v0.11.0"}
+]
+synopsis: "A set of relations (bimap)"
+description: """
+A relation between two sets is a set of pairs made from the
+elements of these sets. This library implements a bidirectional mapping
+between two sets and computes their matching that defines bijections
+between the sets.
+"""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-relocatable/bap-relocatable.2.2.0/opam
+++ b/packages/bap-relocatable/bap-relocatable.2.2.0/opam
@@ -22,7 +22,7 @@ remove: [
 depends: [
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "ocaml" {>= "4.08.0" }
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "bap-abi" {= "2.2.0"}
   "bap-arm" {= "2.2.0"}
   "bap-powerpc" {= "2.2.0"}

--- a/packages/bap-relocatable/bap-relocatable.2.2.0/opam
+++ b/packages/bap-relocatable/bap-relocatable.2.2.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+name: "bap-relocatable"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-relocatable"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-relocatable"]
+        ["bapbundle" "remove" "relocatable.plugin"]
+        ]
+
+depends: [
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ocaml" {>= "4.08.0" }
+  "ppx_bap" {= "2.2.0"}
+  "bap-abi" {= "2.2.0"}
+  "bap-arm" {= "2.2.0"}
+  "bap-powerpc" {= "2.2.0"}
+  "bap-x86" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-relation" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "bitvec-order" {= "2.2.0"}
+  "bitvec-sexp" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+]
+synopsis:"Extracts symbolic information from the program relocations"
+description: """
+The relocation symbolizer leverages the relocation information stored
+in files to extract symbol names."""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-relocatable/bap-relocatable.2.2.0/opam
+++ b/packages/bap-relocatable/bap-relocatable.2.2.0/opam
@@ -22,7 +22,7 @@ remove: [
 depends: [
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "ocaml" {>= "4.08.0" }
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-abi" {= "2.2.0"}
   "bap-arm" {= "2.2.0"}
   "bap-powerpc" {= "2.2.0"}

--- a/packages/bap-report/bap-report.2.2.0/opam
+++ b/packages/bap-report/bap-report.2.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "bap-report"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-report"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-report"]
+         ["bapbundle" "remove" "report.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+]
+synopsis: "A BAP plugin that reports program status"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-run/bap-run.2.2.0/opam
+++ b/packages/bap-run/bap-run.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-run"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-run"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-run"]
+        ["bapbundle" "remove" "run.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+]
+synopsis: "A BAP plugin that executes a binary"
+description: "Uses the Primus Microexecution Framework to execute a binary."
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-signatures/bap-signatures.2.2.0/opam
+++ b/packages/bap-signatures/bap-signatures.2.2.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+name: "bap-signatures"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+install: [
+  ["mkdir" "-p" "%{share}%/bap/"]
+  ["cp" "sigs.zip" "%{share}%/bap/sigs.zip"]
+]
+
+remove: [["rm" "%{share}%/bap/sigs.zip"]]
+synopsis: "A data package with binary signatures for bap"
+description: "A package contains signatures for Byteweight algorithm."
+depends: ["ocaml"]
+flags: light-uninstall
+url {
+  src:
+    "https://github.com/BinaryAnalysisPlatform/bap/releases/download/v2.2.0/sigs.tar.gz"
+}

--- a/packages/bap-specification/bap-specification.2.2.0/opam
+++ b/packages/bap-specification/bap-specification.2.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "bap-specification"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+                 "--enable-specification"
+                 ]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-specification"]
+	 ["bapbundle" "remove" "specification.plugin"]
+]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+]
+synopsis: "Implements the specification command"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-ssa/bap-ssa.2.2.0/opam
+++ b/packages/bap-ssa/bap-ssa.2.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "bap-ssa"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-ssa"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-ssa"]
+         ["bapbundle" "remove" "ssa.plugin"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+]
+synopsis: "A BAP plugin, that translates a program into the SSA form"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-std/bap-std.2.2.0/opam
+++ b/packages/bap-std/bap-std.2.2.0/opam
@@ -45,7 +45,7 @@ depends: [
   "graphlib" {= "2.2.0"}
   "oasis" {build & >= "0.4.7"}
   "ocamlfind" {>= "1.5.6" & < "2.0"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "regular" {= "2.2.0"}
   "uri"
   "utop" {build & >= "2.0.0"}

--- a/packages/bap-std/bap-std.2.2.0/opam
+++ b/packages/bap-std/bap-std.2.2.0/opam
@@ -1,0 +1,79 @@
+opam-version: "2.0"
+name: "bap-std"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--with-cxx=`which clang++`"
+                 "--mandir=%{man}%"
+                 "--enable-bap-std"]
+  [make]
+]
+
+install: [
+  [make "reinstall"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "bap"]
+  ["rm" "-f" "%{bin}%/baptop"]
+  ["rm" "-f" "%{bin}%/ppx-bap"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "base-unix"
+  "bap-future" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "bitvec-order" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-bundle" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-plugins" {= "2.2.0"}
+  "bap-relation" {= "2.2.0"}
+  "camlzip" {>= "1.07"}
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "bin_prot" {>= "v0.14" & < "v0.15"}
+  "fileutils"
+  "graphlib" {= "2.2.0"}
+  "oasis" {build & >= "0.4.7"}
+  "ocamlfind" {>= "1.5.6" & < "2.0"}
+  "ppx_bap" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "uri"
+  "utop" {build & >= "2.0.0"}
+  "uuidm"
+  "zarith"
+  "cmdliner" {>= "0.9.8"}
+  "ogre" {= "2.2.0"}
+  "monads" {= "2.2.0"}
+  "result"
+]
+depexts: [
+  ["libgmp-dev" "libzip-dev" "clang"] {os-distribution = "ubuntu"}
+  ["gmp" "libzip"] {os = "macos" & os-distribution = "macports"}
+  ["clang"] {os-distribution = "debian"}
+  ["binutils" "gmp-dev" "libzip-dev" "m4" "perl" "zlib-dev"] {os-distribution = "alpine"}
+
+
+]
+conflicts: [
+  "fileutils" {= "0.5.0"}
+  "jbuilder" {= "1.0+beta18"}
+]
+synopsis: "The Binary Analysis Platform Standard Library"
+description: "Provides the main BAP library."
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-std/bap-std.2.2.0/opam
+++ b/packages/bap-std/bap-std.2.2.0/opam
@@ -45,7 +45,7 @@ depends: [
   "graphlib" {= "2.2.0"}
   "oasis" {build & >= "0.4.7"}
   "ocamlfind" {>= "1.5.6" & < "2.0"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "regular" {= "2.2.0"}
   "uri"
   "utop" {build & >= "2.0.0"}

--- a/packages/bap-strings/bap-strings.2.2.0/opam
+++ b/packages/bap-strings/bap-strings.2.2.0/opam
@@ -19,6 +19,7 @@ remove: [["ocamlfind" "remove" "bap-strings"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "oasis" {build & >= "0.4.7"}
 ]
 synopsis: "Text utilities useful in Binary Analysis and Reverse Engineering"

--- a/packages/bap-strings/bap-strings.2.2.0/opam
+++ b/packages/bap-strings/bap-strings.2.2.0/opam
@@ -19,7 +19,7 @@ remove: [["ocamlfind" "remove" "bap-strings"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
 ]
 synopsis: "Text utilities useful in Binary Analysis and Reverse Engineering"

--- a/packages/bap-strings/bap-strings.2.2.0/opam
+++ b/packages/bap-strings/bap-strings.2.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+name: "bap-strings"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-strings-library"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-strings"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "oasis" {build & >= "0.4.7"}
+]
+synopsis: "Text utilities useful in Binary Analysis and Reverse Engineering"
+description: """
+The library provides several algorithms:
+
+- Detector - that uses a maximum aposteriori likelihood estimator
+  (MAP) to detect code that operates with textual data (aka Bayesian
+  inference).
+
+- Unscrambler - that is capable of finding all possible words, that
+  can be built from a bag of letters in O(1).
+
+- Scanner - a generic algorithm for finding strings of characters (a
+  library variant of strings tool)"""
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-stub-resolver/bap-stub-resolver.2.2.0/opam
+++ b/packages/bap-stub-resolver/bap-stub-resolver.2.2.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+name: "bap-stub-resolver"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-stub-resolver"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-stub_resolver"]
+        ["bapbundle" "remove" "stub_resolver.plugin"]
+        ]
+
+depends: [
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ocaml" {>= "4.08.0" }
+  "ppx_bap" {= "2.2.0"}
+  "ounit"
+  "bap-abi" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-relation" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "bitvec-order" {= "2.2.0"}
+  "bitvec-sexp" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+]
+synopsis: "Identifies and manages stub functions in a binary"
+description: """
+Identifies functions that are stubs and redirects calls to stubs to
+the calls to the implemenations, in case if the latter is present in
+the binary.
+
+A stub is piece of binary code that is used to call a function
+implementation. Most commonly stubs are employed for external
+functions, whose implementation is later loaded from some library,
+however some ABIs are using stubs for internal functions, in case if
+they have external linkage.
+"""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-stub-resolver/bap-stub-resolver.2.2.0/opam
+++ b/packages/bap-stub-resolver/bap-stub-resolver.2.2.0/opam
@@ -22,7 +22,7 @@ remove: [
 depends: [
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "ocaml" {>= "4.08.0" }
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "ounit"
   "bap-abi" {= "2.2.0"}
   "bap-core-theory" {= "2.2.0"}

--- a/packages/bap-stub-resolver/bap-stub-resolver.2.2.0/opam
+++ b/packages/bap-stub-resolver/bap-stub-resolver.2.2.0/opam
@@ -22,7 +22,7 @@ remove: [
 depends: [
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "ocaml" {>= "4.08.0" }
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "ounit"
   "bap-abi" {= "2.2.0"}
   "bap-core-theory" {= "2.2.0"}

--- a/packages/bap-symbol-reader/bap-symbol-reader.2.2.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.2.2.0/opam
@@ -27,9 +27,13 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "2.2.0"}
-  "cmdliner"
+  "bap-knowledge" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
 ]
 synopsis: "BAP plugin that reads symbol information from files"
 

--- a/packages/bap-symbol-reader/bap-symbol-reader.2.2.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.2.2.0/opam
@@ -28,7 +28,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "2.2.0"}
   "bap-knowledge" {= "2.2.0"}

--- a/packages/bap-symbol-reader/bap-symbol-reader.2.2.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.2.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name: "bap-symbol-reader"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-read-symbols"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-plugin-read_symbols"]
+        [ "bapbundle" "remove" "read_symbols.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+]
+synopsis: "BAP plugin that reads symbol information from files"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-systemz/bap-systemz.2.2.0/opam
+++ b/packages/bap-systemz/bap-systemz.2.2.0/opam
@@ -24,7 +24,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "ogre" {= "2.2.0"}
   "bitvec" {= "2.2.0"}
   "bap-knowledge" {= "2.2.0"}

--- a/packages/bap-systemz/bap-systemz.2.2.0/opam
+++ b/packages/bap-systemz/bap-systemz.2.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+name: "bap-systemz"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-systemz"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-systemz"]
+        ["ocamlfind" "remove" "bap-plugin-systemz"]
+        ["bapbundle" "remove" "systemz.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+]
+synopsis: "A target support package for the Systemz (Z9) ISA"
+description: """
+Provides semantics for Systemz instructions."""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-systemz/bap-systemz.2.2.0/opam
+++ b/packages/bap-systemz/bap-systemz.2.2.0/opam
@@ -24,7 +24,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "ogre" {= "2.2.0"}
   "bitvec" {= "2.2.0"}
   "bap-knowledge" {= "2.2.0"}

--- a/packages/bap-taint-propagator/bap-taint-propagator.2.2.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.2.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "bap-taint-propagator"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-propagate-taint"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
+         ["bapbundle" "remove" "propagate_taint.plugin"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+  "bap-microx" {= "2.2.0"}
+]
+synopsis: "BAP Taint propagation engine using based on microexecution"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-taint/bap-taint.2.2.0/opam
+++ b/packages/bap-taint/bap-taint.2.2.0/opam
@@ -21,8 +21,13 @@ remove: [["ocamlfind" "remove" "bap-taint"]
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "bap-std" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}
+  "bap-strings" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "monads" {= "2.2.0"}
 ]
 synopsis: "BAP Taint Analysis Framework"
 description: """

--- a/packages/bap-taint/bap-taint.2.2.0/opam
+++ b/packages/bap-taint/bap-taint.2.2.0/opam
@@ -22,7 +22,7 @@ remove: [["ocamlfind" "remove" "bap-taint"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "bap-std" {= "2.2.0"}
   "bap-primus" {= "2.2.0"}
   "bap-strings" {= "2.2.0"}

--- a/packages/bap-taint/bap-taint.2.2.0/opam
+++ b/packages/bap-taint/bap-taint.2.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "bap-taint"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"
+   "--enable-taint"
+  ]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bap-taint"]
+  ["ocamlfind" "remove" "bap-plugin-taint"]
+  ["bapbundle" "remove" "taint.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+]
+synopsis: "BAP Taint Analysis Framework"
+description: """
+Provides a generic library for handling program taints, and plugins
+that integrate existing and new taint analysis tools with the new
+framework."""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-term-mapper/bap-term-mapper.2.2.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.2.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bap-term-mapper"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-map-terms"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
+         [ "ocamlfind" "remove" "bap-bml"]
+         [ "bapbundle" "remove" "map_terms.plugin"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+]
+synopsis: "A BAP DSL for mapping program terms"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-term-mapper/bap-term-mapper.2.2.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.2.2.0/opam
@@ -27,7 +27,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "2.2.0"}
   "bap-main" {= "2.2.0"}

--- a/packages/bap-term-mapper/bap-term-mapper.2.2.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.2.2.0/opam
@@ -26,9 +26,12 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "2.2.0"}
-  "cmdliner"
+  "bap-main" {= "2.2.0"}
+  "regular" {= "2.2.0"}
 ]
 synopsis: "A BAP DSL for mapping program terms"
 

--- a/packages/bap-thumb/bap-thumb.2.2.0/opam
+++ b/packages/bap-thumb/bap-thumb.2.2.0/opam
@@ -24,7 +24,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "ogre" {= "2.2.0"}
   "bitvec" {= "2.2.0"}
   "bap-knowledge" {= "2.2.0"}

--- a/packages/bap-thumb/bap-thumb.2.2.0/opam
+++ b/packages/bap-thumb/bap-thumb.2.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+name: "bap-thumb"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-thumb"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-thumb"]
+        ["ocamlfind" "remove" "bap-plugin-thumb"]
+        ["bapbundle" "remove" "thumb.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "bap-arm" {= "2.2.0"}
+]
+synopsis: "A target support package for the Thumb instruction set"
+description: """
+Provides semantics for Thumb instructions. Note, this package will
+be merged with the bap-arm package in the future."""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-thumb/bap-thumb.2.2.0/opam
+++ b/packages/bap-thumb/bap-thumb.2.2.0/opam
@@ -24,7 +24,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "ogre" {= "2.2.0"}
   "bitvec" {= "2.2.0"}
   "bap-knowledge" {= "2.2.0"}

--- a/packages/bap-trace/bap-trace.2.2.0/opam
+++ b/packages/bap-trace/bap-trace.2.2.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "2.2.0"}
   "bap-traces" {= "2.2.0"}

--- a/packages/bap-trace/bap-trace.2.2.0/opam
+++ b/packages/bap-trace/bap-trace.2.2.0/opam
@@ -26,9 +26,14 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "2.2.0"}
   "bap-traces" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "uri"
   "cmdliner"
 ]
 synopsis: "A plugin to load and run program execution traces"

--- a/packages/bap-trace/bap-trace.2.2.0/opam
+++ b/packages/bap-trace/bap-trace.2.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name: "bap-trace"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-trace"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        ["ocamlfind" "remove" "bap-plugin-trace"]
+        ["bapbundle" "remove" "trace.plugin"]
+        ]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.2.0"}
+  "bap-traces" {= "2.2.0"}
+  "cmdliner"
+]
+synopsis: "A plugin to load and run program execution traces"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-traces/bap-traces.2.2.0/opam
+++ b/packages/bap-traces/bap-traces.2.2.0/opam
@@ -25,8 +25,11 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "2.2.0"}
+  "regular" {= "2.2.0"}
   "uri" {>= "1.9.0"}
   "uuidm"
 ]

--- a/packages/bap-traces/bap-traces.2.2.0/opam
+++ b/packages/bap-traces/bap-traces.2.2.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "2.2.0"}
   "regular" {= "2.2.0"}

--- a/packages/bap-traces/bap-traces.2.2.0/opam
+++ b/packages/bap-traces/bap-traces.2.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name: "bap-traces"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-traces"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+        [ "ocamlfind" "remove" "bap-traces"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.2.0"}
+  "uri" {>= "1.9.0"}
+  "uuidm"
+]
+synopsis: "BAP Library for loading and parsing execution traces"
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-trivial-condition-form/bap-trivial-condition-form.2.2.0/opam
+++ b/packages/bap-trivial-condition-form/bap-trivial-condition-form.2.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "bap-trivial-condition-form"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-trivial-condition-form"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bap-plugin-trivial_condition_form"]
+         ["bapbundle" "remove" "trivial_condition_form.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-std" {= "2.2.0"}
+]
+synopsis: "Eliminates complex conditionals in branches"
+description: """
+Ensures that all branching conditions are either a variable
+or a constant. We call such representation a Trivial Condition Form
+(TCF). During the translation all complex condition expressions are
+hoisted into the assignemnt section of a block."""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-warn-unused/bap-warn-unused.2.2.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.2.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "bap-warn-unused"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-warn-unused"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
+        ["bapbundle" "remove" "warn_unused.plugin"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "bap-std" {= "2.2.0"}
+  "cmdliner"
+]
+synopsis:
+  "Emit a warning if an unused result may cause a bug or security issue"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap-x86/bap-x86.2.2.0/opam
+++ b/packages/bap-x86/bap-x86.2.2.0/opam
@@ -24,7 +24,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "ogre" {= "2.2.0"}
   "regular" {= "2.2.0"}
   "bitvec" {= "2.2.0"}

--- a/packages/bap-x86/bap-x86.2.2.0/opam
+++ b/packages/bap-x86/bap-x86.2.2.0/opam
@@ -24,7 +24,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "ogre" {= "2.2.0"}
   "regular" {= "2.2.0"}
   "bitvec" {= "2.2.0"}

--- a/packages/bap-x86/bap-x86.2.2.0/opam
+++ b/packages/bap-x86/bap-x86.2.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+name: "bap-x86"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-x86"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+        ["ocamlfind" "remove" "bap-x86-cpu"]
+        ["ocamlfind" "remove" "bap-plugin-x86"]
+        ["bapbundle" "remove" "x86.plugin"]
+
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "2.2.0"}
+  "ogre" {= "2.2.0"}
+  "regular" {= "2.2.0"}
+  "bitvec" {= "2.2.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
+  "bap-abi" {= "2.2.0"}
+  "bap-api" {= "2.2.0"}
+  "bap-c" {= "2.2.0"}
+  "bap-core-theory" {= "2.2.0"}
+  "bap-future" {= "2.2.0"}
+  "bap-knowledge" {= "2.2.0"}
+  "bap-llvm" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+]
+synopsis: "BAP x86 lifter"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bap/bap.2.2.0/opam
+++ b/packages/bap/bap.2.2.0/opam
@@ -1,0 +1,104 @@
+opam-version: "2.0"
+name: "bap"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "bap-abi" {= "2.2.0"}
+  "bap-analyze" {= "2.2.0"}
+  "bap-api" {= "2.2.0"}
+  "bap-arm" {= "2.2.0"}
+  "bap-beagle" {= "2.2.0"}
+  "bap-beagle-strings" {= "2.2.0"}
+  "bap-bil" {= "2.2.0"}
+  "bap-build" {= "2.2.0"}
+  "bap-bundle" {= "2.2.0"}
+  "bap-byteweight" {= "2.2.0"}
+  "bap-c" {= "2.2.0"}
+  "bap-cache" {= "2.2.0"}
+  "bap-cxxfilt" {= "2.2.0"}
+  "bap-callgraph-collator" {= "2.2.0"}
+  "bap-callsites" {= "2.2.0"}
+  "bap-constant-tracker" {= "2.2.0"}
+  "bap-demangle" {= "2.2.0"}
+  "bap-disassemble" {= "2.2.0"}
+  "bap-dump-symbols" {= "2.2.0"}
+  "bap-elementary" {= "2.2.0"}
+  "bap-elf" {= "2.2.0"}
+  "bap-frontend" {= "2.2.0"}
+  "bap-frontc" {= "2.2.0"}
+  "bap-glibc-runtime" {= "2.2.0"}
+  "bap-llvm" {= "2.2.0"}
+  "bap-main" {= "2.2.0"}
+  "bap-mc" {= "2.2.0"}
+  "bap-microx" {= "2.2.0"}
+  "bap-mips" {= "2.2.0"}
+  "bap-objdump" {= "2.2.0"}
+  "bap-optimization" {= "2.2.0"}
+  "bap-plugins" {= "2.2.0"}
+  "bap-powerpc" {= "2.2.0"}
+  "bap-primus" {= "2.2.0"}
+  "bap-primus-dictionary" {= "2.2.0"}
+  "bap-primus-lisp" {= "2.2.0"}
+  "bap-primus-powerpc" {= "2.2.0"}
+  "bap-primus-random" {= "2.2.0"}
+  "bap-primus-region" {= "2.2.0"}
+  "bap-primus-support" {= "2.2.0"}
+  "bap-primus-symbolic-executor" {= "2.2.0"}
+  "bap-primus-systems" {= "2.2.0"}
+  "bap-primus-test" {= "2.2.0"}
+  "bap-primus-taint" {= "2.2.0"}
+  "bap-primus-propagate-taint" {= "2.2.0"}
+  "bap-primus-x86" {= "2.2.0"}
+  "bap-print" {= "2.2.0"}
+  "bap-raw" {= "2.2.0"}
+  "bap-recipe" {= "2.2.0"}
+  "bap-recipe-command" {= "2.2.0"}
+  "bap-relation" {= "2.2.0"}
+  "bap-relocatable" {= "2.2.0"}
+  "bap-report" {= "2.2.0"}
+  "bap-run" {= "2.2.0"}
+  "bap-specification" {= "2.2.0"}
+  "bap-ssa" {= "2.2.0"}
+  "bap-std" {= "2.2.0"}
+  "bap-strings" {= "2.2.0"}
+  "bap-stub-resolver" {= "2.2.0"}
+  "bap-symbol-reader" {= "2.2.0"}
+  "bap-taint" {= "2.2.0"}
+  "bap-taint-propagator" {= "2.2.0"}
+  "bap-term-mapper" {= "2.2.0"}
+  "bap-trace" {= "2.2.0"}
+  "bap-traces" {= "2.2.0"}
+  "bap-trivial-condition-form" {= "2.2.0"}
+  "bap-warn-unused" {= "2.2.0"}
+  "bap-x86" {= "2.2.0"}
+  "bap-emacs-goodies"
+]
+synopsis: "Binary Analysis Platform"
+description: """
+The Carnegie Mellon University Binary Analysis Platform (CMU BAP) is a
+reverse engineering and program analysis platform that works with
+binary code and doesn't require the source code. BAP supports multiple
+architectures: ARM, x86, x86-64, PowerPC, and MIPS. BAP disassembles
+and lifts binary code into the RISC-like BAP Instruction Language
+(BIL). Program analysis is performed using the BIL representation and
+is architecture independent in a sense that it will work equally well
+for all supported architectures. The main purpose of BAP is to provide
+a toolkit for implementing automated program analysis. BAP is written
+in OCaml and it is the preferred language to write analysis, but we
+have bindings to C, Python and Rust. The Primus Framework also provide
+a Lisp-like DSL for writing program analysis tools.
+
+This is a meta package that installs essential parts of BAP."""
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bare/bare.2.2.0/opam
+++ b/packages/bare/bare.2.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "bare"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bare"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "bare"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "oasis" {build}
+  "parsexp" {>= "v0.14" & < "v0.15"}
+]
+synopsis: "BAP Rule Engine Library"
+description: """
+BARE is a library that provides non-linear pattern matching on streams
+of facts that are represented as s-expressions. We use BARE, in particular,
+to process Primus observations. Since Primus components use observations to
+convey their knowledge downstream it is very convenient to be able to query
+and join observations through the stream. In a sense, BARE could be seen as
+SQL select/join for streams."""
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bitvec-binprot/bitvec-binprot.2.2.0/opam
+++ b/packages/bitvec-binprot/bitvec-binprot.2.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "oasis" {build & >= "0.4.7"}
   "bitvec" {= "2.2.0"}
   "bin_prot"
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
 ]
 synopsis: "Janestreet's Binprot serialization for Bitvec"
 

--- a/packages/bitvec-binprot/bitvec-binprot.2.2.0/opam
+++ b/packages/bitvec-binprot/bitvec-binprot.2.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "oasis" {build & >= "0.4.7"}
   "bitvec" {= "2.2.0"}
   "bin_prot"
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
 ]
 synopsis: "Janestreet's Binprot serialization for Bitvec"
 

--- a/packages/bitvec-binprot/bitvec-binprot.2.2.0/opam
+++ b/packages/bitvec-binprot/bitvec-binprot.2.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "bitvec-binprot"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bitvec-binprot"]
+  [make]
+]
+install: [[make "install"]]
+remove: [ ["ocamlfind" "remove" "bitvec-binprot"] ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "bitvec" {= "2.2.0"}
+  "bin_prot"
+  "ppx_bap" {= "2.2.0"}
+]
+synopsis: "Janestreet's Binprot serialization for Bitvec"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bitvec-order/bitvec-order.2.2.0/opam
+++ b/packages/bitvec-order/bitvec-order.2.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "bitvec-order"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bitvec-order"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bitvec-order"]]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "base"
+  "bitvec" {= "2.2.0"}
+  "bitvec-sexp" {= "2.2.0"}
+]
+synopsis: "Base style comparators and orders for Bitvec"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bitvec-sexp/bitvec-sexp.2.2.0/opam
+++ b/packages/bitvec-sexp/bitvec-sexp.2.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "bitvec-sexp"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bitvec-sexp"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bitvec-sexp"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "bitvec" {= "2.2.0"}
+  "sexplib0"
+]
+synopsis: "Sexp serializers for Bitvec"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/bitvec/bitvec.2.2.0/opam
+++ b/packages/bitvec/bitvec.2.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "bitvec"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-bitvec"]
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "bitvec"] ]
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "oasis" {build & >= "0.4.7"}
+  "zarith"
+]
+synopsis: "Fixed-size bitvectors and modular arithmetic, based on Zarith"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/graphlib/graphlib.2.2.0/opam
+++ b/packages/graphlib/graphlib.2.2.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
   "ocamlgraph"
   "regular" {= "2.2.0"}

--- a/packages/graphlib/graphlib.2.2.0/opam
+++ b/packages/graphlib/graphlib.2.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
   "ocamlgraph"
   "regular" {= "2.2.0"}
 ]

--- a/packages/graphlib/graphlib.2.2.0/opam
+++ b/packages/graphlib/graphlib.2.2.0/opam
@@ -26,8 +26,8 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "oasis" {build & >= "0.4.7"}
   "ppx_bap" {= "v0.14"}
+  "oasis" {build & >= "0.4.7"}
   "ocamlgraph"
   "regular" {= "2.2.0"}
 ]

--- a/packages/graphlib/graphlib.2.2.0/opam
+++ b/packages/graphlib/graphlib.2.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+name: "graphlib"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-graphlib"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "graphlib"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "oasis" {build & >= "0.4.7"}
+  "ppx_bap" {= "2.2.0"}
+  "ocamlgraph"
+  "regular" {= "2.2.0"}
+]
+synopsis: "Generic Graph library"
+description: """
+Graphlib is a generic library that extends a well known OCamlGraph
+library. Graphlib uses its own, more reach, Graph interface that
+is isomorphic to OCamlGraph's `Sigs.P` signature for persistant
+graphs. Two functors witness the isomorphism of the interfaces:
+`Graphlib.To_ocamlgraph` and `Graphlib.Of_ocamlgraph`. Thanks to
+these functors, any algorithm written for OCamlGraph can be used on
+`Graphlibs` graph and vice verse."""
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/monads/monads.2.2.0/opam
+++ b/packages/monads/monads.2.2.0/opam
@@ -19,7 +19,7 @@ remove: [["ocamlfind" "remove" "monads"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
 ]
 synopsis: "A missing monad library"

--- a/packages/monads/monads.2.2.0/opam
+++ b/packages/monads/monads.2.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "monads"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-monads"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "monads"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "oasis" {build & >= "0.4.7"}
+]
+synopsis: "A missing monad library"
+description:
+  "Provides monad transformers for most (if not all) common monads."
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/monads/monads.2.2.0/opam
+++ b/packages/monads/monads.2.2.0/opam
@@ -19,6 +19,7 @@ remove: [["ocamlfind" "remove" "monads"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "oasis" {build & >= "0.4.7"}
 ]
 synopsis: "A missing monad library"

--- a/packages/ogre/ogre.2.2.0/opam
+++ b/packages/ogre/ogre.2.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name: "ogre"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-ogre"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "ogre"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "oasis" {build & >= "0.4.7"}
+  "monads" {= "2.2.0"}
+]
+synopsis: "Open Generic REpresentation NoSQL Database"
+description: """
+OGRE is a NoSQL document-style database, that uses s-exp for data
+representation and provides a type safe monadic interface for quering
+and updating documents."""
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/ogre/ogre.2.2.0/opam
+++ b/packages/ogre/ogre.2.2.0/opam
@@ -19,6 +19,7 @@ remove: [["ocamlfind" "remove" "ogre"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
+  "ppx_bap" {= "v0.14"}
   "oasis" {build & >= "0.4.7"}
   "monads" {= "2.2.0"}
 ]

--- a/packages/ogre/ogre.2.2.0/opam
+++ b/packages/ogre/ogre.2.2.0/opam
@@ -19,7 +19,7 @@ remove: [["ocamlfind" "remove" "ogre"]]
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
   "monads" {= "2.2.0"}
 ]

--- a/packages/regular/regular.2.2.0/opam
+++ b/packages/regular/regular.2.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
-  "ppx_bap" {= "2.2.0"}
+  "ppx_bap" {= "v0.14"}
 ]
 synopsis: "Library for regular data types"
 description: """

--- a/packages/regular/regular.2.2.0/opam
+++ b/packages/regular/regular.2.2.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+name: "regular"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure"
+                 "--prefix=%{prefix}%"
+                 "--mandir=%{man}%"
+                 "--enable-regular"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "regular"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "oasis" {build & >= "0.4.7"}
+  "ppx_bap" {= "2.2.0"}
+]
+synopsis: "Library for regular data types"
+description: """
+Provides functors and typeclasses implementing functionality expected
+for a regular data type, like i/o, containers, printing, etc.
+
+In particular, the library includes:
+
+- module Data that adds generic i/o routines for each regular data type.
+- module Cache that adds caching service for data types
+- module Regular that glues everything together
+- module Opaque for regular but opaque data types
+- module Seq that extends Core_kernel's sequence module
+- module Bytes that provides a rich core-like interface for Bytes data type."""
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}

--- a/packages/regular/regular.2.2.0/opam
+++ b/packages/regular/regular.2.2.0/opam
@@ -26,8 +26,8 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "oasis" {build & >= "0.4.7"}
   "ppx_bap" {= "v0.14"}
+  "oasis" {build & >= "0.4.7"}
 ]
 synopsis: "Library for regular data types"
 description: """

--- a/packages/regular/regular.2.2.0/opam
+++ b/packages/regular/regular.2.2.0/opam
@@ -26,7 +26,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.15"}
-  "ppx_bap" {= "v0.14"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "oasis" {build & >= "0.4.7"}
 ]
 synopsis: "Library for regular data types"

--- a/packages/text-tags/text-tags.2.2.0/opam
+++ b/packages/text-tags/text-tags.2.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "text-tags"
+version: "2.2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-text-tags"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [["ocamlfind" "remove" "text-tags"]]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "oasis" {build & >= "0.4.7"}
+]
+synopsis: "A library for rich formatting using semantics tags"
+flags: light-uninstall
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/bap/archive/v2.2.0.tar.gz"
+  checksum: "md5=5dbc6677d646bec59fd7414f23e88cf8"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.2.0/v2.2.0.tar.gz"
+}


### PR DESCRIPTION
The 2.2.0 release is focusing on stability and usability. It brings,
however, a few new features, some of them highlighted here (see the
full list at the [release][1] page):

- a floating-point lifter, contributed to us by ForAllSecure,
- a new thumb/thumbv2 lifter (thanks to @Phosphorus15 and @XVilka)
- support for interworking and new representation
- new representation of machine targets (instead of the old arch)
- completely rewritten llvm loader backend
- integration with radare2
- improved symbolization facilities (makes bap more autonomous)
- significant performance improvements
- a REPL powered by ocaml-linenoise, see the demo below

[1]: https://github.com/BinaryAnalysisPlatform/bap/releases/tag/v2.2.0

[![asciicast](https://asciinema.org/a/358996.svg)](https://asciinema.org/a/358996)