### PR TITLE
[new release] pratter (1.1)

### DIFF
--- a/packages/pratter/pratter.1.1/opam
+++ b/packages/pratter/pratter.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "An extended Pratt parser"
+description: """
+Pratter is a library that provides a parser that transforms
+streams of terms to applied terms.  Terms may contain infix or prefix operators
+and native applications.  The parser is based on the Pratt parsing
+algorithm and extended to handle term application and non associative
+operators."""
+maintainer: ["leirbag@sdfeu.org"]
+authors: ["Gabriel Hondet"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/gabrielhdt/pratter"
+bug-reports: "https://github.com/gabrielhdt/pratter/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "2.7"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/gabrielhdt/pratter.git"
+x-commit-hash: "de79b3ce0f03f476eaf0d7d1412f56b2c59b7007"
+url {
+  src:
+    "https://github.com/gabrielhdt/pratter/releases/download/1.1/pratter-1.1.tbz"
+  checksum: [
+    "sha256=f927997deab616132f04c03942cb78126e4538e29343cc454d5ddcc0a061f40e"
+    "sha512=f44a9f8214e970af83b158c15835959e7dd39521641ef2d05e63d1b8064046d9f29677515dc76498715aa30d579f49733364cea5f9f9895f9dff81d4a50d9105"
+  ]
+}


### PR DESCRIPTION
An extended Pratt parser

- Project page: <a href="https://github.com/gabrielhdt/pratter">https://github.com/gabrielhdt/pratter</a>

##### CHANGES:

This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## [Unreleased]

## [1.1] -- 2021-01-23
### Added
- Non associative operators
- Error handling on partially applied operators (which raises a
  `Stream.Failure`)
### Changed
- One function `get` for operators in API
- `make_appl` does not use the table of operators

## [1.0.1] -- 2021-01-16
### Fixed
- Correct OCaml dependency
- Tests comply with OCaml 4.02
### Added
- Gitlab continuous integration

## [1.0] -- 2021-01-14
### Changed
- API: parser uses a data structure passed as argument
- renamed CHANGELOG to CHANGELOG.md

## [0.1.1] -- 2021-01-06
### Added
- Initial version
