### PR TITLE
Package bimap.20201231

### DIFF
--- a/packages/bimap/bimap.20201231/opam
+++ b/packages/bimap/bimap.20201231/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "An OCaml library implementing bi-directional maps and multi-maps"
+description:
+  "Bi-directional maps permit clients to not only obtain a value provided a key, but to obtain a key provided a value"
+maintainer: ["papatangonyc@gmail.com"]
+authors: ["papatangonyc@gmail.com"]
+license: "GPLv3"
+homepage: "https://github.com/pat227/bimap.git"
+bug-reports: "https://github.com/pat227/bimap.git/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "core" {>= "v0.11.3"}
+  "dune" {>= "2.0"}
+  "ounit" {with-test & >= "2.2.2"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pat227/bimap.git.git"
+url {
+  src: "https://github.com/pat227/bimap/archive/20201231.tar.gz"
+  checksum: [
+    "md5=f6d279ec651aefd03ece86f4d0a7ed27"
+    "sha512=bf21e5bfbc26bba3835ac65eaa5fb261359aba030d2d7c50794b9e0f87a491b04999dd0053a9ffb3e9a551eabfb212dc7cde4384fb27b553c5044296806c0f3f"
+  ]
+}


### PR DESCRIPTION
### `bimap.20201231`
An OCaml library implementing bi-directional maps and multi-maps
Bi-directional maps permit clients to not only obtain a value provided a key, but to obtain a key provided a value



---
* Homepage: https://github.com/pat227/bimap.git
* Source repo: git+https://github.com/pat227/bimap.git.git
* Bug tracker: https://github.com/pat227/bimap.git/issues

---
:camel: Pull-request generated by opam-publish v2.0.2