### PR TITLE
Add ocaml-option-nnpchecker

### DIFF
--- a/packages/ocaml-option-nnpchecker/ocaml-option-nnpchecker.1/opam
+++ b/packages/ocaml-option-nnpchecker/ocaml-option-nnpchecker.1/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+synopsis: "Set OCaml to be compiled with --enable-naked-pointers-checker"
+depends: [
+  "ocaml-variants" {post & >= "4.12.0~"}
+]
+available: arch = "x86_64" & (os = "linux" | os = "macos" | os = "openbsd" | os = "freebsd" | os = "sunos")
+conflicts: [ "ocaml-option-nnp" "ocaml-option-32bit" ]
+maintainer: "platform@lists.ocaml.org"
+flags: compiler

--- a/packages/ocaml-options-only-afl/ocaml-options-only-afl.1/opam
+++ b/packages/ocaml-options-only-afl/ocaml-options-only-afl.1/opam
@@ -12,6 +12,7 @@ conflicts: [
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-flambda-fp/ocaml-options-only-flambda-fp.1/opam
+++ b/packages/ocaml-options-only-flambda-fp/ocaml-options-only-flambda-fp.1/opam
@@ -11,6 +11,7 @@ conflicts: [
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-flambda/ocaml-options-only-flambda.1/opam
+++ b/packages/ocaml-options-only-flambda/ocaml-options-only-flambda.1/opam
@@ -12,6 +12,7 @@ conflicts: [
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-fp/ocaml-options-only-fp.1/opam
+++ b/packages/ocaml-options-only-fp/ocaml-options-only-fp.1/opam
@@ -12,6 +12,7 @@ conflicts: [
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-nnp/ocaml-options-only-nnp.1/opam
+++ b/packages/ocaml-options-only-nnp/ocaml-options-only-nnp.1/opam
@@ -12,6 +12,7 @@ conflicts: [
   "ocaml-option-no-flat-float-array"
   "ocaml-option-spacetime"
   "ocaml-option-static"
+  "ocaml-option-nnpchecker"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1/opam
+++ b/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1/opam
@@ -12,6 +12,7 @@ conflicts: [
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
+++ b/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
@@ -17,6 +17,7 @@ conflicts: [
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+trunk/opam
@@ -29,6 +29,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
@@ -73,4 +74,5 @@ depopts: [
   "ocaml-option-static"
   "ocaml-option-spacetime"
   "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
@@ -29,6 +29,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
@@ -74,4 +75,5 @@ depopts: [
   "ocaml-option-static"
   "ocaml-option-spacetime"
   "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
 ]


### PR DESCRIPTION
This PR adds `ocaml-option-nnpchecker` to trigger the `--enable-naked-pointers-checker` option in OCaml 4.12+

I haven't updated ocaml-config to emulate a switch name for this - I'm not sure we particularly want one, but it can be added if required.

I have intentionally edited the existing options as they only apply to a beta release - in future we'd expect to bump the versions.

cc @Octachron