### PR TITLE
[new release] repr and ppx_repr (0.2.0)

### DIFF
--- a/packages/ppx_repr/ppx_repr.0.2.0/opam
+++ b/packages/ppx_repr/ppx_repr.0.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "PPX deriver for type representations"
+description: "PPX deriver for type representations"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "ppxlib" {>= "0.12.0" & < "0.18.0"}
+  "hex" {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.2.0/repr-fuzz-0.2.0.tbz"
+  checksum: [
+    "sha256=8cf7f319bce9212abe984df392deb72bdb2cee2e33338adfe9f0f460de2f30b2"
+    "sha512=530c8ef91ec60c8a229aab9f4761e30e08b5d434f39da448df89183472deb5a189fba5029cce8372a5b5691cfbc1536db2ae3494652ac9a3ecd70304a0fa89f1"
+  ]
+}
+x-commit-hash: "4983d61f610a0b0a3873740c265cc5f5c5d3ffc3"

--- a/packages/repr/repr.0.2.0/opam
+++ b/packages/repr/repr.0.2.0/opam
@@ -16,7 +16,7 @@ bug-reports: "https://github.com/mirage/repr/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "fmt" {>= "0.8.0"}
+  "fmt" {>= "0.8.7"}
   "uutf"
   "jsonm" {>= "1.0.0"}
   "base64" {>= "2.0.0"}

--- a/packages/repr/repr.0.2.0/opam
+++ b/packages/repr/repr.0.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Dynamic type representations. Provides no stability guarantee"
+description: """
+This package defines a library of combinators for building dynamic type
+representations and a set of generic operations over representable types, used
+in the implementation of Irmin and related packages.
+
+It is not yet intended for public consumption and provides no stability
+guarantee.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.0"}
+  "uutf"
+  "jsonm" {>= "1.0.0"}
+  "base64" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.2.0/repr-fuzz-0.2.0.tbz"
+  checksum: [
+    "sha256=8cf7f319bce9212abe984df392deb72bdb2cee2e33338adfe9f0f460de2f30b2"
+    "sha512=530c8ef91ec60c8a229aab9f4761e30e08b5d434f39da448df89183472deb5a189fba5029cce8372a5b5691cfbc1536db2ae3494652ac9a3ecd70304a0fa89f1"
+  ]
+}
+x-commit-hash: "4983d61f610a0b0a3873740c265cc5f5c5d3ffc3"


### PR DESCRIPTION
Dynamic type representations. Provides no stability guarantee

- Project page: <a href="https://github.com/mirage/repr">https://github.com/mirage/repr</a>

##### CHANGES:

- Improve performance of variable-size integers encoding. (mirage/repr#24, @samoht)
- Require `short_hash` operations to be explicitly unstaged. (mirage/repr#15, @CraigFe)
- Require `equal` and `compare` operations to be explicitly unstaged. (mirage/repr#16, @samoht)
