### PR TITLE
[new release] cinaps (v0.15.0)

### DIFF
--- a/packages/cinaps/cinaps.v0.15.0/opam
+++ b/packages/cinaps/cinaps.v0.15.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/cinaps"
+bug-reports: "https://github.com/ocaml-ppx/cinaps/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/cinaps.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {>= "2.0.0"}
+  "re"   {>= "1.8.0"}
+  "ppx_jane" {with-test}
+  "base-unix"
+]
+synopsis: "Trivial metaprogramming tool"
+description: "
+Cinaps is a trivial Metaprogramming tool using the OCaml toplevel.  It
+is based on the same idea as expectation tests. The user write some
+OCaml code inside special comments and cinaps make sure that what
+follows is what is printed by the OCaml code.
+"
+x-commit-hash: "3bdcc8c2a881665f1e972eaef86c3454c183f8b4"
+url {
+  src:
+    "https://github.com/ocaml-ppx/cinaps/releases/download/v0.15.0/cinaps-v0.15.0.tbz"
+  checksum: [
+    "sha256=9f5500dbdaeb7ac3f0932eaeafaa9ac7bbe2c730a8f79f782500489b37cd26c2"
+    "sha512=2634d4576451274567c1de6f18c51bb3d8ad91e0a02708c151b5616e53f54f285804157841fa14e16dbeb22a9e7575fc93d28b6122972811aa4b302b218a5183"
+  ]
+}


### PR DESCRIPTION
Trivial metaprogramming tool

- Project page: <a href="https://github.com/ocaml-ppx/cinaps">https://github.com/ocaml-ppx/cinaps</a>

##### CHANGES:

### Fixed

- Make cinaps compatible with ocaml 4.04 (ocaml-ppx/cinaps#4, @NathanReb)
