### PR TITLE
[new release] magic-mime (1.1.3)

### DIFF
--- a/packages/magic-mime/magic-mime.1.1.3/opam
+++ b/packages/magic-mime/magic-mime.1.1.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Map filenames to common MIME types"
+description: """
+This library contains a database of MIME types that maps filename extensions
+into MIME types suitable for use in many Internet protocols such as HTTP or
+e-mail.  It is generated from the `mime.types` file found in Unix systems, but
+has no dependency on a filesystem since it includes the contents of the
+database as an ML datastructure.
+
+For example, here's how to lookup MIME types in the [utop] REPL:
+
+    #require "magic-mime";;
+    Magic_mime.lookup "/foo/bar.txt";;
+    - : bytes = "text/plain"
+    Magic_mime.lookup "bar.css";;
+    - : bytes = "text/css"
+"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy" "Maxence Guesdon"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-magic-mime"
+doc: "https://mirage.github.io/ocaml-magic-mime/"
+bug-reports: "https://github.com/mirage/ocaml-magic-mime/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-magic-mime.git"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+x-commit-hash: "ef9dbc7fbfa2613248bc17070ff4f06f61aa8b62"
+url {
+  src:
+    "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.1.3/magic-mime-v1.1.3.tbz"
+  checksum: [
+    "sha256=7fb36ce619ca479ac44ef923c3bf19eda4c98a4428dbf7f3f7c714b516d212f7"
+    "sha512=25445290f4d73d7cd09a5ef2a1cc6ac538e03a90b09d8f1703b6e1ed3bd499733dc6f7d8932a20ceda646304471cea1099054c3218e7736aab7bf76bfd7e0993"
+  ]
+}


### PR DESCRIPTION
Map filenames to common MIME types

- Project page: <a href="https://github.com/mirage/ocaml-magic-mime">https://github.com/mirage/ocaml-magic-mime</a>
- Documentation: <a href="https://mirage.github.io/ocaml-magic-mime/">https://mirage.github.io/ocaml-magic-mime/</a>

##### CHANGES:

* Fix build system for cross-compilation (@TheLortex, mirage/ocaml-magic-mime#19).
* Fix README (@seliopou, mirage/ocaml-magic-mime#18).
* Fix opam metadata (@CraigFe, mirage/ocaml-magic-mime#17).
