### PR TITLE
release camlp5, (full) pa_ppx suite, compat ocaml 4.12.0

### DIFF
--- a/packages/camlp5/camlp5.8.00.01/opam
+++ b/packages/camlp5/camlp5.8.00.01/opam
@@ -1,0 +1,59 @@
+name: "camlp5"
+version: "8.00.01"
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.02" & < "4.13.0"}
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "conf-diffutils" { with-test & os-distribution = "alpine" }
+  "pcre" { with-test }
+  "ounit" { with-test }
+  "rresult" { with-test }
+  "fmt" { with-test }
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "-j%{jobs}%" "DEBUG=-g" "world.opt"]
+  [make "-j%{jobs}%" "DEBUG=-g" "all"]
+  [make "-C" "testsuite" "clean" "all-tests"] { with-test & ocaml:version >= "4.10.0" }
+  [make "-C" "test" "clean" "all"] {with-test & ocaml:version >= "4.10.0" }
+]
+install: [make "install"]
+
+post-messages:
+  "To use mkcamlp5 and mkcamlp5.opt properly you will require Perl module which contains 'IPC/System/Simple.pm'. We currently don't know the right way to specify this dependecy on BSD and MacOS systems. You can use https://github.com/camlp5/camlp5/issues/66 for discussion." { os = "macos" | os = "freebsd" | os = "openbsd" }
+
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/rel8.00.01.tar.gz"
+  checksum: [
+    "sha512=f40e57845ac4a14cf260ddd9df616d12df09f67efaf6735e915598aee981721e8203bf9203fb83d08e34e43021c08003de64dbf3bdcd4d12fd079542fb7649aa"
+  ]
+}

--- a/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.1/opam
+++ b/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["epel-release" "perl-IPC-System-Simple"] {os-distribution = "centos"}
   ["perl-IPC-System-Simple"] {os-distribution = "ol" & os-version >= "8"}
   ["perl-IPC-System-Simple"] {os-family = "suse"}
