### PR TITLE
[new release] opam-monorepo (0.2.0)

### DIFF
--- a/packages/opam-monorepo/opam-monorepo.0.2.0/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Assemble and manage fully vendored Dune repositories"
+description: """
+The opam monorepo plugin provides a convenient interface to bridge the
+opam package manager with having a local copy of all the source
+code required to build a project using the dune build tool."""
+maintainer: ["anil@recoil.org"]
+authors: [
+  "Anil Madhavapeddy" "Nathan Rebours" "Lucas Pluvinage" "Jules Aguillon"
+]
+license: "ISC"
+homepage: "https://github.com/ocamllabs/opam-monorepo"
+bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "ocaml" {>= "4.08.0" & < "4.12"}
+]
+dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
+build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} "@doc" {with-doc} ]
+flags: [ plugin ]
+x-commit-hash: "641f6ea8e6ce56f716efb723dd974c653aa96ef6"
+url {
+  src:
+    "https://github.com/ocamllabs/opam-monorepo/releases/download/0.2.0/opam-monorepo-0.2.0.tbz"
+  checksum: [
+    "sha256=6f46d7c93232c9ea52651cd4c79e6f722cf0af91c914f5b2435c5fbc8e46df81"
+    "sha512=982f47b055746d0f3d4ef3765621d678299bfcade4a054e5ba1025b74017d027b5fe0102e5854d52d4d44c6e8644a8811c361d993075c70cda60886d50f73896"
+  ]
+}


### PR DESCRIPTION
Assemble and manage fully vendored Dune repositories

- Project page: <a href="https://github.com/ocamllabs/opam-monorepo">https://github.com/ocamllabs/opam-monorepo</a>

##### CHANGES:

### Changed

- Include transitive depexts in the lockfile (ocamllabs/opam-monorepo#144, @NathanReb)
