### PR TITLE
Make opam-repository compatible with opam 2.1.0~beta4

### DIFF
--- a/packages/asli/asli.0.1/opam
+++ b/packages/asli/asli.0.1/opam
@@ -23,6 +23,7 @@ depends: [
   "zarith"
   "z3" {<= "4.7.1"}
 ]
+build-env: [OPAMCLI = "2.0"]
 build: [make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{asli:share}%" "asli"]
 install: [make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{asli:share}%" "install"]
 dev-repo: "git+https://github.com/alastairreid/asl-interpreter.git"

--- a/packages/asli/asli.0.2.0/opam
+++ b/packages/asli/asli.0.2.0/opam
@@ -23,6 +23,7 @@ depends: [
   "z3" {>= "4.8.7"}
   "alcotest" {with-test}
 ]
+build-env: [OPAMCLI = "2.0"]
 build: [
   ["dune" "subst"] {pinned}
   [

--- a/packages/crypt/crypt.1.3/opam
+++ b/packages/crypt/crypt.1.3/opam
@@ -1,10 +1,14 @@
 opam-version: "2.0"
 maintainer: "vb@luminar.eu.org"
+build-env: [OPAMCLI = "2.0"]
 build: make
-remove: [[make "uninstall"]]
-depends: ["ocaml" "ocamlfind" "ocaml-makefile"]
-dev-repo: "git://github.com/vbmithr/ocaml-crypt"
 install: [make "install"]
+depends: [
+  "ocaml"
+  "ocamlfind"
+  "ocaml-makefile"
+]
+dev-repo: "git://github.com/vbmithr/ocaml-crypt"
 synopsis: "Tiny binding for the unix crypt function"
 url {
   src: "https://github.com/vbmithr/ocaml-crypt/archive/1.3.tar.gz"

--- a/packages/gen-bs/gen-bs.0.0.0/opam
+++ b/packages/gen-bs/gen-bs.0.0.0/opam
@@ -5,9 +5,9 @@ homepage: "https://github.com/0zat/gen-bs"
 bug-reports: "https://github.com/0zat/gen-bs"
 license: "MIT"
 dev-repo: "git+https://github.com/0zat/gen-bs.git"
+build-env: [OPAMCLI = "2.0"]
 build: ["ocaml" "setup.ml" "build"]
 install: ["ocaml" "setup.ml" "install"]
-remove: ["ocaml" "setup.ml" "remove"]
 depends: [
   "ocaml"
   "ocamlfind" {build & >= "1.7.1"}

--- a/packages/labrys/labrys.0.1/opam
+++ b/packages/labrys/labrys.0.1/opam
@@ -6,6 +6,7 @@ homepage: "https://github.com/kit-ty-kate/labrys"
 dev-repo: "git+https://github.com/kit-ty-kate/labrys.git"
 bug-reports: "https://github.com/kit-ty-kate/labrys/issues"
 patches: ["fix-dune.patch"]
+build-env: [OPAMCLI = "2.0"]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/lascar/lascar.0.5/opam
+++ b/packages/lascar/lascar.0.5/opam
@@ -11,6 +11,7 @@ depends: [
   "camlp4"
   "ocamlfind" {build}
 ]
+build-env: [OPAMCLI = "2.0"]
 build: [
   ["./configure"]
   [make]

--- a/packages/lwt/lwt.5.0.0/opam
+++ b/packages/lwt/lwt.5.0.0/opam
@@ -46,6 +46,7 @@ post-messages: [
   https://github.com/ocsigen/lwt/issues/584"
 ]
 
+build-env: [OPAMCLI = "2.0"]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/lwt/lwt.5.1.1/opam
+++ b/packages/lwt/lwt.5.1.1/opam
@@ -46,6 +46,7 @@ post-messages: [
   https://github.com/ocsigen/lwt/issues/584"
 ]
 
+build-env: [OPAMCLI = "2.0"]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/mirage-xen-minios/mirage-xen-minios.0.2/opam
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.2/opam
@@ -3,6 +3,7 @@ maintainer: "mirageos-devel@lists.openmirage.org"
 tags: [
   "org:mirage"
 ]
+build-env: [OPAMCLI = "2.0"]
 build: [
   [make "build"]
 ]
@@ -12,7 +13,6 @@ This is used by the MirageOS framework to link OCaml unikernels to run
 directly as Xen guest kernels."""
 depends: ["ocaml"]
 available: os = "linux"
-flags: light-uninstall
 url {
   src:
     "https://github.com/mirage/mirage-xen-minios/releases/download/v0.2/mirage-xen-minios-v0.2.tar.bz2"

--- a/packages/mirage-xen-minios/mirage-xen-minios.0.3/opam
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.3/opam
@@ -3,6 +3,7 @@ maintainer: "mirageos-devel@lists.openmirage.org"
 tags: [
   "org:mirage"
 ]
+build-env: [OPAMCLI = "2.0"]
 build: [
   [make "build"]
 ]
@@ -12,7 +13,6 @@ This is used by the MirageOS framework to link OCaml unikernels to run
 directly as Xen guest kernels."""
 depends: ["ocaml"]
 available: os = "linux"
-flags: light-uninstall
 url {
   src:
     "https://github.com/mirage/mirage-xen-minios/releases/download/v0.3/mirage-xen-minios-v0.3.tar.bz2"

--- a/packages/mirage-xen-minios/mirage-xen-minios.0.4.1/opam
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.4.1/opam
@@ -3,6 +3,7 @@ maintainer: "mirageos-devel@lists.openmirage.org"
 tags: [
   "org:mirage"
 ]
+build-env: [OPAMCLI = "2.0"]
 build: [
   [make "build"]
 ]
@@ -12,7 +13,6 @@ This is used by the MirageOS framework to link OCaml unikernels to run
 directly as Xen guest kernels."""
 depends: ["ocaml"]
 available: os = "linux"
-flags: light-uninstall
 url {
   src:
     "https://github.com/mirage/mirage-xen-minios/releases/download/v0.4.1/mirage-xen-minios-v0.4.1.tar.bz2"

--- a/packages/mirage-xen-minios/mirage-xen-minios.0.4.2/opam
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.4.2/opam
@@ -3,6 +3,7 @@ maintainer: "mirageos-devel@lists.openmirage.org"
 tags: [
   "org:mirage"
 ]
+build-env: [OPAMCLI = "2.0"]
 build: [
   [make "build"]
 ]
@@ -12,7 +13,6 @@ This is used by the MirageOS framework to link OCaml unikernels to run
 directly as Xen guest kernels."""
 depends: ["ocaml"]
 available: os = "linux"
-flags: light-uninstall
 url {
   src:
     "https://github.com/mirage/mirage-xen-minios/releases/download/v0.4.2/mirage-xen-minios-v0.4.2.tar.bz2"

--- a/packages/mirage-xen-minios/mirage-xen-minios.0.4/opam
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.4/opam
@@ -3,6 +3,7 @@ maintainer: "mirageos-devel@lists.openmirage.org"
 tags: [
   "org:mirage"
 ]
+build-env: [OPAMCLI = "2.0"]
 build: [
   [make "build"]
 ]
@@ -12,7 +13,6 @@ This is used by the MirageOS framework to link OCaml unikernels to run
 directly as Xen guest kernels."""
 depends: ["ocaml"]
 available: os = "linux"
-flags: light-uninstall
 url {
   src:
     "https://github.com/mirage/mirage-xen-minios/releases/download/v0.4/mirage-xen-minios-v0.4.tar.bz2"

--- a/packages/mirage-xen-minios/mirage-xen-minios.0.5.0/opam
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.5.0/opam
@@ -3,6 +3,7 @@ maintainer: "mirageos-devel@lists.openmirage.org"
 tags: [
   "org:mirage"
 ]
+build-env: [OPAMCLI = "2.0"]
 build: [
   [make "build"]
 ]
@@ -12,7 +13,6 @@ This is used by the MirageOS framework to link OCaml unikernels to run
 directly as Xen guest kernels."""
 depends: ["ocaml"]
 available: os = "linux"
-flags: light-uninstall
 url {
   src:
     "https://github.com/mirage/mirage-xen-minios/releases/download/v0.5.0/mirage-xen-minios-v0.5.0.tar.bz2"

--- a/packages/mirage-xen-minios/mirage-xen-minios.0.6.0/opam
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.6.0/opam
@@ -3,6 +3,7 @@ maintainer: "mirageos-devel@lists.openmirage.org"
 tags: [
   "org:mirage"
 ]
+build-env: [OPAMCLI = "2.0"]
 build: [
   [make "build"]
 ]
@@ -12,7 +13,6 @@ This is used by the MirageOS framework to link OCaml unikernels to run
 directly as Xen guest kernels."""
 depends: ["ocaml"]
 available: os = "linux"
-flags: light-uninstall
 url {
   src:
     "https://github.com/mirage/mirage-xen-minios/releases/download/v0.6.0/mirage-xen-minios-v0.6.0.tar.bz2"

--- a/packages/mirage-xen-minios/mirage-xen-minios.0.7.0/opam
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.7.0/opam
@@ -3,6 +3,7 @@ maintainer: "mirageos-devel@lists.openmirage.org"
 tags: [
   "org:mirage"
 ]
+build-env: [OPAMCLI = "2.0"]
 build: [
   [make "build"]
 ]
@@ -15,7 +16,6 @@ description: """
 This is used by the MirageOS framework to link OCaml unikernels to run
 directly as Xen guest kernels."""
 available: os = "linux"
-flags: light-uninstall
 url {
   src:
     "https://github.com/mirage/mirage-xen-minios/releases/download/v0.7.0/mirage-xen-minios-v0.7.0.tar.bz2"

--- a/packages/mirage-xen-minios/mirage-xen-minios.0.8.0/opam
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.8.0/opam
@@ -11,7 +11,7 @@ tags: [
   "org:mirage"
 ]
 install: [
-  [make "build"]
+  ["env" "OPAMCLI=2.0" make "build"]
 ]
 available: [os = "linux"]
 depends: ["ocaml" "minios-xen"]
@@ -19,7 +19,6 @@ synopsis: "Xen MiniOS guest operating system library"
 description: """
 This is used by the MirageOS framework to link OCaml unikernels to run
 directly as Xen guest kernels."""
-flags: light-uninstall
 url {
   src:
     "https://github.com/mirage/mirage-xen-minios/releases/download/v0.8.0/mirage-xen-minios-v0.8.0.tar.bz2"

--- a/packages/mirage-xen-minios/mirage-xen-minios.0.9.3/opam
+++ b/packages/mirage-xen-minios/mirage-xen-minios.0.9.3/opam
@@ -11,8 +11,8 @@ tags: [
   "org:mirage"
 ]
 install: [
-  [make "depend"]
-  [make "build"]
+  ["env" "OPAMCLI=2.0" make "depend"]
+  ["env" "OPAMCLI=2.0" make "build"]
 ]
 available: [os = "linux"]
 depends: ["ocaml" "minios-xen"]
@@ -20,7 +20,6 @@ synopsis: "Xen MiniOS guest operating system library"
 description: """
 This is used by the MirageOS framework to link OCaml unikernels to run
 directly as Xen guest kernels."""
-flags: light-uninstall
 url {
   src: "https://github.com/mirage/mirage-xen-minios/archive/v0.9.3.tar.gz"
   checksum: "md5=d86817675f351d8fcc4f887f129ec953"

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.2/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.2/opam
@@ -6,9 +6,9 @@ bug-reports: "https://github.com/mirage/ocaml-freestanding/issues/"
 license: "MIT"
 tags: "org:mirage"
 dev-repo: "git+https://github.com/mirage/ocaml-freestanding.git"
+build-env: [OPAMCLI = "2.0"]
 build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
-remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "conf-pkg-config"
   "ocamlfind" {build}

--- a/packages/oranger/oranger.0.9.11/opam
+++ b/packages/oranger/oranger.0.9.11/opam
@@ -5,14 +5,12 @@ homepage: "https://github.com/UnixJunkie/oranger"
 bug-reports: "https://github.com/UnixJunkie/oranger/issues"
 dev-repo: "git+https://github.com/UnixJunkie/oranger.git"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+build-env: [OPAMCLI = "2.0"]
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 install: [
   ["sh" "compile_ranger.sh"]
-]
-remove: [
-  ["rm" "-f" "%{prefix}%/bin/ml_rf_ranger"]
 ]
 depends: [
   "jbuilder"
@@ -26,7 +24,6 @@ depends: [
   "cpm" {with-test}
   "conf-gnuplot" {with-test}
 ]
-flags: light-uninstall
 synopsis: "OCaml wrapper for the ranger (C++) random forests implementation"
 description: """
 Ranger is run from the command line and data are exchanged via text files.

--- a/packages/oranger/oranger.2.0.1/opam
+++ b/packages/oranger/oranger.2.0.1/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/UnixJunkie/oranger"
 bug-reports: "https://github.com/UnixJunkie/oranger/issues"
 dev-repo: "git+https://github.com/UnixJunkie/oranger.git"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+build-env: [OPAMCLI = "2.0"]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/pfff/pfff.0.40.4/opam
+++ b/packages/pfff/pfff.0.40.4/opam
@@ -19,6 +19,7 @@ homepage: "https://github.com/facebook/pfff/wiki/Main"
 bug-reports: "https://github.com/returntocorp/pfff/issues"
 dev-repo: "git+https://github.com/returntocorp/pfff.git"
 
+build-env: [OPAMCLI = "2.0"]
 build: [
   ["./configure" "--novisual" "--nocmt" "--nobytecode"]
   [make "depend"]

--- a/packages/rdbg/rdbg.1.184.1/opam
+++ b/packages/rdbg/rdbg.1.184.1/opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlfind"
   "ounit" {build & >= "2.0.0"}
 ]
+build-env: [OPAMCLI = "2.0"]
 build: [
   [make "build"]
   ["ocaml" "setup.ml" "-doc"] {with-doc}

--- a/packages/rfsm/rfsm.1.4.2/opam
+++ b/packages/rfsm/rfsm.1.4.2/opam
@@ -7,6 +7,7 @@ homepage: "http://cloud.ip.uca.fr/~serot/rfsm/"
 dev-repo: "git://github.com/jserot/rfsm.git"
 bug-reports: "jocelyn.serot@uca.fr"
 license: "MIT"
+build-env: [OPAMCLI = "2.0"]
 build: [
   ["./configure" "--no-gui" "--no-doc"]
   [make "opam"]

--- a/packages/rfsm/rfsm.1.5/opam
+++ b/packages/rfsm/rfsm.1.5/opam
@@ -7,6 +7,7 @@ homepage: "http://dream.ispr-ip.fr/RFSM"
 dev-repo: "git://github.com/jserot/rfsm.git"
 bug-reports: "jocelyn.serot@uca.fr"
 license: "MIT"
+build-env: [OPAMCLI = "2.0"]
 build: [
   ["./configure" "--no-gui" "--no-doc"]
   [make "opam"]

--- a/packages/user-setup/user-setup.0.1/opam
+++ b/packages/user-setup/user-setup.0.1/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/OCamlPro/opam-user-setup"
 bug-reports: "https://github.com/OCamlPro/opam-user-setup/issues"
 license: "ISC"
 dev-repo: "git+https://github.com/OCamlPro/opam-user-setup.git"
+build-env: [OPAMCLI = "2.0"]
 build: [make]
 install: [
   "./opam-user-setup"

--- a/packages/user-setup/user-setup.0.2/opam
+++ b/packages/user-setup/user-setup.0.2/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/OCamlPro/opam-user-setup"
 bug-reports: "https://github.com/OCamlPro/opam-user-setup/issues"
 license: "ISC"
 dev-repo: "git+https://github.com/OCamlPro/opam-user-setup.git"
+build-env: [OPAMCLI = "2.0"]
 build: [make]
 install: [
   "./opam-user-setup"

--- a/packages/user-setup/user-setup.0.3/opam
+++ b/packages/user-setup/user-setup.0.3/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/OCamlPro/opam-user-setup"
 bug-reports: "https://github.com/OCamlPro/opam-user-setup/issues"
 license: "ISC"
 dev-repo: "git+https://github.com/OCamlPro/opam-user-setup.git"
+build-env: [OPAMCLI = "2.0"]
 build: [make]
 install: [
   "./opam-user-setup"

--- a/packages/valentine/valentine.1.0.0/opam
+++ b/packages/valentine/valentine.1.0.0/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/fxfactorial/valentine"
 bug-reports: "https://github.com/fxfactorial/valentine/issues"
 license: "BSD-3-Clause"
 dev-repo: "git+https://github.com/fxfactorial/valentine.git"
+build-env: [OPAMCLI = "2.0"]
 build: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]


### PR DESCRIPTION
There are many other packages which now require `OPAMCLI=2.0` but let's start with these ones.
We will also need to to a thorough search of the logs as errors might be ignored in some cases and the only discovered when actually using the package.

cc @rjbou @AltGr 