-  ["perl-IPC-System-Simple"] {os-family = "fedora"}
+  ["perl-IPC-System-Simple"] {os-distribution = "fedora"}
   ["perl-ipc-system-simple"] {os-family = "arch"}
 ]
 x-ci-accept-failures: [

--- a/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.1/opam
+++ b/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.1/opam
@@ -15,10 +15,13 @@ depexts: [
   ["libipc-system-simple-perl"] {os-family = "debian"}
   ["perl-ipc-system-simple"] {os-distribution = "alpine"}
   ["epel-release" "perl-IPC-System-Simple"] {os-distribution = "centos"}
-  ["perl-IPC-System-Simple"] {os-distribution = "ol"}
+  ["perl-IPC-System-Simple"] {os-distribution = "ol" & os-version >= "8"}
   ["perl-IPC-System-Simple"] {os-family = "suse"}
   ["perl-IPC-System-Simple"] {os-family = "fedora"}
   ["perl-ipc-system-simple"] {os-family = "arch"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7"
 ]
 synopsis: "Virtual package relying on perl's IPC::System::Simple"
 description:

--- a/packages/pa_ppx/pa_ppx.0.07.02/opam
+++ b/packages/pa_ppx/pa_ppx.0.07.02/opam
@@ -1,0 +1,67 @@
+version: "0.07.02"
+synopsis: "PPX Rewriters for Ocaml, written using Camlp5"
+description:
+"""
+This is a collection of PPX rewriters, re-implementing those based on ppxlib
+and other libraries, but instead based on Camlp5.  Included is also a collection
+of support libraries for writing new PPX rewriters.  Included are:
+
+pa_assert: ppx_assert
+pa_ppx.deriving, pa_ppx.deriving_plugins (enum, eq, fold, iter, make, map, ord, sexp, show, yojson):
+  ppx_deriving, plugins, ppx_sexp_conv, ppx_deriving_yojson
+pa_ppx.expect_test: ppx_expect_test
+pa_ppx.here: ppx_here
+pa_ppx.import: ppx_import
+pa_ppx.inline_test: ppx_inline_test
+
+pa_ppx.undo_deriving: pa_ppx.deriving expands [@@deriving ...] into code; this rewriter undoes that.
+pa_ppx.unmatched_vala: expands to match-cases (support library for camlp5-based PPX rewriters)
+pa_ppx.hashrecons: support for writing AST rewriters that automatically fills in hash-consing boilerplate
+pa_dock: implements doc-comment extraction for camlp5 preprocessors
+
+Many of the reimplementations in fact offer significant enhanced
+function, described in the pa_ppx documentation.  In addition, there
+is an extensive test-suite, much of it slightly modified versions of
+the tests for the respective PPX rewriters.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx.git"
+doc: "https://github.com/camlp5/pa_ppx/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "4.13.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "yojson" { >= "1.7.0" }
+  "sexplib0"
+  "bos" { >= "0.2.0" }
+  "uint" { >= "2.0.1" }
+  "ounit"
+#  "ppx_import" { with-test & >= "1.7.1" }
+#  "ppx_deriving_yojson" { with-test & >= "3.5.2" }
+#  "ppx_here" { with-test & >= "v0.13.0" }
+#  "ppx_sexp_conv" { with-test & >= "v0.13.0" }
+#  "expect_test_helpers" { with-test & >= "v0.13.0" }
+]
+build: [
+  [make "get-generated"]
+  [make "-j%{jobs}%" "DEBUG=-g" "sys"]
+#  [make "DEBUG=-g" "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx/archive/0.07.02.tar.gz"
+  checksum: [
+    "sha512=f2edc95ae6b2cf2ea23f540ec6d268d028a73d4099565e003813e50019d5a982e5f9c52710fab6cafb238cf577e4c71486a6a411554e7865187fee567533d632"
+  ]
+}

--- a/packages/pa_ppx_ag/pa_ppx_ag.0.07.02/opam
+++ b/packages/pa_ppx_ag/pa_ppx_ag.0.07.02/opam
@@ -1,0 +1,43 @@
+version: "0.07.02"
+synopsis: "A PPX Rewriter that Generates Attribute Grammar Evaulators"
+description:
+"""
+This is a PPX Rewriter that generates Attribute Grammar evaulators.
+Initially only ordered ones, but eventually other strategies too.
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_ag"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_ag/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_ag.git"
+doc: "https://github.com/camlp5/pa_ppx_ag/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "4.13.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "pa_ppx"      { >= "0.07.02" }
+  "pa_ppx_migrate"     { >= "0.07.02" }
+  "pa_ppx_hashcons"    { >= "0.07.02" }
+  "pa_ppx_unique"      { >= "0.07.02" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "vec"
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "sys"]
+#  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_ag/archive/0.07.02.tar.gz"
+  checksum: [
+    "sha512=80cbe231973379e7483bcfdbd25b29c0cbed6872f122cb25c55f4d4b164b78ac5e0f79d3af0458b65362bba89779c092be3e192bdc57885e9e8005b267e5fb6b"
+  ]
+}

--- a/packages/pa_ppx_hashcons/pa_ppx_hashcons.0.07.02/opam
+++ b/packages/pa_ppx_hashcons/pa_ppx_hashcons.0.07.02/opam
@@ -1,0 +1,43 @@
+version: "0.07.02"
+synopsis: "A PPX Rewriter for Hashconsing"
+description:
+"""
+This is a PPX Rewriter for generating hashconsing implementations
+of ASTs, mechanizing the ideas and code of Jean-Christophe Filliatre
+and Sylvain Conchon.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_hashcons"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_hashcons/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_hashcons.git"
+doc: "https://github.com/camlp5/pa_ppx_hashcons/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "4.13.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "pa_ppx"      { >= "0.07.02" }
+  "pa_ppx_migrate"      { with-test & >= "0.07.02" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+  "hashcons"
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_hashcons/archive/0.07.02.tar.gz"
+  checksum: [
+    "sha512=c742da1be4406918289eabeb08100e89a150602a4ec24e8736e6167e064839d18754db5f424817b0227671b9805f235182add2090f8cd4cb9b03594f559c8123"
+  ]
+}

--- a/packages/pa_ppx_migrate/pa_ppx_migrate.0.07.02/opam
+++ b/packages/pa_ppx_migrate/pa_ppx_migrate.0.07.02/opam
@@ -1,0 +1,46 @@
+version: "0.07.02"
+synopsis: "A PPX Rewriter for Migrating AST types (written using Camlp5)"
+description:
+"""
+This is a PPX Rewriter for generating "migrations" like those written
+by-hand (with some automated support) in "ocaml-migrate-parsetree".
+The goal here is that the input to the automated tool is the minimum
+possible, with no need for human massaging of output from the tool.
+
+There are two examples: a small one (in a unit-test) and a full set of
+migrations from Ocaml's AST 4.02 all the way up to 4.11, with all the
+intermediate ASTs, and migrations forward as well as backward.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_migrate"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_migrate/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_migrate.git"
+doc: "https://github.com/camlp5/pa_ppx_migrate/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "4.13.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "pa_ppx"      { >= "0.07.02" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_migrate/archive/0.07.02.tar.gz"
+  checksum: [
+    "sha512=e5fda29951f18c13b46ac5ed096d5d1a40957a47badeb0c23abded0eb5abcc0c7b71c6803afec8da5af96d82533b8c9064908a096d4edd04557203f1549f34bd"
+  ]
+}

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.07.02/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.07.02/opam
@@ -1,0 +1,43 @@
+version: "0.07.02"
+synopsis: "A PPX Rewriter for automating generation of data-conversion code for use with Camlp5's Q_ast"
+description:
+"""
+This is a PPX Rewriter for generating data-conversion code that is otherwise
+hand-written, when using Camlp5's Q_ast.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_q_ast"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_q_ast/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_q_ast.git"
+doc: "https://github.com/camlp5/pa_ppx_q_ast/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "4.13.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "pa_ppx"      { >= "0.07.02" }
+  "pa_ppx_migrate"      { with-test & >= "0.07.02" }
+  "pa_ppx_hashcons"      { >= "0.07.02" }
+  "pa_ppx_unique"      { >= "0.07.02" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_q_ast/archive/0.07.02.tar.gz"
+  checksum: [
+    "sha512=82dc57ea44ba268252e5e82f6cd8a01c724d7c04eaede80743bbca8f2aa7636319583e408f1829d631af3c1dae702f171e765d63eb571d060e48e63fd02d57dc"
+  ]
+}

--- a/packages/pa_ppx_unique/pa_ppx_unique.0.07.02/opam
+++ b/packages/pa_ppx_unique/pa_ppx_unique.0.07.02/opam
@@ -1,0 +1,40 @@
+version: "0.07.02"
+synopsis: "A PPX Rewriter for Uniqifying ASTs"
+description:
+"""
+This is a PPX Rewriter for uniqifying ASTs: inserting unique IDs
+systematically throughout an AST.
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_unique"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_unique/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_unique.git"
+doc: "https://github.com/camlp5/pa_ppx_unique/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "4.13.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "pa_ppx"      { >= "0.07.02" }
+  "pa_ppx_migrate"      { with-test & >= "0.07.02" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_unique/archive/0.07.02.tar.gz"
+  checksum: [
+    "sha512=7649db01a15f4bcb362ec8613979ea499a7c5f472c1ef505b672ebcadfd98a7937776618354a6d68df4d94ca9aa0dc243e0c8501566bff043db6beffa442586f"
+  ]
+}


### PR DESCRIPTION
This releases

* camlp5 compat with ocaml 4.12.0, along with some bugfixes
* pa_ppx, same as above
* new PPX rewriters for:
  * migrating ASTs
  * hashconsing types automatically (and generating memoizing functions)
  * adding unique-ids to nodes in an AST
  * automatically generating Camlp5-style quotations for new AST types
  * the start of an attribute-grammar evaluator-generator: currently support topological and ordered evaluation

Lot of code here, and I broke it up b/c they really are independent, and some are big enough that someone might not want to install them all in order to just get one bit of function.
