### PR TITLE
Release caqti 1.3.0.

### DIFF
--- a/packages/caqti-async/caqti-async.1.3.0/opam
+++ b/packages/caqti-async/caqti-async.1.3.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "async_kernel" {>= "v0.11.0" & < "v0.14.0~"}
+  "async_unix" {>= "v0.11.0" & < "v0.14.0~"}
+  "caqti" {>= "1.3.0" & < "1.4.0~"}
+  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "core_kernel" {< "v0.14.0~"}
+  "dune" {>= "1.11"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Async support for Caqti"
+x-commit-hash: "60bd0293d8deffe72e8f909775bfdd2ed4a8ec0d"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.3.0/caqti-v1.3.0.tbz"
+  checksum: [
+    "sha256=a15d71b6428997703273dc6d55a99045fb62c3243c751de5ae8c3fc25421f16a"
+    "sha512=386502d9ea2f1769081b81e6888bf4c2a27248498eabc0d4eb4adfde04c74f48f2aa587c0ce3a34604c73d157ed6533052b4d0b9a0fb3f352929ef847f3aa9fa"
+  ]
+}

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.3.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.3.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.3.0" & < "1.4.0~"}
+  "dune" {>= "1.11"}
+  "mariadb" {>= "1.1.1"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MariaDB driver for Caqti using C bindings"
+x-commit-hash: "60bd0293d8deffe72e8f909775bfdd2ed4a8ec0d"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.3.0/caqti-v1.3.0.tbz"
+  checksum: [
+    "sha256=a15d71b6428997703273dc6d55a99045fb62c3243c751de5ae8c3fc25421f16a"
+    "sha512=386502d9ea2f1769081b81e6888bf4c2a27248498eabc0d4eb4adfde04c74f48f2aa587c0ce3a34604c73d157ed6533052b4d0b9a0fb3f352929ef847f3aa9fa"
+  ]
+}

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.3.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.3.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.3.0" & < "1.4.0~"}
+  "dune" {>= "1.11"}
+  "postgresql" {>= "4.6.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+x-commit-hash: "60bd0293d8deffe72e8f909775bfdd2ed4a8ec0d"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.3.0/caqti-v1.3.0.tbz"
+  checksum: [
+    "sha256=a15d71b6428997703273dc6d55a99045fb62c3243c751de5ae8c3fc25421f16a"
+    "sha512=386502d9ea2f1769081b81e6888bf4c2a27248498eabc0d4eb4adfde04c74f48f2aa587c0ce3a34604c73d157ed6533052b4d0b9a0fb3f352929ef847f3aa9fa"
+  ]
+}

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.3.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.3.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.3.0" & < "1.4.0~"}
+  "dune" {>= "1.11"}
+  "sqlite3"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Sqlite3 driver for Caqti using C bindings"
+x-commit-hash: "60bd0293d8deffe72e8f909775bfdd2ed4a8ec0d"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.3.0/caqti-v1.3.0.tbz"
+  checksum: [
+    "sha256=a15d71b6428997703273dc6d55a99045fb62c3243c751de5ae8c3fc25421f16a"
+    "sha512=386502d9ea2f1769081b81e6888bf4c2a27248498eabc0d4eb4adfde04c74f48f2aa587c0ce3a34604c73d157ed6533052b4d0b9a0fb3f352929ef847f3aa9fa"
+  ]
+}

--- a/packages/caqti-dynload/caqti-dynload.1.3.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.1.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "caqti" {>= "1.3.0" & < "1.4.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "dune" {>= "1.11"}
+  "ocamlfind"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Dynamic linking of Caqti drivers using findlib.dynload"
+description: """
+This library registers a dynamic linker which will be called when
+encoutering an unhandled database URI.  It tries to load a findlib package
+named "caqti-driver-<scheme>" where "<scheme>" is the scheme of the URI,
+which is expected register a driver for the scheme.
+
+This is a separate package to avoid the dependency on the findlib.dynload
+for architectures, like MirageOS, where dynamic linking may be unavailable.
+The alternative is to link drivers directly into the application.
+"""
+x-commit-hash: "60bd0293d8deffe72e8f909775bfdd2ed4a8ec0d"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.3.0/caqti-v1.3.0.tbz"
+  checksum: [
+    "sha256=a15d71b6428997703273dc6d55a99045fb62c3243c751de5ae8c3fc25421f16a"
+    "sha512=386502d9ea2f1769081b81e6888bf4c2a27248498eabc0d4eb4adfde04c74f48f2aa587c0ce3a34604c73d157ed6533052b4d0b9a0fb3f352929ef847f3aa9fa"
+  ]
+}

--- a/packages/caqti-lwt/caqti-lwt.1.3.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.1.3.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.3.0" & < "1.4.0~"}
+  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "dune" {>= "1.11"}
+  "logs"
+  "lwt" {>= "3.2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Lwt support for Caqti"
+x-commit-hash: "60bd0293d8deffe72e8f909775bfdd2ed4a8ec0d"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.3.0/caqti-v1.3.0.tbz"
+  checksum: [
+    "sha256=a15d71b6428997703273dc6d55a99045fb62c3243c751de5ae8c3fc25421f16a"
+    "sha512=386502d9ea2f1769081b81e6888bf4c2a27248498eabc0d4eb4adfde04c74f48f2aa587c0ce3a34604c73d157ed6533052b4d0b9a0fb3f352929ef847f3aa9fa"
+  ]
+}

