### PR TITLE
adds bap-thumb and bap-systemz to the bap meta package

### DIFF
--- a/packages/bap/bap.2.2.0/opam
+++ b/packages/bap/bap.2.2.0/opam
@@ -70,8 +70,10 @@ depends: [
   "bap-strings" {= "2.2.0"}
   "bap-stub-resolver" {= "2.2.0"}
   "bap-symbol-reader" {= "2.2.0"}
+  "bap-systemz" {= "2.2.0"}
   "bap-taint" {= "2.2.0"}
   "bap-taint-propagator" {= "2.2.0"}
+  "bap-thumb" {= "2.2.0"}
   "bap-term-mapper" {= "2.2.0"}
   "bap-trace" {= "2.2.0"}
   "bap-traces" {= "2.2.0"}


### PR DESCRIPTION
We forgot to add those packages during the BAP 2.2.0 release. The packages implement support for systemz (very minimal) and thumb/thumb2 instruction sets.