### PR TITLE
macOS 11 / XCode 12 fix for remake (used by gappa)

### DIFF
--- a/packages/gappa/gappa.1.3.5/files/remake.patch
+++ b/packages/gappa/gappa.1.3.5/files/remake.patch
@@ -1,7 +1,16 @@
 diff --git a/remake.cpp b/remake.cpp
-index 3a6af80..47d5be8 100644
+index 3a6af80..d5ac424 100644
 --- a/remake.cpp
 +++ b/remake.cpp
+@@ -450,7 +450,7 @@ enum { INVALID_SOCKET = -1 };
+ extern char **environ;
+ #endif
+ 
+-#if defined(WINDOWS) || defined(MACOSX)
++# if (defined(WINDOWS) || defined(MACOSX)) && ! defined(MSG_NOSIGNAL)
+ enum { MSG_NOSIGNAL = 0 };
+ #endif
+ 
 @@ -786,7 +786,7 @@ struct log
  	}
  };


### PR DESCRIPTION
This PR fixes an issue with the remake tool which came up on macOS 11 / XCode 12.

@silene : FYI.