### PR TITLE
OCaml 4.12.0~alpha3 packages

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Third alpha release of OCaml 4.12.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml#4.12"
+depends: [
+  "ocaml" {= "4.12.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler hidden-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%" {os != "cygwin"}]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.12.0-alpha3.tar.gz"
+  checksum: "sha256=177e6bf5df8e5179e52e285e0d590fe7f4ec798c4a98a137fa05f69a1a430af1"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+synopsis: "Third alpha release of OCaml 4.12.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml#4.12"
+depends: [
+  "ocaml" {= "4.12.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta" {opam-version < "2.1"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler hidden-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--enable-spacetime" {ocaml-option-spacetime:installed}
+    "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+  ]
+  [make "-j%{jobs}%" {os != "cygwin"}]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.12.0-alpha3.tar.gz"
+  checksum: "sha256=177e6bf5df8e5179e52e285e0d590fe7f4ec798c4a98a137fa05f69a1a430af1"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+  "ocaml-option-spacetime"
+  "ocaml-option-nnp"
+]


### PR DESCRIPTION
This third (and maybe last) alpha is here to expose the API changes in the Gc.Memprof and the Unix modules.
There is also one regression fix for the increase in size of cmo/cma file due to the new improved backtraces.
The rest are the usual bug fixes and configuration fixes with some documentation updates.

There is one breaking change hidden in the change log below; but this concerns a corner case of a corner case of the type system (conjunctive types that appear in inferred signature follow slightly different rules than the one that appears in explicit mli files), that should not affect any users. 


## Changes compared to the alpha2 release

* [*additional fixes*] [1128](https://github.com/ocaml/ocaml/issues/1128), [7503](https://github.com/ocaml/ocaml/issues/7503), [9036](https://github.com/ocaml/ocaml/issues/9036), [9722](https://github.com/ocaml/ocaml/issues/9722), [+10069](https://github.com/ocaml/ocaml/issues/10069): EINTR-based signal handling.
   When a signal arrives, avoid running its OCaml handler in the middle
   of a blocking section. Instead, allow control to return quickly to
   a polling point where the signal handler can safely run, ensuring that

- [9907](https://github.com/ocaml/ocaml/issues/9907): Fix native toplevel on native Windows.
  (David Allsopp, review by Florian Angeletti)

- [10056](https://github.com/ocaml/ocaml/issues/10056): Memprof: ensure young_trigger is within the bounds of the minor
  heap in caml_memprof_renew_minor_sample (regression from [8684](https://github.com/ocaml/ocaml/issues/8684))
  (David Allsopp, review by Guillaume Munch-Maccagnoni and
  Jacques-Henri Jourdan)

- [10062](https://github.com/ocaml/ocaml/issues/10062): set ARCH_INT64_PRINTF_FORMAT correctly for both modes of mingw-w64
  (David Allsopp, review by Xavier Leroy)

- [10025](https://github.com/ocaml/ocaml/issues/10025): Track custom blocks (e.g. Bigarray) with Statmemprof
  (Stephen Dolan, review by Leo White, Gabriel Scherer and Jacques-Henri
   Jourdan)

- [10070](https://github.com/ocaml/ocaml/issues/10070): Fix Float.Array.blit when source and destination arrays coincide.
  (Nicolás Ojeda Bär, review by Alain Frisch and Xavier Leroy)

- [9869](https://github.com/ocaml/ocaml/issues/9869), [10073](https://github.com/ocaml/ocaml/issues/10073): Add Unix.SO_REUSEPORT
  (Yishuai Li, review by Xavier Leroy, amended by David Allsopp)

- [9877](https://github.com/ocaml/ocaml/issues/9877): manual, warn that multi-index indexing operators should be defined in
  conjunction of single-index ones.
  (Florian Angeletti, review by Hezekiah M. Carty, Gabriel Scherer,
   and Marcello Seri)

- [10046](https://github.com/ocaml/ocaml/issues/10046): Link all DLLs with -static-libgcc on mingw32 to prevent dependency
  on libgcc_s_sjlj-1.dll with mingw-w64 runtime 8.0.0 (previously this was
  only needed for dllunix.dll).
  (David Allsopp, report by Andreas Hauptmann, review by Xavier Leroy)

- [9896](https://github.com/ocaml/ocaml/issues/9896): Share the strings representing scopes, fixing some regression
  on .cmo/.cma sizes
  (Alain Frisch and Xavier Clerc, review by Gabriel Scherer)

- [10044](https://github.com/ocaml/ocaml/issues/10044): Always report the detected ARCH, MODEL and SYSTEM, even for bytecode-
  only builds (fixes a "configuration regression" from 4.08 for the Windows
  builds)
  (David Allsopp, review by Xavier Leroy)

- [10071](https://github.com/ocaml/ocaml/issues/10071): Fix bug in tests/misc/weaklifetime.ml that was reported in [10055](https://github.com/ocaml/ocaml/issues/10055)
  (Damien Doligez and Gabriel Scherer, report by David Allsopp)

* [*breaking change*] [8907](https://github.com/ocaml/ocaml/issues/8907), [9878](https://github.com/ocaml/ocaml/issues/9878): `Typemod.normalize_signature` uses wrong environment
  Does not treat submodules differently when normalizing conjunctive types in polymorphic variants.
  This may break code that expose conjunctive types in inferred interface.
  (Jacques Garrigue, report and review by Leo White)

- [9739](https://github.com/ocaml/ocaml/issues/9739), [9747](https://github.com/ocaml/ocaml/issues/9747): Avoid calling type variables, types that are not variables in
  recursive occurence error messages
  (for instance, "Type variable int occurs inside int list")
  (Florian Angeletti, report by Stephen Dolan, review by Armaël Guéneau)

- [10048](https://github.com/ocaml/ocaml/issues/10048): Fix bug with generalized local opens.
  (Leo White, review by Thomas Refis)
