### PR TITLE
add virtual package for diffutils

### DIFF
--- a/packages/conf-diffutils/conf-diffutils.1/opam
+++ b/packages/conf-diffutils/conf-diffutils.1/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+homepage: "https://www.gnu.org/software/diffutils/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "GNU Project"
+license: "GPL-3.0-or-later"
+build: [["sh" "-exc" "find . -name ."]]
+depexts: [
+  ["diffutils"] {os-family = "debian"}
+  ["diffutils"] {os-distribution = "fedora"}
+  ["diffutils"] {os-distribution = "rhel"}
+  ["diffutils"] {os-distribution = "centos"}
+  ["diffutils"] {os-distribution = "alpine"}
+  ["diffutils"] {os-distribution = "nixos"}
+  ["diffutils"] {os-family = "suse"}
+  ["diffutils"] {os-distribution = "ol"}
+  ["diffutils"] {os-distribution = "arch"}
+]
+synopsis: "Virtual package relying on diffutils"
+description:
+  "This package can only install if the diffutils binary is installed on the system."
+flags: conf


### PR DESCRIPTION
the CI for some distros uses busybox, which doesn't have a full-featured diff (so tests break).