### PR TITLE
3 packages from gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.9/json-data-encoding-0.9.tar.gz

### DIFF
--- a/packages/json-data-encoding-browser/json-data-encoding-browser.0.9/opam
+++ b/packages/json-data-encoding-browser/json-data-encoding-browser.0.9/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (browser support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.7"}
+  "json-data-encoding" {= version }
+  "js_of_ocaml" {>= "3.3.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.9/json-data-encoding-0.9.tar.gz"
+  checksum: [
+    "md5=92b5bab2e34932632dba7e96267a3159"
+    "sha512=3778952db138d6279e9f0163d91a016a2f7151adc3ed57a4631e5aec85c3d9253bb9ef57ccfe70c09aa95da22529ab8ff21adad001bd92e2506991b334bdff66"
+  ]
+}

--- a/packages/json-data-encoding-bson/json-data-encoding-bson.0.9/opam
+++ b/packages/json-data-encoding-bson/json-data-encoding-bson.0.9/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (bson support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.7"}
+  "json-data-encoding" {= version }
+  "ocplib-endian" {>= "1.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.9/json-data-encoding-0.9.tar.gz"
+  checksum: [
+    "md5=92b5bab2e34932632dba7e96267a3159"
+    "sha512=3778952db138d6279e9f0163d91a016a2f7151adc3ed57a4631e5aec85c3d9253bb9ef57ccfe70c09aa95da22529ab8ff21adad001bd92e2506991b334bdff66"
+  ]
+}

--- a/packages/json-data-encoding/json-data-encoding.0.9/opam
+++ b/packages/json-data-encoding/json-data-encoding.0.9/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "LGPLv3 w/ linking exception"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.7"}
+  "uri" {>= "1.9.0" }
+  "crowbar" { with-test }
+  "alcotest" { with-test }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.9/json-data-encoding-0.9.tar.gz"
+  checksum: [
+    "md5=92b5bab2e34932632dba7e96267a3159"
+    "sha512=3778952db138d6279e9f0163d91a016a2f7151adc3ed57a4631e5aec85c3d9253bb9ef57ccfe70c09aa95da22529ab8ff21adad001bd92e2506991b334bdff66"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`json-data-encoding.0.9`: Type-safe encoding to and decoding from JSON
-`json-data-encoding-browser.0.9`: Type-safe encoding to and decoding from JSON (browser support)
-`json-data-encoding-bson.0.9`: Type-safe encoding to and decoding from JSON (bson support)



---
* Homepage: https://gitlab.com/nomadic-labs/json-data-encoding
* Source repo: git+https://gitlab.com/nomadic-labs/json-data-encoding
* Bug tracker: https://gitlab.com/nomadic-labs/json-data-encoding/issues

---
:camel: Pull-request generated by opam-publish v2.0.2