### PR TITLE
[new release] dap (1.0.4)

### DIFF
--- a/packages/dap/dap.1.0.4/opam
+++ b/packages/dap/dap.1.0.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Debug adapter protocol"
+description: """
+The Debug Adapter Protocol defines the protocol used between an editor or IDE and a debugger or runtime.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocaml-dap"
+bug-reports: "https://github.com/hackwaly/ocaml-dap/issues"
+dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
+doc: "https://hackwaly.github.io/ocaml-dap/"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "yojson"
+  "ppx_here"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "lwt"
+  "lwt_ppx"
+  "lwt_react"
+  "react"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+x-commit-hash: "113b68dcc4a61344adac9c08096424f8fb7628df"
+url {
+  src:
+    "https://github.com/hackwaly/ocaml-dap/releases/download/1.0.4/dap-1.0.4.tbz"
+  checksum: [
+    "sha256=93505ff0a7cfb411b45df9420a1f77aee5a06a46a38e483438da72978fa3927a"
+    "sha512=5e91fa18e18908ec7226b8a78b5205f700124613797b6562631648349e952b06f011badd494a77ebfcfaa1f7223acc2a7c252cd033b1cbd2073d774c89dc5854"
+  ]
+}


### PR DESCRIPTION
Debug adapter protocol

- Project page: <a href="https://github.com/hackwaly/ocaml-dap">https://github.com/hackwaly/ocaml-dap</a>
- Documentation: <a href="https://hackwaly.github.io/ocaml-dap/">https://hackwaly.github.io/ocaml-dap/</a>

##### CHANGES:

### Added

- Added Debug_rpc.log_src to allow to control log level externally
