### PR TITLE
+ extlib 1.7.8

### DIFF
--- a/packages/dose3/dose3.4.3/opam
+++ b/packages/dose3/dose3.4.3/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml"
   "ocamlgraph" {= "1.8.6"}
   "cudf" {>= "0.7"}
-  ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})
+  ("extlib" {>= "1.7.0" & < "1.7.8"} | "extlib-compat" {>= "1.7.0"})
   "re" {>= "1.2.2"}
   "ocamlbuild" {build}
   "cppo" {build & >= "1.1.2"}

--- a/packages/dose3/dose3.5.0.1-1/opam
+++ b/packages/dose3/dose3.5.0.1-1/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml"
   "ocamlgraph" {>= "1.8.6"}
   "cudf" {>= "0.7"}
-  ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})
+  ("extlib" {>= "1.7.0" & < "1.7.8"} | "extlib-compat" {>= "1.7.0"})
   "re" {>= "1.2.2"}
   "ocamlbuild" {build}
   "cppo" {build & >= "1.1.2"}

--- a/packages/dose3/dose3.5.0.1/opam
+++ b/packages/dose3/dose3.5.0.1/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml"
   "ocamlgraph" {>= "1.8.6" & < "2.0.0"}
   "cudf" {>= "0.7"}
-  ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})
+  ("extlib" {>= "1.7.0" & < "1.7.8"} | "extlib-compat" {>= "1.7.0"})
   "re" {>= "1.2.2"}
   "ocamlbuild" {build}
   "cppo" {build & >= "1.1.2"}

--- a/packages/dose3/dose3.5.0/opam
+++ b/packages/dose3/dose3.5.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml"
   "ocamlgraph" {= "1.8.6"}
   "cudf" {>= "0.7"}
-  ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})
+  ("extlib" {>= "1.7.0" & < "1.7.8"} | "extlib-compat" {>= "1.7.0"})
   "re" {>= "1.2.2"}
   "ocamlbuild" {build}
   "cppo" {build & >= "1.1.2"}

--- a/packages/extlib/extlib.1.7.8/opam
+++ b/packages/extlib/extlib.1.7.8/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "ygrek@autistici.org"
+homepage: "https://github.com/ygrek/ocaml-extlib"
+dev-repo: "git://github.com/ygrek/ocaml-extlib.git"
+bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
+doc: ["https://ygrek.org/p/extlib/doc/"]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+authors: [
+  "Nicolas Cannasse"
+  "Brian Hurt"
+  "Yamagata Yoriyuki"
+  "Markus Mottl"
+  "Jesse Guardiani"
+  "John Skaller"
+  "Bardur Arantsson"
+  "Janne Hellsten"
+  "Richard W.M. Jones"
+  "ygrek"
+  "Gabriel Scherer"
+  "Pietro Abate"
+]
+build: [
+  [make "minimal=1" "build"]
+  [make "minimal=1" "test"] {with-test}
+  [make "minimal=1" "doc"] {with-doc}
+]
+install: [ [make "minimal=1" "install"] ]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+  "cppo" {build}
+  "base-bytes" {build}
+]
+synopsis:
+  "A complete yet small extension for OCaml standard library (reduced, recommended)"
+description: """
+The purpose of this library is to add new functions to OCaml standard library
+modules, to modify some functions in order to get better performances or
+safety (tail-recursive) and also to provide new modules which should be useful
+for day to day programming.
+
+Current goal is to maintain compatibility, new software is encouraged to not use extlib since stdlib
+is now seeing many additions and improvements which make many parts of extlib obsolete.
+For tail-recursion safety consider using other libraries e.g. containers.
+"""
+url {
+  src: "https://ygrek.org/p/release/ocaml-extlib/extlib-1.7.8.tar.gz"
+  checksum: [
+    "md5=7e0df072af4e2daa094e5936a661cb11"
+    "sha256=935ca46843af40dc33306d9cce66163d3733312bf444e969b5a8fa3f3024f85a"
+    "sha512=664a8366fb4eed685bd8f8907dbc9a8103bbf75ebb5d7635f6db890722e673107aa052bd09c276f5ed10dc3695220234c382d90d4f8c4e6b93ff68dd22e876e4"
+  ]
+  mirrors: "https://github.com/ygrek/ocaml-extlib/releases/download/1.7.8/extlib-1.7.8.tar.gz"
+}

