### PR TITLE
Relax version constraint for caqti-async.

### DIFF
--- a/packages/caqti-async/caqti-async.1.3.0/opam
+++ b/packages/caqti-async/caqti-async.1.3.0/opam
@@ -7,12 +7,12 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml"
-  "async_kernel" {>= "v0.11.0" & < "v0.14.0~"}
-  "async_unix" {>= "v0.11.0" & < "v0.14.0~"}
+  "async_kernel" {>= "v0.11.0"}
+  "async_unix" {>= "v0.11.0"}
   "caqti" {>= "1.3.0" & < "1.4.0~"}
   "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
   "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
-  "core_kernel" {< "v0.14.0~"}
+  "core_kernel"
   "dune" {>= "1.11"}
 ]
 build: [


### PR DESCRIPTION
I have overlooked that the async constraint had been relaxed since the
previous release.  Thanks to Aaron Zeng (@bcc32) for reporting the
issue.