### PR TITLE
Package opam-publish.2.0.3

### DIFF
--- a/packages/opam-publish/opam-publish.2.0.3/opam
+++ b/packages/opam-publish/opam-publish.2.0.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+build: [ "dune" "build" "-p" name "-j" jobs ]
+depends: [
+  "cmdliner"
+  "dune" {>= "1.0"}
+  "lwt_ssl"
+  "ocaml" {>= "4.03.0"}
+  "opam-core" {>= "2.0.0" & < "2.1"}
+  "opam-format" {>= "2.0.0" & < "2.1"}
+  "opam-state" {>= "2.0.0" & < "2.1"}
+  "github" {>= "2.0.0" & < "4.3.0" | >= "4.3.2"}
+  "github-unix" {>= "2.0.0" & < "4.3.0" | >= "4.3.2"}
+  ("ssl" {= "0.5.5"} | "tls")
+]
+flags: plugin
+synopsis: "A tool to ease contributions to opam repositories"
+description: """
+opam-publish automates publishing packages to package repositories: it checks that the
+opam file is complete using `opam lint`, verifies and adds the archive URL and its
+checksum and files a GitHub pull request for merging it.
+"""
+url {
+  src: "https://github.com/ocaml/opam-publish/archive/2.0.3.tar.gz"
+  checksum: [
+    "md5=70c85c2cd9247c2717aebba28891db7b"
+    "sha512=f095581dcf1b8ac77ce133b7de6f93a0b1b7583148fd6a67820932a1338bdcd6713be40cbbd778d20b82d28f08e81a5c706f2e6d0ba39f579895fd24b439dd75"
+  ]
+}


### PR DESCRIPTION
### `opam-publish.2.0.3`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.0.2