### PR TITLE
[new release] owl-zoo, owl-top, owl-base, owl and owl-plplot (1.0.1)

### DIFF
--- a/packages/owl-base/owl-base.1.0.1/opam
+++ b/packages/owl-base/owl-base.1.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/"
+synopsis: "OCaml Scientific and Engineering Computing - Base"
+description: "Owl is an OCaml scientific library."
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "base-bigarray"
+  "dune" {>= "2.0.0"}
+]
+x-commit-hash: "49f90eb1be8adb089fb3daca490cbc90fa1a1508"
+url {
+  src: "https://github.com/owlbarn/owl/releases/download/1.0.1/owl-1.0.1.tbz"
+  checksum: [
+    "sha256=29c3334aa767c31f474ed7bf8e36995da635d48b468252d1c06136f0e9268a70"
+    "sha512=38fb45a4f1101634b3049e07caa20a169e679c4f0d8ff2fd53c39a042418452108687d106733b876436af4b98117fc53f5c2de58f876c6d2d5ffbd66509646ca"
+  ]
+}

--- a/packages/owl-plplot/owl-plplot.1.0.1/opam
+++ b/packages/owl-plplot/owl-plplot.1.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/owl/"
+synopsis: "OCaml Scientific and Engineering Computing"
+description: """
+Owl: OCaml Scientific and Engineering Computing
+
+Owl is an OCaml numerical library.
+It supports N-dimensional arrays, both dense and sparse matrix operations, linear algebra, regressions, fast Fourier transforms, and many advanced mathematical and statistical functions (such as Markov chain Monte Carlo methods).
+Recently, Owl has implemented algorithmic differentiation which essentially makes developing machine learning and neural network algorithms trivial.
+"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "owl" {= version}
+  "plplot"
+]
+x-commit-hash: "49f90eb1be8adb089fb3daca490cbc90fa1a1508"
+url {
+  src: "https://github.com/owlbarn/owl/releases/download/1.0.1/owl-1.0.1.tbz"
+  checksum: [
+    "sha256=29c3334aa767c31f474ed7bf8e36995da635d48b468252d1c06136f0e9268a70"
+    "sha512=38fb45a4f1101634b3049e07caa20a169e679c4f0d8ff2fd53c39a042418452108687d106733b876436af4b98117fc53f5c2de58f876c6d2d5ffbd66509646ca"
+  ]
+}

--- a/packages/owl-top/owl-top.1.0.1/opam
+++ b/packages/owl-top/owl-top.1.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/"
+synopsis: "OCaml Scientific and Engineering Computing - Top"
+description: "Owl is an OCaml scientific library."
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml-compiler-libs"
+  "owl" {= version}
+  "owl-zoo" {= version}
+]
+x-commit-hash: "49f90eb1be8adb089fb3daca490cbc90fa1a1508"
+url {
+  src: "https://github.com/owlbarn/owl/releases/download/1.0.1/owl-1.0.1.tbz"
+  checksum: [
+    "sha256=29c3334aa767c31f474ed7bf8e36995da635d48b468252d1c06136f0e9268a70"
+    "sha512=38fb45a4f1101634b3049e07caa20a169e679c4f0d8ff2fd53c39a042418452108687d106733b876436af4b98117fc53f5c2de58f876c6d2d5ffbd66509646ca"
+  ]
+}

--- a/packages/owl-zoo/owl-zoo.1.0.1/opam
+++ b/packages/owl-zoo/owl-zoo.1.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/"
+synopsis: "OCaml Scientific and Engineering Computing - Zoo"
+description: """
+Owl's Zoo System
+
+The Zoo System is Owl's customised toplevel.
+It is used for scripting numerical applications and sharing small code snippets via gist among users.
+The Zoo system introduces a zoo directive into toplevel, the referred gist id will be automatically downloaded and imported as a module in the script.
+The nested zoo reference is also supported.
+"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml-compiler-libs"
+  "owl" {= version}
+]
+x-commit-hash: "49f90eb1be8adb089fb3daca490cbc90fa1a1508"
+url {
+  src: "https://github.com/owlbarn/owl/releases/download/1.0.1/owl-1.0.1.tbz"
+  checksum: [
+    "sha256=29c3334aa767c31f474ed7bf8e36995da635d48b468252d1c06136f0e9268a70"
+    "sha512=38fb45a4f1101634b3049e07caa20a169e679c4f0d8ff2fd53c39a042418452108687d106733b876436af4b98117fc53f5c2de58f876c6d2d5ffbd66509646ca"
+  ]
+}

--- a/packages/owl/owl.1.0.1/opam
+++ b/packages/owl/owl.1.0.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+license: "MIT"
+homepage: "https://github.com/owlbarn/owl"
+dev-repo: "git+https://github.com/owlbarn/owl.git"
+bug-reports: "https://github.com/owlbarn/owl/issues"
+doc: "https://owlbarn.github.io/owl/"
+synopsis: "OCaml Scientific and Engineering Computing"
+description: """
+Owl: OCaml Scientific and Engineering Computing
+
+Owl is an OCaml numerical library.
+It supports N-dimensional arrays, both dense and sparse matrix operations, linear algebra, regressions, fast Fourier transforms, and many advanced mathematical and statistical functions (such as Markov chain Monte Carlo methods).
+Recently, Owl has implemented algorithmic differentiation which essentially makes developing machine learning and neural network algorithms trivial.
+"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "alcotest" {with-test}
+  "base" {build}
+  "base-bigarray"
+  "conf-openblas" {>= "0.2.1"}
+  "ctypes" {>= "0.16.0"}
+  "dune" {>= "2.0.0"}
+  "dune-configurator"
+  "eigen" {>= "0.3.0"}
+  "owl-base" {= version}
+  "stdio" {build}
+  "npy"
+]
+x-commit-hash: "49f90eb1be8adb089fb3daca490cbc90fa1a1508"
+url {
+  src: "https://github.com/owlbarn/owl/releases/download/1.0.1/owl-1.0.1.tbz"
+  checksum: [
+    "sha256=29c3334aa767c31f474ed7bf8e36995da635d48b468252d1c06136f0e9268a70"
+    "sha512=38fb45a4f1101634b3049e07caa20a169e679c4f0d8ff2fd53c39a042418452108687d106733b876436af4b98117fc53f5c2de58f876c6d2d5ffbd66509646ca"
+  ]
+}


### PR DESCRIPTION
OCaml Scientific and Engineering Computing - Zoo

- Project page: <a href="https://github.com/owlbarn/owl">https://github.com/owlbarn/owl</a>
- Documentation: <a href="https://owlbarn.github.io/">https://owlbarn.github.io/</a>

##### CHANGES:

* Add eighth-order finite difference approximation
* Fix bug in Jacobian with different input/output dimensions (owlbarn/owl#557)
* Fix bug in nested grads (owlbarn/owl#558)
* Update to ocamlformat.0.16.0 (thanks @gpetiot owlbarn/owl#556)
* Add get_fancy to AD
* Check input and output type of `diff` operation
* Fix bug in `build_info` of aiso pattern in AD
* Implement split forward mode and check max tag of `build_info` 
* Add initial implementation of fft2 and ifft2
* Add nonsymmetric qs suppport for continuous and discrete time lyapunov gradients
* Improve `care` and `dare` operations in AD
* Improve forward mode efficiency for sylv, clyap and dlyap operations in AD
