### PR TITLE
[new release] irmin et al. (2.3.0)

### DIFF
--- a/packages/irmin-bench/irmin-bench.2.3.0/opam
+++ b/packages/irmin-bench/irmin-bench.2.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/irmin-bench/irmin-bench.2.3.0/opam
+++ b/packages/irmin-bench/irmin-bench.2.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"         {>= "2.7.0"}
+  "irmin-pack"   {= version}
+  "irmin-layers" {= version}
+  "irmin-test"   {= version}
+  "cmdliner"
+  "logs"
+  "lwt"
+  "ppx_deriving_yojson"
+  "yojson"
+  "memtrace"
+  "repr" {>= "0.2.0"}
+  "ppx_repr"
+]
+
+synopsis: "Irmin benchmarking suite"
+description: """
+`irmin-bench` provides access to the Irmin suite for benchmarking storage backend
+implementations.
+"""
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-chunk/irmin-chunk.2.3.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.2.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Mounir Nasr Allah" "Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "fmt"
+  "logs"
+  "lwt"
+  "irmin-mem"  {with-test & = version}
+  "irmin-test" {with-test & = version}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Irmin backend which allow to store values into chunks"
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-chunk/irmin-chunk.2.3.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.2.3.0/opam
@@ -7,9 +7,9 @@ bug-reports:  "https://github.com/mirage/irmin/issues"
 dev-repo:     "git+https://github.com/mirage/irmin.git"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-containers/irmin-containers.2.3.0/opam
