### PR TITLE
8 packages from ocaml/opam at 2.1.0~beta4

### DIFF
--- a/packages/opam-0install/opam-0install.0.1/opam
+++ b/packages/opam-0install/opam-0install.0.1/opam
@@ -45,7 +45,7 @@ build: [
 dev-repo: "git+https://github.com/talex5/opam-0install-solver.git"
 url {
   src:
-    "https://github.com/talex5/opam-0install-solver/releases/download/v0.1/opam-0install-v0.1.tbz"
+    "https://github.com/ocaml-opam/opam-0install-solver/releases/download/v0.1/opam-0install-v0.1.tbz"
   checksum: [
     "sha256=c41d5cc24669819d336db883c0e57e4dd9e3117a394cce10c8d369bbdd50b50f"
     "sha512=93bf8212bad305368c690ce721f5042f7f586f453ce5783d393de11d0d91dcb793e7174e1920d7f5093cea887ef0e7bff245b2e8a91fde6bed3f852f9cf27250"

--- a/packages/opam-0install/opam-0install.0.2/opam
+++ b/packages/opam-0install/opam-0install.0.2/opam
@@ -45,7 +45,7 @@ build: [
 dev-repo: "git+https://github.com/talex5/opam-0install-solver.git"
 url {
   src:
-    "https://github.com/talex5/opam-0install-solver/releases/download/v0.2/opam-0install-cudf-v0.2.tbz"
+    "https://github.com/ocaml-opam/opam-0install-solver/releases/download/v0.2/opam-0install-cudf-v0.2.tbz"
   checksum: [
     "sha256=78591f054e66234169337530ab3eb2ee0e8a8ba13b9fc5f221aff6f717df9aab"
     "sha512=f9bfeaea27b250d399d5df59dc6cd9c1db32795392c118dfd343c4e7a2187702fce15da67511ade544a3584797b8b5459815fa18b38f5ae4a14d44cd940759bf"

--- a/packages/opam-client/opam-client.2.1.0~beta4/opam
+++ b/packages/opam-client/opam-client.2.1.0~beta4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 development libraries (client)"
+description: """
+Actions on the opam root, switches, installations, and front-end.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-state" {= version}
+  "opam-solver" {= version}
+  "extlib" {>= "1.7.3"}
+  "opam-repository" {= version}
+  "re" {>= "1.9.0"}
+  "cmdliner" {>= "1.0.0"}
+  "dune" {>= "1.5.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta4.tar.gz"
+  checksum: [
+    "md5=c8b674ab0803330a1daaa241b067c7e3"
+    "sha512=d9ee987a173a013a40a2ab1765f7e2d71bdc1b191e868ec99f4b60e9b6792b1850894a484b9770ae7fb4a540a9fd3f2417506701924f45430a2a31125ba5784f"
+  ]
+}

--- a/packages/opam-core/opam-core.2.1.0~beta4/opam
+++ b/packages/opam-core/opam-core.2.1.0~beta4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 development libraries (core)"
+description: """
+Small standard library extensions, and generic system interaction modules used by opam.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.9.0"}
+  "dune" {>= "1.5.0"}
+  "cppo" {build}
+]
+conflicts: "extlib-compat"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta4.tar.gz"
+  checksum: [
+    "md5=c8b674ab0803330a1daaa241b067c7e3"
+    "sha512=d9ee987a173a013a40a2ab1765f7e2d71bdc1b191e868ec99f4b60e9b6792b1850894a484b9770ae7fb4a540a9fd3f2417506701924f45430a2a31125ba5784f"
+  ]
+}

--- a/packages/opam-devel/opam-devel.2.1.0~beta4/opam
+++ b/packages/opam-devel/opam-devel.2.1.0~beta4/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 bootstrapped binary"
+description: """
+This package compiles (bootstraps) opam. For consistency and safety of the installation, the binaries are not installed into the PATH, but into lib/opam-devel, from where the user can manually install them system-wide.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+  [make "tests"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-client" {= version}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {>= "1.5.0"}
+]
+post-messages: [
+"The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/opam /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2=\"OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""
+  {success}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta4.tar.gz"
+  checksum: [
+    "md5=c8b674ab0803330a1daaa241b067c7e3"
+    "sha512=d9ee987a173a013a40a2ab1765f7e2d71bdc1b191e868ec99f4b60e9b6792b1850894a484b9770ae7fb4a540a9fd3f2417506701924f45430a2a31125ba5784f"
+  ]
+}

--- a/packages/opam-devel/opam-devel.2.1.0~beta4/opam
+++ b/packages/opam-devel/opam-devel.2.1.0~beta4/opam
@@ -22,7 +22,7 @@ dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
+  [make "tests"] {with-test & opam-version < "2.1" & os-distribution != "alpine" & os-distribution != "arch" & os-distribution != "centos"} # https://github.com/ocaml/opam/pull/4500
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/opam-format/opam-format.2.1.0~beta4/opam
+++ b/packages/opam-format/opam-format.2.1.0~beta4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 development libraries (format)"
+description: """
+Definition of opam datastructures and its file interface.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-core" {= version}
+  "opam-file-format" {>= "2.1.1"}
+  "dune" {>= "1.5.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta4.tar.gz"
+  checksum: [
+    "md5=c8b674ab0803330a1daaa241b067c7e3"
+    "sha512=d9ee987a173a013a40a2ab1765f7e2d71bdc1b191e868ec99f4b60e9b6792b1850894a484b9770ae7fb4a540a9fd3f2417506701924f45430a2a31125ba5784f"
+  ]
+}

--- a/packages/opam-installer/opam-installer.2.1.0~beta4/opam
+++ b/packages/opam-installer/opam-installer.2.1.0~beta4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Installation of files to a prefix, following opam conventions"
+description: """
+opam-installer is a small tool that can read *.install files, as defined by opam [1], and execute them to install or remove package files without going through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {>= "1.5.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta4.tar.gz"
+  checksum: [
+    "md5=c8b674ab0803330a1daaa241b067c7e3"
+    "sha512=d9ee987a173a013a40a2ab1765f7e2d71bdc1b191e868ec99f4b60e9b6792b1850894a484b9770ae7fb4a540a9fd3f2417506701924f45430a2a31125ba5784f"
+  ]
+}

--- a/packages/opam-repository/opam-repository.2.1.0~beta4/opam
+++ b/packages/opam-repository/opam-repository.2.1.0~beta4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 development libraries (repository)"
+description: """
+This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "dune" {>= "1.5.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta4.tar.gz"
+  checksum: [
+    "md5=c8b674ab0803330a1daaa241b067c7e3"
+    "sha512=d9ee987a173a013a40a2ab1765f7e2d71bdc1b191e868ec99f4b60e9b6792b1850894a484b9770ae7fb4a540a9fd3f2417506701924f45430a2a31125ba5784f"
+  ]
+}

--- a/packages/opam-solver/opam-solver.2.1.0~beta4/opam
+++ b/packages/opam-solver/opam-solver.2.1.0~beta4/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 development libraries (solver)"
+description: """
+Solver and Cudf interaction. This library is based on the Cudf and Dose libraries, and handles calls to the external solver from opam.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "mccs" {>= "1.1+9"}
+  "dose3" {>= "5"}
+  "cudf" {>= "0.7"}
+  "dune" {>= "1.5.0"}
+]
+depopts: [
+  "z3"
+  "opam-0install-cudf"
+]
+conflicts: [
+  "z3" {< "4.8.4"}
+  "opam-0install-cudf" {< "0.4"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta4.tar.gz"
+  checksum: [
+    "md5=c8b674ab0803330a1daaa241b067c7e3"
+    "sha512=d9ee987a173a013a40a2ab1765f7e2d71bdc1b191e868ec99f4b60e9b6792b1850894a484b9770ae7fb4a540a9fd3f2417506701924f45430a2a31125ba5784f"
+  ]
+}

--- a/packages/opam-state/opam-state.2.1.0~beta4/opam
+++ b/packages/opam-state/opam-state.2.1.0~beta4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "opam 2.1 development libraries (state)"
+description: """
+Handling of the ~/.opam hierarchy, repository and switch states.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-repository" {= version}
+  "dune" {>= "1.5.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-beta4.tar.gz"
+  checksum: [
+    "md5=c8b674ab0803330a1daaa241b067c7e3"
+    "sha512=d9ee987a173a013a40a2ab1765f7e2d71bdc1b191e868ec99f4b60e9b6792b1850894a484b9770ae7fb4a540a9fd3f2417506701924f45430a2a31125ba5784f"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`opam-client.2.1.0~beta4`: opam 2.1 development libraries (client)
-`opam-core.2.1.0~beta4`: opam 2.1 development libraries (core)
-`opam-devel.2.1.0~beta4`: opam 2.1 bootstrapped binary
-`opam-format.2.1.0~beta4`: opam 2.1 development libraries (format)
-`opam-installer.2.1.0~beta4`: Installation of files to a prefix, following opam conventions
-`opam-repository.2.1.0~beta4`: opam 2.1 development libraries (repository)
-`opam-solver.2.1.0~beta4`: opam 2.1 development libraries (solver)
-`opam-state.2.1.0~beta4`: opam 2.1 development libraries (state)



---
* Source repo: git+https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---
:camel: Pull-request generated by opam-publish v2.0.2