### PR TITLE
Fix dune 2.8.0's revdeps

### DIFF
--- a/packages/drom/drom.0.2.0/opam
+++ b/packages/drom/drom.0.2.0/opam
@@ -42,6 +42,7 @@ build: [
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "2.6.0"}
+  "dune" {with-test & < "2.8.0"} # TODO: make this package "available: false", see https://github.com/OCamlPro/drom/pull/122
   "drom_lib" {= version}
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}

--- a/packages/drom_lib/drom_lib.0.2.0/opam
+++ b/packages/drom_lib/drom_lib.0.2.0/opam
@@ -42,6 +42,7 @@ build: [
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "2.6.0"}
+  "dune" {with-test & < "2.8.0"}
   "toml" {>= "5.0.0" & < "6.0"}
   "opam-file-format" {>= "2.1.1" & < "3.0.0"}
   "ez_file" {>= "0.2.0" & < "1.0.0"}

--- a/packages/ez_file/ez_file.0.2.0/opam
+++ b/packages/ez_file/ez_file.0.2.0/opam
@@ -33,6 +33,7 @@ build: [
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "2.6.0"}
+  "dune" {with-test & < "2.8.0"}
   "re" {>= "1.8.0" & < "2.0.0"}
   "ocplib_stuff" {>= "0.1.0" & < "1.0.0"}
   "base-unix" {>= "base"}

--- a/packages/ez_opam_file/ez_opam_file.0.1.0/opam
+++ b/packages/ez_opam_file/ez_opam_file.0.1.0/opam
@@ -30,6 +30,7 @@ build: [
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "2.6.0"}
+  "dune" {with-test & < "2.8.0"}
   "opam-file-format" {>= "2.0"}
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}

--- a/packages/functoria-runtime/functoria-runtime.3.0.2/opam
+++ b/packages/functoria-runtime/functoria-runtime.3.0.2/opam
@@ -22,6 +22,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.1.0"}
+  "dune" {with-test & < "2.8.0"}
   "cmdliner" {>= "0.9.8"}
   "fmt"
   "functoria" {with-test & >= "2.2.0"}

--- a/packages/functoria-runtime/functoria-runtime.3.0.3/opam
+++ b/packages/functoria-runtime/functoria-runtime.3.0.3/opam
@@ -22,6 +22,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.1.0"}
+  "dune" {with-test & < "2.8.0"}
   "cmdliner" {>= "0.9.8"}
   "fmt"
   "functoria" {with-test & >= "2.2.0"}

--- a/packages/mdx/mdx.1.7.0/opam
+++ b/packages/mdx/mdx.1.7.0/opam
@@ -10,12 +10,13 @@ doc:          "https://realworldocaml.github.io/mdx/"
 build: [
  ["dune" "subst"] {pinned}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
   "ocaml" {>= "4.02.3" & < "4.12.0"}
   "dune" {>= "2.0"}
+  "dune" {with-test & < "2.8.0"}
   "ocamlfind"
   "fmt"
   "cppo" {build}

--- a/packages/ocplib_stuff/ocplib_stuff.0.3.0/opam
+++ b/packages/ocplib_stuff/ocplib_stuff.0.3.0/opam
@@ -35,6 +35,7 @@ build: [
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "2.6.0"}
+  "dune" {with-test & < "2.8.0"}
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}

--- a/packages/opam-bin/opam-bin.0.9.5/opam
+++ b/packages/opam-bin/opam-bin.0.9.5/opam
@@ -33,6 +33,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "2.6.0"}
+  "dune" {with-test & < "2.8.0"}
   "opam_bin_lib" {= version}
   "re" {> "1.0"}
   "opam-file-format" {>= "2.0.0" & < "3.0.0"}

--- a/packages/opam-dune-lint/opam-dune-lint.0.1/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "astring" {>= "0.8.5"}
   "sexplib" {>= "v0.14.0"}
   "cmdliner" {>= "1.0.4"}
-  "dune-private-libs" {>= "2.7.1"}
+  "dune-private-libs" {>= "2.7.1" & < "2.8.0"}
   "ocaml" {>= "4.11.0"}
   "ocamlfind"
   "bos"

--- a/packages/opam_bin_lib/opam_bin_lib.0.9.5/opam
+++ b/packages/opam_bin_lib/opam_bin_lib.0.9.5/opam
@@ -33,6 +33,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "2.6.0"}
+  "dune" {with-test & < "2.8.0"}
   "re" {> "1.0"}
   "opam-file-format" {>= "2.0.0" & < "3.0.0"}
   "ocplib-json-typed" {>= "0.7.0" & < "1.0.0"}

--- a/packages/psmt2-frontend/psmt2-frontend.0.3.1/opam
+++ b/packages/psmt2-frontend/psmt2-frontend.0.3.1/opam
@@ -32,6 +32,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "2.6.0"}
+  "dune" {with-test & < "2.8.0"}
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
Related to https://github.com/ocaml/opam-repository/pull/17967

- `functoria-runtime`: cc @Drup 
- `opam-dune-lint`: fixed upstream in https://github.com/ocurrent/opam-dune-lint/pull/20
- `mdx`: cc @gpetiot 
- packages generated by `drom`: cc @lefessan 