### PR TITLE
tezos-rust-libs: compatibility with sandbox

### DIFF
--- a/packages/tezos-rust-libs/tezos-rust-libs.1.0/opam
+++ b/packages/tezos-rust-libs/tezos-rust-libs.1.0/opam
@@ -9,6 +9,8 @@ depends: [
   "conf-rust"
 ]
 build:[
+  ["mkdir" ".cargo"]
+  ["mv" "cargo-config" ".cargo/config"]
   ["cargo" "build" "--target-dir" "target" "--release"]
 ]
 synopsis: "Tezos: all rust dependencies and their dependencies"


### PR DESCRIPTION
I don't understand why it hasn't been caught by the CI. (Is the CI using `--disable-sandbox`?) Anyway, as soon as you try to compile tezos-rust-libs on a machine where you didn't compile some rust already, it failed with
```
+ /home/pirbo/.opam/opam-init/hooks/sandbox.sh "build" "cargo" "build" "--target-dir" "target" "--release" (CWD=/home/pirbo/.opam/4.10.2+flambda/.opam-switch/build/tezos-rust-libs.1.0)
- error: failed to get `bellman` as a dependency of package `librustzcash v0.2.0 (/home/pirbo/.opam/4.10.2+flambda/.opam-switch/build/tezos-rust-libs.1.0/librustzcash)`
- 
- Caused by:
-   failed to create directory `/home/pirbo/.cargo/registry/index/github.com-1ecc6299db9ec823`
- 
- Caused by:
-   Read-only file system (os error 30)
```
because the config file is not in the right place.

Of course, a new release with the file in the correct place would be better than a `mv` in the opam file but it requires my professional PGP key so I'll do that only as soon as I'm back to work and I think this may be worth a "hot fix".

Happy holidays :-)
