### PR TITLE
Package lastfm.0.3.3

### DIFF
--- a/packages/lastfm/lastfm.0.3.3/opam
+++ b/packages/lastfm/lastfm.0.3.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis:
+  "The lastfm library is an implementation of the API used by the last.fm to keep count of played songs"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["Romain Beauxis <toots@rastageeks.org>"]
+license: "LGPL-2.1"
+homepage: "https://github.com/savonet/ocaml-lastfm"
+bug-reports: "https://github.com/savonet/ocaml-lastfm/issues"
+depends: [
+  "xmlplaylist"
+  "pcre"
+  "dune" {>= "2.0"}
+]
+depopts: ["ocamlnet"]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-lastfm.git"
+url {
+  src: "https://github.com/savonet/ocaml-lastfm/archive/v0.3.3.tar.gz"
+  checksum: [
+    "md5=9daf9cf01667e1988bbf264be26fb424"
+    "sha512=2bbd0483719d0ea17862e761651eaccbc8ffa7d264ad03b8b1104077df9398fcfb879bd1914b68dc300c974c4ba3e2161d674cb1579ffd29e1e60f7dd3d3c2db"
+  ]
+}


### PR DESCRIPTION
### `lastfm.0.3.3`
The lastfm library is an implementation of the API used by the last.fm to keep count of played songs



---
* Homepage: https://github.com/savonet/ocaml-lastfm
* Source repo: git+https://github.com/savonet/ocaml-lastfm.git
* Bug tracker: https://github.com/savonet/ocaml-lastfm/issues

---
:camel: Pull-request generated by opam-publish v2.0.2