### PR TITLE
[new release] http-cookie (3.0.0)

### DIFF
--- a/packages/http-cookie/http-cookie.3.0.0/opam
+++ b/packages/http-cookie/http-cookie.3.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "HTTP cookie library for OCaml"
+description: "OCaml library to manipulate HTTP cookie. Adheres to RFC 6265."
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/http-cookie"
+bug-reports: "https://github.com/lemaetech/http-cookie/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/http-cookie.git"
+x-commit-hash: "8d9e601e994ab43ba610d46856b1ea939671041e"
+url {
+  src:
+    "https://github.com/lemaetech/http-cookie/releases/download/v3.0.0/http-cookie-v3.0.0.tbz"
+  checksum: [
+    "sha256=66b131ca6e63bc46ef859fc8924c815377377abfb2c52324c658d9c000130475"
+    "sha512=42d351a522355edca8bdf64b0048e7fb6af0be21bded8ff8fb75bf7ff463360511b2e17de4b22a9ad29887993baf916bc0ee3d1092496a6ca86bb05832abf118"
+  ]
+}


### PR DESCRIPTION
HTTP cookie library for OCaml

- Project page: <a href="https://github.com/lemaetech/http-cookie">https://github.com/lemaetech/http-cookie</a>

##### CHANGES:

- Backwards incompatible change: remove `base-unix` dependency. Uses own `date_time` instead of `Unix.tm`.
