### PR TITLE
[new release] dap (1.0.3)

### DIFF
--- a/packages/dap/dap.1.0.3/opam
+++ b/packages/dap/dap.1.0.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Debug adapter protocol"
+description: """
+The Debug Adapter Protocol defines the protocol used between an editor or IDE and a debugger or runtime.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocaml-dap"
+bug-reports: "https://github.com/hackwaly/ocaml-dap/issues"
+dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
+doc: "https://hackwaly.github.io/ocaml-dap/"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "yojson"
+  "ppx_here"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "lwt"
+  "lwt_ppx"
+  "lwt_react"
+  "react"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+x-commit-hash: "c811d5331984b6a5cd1fba7f2fe62d7990021c65"
+url {
+  src:
+    "https://github.com/hackwaly/ocaml-dap/releases/download/1.0.3/dap-1.0.3.tbz"
+  checksum: [
+    "sha256=a7a925d4633f65f89d401b7f267aaa3b5e0a14b16f34d533151bb8ca854e2938"
+    "sha512=a4174aa17e91832e444127881d42026ab41026bcf0f6ba521de609143cac3f5271e7031553d99d8f32a5a4da5ece6c1d4cf7a95835fdc089c1b098ef86de1fc7"
+  ]
+}


### PR DESCRIPTION
Debug adapter protocol

- Project page: <a href="https://github.com/hackwaly/ocaml-dap">https://github.com/hackwaly/ocaml-dap</a>
- Documentation: <a href="https://hackwaly.github.io/ocaml-dap/">https://hackwaly.github.io/ocaml-dap/</a>

##### CHANGES:

### Fixed

- Fix command failure will send response with `success=true`