--- a/packages/extprot/extprot.1.1.1/opam
+++ b/packages/extprot/extprot.1.1.1/opam
@@ -14,7 +14,7 @@ remove: [
 depends: [
   "ocaml" {< "4.02.0"}
   "ocamlfind"
-  ("extlib" | "extlib-compat")
+  ("extlib" {< "1.7.8"} | "extlib-compat")
   "sexplib" {< "113.01.00"}
   "type_conv"
   "omake"

--- a/packages/extprot/extprot.1.1.2/opam
+++ b/packages/extprot/extprot.1.1.2/opam
@@ -14,7 +14,7 @@ remove: [
 depends: [
   "ocaml"
   "ocamlfind"
-  ("extlib" | "extlib-compat")
+  ("extlib" {< "1.7.8"} | "extlib-compat")
   "sexplib" {< "113.01.00"}
   "type_conv"
   "omake"

--- a/packages/extprot/extprot.1.2.0/opam
+++ b/packages/extprot/extprot.1.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "sexplib" {build & < "113.01.00"}
   "type_conv" {build}
   "ounit" {with-test}
-  ("extlib" | "extlib-compat")
+  ("extlib" {< "1.7.8"} | "extlib-compat")
   "base-bytes"
 ]
 synopsis:

--- a/packages/extprot/extprot.1.3.0/opam
+++ b/packages/extprot/extprot.1.3.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlfind" {build}
   "ounit" {with-test}
   "camlp4" {build}
-  "extlib" | "extlib-compat"
+  "extlib" {< "1.7.8"} | "extlib-compat"
   "base-bytes"
 ]
 synopsis:

--- a/packages/extprot/extprot.1.4.0/opam
+++ b/packages/extprot/extprot.1.4.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlfind" {build}
   "ounit" {with-test}
   "camlp4" {build}
-  "extlib" | "extlib-compat"
+  "extlib" {< "1.7.8"} | "extlib-compat"
   "base-bytes"
 ]
 synopsis:

--- a/packages/extprot/extprot.1.5.0/opam
+++ b/packages/extprot/extprot.1.5.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlfind" {build}
   "ounit" {with-test}
   "camlp4" {build}
-  ("extlib" | "extlib-compat")
+  ("extlib" {< "1.7.8"} | "extlib-compat")
   "base-bytes"
 ]
 synopsis:

--- a/packages/extprot/extprot.1.6.0/opam
+++ b/packages/extprot/extprot.1.6.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlfind" {build}
   "ounit" {with-test}
   "camlp4" {build}
