### PR TITLE
Release mirage crypto 0.8.10

### DIFF
--- a/packages/conduit-lwt-tls/conduit-lwt-tls.3.0.0/opam
+++ b/packages/conduit-lwt-tls/conduit-lwt-tls.3.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "conduit-lwt"       {= version}
   "conduit-tls"       {= version}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "mirage-crypto-pk"  {with-test & < "0.8.9"}
+  "mirage-crypto-pk"  {with-test & != "0.8.9"}
 ]
 x-commit-hash: "126ace170981b0c0bdb5d73c232099302ecf4af8"
 url {

--- a/packages/letsencrypt/letsencrypt.0.2.1/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.1/opam
@@ -24,7 +24,7 @@ depends: [
   "lwt" {>= "2.6.0"}
   "mirage-crypto"
   "mirage-crypto-pk"
-  "mirage-crypto-pk" {with-test & < "0.8.9"}
+  "mirage-crypto-pk" {with-test & != "0.8.9"}
   "mirage-crypto-rng"
   "x509" {>= "0.10.0" & < "0.11.0"}
   "yojson" {>= "1.6.0"}

--- a/packages/letsencrypt/letsencrypt.0.2.2/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.2/opam
@@ -24,7 +24,7 @@ depends: [
   "lwt" {>= "2.6.0"}
   "mirage-crypto"
   "mirage-crypto-pk"
-  "mirage-crypto-pk" {with-test & < "0.8.9"}
+  "mirage-crypto-pk" {with-test & != "0.8.9"}
   "mirage-crypto-rng"
   "x509" {>= "0.11.0"}
   "yojson" {>= "1.6.0"}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.10/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.10/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.7"}
+  "rresult" {>= "0.6.0"}
+  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding")
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.10/mirage-crypto-v0.8.10.tbz"
+  checksum: [
+    "sha256=8a5976fe7837491d2fbd1917b77524776f70ae590e9f55cf757cc8951b5481fc"
+    "sha512=ea3a1717574d3dcc3e6ea1e930d2c0c0ffe4e69600886bff1bbaef88333f8ec7e603eb0fae4fe8dece7fc6eb5d7c300ff4e7d20ca276a336b78b401a7139ee77"
+  ]
+}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.9/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.9/opam
@@ -42,3 +42,4 @@ url {
     "sha512=711a6da6ada6a9f2430b147a4b243d73cb2665391828465d2ec47e2d86e31ad04fe4afd964065e0f31ece3c1623d3ea3c81d0c9d6ccc8bebee924abea2cef554"
   ]
 }
+available: false

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.8.10/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.8.10/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an Async-friendly way"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "async"
+  "logs"
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+]
+available: os != "win32"
+description: """
+
+Mirage-crypto-rng-async feeds the entropy source for Mirage_crypto_rng-based
+random number genreator implementations, in an Async-friendly way.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.10/mirage-crypto-v0.8.10.tbz"
+  checksum: [
+    "sha256=8a5976fe7837491d2fbd1917b77524776f70ae590e9f55cf757cc8951b5481fc"
+    "sha512=ea3a1717574d3dcc3e6ea1e930d2c0c0ffe4e69600886bff1bbaef88333f8ec7e603eb0fae4fe8dece7fc6eb5d7c300ff4e7d20ca276a336b78b401a7139ee77"
+  ]
+}

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.8.9/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.8.9/opam
@@ -21,7 +21,6 @@ depends: [
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}
 ]
-available: os != "win32"
 description: """
 
 Mirage-crypto-rng-async feeds the entropy source for Mirage_crypto_rng-based

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.8.9/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.8.9/opam
@@ -35,3 +35,4 @@ url {
     "sha512=711a6da6ada6a9f2430b147a4b243d73cb2665391828465d2ec47e2d86e31ad04fe4afd964065e0f31ece3c1623d3ea3c81d0c9d6ccc8bebee924abea2cef554"
   ]
 }
+available: false

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.10/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.10/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "lwt" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.10/mirage-crypto-v0.8.10.tbz"
+  checksum: [
+    "sha256=8a5976fe7837491d2fbd1917b77524776f70ae590e9f55cf757cc8951b5481fc"
+    "sha512=ea3a1717574d3dcc3e6ea1e930d2c0c0ffe4e69600886bff1bbaef88333f8ec7e603eb0fae4fe8dece7fc6eb5d7c300ff4e7d20ca276a336b78b401a7139ee77"
+  ]
+}

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.9/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.9/opam
@@ -38,3 +38,4 @@ url {
     "sha512=711a6da6ada6a9f2430b147a4b243d73cb2665391828465d2ec47e2d86e31ad04fe4afd964065e0f31ece3c1623d3ea3c81d0c9d6ccc8bebee924abea2cef554"
   ]
 }
+available: false

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.10/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.10/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "mirage-crypto" {=version}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+# lwt sublibrary
+  "mtime"
+  "lwt" {>= "4.0.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.10/mirage-crypto-v0.8.10.tbz"
+  checksum: [
+    "sha256=8a5976fe7837491d2fbd1917b77524776f70ae590e9f55cf757cc8951b5481fc"
+    "sha512=ea3a1717574d3dcc3e6ea1e930d2c0c0ffe4e69600886bff1bbaef88333f8ec7e603eb0fae4fe8dece7fc6eb5d7c300ff4e7d20ca276a336b78b401a7139ee77"
+  ]
+}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.9/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.9/opam
@@ -40,3 +40,4 @@ url {
     "sha512=711a6da6ada6a9f2430b147a4b243d73cb2665391828465d2ec47e2d86e31ad04fe4afd964065e0f31ece3c1623d3ea3c81d0c9d6ccc8bebee924abea2cef554"
   ]
 }
+available: false

--- a/packages/mirage-crypto/mirage-crypto.0.8.10/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.10/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "eqaf" {>= "0.7"}
+]
+depopts: [
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
+hashes (MD5, SHA-1, SHA-2).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.10/mirage-crypto-v0.8.10.tbz"
+  checksum: [
+    "sha256=8a5976fe7837491d2fbd1917b77524776f70ae590e9f55cf757cc8951b5481fc"
+    "sha512=ea3a1717574d3dcc3e6ea1e930d2c0c0ffe4e69600886bff1bbaef88333f8ec7e603eb0fae4fe8dece7fc6eb5d7c300ff4e7d20ca276a336b78b401a7139ee77"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.8.9/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.9/opam
@@ -40,3 +40,4 @@ url {
     "sha512=711a6da6ada6a9f2430b147a4b243d73cb2665391828465d2ec47e2d86e31ad04fe4afd964065e0f31ece3c1623d3ea3c81d0c9d6ccc8bebee924abea2cef554"
   ]
 }
+available: false


### PR DESCRIPTION
[new release] mirage-crypto-pk, mirage-crypto, mirage-crypto-rng, mirage-crypto-rng-mirage and mirage-crypto-rng-async (0.8.10)
    
CHANGES:
    
- Rsa.priv: require 1 = d * e mod (lam n). This allows interoperability with OpenSSL generated keys. Reported and fixed by @psafont in mirage/mirage-crypto#100.
