### PR TITLE
Package hevea.2.35

### DIFF
--- a/packages/hevea/hevea.2.35/opam
+++ b/packages/hevea/hevea.2.35/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
+authors: "Luc Maranget"
+homepage: "http://hevea.inria.fr/"
+bug-reports: "http://github.com/herd/hevea/issues/"
+doc: "http://hevea.inria.fr/doc/index.html"
+dev-repo: "git+https://github.com/maranget/hevea.git"
+license: ["QPL-1.0" "LGPL-2 with exceptions"]
+build: [make "PREFIX=%{prefix}%"]
+install: [make "PREFIX=%{prefix}%" "install"]
+remove: [ [ "rm" "-r" "%{lib}%/hevea" ]
+	  [ "rm" "%{bin}%/hevea" "%{bin}%/hacha" "%{bin}%/esponja" "%{bin}%/bibhva" ]
+	  [ "rm" "%{bin}%/imagen" ] ]
+post-messages: [
+  "The file 'hevea.sty' has been installed in %{lib}%/hevea but latex won't see it by itself" {success}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlbuild" {build}
+]
+synopsis: "A quite complete and fast LATEX to HTML translator"
+url {
+  src: "https://github.com/maranget/hevea/archive/v2.35.tar.gz"
+  checksum: "md5=b9414b217641411c594c3d7c08573873"
+}

--- a/packages/hevea/hevea.2.35/opam
+++ b/packages/hevea/hevea.2.35/opam
@@ -8,9 +8,6 @@ dev-repo: "git+https://github.com/maranget/hevea.git"
 license: ["QPL-1.0" "LGPL-2 with exceptions"]
 build: [make "PREFIX=%{prefix}%"]
 install: [make "PREFIX=%{prefix}%" "install"]
-remove: [ [ "rm" "-r" "%{lib}%/hevea" ]
-	  [ "rm" "%{bin}%/hevea" "%{bin}%/hacha" "%{bin}%/esponja" "%{bin}%/bibhva" ]
-	  [ "rm" "%{bin}%/imagen" ] ]
 post-messages: [
   "The file 'hevea.sty' has been installed in %{lib}%/hevea but latex won't see it by itself" {success}
 ]


### PR DESCRIPTION
### `hevea.2.35`
A quite complete and fast LATEX to HTML translator



---
* Homepage: http://hevea.inria.fr/
* Source repo: git+https://github.com/maranget/hevea.git
* Bug tracker: http://github.com/herd/hevea/issues/

---
:camel: Pull-request generated by opam-publish v2.0.3