### PR TITLE
new conf package for perl packages

### DIFF
--- a/packages/conf-perl-packages/conf-perl-packages.1/opam
+++ b/packages/conf-perl-packages/conf-perl-packages.1/opam
@@ -35,6 +35,7 @@ depexts: [
     "perl-ipc-system-simple"
   ] {os-family = "arch"}
 ]
+available: [ os-distribution != "centos" & os-distribution != "ol" ]
 synopsis: "Virtual package relying on various perl package (so we can just depend-upon and test this"
 description:
   "This package can only install if the specified perl packages are on the system."

--- a/packages/conf-perl-packages/conf-perl-packages.1/opam
+++ b/packages/conf-perl-packages/conf-perl-packages.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "chetsky@gmail.com"
+homepage: "https://www.perl.org/"
+bug-reports: "chesky@gmail.com"
+license: "GPL-1.0-or-later"
+authors: "Larry Wall et. al."
+build: [
+  ["perl" "--version"]
+  ["perl" "-MIPC::System::Simple" "-e" "1"]
+  ["perl" "-MString::ShellQuote" "-e" "1"]
+]
+depexts: [
+  [
+    "libstring-shellquote-perl"
+    "libipc-system-simple-perl"
+  ] {os-family = "debian"}
+  [
+    "perl-string-shellquote"
+    "perl-ipc-system-simple"
+  ] {os-distribution = "alpine"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-distribution = "centos"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-family = "suse"}
+  [
+    "perl-String-ShellQuote"
+    "perl-IPC-System-Simple"
+  ] {os-family = "fedora"}
+  [
+    "perl-string-shellquote"
+    "perl-ipc-system-simple"
+  ] {os-family = "arch"}
+]
+synopsis: "Virtual package relying on various perl package (so we can just depend-upon and test this"
+description:
+  "This package can only install if the specified perl packages are on the system."
+flags: conf


### PR DESCRIPTION
This conf package depends on a list of external Perl packages, so that
(a) each package-maintainer can just add whatever they want to the list
(b) they don't have to divine how to do it themselves -- they can copy from other packages in the opam file already.
(c) when external-deps fail, they'll fail in this package, and not in every package that has those external deps.
(d) and of course, we can test them here, instead of in every package.