### PR TITLE
[new release] current_examples, current, current_ansi, current_incr, current_slack, current_git, current_web, current_github, current_docker and current_rpc (0.4)

### DIFF
--- a/packages/current/current.0.4/opam
+++ b/packages/current/current.0.4/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Pipeline language for keeping things up-to-date"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+It is used in ocaml-ci (which provides CI for OCaml projects on GitHub),
+and in docker-base-images (a pipeline that builds Docker images for various
+Linux distributions, OCaml compiler versions and CPU types, and pushes them
+to Docker Hub).
+
+A pipeline is written much like you would write a one-shot sequential script,
+but OCurrent will automatically re-run steps when the inputs change, and will
+run steps in parallel where possible."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "current_incr" {= version}
+  "fmt"
+  "bos"
+  "ppx_deriving"
+  "lwt"
+  "cmdliner"
+  "sqlite3"
+  "duration"
+  "prometheus"
+  "dune" {>= "2.0"}
+  "re"
+  "lwt-dllist"
+  "alcotest" {>= "1.2.0" & with-test}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "astring" {>= "0.8.5"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
+  "prometheus-app" {>= "0.7" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "1f5877041035052ae1701214ddec8f2426968c89"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.4/current-v0.4.tbz"
+  checksum: [
+    "sha256=85d65779b104da6ccfdb33b65fc6d2492dd3942d9fd74127059cb6f850684a17"
+    "sha512=6cc24530a9e58dcf32cf00b5ed17e93cb949786e30d625fbc07b24f380e536d6a4e7c2902ede86af3ddf2ac48135efb9483144514f40d298adab11be4f8c473d"
+  ]
+}

--- a/packages/current_ansi/current_ansi.0.4/opam
+++ b/packages/current_ansi/current_ansi.0.4/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "ANSI escape sequence parser"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a basic ANSI escape parser,
+allowing the OCurrent web UI to show logs in colour."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "astring"
+  "fmt"
+  "tyxml"
+  "dune" {>= "2.0"}
+]
+x-commit-hash: "1f5877041035052ae1701214ddec8f2426968c89"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.4/current-v0.4.tbz"
+  checksum: [
+    "sha256=85d65779b104da6ccfdb33b65fc6d2492dd3942d9fd74127059cb6f850684a17"
+    "sha512=6cc24530a9e58dcf32cf00b5ed17e93cb949786e30d625fbc07b24f380e536d6a4e7c2902ede86af3ddf2ac48135efb9483144514f40d298adab11be4f8c473d"
+  ]
+}

--- a/packages/current_docker/current_docker.0.4/opam
+++ b/packages/current_docker/current_docker.0.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "OCurrent Docker plugin"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a plugin for interacting with Docker.
+It can pull, build, run and push images, and can coordinate
+multiple Docker Engine instances."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "ppx_deriving"
+  "lwt"
+  "dockerfile"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune" {>= "2.0"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "duration" {>= "0.1.3"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "1f5877041035052ae1701214ddec8f2426968c89"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.4/current-v0.4.tbz"
+  checksum: [
+    "sha256=85d65779b104da6ccfdb33b65fc6d2492dd3942d9fd74127059cb6f850684a17"
+    "sha512=6cc24530a9e58dcf32cf00b5ed17e93cb949786e30d625fbc07b24f380e536d6a4e7c2902ede86af3ddf2ac48135efb9483144514f40d298adab11be4f8c473d"
+  ]
+}

--- a/packages/current_examples/current_examples.0.4/opam
+++ b/packages/current_examples/current_examples.0.4/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Example pipelines for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides some example pipelines.
+It exists mainly to test the integration of various OCurrent
+plugins."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "lwt"
+  "cmdliner"
+  "duration"
+  "current" {= version}
+  "current_web" {= version}
+  "current_git" {= version}
+  "current_github" {= version}
+  "current_docker" {= version}
+  "current_rpc" {= version}
+  "capnp-rpc-unix" {>= "0.5"}
+  "dune" {>= "2.0"}
+  "capnp-rpc" {>= "0.8.0"}
+  "capnp-rpc-lwt" {>= "0.8.0"}
+  "capnp-rpc-net" {>= "0.8.0"}
+  "dockerfile" {>= "7.0.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "routes" {>= "0.8.0"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+  "prometheus-app" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "1f5877041035052ae1701214ddec8f2426968c89"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.4/current-v0.4.tbz"
+  checksum: [
+    "sha256=85d65779b104da6ccfdb33b65fc6d2492dd3942d9fd74127059cb6f850684a17"
+    "sha512=6cc24530a9e58dcf32cf00b5ed17e93cb949786e30d625fbc07b24f380e536d6a4e7c2902ede86af3ddf2ac48135efb9483144514f40d298adab11be4f8c473d"
+  ]
+}