+++ b/packages/irmin-containers/irmin-containers.2.3.0/opam
@@ -8,9 +8,9 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-containers/irmin-containers.2.3.0/opam
+++ b/packages/irmin-containers/irmin-containers.2.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["KC Sivaramakrishnan" "Anirudh Sunder Raj"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "irmin-mem"  {= version}
+  "irmin-unix" {= version}
+  "irmin-git"  {= version}
+  "ppx_irmin"  {= version}
+  "lwt"
+  "mtime"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+
+synopsis: "Mergeable Irmin data structures"
+description: """
+A collection of simple, ready-to-use mergeable data structures built using
+Irmin. Each data structure works with an arbitrary Irmin backend and is
+customisable in a variety of ways.
+"""
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-fs/irmin-fs.2.3.0/opam
+++ b/packages/irmin-fs/irmin-fs.2.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "astring"
+  "logs"
+  "lwt"
+  "irmin-test" {with-test & = version}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Generic file-system backend for Irmin"
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-fs/irmin-fs.2.3.0/opam
+++ b/packages/irmin-fs/irmin-fs.2.3.0/opam
@@ -8,9 +8,9 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-git/irmin-git.2.3.0/opam
+++ b/packages/irmin-git/irmin-git.2.3.0/opam
@@ -8,9 +8,9 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-git/irmin-git.2.3.0/opam
+++ b/packages/irmin-git/irmin-git.2.3.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "ppx_irmin"  {= version}
+  "git"        {>= "3.0.0"}
+  "digestif"   {>= "0.9.0"}
+  "cstruct"
+  "fmt"
+  "astring"
+  "fpath"
+  "logs"
+  "lwt"
+  "uri"
+  "git-cohttp-unix" {with-test}
+  "irmin-test" {with-test & = version}
+  "irmin-mem"  {with-test & = version}
+  "git-unix"   {with-test}
+  "mtime"      {with-test & >= "1.0.0"}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Git backend for Irmin"
+description: """
+`Irmin_git` expose a bi-directional bridge between Git repositories and
+Irmin stores.
+"""
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-graphql/irmin-graphql.2.3.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/packages/irmin-graphql/irmin-graphql.2.3.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors:      "Andreas Garnaes <andreas.garnaes@gmail.com>"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {>= "2.7.0"}
+  "irmin"          {= version}
+  "graphql"        {>= "0.13.0"}
+  "graphql-lwt"    {>= "0.13.0"}
+  "graphql-cohttp" {>= "0.13.0"}
+  "graphql_parser" {>= "0.13.0"}
+  "cohttp-lwt"
+  "cohttp"
+  "fmt"
+  "lwt"
+  "irmin-mem"       {with-test & = version}
+  "alcotest-lwt"    {with-test & >= "1.1.0"}
+  "yojson"          {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "alcotest"        {with-test & >= "1.2.3"}
+]
+
+
+synopsis: "GraphQL server for Irmin"
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-http/irmin-http.2.3.0/opam
+++ b/packages/irmin-http/irmin-http.2.3.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.7.0"}
+  "crunch"     {>= "2.2.0"}
+  "webmachine" {>= "0.6.0"}
+  "irmin"      {= version}
+  "ppx_irmin"  {= version}
+  "cohttp-lwt" {>= "1.0.0"}
+  "astring"
+  "cohttp"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt"
+  "uri"
+  "irmin-git"  {with-test & = version}
+  "irmin-mem"  {with-test & = version}
+  "irmin-test" {with-test & = version}
+  "git-unix"   {with-test & >= "3.0.0"}
+  "digestif"   {with-test & >= "0.9.0"}
+]
+
+synopsis: "HTTP client and server for Irmin"
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-http/irmin-http.2.3.0/opam
+++ b/packages/irmin-http/irmin-http.2.3.0/opam
@@ -8,9 +8,9 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-layers/irmin-layers.2.3.0/opam
+++ b/packages/irmin-layers/irmin-layers.2.3.0/opam
@@ -8,9 +8,9 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-layers/irmin-layers.2.3.0/opam
+++ b/packages/irmin-layers/irmin-layers.2.3.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.7.0"}
+  "mtime"      {>= "1.0.0"}
+  "irmin"      {= version}
+  "logs"
+  "lwt"
+  "irmin-test" {with-test & post & = version}
+]
+
+synopsis: "Combine different Irmin stores into a single, layered store"
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-mem/irmin-mem.2.3.0/opam
+++ b/packages/irmin-mem/irmin-mem.2.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"        {>= "4.03.0"}
+  "dune"         {>= "2.7.0"}
+  "irmin"        {= version}
+  "irmin-layers" {= version}
+  "logs"
+  "lwt"
+  "irmin-test" {with-test & = version}
+  "alcotest"   {with-test & >= "1.2.3"}
+]
+
+
+synopsis: "Generic in-memory Irmin stores"
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-mem/irmin-mem.2.3.0/opam
+++ b/packages/irmin-mem/irmin-mem.2.3.0/opam
@@ -8,9 +8,9 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.3.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.3.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"         {>= "2.7.0"}
+  "irmin-mirage" {= version}
+  "irmin-git"    {= version}
+  "mirage-kv"    {>= "3.0.0"}
+  "cohttp"
+  "conduit-lwt"
+  "conduit-mirage"
+  "git-cohttp-mirage" {>= "3.0.0"}
+  "fmt"
+  "git"               {>= "3.0.0"}
+  "lwt"
+  "mirage-clock"
+  "uri"
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.3.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.3.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.3.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"          {>= "2.7.0"}
+  "irmin-mirage"  {= version}
+  "irmin-graphql" {= version}
+  "mirage-clock"
+  "cohttp-lwt"
+  "lwt"
+  "uri"
+  "git"           {>= "3.0.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-mirage/irmin-mirage.2.3.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.2.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/irmin-mirage/irmin-mirage.2.3.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.2.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "irmin-mem"  {= version}
+  "fmt"
+  "ptime"
+  "mirage-clock" {>= "3.0.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-pack/irmin-pack.2.3.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.3.0/opam
@@ -9,7 +9,6 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 build: [
  ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
@@ -24,11 +23,6 @@ depends: [
   "lwt"
   "mtime"
   "cmdliner"
-  "irmin-test"   {with-test & = version}
-  "alcotest-lwt" {with-test}
-  "astring"      {with-test}
-  "fpath"        {with-test}
-  "alcotest"     {with-test}
 ]
 
 synopsis: "Irmin backend which stores values in a pack file"

--- a/packages/irmin-pack/irmin-pack.2.3.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"        {>= "4.08.0"}
+  "dune"         {>= "2.7.0"}
+  "irmin"        {= version}
+  "irmin-layers" {= version}
+  "ppx_irmin"    {= version}
+  "index"        {>= "1.3.0"}
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime"
+  "cmdliner"
+  "irmin-test"   {with-test & = version}
+  "alcotest-lwt" {with-test}
+  "astring"      {with-test}
+  "fpath"        {with-test}
+  "alcotest"     {with-test}
+]
+
+synopsis: "Irmin backend which stores values in a pack file"
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-pack/irmin-pack.2.3.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.3.0/opam
@@ -7,9 +7,9 @@ bug-reports:  "https://github.com/mirage/irmin/issues"
 dev-repo:     "git+https://github.com/mirage/irmin.git"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-test/irmin-test.2.3.0/opam
+++ b/packages/irmin-test/irmin-test.2.3.0/opam
@@ -8,7 +8,7 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/irmin-test/irmin-test.2.3.0/opam
+++ b/packages/irmin-test/irmin-test.2.3.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "irmin"        {= version}
+  "irmin-layers" {= version}
+  "ppx_irmin"    {= version}
+  "ocaml"        {>= "4.02.3"}
+  "dune"         {>= "2.7.0"}
+  "alcotest"     {>= "1.0.1"}
+  "mtime"        {>= "1.0.0"}
+  "astring"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt"
+  "metrics-unix"
+  "ocaml-syntax-shims"
+  "cmdliner"
+  "metrics" {>= "0.2.0"}
+]
+
+synopsis: "Irmin test suite"
+description: """
+`irmin-test` provides access to the Irmin test suite for testing storage backend
+implementations.
+"""
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-unix/irmin-unix.2.3.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.3.0/opam
@@ -8,9 +8,9 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-unix/irmin-unix.2.3.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.3.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.01.0"}
+  "dune"          {>= "2.7.0"}
+  "irmin"         {= version}
+  "irmin-mem"     {= version}
+  "irmin-git"     {= version}
+  "irmin-http"    {= version}
+  "irmin-fs"      {= version}
+  "irmin-pack"    {= version}
+  "irmin-graphql" {= version}
+  "irmin-layers"  {= version}
+  "git-unix"
+  "digestif"      {>= "0.9.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "yaml"          {>= "0.1.0"}
+  "astring"
+  "astring"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit"
+  "conduit-lwt"
+  "conduit-lwt-unix"
+  "logs"
+  "uri"
+  "cmdliner"
+  "cohttp-lwt-unix"
+  "fmt"
+  "git"             {>= "3.0.0"}
+  "git-cohttp-unix" {>= "3.0.0"}
+  "lwt"
+  "irmin-test"    {with-test & = version}
+  "alcotest"      {with-test}
+]
+
+synopsis: "Unix backends for Irmin"
+description: """
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.
+"""
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin-unix/irmin-unix.2.3.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.3.0/opam
@@ -10,7 +10,6 @@ doc:          "https://mirage.github.io/irmin/"
 build: [
  ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
@@ -44,8 +43,6 @@ depends: [
   "git"             {>= "3.0.0"}
   "git-cohttp-unix" {>= "3.0.0"}
   "lwt"
-  "irmin-test"    {with-test & = version}
-  "alcotest"      {with-test}
 ]
 
 synopsis: "Unix backends for Irmin"

--- a/packages/irmin/irmin.2.3.0/opam
+++ b/packages/irmin/irmin.2.3.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.07.0"}
+  "dune"    {>= "2.7.0"}
+  "repr"    {>= "0.2.0"}
+  "fmt"     {>= "0.8.0"}
+  "uri"     {>= "1.3.12"}
+  "uutf"
+  "jsonm"   {>= "1.0.0"}
+  "lwt"     {>= "2.4.7"}
+  "base64"  {>= "2.0.0"}
+  "digestif" {>= "0.9.0"}
+  "ocamlgraph"
+  "logs"    {>= "0.5.0"}
+  "bheap" {>= "2.0.0"}
+  "astring"
+  "ppx_irmin" {= version}
+  "hex"      {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "alcotest-lwt" {with-test}
+  "irmin-mem" {with-test & post & = version}
+]
+synopsis: """
+Irmin, a distributed database that follows the same design principles as Git
+"""
+description: """
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.
+"""
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/irmin/irmin.2.3.0/opam
+++ b/packages/irmin/irmin.2.3.0/opam
@@ -8,9 +8,9 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin/irmin.2.3.0/opam
+++ b/packages/irmin/irmin.2.3.0/opam
@@ -10,7 +10,6 @@ doc:          "https://mirage.github.io/irmin/"
 build: [
  ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
@@ -29,10 +28,6 @@ depends: [
   "bheap" {>= "2.0.0"}
   "astring"
   "ppx_irmin" {= version}
-  "hex"      {with-test}
-  "alcotest" {>= "1.1.0" & with-test}
-  "alcotest-lwt" {with-test}
-  "irmin-mem" {with-test & post & = version}
 ]
 synopsis: """
 Irmin, a distributed database that follows the same design principles as Git

--- a/packages/ppx_irmin/ppx_irmin.2.3.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.2.3.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Craig Ferguson <craig@tarides.com>"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mirage/irmin.git"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {>= "2.7.0"}
+  "ocaml" {>= "4.08.0"}
+  "ppxlib" {>= "0.12.0" & < "0.18.0"}
+  "ppx_repr" {>= "0.2.0"}
+  "irmin" {with-test & post & = version}
+]
+
+synopsis: "PPX deriver for Irmin type representations"
+x-commit-hash: "3e22238e86b6bac0c4eddff5b899efeaebe49dc9"
+authors: "Craig Ferguson <craig@tarides.com>"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.3.0/irmin-2.3.0.tbz"
+  checksum: [
+    "sha256=41d1d08cedb19d17935b7e840f18265ebd8b8a50cc3797d031aee992125070a6"
+    "sha512=ff527303850c2e36853ae0857f2ecbc22b5096f87197521dd049f80a234228c74f840aadef6d7c826acceda7b0a49e1dc2b5c105bb65d7c9551f0f8f377b2fc6"
+  ]
+}

--- a/packages/ppx_irmin/ppx_irmin.2.3.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.2.3.0/opam
@@ -6,7 +6,7 @@ license: "ISC"
 dev-repo: "git+https://github.com/mirage/irmin.git"
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/packages/tezos-storage/tezos-storage.8.0/opam
+++ b/packages/tezos-storage/tezos-storage.8.0/opam
@@ -8,8 +8,8 @@ license: "MIT"
 depends: [
   "dune" { >= "2.0" }
   "tezos-lmdb" { = "7.4" }
-  "irmin" { >= "2.2.0" }
-  "irmin-pack" { >= "2.1.0" }
+  "irmin" { >= "2.2.0" & < "2.3"}
+  "irmin-pack" { >= "2.1.0" & < "2.3"}
   "digestif" {>= "0.7.3"}
   "tezos-shell-services" { = version }
   "alcotest-lwt" { with-test & >= "1.1.0" }


### PR DESCRIPTION
- Project page: <a href="https://github.com/mirage/irmin">https://github.com/mirage/irmin</a>

### Fixed

- **irmin-git**
  - Update `irmin` to the last version of `ocaml-git` (#1065)
    It fixes an issue on serialization/deserialization of big tree object
    (see #1001) 

- **irmin-pack***
  - Fix a major bug in the LRU which was never used (#1035, @samoht)

- **irmin***
  - Improve performance of `last_modified` (#948, @pascutto)

  - Changed the pattern matching of the function `last_modified`. The case of a
    created key is now considered a modification by the function. (#1167,
    @clecat)

  - Make Tree.clear tail-recursive (#1171, @samoht)

  - Fix `Tree.fold ~force:(False f)` where results where partially skipped
    (#1174, @Ngoguey42, @samoht and @CraigFe )

  - Fix `Tree.kind`. Empty path on a tree used to return a None instead of a
	`` `Node``. (#1218, @Ngoguey42)

- **ppx_irmin**
  - Fix a bug causing certain type derivations to be incorrect due to unsound
    namespacing. (#1083, @CraigFe)

- **irmin-unix**
  - Update irmin config path to respect `XDG_CONFIG_HOME`. (#1168, @zshipko)

#### Added

- **irmin-layers** (_new_):
  - Created a new package, `irmin-layers` that includes common signatures for
    layered stores. It contains a stub `Make_layers` functor (#882, @icristescu)

- **irmin-bench** (_new_):
  - Created a new package to contain benchmarks for Irmin and its various
    backends. (#1142, @CraigFe)
  - Added ability to get json output and a make target to run layers benchmark.
    (#1146, @gs0510)

- **irmin**
  - Added `Tree.{Contents,Node}` modules exposing operations over lazy tree
    contents and nodes respectively. (#1022, @CraigFe)

  - Added `Type.Unboxed.{encode_bin,decode_bin,size_of}` to work with unboxed
    values (#1030, @samoht)

  - Remove the `headers` option in `Type.{encode_bin,decode_bin,size_of}`. Use
    `Type.Unboxed.<fn>` instead (#1030, @samoht)

  - `Type.v` now takes an extra mandatory `unit` argument (#1030, @samoht)

  - Added `Type.pp_dump`, which provides a way to pretty-print values with a
    syntax almost identical to native OCaml syntax, so that they can easily be
    copy-pasted into an OCaml REPL for inspection. (#1046, @liautaud)

  - Generic functions in `Irmin.Type` are now more efficient when a partial
    closure is constructed to the type representation (#1030 #1093, @samoht
    @CraigFe).  To make this even more explicit, these functions are now staged
    and `Type.{unstage,stage}` can manipulate these. The goal is to encourage
    users to write this kind of (efficent) pattern:
    ```ocaml
    let encode_bin = Type.(unstage (encode_bin ty))
    let _ = <begin loop> ... encode_bin foo ... <end loop>
    ```
  - Added a `clear` function for stores (#1071, @icristescu, @CraigFe)

  - Requires digestif>=0.9 to use digestif's default variants
    (#873, @pascutto, @samoht)

  - Added `iter_commits` and `iter_nodes` functions to traverse the commits and
    nodes graphs (#1077, @icristescu)

  - Added `Repo.iter` to traverse object graphs (#1128, @samoht)

- **irmin-pack**:
  - Added `index_throttle` option to `Irmin_pack.config`, which exposes the
    memory throttle feature of `Index` in `Irmin-Pack`. (#1049, @icristescu)

  - Added `Pack.clear` and `Dict.clear` (#1047, @icristescu, @CraigFe, @samoht)

  - Added a `migrate` function for upgrading stores with old formats (#1070,
    @icristescu, @CraigFe)

  - Added a `flush` function for a repo (#1092, @icristescu)

  - Added `Layered.Make functor, to construct layered stores from irmin-pack.
    (#882, @icristescu)

  - Added `Checks.Make which provides some offline checks for irmin-pack
    stores. (#1117, @icristescu, @CraigFe)

  - Added `reconstruct_index` to reconstruct an index from a pack file. (#1097,
    @icristescu)

  - Added `reconstruct-index` command to `irmin-fsck` for reconstructing an index from
    the command line (#1189, @zshipko)

  - Added `integrity-check` command to `irmin-fsck` for checking the integrity of
    an `irmin-pack` store (#1196, @zshipko)

- **ppx_irmin**:

  - Added support for deriving type representations for types with type
    parameters. Type `'a t` generates a representation of type
    `'a Type.t -> 'a t Type.t` (#1085, @CraigFe)

  - Added a `--lib` command-line option which has the same behaviour as the
    `lib` run-time argument (i.e. `--lib Foo` will cause `ppx_irmin` to derive
    type representations using combinators in the `Foo` module). (#1086,
    @CraigFe)

  - Added an extension point `[typ: <core-type>]` for deriving type
    representations inline. (#1087, @CraigFe)

#### Changed

- **irmin**
  - Renamed the `Tree.tree` type to `Tree.t`. (#1022, @CraigFe)

  - Replaced `Tree.pp_stats` with the type representation `Tree.stats_t`. (#TODO, @CraigFe)

  - Changed the JSON encoding of special floats. `Float.nan`, `Float.infinity`
    and `Float.neg_infinity` are now encoded as `"nan"`, `"inf"` and `"-inf"`
    respectively. (#979, @liautaud)

  - The functions `Type.{v,like,map}` no longer take a `~cli` argument, and now
    take separate `~pp` and `~of_string` arguments instead. (#1103, @CraigFe)

  - The `Irmin.Type` combinators are now supplied by the `repr` package. The
    API of `Irmin.Type` is not changed. (#1106, @CraigFe)

  - `Irmin.Type` uses staging for `equal`, `short_hash` and `compare` to
    speed-up generic operations (#1130, #1131, #1132, @samoht)

  - Make `Tree.fold` more expressive and ensure it uses a bounded memory
    (#1169, @samoht)

- **irmin-pack**:
  - `sync` has to be called by the read-only instance to synchronise with the
    files on disk. (#1008, @icristescu)

  - Renamed `sync` to `flush` for the operation that flushes to disk all buffers
    of a read-write instance. (#1008, @icristescu)

  - Changed the format of headers for the files on disk to include a generation
    number. Version 1 of irmin-pack was used for the previous format, version 2
    is used with the new format. (#1047, @icristescu, @CraigFe, @samoht)

  - Use `Repo.iter` to speed-up copies between layers (#1149, #1150 @samoht)

  - Add an option to bypass data integrity checks on reads (#1154, @samoht)

  - Add `heads` parameter to `check-self-contained` command in `Checks` (#1224, @zshipko)

- **ppx_irmin**:

  - The `[@generic ...]` attribute has been renamed to `[@repr ...]`. (#1082,
    @CraigFe)

