### PR TITLE
[new release] ca-certs-nss (3.60)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.60/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.60/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "X.509 trust anchors extracted from Mozilla's NSS"
+description: """
+Trust anchors extracted from Mozilla's NSS certdata.txt package,
+to be used in MirageOS unikernels.
+"""
+maintainer: ["Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs-nss"
+doc: "https://mirage.github.io/ca-certs-nss/doc"
+bug-reports: "https://github.com/mirage/ca-certs-nss/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "rresult"
+  "mirage-crypto"
+  "mirage-clock"
+  "x509" {>= "0.11.0"}
+  "ocaml" {>= "4.07.0"}
+  "logs" {build}
+  "fmt" {build}
+  "hex" {build}
+  "bos" {build}
+  "astring" {build}
+  "cmdliner" {build}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ca-certs-nss.git"
+tags: ["org:mirage"]
+x-commit-hash: "e42192c3e930be2f411e382b5d213a517aa41927"
+url {
+  src:
+    "https://github.com/mirage/ca-certs-nss/releases/download/v3.60/ca-certs-nss-v3.60.tbz"
+  checksum: [
+    "sha256=586dc3664fb230a47e4e4871ac2b8f2207a0016830028a27c3793c415dc91361"
+    "sha512=9182c224b979b98dde29278121afcbe46bb5b92708d50dc8516cb1d2c49930264c84644ed5701a707444253b02faf80320ec8192c45bd7dbf07aa323d2536f0a"
+  ]
+}


### PR DESCRIPTION
X.509 trust anchors extracted from Mozilla's NSS

- Project page: <a href="https://github.com/mirage/ca-certs-nss">https://github.com/mirage/ca-certs-nss</a>
- Documentation: <a href="https://mirage.github.io/ca-certs-nss/doc">https://mirage.github.io/ca-certs-nss/doc</a>

##### CHANGES:

* Update to NSS 3.60 release (Dec 11th)
