### PR TITLE
[new release] prometheus and prometheus-app (1.0)

### DIFF
--- a/packages/prometheus-app/prometheus-app.1.0/opam
+++ b/packages/prometheus-app/prometheus-app.1.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Client library for Prometheus monitoring"
+description: """\
+Applications can enable metric reporting using the `prometheus-app` opam package.
+This depends on cohttp and can serve the metrics collected above over HTTP.
+
+The `prometheus-app.unix` ocamlfind library provides the `Prometheus_unix` module,
+which includes a cmdliner option and pre-configured web-server.
+See the `examples/example.ml` program for an example, which can be run as:
+
+```shell
+$ dune exec -- examples/example.exe --listen-prometheus=9090
+If run with the option --listen-prometheus=9090, this program serves metrics at
+http://localhost:9090/metrics
+Tick!
+Tick!
+...
+```
+
+Unikernels can use `Prometheus_app` instead of `Prometheus_unix` to avoid the `Unix` dependency."""
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.0"}
+  "prometheus" {= version}
+  "fmt"
+  "re"
+  "cohttp" {>= "1.0.0"}
+  "cohttp-lwt" {< "3.0.0"}
+  "cohttp-lwt-unix" {< "3.0.0"}
+  "lwt" {>= "2.5.0"}
+  "cmdliner"
+  "alcotest" {with-test}
+  "asetmap"
+  "astring"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v1.0/prometheus-v1.0.tbz"
+  checksum: [
+    "sha256=d17cec111516fa188d4a41add0c6c1f0dba1bc9ca4aa53c52cc9be21019aac26"
+    "sha512=be54f970d9397e2f338fe30bcd463ae1b11d9337027290ec272d7a9f8cceea8b8907d6d1ccb5708f0378810b7df13d598bbed461a8e37b145435a3e66f733956"
+  ]
+}

--- a/packages/prometheus/prometheus.1.0/opam
+++ b/packages/prometheus/prometheus.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Client library for Prometheus monitoring"
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "dune"
+  "astring"
+  "asetmap"
+  "fmt"
+  "re"
+  "lwt" {>= "2.5.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+description: """
+To run services reliably, it is useful if they can report various metrics
+(for example, heap size, queue lengths, number of warnings logged, etc).
+
+A monitoring service can be configured to collect this data regularly.
+The data can be graphed to help understand the performance of the service over time,
+or to help debug problems quickly.
+It can also be used to send alerts if a service is down or behaving poorly.
+"""
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v1.0/prometheus-v1.0.tbz"
+  checksum: [
+    "sha256=d17cec111516fa188d4a41add0c6c1f0dba1bc9ca4aa53c52cc9be21019aac26"
+    "sha512=be54f970d9397e2f338fe30bcd463ae1b11d9337027290ec272d7a9f8cceea8b8907d6d1ccb5708f0378810b7df13d598bbed461a8e37b145435a3e66f733956"
+  ]
+}


### PR DESCRIPTION
Client library for Prometheus monitoring

- Project page: <a href="https://github.com/mirage/prometheus">https://github.com/mirage/prometheus</a>
- Documentation: <a href="https://mirage.github.io/prometheus/">https://mirage.github.io/prometheus/</a>

##### CHANGES:

- Add logging configuration (mirage/prometheus#29, @talex5).  
  To configure a server to report counts for log messages:
  ```ocaml
  let () = Prometheus_unix.Logging.init ()
  ```
  This installs a reporter that reports the number of messages logged by each log source and at each level.
  The reporter also displays the timestamp and log source with each message, which is a more suitable configuration for servers.

- Add bounds on cohttp to prepare for cohttp 3 release (mirage/prometheus#28, @talex5).
