### PR TITLE
[new release] semaphore-compat (1.0.1)

### DIFF
--- a/packages/index/index.1.3.0/opam
+++ b/packages/index/index.1.3.0/opam
@@ -28,7 +28,7 @@ depends: [
   "mtime"   {>= "1.0.0"}
   "cmdliner"
   "progress"
-  "semaphore-compat"
+  "semaphore-compat" {>= "1.0.1"}
   "jsonm"
   "stdlib-shims"
   "alcotest" {with-test}

--- a/packages/semaphore-compat/semaphore-compat.1.0.1/opam
+++ b/packages/semaphore-compat/semaphore-compat.1.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Compatibility Semaphore module"
+description: """
+Projects that want to use the Semaphore module defined in OCaml 4.12.0 while
+staying compatible with older versions of OCaml should use this library
+instead.
+"""
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Xavier Leroy"]
+license: "LGPLv2"
+homepage: "https://github.com/mirage/semaphore-compat"
+doc: "https://mirage.github.io/semaphore-compat"
+bug-reports: "https://github.com/mirage/semaphore-compat/issues"
+depends: [
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/semaphore-compat.git"
+x-commit-hash: "8ff3ea8e1f441f86d295a8be619e3f5df3d0c429"
+url {
+  src:
+    "https://github.com/mirage/semaphore-compat/releases/download/1.0.1/semaphore-compat-1.0.1.tbz"
+  checksum: [
+    "sha256=2b771ff5bdcc658404ab6029415b0f7404817287bb7bcf990caf91db7a2e2c8d"
+    "sha512=075fbfc2037dabcbc4a9d135d1a9301825819adb5c8dbf9024c4aa8615f769676121bdf1c98739c306457a59507bb361514d6c1206947c1c1080eeffc261a025"
+  ]
+}


### PR DESCRIPTION
Compatibility Semaphore module

- Project page: <a href="https://github.com/mirage/semaphore-compat">https://github.com/mirage/semaphore-compat</a>
- Documentation: <a href="https://mirage.github.io/semaphore-compat">https://mirage.github.io/semaphore-compat</a>

##### CHANGES:

- Avoid destructive substitution in 4.12+ alias to ensure equivalent
  `Semaphore` signatures. (mirage/semaphore-compat#1, @CraigFe)
