### PR TITLE
opam-monorepo.0.1.0 requires dune >= 2.7

### DIFF
--- a/packages/opam-monorepo/opam-monorepo.0.1.0/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.1.0/opam
@@ -12,7 +12,7 @@ license: "ISC"
 homepage: "https://github.com/ocamllabs/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0" & < "4.12"}
   "conf-m4"
   "conf-pkg-config"


### PR DESCRIPTION
It vendors its dependencies, including dune 2.7 (for dune libraries), so it needs a dune that can interpret `(lang dune 2.7)`.