### PR TITLE
[new release] index and index-bench (1.3.0)

### DIFF
--- a/packages/index-bench/index-bench.1.3.0/opam
+++ b/packages/index-bench/index-bench.1.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.03.0"}
+  "cmdliner"
+  "dune"    {>= "2.7.0"}
+  "fmt"
+  "index"
+  "metrics"
+  "metrics-unix"
+  "ppx_deriving_yojson"
+  "re"
+  "stdlib-shims"
+  "yojson"
+  "ppx_repr"
+]
+
+synopsis: "Index benchmarking suite"
+x-commit-hash: "70bd80e40e0320075e80ddf443f7f462684cbdd3"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.3.0/index-1.3.0.tbz"
+  checksum: [
+    "sha256=d6fc288801f05962203dd820e358843e696cc0be775974df2a9ae9741e871c03"
+    "sha512=29b7659bd715e93ae9274db6e62d415bc514dd486dbb61a78f7f53bed421f0935ae3a1b99e19f2f7cebd06a13ba0e03538469ee228ff9feaf0c795e4d28c7410"
+  ]
+}

--- a/packages/index/index.1.3.0/opam
+++ b/packages/index/index.1.3.0/opam
@@ -13,9 +13,9 @@ dev-repo:     "git+https://github.com/mirage/index.git"
 doc:          "https://mirage.github.io/index/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/index/index.1.3.0/opam
+++ b/packages/index/index.1.3.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      [
+   "Craig Ferguson <craig@tarides.com>"
+   "Thomas Gazagnaire <thomas@tarides.com>"
+   "Ioana Cristescu <ioana@tarides.com>"
+   "Clément Pascutto <clement@tarides.com>"
+]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+doc:          "https://mirage.github.io/index/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "repr"    {>= "0.2.0"}
+  "ppx_repr"
+  "fmt"
+  "logs"
+  "mtime"   {>= "1.0.0"}
+  "cmdliner"
+  "progress"
+  "semaphore-compat"
+  "jsonm"
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "crowbar"  {with-test & >= "0.2"}
+  "re"       {with-test}
+]
+synopsis: "A platform-agnostic multi-level index for OCaml"
+description:"""
+Index is a scalable implementation of persistent indices in OCaml.
+
+It takes an arbitrary IO implementation and user-supplied content
+types and supplies a standard key-value interface for persistent
+storage. Index provides instance sharing: each OCaml
+run-time can share a common singleton instance.
+
+Index supports multiple-reader/single-writer access. Concurrent access
+is safely managed using lock files."""
+x-commit-hash: "70bd80e40e0320075e80ddf443f7f462684cbdd3"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.3.0/index-1.3.0.tbz"
+  checksum: [
+    "sha256=d6fc288801f05962203dd820e358843e696cc0be775974df2a9ae9741e871c03"
+    "sha512=29b7659bd715e93ae9274db6e62d415bc514dd486dbb61a78f7f53bed421f0935ae3a1b99e19f2f7cebd06a13ba0e03538469ee228ff9feaf0c795e4d28c7410"
+  ]
+}

--- a/packages/irmin-pack/irmin-pack.2.0.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"      {>= "4.02.3"}
   "dune"       {>= "1.1.0"}
   "irmin" {>= "2.0.0" & < "2.2.0"}
-  "index"      {>= "1.0.0"}
+  "index" {>= "1.0.0" & < "1.3.0"}
   "lwt"
   "irmin-test" {with-test & >= "2.0.0" & < "2.2.0"}
   "alcotest-lwt" {with-test}

--- a/packages/irmin-pack/irmin-pack.2.1.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"      {>= "4.02.3"}
   "dune"       {>= "1.8.0"}
   "irmin" {>= "2.0.0" & < "2.2.0"}
-  "index"      {>= "1.2.0"}
+  "index" {>= "1.2.0" & < "1.3.0"}
   "lwt"
   "irmin-test" {with-test & >= "2.0.0" & < "2.2.0"}
   "alcotest-lwt" {with-test}

--- a/packages/irmin-pack/irmin-pack.2.2.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"      {>= "4.02.3"}
   "dune"       {>= "1.8.0"}
   "irmin" {>= "2.2.0" & < "2.3.0"}
-  "index"      {>= "1.2.1"}
+  "index" {>= "1.2.1" & < "1.3.0"}
   "lwt"
   "irmin-test" {with-test & >= "2.2.0" & < "2.3.0"}
   "alcotest-lwt" {with-test}


### PR DESCRIPTION
A platform-agnostic multi-level index for OCaml

- Project page: <a href="https://github.com/mirage/index">https://github.com/mirage/index</a>
- Documentation: <a href="https://mirage.github.io/index/">https://mirage.github.io/index/</a>

##### CHANGES:

## Added

- Added `flush_callback` parameter to the creation of a store, to register
  a callback before a flush. This callback can be temporarily disabled by
  `~no_callback:()` to `flush`. (mirage/index#189, mirage/index#216)

- Added `Stats.merge_durations` to list the duration of the last 10 merges.
  (mirage/index#193)

- Added `is_merging` to detect if a merge is running. (mirage/index#192)

- New `IO.Header.{get,set}` functions to read and write the file headers
  atomically (mirage/index#175, mirage/index#204, @icristescu, @CraigFe, @samoht)

- Added a `throttle` configuration option to select the strategy to use
  when the cache are full and an async merge is already in progress. The
  current behavior is the (default) `` `Block_writes`` strategy. The new
  `` `Overcommit_memory`` does not block but continue to fill the cache instead.
  (mirage/index#209, @samoht)

- Add `IO.exists` obligation for IO implementations, to be used for lazy
  creation of IO instances. (mirage/index#233, @CraigFe)

- `Index.close` now takes an `~immediately:()` argument. When passed, this
  causes `close` to terminate any ongoing asynchronous merge operation, rather
  than waiting for it to finish. (mirage/index#185, mirage/index#234)

- Added `Index.Checks.cli`, which provides offline integrity checking of Index
  stores. (mirage/index#236)

- `Index.replace` now takes a `~overcommit` argument to postpone a merge. (mirage/index#253)

- `Index.merge` is now part of the public API. (mirage/index#253)

- `Index.try_merge` is now part of the public API. `try_merge' is a no-op if
  the number of entries in the write-ahead log is smaller than `log_size`,
  otherwise it's `merge'. (mirage/index#253 @samoht)

## Changed

- `sync` has to be called by the read-only instance to synchronise with the
  files on disk. (mirage/index#175)
- Caching of `Index` instances is now explicit: `Index.Make` requires a cache
  implementation, and `Index.v` may be passed a cache to be used for instance
  sharing. The default behaviour is _not_ to share instances. (mirage/index#188)

## Fixed

- Added values after a clear are found by read-only instances. (mirage/index#168)
- Fix a race between `merge` and `sync` (mirage/index#203, @samoht, @CraigFe)
- Fix a potential loss of data if a crash occurs at the end of a merge (mirage/index#232)
- Fix `Index.iter` to only iterate once over elements persisted on the disk
  (mirage/index#260, @samoht, @icristescu)
