### PR TITLE
Import metadata from repository in xapi-project/xs-opam

### DIFF
--- a/packages/netlink/netlink.0.3.4/opam
+++ b/packages/netlink/netlink.0.3.4/opam
@@ -10,11 +10,7 @@ depends: [
   "dune" {>= "1.4"}
   "ctypes"
   "ctypes-foreign"
-]
-depexts: [
-  ["libnl-3-200" "libnl-route-3-200"] {os-distribution = "debian"}
-  ["libnl-3-200" "libnl-route-3-200"] {os-distribution = "ubuntu"}
-  ["libnl3"] {os-distribution = "centos"}
+  "conf-libnl3"
 ]
 synopsis: "Bindings to the Netlink Protocol Library Suite (libnl)"
 description: """

--- a/packages/xapi-stdext-pervasives/xapi-stdext-pervasives.4.16.0/opam
+++ b/packages/xapi-stdext-pervasives/xapi-stdext-pervasives.4.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "jonathan.ludlam@citrix.com"
+authors: "xen-api@list.xen.org"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+dev-repo: "git://github.com/xapi-project/stdext.git"
+homepage: "https://xapi-project.github.io/"
+tags: [ "org:xapi-project" ]
+
+build:  [[ "dune" "build" "-p" name "-j" jobs ]]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.11"}
+  "logs"
+  "xapi-backtrace"
+]
+synopsis:
+  "A deprecated collection of utility functions - Pervasives extension"
+description: """
+This library is provided for a transitionary period only.
+No new code should use this library."""
+url {
+  src:
+    "https://github.com/xapi-project/stdext/archive/v4.16.0.tar.gz"
+  checksum:
+    "sha256=ed012587042f93b2cf2b1c49ecf7fb2c4ffd6bfea4af82cdfb8b9b78fd957215"
+}

--- a/packages/xapi-stdext-std/xapi-stdext-std.4.16.0/opam
+++ b/packages/xapi-stdext-std/xapi-stdext-std.4.16.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "jonathan.ludlam@citrix.com"
+authors: "xen-api@list.xen.org"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+dev-repo: "git://github.com/xapi-project/stdext.git"
+homepage: "https://xapi-project.github.io/"
+tags: [ "org:xapi-project" ]
+
+build:  [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.11"}
+  "uuidm"
+  "alcotest" {with-test}
+]
+synopsis:
+  "A deprecated collection of utility functions - Standard library extensions"
+description: """
+This library is provided for a transitionary period only.
+No new code should use this library."""
+url {
+  src:
+    "https://github.com/xapi-project/stdext/archive/v4.16.0.tar.gz"
+  checksum:
+    "sha256=ed012587042f93b2cf2b1c49ecf7fb2c4ffd6bfea4af82cdfb8b9b78fd957215"
+}

--- a/packages/xapi-stdext-threads/xapi-stdext-threads.4.16.0/opam
+++ b/packages/xapi-stdext-threads/xapi-stdext-threads.4.16.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "jonathan.ludlam@citrix.com"
+authors: "xen-api@list.xen.org"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+dev-repo: "git://github.com/xapi-project/stdext.git"
+homepage: "https://xapi-project.github.io/"
+tags: [ "org:xapi-project" ]
+
+build:  [[ "dune" "build" "-p" name "-j" jobs ]]
+
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "base-threads"
+  "base-unix"
+  "xapi-stdext-pervasives" {=version}
+]
+synopsis:
+  "A deprecated collection of utility functions - Threads extensions and Semaphore"
+description: """
+This library is provided for a transitionary period only.
+No new code should use this library."""
+url {
+  src:
+    "https://github.com/xapi-project/stdext/archive/v4.16.0.tar.gz"
+  checksum:
+    "sha256=ed012587042f93b2cf2b1c49ecf7fb2c4ffd6bfea4af82cdfb8b9b78fd957215"
+}

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.16.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.16.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "jonathan.ludlam@citrix.com"
+authors: "xen-api@list.xen.org"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+dev-repo: "git://github.com/xapi-project/stdext.git"
+homepage: "https://xapi-project.github.io/"
+tags: [ "org:xapi-project" ]
+
+build:  [[ "dune" "build" "-p" name "-j" jobs ]]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.11"}
+  "base-unix"
+  "fd-send-recv" {>= "2.0.0"}
+  "xapi-stdext-pervasives" {=version}
+  "xapi-stdext-std" {=version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+]
+available: [ os = "linux" ]
+synopsis:
+  "A deprecated collection of utility functions - Unix module extensions"
+description: """
+This library is provided for a transitionary period only.
+No new code should use this library."""
+url {
+  src:
+    "https://github.com/xapi-project/stdext/archive/v4.16.0.tar.gz"
+  checksum:
+    "sha256=ed012587042f93b2cf2b1c49ecf7fb2c4ffd6bfea4af82cdfb8b9b78fd957215"
+}

--- a/packages/xenstore_transport/xenstore_transport.1.3.0/opam
+++ b/packages/xenstore_transport/xenstore_transport.1.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: [
+  "Christian Lindig"
+  "David Scott"
+  "Euan Harris"
+  "John Else"
+  "Jon Ludlam"
+  "Jonathan Davies"
+  "Marcello Seri"
+  "Si Beaumont"
+  "Thomas Sanders"
+  "Vincent Bernardoff"
+]
+license: "LGPL-2.1-only"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "http://github.com/xapi-project/ocaml-xenstore-clients"
+doc: "http://xapi-project.github.io/ocaml-xenstore-clients"
+bug-reports: "http://github.com/xapi-project/ocaml-xenstore-clients/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.0"}
+  "lwt"
+  "xenstore" {>= "2.0.0"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+http://github.com/xapi-project/ocaml-xenstore-clients.git"
+synopsis: "Low-level libraries for connecting to a xenstore service on a xen host"
+description: """
+These libraries contain the IO functions for communicating with a
+xenstore service on a xen host. One subpackage deals with regular Unix
+threads and another deals with Lwt co-operative threads.
+"""
+url {
+  src:
+    "https://github.com/xapi-project/ocaml-xenstore-clients/archive/v1.3.0.tar.gz"
+  checksum: "md5=7e1ef30d1958c65751c119075d2ba78a"
+}


### PR DESCRIPTION
[new release] xapi-stdext-pervasives xapi-stdext-std xapi-stdext-threads xapi-stdext-unix (4.16.0)
changes:
 - all: remove obsoleted modules and packages
 - unixext: remove Fdset module and stubs
 - pervasiveext: deprecate non-idiomatic pervasivesext functions
 - std: add tests for xstringext
 - std: do not reimplement functions from Stdlib

[new release] xenstore_transport (1.3.0)
changes:
 - Set spdx license identifiers for LGPL 2.1 only in opam files (@sternenseemann) 

[update] netlink (0.3.4)
changes:
 - use conf-libnl3