### PR TITLE
[new release] sihl-web, sihl-email, sihl-persistence, sihl-type, sihl-contract, sihl-core, sihl-queue, sihl-user, sihl-storage and sihl (0.2.2)

### DIFF
--- a/packages/sihl-contract/sihl-contract.0.2.2/opam
+++ b/packages/sihl-contract/sihl-contract.0.2.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Contains Sihl service signatures"
+description:
+  "Use the service contracts to implement your own services with the rest of the Sihl ecosystem."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-type" {= version}
+  "sihl-core" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "57e1a542fae708251f08da84b85cdb30b498c96a"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.2/sihl-0.2.2.tbz"
+  checksum: [
+    "sha256=cfdbfc4b5b122d5be73480dc6050ea19f970c918d19ecfde1fe1f3b152154d28"
+    "sha512=2bcb39b1e7e98892d65ded542b143259156671106e7a30ad5211c22ec54b87047320c2cf6c115db1931a563ff8204e9f420cf3edfc1559d4c9ce53b0ef40e529"
+  ]
+}

--- a/packages/sihl-core/sihl-core.0.2.2/opam
+++ b/packages/sihl-core/sihl-core.0.2.2/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "The core of the Sihl web framework"
+description:
+  "Deals with configuration, service lifecycle, app, CLI commands, logging and randomness."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "conformist" {>= "0.1.0"}
+  "tsort" {>= "2.0.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.8"}
+  "sexplib" {>= "v0.13.0"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.5.2"}
+  "tls" {>= "0.11.1"}
+  "ssl" {>= "0.5.9"}
+  "uuidm" {>= "0.9.7"}
+  "lwt_ssl" {>= "1.1.3"}
+  "caqti" {>= "1.2.1"}
+  "safepass" {>= "3.0"}
+  "jwto" {>= "0.3.0"}
+  "ppx_fields_conv" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "cohttp-lwt-unix" {>= "2.5.4" & with-test}
+  "alcotest-lwt" {>= "1.2.0" & < "3.0.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "57e1a542fae708251f08da84b85cdb30b498c96a"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.2/sihl-0.2.2.tbz"
+  checksum: [
+    "sha256=cfdbfc4b5b122d5be73480dc6050ea19f970c918d19ecfde1fe1f3b152154d28"
+    "sha512=2bcb39b1e7e98892d65ded542b143259156671106e7a30ad5211c22ec54b87047320c2cf6c115db1931a563ff8204e9f420cf3edfc1559d4c9ce53b0ef40e529"
+  ]
+}

--- a/packages/sihl-email/sihl-email.0.2.2/opam
+++ b/packages/sihl-email/sihl-email.0.2.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A Sihl service for sending emails using Lwt"
+description: """
+
+A Sihl service for sending emails using Lwt. Various email transports are provided that can be used in production or testing such as SMTP, Sendgrid, in-memory and console printing."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "letters" {>= "0.2.1"}
+  "sihl-contract" {= version}
+  "sihl-persistence" {= version}
+  "cohttp-lwt-unix" {>= "2.5.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "57e1a542fae708251f08da84b85cdb30b498c96a"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.2/sihl-0.2.2.tbz"
+  checksum: [
+    "sha256=cfdbfc4b5b122d5be73480dc6050ea19f970c918d19ecfde1fe1f3b152154d28"
+    "sha512=2bcb39b1e7e98892d65ded542b143259156671106e7a30ad5211c22ec54b87047320c2cf6c115db1931a563ff8204e9f420cf3edfc1559d4c9ce53b0ef40e529"
+  ]
+}

--- a/packages/sihl-persistence/sihl-persistence.0.2.2/opam
+++ b/packages/sihl-persistence/sihl-persistence.0.2.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Contains Sihl services regarding data persistence"
+description:
+  "Use this package to deal with database pools, transactions, migrations and integration tests involving the database layer."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-contract" {= version}
+  "caqti" {>= "1.2.1"}
+  "caqti-lwt" {>= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "57e1a542fae708251f08da84b85cdb30b498c96a"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.2/sihl-0.2.2.tbz"
+  checksum: [
+    "sha256=cfdbfc4b5b122d5be73480dc6050ea19f970c918d19ecfde1fe1f3b152154d28"
+    "sha512=2bcb39b1e7e98892d65ded542b143259156671106e7a30ad5211c22ec54b87047320c2cf6c115db1931a563ff8204e9f420cf3edfc1559d4c9ce53b0ef40e529"
+  ]
+}

--- a/packages/sihl-queue/sihl-queue.0.2.2/opam
+++ b/packages/sihl-queue/sihl-queue.0.2.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A Sihl service for queue jobs"
+description: """
+
+A Sihl service for putting and working jobs on queues. Various queue backends are provided."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-contract" {= version}
+  "sihl-persistence" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "57e1a542fae708251f08da84b85cdb30b498c96a"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.2/sihl-0.2.2.tbz"
+  checksum: [
+    "sha256=cfdbfc4b5b122d5be73480dc6050ea19f970c918d19ecfde1fe1f3b152154d28"
+    "sha512=2bcb39b1e7e98892d65ded542b143259156671106e7a30ad5211c22ec54b87047320c2cf6c115db1931a563ff8204e9f420cf3edfc1559d4c9ce53b0ef40e529"
+  ]
+}

