### PR TITLE
[new release] dune, dune-build-info, dune-glob, dune-private-libs, dune-site, dune-configurator and dune-action-plugin (2.8.1)

### DIFF
--- a/packages/dune-action-plugin/dune-action-plugin.2.8.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.8.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "dune-glob"
+  "ppx_expect" {with-test}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "b796156167490e777131403f651e83779e954000"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.8.1/dune-2.8.1.tbz"
+  checksum: [
+    "sha256=e7b405c75af321ce6518aa8e70ebdd403dbcc2ede931713e69c2b5addda4bd44"
+    "sha512=300c9f5074af5db78c8ffb17b4a1c402fce322d9af4b213aa847bfd9f9fd053e757182f3da8b207f2d24afbd609a227e8c0e57ef038ab236322229c41e240c43"
+  ]
+}

--- a/packages/dune-build-info/dune-build-info.2.8.1/opam
+++ b/packages/dune-build-info/dune-build-info.2.8.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Embed build informations inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "b796156167490e777131403f651e83779e954000"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.8.1/dune-2.8.1.tbz"
+  checksum: [
+    "sha256=e7b405c75af321ce6518aa8e70ebdd403dbcc2ede931713e69c2b5addda4bd44"
+    "sha512=300c9f5074af5db78c8ffb17b4a1c402fce322d9af4b213aa847bfd9f9fd053e757182f3da8b207f2d24afbd609a227e8c0e57ef038ab236322229c41e240c43"
+  ]
+}

--- a/packages/dune-configurator/dune-configurator.2.8.1/opam
+++ b/packages/dune-configurator/dune-configurator.2.8.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.03.0"}
+  "result"
+  "csexp" {>= "1.3.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "b796156167490e777131403f651e83779e954000"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.8.1/dune-2.8.1.tbz"
+  checksum: [
+    "sha256=e7b405c75af321ce6518aa8e70ebdd403dbcc2ede931713e69c2b5addda4bd44"
+    "sha512=300c9f5074af5db78c8ffb17b4a1c402fce322d9af4b213aa847bfd9f9fd053e757182f3da8b207f2d24afbd609a227e8c0e57ef038ab236322229c41e240c43"
+  ]
+}

--- a/packages/dune-glob/dune-glob.2.8.1/opam
+++ b/packages/dune-glob/dune-glob.2.8.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "b796156167490e777131403f651e83779e954000"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.8.1/dune-2.8.1.tbz"
+  checksum: [
+    "sha256=e7b405c75af321ce6518aa8e70ebdd403dbcc2ede931713e69c2b5addda4bd44"
+    "sha512=300c9f5074af5db78c8ffb17b4a1c402fce322d9af4b213aa847bfd9f9fd053e757182f3da8b207f2d24afbd609a227e8c0e57ef038ab236322229c41e240c43"
+  ]
+}

--- a/packages/dune-private-libs/dune-private-libs.2.8.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.8.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "b796156167490e777131403f651e83779e954000"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.8.1/dune-2.8.1.tbz"
+  checksum: [
+    "sha256=e7b405c75af321ce6518aa8e70ebdd403dbcc2ede931713e69c2b5addda4bd44"
+    "sha512=300c9f5074af5db78c8ffb17b4a1c402fce322d9af4b213aa847bfd9f9fd053e757182f3da8b207f2d24afbd609a227e8c0e57ef038ab236322229c41e240c43"
+  ]
+}

--- a/packages/dune-site/dune-site.2.8.1/opam
+++ b/packages/dune-site/dune-site.2.8.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Embed locations informations inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-commit-hash: "b796156167490e777131403f651e83779e954000"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.8.1/dune-2.8.1.tbz"
+  checksum: [
+    "sha256=e7b405c75af321ce6518aa8e70ebdd403dbcc2ede931713e69c2b5addda4bd44"
+    "sha512=300c9f5074af5db78c8ffb17b4a1c402fce322d9af4b213aa847bfd9f9fd053e757182f3da8b207f2d24afbd609a227e8c0e57ef038ab236322229c41e240c43"
+  ]
+}

--- a/packages/dune-site/dune-site.2.8.1/opam
+++ b/packages/dune-site/dune-site.2.8.1/opam
@@ -21,7 +21,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/dune/dune.2.8.1/opam
+++ b/packages/dune/dune.2.8.1/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "1.3.0"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+]
+x-commit-hash: "b796156167490e777131403f651e83779e954000"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.8.1/dune-2.8.1.tbz"
+  checksum: [
+    "sha256=e7b405c75af321ce6518aa8e70ebdd403dbcc2ede931713e69c2b5addda4bd44"
+    "sha512=300c9f5074af5db78c8ffb17b4a1c402fce322d9af4b213aa847bfd9f9fd053e757182f3da8b207f2d24afbd609a227e8c0e57ef038ab236322229c41e240c43"
+  ]
+}


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- Fixed `dune --version` printing `n/a` rather than the version
