### PR TITLE
[new release] opam-monorepo (0.2.1)

### DIFF
--- a/packages/opam-monorepo/opam-monorepo.0.2.0/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.0/opam
@@ -18,6 +18,24 @@ depends: [
 dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
 build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} "@doc" {with-doc} ]
 flags: [ plugin ]
+depexts: [
+  ["devel/pkgconf"] {os = "openbsd"}
+  ["pkg-config"] {os-distribution = "cygwinports"}
+  ["pkg-config"] {os-family = "debian"}
+  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "freebsd"}
+  ["pkgconf"] {os-distribution = "alpine"}
+  ["pkgconf"] {os-distribution = "arch"}
+  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
+  ["pkgconfig"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-distribution = "mageia"}
+  ["pkgconfig"] {os-distribution = "nixos"}
+  ["pkgconfig"] {os-distribution = "ol"}
+  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
+  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
+]
 x-commit-hash: "641f6ea8e6ce56f716efb723dd974c653aa96ef6"
 url {
   src:

--- a/packages/opam-monorepo/opam-monorepo.0.2.0/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.0/opam
@@ -14,28 +14,11 @@ bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.6"}
   "ocaml" {>= "4.08.0" & < "4.12"}
+  "conf-pkg-config" {build}
 ]
 dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
 build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} "@doc" {with-doc} ]
 flags: [ plugin ]
-depexts: [
-  ["devel/pkgconf"] {os = "openbsd"}
-  ["pkg-config"] {os-distribution = "cygwinports"}
-  ["pkg-config"] {os-family = "debian"}
-  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
-  ["pkgconf"] {os = "freebsd"}
-  ["pkgconf"] {os-distribution = "alpine"}
-  ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
-  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
-  ["pkgconfig"] {os-distribution = "fedora"}
-  ["pkgconfig"] {os-distribution = "mageia"}
-  ["pkgconfig"] {os-distribution = "nixos"}
-  ["pkgconfig"] {os-distribution = "ol"}
-  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
-  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
-  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
-]
 x-commit-hash: "641f6ea8e6ce56f716efb723dd974c653aa96ef6"
 url {
   src:

--- a/packages/opam-monorepo/opam-monorepo.0.2.1/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Assemble and manage fully vendored Dune repositories"
+description: """
+The opam monorepo plugin provides a convenient interface to bridge the
+opam package manager with having a local copy of all the source
+code required to build a project using the dune build tool."""
+maintainer: ["anil@recoil.org"]
+authors: [
+  "Anil Madhavapeddy" "Nathan Rebours" "Lucas Pluvinage" "Jules Aguillon"
+]
+license: "ISC"
+homepage: "https://github.com/ocamllabs/opam-monorepo"
+bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "ocaml" {>= "4.08.0" & < "4.12"}
+]
+dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
+build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} ]
+flags: [ plugin ]
+depexts: [
+  ["devel/pkgconf"] {os = "openbsd"}
+  ["pkg-config"] {os-distribution = "cygwinports"}
+  ["pkg-config"] {os-family = "debian"}
+  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "freebsd"}
+  ["pkgconf"] {os-distribution = "alpine"}
+  ["pkgconf"] {os-distribution = "arch"}
+  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
+  ["pkgconfig"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-distribution = "mageia"}
+  ["pkgconfig"] {os-distribution = "nixos"}
+  ["pkgconfig"] {os-distribution = "ol"}
+  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
+  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
+]
+x-commit-hash: "89ecff43af77614a58c11ffc565af9dd26dca555"
+url {
+  src:
+    "https://github.com/ocamllabs/opam-monorepo/releases/download/0.2.1/opam-monorepo-0.2.1.tbz"
+  checksum: [
+    "sha256=e066eaf0dedcc7733f8d0eb0e53f36f4d07ef55a2cccc0e526e25b23df25b6f8"
+    "sha512=358815be8d7a73a49eb4bc4e926cd85cec33207a1871bac3d35e3cf76a828c4135a6601fa1af8e423c7c1878b543aebbda7466d227a1e69b4a4a586ea6290679"
+  ]
+}

--- a/packages/opam-monorepo/opam-monorepo.0.2.1/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.1/opam
@@ -14,28 +14,11 @@ bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.6"}
   "ocaml" {>= "4.08.0" & < "4.12"}
+  "conf-pkg-config" {build}
 ]
 dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
 build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} ]
 flags: [ plugin ]
-depexts: [
-  ["devel/pkgconf"] {os = "openbsd"}
-  ["pkg-config"] {os-distribution = "cygwinports"}
-  ["pkg-config"] {os-family = "debian"}
-  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
-  ["pkgconf"] {os = "freebsd"}
-  ["pkgconf"] {os-distribution = "alpine"}
-  ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
-  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
-  ["pkgconfig"] {os-distribution = "fedora"}
-  ["pkgconfig"] {os-distribution = "mageia"}
-  ["pkgconfig"] {os-distribution = "nixos"}
-  ["pkgconfig"] {os-distribution = "ol"}
-  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
-  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
-  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
-]
 x-commit-hash: "89ecff43af77614a58c11ffc565af9dd26dca555"
 url {
   src:


### PR DESCRIPTION
Assemble and manage fully vendored Dune repositories

- Project page: <a href="https://github.com/ocamllabs/opam-monorepo">https://github.com/ocamllabs/opam-monorepo</a>

##### CHANGES:

### Fixed

- Fix `--recurse-opam` option for the monorepo lock phase: correctly perform special directory
  filtering, add an error message when two versions of the same package opam file exist in the
  source tree, perform package name filtering before checking for uniqueness (ocamllabs/opam-monorepo#151, @TheLortex)
