### PR TITLE
conf-linux-libc-dev: Remove absolute path to header

### DIFF
--- a/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/files/configure.sh
+++ b/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/files/configure.sh
@@ -1,0 +1,3 @@
+# Check if stdenv.h is installed
+
+echo '#include <linux/stddef.h>' | cc -E - >/dev/null

--- a/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/files/configure.sh
+++ b/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/files/configure.sh
@@ -1,3 +1,0 @@
-# Check if stdenv.h is installed
-
-echo '#include <linux/stddef.h>' | cc -E - >/dev/null

--- a/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
+++ b/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
@@ -4,7 +4,7 @@ authors: [ "Markus W. Weissmann <markus.weissmann@in.tum.de>" ]
 homepage: "https://kernel.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: [ "GPL-2.0-only" ]
-build: [["ls" "/usr/include/linux/stddef.h"]]
+build: [["bash" "-ex" "configure.sh"]]
 depexts: [
   ["linux-libc-dev"] {os-family = "debian"}
   ["linux-libc-dev"] {os-family = "ubuntu"}
@@ -18,4 +18,5 @@ synopsis:
   "Virtual package relying on the installation of the Linux kernel headers files"
 description:
   "This package can only install if the kernel headers for user space applications are installed on the system."
+extra-files: ["configure.sh" "sha256=2e3e51496649fde2fff2bc8e6ad6ed3360be5b0595dc800dce99f4391951e261"]
 flags: conf

--- a/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
+++ b/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
@@ -4,7 +4,10 @@ authors: [ "Markus W. Weissmann <markus.weissmann@in.tum.de>" ]
 homepage: "https://kernel.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: [ "GPL-2.0-only" ]
-build: [["bash" "-ex" "configure.sh"]]
+build: [
+  ["sh" "-exc" "echo '#include <linux/stddef.h>' > test.c"]
+  ["cc" "-E" "test.c"]
+]
 depexts: [
   ["linux-libc-dev"] {os-family = "debian"}
   ["linux-libc-dev"] {os-family = "ubuntu"}
@@ -18,5 +21,4 @@ synopsis:
   "Virtual package relying on the installation of the Linux kernel headers files"
 description:
   "This package can only install if the kernel headers for user space applications are installed on the system."
-extra-files: ["configure.sh" "sha256=2e3e51496649fde2fff2bc8e6ad6ed3360be5b0595dc800dce99f4391951e261"]
 flags: conf


### PR DESCRIPTION
Absolute paths can't work on some systems (for example, NixOS, opam2nix, termux).
This PR looks up `linux/stddef.h` using the C compiler.

If the header still can't be found, the error will look like this:

```
# + echo '#include <doesnt_exist.h>'
# + cc -E -
# <stdin>:1:10: fatal error: doesnt_exist.h: No such file or directory
# compilation terminated.
```
