### PR TITLE
[new release] uri-sexp, uri and uri-re (4.1.0)

### DIFF
--- a/packages/uri-re/uri-re.4.1.0/opam
+++ b/packages/uri-re/uri-re.4.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "re" {>= "1.9.0"}
+  "stringext" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+messages: [ "Deprecated. This package is outdated, you should consider using uri instead" ]
+x-commit-hash: "b4a8375d9352d29ff495d35fc309609fad74631a"
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v4.1.0/uri-v4.1.0.tbz"
+  checksum: [
+    "sha256=d269901cd27cffaadfa077fe761ef334ad4cdbebeb065faeb833824617ab2ce1"
+    "sha512=bf9eb9aa29ced3ae9d39cb3ca8772de118bfe67d8fe2280f213e627f0fef7e80c7703a0dbb7d16c3d23c427866ee6b09c0973e6836e9c3b7225f55597356537c"
+  ]
+}

--- a/packages/uri-sexp/uri-sexp.4.1.0/opam
+++ b/packages/uri-sexp/uri-sexp.4.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+ocaml-uri with sexp support
+"""
+depends: [
+  "uri" {= version}
+  "dune" {>= "1.2.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "sexplib0"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+x-commit-hash: "b4a8375d9352d29ff495d35fc309609fad74631a"
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v4.1.0/uri-v4.1.0.tbz"
+  checksum: [
+    "sha256=d269901cd27cffaadfa077fe761ef334ad4cdbebeb065faeb833824617ab2ce1"
+    "sha512=bf9eb9aa29ced3ae9d39cb3ca8772de118bfe67d8fe2280f213e627f0fef7e80c7703a0dbb7d16c3d23c427866ee6b09c0973e6836e9c3b7225f55597356537c"
+  ]
+}

--- a/packages/uri/uri.4.1.0/opam
+++ b/packages/uri/uri.4.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "stringext" {>= "1.4.0"}
+  "angstrom" {>= "0.14.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+x-commit-hash: "b4a8375d9352d29ff495d35fc309609fad74631a"
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v4.1.0/uri-v4.1.0.tbz"
+  checksum: [
+    "sha256=d269901cd27cffaadfa077fe761ef334ad4cdbebeb065faeb833824617ab2ce1"
+    "sha512=bf9eb9aa29ced3ae9d39cb3ca8772de118bfe67d8fe2280f213e627f0fef7e80c7703a0dbb7d16c3d23c427866ee6b09c0973e6836e9c3b7225f55597356537c"
+  ]
+}


### PR DESCRIPTION
An RFC3986 URI/URL parsing library

- Project page: <a href="https://github.com/mirage/ocaml-uri">https://github.com/mirage/ocaml-uri</a>
- Documentation: <a href="https://mirage.github.io/ocaml-uri/">https://mirage.github.io/ocaml-uri/</a>

##### CHANGES:

* `uri-re` is deprecated, it is a legacy implementation that is now outdated. 
  `uri` should be used instead (@dinosaure, mirage/ocaml-uri#152).
* Fix build system for cross-compilation (@TheLortex, mirage/ocaml-uri#151).
