### PR TITLE
Package ezjs_min.0.2.1

### DIFF
--- a/packages/ezjs_min/ezjs_min.0.2.1/opam
+++ b/packages/ezjs_min/ezjs_min.0.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A bunch of js_of_ocaml shortcuts"
+description: "A bunch of js_of_ocaml shortcuts"
+maintainer: "OCamlPro <contact@ocamlpro.com>"
+authors: "OCamlPro <contact@ocamlpro.com>"
+license: "LGPL-2.1"
+homepage: "https://github.com/ocamlpro/ezjs_min"
+bug-reports: "https://github.com/ocamlpro/ezjs_min/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "2.0"}
+  "js_of_ocaml-ppx"
+  "stdlib-shims" {>= "0.1"}
+]
+depopts: ["lwt"]
+conflicts: [
+  "lwt" {< "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamlpro/ezjs_min.git"
+url {
+  src: "https://github.com/ocamlpro/ezjs_min/archive/0.2.1.tar.gz"
+  checksum: [
+    "md5=47809a9158303a83d5998a20c1d66ff2"
+    "sha512=b9b95f145e06a66cf6daf15cd14d1934e60381fdc9bc534f4d0717c2af3c457b0cf9e704d0830ef0d2c4616a3d83e656d100b351a1afe1263699fb424bcd9dff"
+  ]
+}


### PR DESCRIPTION
### `ezjs_min.0.2.1`
A bunch of js_of_ocaml shortcuts
A bunch of js_of_ocaml shortcuts



---
* Homepage: https://github.com/ocamlpro/ezjs_min
* Source repo: git+https://github.com/ocamlpro/ezjs_min.git
* Bug tracker: https://github.com/ocamlpro/ezjs_min/issues

---
:camel: Pull-request generated by opam-publish v2.0.2