### PR TITLE
Package ppx_deriving_jsoo.0.2

### DIFF
--- a/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.2/opam
+++ b/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.2/opam
@@ -9,10 +9,10 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.08"}
   "ezjs_min" {>= "0.2.1"}
-  "ppxlib" {>= "0.16.0"}
+  "ppxlib" {>= "0.18.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.2/opam
+++ b/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for Js_of_ocaml"
+maintainer: ["contact@origin-labs.com"]
+authors: ["Maxime Levillain <maxime.levillain@origin-labs.com"]
+license: "LGPL-2.1-or-later"
+homepage: "https://gitlab.com/o-labs/ppx_deriving_jsoo"
+bug-reports: "https://gitlab.com/o-labs/ppx_deriving_jsoo/-/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "ezjs_min" {>= "0.2.1"}
+  "ppxlib" {>= "0.16.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://gitlab.com/o-labs/ppx_deriving_jsoo"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/22645789/repository/archive?sha=1544d22e6e68f309608f46b48f5349a692003ab8"
+  checksum: [
+    "md5=a642b0ced6eec63f722075a5e2767011"
+    "sha512=065e20e768dd8ab5c98506f025d8200ef369c35aa927c1f50733d74e08a8bd45321c40d8c8790d8a67fd2948c5e01aaccdb3ce6f09ba9502ebf5d0a0088bbb87"
+  ]
+}


### PR DESCRIPTION
### `ppx_deriving_jsoo.0.2`
Ppx deriver for Js_of_ocaml



---
* Homepage: https://gitlab.com/o-labs/ppx_deriving_jsoo
* Source repo: git://gitlab.com/o-labs/ppx_deriving_jsoo
* Bug tracker: https://gitlab.com/o-labs/ppx_deriving_jsoo/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.2