### PR TITLE
Fix the libtorch macos checksum

### DIFF
--- a/packages/libtorch/libtorch.1.7.0+macos-x86_64/opam
+++ b/packages/libtorch/libtorch.1.7.0+macos-x86_64/opam
@@ -21,7 +21,7 @@ This is used by the torch package to trigger the install of the
 libtorch library."""
 extra-source "libtorch-macos.zip" {
   src: "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.7.0.zip"
-  checksum: "md5=da1ba1099f0d0151c78221e3f55506e2"
+  checksum: "md5=4c5a79e919a63419ba7258b867c170ff"
 }
 extra-source "mklml-macos.tgz" {
   src: "https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_mac_2019.0.1.20181227.tgz"


### PR DESCRIPTION
The md5 checksum for the macos libtorch version was wrong, I'm only discovering it now as it fails in the workflow tests of the ocaml-torch repo, sorry about that.
I'm not sure if it's ok to fix in place or if this requires a new version to be crafted (this PR fixes it in place).