--- a/packages/sihl-storage/sihl-storage.0.2.2/opam
+++ b/packages/sihl-storage/sihl-storage.0.2.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A Sihl service for storing and retrieving large files"
+description: """
+
+This service can be used to handle large binary blobs that are typically not stored in relational databases. Various storage backends are provided."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-contract" {= version}
+  "sihl-persistence" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "57e1a542fae708251f08da84b85cdb30b498c96a"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.2/sihl-0.2.2.tbz"
+  checksum: [
+    "sha256=cfdbfc4b5b122d5be73480dc6050ea19f970c918d19ecfde1fe1f3b152154d28"
+    "sha512=2bcb39b1e7e98892d65ded542b143259156671106e7a30ad5211c22ec54b87047320c2cf6c115db1931a563ff8204e9f420cf3edfc1559d4c9ce53b0ef40e529"
+  ]
+}

--- a/packages/sihl-type/sihl-type.0.2.2/opam
+++ b/packages/sihl-type/sihl-type.0.2.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Contains Sihl types that are returned by Sihl services"
+description:
+  "Use this package together with sihl-contract to implement your own services. Sihl types are things like Email.t, User.t, Queue_job.t or Migration.t."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-core" {= version}
+  "opium" {>= "0.20.0"}
+  "caqti-lwt" {>= "1.2.0"}
+  "multipart-form-data" {>= "0.3.0"}
+  "alcotest" {>= "1.2.0"}
+  "alcotest-lwt" {>= "1.2.0" & < "3.0.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "57e1a542fae708251f08da84b85cdb30b498c96a"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.2/sihl-0.2.2.tbz"
+  checksum: [
+    "sha256=cfdbfc4b5b122d5be73480dc6050ea19f970c918d19ecfde1fe1f3b152154d28"
+    "sha512=2bcb39b1e7e98892d65ded542b143259156671106e7a30ad5211c22ec54b87047320c2cf6c115db1931a563ff8204e9f420cf3edfc1559d4c9ce53b0ef40e529"
+  ]
+}

--- a/packages/sihl-user/sihl-user.0.2.2/opam
+++ b/packages/sihl-user/sihl-user.0.2.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Contains Sihl services to deal with user related topics"
+description:
+  "Use this package to handle tokens, sessions, users, flash messages and password reset workflows."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-contract" {= version}
+  "sihl-persistence" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "57e1a542fae708251f08da84b85cdb30b498c96a"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.2/sihl-0.2.2.tbz"
+  checksum: [
+    "sha256=cfdbfc4b5b122d5be73480dc6050ea19f970c918d19ecfde1fe1f3b152154d28"
+    "sha512=2bcb39b1e7e98892d65ded542b143259156671106e7a30ad5211c22ec54b87047320c2cf6c115db1931a563ff8204e9f420cf3edfc1559d4c9ce53b0ef40e529"
+  ]
+}

--- a/packages/sihl-web/sihl-web.0.2.2/opam
+++ b/packages/sihl-web/sihl-web.0.2.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Contains HTTP server implementations as Sihl service"
+description:
+  "Use this package to implement run your HTTP routers on a HTTP server."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-contract" {= version}
+  "opium" {>= "0.20.0"}
+  "multipart-form-data" {>= "0.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "57e1a542fae708251f08da84b85cdb30b498c96a"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.2/sihl-0.2.2.tbz"
+  checksum: [
+    "sha256=cfdbfc4b5b122d5be73480dc6050ea19f970c918d19ecfde1fe1f3b152154d28"
+    "sha512=2bcb39b1e7e98892d65ded542b143259156671106e7a30ad5211c22ec54b87047320c2cf6c115db1931a563ff8204e9f420cf3edfc1559d4c9ce53b0ef40e529"
+  ]
+}

--- a/packages/sihl/sihl.0.2.2/opam
+++ b/packages/sihl/sihl.0.2.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A modular functional web framework"
+description: "Build web apps fast with long-term maintainability in mind."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl-core" {= version}
+  "sihl-type" {= version}
+  "sihl-contract" {= version}
+  "sihl-persistence" {= version}
+  "sihl-web" {= version}
+  "sihl-user" {= version}
+  "sihl-queue" {= version}
+  "sihl-storage" {= version}
+  "sihl-email" {= version}
+  "alcotest-lwt" {>= "1.2.0" & < "3.0.0" & with-test}
+  "cohttp-lwt-unix" {>= "2.5.1" & < "3.0.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+x-commit-hash: "57e1a542fae708251f08da84b85cdb30b498c96a"
+url {
+  src:
+    "https://github.com/oxidizing/sihl/releases/download/0.2.2/sihl-0.2.2.tbz"
+  checksum: [
+    "sha256=cfdbfc4b5b122d5be73480dc6050ea19f970c918d19ecfde1fe1f3b152154d28"
+    "sha512=2bcb39b1e7e98892d65ded542b143259156671106e7a30ad5211c22ec54b87047320c2cf6c115db1931a563ff8204e9f420cf3edfc1559d4c9ce53b0ef40e529"
+  ]
+}


### PR DESCRIPTION
Contains HTTP server implementations as Sihl service

- Project page: <a href="https://github.com/oxidizing/sihl">https://github.com/oxidizing/sihl</a>
- Documentation: <a href="https://oxidizing.github.io/sihl/">https://oxidizing.github.io/sihl/</a>

##### CHANGES:

### Fixed
- Merge form data and urlencoded form parsing and provide them in one middleware
