### PR TITLE
[new release] portaudio_c_bindings (19.6.0)

### DIFF
--- a/packages/portaudio_c_bindings/portaudio_c_bindings.19.6.0/opam
+++ b/packages/portaudio_c_bindings/portaudio_c_bindings.19.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Bindings to the C PortAudio library"
+description:
+  "Bindings to the C PortAudio library. Exposes low-level C bindings and a higher level OCaml interface. Version corresponds to the portaudio version this was built to."
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/portaudio_c_bindings"
+bug-reports: "https://github.com/wlitwin/portaudio_c_bindings/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "ocaml" {>= "4.08"}
+  "conf-portaudio"
+  "ctypes"
+  "ctypes-foreign"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/portaudio_c_bindings.git"
+x-commit-hash: "28f555d2e80a7ac24dffdb5d27ef09b6da58ee57"
+url {
+  src:
+    "https://github.com/wlitwin/portaudio_c_bindings/releases/download/19.6.0/portaudio_c_bindings-19.6.0.tbz"
+  checksum: [
+    "sha256=2cf27412d3dc5c4b748637b1655b393e8cc072386d4de66923bc39284b642dd2"
+    "sha512=c473bc2e68d313f94170b8aaa2b4e20457d2dd2f01593309f2b7971bfa224d58b0573069bab68cef8a2e232a44a48faf85e1a810e9a8dfd0d73b3a95e9b90b8d"
+  ]
+}


### PR DESCRIPTION
CHANGES:

First release of the bindings. These bindings are made for portaudio v19.6, may work with other versions. The bindings are more or less 1:1. The Portaudio_c_bindings.C_ffi module contains the raw C bindings. The Portaudio_c_bindings module contains a higher-level OCaml interface to the portaudio library. *Warning* The Portaudio.View module wraps plain C arrays, so be careful with them.