### PR TITLE
Add the packages for pytorch 1.7.

### DIFF
--- a/packages/libtorch/libtorch.1.7.0+linux-x86_64/opam
+++ b/packages/libtorch/libtorch.1.7.0+linux-x86_64/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+homepage: "https://github.com/LaurentMazare/ocaml-torch"
+maintainer: "lmazare@gmail.com"
+bug-reports: "https://github.com/LaurentMazare/ocaml-torch/issues"
+authors: [
+  "Laurent Mazare"
+]
+install: [
+  [
+    "sh"
+    "-c"
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-linux.zip && mv -f libtorch %{lib}%/ )"
+  ]
+]
+synopsis: "LibTorch library package"
+description: """
+This is used by the torch package to trigger the install of the
+libtorch library."""
+extra-source "libtorch-linux.zip" {
+  src: "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.7.0%2Bcpu.zip"
+  checksum: "md5=e7700c8fb430e18da5d42b4e9e7bb334"
+}
+available: arch = "x86_64" & os = "linux"

--- a/packages/libtorch/libtorch.1.7.0+macos-x86_64/opam
+++ b/packages/libtorch/libtorch.1.7.0+macos-x86_64/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+homepage: "https://github.com/LaurentMazare/ocaml-torch"
+maintainer: "lmazare@gmail.com"
+bug-reports: "https://github.com/LaurentMazare/ocaml-torch/issues"
+authors: [
+  "Laurent Mazare"
+]
+install: [
+  [
+    "sh"
+    "-c"
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-macos.zip && mv -f libtorch %{lib}%/ && tar xzf mklml-macos.tgz && mv -f mklml_mac_2019.0.1.20181227/lib/libmklml.dylib %{lib}%/libtorch/lib/ && mv -f mklml_mac_2019.0.1.20181227/lib/libiomp5.dylib %{lib}%/libtorch/lib/ )"
+  ]
+]
+depexts: [
+  ["libomp"] {os-distribution = "homebrew"}
+]
+synopsis: "LibTorch library package"
+description: """
+This is used by the torch package to trigger the install of the
+libtorch library."""
+extra-source "libtorch-macos.zip" {
+  src: "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.7.0.zip"
+  checksum: "md5=da1ba1099f0d0151c78221e3f55506e2"
+}
+extra-source "mklml-macos.tgz" {
+  src: "https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_mac_2019.0.1.20181227.tgz"
+  checksum: "md5=a8b4b158dc8e7aad13c0d594a9a8d241"
+}
+available: arch = "x86_64" & os = "macos"

--- a/packages/torch/torch.0.11/opam
+++ b/packages/torch/torch.0.11/opam
@@ -16,7 +16,7 @@ depends: [
   "dune-configurator"
   "libtorch" {>= "1.7.0" & < "1.8.0"}
   "npy"
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.08"}
   "ocaml-compiler-libs"
   "ppx_custom_printf" {< "v0.15"}
   "ppx_expect" {< "v0.15"}

--- a/packages/torch/torch.0.11/opam
+++ b/packages/torch/torch.0.11/opam
@@ -25,7 +25,7 @@ depends: [
   "stdio" {< "v0.15"}
 ]
 
-available: os = "linux" | os = "macos"
+available: arch = "x86_64" & (os = "linux" | os = "macos")
 
 synopsis: "PyTorch bindings for OCaml"
 description: """

--- a/packages/torch/torch.0.11/opam
+++ b/packages/torch/torch.0.11/opam
@@ -14,7 +14,7 @@ depends: [
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
   "dune-configurator"
-  "libtorch" {= "1.7.0"}
+  "libtorch" {>= "1.7.0" & < "1.8.0"}
   "npy"
   "ocaml" {>= "4.07"}
   "ocaml-compiler-libs"

--- a/packages/torch/torch.0.11/opam
+++ b/packages/torch/torch.0.11/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+bug-reports:  "https://github.com/LaurentMazare/ocaml-torch/issues"
+homepage:     "https://github.com/LaurentMazare/ocaml-torch"
+dev-repo:     "git+https://github.com/LaurentMazare/ocaml-torch.git"
+maintainer:   "Laurent Mazare <lmazare@gmail.com>"
+authors:      [ "Laurent Mazare" ]
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "base" {>= "v0.11.0" & < "v0.15"}
+  "cmdliner"
+  "ctypes" {>= "0.5"}
+  "ctypes-foreign"
+  "dune" {>= "1.3.0"}
+  "dune-configurator"
+  "libtorch" {= "1.7.0"}
+  "npy"
+  "ocaml" {>= "4.07"}
+  "ocaml-compiler-libs"
+  "ppx_custom_printf" {< "v0.15"}
+  "ppx_expect" {< "v0.15"}
+  "ppx_sexp_conv" {< "v0.15"}
+  "sexplib" {< "v0.15"}
+  "stdio" {< "v0.15"}
+]
+
+available: os = "linux" | os = "macos"
+
+synopsis: "PyTorch bindings for OCaml"
+description: """
+The ocaml-torch project provides some OCaml bindings for the PyTorch library.
+This brings to OCaml NumPy-like tensor computations with GPU acceleration and
+tape-based automatic differentiation.
+"""
+
+url {
+  src: "https://github.com/LaurentMazare/ocaml-torch/archive/0.11.tar.gz"
+  checksum: [
+    "md5=45ccaed01b4aea5d1f9ae0c89c85f78b"
+    "sha512=c3d02319adb88f641c0eaf312c4a15525a28f1ee8ef46be10111aafbefb40b29fc1746733be49f6a2049a5a17ccc203a8c0481a18f70eed05b9cf4a34830a2c2"
+  ]
+}


### PR DESCRIPTION
This also splits the libtorch package in some specific macos and linux versions to avoid the extra downloads where not needed.