--- a/packages/current_git/current_git.0.4/opam
+++ b/packages/current_git/current_git.0.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Git plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Git.
+It can pull from remote repositories, or monitor local ones for changes."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "ppx_deriving"
+  "lwt"
+  "irmin-watcher"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune" {>= "2.0"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "1f5877041035052ae1701214ddec8f2426968c89"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.4/current-v0.4.tbz"
+  checksum: [
+    "sha256=85d65779b104da6ccfdb33b65fc6d2492dd3942d9fd74127059cb6f850684a17"
+    "sha512=6cc24530a9e58dcf32cf00b5ed17e93cb949786e30d625fbc07b24f380e536d6a4e7c2902ede86af3ddf2ac48135efb9483144514f40d298adab11be4f8c473d"
+  ]
+}

--- a/packages/current_github/current_github.0.4/opam
+++ b/packages/current_github/current_github.0.4/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "GitHub plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with GitHub.
+It can monitor and clone remote GitHub repositories, and can
+push GitHub status messages to show the results of testing
+PRs and branches."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "current_web" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "lwt"
+  "yojson"
+  "cohttp-lwt-unix" {< "3.0.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "x509" {>= "0.10.0"}
+  "tls" {>= "0.11.0"}
+  "dune" {>= "2.0"}
+  "astring" {>= "0.8.5"}
+  "base64" {>= "3.4.0"}
+  "cmdliner" {>= "1.0.4"}
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "cstruct" {>= "5.2.0"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "tyxml" {>= "4.4.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "1f5877041035052ae1701214ddec8f2426968c89"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.4/current-v0.4.tbz"
+  checksum: [
+    "sha256=85d65779b104da6ccfdb33b65fc6d2492dd3942d9fd74127059cb6f850684a17"
+    "sha512=6cc24530a9e58dcf32cf00b5ed17e93cb949786e30d625fbc07b24f380e536d6a4e7c2902ede86af3ddf2ac48135efb9483144514f40d298adab11be4f8c473d"
+  ]
+}

--- a/packages/current_incr/current_incr.0.4/opam
+++ b/packages/current_incr/current_incr.0.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Self-adjusting computations"
+description: """\
+This is a small, self-contained library for self-adjusting (incremental) computations.
+It was written for OCurrent, but can be used separately too.
+
+It is similar to Jane Street's incremental library, but much smaller and
+has no external dependencies.
+
+It is also similar to the react library, but the results do not depend on the
+behaviour of the garbage collector. In particular, functions stop being called
+as soon as they are no longer needed."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "1f5877041035052ae1701214ddec8f2426968c89"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.4/current-v0.4.tbz"
+  checksum: [
+    "sha256=85d65779b104da6ccfdb33b65fc6d2492dd3942d9fd74127059cb6f850684a17"
+    "sha512=6cc24530a9e58dcf32cf00b5ed17e93cb949786e30d625fbc07b24f380e536d6a4e7c2902ede86af3ddf2ac48135efb9483144514f40d298adab11be4f8c473d"
+  ]
+}

--- a/packages/current_rpc/current_rpc.0.4/opam
+++ b/packages/current_rpc/current_rpc.0.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Cap'n Proto RPC plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a Cap'n Proto RPC interface, allowing
+an OCurrent engine to be controlled remotely."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {>= "0.8.0"}
+  "capnp-rpc-lwt" {>= "0.4"}
+  "fpath"
+  "dune" {>= "2.0"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "stdint" {>= "0.7.0"}
+]
+conflicts: [
+  "x509" {= "0.11.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "1f5877041035052ae1701214ddec8f2426968c89"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.4/current-v0.4.tbz"
+  checksum: [
+    "sha256=85d65779b104da6ccfdb33b65fc6d2492dd3942d9fd74127059cb6f850684a17"
+    "sha512=6cc24530a9e58dcf32cf00b5ed17e93cb949786e30d625fbc07b24f380e536d6a4e7c2902ede86af3ddf2ac48135efb9483144514f40d298adab11be4f8c473d"
+  ]
+}

--- a/packages/current_slack/current_slack.0.4/opam
+++ b/packages/current_slack/current_slack.0.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Slack plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Slack.
+It can post messages to slack channels."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "yojson"
+  "lwt"
+  "tls" {>= "0.12.0"}
+  "cohttp" {>= "2.2.0" & < "3.0.0"}
+  "cohttp-lwt" {>= "2.2.0" & < "3.0.0"}
+  "cohttp-lwt-unix" {>= "2.2.0" & < "3.0.0"}
+  "dune" {>= "2.0"}
+  "logs" {>= "0.7.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "1f5877041035052ae1701214ddec8f2426968c89"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.4/current-v0.4.tbz"
+  checksum: [
+    "sha256=85d65779b104da6ccfdb33b65fc6d2492dd3942d9fd74127059cb6f850684a17"
+    "sha512=6cc24530a9e58dcf32cf00b5ed17e93cb949786e30d625fbc07b24f380e536d6a4e7c2902ede86af3ddf2ac48135efb9483144514f40d298adab11be4f8c473d"
+  ]
+}

--- a/packages/current_web/current_web.0.4/opam
+++ b/packages/current_web/current_web.0.4/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Test web UI for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a basic web UI for service administrators.
+It shows the current pipeline visually and allows viewing job
+logs and configuring the log analyser."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "current_ansi" {= version}
+  "ocaml" {>= "4.08.0"}
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "base64"
+  "session"
+  "session-cohttp-lwt"
+  "mirage-crypto" {>= "0.8.7"}
+  "mirage-crypto-rng"
+  "fmt"
+  "bos"
+  "lwt"
+  "cmdliner"
+  "prometheus" {>= "0.7"}
+  "prometheus-app"
+  "cohttp" {>= "2.2.0" & < "3.0.0"}
+  "cohttp-lwt" {>= "2.2.0" & < "3.0.0"}
+  "cohttp-lwt-unix" {>= "2.2.0" & < "3.0.0"}
+  "tyxml"
+  "routes" {>= "0.8.0"}
+  "dune" {>= "2.0"}
+  "conf-graphviz"
+  "astring" {>= "0.8.5"}
+  "conduit-lwt-unix" {>= "2.2.2"}
+  "cstruct" {>= "5.2.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_sexp_conv" {>= "v0.14.1"}
+  "re" {>= "1.9.0"}
+  "result" {>= "1.5"}
+  "sexplib" {>= "v0.14.0"}
+  "sqlite3" {>= "5.0.2"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "1f5877041035052ae1701214ddec8f2426968c89"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.4/current-v0.4.tbz"
+  checksum: [
+    "sha256=85d65779b104da6ccfdb33b65fc6d2492dd3942d9fd74127059cb6f850684a17"
+    "sha512=6cc24530a9e58dcf32cf00b5ed17e93cb949786e30d625fbc07b24f380e536d6a4e7c2902ede86af3ddf2ac48135efb9483144514f40d298adab11be4f8c473d"
+  ]
+}


### PR DESCRIPTION
Example pipelines for OCurrent

- Project page: <a href="https://github.com/ocurrent/ocurrent">https://github.com/ocurrent/ocurrent</a>
- Documentation: <a href="https://ocurrent.github.io/ocurrent/">https://ocurrent.github.io/ocurrent/</a>

##### CHANGES:

Core:

- Optimise the SQL query for the Query page, by adding an
  index on the finish time and doing a case-insensitive
  search (@talex5 ocurrent/ocurrent#215).

- Remove in-memory cache entries when no longer needed (@talex5 ocurrent/ocurrent#235).

- Provide `Analysis.quick_stat` for faster stats (@talex5 ocurrent/ocurrent#239).  
  With large pipelines (above 20,000 boxes or so) collecting the Prometheus stats
  for pipeline states was getting slow.

- Improve error message if a cancel hook raises (@talex5 ocurrent/ocurrent#214).  
  Say which job raised the error.

Web UI:

- Add dependency on conf-graphviz (@dra27 ocurrent/ocurrent#225).

Docker plugin:

- Add an architecture flag in the Docker builder to enable
  multiarch builds (including 32-bit) (@avsm ocurrent/ocurrent#213).

- Add `Current_docker.Raw.peek` (@talex5 ocurrent/ocurrent#226).  
  This can be used to check the latest version of an image without pulling it.

- Add Docker Compose support to the Docker plugin (@avsm ocurrent/ocurrent#228).

- Log in before creating manifests (@talex5 ocurrent/ocurrent#232).  
  Otherwise, we may hit the anonymous use limit.

Git plugin:

- Use `--init` with `git submodule update --init --recursive` (@talex5 ocurrent/ocurrent#224).  
  Otherwise, it's not really recursive.

GitHub plugin:

- Use the term `allowlist` for permitted usernames and make it case-insensitive (@avsm ocurrent/ocurrent#210, @Julow ocurrent/ocurrent#211).

- Handle larger numbers of app installations (@talex5 ocurrent/ocurrent#219).  
  GitHub sends them in batches, and we previously only used the first batch.

Examples:

- Replace custom logging in examples with Prometheus defaults (@talex5 ocurrent/ocurrent#241).

Build fixes and cleanup:

- Adapt to the Alcotest 1.2 interface (@talex5 ocurrent/ocurrent#212).

- Add missing dependency on `ppx_deriving_yojson` (@talex5 ocurrent/ocurrent#209).

- Remove unused `Option.map` (@talex5 ocurrent/ocurrent#216)

- Switch from "capnpc" to "capnp compile" (@MisterDA  ocurrent/ocurrent#233).  
  `capnpc` is the old name, and isn't present on Windows.

- Switch to `ocaml/opam` as the base image for the Dockerfile (@avsm ocurrent/ocurrent#230).

- Use `Cmdliner.Term.term_result` for correct error handling (@talex5 ocurrent/ocurrent#241).
