### PR TITLE
constraints the version of piqilib on sedlex

### DIFF
--- a/packages/piqilib/piqilib.0.6.15/opam
+++ b/packages/piqilib/piqilib.0.6.15/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "ocamlfind" {build}
   "easy-format"
-  "sedlex"
+  "sedlex" {>= "2.2.0"}
   "xmlm"
   "base64" {>="3.1.0"}
 ]

--- a/packages/piqilib/piqilib.0.6.15/opam
+++ b/packages/piqilib/piqilib.0.6.15/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "ocamlfind" {build}
   "easy-format"
-  "sedlex" {>= "2.2.0"}
+  "sedlex" {>= "2.2"}
   "xmlm"
   "base64" {>="3.1.0"}
 ]

--- a/packages/piqilib/piqilib.0.6.15/opam
+++ b/packages/piqilib/piqilib.0.6.15/opam
@@ -25,6 +25,7 @@ depends: [
   "sedlex" {>= "2.2"}
   "xmlm"
   "base64" {>="3.1.0"}
+  "conf-which" {build}
 ]
 dev-repo: "git://github.com/alavrik/piqi"
 url {


### PR DESCRIPTION
It was [detected][1] in #17799 build that piqilib.0.6.15 fails to
compile with sedlex.1.99.  The version 2.2.0 works for me, it might be
that others are also working, but I decided to be more conservative
and select 2.2.0 and above only.

CC @alavrik for situational awareness. And if you know better which
version works (and whether it affects the older versions of piqilib)
then please tell.

[1]: https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/c56ed99592368ed1bc27bb36062b6dce4ad23888/variant/compilers,4.08,bap-piqi.2.2.0