--- a/packages/caqti/caqti.1.3.0/opam
+++ b/packages/caqti/caqti.1.3.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "Nathan Rebours <nathan@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "cppo" {build}
+  "dune" {>= "1.11"}
+  "logs"
+  "ocaml" {>= "4.04.0"}
+  "ptime"
+  "uri" {>= "1.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Unified interface to relational database libraries"
+description: """
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators."""
+x-commit-hash: "60bd0293d8deffe72e8f909775bfdd2ed4a8ec0d"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.3.0/caqti-v1.3.0.tbz"
+  checksum: [
+    "sha256=a15d71b6428997703273dc6d55a99045fb62c3243c751de5ae8c3fc25421f16a"
+    "sha512=386502d9ea2f1769081b81e6888bf4c2a27248498eabc0d4eb4adfde04c74f48f2aa587c0ce3a34604c73d157ed6533052b4d0b9a0fb3f352929ef847f3aa9fa"
+  ]
+}

--- a/packages/conf-mariadb/conf-mariadb.2/opam
+++ b/packages/conf-mariadb/conf-mariadb.2/opam
@@ -6,7 +6,7 @@ bug-reports: "https://jira.mariadb.org/projects/MDEV/issues"
 dev-repo: "git+https://github.com/MariaDB/server.git"
 license: "GPL-2.0-only"
 build: [
-  ["pkg-config" "--exists" "libmariadb"]
+  ["sh" "-exc" "pkg-config --exists libmariadb || pkg-config --exists mariadb"] # libmariadb is a newer library name
 ]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-mariadb/conf-mariadb.2/opam
+++ b/packages/conf-mariadb/conf-mariadb.2/opam
@@ -18,7 +18,7 @@ depexts: [
   ["mariadb-connector-c-dev"] {os-family = "alpine"}
   ["mariadb-connector-c-devel"] {os-distribution = "centos" & os-version >= "8"}
   ["mariadb-connector-c-devel"] {os-distribution = "fedora"}
-  ["mariadb-connector-c-devel"] {os-distribution = "ol"}
+  ["mariadb-connector-c-devel"] {os-distribution = "ol" & os-version >= "8"}
   ["libmariadb-devel"] {os-family = "suse"}
   ["mariadb-libs"] {os-family = "arch"}
   ["mariadb-connector-c"] {os = "macos" & os-distribution = "homebrew"}
@@ -26,6 +26,7 @@ depexts: [
 ]
 x-ci-accept-failures: [
   "centos-7"
+  "oraclelinux-7"
   "ubuntu-16.04"
 ]
 synopsis:

--- a/packages/conf-mariadb/conf-mariadb.2/opam
+++ b/packages/conf-mariadb/conf-mariadb.2/opam
@@ -6,17 +6,27 @@ bug-reports: "https://jira.mariadb.org/projects/MDEV/issues"
 dev-repo: "git+https://github.com/MariaDB/server.git"
 license: "GPL-2.0-only"
 build: [
-  ["pkg-config" "mariadb"] {os != "macos" & os-distribution != "alpine"}
-  ["pkg-config" "libmariadb"] {os = "macos" | os-distribution = "alpine"}
+  ["pkg-config" "--exists" "libmariadb"]
 ]
 depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libmariadbclient-dev"] {os-family = "debian"}
-  ["mariadb-devel"] {os-distribution = "centos"}
+  ["libmariadbclient-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
+  ["libmariadbclient-dev"] {os-family = "ubuntu"}
+  ["libmariadbclient-dev"] {os-distribution = "ubuntu" & os-version >= "18.04"}
+  ["mariadb-connector-c-dev"] {os-family = "alpine"}
+  ["mariadb-connector-c-devel"] {os-distribution = "centos" & os-version >= "8"}
+  ["mariadb-connector-c-devel"] {os-distribution = "fedora"}
+  ["mariadb-connector-c-devel"] {os-distribution = "ol"}
+  ["libmariadb-devel"] {os-family = "suse"}
+  ["mariadb-libs"] {os-family = "arch"}
   ["mariadb-connector-c"] {os = "macos" & os-distribution = "homebrew"}
-  ["mariadb-connector-c-dev"] {os-distribution = "alpine"}
+  ["mariadb-connector-c"] {os = "freebsd"}
+]
+x-ci-accept-failures: [
+  "centos-7"
+  "ubuntu-16.04"
 ]
 synopsis:
   "Virtual package relying on a libmariadbclient system installation"

--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -14,8 +14,10 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
   ["postgresql-devel"] {os-distribution = "fedora"}
-  ["postgresql-devel"] {os-family = "suse"}
+  ["postgresql-devel"] {os-distribution = "ol"}
+  ["postgresql-server-devel"] {os-family = "suse"}
   ["postgresql-dev"] {os-distribution = "alpine"}
+  ["postgresql-libs"] {os-family = "arch"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/mariadb/mariadb.1.1.4/opam
+++ b/packages/mariadb/mariadb.1.1.4/opam
@@ -18,9 +18,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
-]
-depexts: [
-  ["libmariadb-dev"] {os-family = "debian"}
+  "conf-mariadb"
 ]
 url {
   src: "https://github.com/andrenth/ocaml-mariadb/archive/1.1.4.tar.gz"


### PR DESCRIPTION
All sub-packages are updated except caqti-type-calendar.

From the release notes:

- Implement `affected_count` for sqlite backend (GPR#46 jakob).
- Add method `exec_with_affected_count` to `Caqti_connection_sig.S` (GPR#45
  jakob).
- Add `?max_idle_size` to pool creation functions.
- Dropped dependency on `ppx_deriving` due to issue with static compilation
  (GPR#50 Ulrik Strid).
- Pass through `$<var>$` in query strings and deprecate `$$`.
- Log statements to be executed at debug level.
- Add COPYING.OCAML and fix license expression in opam files.
- Misc improvements to tests and documentation (GPR#51 Philippe Wang, GPR#54
  Reynir Björnsson, etc.).
