### PR TITLE
[new release] repr and ppx_repr (0.2.0)

### DIFF
--- a/packages/ppx_repr/ppx_repr.0.2.0/opam
+++ b/packages/ppx_repr/ppx_repr.0.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "PPX deriver for type representations"
+description: "PPX deriver for type representations"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "ppxlib" {>= "0.12.0" & < "0.18.0"}
+  "hex" {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.2.0/repr-fuzz-0.2.0.tbz"
+  checksum: [
+    "sha256=36db1188217a8b0ad3c5c745f120ac1a46ff1767a6440988bd7280e68e751850"
+    "sha512=c7399f64b8bdc5b0aad63b66feb6142096b9b72bc27aee94d8896d780271d0dadbf242f09b1a92cc2b1a4f29e2ca5db08f77d1ebeb0ee5761c61a031a3ca3657"
+  ]
+}
+x-commit-hash: "1c89adff2f6b504a44ce2e9077068ba216ec342b"

--- a/packages/ppx_repr/ppx_repr.0.2.0/opam
+++ b/packages/ppx_repr/ppx_repr.0.2.0/opam
@@ -12,7 +12,6 @@ depends: [
   "ppxlib" {>= "0.12.0" & < "0.18.0"}
   "hex" {with-test}
   "alcotest" {>= "1.1.0" & with-test}
-  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/repr/repr.0.2.0/opam
+++ b/packages/repr/repr.0.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Dynamic type representations. Provides no stability guarantee"
+description: """
+This package defines a library of combinators for building dynamic type
+representations and a set of generic operations over representable types, used
+in the implementation of Irmin and related packages.
+
+It is not yet intended for public consumption and provides no stability
+guarantee.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.7"}
+  "uutf"
+  "jsonm" {>= "1.0.0"}
+  "base64" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.2.0/repr-fuzz-0.2.0.tbz"
+  checksum: [
+    "sha256=36db1188217a8b0ad3c5c745f120ac1a46ff1767a6440988bd7280e68e751850"
+    "sha512=c7399f64b8bdc5b0aad63b66feb6142096b9b72bc27aee94d8896d780271d0dadbf242f09b1a92cc2b1a4f29e2ca5db08f77d1ebeb0ee5761c61a031a3ca3657"
+  ]
+}
+x-commit-hash: "1c89adff2f6b504a44ce2e9077068ba216ec342b"


### PR DESCRIPTION
Dynamic type representations. Provides no stability guarantee

- Project page: <a href="https://github.com/mirage/repr">https://github.com/mirage/repr</a>

##### CHANGES:

- Improve performance of variable-size integers encoding and decoding.
  (mirage/repr#24, mirage/repr#30, @samoht)
- Require `short_hash` operations to be explicitly unstaged.
  (mirage/repr#15, @CraigFe)
- Require `equal` and `compare` operations to be explicitly unstaged.
  (mirage/repr#16, @samoht)
