### PR TITLE
Package bimap.2020Dec19

### DIFF
--- a/packages/bimap/bimap.2020Dec19/opam
+++ b/packages/bimap/bimap.2020Dec19/opam
@@ -12,7 +12,7 @@ depends: [
   "core" {>= "v0.11.3"}
   "ocamlfind" {>= "1.8"}
   "dune" {>= "2.0"}
-  "oUnit" {>= "2.08"}
+  "ounit" {>= "2.08"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/bimap/bimap.2020Dec19/opam
+++ b/packages/bimap/bimap.2020Dec19/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "An OCaml library implementing bi-directional maps and multi-maps"
+description:
+  "Bi-directional maps permit clients to not only obtain a value provided a key, but to obtain a key provided a value"
+maintainer: ["papatangonyc@gmail.com"]
+authors: ["papatangonyc@gmail.com"]
+license: "GPLv3"
+homepage: "https://github.com/pat227/bimap.git"
+bug-reports: "https://github.com/pat227/bimap.git/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "core" {>= "v0.11.3"}
+  "ocamlfind" {>= "1.8"}
+  "dune" {>= "2.0"}
+  "oUnit" {>= "2.08"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pat227/bimap.git.git"
+url {
+  src: "https://github.com/pat227/bimap/archive/2020Dec19.tar.gz"
+  checksum: [
+    "md5=1e03b6ea6bf663c7c1eb21c7a05dec46"
+    "sha512=f0f42ee105a227d3e840023aa3ae8113e47e4f1f0fce45bebf29e4a67aae49f19d7aecc75e0cdf0ef32abffbea24831ff4db61d974bafb02cdbd0fb67ccf8fea"
+  ]
+}


### PR DESCRIPTION
### `bimap.2020Dec19`
An OCaml library implementing bi-directional maps and multi-maps
Bi-directional maps permit clients to not only obtain a value provided a key, but to obtain a key provided a value



---
* Homepage: https://github.com/pat227/bimap.git
* Source repo: git+https://github.com/pat227/bimap.git.git
* Bug tracker: https://github.com/pat227/bimap.git/issues

---
:camel: Pull-request generated by opam-publish v2.0.2