### PR TITLE
[new release] ocaml_portaudio (0.19.6)

### DIFF
--- a/packages/ocaml_portaudio/ocaml_portaudio.0.19.6/opam
+++ b/packages/ocaml_portaudio/ocaml_portaudio.0.19.6/opam
@@ -14,6 +14,7 @@ depends: [
   "dune" {>= "2.7"}
   "conf-portaudio"
   "ctypes"
+  "ctypes-foreign"
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ocaml_portaudio/ocaml_portaudio.0.19.6/opam
+++ b/packages/ocaml_portaudio/ocaml_portaudio.0.19.6/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Bindings to the C portaudio library"
+description: """
+Bindings to the C portaudio library."
+Exposes low-level C bindings and a higher level OCaml interface."
+Version corresponds to the portaudio version this was built to."
+"""
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/ocaml_portaudio"
+bug-reports: "https://github.com/wlitwin/ocaml_portaudio/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "conf-portaudio"
+  "ctypes"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/ocaml_portaudio.git"
+x-commit-hash: "22e69fc4e0a28e3290685e6c09e39b7f2b214e72"
+url {
+  src:
+    "https://github.com/wlitwin/ocaml_portaudio/releases/download/0.19.6/ocaml_portaudio-0.19.6.tbz"
+  checksum: [
+    "sha256=6c44b2c55ff0ed577ef158daeb5219dda3b0198958559db0a2142995bbbe0f2d"
+    "sha512=fc95800a4b83f214478363a68ab91475dfcf938882e140e7bddca9e131c49cec4e3e5eb9ebaae3b380369970b04473e9d021fa4e84560543ee3a7f54f07b85e9"
+  ]
+}


### PR DESCRIPTION
CHANGES:

First release of ocaml_portaudio bindings. These bindings are made for portaudio v19.6, may work with other versions. The bindings are more or less 1:1. The Ocaml_portaudio.Portaudio.C module contains the raw C bindings. The Ocaml_portaudio.Portaudio module contains a higher-level OCaml interface to the portaudio library. *Warning* The Portaudio.View module wraps plain C arrays, so be careful with them.