### PR TITLE
Package ppx_deriving_encoding.0.2.1

### DIFF
--- a/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2.1/opam
+++ b/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for json-encoding"
+maintainer: ["contact@origin-labs.com"]
+authors: ["Maxime Levillain <maxime.levillain@origin-labs.com"]
+license: "LGPL-2.1-or-later"
+homepage: "https://gitlab.com/o-labs/ppx_deriving_encoding"
+bug-reports: "https://gitlab.com/o-labs/ppx_deriving_encoding/-/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "ocplib-json-typed"
+  "ppxlib" {>= "0.18.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://gitlab.com/o-labs/ppx_deriving_encoding"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/22769538/repository/archive?sha=c094a9058c849266dd52dca52c172841a6965bab"
+  checksum: [
+    "md5=a5d7925af192f6dbcc2e3318ccfa736c"
+    "sha512=0ef1efd04b072edc4006a438109cfecad2e4f172adbf1889b1f1bec4da4e30f2ccf039b4a47c637b1ac43f534aaf9f4e74925710a54193c4155ecfcca825b4c6"
+  ]
+}


### PR DESCRIPTION
### `ppx_deriving_encoding.0.2.1`
Ppx deriver for json-encoding



---
* Homepage: https://gitlab.com/o-labs/ppx_deriving_encoding
* Source repo: git://gitlab.com/o-labs/ppx_deriving_encoding
* Bug tracker: https://gitlab.com/o-labs/ppx_deriving_encoding/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.2