### PR TITLE
Ocaml 4.12.0, first beta

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "First beta release of OCaml 4.12.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml#4.12"
+depends: [
+  "ocaml" {= "4.12.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler hidden-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%" {os != "cygwin"}]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.12.0-beta1.tar.gz"
+  checksum: "sha256=b9a30a8473a0eda7accc299ac5bacb44a30932e57e1b1662673d9840e2fb3b85"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+synopsis: "First beta release of OCaml 4.12.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml#4.12"
+depends: [
+  "ocaml" {= "4.12.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta" {opam-version < "2.1"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler hidden-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--enable-spacetime" {ocaml-option-spacetime:installed}
+    "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+  ]
+  [make "-j%{jobs}%" {os != "cygwin"}]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.12.0-beta1.tar.gz"
+  checksum: "sha256=b9a30a8473a0eda7accc299ac5bacb44a30932e57e1b1662673d9840e2fb3b85"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+  "ocaml-option-spacetime"
+  "ocaml-option-nnp"
+]

--- a/packages/ocaml/ocaml.4.12.0/opam
+++ b/packages/ocaml/ocaml.4.12.0/opam
@@ -5,7 +5,7 @@ This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
 maintainer: "platform@lists.ocaml.org"
 depends: [
-  "ocaml-config"
+  "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {>= "4.12.0~" & < "4.12.1~"} |
   "ocaml-variants" {>= "4.12.0~" & < "4.12.1~"} |
   "ocaml-system" {>= "4.12.0" & < "4.12.1~"}

--- a/packages/ocaml/ocaml.4.13.0/opam
+++ b/packages/ocaml/ocaml.4.13.0/opam
@@ -5,7 +5,7 @@ This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
 maintainer: "platform@lists.ocaml.org"
 depends: [
-  "ocaml-config"
+  "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {= "4.13.0"} |
   "ocaml-variants" {>= "4.13.0" & < "4.13.1~"} |
   "ocaml-system" {>= "4.13.0" & < "4.13.1~"}


### PR DESCRIPTION
This PR adds the package for the first beta for OCaml 4.12.0 .

On the compiler side, this is a quiet release with 3 bug fixes:
- one error message fix
- one performance regression fix for immediate objects
- one gc control fix (which fix some performance regression in Coq present since 4.08)

The major change is on the standard library side with two functions postponed to avoid some potential conflicts with extlib.

### Postponed features

- [9533](https://github.com/ocaml/ocaml/issues/9533), [10105](https://github.com/ocaml/ocaml/issues/10105), [10127](https://github.com/ocaml/ocaml/issues/10127) : Added String.starts_with and String.ends_with.
  (Bernhard Schommer, review by Daniel Bünzli, Gabriel Scherer and
  Alain Frisch)

### Additional bug fixes

- [9096](https://github.com/ocaml/ocaml/issues/9096), [10096](https://github.com/ocaml/ocaml/issues/10096): fix a 4.11.0 performance regression in classes/objects
  declared within a function
  (Gabriel Scherer, review by Leo White, report by Sacha Ayoun)


- [9326](https://github.com/ocaml/ocaml/issues/9326), [10125](https://github.com/ocaml/ocaml/issues/10125): Gc.set incorrectly handles the three `custom_*` fields,
  causing a performance regression
  (report by Emilio Jesús Gallego Arias, analysis and fix by Stephen Dolan,
   code by Xavier Leroy, review by Hugo Heuzard and Gabriel Scherer)

- [10106](https://github.com/ocaml/ocaml/issues/10106), [10112](https://github.com/ocaml/ocaml/issues/10112): some expected-type explanations where forgotten
  after some let-bindings
  (Gabriel Scherer, review by Thomas Refis and Florian Angeletti,
   report by Daniil Baturin)
