### PR TITLE
Package ppx_deriving_jsoo.0.1

### DIFF
--- a/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.1/opam
+++ b/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for Js_of_ocaml"
+maintainer: ["contact@origin-labs.com"]
+authors: ["Maxime Levillain <maxime.levillain@origin-labs.com"]
+license: "LGPL-2.1-or-later"
+homepage: "https://gitlab.com/o-labs/ppx_deriving_jsoo"
+bug-reports: "https://gitlab.com/o-labs/ppx_deriving_jsoo/-/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "ezjs_min" {>= "0.2.1"}
+  "ppxlib" {<= "0.15.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://gitlab.com/o-labs/ppx_deriving_jsoo"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/22645789/repository/archive?sha=2fa6de4c7361e71048c308180e2d47aa1ae255f5"
+  checksum: [
+    "md5=92bd8558941672837b2074bf0812ba4e"
+    "sha512=0ef7126f0949a7f85ea8455fc1bc0357d940bbcb70d4aa065086c3f5cec698fc29fd4af105f3083b05fc16d6a75e541ac8090112d13638da99d48a11fd72e3b9"
+  ]
+}


### PR DESCRIPTION
### `ppx_deriving_jsoo.0.1`
Ppx deriver for Js_of_ocaml



---
* Homepage: https://gitlab.com/o-labs/ppx_deriving_jsoo
* Source repo: git://gitlab.com/o-labs/ppx_deriving_jsoo
* Bug tracker: https://gitlab.com/o-labs/ppx_deriving_jsoo/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.2