### PR TITLE
[new release] git, git-cohttp, git-cohttp-mirage, git-cohttp-unix, git-unix and git-mirage (3.1.0)

### DIFF
--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.1.0/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.6.0"}
+  "git" {= version}
+  "mimic"
+  "cohttp-mirage"
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "bigarray-compat" {>= "1.0.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "6f135113c007d53174f2ec158a9d9550117af2e7"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.1.0/git-3.1.0.tbz"
+  checksum: [
+    "sha256=7d92ac3d50647e1e0695048f47da12c7308adfcae59e45cd1a586f78f905c606"
+    "sha512=d703b5456f5157b26d599c35cb01e8480e22a1287c61c43001f4aa6185f15c9b7840a95a2469846cd61d1cf831b4fe77207be7e48d0b0d00d38a1e8f063e96fd"
+  ]
+}

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.1.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.6.0"}
+  "git" {= version}
+  "git-cohttp" {= version}
+  "cohttp-lwt-unix"
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "bigarray-compat" {>= "1.0.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "6f135113c007d53174f2ec158a9d9550117af2e7"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.1.0/git-3.1.0.tbz"
+  checksum: [
+    "sha256=7d92ac3d50647e1e0695048f47da12c7308adfcae59e45cd1a586f78f905c606"
+    "sha512=d703b5456f5157b26d599c35cb01e8480e22a1287c61c43001f4aa6185f15c9b7840a95a2469846cd61d1cf831b4fe77207be7e48d0b0d00d38a1e8f063e96fd"
+  ]
+}

--- a/packages/git-cohttp/git-cohttp.3.1.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.6.0"}
+  "git" {= version}
+  "cohttp"
+  "cohttp-lwt"
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "bigarray-compat" {>= "1.0.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "6f135113c007d53174f2ec158a9d9550117af2e7"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.1.0/git-3.1.0.tbz"
+  checksum: [
+    "sha256=7d92ac3d50647e1e0695048f47da12c7308adfcae59e45cd1a586f78f905c606"
+    "sha512=d703b5456f5157b26d599c35cb01e8480e22a1287c61c43001f4aa6185f15c9b7840a95a2469846cd61d1cf831b4fe77207be7e48d0b0d00d38a1e8f063e96fd"
+  ]
+}

--- a/packages/git-mirage/git-mirage.3.1.0/opam
+++ b/packages/git-mirage/git-mirage.3.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "A package to use ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.6.0"}
+  "mimic"
+  "mirage-stack"
+  "git" {= version}
+  "awa"
+  "awa-mirage"
+  "dns-client" {>= "4.6.2"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "5.0.1"}
+  "lwt" {>= "5.3.0"}
+  "mirage-clock" {>= "3.1.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "mirage-protocols" {>= "5.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.1"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "bigarray-compat" {>= "1.0.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "6f135113c007d53174f2ec158a9d9550117af2e7"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.1.0/git-3.1.0.tbz"
+  checksum: [
+    "sha256=7d92ac3d50647e1e0695048f47da12c7308adfcae59e45cd1a586f78f905c606"
+    "sha512=d703b5456f5157b26d599c35cb01e8480e22a1287c61c43001f4aa6185f15c9b7840a95a2469846cd61d1cf831b4fe77207be7e48d0b0d00d38a1e8f063e96fd"
+  ]
+}

--- a/packages/git-unix/git-unix.3.1.0/opam
+++ b/packages/git-unix/git-unix.3.1.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install and configure ocaml-git's Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.6.0"}
+  "mmap" {>= "1.1.0"}
+  "stdlib-shims"
+  "git" {= version}
+  "rresult"
+  "result"
+  "bigarray-compat"
+  "bigstringaf"
+  "fmt" {>= "0.8.7"}
+  "bos"
+  "fpath"
+  "uri" {with-test}
+  "digestif" {>= "0.8.1"}
+  "logs"
+  "lwt"
+  "base-unix"
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "git-cohttp-unix" {= version}
+  "mirage-clock"
+  "mirage-clock-unix"
+  "astring" {>= "0.8.5"}
+  "awa"
+  "cmdliner" {>= "1.0.4"}
+  "cohttp-lwt-unix" {>= "2.5.4"}
+  "decompress" {>= "1.2.0"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "5.0.1"}
+  "mtime" {>= "1.2.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "tcpip" {>= "6.0.0"}
+  "cstruct" {>= "6.0.0" & with-test}
+  "awa-mirage"
+  "mirage-flow" {>= "2.0.1"}
+  "ke" {>= "0.4" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "ocurl" {>= "0.9.1" & with-test}
+]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "6f135113c007d53174f2ec158a9d9550117af2e7"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.1.0/git-3.1.0.tbz"
+  checksum: [
+    "sha256=7d92ac3d50647e1e0695048f47da12c7308adfcae59e45cd1a586f78f905c606"
+    "sha512=d703b5456f5157b26d599c35cb01e8480e22a1287c61c43001f4aa6185f15c9b7840a95a2469846cd61d1cf831b4fe77207be7e48d0b0d00d38a1e8f063e96fd"
+  ]
+}

--- a/packages/git/git.3.1.0/opam
+++ b/packages/git/git.3.1.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "Git format and protocol in pure OCaml"
+description: """\
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.6.0"}
+  "digestif" {>= "0.8.1"}
+  "stdlib-shims"
+  "rresult"
+  "result"
+  "bigarray-compat"
+  "bigstringaf"
+  "optint"
+  "decompress"
+  "logs"
+  "lwt"
+  "mimic"
+  "cstruct" {>= "5.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "carton"
+  "carton-lwt"
+  "carton-git"
+  "ke" {>= "0.4"}
+  "fmt" {>= "0.8.7"}
+  "checkseum" {>= "0.2.1"}
+  "ocamlgraph" {>= "1.8.8"}
+  "astring"
+  "fpath"
+  "encore" {>= "0.7"}
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng" {with-test & >= "0.8.0"}
+  "cmdliner" {with-test}
+  "base-unix" {with-test}
+  "fpath"
+  "base64" {with-test & >= "3.0.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "domain-name" {>= "0.3.0"}
+  "emile" {>= "1.1"}
+  "ipaddr" {>= "5.0.1"}
+  "psq" {>= "0.2.0"}
+  "uri" {>= "4.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "6f135113c007d53174f2ec158a9d9550117af2e7"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.1.0/git-3.1.0.tbz"
+  checksum: [
+    "sha256=7d92ac3d50647e1e0695048f47da12c7308adfcae59e45cd1a586f78f905c606"
+    "sha512=d703b5456f5157b26d599c35cb01e8480e22a1287c61c43001f4aa6185f15c9b7840a95a2469846cd61d1cf831b4fe77207be7e48d0b0d00d38a1e8f063e96fd"
+  ]
+}


### PR DESCRIPTION
Git format and protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Handle IP address on the endpoint (@dinosaure, mirage/ocaml-git#436)
