### PR TITLE
[new release] obuilder and obuilder-spec (0.2)

### DIFF
--- a/packages/obuilder-spec/obuilder-spec.0.2/opam
+++ b/packages/obuilder-spec/obuilder-spec.0.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Build specification format"
+description:
+  "A library for constructing, reading and writing OBuilder build specification files."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "fmt" {>= "0.8.9"}
+  "sexplib"
+  "astring"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ocaml" {>= "4.10.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+x-commit-hash: "4c2136d0975fae1880af38b7274a6765dea64da8"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.2/obuilder-spec-v0.2.tbz"
+  checksum: [
+    "sha256=598a7a5b1059842ca712674705f87c11efcf0491a26ec2c0a2c07448066edc5d"
+    "sha512=e6254b015d59ac48cf732a56ba6b78d38ac45fbd852f28a225ff4487d0379be0b004958805aee2be469d52e68a8e360a35d62cf10be79ecc96e975c97bce1a24"
+  ]
+}

--- a/packages/obuilder/obuilder.0.1/opam
+++ b/packages/obuilder/obuilder.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "sha"
   "sqlite3"
   "dockerfile"
-  "obuilder-spec"
+  "obuilder-spec" {= version}
   "ocaml" {>= "4.10.0"}
   "alcotest-lwt" {with-test}
   "odoc" {with-doc}

--- a/packages/obuilder/obuilder.0.2/opam
+++ b/packages/obuilder/obuilder.0.2/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_sexp_conv"
   "sha"
   "sqlite3"
-  "obuilder-spec"
+  "obuilder-spec" {= version}
   "ocaml" {>= "4.10.0"}
   "alcotest-lwt" {with-test}
   "odoc" {with-doc}

--- a/packages/obuilder/obuilder.0.2/opam
+++ b/packages/obuilder/obuilder.0.2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Run build scripts for CI"
+description:
+  "OBuilder takes a build script (similar to a Dockerfile) and performs the steps in it in a sandboxed environment."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "lwt"
+  "astring"
+  "fmt" {>= "0.8.9"}
+  "logs"
+  "cmdliner"
+  "tar-unix"
+  "yojson"
+  "sexplib"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "sha"
+  "sqlite3"
+  "obuilder-spec"
+  "ocaml" {>= "4.10.0"}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+x-commit-hash: "4c2136d0975fae1880af38b7274a6765dea64da8"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.2/obuilder-spec-v0.2.tbz"
+  checksum: [
+    "sha256=598a7a5b1059842ca712674705f87c11efcf0491a26ec2c0a2c07448066edc5d"
+    "sha512=e6254b015d59ac48cf732a56ba6b78d38ac45fbd852f28a225ff4487d0379be0b004958805aee2be469d52e68a8e360a35d62cf10be79ecc96e975c97bce1a24"
+  ]
+}


### PR DESCRIPTION
Run build scripts for CI

- Project page: <a href="https://github.com/ocurrent/obuilder">https://github.com/ocurrent/obuilder</a>
- Documentation: <a href="https://ocurrent.github.io/obuilder/">https://ocurrent.github.io/obuilder/</a>

##### CHANGES:

- Add support for nested / multi-stage builds (@talex5 ocurrent/obuilder#48 ocurrent/obuilder#49).  
  This allows you to use a large build environment to create a binary and then
  copy that into a smaller runtime environment. It's also useful to get better caching
  if two things can change independently (e.g. you want to build your software and also
  a linting tool, and be able to update either without rebuilding the other).

- Add healthcheck feature (@talex5 ocurrent/obuilder#52).  
  - Checks that Docker is running.
  - Does a test build using busybox.

- Clean up left-over runc containers on restart (@talex5 ocurrent/obuilder#53).  
  If btrfs crashes and makes the filesystem read-only then after rebooting there will be stale runc directories.
  New jobs with the same IDs would then fail.

- Remove dependency on dockerfile (@talex5 ocurrent/obuilder#51).  
  This also allows us more control over the formatting
  (e.g. putting a blank line between stages in multi-stage builds).

- Record log output from docker pull (@talex5 ocurrent/obuilder#46).  
  Otherwise, it's not obvious why we've stopped at a pull step, or what is happening.

- Improve formatting of OBuilder specs (@talex5 ocurrent/obuilder#45).

- Use seccomp policy to avoid necessary sync operations (@talex5 ocurrent/obuilder#44).  
  Sync operations are really slow on btrfs. They're also pointless,
  since if the computer crashes while we're doing a build then we'll just throw it away and start again anyway.
  Use a seccomp policy that causes all sync operations to "fail", with errno 0 ("success").
  On my machine, this reduces the time to `apt-get install -y shared-mime-info` from 18.5s to 4.7s.
  Use `--fast-sync` to enable to new behaviour (it requires runc 1.0.0-rc92).

- Use a mutex to avoid concurrent btrfs operations (@talex5 ocurrent/obuilder#43).  
  Btrfs deadlocks enough as it is. Don't stress it further by trying to do two things at once.

Internal changes:

- Improve handling of file redirections (@talex5 ocurrent/obuilder#46).  
  Instead of making the caller do all the work of closing the file descriptors safely, add an `FD_move_safely` mode.

- Travis tests: ensure apt cache is up-to-date (@talex5 ocurrent/obuilder#50).
