### PR TITLE
[new release] sihl-web, sihl-email, sihl-persistence, sihl-type, sihl-contract, sihl-core, sihl-queue, sihl-user, sihl-storage and sihl (0.2.1)

### DIFF
--- a/packages/sihl-contract/sihl-contract.0.2.1/opam
+++ b/packages/sihl-contract/sihl-contract.0.2.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Contains Sihl service signatures"
+description:
+  "Use the service contracts to implement your own services with the rest of the Sihl ecosystem."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-type" {= version}
+  "sihl-core" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "465cd2cf6e0c1e9156f5c3b34d4d105a17084baa"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.1/sihl-0.2.1.tbz"
+  checksum: [
+    "sha256=13f136603aa0a0e4a3d0ea112f8463352cf8961fe3fa5c1415f519824ba66161"
+    "sha512=e32f592f81b13d73d7a25e67fb0825fc679e6be6170da7d36429e73e8e3763dd000b26fae2dfc746eb214491438891f32a9476c8a3ce1803a131bcc8818ba62d"
+  ]
+}

--- a/packages/sihl-core/sihl-core.0.2.1/opam
+++ b/packages/sihl-core/sihl-core.0.2.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "The core of the Sihl web framework"
+description:
+  "Deals with configuration, service lifecycle, app, CLI commands, logging and randomness."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "conformist" {>= "0.1.0"}
+  "tsort" {>= "2.0.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.8"}
+  "sexplib" {>= "v0.13.0"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.5.2"}
+  "tls" {>= "0.11.1"}
+  "ssl" {>= "0.5.9"}
+  "lwt_ssl" {>= "1.1.3"}
+  "caqti" {>= "1.2.1"}
+  "safepass" {>= "3.0"}
+  "jwto" {>= "0.3.0"}
+  "ppx_fields_conv" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "cohttp-lwt-unix" {>= "2.5.4" & with-test}
+  "alcotest-lwt" {>= "1.2.0" & < "3.0.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "465cd2cf6e0c1e9156f5c3b34d4d105a17084baa"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.1/sihl-0.2.1.tbz"
+  checksum: [
+    "sha256=13f136603aa0a0e4a3d0ea112f8463352cf8961fe3fa5c1415f519824ba66161"
+    "sha512=e32f592f81b13d73d7a25e67fb0825fc679e6be6170da7d36429e73e8e3763dd000b26fae2dfc746eb214491438891f32a9476c8a3ce1803a131bcc8818ba62d"
+  ]
+}

--- a/packages/sihl-email/sihl-email.0.2.1/opam
+++ b/packages/sihl-email/sihl-email.0.2.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A Sihl service for sending emails using Lwt"
+description: """
+
+A Sihl service for sending emails using Lwt. Various email transports are provided that can be used in production or testing such as SMTP, Sendgrid, in-memory and console printing."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "letters" {>= "0.2.1"}
+  "sihl-contract" {= version}
+  "sihl-persistence" {= version}
+  "cohttp-lwt-unix" {>= "2.5.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "465cd2cf6e0c1e9156f5c3b34d4d105a17084baa"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.1/sihl-0.2.1.tbz"
+  checksum: [
+    "sha256=13f136603aa0a0e4a3d0ea112f8463352cf8961fe3fa5c1415f519824ba66161"
+    "sha512=e32f592f81b13d73d7a25e67fb0825fc679e6be6170da7d36429e73e8e3763dd000b26fae2dfc746eb214491438891f32a9476c8a3ce1803a131bcc8818ba62d"
+  ]
+}

--- a/packages/sihl-persistence/sihl-persistence.0.2.1/opam
+++ b/packages/sihl-persistence/sihl-persistence.0.2.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Contains Sihl services regarding data persistence"
+description:
+  "Use this package to deal with database pools, transactions, migrations and integration tests involving the database layer."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-contract" {= version}
+  "caqti" {>= "1.2.1"}
+  "caqti-lwt" {>= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "465cd2cf6e0c1e9156f5c3b34d4d105a17084baa"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.1/sihl-0.2.1.tbz"
+  checksum: [
+    "sha256=13f136603aa0a0e4a3d0ea112f8463352cf8961fe3fa5c1415f519824ba66161"
+    "sha512=e32f592f81b13d73d7a25e67fb0825fc679e6be6170da7d36429e73e8e3763dd000b26fae2dfc746eb214491438891f32a9476c8a3ce1803a131bcc8818ba62d"
+  ]
+}

--- a/packages/sihl-queue/sihl-queue.0.2.1/opam
+++ b/packages/sihl-queue/sihl-queue.0.2.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A Sihl service for queue jobs"
+description: """
+
+A Sihl service for putting and working jobs on queues. Various queue backends are provided."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-contract" {= version}
+  "sihl-persistence" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "465cd2cf6e0c1e9156f5c3b34d4d105a17084baa"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.1/sihl-0.2.1.tbz"
+  checksum: [
+    "sha256=13f136603aa0a0e4a3d0ea112f8463352cf8961fe3fa5c1415f519824ba66161"
+    "sha512=e32f592f81b13d73d7a25e67fb0825fc679e6be6170da7d36429e73e8e3763dd000b26fae2dfc746eb214491438891f32a9476c8a3ce1803a131bcc8818ba62d"
+  ]
+}

