### PR TITLE
Package bimap.2020Dec27

### DIFF
--- a/packages/bimap/bimap.2020Dec27/opam
+++ b/packages/bimap/bimap.2020Dec27/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "An OCaml library implementing bi-directional maps and multi-maps"
+description:
+  "Bi-directional maps permit clients to not only obtain a value provided a key, but to obtain a key provided a value"
+maintainer: ["papatangonyc@gmail.com"]
+authors: ["papatangonyc@gmail.com"]
+license: "GPLv3"
+homepage: "https://github.com/pat227/bimap.git"
+bug-reports: "https://github.com/pat227/bimap.git/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "core" {>= "v0.11.3"}
+  "dune" {>= "2.0"}
+  "ounit" {>= "2.2.2"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pat227/bimap.git.git"
+url {
+  src: "https://github.com/pat227/bimap/archive/2020Dec27.tar.gz"
+  checksum: [
+    "md5=7179245b4b0812b7f17e46ec0f3af115"
+    "sha512=6e5cf972042e5a461554cf5a3d6ca469853f4de11251a4dd4c8df454540cce077c2fc02cad046db385e6a4e930403dc40737c1f857a3b3465623c514614afdd0"
+  ]
+}


### PR DESCRIPTION
### `bimap.2020Dec27`
An OCaml library implementing bi-directional maps and multi-maps
Bi-directional maps permit clients to not only obtain a value provided a key, but to obtain a key provided a value



---
* Homepage: https://github.com/pat227/bimap.git
* Source repo: git+https://github.com/pat227/bimap.git.git
* Bug tracker: https://github.com/pat227/bimap.git/issues

---
:camel: Pull-request generated by opam-publish v2.0.2