### PR TITLE
[new release] ppxlib (0.21.0)

### DIFF
--- a/packages/ppxlib/ppxlib.0.21.0/opam
+++ b/packages/ppxlib/ppxlib.0.21.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.07" }
+]
+depends: [
+  "ocaml"                   {>= "4.04.1" & < "4.13"}
+  "dune"                    {>= "1.11"}
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "2.1.0"}
+  "ppx_derivers"            {>= "1.0"}
+  "sexplib0"
+  "stdlib-shims"
+  "ocamlfind"               {with-test}
+  "re"                      {with-test & >= "1.9.0"}
+  "cinaps"                  {with-test & >= "v0.12.1"}
+  "base"                    {with-test}
+  "stdio"                   {with-test}
+]
+synopsis: "Standard library for ppx rewriters"
+description: """
+Ppxlib is the standard library for ppx rewriters and other programs
+that manipulate the in-memory reprensation of OCaml programs, a.k.a
+the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+x-commit-hash: "995f7175affc8c83af2e5d791122229b63801a08"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.21.0/ppxlib-0.21.0.tbz"
+  checksum: [
+    "sha256=f367841752a6132f50fefa93d780f955722b6d9be71d200c8e70704e2754c7b5"
+    "sha512=02393ef4f6c9dd6952366450a4c6678b9f24dcbdf6580ddc6c5289cf4b7c9796394b5868bf7e11f2b0c830ba86a75f05a762e062adc4e4490481e16cffb55cc9"
+  ]
+}


### PR DESCRIPTION
Standard library for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Driver (important for bucklescript): handling binary AST's, accept any
  supported version as input; preserve that version (ocaml-ppx/ppxlib#205, @pitag-ha)

- `-as-ppx`: take into account the `-loc-filename` argument (ocaml-ppx/ppxlib#197, @pitag-ha)

- Add input name to expansion context (ocaml-ppx/ppxlib#202, @pitag-ha)

- Add Driver.V2: give access to expansion context in whole file transformation
  callbacks of `register_transformation` (ocaml-ppx/ppxlib#202, @pitag-ha)

- Driver: take `-cookie` argument into account, also when the input is a
  binary AST (@pitag-ha, ocaml-ppx/ppxlib#209)

- `run_as_ppx_rewriter`: take into account the arguments
  `-loc-filename`, `apply` and `dont-apply` (ocaml-ppx/ppxlib#205, @pitag-ha)

- Location.Error: add functions `raise` and `update_loc`
  (ocaml-ppx/ppxlib#205, @pitag-ha)
