### PR TITLE
[new release] capnp-rpc-net, capnp-rpc-lwt, capnp-rpc-mirage, capnp-rpc and capnp-rpc-unix (0.9.0)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.9.0/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.0.9.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "lwt"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "48ab696fef4760122847ac4ef9cbb4a85ab45d51"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.9.0/capnp-rpc-v0.9.0.tbz"
+  checksum: [
+    "sha256=20b8878bbc88b82a3aa1efc46c48192fa9302754d64e6ba93474a64ca314fe2a"
+    "sha512=742e3a15f2ea5af9624ffcd8955e19a3ee07f0bfc2bfed73e6662e8ee5510692f196d69a156cec7a28f50ca30e5ad233b6b78b9d6d602405a023d496d4534a40"
+  ]
+}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.9.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.9.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp" {>= "3.1.0"}
+  "capnp-rpc-net" {= version}
+  "astring" {with-test}
+  "fmt"
+  "logs"
+  "dns-client" {>= "4.5.0"}
+  "tls-mirage"
+  "mirage-stack" {>= "2.0.0"}
+  "arp-mirage" {with-test}
+  "alcotest" {>= "1.0.1" & with-test}
+  "alcotest-lwt" {>= "1.0.1" & with-test}
+  "io-page-unix" {with-test}
+  "tcpip" {>= "5.0.0" & with-test}
+  "mirage-vnetif" {with-test}
+  "mirage-crypto-rng" {>= "0.7.0" & with-test}
+  "dune" {>= "2.0"}
+  "asetmap" {with-test}
+  "ethernet" {>= "2.2.0" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "48ab696fef4760122847ac4ef9cbb4a85ab45d51"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.9.0/capnp-rpc-v0.9.0.tbz"
+  checksum: [
+    "sha256=20b8878bbc88b82a3aa1efc46c48192fa9302754d64e6ba93474a64ca314fe2a"
+    "sha512=742e3a15f2ea5af9624ffcd8955e19a3ee07f0bfc2bfed73e6662e8ee5510692f196d69a156cec7a28f50ca30e5ad233b6b78b9d6d602405a023d496d4534a40"
+  ]
+}

--- a/packages/capnp-rpc-net/capnp-rpc-net.0.9.0/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.0.9.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "capnp-rpc-lwt" {= version}
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "mirage-flow" {>="2.0.0"}
+  "tls" {>= "0.8.0"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "0.11.0"}
+  "tls-mirage"
+  "dune" {>= "2.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "48ab696fef4760122847ac4ef9cbb4a85ab45d51"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.9.0/capnp-rpc-v0.9.0.tbz"
+  checksum: [
+    "sha256=20b8878bbc88b82a3aa1efc46c48192fa9302754d64e6ba93474a64ca314fe2a"
+    "sha512=742e3a15f2ea5af9624ffcd8955e19a3ee07f0bfc2bfed73e6662e8ee5510692f196d69a156cec7a28f50ca30e5ad233b6b78b9d6d602405a023d496d4534a40"
+  ]
+}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.9.0/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.9.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp-rpc-net" {= version}
+  "cmdliner"
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.4"}
+  "logs"
+  "extunix"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "2.0"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "alcotest-lwt" { >= "1.0.1" & with-test}
+  "mirage-crypto-rng" {>= "0.7.0"}
+  "lwt"
+  "asetmap" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "48ab696fef4760122847ac4ef9cbb4a85ab45d51"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.9.0/capnp-rpc-v0.9.0.tbz"
+  checksum: [
+    "sha256=20b8878bbc88b82a3aa1efc46c48192fa9302754d64e6ba93474a64ca314fe2a"
+    "sha512=742e3a15f2ea5af9624ffcd8955e19a3ee07f0bfc2bfed73e6662e8ee5510692f196d69a156cec7a28f50ca30e5ad233b6b78b9d6d602405a023d496d4534a40"
+  ]
+}

--- a/packages/capnp-rpc/capnp-rpc.0.9.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.9.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "stdint"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "dune" {>= "2.0"}
+  "alcotest" {with-test & >= "1.0.1"}
+  "afl-persistent" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "48ab696fef4760122847ac4ef9cbb4a85ab45d51"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v0.9.0/capnp-rpc-v0.9.0.tbz"
+  checksum: [
+    "sha256=20b8878bbc88b82a3aa1efc46c48192fa9302754d64e6ba93474a64ca314fe2a"
+    "sha512=742e3a15f2ea5af9624ffcd8955e19a3ee07f0bfc2bfed73e6662e8ee5510692f196d69a156cec7a28f50ca30e5ad233b6b78b9d6d602405a023d496d4534a40"
+  ]
+}


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

- Add connection progress indicator (@talex5 mirage/capnp-rpc#220).  
  Clients can now use `Capnp_rpc_unix.with_cap_exn` to show a progress indicator while waiting to connect.
  It will use the log if enabled.
  If not, but stderr is a tty, it shows a message while connecting and then erases it (if connecting takes longer than 0.5s).
  If stderr is not a tty, it just prints a message there.

- Use `Mirage_crypto_rng_lwt.initialize` instead of `Mirage_crypto_rng_unix.initialize` (@hannesm mirage/capnp-rpc#217).  
  The former periodically feeds entropy to the RNG, while the latter seeds the RNG only once.

- Set TCP_KEEPIDLE=60 if possible (@talex5 mirage/capnp-rpc#214).  
  Cap'n Proto connections tend to be long lived and we therefore turn on the `SO_KEEPALIVE` option.
  However, the default keepalive timeout of 2 hours is much too long for some networks.
  In particular, Docker's libnetwork silently drops idle connections after about 10 minutes.

Windows support:

- Prevent crash if ExtUnix wasn't built with sockopt (@MisterDA mirage/capnp-rpc#218).  
  If ExtUnix isn't built with sockopt then the symbol `have_sockopt_int` isn't available and an exception is raised. 
  This may be the case on some environments (e.g., ExtUnix built with mingw-w64).
  It is a workaround until support for `TCP_KEEPIDLE` is added for these environments (e.g., using Winsock instead).

- There is no SIGPIPE on Windows (@dra27 mirage/capnp-rpc#212).

- Switch from "capnpc" to "capnp compile" (@talex5 mirage/capnp-rpc#213).  
  `capnpc` seems to be the old name, and isn't present on Windows.

Build changes:

- Remove Travis and Dockerfile (@talex5 mirage/capnp-rpc#220).  
  Travis is very slow and error-prone now, and ocaml-ci generates a working Dockerfile automatically for people who want it.

- Include transitive dependencies in opam files (@talex5 mirage/capnp-rpc#219).  
  Patch generated by https://github.com/ocurrent/opam-dune-lint/

- Require `tcpip.unix` specifically to get the checksum stubs linked (@hannesm mirage/capnp-rpc#216).
