### PR TITLE
Package bimap.2020Dec27

### DIFF
--- a/packages/bimap/bimap.2020Dec27/opam
+++ b/packages/bimap/bimap.2020Dec27/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "An OCaml library implementing bi-directional maps and multi-maps"
+description:
+  "Bi-directional maps permit clients to not only obtain a value provided a key, but to obtain a key provided a value"
+maintainer: ["papatangonyc@gmail.com"]
+authors: ["papatangonyc@gmail.com"]
+license: "GPLv3"
+homepage: "https://github.com/pat227/bimap.git"
+bug-reports: "https://github.com/pat227/bimap.git/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "core" {>= "v0.11.3"}
+  "dune" {>= "2.0"}
+  "ounit" {>= "2.08"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pat227/bimap.git.git"
+url {
+  src: "https://github.com/pat227/bimap/archive/2020Dec27.tar.gz"
+  checksum: [
+    "md5=dc15aa5782997fc4fdba16916657bb14"
+    "sha512=725f8778c61fde7a0f0d865398a8240bd813b988321d0f42a4b545314bd8d970fcb52a804002bcccc840144072024c0a4a8d8d9d5a29dc8f46ccda5a55328ad2"
+  ]
+}


### PR DESCRIPTION
### `bimap.2020Dec27`
An OCaml library implementing bi-directional maps and multi-maps
Bi-directional maps permit clients to not only obtain a value provided a key, but to obtain a key provided a value



---
* Homepage: https://github.com/pat227/bimap.git
* Source repo: git+https://github.com/pat227/bimap.git.git
* Bug tracker: https://github.com/pat227/bimap.git/issues

---
:camel: Pull-request generated by opam-publish v2.0.2