--- a/packages/sihl-storage/sihl-storage.0.2.1/opam
+++ b/packages/sihl-storage/sihl-storage.0.2.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A Sihl service for storing and retrieving large files"
+description: """
+
+This service can be used to handle large binary blobs that are typically not stored in relational databases. Various storage backends are provided."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-contract" {= version}
+  "sihl-persistence" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "465cd2cf6e0c1e9156f5c3b34d4d105a17084baa"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.1/sihl-0.2.1.tbz"
+  checksum: [
+    "sha256=13f136603aa0a0e4a3d0ea112f8463352cf8961fe3fa5c1415f519824ba66161"
+    "sha512=e32f592f81b13d73d7a25e67fb0825fc679e6be6170da7d36429e73e8e3763dd000b26fae2dfc746eb214491438891f32a9476c8a3ce1803a131bcc8818ba62d"
+  ]
+}

--- a/packages/sihl-type/sihl-type.0.2.1/opam
+++ b/packages/sihl-type/sihl-type.0.2.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Contains Sihl types that are returned by Sihl services"
+description:
+  "Use this package together with sihl-contract to implement your own services. Sihl types are things like Email.t, User.t, Queue_job.t or Migration.t."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-core" {= version}
+  "opium" {>= "0.19.0"}
+  "caqti-lwt" {>= "1.2.0"}
+  "multipart-form-data" {>= "0.3.0"}
+  "uuidm" {>= "0.9.7"}
+  "alcotest" {>= "1.2.0"}
+  "alcotest-lwt" {>= "1.2.0" & < "3.0.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "465cd2cf6e0c1e9156f5c3b34d4d105a17084baa"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.1/sihl-0.2.1.tbz"
+  checksum: [
+    "sha256=13f136603aa0a0e4a3d0ea112f8463352cf8961fe3fa5c1415f519824ba66161"
+    "sha512=e32f592f81b13d73d7a25e67fb0825fc679e6be6170da7d36429e73e8e3763dd000b26fae2dfc746eb214491438891f32a9476c8a3ce1803a131bcc8818ba62d"
+  ]
+}

--- a/packages/sihl-user/sihl-user.0.2.1/opam
+++ b/packages/sihl-user/sihl-user.0.2.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Contains Sihl services to deal with user related topics"
+description:
+  "Use this package to handle tokens, sessions, users, flash messages and password reset workflows."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-contract" {= version}
+  "sihl-persistence" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "465cd2cf6e0c1e9156f5c3b34d4d105a17084baa"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.1/sihl-0.2.1.tbz"
+  checksum: [
+    "sha256=13f136603aa0a0e4a3d0ea112f8463352cf8961fe3fa5c1415f519824ba66161"
+    "sha512=e32f592f81b13d73d7a25e67fb0825fc679e6be6170da7d36429e73e8e3763dd000b26fae2dfc746eb214491438891f32a9476c8a3ce1803a131bcc8818ba62d"
+  ]
+}

--- a/packages/sihl-web/sihl-web.0.2.1/opam
+++ b/packages/sihl-web/sihl-web.0.2.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Contains HTTP server implementations as Sihl service"
+description:
+  "Use this package to implement run your HTTP routers on a HTTP server."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-contract" {= version}
+  "opium" {>= "0.19.0"}
+  "multipart-form-data" {>= "0.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "465cd2cf6e0c1e9156f5c3b34d4d105a17084baa"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.1/sihl-0.2.1.tbz"
+  checksum: [
+    "sha256=13f136603aa0a0e4a3d0ea112f8463352cf8961fe3fa5c1415f519824ba66161"
+    "sha512=e32f592f81b13d73d7a25e67fb0825fc679e6be6170da7d36429e73e8e3763dd000b26fae2dfc746eb214491438891f32a9476c8a3ce1803a131bcc8818ba62d"
+  ]
+}

--- a/packages/sihl/sihl.0.2.1/opam
+++ b/packages/sihl/sihl.0.2.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A modular functional web framework"
+description: "Build web apps fast with long-term maintainability in mind."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-core" {= version}
+  "sihl-type" {= version}
+  "sihl-contract" {= version}
+  "sihl-persistence" {= version}
+  "sihl-web" {= version}
+  "sihl-user" {= version}
+  "sihl-queue" {= version}
+  "sihl-storage" {= version}
+  "sihl-email" {= version}
+  "alcotest-lwt" {>= "1.2.0" & < "3.0.0" & with-test}
+  "cohttp-lwt-unix" {>= "2.5.1" & < "3.0.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "465cd2cf6e0c1e9156f5c3b34d4d105a17084baa"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.1/sihl-0.2.1.tbz"
+  checksum: [
+    "sha256=13f136603aa0a0e4a3d0ea112f8463352cf8961fe3fa5c1415f519824ba66161"
+    "sha512=e32f592f81b13d73d7a25e67fb0825fc679e6be6170da7d36429e73e8e3763dd000b26fae2dfc746eb214491438891f32a9476c8a3ce1803a131bcc8818ba62d"
+  ]
+}


### PR DESCRIPTION
Contains HTTP server implementations as Sihl service

- Project page: <a href="https://github.com/oxidizing/sihl">https://github.com/oxidizing/sihl</a>
- Documentation: <a href="https://oxidizing.github.io/sihl/">https://oxidizing.github.io/sihl/</a>

##### CHANGES:

### Fixed
- Two subsequent `POST` request works now with the CSRF middleware
