### PR TITLE
[new release] mdx (1.8.0)

### DIFF
--- a/packages/mdx/mdx.1.8.0/opam
+++ b/packages/mdx/mdx.1.8.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date.
+
+`ocaml-mdx` is released as two binaries called `ocaml-mdx` and `mdx` which are
+the same, mdx being the deprecated name, kept for now for compatibility."""
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "ISC"
+homepage: "https://github.com/realworldocaml/mdx"
+bug-reports: "https://github.com/realworldocaml/mdx/issues"
+depends: [
+  "dune" {>= "2.2"}
+  "ocaml" {>= "4.02.3"}
+  "ocamlfind"
+  "fmt"
+  "cppo" {build}
+  "astring"
+  "logs"
+  "cmdliner" {>= "1.0.0"}
+  "re" {>= "1.7.2"}
+  "result"
+  "ocaml-migrate-parsetree" {>= "1.0.6" & < "2.0.0"}
+  "ocaml-version" {>= "2.3.0"}
+  "odoc"
+  "lwt" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/realworldocaml/mdx.git"
+x-commit-hash: "bba086984e8cfe65197b476a6ee889ab17b63026"
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/1.8.0/mdx-1.8.0.tbz"
+  checksum: [
+    "sha256=a248a58792c132f5b63982148ad85cc1d531a354cbbdd08156e108d5c6b951dc"
+    "sha512=1233893859b0f67a43759ec0c1c795dbbffa40555eb37440ea161dc3f773b8724f368d749a05555687244a62af8036a97357bec86376659d70f3d9d4355496e2"
+  ]
+}


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>

##### CHANGES:

#### Added

- Allow to explicitly set the kind of blocks in labels: `ocaml`, `cram`, `toplevel` or `include`. (realworldocaml/mdx#237, @gpetiot)
- Include blocks do not require an empty block anymore (realworldocaml/mdx#286, @gpetiot)
- Support for OCaml 4.12 (realworldocaml/mdx#298, @kit-ty-kate)

#### Changed

- Improve error message of cram test exceptions due to empty lines in a block (realworldocaml/mdx#270, @pitag-ha)

#### Fixed

- Report `#require` directive errors (realworldocaml/mdx#276, @gpetiot)
- Handle no such file exception: the input file and the values of options `--root` and `--prelude` are checked (realworldocaml/mdx#292, @gpetiot)
- Keep locations from parsing instead of recomputing the lines, providing better error messages (realworldocaml/mdx#241, @gpetiot)
- Use `create_process` instead of `execvp` to call `mdx-test` from `mdx`. This fixes running mdx from dune on Windows (realworldocaml/mdx#299, @emillon)
