### PR TITLE
Package stringOf.1.0

### DIFF
--- a/packages/stringOf/stringOf.1.0/opam
+++ b/packages/stringOf/stringOf.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "StringOf data structure to string framework"
+description: """
+stringOf is a data structure to string framework that is used
+to convert various data structures to [string]s that do not
+have a string_of function associated with it
+"""
+maintainer: "Nikunj Chawla <nikchawla312@gmail.com>"
+authors: "Nikunj Chawla <nikchawla312@gmail.com>"
+homepage: "https://github.com/nik312123/stringOf"
+dev-repo: "git+https://github.com/nik312123/stringOf.git"
+bug-reports: "https://github.com/nik312123/stringOf/issues"
+doc: "https://nik312123.github.io/ocamlLibDocs/stringOf/StringOf/"
+depends: [
+    "ocaml" {>= "4.08.1"}
+    "dune" {>= "2.7.1"}
+    "base-bytes"
+    "base-unix"
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+    ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+url {
+  src: "https://github.com/nik312123/stringOf/archive/1.0.tar.gz"
+  checksum: [
+    "md5=ee53e4bc26c56fbd609405e31572bdde"
+    "sha512=ac2f2178a5f17db09ef3876136c40ebf287abbaa429c7252578ffa953f7cf839961e15d93e2e364711db9df30952ed2ea67f8c37caa498a5a27f3fd4db2410e4"
+  ]
+}


### PR DESCRIPTION
### `stringOf.1.0`
StringOf data structure to string framework
stringOf is a data structure to string framework that is used
to convert various data structures to [string]s that do not
have a string_of function associated with it



---
* Homepage: https://github.com/nik312123/stringOf
* Source repo: git+https://github.com/nik312123/stringOf.git
* Bug tracker: https://github.com/nik312123/stringOf/issues

---
:camel: Pull-request generated by opam-publish v2.0.2