### PR TITLE
Package bimap.2020Dec27

### DIFF
--- a/packages/bimap/bimap.2020Dec27/opam
+++ b/packages/bimap/bimap.2020Dec27/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "An OCaml library implementing bi-directional maps and multi-maps"
+description:
+  "Bi-directional maps permit clients to not only obtain a value provided a key, but to obtain a key provided a value"
+maintainer: ["papatangonyc@gmail.com"]
+authors: ["papatangonyc@gmail.com"]
+license: "GPLv3"
+homepage: "https://github.com/pat227/bimap.git"
+bug-reports: "https://github.com/pat227/bimap.git/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "core" {>= "v0.11.3"}
+  "dune" {>= "2.0"}
+  "oUnit" {>= "2.08"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pat227/bimap.git.git"
+url {
+  src: "https://github.com/pat227/bimap/archive/2020Dec27.tar.gz"
+  checksum: [
+    "md5=3049dc9cb273a53f91cbb2529f2a252c"
+    "sha512=faeec335fd737d83c75c019e0e3a25bf10d1e601d7464e04bfd3b7bbd2fdd422fb9a16a8c98af4460bef3624b216c7c674f3ce6c9a0f37b2be29d58d71c44465"
+  ]
+}


### PR DESCRIPTION
### `bimap.2020Dec27`
An OCaml library implementing bi-directional maps and multi-maps
Bi-directional maps permit clients to not only obtain a value provided a key, but to obtain a key provided a value



---
* Homepage: https://github.com/pat227/bimap.git
* Source repo: git+https://github.com/pat227/bimap.git.git
* Bug tracker: https://github.com/pat227/bimap.git/issues

---
:camel: Pull-request generated by opam-publish v2.0.2