### PR TITLE
Package soupault.2.4.0

### DIFF
--- a/packages/soupault/soupault.2.4.0/opam
+++ b/packages/soupault/soupault.2.4.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Static website generator based on HTML rewriting"
+description: """\
+A website generator that works with page element tree rather than text
+and allows you to manipulate pages and retrieve metadata from
+existing HTML using arbitrary CSS selectors.
+
+With soupault you can:
+
+* Generate ToC and footnotes.
+* Insert file content or an HTML snippet in any element.
+* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
+* Extract page metadata (think microformats) and render it using a Jingoo template or an external script.
+* Export extracted metadata to JSON.
+
+Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
+similar to web browsers.
+
+The website generator mode is optional, you can use it as post-processor for existing sites."""
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: "Daniil Baturin <daniil+soupault@baturin.org>"
+license: "MIT"
+homepage: "https://www.soupault.app"
+bug-reports: "https://github.com/dmbaturin/soupault/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0.0"}
+  "lambdasoup" {>= "0.7.2"}
+  "markup" {>= "1.0.0-1"}
+  "toml" {>= "6.0.0"}
+  "fileutils"
+  "logs"
+  "fmt"
+  "re"
+  "ezjsonm"
+  "containers"
+  "stringext"
+  "odate"
+  "spelll"
+  "base64"
+  "jingoo" {>= "1.4.2"}
+  "tsort" {>= "2.0.0"}
+  "lua-ml" {>= "0.9.2"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/dmbaturin/soupault"
+url {
+  src: "https://github.com/dmbaturin/soupault/archive/2.4.0.tar.gz"
+  checksum: [
+    "md5=80b51662396c7ce1805322c0783b2371"
+    "sha512=eb585a338a04176be4dc9b495589dd6dbcdf488955b3fb803e11400b274b6fef9d323ca7aa38dd31450c3533f6bbf5d4540917092d1e912ac83964bc1690230e"
+  ]
+}


### PR DESCRIPTION
### `soupault.2.4.0`
Static website generator based on HTML rewriting
A website generator that works with page element tree rather than text
and allows you to manipulate pages and retrieve metadata from
existing HTML using arbitrary CSS selectors.

With soupault you can:

* Generate ToC and footnotes.
* Insert file content or an HTML snippet in any element.
* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
* Extract page metadata (think microformats) and render it using a Jingoo template or an external script.
* Export extracted metadata to JSON.

Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
similar to web browsers.

The website generator mode is optional, you can use it as post-processor for existing sites.



---
* Homepage: https://www.soupault.app
* Source repo: git+https://github.com/dmbaturin/soupault
* Bug tracker: https://github.com/dmbaturin/soupault/issues

---
:camel: Pull-request generated by opam-publish v2.0.2