### PR TITLE
Package ppx_deriving_encoding.0.1

### DIFF
--- a/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.1/opam
+++ b/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for json-encoding"
+maintainer: ["contact@origin-labs.com"]
+authors: ["Maxime Levillain <maxime.levillain@origin-labs.com"]
+license: "LGPL-2.1-or-later"
+homepage: "https://gitlab.com/o-labs/ppx_deriving_encoding"
+bug-reports: "https://gitlab.com/o-labs/ppx_deriving_encoding/-/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "ocplib-json-typed"
+  "ppxlib" {<= "0.15.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://gitlab.com/o-labs/ppx_deriving_encoding"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/22769538/repository/archive?sha=81ca6736a770a3f09ec7051c30dca081564e33e4"
+  checksum: [
+    "md5=98311527a342fa4d2106bf0d1570393a"
+    "sha512=e42f29949d304ad5c8936dced9cad989c8a85bade50aba696aca66e5c1544d170315dd79c3a5533d379401a8fcb414478125754ec5c5203d0f0eb943a083c13c"
+  ]
+}


### PR DESCRIPTION
### `ppx_deriving_encoding.0.1`
Ppx deriver for json-encoding



---
* Homepage: https://gitlab.com/o-labs/ppx_deriving_encoding
* Source repo: git://gitlab.com/o-labs/ppx_deriving_encoding
* Bug tracker: https://gitlab.com/o-labs/ppx_deriving_encoding/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.2