### PR TITLE
Package ppx_deriving_encoding.0.2

### DIFF
--- a/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2/opam
+++ b/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for json-encoding"
+maintainer: ["contact@origin-labs.com"]
+authors: ["Maxime Levillain <maxime.levillain@origin-labs.com"]
+license: "LGPL-2.1-or-later"
+homepage: "https://gitlab.com/o-labs/ppx_deriving_encoding"
+bug-reports: "https://gitlab.com/o-labs/ppx_deriving_encoding/-/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "ocplib-json-typed"
+  "ppxlib" {>= "0.16.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://gitlab.com/o-labs/ppx_deriving_encoding"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/22769538/repository/archive?sha=1448f85d0ba13b4d1b7f780758e4088a8b68c6cf"
+  checksum: [
+    "md5=611eca004497df185dac3d13fbb732d6"
+    "sha512=16fd3e17dabd1551344d719ef30ee2e3d85f499125e8e79f0d644f376b7d5d22f2ff0336a6653b2a22ea50e15d413d46e422d10fcf1e5a80b17ac6c103bf9bc8"
+  ]
+}


### PR DESCRIPTION
### `ppx_deriving_encoding.0.2`
Ppx deriver for json-encoding



---
* Homepage: https://gitlab.com/o-labs/ppx_deriving_encoding
* Source repo: git://gitlab.com/o-labs/ppx_deriving_encoding
* Bug tracker: https://gitlab.com/o-labs/ppx_deriving_encoding/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.2