### PR TITLE
Package opam-file-format.2.1.2

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.1.2/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Parser and printer for the opam file syntax"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-file-format/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+]
+depopts: ["dune"]
+build: [
+  [make "byte" {!ocaml:native} "all" {ocaml:native}] {!dune:installed}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+    {dune:installed}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:installed}
+]
+install: [make "install" "PREFIX=%{prefix}%"] {!dune:installed}
+dev-repo: "git+https://github.com/ocaml/opam-file-format"
+url {
+  src: "https://github.com/ocaml/opam-file-format/archive/2.1.2.tar.gz"
+  checksum: [
+    "md5=f16ed774167fc1881876b8185087e0ab"
+    "sha512=24fcc8a89dd79fee4fb54cfcd3a9b392819eb8214c97f43e226d44f1bc98111effade15f21f1e13aa5d3555cb458cbe269ba78ee4a1470c554f479446012d7ee"
+  ]
+}


### PR DESCRIPTION
### `opam-file-format.2.1.2`
Parser and printer for the opam file syntax



---
* Homepage: https://opam.ocaml.org
* Source repo: git+https://github.com/ocaml/opam-file-format
* Bug tracker: https://github.com/ocaml/opam-file-format/issues

---
:camel: Pull-request generated by opam-publish v2.0.3