### PR TITLE
release compatibility update for the legacy camlp5 7.xx releases

### DIFF
--- a/packages/camlp5/camlp5.7.14/opam
+++ b/packages/camlp5/camlp5.7.14/opam
@@ -31,6 +31,7 @@ doc: "https://camlp5.github.io/doc/html"
 
 depends: [
   "ocaml"       { >= "4.02" & < "4.13.0" }
+  "conf-perl"
 ]
 
 build: [

--- a/packages/camlp5/camlp5.7.14/opam
+++ b/packages/camlp5/camlp5.7.14/opam
@@ -1,0 +1,46 @@
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description:
+"""
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel.
+"""
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre"]
+homepage: "https://camlp5.github.io"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+doc: "https://camlp5.github.io/doc/html"
+
+depends: [
+  "ocaml"       { >= "4.02" & < "4.13.0" }
+]
+
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/camlp5/archive/rel714.tar.gz"
+  checksum: [
+    "sha512=1b39949c532ca622b01a8e800aa1dcad34f1c944ffe580003642bd742dedc158f3ee54602f3b05f89c0e259525d7feed101b971ebd589449b6d56046389a5bf6"
+  ]
+}


### PR DESCRIPTION
This updates the 7.xx legacy version of camlp5 to support ocaml 4.12.0 (and 4.10.2).  No new function, just compatibility.