### PR TITLE
[new release] repr, repr-fuzz, repr-bench and ppx_repr (0.2.1)

### DIFF
--- a/packages/ppx_repr/ppx_repr.0.2.1/opam
+++ b/packages/ppx_repr/ppx_repr.0.2.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "PPX deriver for type representations"
+description: "PPX deriver for type representations"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "ppxlib" {>= "0.12.0"}
+  "ppx_deriving"
+  "hex" {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "4580711e964edcbb0cbced99cb4d456ca453c1c9"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.2.1/repr-fuzz-0.2.1.tbz"
+  checksum: [
+    "sha256=0ca29b7273870190b724e6db1f782980c175c50d9a208ff8ad351cbbb85a7fb1"
+    "sha512=5b7d32724e70ffcbc15bdefc71871148d0f2b743f6d664891e1126d194d3752dfb7715dbbe6046bcbd6f19c384a840b3e66c4130b5bb663580aeb6d697d7a20d"
+  ]
+}

--- a/packages/repr-bench/repr-bench.0.2.1/opam
+++ b/packages/repr-bench/repr-bench.0.2.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Benchmarks for the `repr` package"
+description: "Benchmarks for the `repr` package"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "ppx_repr" {= version}
+  "bechamel"
+  "yojson"
+  "fpath"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "4580711e964edcbb0cbced99cb4d456ca453c1c9"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.2.1/repr-fuzz-0.2.1.tbz"
+  checksum: [
+    "sha256=0ca29b7273870190b724e6db1f782980c175c50d9a208ff8ad351cbbb85a7fb1"
+    "sha512=5b7d32724e70ffcbc15bdefc71871148d0f2b743f6d664891e1126d194d3752dfb7715dbbe6046bcbd6f19c384a840b3e66c4130b5bb663580aeb6d697d7a20d"
+  ]
+}

--- a/packages/repr-fuzz/repr-fuzz.0.2.1/opam
+++ b/packages/repr-fuzz/repr-fuzz.0.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Fuzz tests for the `repr` package"
+description: "Fuzz tests for the `repr` package"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "crowbar" {= "0.2"}
+  "ppxlib" {>= "0.12.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "4580711e964edcbb0cbced99cb4d456ca453c1c9"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.2.1/repr-fuzz-0.2.1.tbz"
+  checksum: [
+    "sha256=0ca29b7273870190b724e6db1f782980c175c50d9a208ff8ad351cbbb85a7fb1"
+    "sha512=5b7d32724e70ffcbc15bdefc71871148d0f2b743f6d664891e1126d194d3752dfb7715dbbe6046bcbd6f19c384a840b3e66c4130b5bb663580aeb6d697d7a20d"
+  ]
+}

--- a/packages/repr/repr.0.2.1/opam
+++ b/packages/repr/repr.0.2.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Dynamic type representations. Provides no stability guarantee"
+description: """
+This package defines a library of combinators for building dynamic type
+representations and a set of generic operations over representable types, used
+in the implementation of Irmin and related packages.
+
+It is not yet intended for public consumption and provides no stability
+guarantee.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.7"}
+  "uutf"
+  "either"
+  "jsonm" {>= "1.0.0"}
+  "base64" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "4580711e964edcbb0cbced99cb4d456ca453c1c9"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.2.1/repr-fuzz-0.2.1.tbz"
+  checksum: [
+    "sha256=0ca29b7273870190b724e6db1f782980c175c50d9a208ff8ad351cbbb85a7fb1"
+    "sha512=5b7d32724e70ffcbc15bdefc71871148d0f2b743f6d664891e1126d194d3752dfb7715dbbe6046bcbd6f19c384a840b3e66c4130b5bb663580aeb6d697d7a20d"
+  ]
+}


### PR DESCRIPTION
Dynamic type representations. Provides no stability guarantee

- Project page: <a href="https://github.com/mirage/repr">https://github.com/mirage/repr</a>

##### CHANGES:

- Support Ppxlib versions >= 0.18.0. (mirage/repr#35, @CraigFe)
- Add missing dependency on `ppx_deriving`. (mirage/repr#36, CraigFe)
- Add a representation of the `Either.t` type. (mirage/repr#33, @CraigFe)
