### PR TITLE
[new release] mirage-crypto-pk, mirage-crypto, mirage-crypto-rng, mirage-crypto-rng-mirage and mirage-crypto-rng-async (0.8.8)

### DIFF
--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.8/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.8/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.7"}
+  "rresult" {>= "0.6.0"}
+  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding")
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+x-commit-hash: "61488bba767a1b084002a26bfea0a182ce301a8a"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.8/mirage-crypto-v0.8.8.tbz"
+  checksum: [
+    "sha256=8b6ba8c51494c1b4585bf3a3a94e8f7c10419f4ffbe1c5fe77934de51df59fa5"
+    "sha512=5f130ae2690dcd4f9fa1df08209d3f7943120e87ac5833b3ba8b678e915be6efbca0dd062abedb71e0c1d158f229b4d35fa22bbb1d4a0c3aa0776d9133bb558c"
+  ]
+}

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.8.8/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.8.8/opam
@@ -18,8 +18,8 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "async"
   "logs"
-  "mirage-crypto"
-  "mirage-crypto-rng"
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
 ]
 available: os != "win32"
 description: """

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.8.8/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.8.8/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an Async-friendly way"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "async"
+  "logs"
+  "mirage-crypto"
+  "mirage-crypto-rng"
+]
+available: os != "win32"
+description: """
+
+Mirage-crypto-rng-async feeds the entropy source for Mirage_crypto_rng-based
+random number genreator implementations, in an Async-friendly way.
+"""
+x-commit-hash: "61488bba767a1b084002a26bfea0a182ce301a8a"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.8/mirage-crypto-v0.8.8.tbz"
+  checksum: [
+    "sha256=8b6ba8c51494c1b4585bf3a3a94e8f7c10419f4ffbe1c5fe77934de51df59fa5"
+    "sha512=5f130ae2690dcd4f9fa1df08209d3f7943120e87ac5833b3ba8b678e915be6efbca0dd062abedb71e0c1d158f229b4d35fa22bbb1d4a0c3aa0776d9133bb558c"
+  ]
+}

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.8/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.8/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "lwt" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+x-commit-hash: "61488bba767a1b084002a26bfea0a182ce301a8a"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.8/mirage-crypto-v0.8.8.tbz"
+  checksum: [
+    "sha256=8b6ba8c51494c1b4585bf3a3a94e8f7c10419f4ffbe1c5fe77934de51df59fa5"
+    "sha512=5f130ae2690dcd4f9fa1df08209d3f7943120e87ac5833b3ba8b678e915be6efbca0dd062abedb71e0c1d158f229b4d35fa22bbb1d4a0c3aa0776d9133bb558c"
+  ]
+}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.8/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.8/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "mirage-crypto" {=version}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+# lwt sublibrary
+  "mtime"
+  "lwt" {>= "4.0.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+x-commit-hash: "61488bba767a1b084002a26bfea0a182ce301a8a"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.8/mirage-crypto-v0.8.8.tbz"
+  checksum: [
+    "sha256=8b6ba8c51494c1b4585bf3a3a94e8f7c10419f4ffbe1c5fe77934de51df59fa5"
+    "sha512=5f130ae2690dcd4f9fa1df08209d3f7943120e87ac5833b3ba8b678e915be6efbca0dd062abedb71e0c1d158f229b4d35fa22bbb1d4a0c3aa0776d9133bb558c"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.8.8/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.8/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "eqaf" {>= "0.7"}
+]
+depopts: [
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
+hashes (MD5, SHA-1, SHA-2).
+"""
+x-commit-hash: "61488bba767a1b084002a26bfea0a182ce301a8a"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.8/mirage-crypto-v0.8.8.tbz"
+  checksum: [
+    "sha256=8b6ba8c51494c1b4585bf3a3a94e8f7c10419f4ffbe1c5fe77934de51df59fa5"
+    "sha512=5f130ae2690dcd4f9fa1df08209d3f7943120e87ac5833b3ba8b678e915be6efbca0dd062abedb71e0c1d158f229b4d35fa22bbb1d4a0c3aa0776d9133bb558c"
+  ]
+}


### PR DESCRIPTION
Simple public-key cryptography for the modern age

- Project page: <a href="https://github.com/mirage/mirage-crypto">https://github.com/mirage/mirage-crypto</a>
- Documentation: <a href="https://mirage.github.io/mirage-crypto/doc">https://mirage.github.io/mirage-crypto/doc</a>

##### CHANGES:

- new package mirage-crypto-rng-async, entropy feeding using async (mirage/mirage-crypto#90 @seliopou)
- Entropy.cpu_rng and Entropy.cpu_rng_bootstrap result in Error `Not_supported
  on CPUs without RDRAND/RDSEED support (previously an exception was raised
  in cpu_rng_bootstrap, and cpu_rng resulted in a no-op) (mirage/mirage-crypto#92 @seliopou)
- Entropy.cpu_rng delays entropy feeding (returns unit -> unit instead of unit).
  This fixes a memory leak, reported by @talex5 mirage/mirage-crypto#94, fixed in mirage/mirage-crypto#95 by @hannesm
- Avoid illegal instructions on X86 CPUs without SSSE3 instruction set. Both
  SHA256 and ChaCha used PSHUFB which is not available on e.g. AMD Phenom II
  (report mirage/mirage-crypto#93 by @dinosaure @samoht @pirbo @RichAyotte @sebeec, fixed in mirage/mirage-crypto#96 by
  @hannesm)