-  ("extlib" | "extlib-compat")
+  ("extlib" {< "1.7.8"} | "extlib-compat")
   "base-bytes"
 ]
 synopsis:

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.6.21/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.6.21/opam
@@ -27,6 +27,7 @@ depends: [
   "ocamlfuse" {< "2.7.1-cvs6"}
   "ounit" {with-test}
   "sqlite3"
+  "extlib" {< "1.7.8"}
 ]
 synopsis: "A FUSE filesystem over Google Drive"
 description: """

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.6.22/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.6.22/opam
@@ -27,6 +27,7 @@ depends: [
   "ocamlfuse" {< "2.7.1-cvs6"}
   "ounit" {build}
   "sqlite3"
+  "extlib" {< "1.7.8"}
 ]
 synopsis: "A FUSE filesystem over Google Drive"
 description: """

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.6.23/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.6.23/opam
@@ -17,7 +17,7 @@ depends: [
   "jbuilder"
   "ocamlfuse" {< "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.6.26/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.6.26/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {< "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.1/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {< "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.11/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.11/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.13/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.13/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.14/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.14/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.15/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.15/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.16/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.16/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.17/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.17/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.18/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.18/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.19/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.19/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.2/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.2/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {< "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.20/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.20/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.21/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.21/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.22/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.22/opam
@@ -13,12 +13,11 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "base-threads" {build}
   "camlidl" {build}
-  "extlib" | "extlib-compat"
   "gapi-ocaml" {>= "0.3.19"}
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.23/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.23/opam
@@ -13,12 +13,11 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "base-threads" {build}
   "camlidl" {build}
-  "extlib" | "extlib-compat"
   "gapi-ocaml" {>= "0.3.19"}
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.24/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.24/opam
@@ -13,12 +13,11 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "base-threads" {build}
   "camlidl" {build}
-  "extlib" | "extlib-compat"
   "gapi-ocaml" {>= "0.3.19"}
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.3/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.3/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.4/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.4/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.5/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.5/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.6/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.6/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.7/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.7/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.8/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.8/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.9/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.7.9/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "ocamlfuse" {>= "2.7.1-cvs6"}
   "cryptokit"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ounit" {with-test}
   "sqlite3"
 ]

--- a/packages/haxe/haxe.4.0.0/opam
+++ b/packages/haxe/haxe.4.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "camlp5" {build}
   "sedlex" {build & >= "2.0"}
   "xml-light" {build}
-  "extlib" {build & >= "1.7.6"}
+  "extlib" {build & >= "1.7.6" & < "1.7.8"}
   "ptmap" {build & >= "2.0.0"}
   "sha" {build}
   "conf-libpcre"

--- a/packages/haxe/haxe.4.0.1/opam
+++ b/packages/haxe/haxe.4.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "camlp5" {build}
   "sedlex" {build & >= "2.0"}
   "xml-light" {build}
-  "extlib" {build & >= "1.7.6"}
+  "extlib" {build & >= "1.7.6" & < "1.7.8"}
   "ptmap" {build & >= "2.0.0"}
   "sha" {build}
   "conf-libpcre"

--- a/packages/haxe/haxe.4.0.2/opam
+++ b/packages/haxe/haxe.4.0.2/opam
@@ -21,7 +21,7 @@ depends: [
   "camlp5" {build}
   "sedlex" {build & >= "2.0"}
   "xml-light" {build}
-  "extlib" {build & >= "1.7.6"}
+  "extlib" {build & >= "1.7.6" & < "1.7.8"}
   "ptmap" {build & >= "2.0.0"}
   "sha" {build}
   "conf-libpcre"

--- a/packages/haxe/haxe.4.0.3/opam
+++ b/packages/haxe/haxe.4.0.3/opam
@@ -21,7 +21,7 @@ depends: [
   "camlp5" {build}
   "sedlex" {build & >= "2.0"}
   "xml-light" {build}
-  "extlib" {build & >= "1.7.6"}
+  "extlib" {build & >= "1.7.6" & < "1.7.8"}
   "ptmap" {build & >= "2.0.0"}
   "sha" {build}
   "conf-libpcre"

--- a/packages/haxe/haxe.4.0.5/opam
+++ b/packages/haxe/haxe.4.0.5/opam
@@ -21,7 +21,7 @@ depends: [
   "camlp5" {build}
   "sedlex" {build & >= "2.0"}
   "xml-light" {build}
-  "extlib" {build & >= "1.7.6"}
+  "extlib" {build & >= "1.7.6" & < "1.7.8"}
   "ptmap" {build & >= "2.0.0"}
   "sha" {build}
   "conf-libpcre"

--- a/packages/haxe/haxe.4.1.1/opam
+++ b/packages/haxe/haxe.4.1.1/opam
@@ -22,7 +22,7 @@ depends: [
   "camlp5" {build}
   "sedlex" {>= "2.0"}
   "xml-light"
-  "extlib" {>= "1.7.6"}
+  "extlib" {>= "1.7.6" & < "1.7.8"}
   "ptmap" {>= "2.0.0"}
   "sha"
   "conf-libpcre"


### PR DESCRIPTION
1.7.8 (2021-01-19)
* sync with OCaml 4.12
* breaking change: ExtList.find_map type updated to match stdlib (following deprecation in previous release)
* breaking change: minimal (recommended) build of extlib now excludes Base64 module