### PR TITLE
[new release] imagelib (20210116)

### DIFF
--- a/packages/imagelib/imagelib.20210116/opam
+++ b/packages/imagelib/imagelib.20210116/opam
@@ -1,0 +1,61 @@
+synopsis: "Library implementing parsing of image formats such as PNG, BMP, PPM"
+description:
+"""
+The imagelib library implements image formats such as PNG, BMP, and PPM in
+OCaml, relying on only one external dependency: 'decompress'.
+
+Unix-dependent functionality such as reading or writing to files in the
+filesystem are packaged separately in the 'imagelib-unix' OPAM package.
+
+Supported image formats:
+ - PNG (full implementation of RFC 2083),
+ - PPM, PGM, PBM, ... (fully supported),
+ - BMP (read-only)
+ - JPG (only image size natively, conversion to PNG otherwise),
+ - GIF (only image size natively, conversion to PNG otherwise),
+ - XCF (only image size natively, conversion to PNG otherwise),
+ - Utility functions for handling unimplemented formats are available in
+   the 'imagelib-unix' OPAM package. See that package description for more info.
+
+As imagelib only requires 'decompress', it can be used together with
+js_of_ocaml to compile projects to Javascript, or from MirageOS unikernels.
+"""
+opam-version: "2.0"
+maintainer: "rodolphe.lepigre@inria.fr"
+bug-reports: "https://github.com/rlepigre/ocaml-imagelib/issues"
+homepage: "https://github.com/rlepigre/ocaml-imagelib"
+dev-repo: "git+https://github.com/rlepigre/ocaml-imagelib.git"
+authors: [
+  "Rodolphe Lepigre <rodolphe.lepigre@inria.fr>"
+]
+license: "GPL-3.0"
+doc: "https://rlepigre.github.io/ocaml-imagelib"
+
+depends: [
+  "ocaml"        { >= "4.07.0" }
+  "base-unix"
+  "dune"         { >= "2.3.0"  }
+  "decompress"   { >= "1.2.0" }
+  "stdlib-shims"
+  "alcotest"     { with-test }
+]
+
+depopts: [
+  "crowbar"        { with-test }
+  "afl-persistent" { with-test }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs
+      "@install"
+      "@runtest" {with-test} ]
+]
+x-commit-hash: "17eb8c5c45d41a8e023025f70d13fce5e97a480a"
+url {
+  src:
+    "https://github.com/rlepigre/ocaml-imagelib/releases/download/20210116/imagelib-20210116.tbz"
+  checksum: [
+    "sha256=e8be5acf0fe38d840331fe505db090b3b2e36089d012530ec9353e79d8ab4870"
+    "sha512=d5386b5d6036293f53f5910553fb2f6898f5c7d72fde67eec1e953ac5846c6b05b061074ec237741e89cea3653fb88f4a1a0554ebb57b402a0a396882c5545ff"
+  ]
+}


### PR DESCRIPTION
Library implementing parsing of image formats such as PNG, BMP, PPM

- Project page: <a href="https://github.com/rlepigre/ocaml-imagelib">https://github.com/rlepigre/ocaml-imagelib</a>
- Documentation: <a href="https://rlepigre.github.io/ocaml-imagelib">https://rlepigre.github.io/ocaml-imagelib</a>

##### CHANGES:

- Fix alpha handling for GIF and resizing
- Add transparency support to PNG
