### PR TITLE
hacl-star-raw: fails on powerpc, so disable

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.1.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1.1/opam
@@ -17,6 +17,10 @@ depends: [
   "ctypes-foreign"
   "conf-which" {build}
 ]
+x-ci-accept-failures: [
+  "centos-7" # Default C compiler is too old
+  "oraclelinux-7" # Default C compiler is too old
+]
 available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.1.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1.1/opam
@@ -15,6 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ctypes"
   "ctypes-foreign"
+  "conf-which" {build}
 ]
 available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [

--- a/packages/hacl-star-raw/hacl-star-raw.0.1.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1.1/opam
@@ -16,6 +16,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
+available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.1.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
-available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" ]
+available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1/opam
@@ -15,7 +15,9 @@ depends: [
   "ocamlfind" {build}
   "ctypes"
   "ctypes-foreign"
+  "conf-which" {build}
 ]
+available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1/opam
@@ -17,6 +17,10 @@ depends: [
   "ctypes-foreign"
   "conf-which" {build}
 ]
+x-ci-accept-failures: [
+  "centos-7" # Default C compiler is too old
+  "oraclelinux-7" # Default C compiler is too old
+]
 available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1/opam
@@ -21,7 +21,7 @@ x-ci-accept-failures: [
   "centos-7" # Default C compiler is too old
   "oraclelinux-7" # Default C compiler is too old
 ]
-available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
+available: [ os-family != "bsd" & arch = "x86_64" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.0/opam
@@ -17,6 +17,10 @@ depends: [
   "ctypes-foreign"
   "conf-which" {build}
 ]
+x-ci-accept-failures: [
+  "centos-7" # Default C compiler is too old
+  "oraclelinux-7" # Default C compiler is too old
+]
 available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ctypes"
   "ctypes-foreign"
+  "conf-which" {build}
 ]
 available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.0/opam
@@ -16,6 +16,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
+available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
-available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" ]
+available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.1/opam
@@ -17,6 +17,10 @@ depends: [
   "ctypes-foreign"
   "conf-which" {build}
 ]
+x-ci-accept-failures: [
+  "centos-7" # Default C compiler is too old
+  "oraclelinux-7" # Default C compiler is too old
+]
 available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.1/opam
@@ -15,6 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ctypes"
   "ctypes-foreign"
+  "conf-which" {build}
 ]
 available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.1/opam
@@ -16,6 +16,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
+available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
-available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" ]
+available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.2/opam
@@ -17,6 +17,10 @@ depends: [
   "ctypes-foreign"
   "conf-which" {build}
 ]
+x-ci-accept-failures: [
+  "centos-7" # Default C compiler is too old
+  "oraclelinux-7" # Default C compiler is too old
+]
 available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.2/opam
@@ -15,6 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ctypes"
   "ctypes-foreign"
+  "conf-which" {build}
 ]
 available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.2/opam
@@ -16,6 +16,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
+available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.2/opam
@@ -16,7 +16,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
-available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" ]
+available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
-available: os-family != "bsd"
+available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
@@ -17,6 +17,10 @@ depends: [
   "ctypes-foreign"
   "conf-which" {build}
 ]
+x-ci-accept-failures: [
+  "centos-7" # Default C compiler is too old
+  "oraclelinux-7" # Default C compiler is too old
+]
 available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ctypes"
   "ctypes-foreign"
+  "conf-which" {build}
 ]
 available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [

--- a/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
-available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" ]
+available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/tezos-crypto/tezos-crypto.8.0/opam
+++ b/packages/tezos-crypto/tezos-crypto.8.0/opam
@@ -10,7 +10,7 @@ depends: [
   "tezos-clic" { = version }
   "tezos-rpc" { = version }
   "bls12-381" { = "0.3.14" }
-  "hacl-star"
+  "hacl-star" { >= "0.3.0" }
   "secp256k1-internal"
   "uecc" { >= "0.3" }
   "ringo" { = "0.5" }

--- a/packages/tezos-crypto/tezos-crypto.8.1/opam
+++ b/packages/tezos-crypto/tezos-crypto.8.1/opam
@@ -10,7 +10,7 @@ depends: [
   "tezos-clic" { = version }
   "tezos-rpc" { = version }
   "bls12-381" { = "0.3.14" }
-  "hacl-star"
+  "hacl-star" { >= "0.3.0" }
   "secp256k1-internal"
   "uecc" { >= "0.3" }
   "ringo" { = "0.5" }


### PR DESCRIPTION
See failures in https://github.com/ocaml/opam-repository/pull/17947

```
cc -fPIC -I. -I kremlin/include -I kremlin/kremlib/dist/minimal -Wall -Wextra -Werror -std=c11 -Wno-unused-variable -Wno-unknown-warning-option -Wno-unused-but-set-variable -Wno-unused-parameter -Wno-infinite-recursion -g -fwrapv -D_BSD_SOURCE -D_DEFAULT_SOURCE -fPIC -Wno-unused -Wno-parentheses -Wno-deprecated-declarations -Wno-#warnings -Wno-error=cpp -Wno-cpp -g -std=gnu11 -O3 -I "/home/opam/.opam/4.11/lib/ctypes" -I "/home/opam/.opam/4.11/lib/ocaml" -mavx -mavx2   -c -o Hacl_Blake2b_256.o Hacl_Blake2b_256.c
cc: error: unrecognized command line option '-mavx'; did you mean '-mads'?
cc: error: unrecognized command line option '-mavx2'
make: *** [<builtin>: Hacl_Blake2b_256.o] Error 1
```

cc @victor-dumitrescu 