### PR TITLE
[new release] plotkicadsch and kicadsch (0.8.0)

### DIFF
--- a/packages/kicadsch/kicadsch.0.8.0/opam
+++ b/packages/kicadsch/kicadsch.0.8.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+authors: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+doc: "https://jnavila.github.io/plotkicadsch/index"
+synopsis: "Library to read and convert Kicad Sch files"
+description: """
+Library able to read Kicad libraries and sch file and
+drive a painter to paint the schematics.
+"""
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "ocaml" {>="4.07"}
+]
+url {
+  src:
+    "https://github.com/jnavila/plotkicadsch/releases/download/v0.8.0/plotkicadsch-v0.8.0.tbz"
+  checksum: [
+    "sha256=111d894a5b88f079f9670e991da534c103d900c8dac3578f683738ecc3856344"
+    "sha512=c8d62ac20267f5bbe659a56e61e11e57b6ee52551fa58c04dcb189caa83b21aff7bdb52f749c5abcb4cb09749fd4e22a8b1c520304e9d4e88ee88aa447c5f2df"
+  ]
+}

--- a/packages/plotkicadsch/plotkicadsch.0.8.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.8.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+authors: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+doc: "https://jnavila.github.io/plotkicadsch/index"
+synopsis: "Utilities to print and compare version of Kicad schematics"
+description: """
+Two utilities:
+ * plotkicadsch is able to plot schematic sheets to SVG files
+ * plotgitsch is able to compare git revisions of schematics
+"""
+license: "ISC"
+dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="4.09"}
+  "dune" {>= "1.0"}
+  "kicadsch" {= version}
+  "tyxml" {>= "4.0.0"}
+  "lwt"
+  "lwt_ppx" {build}
+  "sha"
+  "git" {>= "2.0.0"}
+  "git-unix"
+  "base64" {>= "3.0.0"}
+  "cmdliner"
+]
+url {
+  src:
+    "https://github.com/jnavila/plotkicadsch/releases/download/v0.8.0/plotkicadsch-v0.8.0.tbz"
+  checksum: [
+    "sha256=111d894a5b88f079f9670e991da534c103d900c8dac3578f683738ecc3856344"
+    "sha512=c8d62ac20267f5bbe659a56e61e11e57b6ee52551fa58c04dcb189caa83b21aff7bdb52f749c5abcb4cb09749fd4e22a8b1c520304e9d4e88ee88aa447c5f2df"
+  ]
+}


### PR DESCRIPTION
Utilities to print and compare version of Kicad schematics

- Project page: <a href="https://jnavila.github.io/plotkicadsch/">https://jnavila.github.io/plotkicadsch/</a>
- Documentation: <a href="https://jnavila.github.io/plotkicadsch/index">https://jnavila.github.io/plotkicadsch/index</a>

##### CHANGES:

- plotgitsch: split wires with respect to jonction points to refine diff
 - manage escaped strings in fields
 - Remove dependency to Core_kernel
