### PR TITLE
Unlock the whole bap stack for OCaml 4.12

### DIFF
--- a/packages/bap-relation/bap-relation.2.2.0/opam
+++ b/packages/bap-relation/bap-relation.2.2.0/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-relation"]]
 depends: [
-  "ocaml" {>= "4.08.0" & < "4.12.0"}
+  "ocaml" {>= "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "base" {>= "v0.11.0"}
 ]


### PR DESCRIPTION
cc @ivg is that ok for you? I've compiled the whole stack (or at least the path used by `bap-pheonix.2.2.0`) locally on OCaml 4.12 and it works perfectly