### PR TITLE
[new release] opium-graphql, rock, opium and opium-testing (0.20.0)

### DIFF
--- a/packages/opium-graphql/opium-graphql.0.20.0/opam
+++ b/packages/opium-graphql/opium-graphql.0.20.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Run GraphQL servers with Opium"
+description:
+  "This package allows you to execute Opium requests against GraphQL schemas built with `graphql`."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: ["Rudi Grinberg" "Anurag Soni" "Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/rgrinberg/opium"
+doc: "https://rgrinberg.github.io/opium/"
+bug-reports: "https://github.com/rgrinberg/opium/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "opium" {= version}
+  "lwt" {>= "5.3.0"}
+  "graphql"
+  "graphql-lwt"
+  "crunch" {build}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rgrinberg/opium.git"
+x-commit-hash: "5e3d601a3ef7b9fdbcc7ea93fd698b6adc2a45c5"
+url {
+  src:
+    "https://github.com/rgrinberg/opium/releases/download/0.20.0/opium-0.20.0.tbz"
+  checksum: [
+    "sha256=326b91866de90baf535f8b7d4b2ff23e39d952e573c04b3c13f1054b59ff2fb6"
+    "sha512=59b83e7c8fe5f7ae328fb7f2343fe5b8fb735e8f6ee263cfd6c75bb179688ef7cf2b4586b35a2231ed3f3c1ada543021b7a4759326ae095eb77a5f38b9fa3a8a"
+  ]
+}

--- a/packages/opium-testing/opium-testing.0.20.0/opam
+++ b/packages/opium-testing/opium-testing.0.20.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Testing library for Opium"
+description:
+  "A library that provides helpers to easily test your Opium applications."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: ["Rudi Grinberg" "Anurag Soni" "Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/rgrinberg/opium"
+doc: "https://rgrinberg.github.io/opium/"
+bug-reports: "https://github.com/rgrinberg/opium/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "opium" {= version}
+  "alcotest"
+  "alcotest-lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rgrinberg/opium.git"
+x-commit-hash: "5e3d601a3ef7b9fdbcc7ea93fd698b6adc2a45c5"
+url {
+  src:
+    "https://github.com/rgrinberg/opium/releases/download/0.20.0/opium-0.20.0.tbz"
+  checksum: [
+    "sha256=326b91866de90baf535f8b7d4b2ff23e39d952e573c04b3c13f1054b59ff2fb6"
+    "sha512=59b83e7c8fe5f7ae328fb7f2343fe5b8fb735e8f6ee263cfd6c75bb179688ef7cf2b4586b35a2231ed3f3c1ada543021b7a4759326ae095eb77a5f38b9fa3a8a"
+  ]
+}

--- a/packages/opium/opium.0.20.0/opam
+++ b/packages/opium/opium.0.20.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "OCaml web framework"
+description:
+  "Opium is a web framework for OCaml that provides everything you need to build safe, fast and extensible web applications."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: ["Rudi Grinberg" "Anurag Soni" "Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/rgrinberg/opium"
+doc: "https://rgrinberg.github.io/opium/"
+bug-reports: "https://github.com/rgrinberg/opium/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "rock" {= version}
+  "lwt" {>= "5.3.0"}
+  "httpaf-lwt-unix"
+  "conf-libev"
+  "logs"
+  "fmt"
+  "mtime"
+  "cmdliner"
+  "ptime"
+  "magic-mime"
+  "yojson"
+  "tyxml"
+  "mirage-crypto"
+  "base64"
+  "astring"
+  "re"
+  "uri"
+  "multipart-form-data"
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rgrinberg/opium.git"
+x-commit-hash: "5e3d601a3ef7b9fdbcc7ea93fd698b6adc2a45c5"
+url {
+  src:
+    "https://github.com/rgrinberg/opium/releases/download/0.20.0/opium-0.20.0.tbz"
+  checksum: [
+    "sha256=326b91866de90baf535f8b7d4b2ff23e39d952e573c04b3c13f1054b59ff2fb6"
+    "sha512=59b83e7c8fe5f7ae328fb7f2343fe5b8fb735e8f6ee263cfd6c75bb179688ef7cf2b4586b35a2231ed3f3c1ada543021b7a4759326ae095eb77a5f38b9fa3a8a"
+  ]
+}

--- a/packages/rock/rock.0.20.0/opam
+++ b/packages/rock/rock.0.20.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Minimalist framework to build extensible HTTP servers and clients"
+description:
+  "Rock is a Unix indpendent API to build extensible HTTP servers and clients. It provides building blocks such as middlewares and handlers (a.k.a controllers)."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: ["Rudi Grinberg" "Anurag Soni" "Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/rgrinberg/opium"
+doc: "https://rgrinberg.github.io/opium/"
+bug-reports: "https://github.com/rgrinberg/opium/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "lwt" {>= "5.3.0"}
+  "bigstringaf"
+  "hmap"
+  "httpaf"
+  "lwt"
+  "sexplib0"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rgrinberg/opium.git"
+x-commit-hash: "5e3d601a3ef7b9fdbcc7ea93fd698b6adc2a45c5"
+url {
+  src:
+    "https://github.com/rgrinberg/opium/releases/download/0.20.0/opium-0.20.0.tbz"
+  checksum: [
+    "sha256=326b91866de90baf535f8b7d4b2ff23e39d952e573c04b3c13f1054b59ff2fb6"
+    "sha512=59b83e7c8fe5f7ae328fb7f2343fe5b8fb735e8f6ee263cfd6c75bb179688ef7cf2b4586b35a2231ed3f3c1ada543021b7a4759326ae095eb77a5f38b9fa3a8a"
+  ]
+}


### PR DESCRIPTION
Run GraphQL servers with Opium

- Project page: <a href="https://github.com/rgrinberg/opium">https://github.com/rgrinberg/opium</a>
- Documentation: <a href="https://rgrinberg.github.io/opium/">https://rgrinberg.github.io/opium/</a>

##### CHANGES:

## Added

- New `Auth` module to work with `Authorization` header (rgrinberg/opium#238)
- New `basic_auth` middleware to protect handlers with a `Basic` authentication method (rgrinberg/opium#238)
- New `Response.of_file` API for conveniently creating a response of a file (rgrinberg/opium#244)
- Add a package `opium-graphql` to easily create GraphQL server with Opium (rgrinberg/opium#235)
- Add a function `App.run_multicore` that uses pre-forking and spawns multiple processes that will handle incoming requests (rgrinberg/opium#239)

## Fixed

- Fix reading cookie values when multiple cookies are present in `Cookie` header (rgrinberg/opium#246)
