### PR TITLE
camlbz2 changed upstream to gitlab.com

### DIFF
--- a/packages/camlbz2/camlbz2.0.6.0/opam
+++ b/packages/camlbz2/camlbz2.0.6.0/opam
@@ -14,16 +14,15 @@ build: [
   ["./configure" "--prefix" prefix]
   [make]
 ]
-remove: [["ocamlfind" "remove" "bz2"]]
-depends: ["ocaml" "ocamlfind" "conf-autoconf" "conf-aclocal"]
-depexts: [
-  ["libbz2-dev" "autoconf"] {os-family = "debian"}
-  ["bzip2-dev"] {os-family = "alpine"}
-  ["bzip2-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os = "oraclelinux"}
+depends: [
+  "ocaml"
+  "ocamlfind"
+  "conf-autoconf"
+  "conf-aclocal"
+  "conf-libbz2"
 ]
 install: [make "install"]
 synopsis: "Bindings for bzip2"
-flags: light-uninstall
 url {
   src: "https://gitlab.com/irill/camlbz2/-/archive/0.6.1/camlbz2-0.6.1.tar.gz"
   checksum: "md5=cfb844c53833f9c9726a79fe093490ad"

--- a/packages/camlbz2/camlbz2.0.6.0/opam
+++ b/packages/camlbz2/camlbz2.0.6.0/opam
@@ -9,21 +9,17 @@ license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 bug-reports: "https://gitlab.com/irill/camlbz2/issues"
 dev-repo: "git+https://gitlab.com/irill/camlbz2.git"
 build: [
-  ["aclocal" "-I" "."]
-  ["autoconf"]
   ["./configure" "--prefix" prefix]
   [make]
 ]
 depends: [
   "ocaml"
   "ocamlfind"
-  "conf-autoconf"
-  "conf-aclocal"
   "conf-libbz2"
 ]
 install: [make "install"]
 synopsis: "Bindings for bzip2"
 url {
-  src: "https://gitlab.com/irill/camlbz2/-/archive/0.6.1/camlbz2-0.6.1.tar.gz"
-  checksum: "md5=cfb844c53833f9c9726a79fe093490ad"
+  src: "https://gitlab.com/irill/camlbz2/uploads/77de1eae9411b4927b6849a3562341a1/camlbz2-0.6.0.tar.gz"
+  checksum: "md5=7a1cf822b3fe0ef57df4f8ebd86cac99"
 }

--- a/packages/camlbz2/camlbz2.0.6.0/opam
+++ b/packages/camlbz2/camlbz2.0.6.0/opam
@@ -4,21 +4,27 @@ authors: [
   "Olivier Andrieu"
   "Stefano Zacchiroli"
 ]
-homepage: "http://camlbz2.forge.ocamlcore.org/"
+homepage: "https://gitlab.com/irill/camlbz2"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+bug-reports: "https://gitlab.com/irill/camlbz2/issues"
+dev-repo: "git+https://gitlab.com/irill/camlbz2.git"
 build: [
+  ["aclocal" "-I" "."]
+  ["autoconf"]
   ["./configure" "--prefix" prefix]
   [make]
 ]
 remove: [["ocamlfind" "remove" "bz2"]]
-depends: ["ocaml" "ocamlfind"]
+depends: ["ocaml" "ocamlfind" "conf-autoconf" "conf-aclocal"]
 depexts: [
-  ["libbz2-dev"] {os-family = "debian"}
+  ["libbz2-dev" "autoconf"] {os-family = "debian"}
+  ["bzip2-dev"] {os-family = "alpine"}
+  ["bzip2-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os = "oraclelinux"}
 ]
 install: [make "install"]
 synopsis: "Bindings for bzip2"
 flags: light-uninstall
 url {
-  src: "https://download.ocamlcore.org/camlbz2/camlbz2/0.6.0/camlbz2-0.6.0.tar.gz"
-  checksum: "md5=7a1cf822b3fe0ef57df4f8ebd86cac99"
+  src: "https://gitlab.com/irill/camlbz2/-/archive/0.6.1/camlbz2-0.6.1.tar.gz"
+  checksum: "md5=cfb844c53833f9c9726a79fe093490ad"
 }

--- a/packages/conf-libbz2/conf-libbz2.1/opam
+++ b/packages/conf-libbz2/conf-libbz2.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://sourceware.org/bzip2/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "Bzip2 dev team"
+license: "BSD"
+build: [
+  ["sh" "-exc" "echo '#include <bzlib.h>' > test.c"]
+  ["sh" "-exc" "echo 'int main() { return 0; }' >> test.c"]
+  ["cc" "-lbz2" "test.c"]
+]
+depexts: [
+  ["libbz2-dev"] {os-family = "debian"}
+  ["libbz2-dev"] {os-family = "ubuntu"}
+  ["bzip2-dev"] {os-family = "alpine"}
+  ["bzip2-devel"] {os-distribution = "fedora"}
+  ["bzip2-devel"] {os-distribution = "rhel"}
+  ["bzip2-devel"] {os-distribution = "centos"}
+  ["bzip2-devel"] {os-distribution = "ol"}
+  ["libbz2-devel"] {os-family = "suse"}
+  ["bzip2"] {os-family = "arch"}
+  ["bzip2"] {os = "freebsd"}
+  ["bzip2"] {os = "openbsd"}
+  ["bzip2"] {os = "netbsd"}
+  ["bzip2"] {os = "macos" & os-distribution = "homebrew"}
+  ["bzip2"] {os = "macos" & os-distribution = "macports"}
+]
+synopsis: "Virtual package relying on libbz2"
+description:
+  "This package can only install if the libbz2 library is installed on the system."
+flags: conf


### PR DESCRIPTION
Hi,

with the blessings of its former maintainer @zacchiro the camlbz2 sources moved from the abandoned forge.ocamlcore to gitlab.com/irill/camlbz2.

Unfortunately, the tarball hashes are different because the new tarball is generated directly from git. As such, some files are now missing:

```
$ tar xf camlbz2-camlbz2-0.6.0.tar.gz
$ tar xf camlbz2-0.6.0.tar.gz
$ diff -ru camlbz2-0.6.0 camlbz2-camlbz2-0.6.0
Only in camlbz2-0.6.0: aclocal.m4
Only in camlbz2-0.6.0: configure
Only in camlbz2-0.6.0: doc
Only in camlbz2-camlbz2-0.6.0: .gitignore
Only in camlbz2-camlbz2-0.6.0: ocaml.m4
```

So before calling `./configure`, opam has to call `autoreconf` to generate `configure`. I am not an opam user, so I leave this change up to you.

Thanks!