### PR TITLE
Package catala.0.2.0

### DIFF
--- a/packages/catala/catala.0.2.0/opam
+++ b/packages/catala/catala.0.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Low-level language for tax code specification"
+description: """
+The Catala language is designed to be a low-level target for
+higher-level specification languages for fiscal legislation.
+"""
+maintainer: ["contact@catala-lang.org"]
+authors: ["Denis Merigoux"]
+license: "Apache2"
+homepage: "https://github.com/CatalaLang/catala"
+bug-reports: "https://github.com/CatalaLang/catala/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "ANSITerminal" {>= "0.8.2"}
+  "sedlex" {>= "2.1"}
+  "menhir" {>= "20200211"}
+  "menhirLib" {>= "20200211"}
+  "unionFind" {>= "20200320"}
+  "bindlib" {>= "5.0.1"}
+  "dune-build-info" {>= "2.0.1"}
+  "cmdliner" {>= "1.0.4"}
+  "re" {>= "1.9.0"}
+  "zarith" {>= "1.10"}
+  "dune" {build}
+  "ocamlgraph" {>= "1.8.8"}
+  "odate" {>= "0.6"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CatalaLang/catala.git"
+url {
+  src: "https://github.com/CatalaLang/catala/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=4c6f725ef4d21c5ff91f60d74b454ef7"
+    "sha512=98806e03daa6f33740b80a0f78a37320fb70ebea8cb927ea8fed022673459189c32e2389ccba0fa25d93f754b0fa0128a5ee28e1bb9abefa330deb4be8cc7d95"
+  ]
+}

--- a/packages/catala/catala.0.2.0/opam
+++ b/packages/catala/catala.0.2.0/opam
@@ -10,7 +10,7 @@ license: "Apache2"
 homepage: "https://github.com/CatalaLang/catala"
 bug-reports: "https://github.com/CatalaLang/catala/issues"
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "ANSITerminal" {>= "0.8.2"}
   "sedlex" {>= "2.1"}
   "menhir" {>= "20200211"}
@@ -21,12 +21,12 @@ depends: [
   "cmdliner" {>= "1.0.4"}
   "re" {>= "1.9.0"}
   "zarith" {>= "1.10"}
-  "dune" {build}
+  "dune" {>= "2.2"}
   "ocamlgraph" {>= "1.8.8"}
   "odate" {>= "0.6"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
### `catala.0.2.0`
Low-level language for tax code specification
The Catala language is designed to be a low-level target for
higher-level specification languages for fiscal legislation.



---
* Homepage: https://github.com/CatalaLang/catala
* Source repo: git+https://github.com/CatalaLang/catala.git
* Bug tracker: https://github.com/CatalaLang/catala/issues

---
:camel: Pull-request generated by opam-publish v2.0.2