### PR TITLE
4 packages from sneeuwballen/zipperposition at 2.0

### DIFF
--- a/packages/libzipperposition/libzipperposition.2.0/opam
+++ b/packages/libzipperposition/libzipperposition.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "Petar Vukmirovic" "Alexander Bentkamp" "Sophie Tourret" "Visa Nummelin"]
+homepage: "https://github.com/sneeuwballen/zipperposition"
+synopsis: "Library for Zipperposition"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "base-bytes"
+  "base-unix"
+  "zarith"
+  "logtk" { = version }
+  "containers" { >= "3.0" & < "4.0" }
+  "iter" { >= "1.2" }
+  "oseq"
+  "dune" { >= "1.11" }
+  "msat" { >= "0.8.1" < "0.9" }
+  "menhir" {build}
+  "logtk" { = version }
+  "ocaml" {>= "4.07"}
+]
+tags: [ "logic" "unification" "term" "superposition" "prover" ]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/2.0.tar.gz"
+  checksum: [
+    "md5=7a8e57388083ed763d12d18324c8a086"
+    "sha512=5c5ac312ada6b42907d1e91e349454a8375f7bf8165d3459721a40b707a840a3d6b3dc968a66f1040cb4de7aedf5c1c13f3e90b51337eae5ea6de41651d7bd63"
+  ]
+}

--- a/packages/logtk/logtk.2.0/opam
+++ b/packages/logtk/logtk.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "Petar Vukmirovic" "Alexander Bentkamp" "Sophie Tourret" "Visa Nummelin"]
+homepage: "https://github.com/sneeuwballen/zipperposition"
+synopsis: "Core types and algorithms for logic"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "base-bytes"
+  "base-unix"
+  "zarith"
+  "oseq" { >= "0.3" & < "0.4" }
+  "containers" { >= "3.0" & < "4.0" }
+  "containers-data" { >= "3.0" & < "4.0" }
+  "iter" { >= "1.2" }
+  "menhir" {build}
+  "dune" { >= "1.11" }
+  "alcotest" {with-test}
+  "qcheck-core" {with-test & >= "0.9"}
+  "qcheck-alcotest" {with-test & >= "0.9"}
+  "ocaml" {>= "4.07"}
+]
+depopts: [
+  "msat"
+]
+conflicts: [
+  "msat" { < "0.8.1" }
+  "msat" { >= "0.9" }
+]
+tags: [ "logic" "unification" "term" ]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/2.0.tar.gz"
+  checksum: [
+    "md5=7a8e57388083ed763d12d18324c8a086"
+    "sha512=5c5ac312ada6b42907d1e91e349454a8375f7bf8165d3459721a40b707a840a3d6b3dc968a66f1040cb4de7aedf5c1c13f3e90b51337eae5ea6de41651d7bd63"
+  ]
+}

--- a/packages/zipperposition-tools/zipperposition-tools.2.0/opam
+++ b/packages/zipperposition-tools/zipperposition-tools.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "Petar Vukmirovic" "Alexander Bentkamp" "Sophie Tourret" "Visa Nummelin"]
+homepage: "https://github.com/sneeuwballen/zipperposition"
+synopsis: "Support tools for Zipperposition"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.11" }
+  "containers" { >= "3.0" & < "4.0" }
+  "iter" { >= "1.2" }
+  "oseq" { >= "0.2" }
+  "msat" { >= "0.8" < "0.9" }
+  "zarith"
+  "logtk" { = version }
+  "libzipperposition" { = version }
+  "ocaml" {>= "4.07"}
+]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/2.0.tar.gz"
+  checksum: [
+    "md5=7a8e57388083ed763d12d18324c8a086"
+    "sha512=5c5ac312ada6b42907d1e91e349454a8375f7bf8165d3459721a40b707a840a3d6b3dc968a66f1040cb4de7aedf5c1c13f3e90b51337eae5ea6de41651d7bd63"
+  ]
+}

--- a/packages/zipperposition/zipperposition.2.0/opam
+++ b/packages/zipperposition/zipperposition.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: ["Simon Cruanes" "Petar Vukmirovic" "Alexander Bentkamp" "Sophie Tourret" "Visa Nummelin"]
+homepage: "https://github.com/sneeuwballen/zipperposition"
+synopsis: "A fully automatic theorem prover for typed higher-order and beyond"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "base-unix"
+  "zarith"
+  "logtk" { = version }
+  "libzipperposition" { = version }
+  "containers" { >= "3.0" & < "4.0" }
+  "iter" { >= "1.2" }
+  "oseq"
+  "dune" { >= "1.11" }
+  "msat" { >= "0.8" < "0.9" }
+  "menhir" {build}
+  "ocaml" {>= "4.07"}
+]
+tags: [ "logic" "unification" "term" "superposition" "prover" ]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/2.0.tar.gz"
+  checksum: [
+    "md5=7a8e57388083ed763d12d18324c8a086"
+    "sha512=5c5ac312ada6b42907d1e91e349454a8375f7bf8165d3459721a40b707a840a3d6b3dc968a66f1040cb4de7aedf5c1c13f3e90b51337eae5ea6de41651d7bd63"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`libzipperposition.2.0`: Library for Zipperposition
-`logtk.2.0`: Core types and algorithms for logic
-`zipperposition.2.0`: A fully automatic theorem prover for typed higher-order and beyond
-`zipperposition-tools.2.0`: Support tools for Zipperposition



---
* Homepage: https://github.com/sneeuwballen/zipperposition
* Source repo: git+https://github.com/sneeuwballen/zipperposition.git
* Bug tracker: https://github.com/sneeuwballen/zipperposition/issues

---
:camel: Pull-request generated by opam-publish v2.0.0