### PR TITLE
+tezos-rust-libs.1.0

### DIFF
--- a/packages/tezos-rust-libs/tezos-rust-libs.1.0/opam
+++ b/packages/tezos-rust-libs/tezos-rust-libs.1.0/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos-rust-libs/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos-rust-libs.git"
+license: "multiple"
+depends: [
+  "conf-rust"
+]
+build:[
+  ["cargo" "build" "--target-dir" "target" "--release"]
+]
+synopsis: "Tezos: all rust dependencies and their dependencies"
+
+url {
+  src: "https://gitlab.com/tezos/tezos-rust-libs/-/archive/v1.0/tezos-rust-libs-v1.0.tar.bz2"
+  checksum: [
+    "sha256=f2c81f65a8ab5bfd57e8d793f3abd0f1e696ba896dee73c6c88f33b9b130d7bd"
+    "sha512=446a114badbbb0a2f611fb04ff5d3017e7605f50842c5c8cd16b11772db1da97b9501752914d57d918a5272421cf4e4840a97840038bb0bab2e7d63c4323a80d"
+  ]
+}


### PR DESCRIPTION
This package is a pragmatic solution to unlock the release of tezos version 8.0 in opam.

In order to work inside opam sandbox, we generated an archive where are vendored all the rust dependencies of our rust dependencies. This way we can `cargo build` locally the `.a` we've done binding for in the tezos-crypto package...