### PR TITLE
Add soupault.2.3.1 and adjust dependency of soupault.2.3.0 for a breaking change in To.ml

### DIFF
--- a/packages/soupault/soupault.2.3.0/opam
+++ b/packages/soupault/soupault.2.3.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "lambdasoup" {>= "0.7.2"}
   "markup" {>= "1.0.0-1"}
-  "toml" {<= "5.0.0"}
+  "toml" {< "6.0.0"}
   "fileutils"
   "logs"
   "fmt"

--- a/packages/soupault/soupault.2.3.1/opam
+++ b/packages/soupault/soupault.2.3.1/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "lambdasoup" {>= "0.7.2"}
   "markup" {>= "1.0.0-1"}
-  "toml" {<= "5.0.0"}
+  "toml" {>= "6.0.0"}
   "fileutils"
   "logs"
   "fmt"
@@ -43,9 +43,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/dmbaturin/soupault"
 url {
-  src: "https://github.com/dmbaturin/soupault/archive/2.3.0.tar.gz"
+  src: "https://github.com/dmbaturin/soupault/archive/2.3.1.tar.gz"
   checksum: [
-    "md5=e90eed0aa282c9670080b000660b4e76"
-    "sha512=086e0d0551cb0325c0aefddb226c6e8176796655799461fe1a9eca4abeffe77cfece65016b67ea186574b97c3f9f7bf22c9566086c432721cf37ae00ab927ef6"
+    "md5=7e182db28f67fd71c0d4cc6c15605fd6"
+    "sha512=47e45d308e34fbd6435d9f15a4c83a1d22fd5988653f2ead36c76bcf32f4da453a58255e7fdcf546747c34a6f63f92d585f002fb6d650648d9de71fee5070477"
   ]
 }


### PR DESCRIPTION
To.ml 6.0.0 released just after soupault 2.3.0 made a [breaking change](https://github.com/ocaml-toml/To.ml/issues/68).
Now soupault 2.3.0 doesn't build anymore. This requires both updating the dependency of 2.3.0 and a maintenance release.