### PR TITLE
Package portaudio.0.2.2

### DIFF
--- a/packages/conf-portaudio/conf-portaudio.1/opam
+++ b/packages/conf-portaudio/conf-portaudio.1/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "http://www.portaudio.com/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "portaudio dev team"
+license: "BSD"
+build: ["pkg-config" "--exists" "portaudio-2.0"]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["portaudio-dev"] {os-distribution = "alpine"}
+  ["portaudio-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}
+  ["portaudio"] {os = "macos" & os-distribution = "homebrew"}
+  ["portaudio"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "oraclelinux"}
+  ["portaudio19-dev"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Virtual package relying on portaudio"
+description:
+  "This package can only install if the portaudio library is installed on the system."
+flags: conf

--- a/packages/portaudio/portaudio.0.2.2/opam
+++ b/packages/portaudio/portaudio.0.2.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings for the portaudio library which provides high-level functions for using soundcards"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1"
+homepage: "https://github.com/savonet/ocaml-portaudio"
+bug-reports: "https://github.com/savonet/ocaml-portaudio/issues"
+depends: [
+  "conf-portaudio"
+  "conf-pkg-config"
+  "dune" {>= "2.0"}
+  "dune-configurator"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-portaudio.git"
+url {
+  src: "https://github.com/savonet/ocaml-portaudio/archive/v0.2.2.tar.gz"
+  checksum: [
+    "md5=b79cb7442c5148d594aed9257d6c52a0"
+    "sha512=4239592ad8d9cd272d9fa936b7c0b0ded0ad5b88933b1e1f18253189a5ef550123a84ecf1df23c8d24c105f16ff9088e47a7fe4ec7cf821b7478f62bb569b4b1"
+  ]
+}


### PR DESCRIPTION
### `portaudio.0.2.2`
SBindings for the portaudio library which provides high-level functions for using soundcards



---
* Homepage: https://github.com/savonet/ocaml-portaudio
* Source repo: git+https://github.com/savonet/ocaml-portaudio.git
* Bug tracker: https://github.com/savonet/ocaml-portaudio/issues

---
:camel: Pull-request generated by opam-publish v2.0.2