### PR TITLE
Package binaryen.0.6.0

### DIFF
--- a/packages/binaryen/binaryen.0.6.0/opam
+++ b/packages/binaryen/binaryen.0.6.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.09"}
+  "dune" {>= "2.7.1"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+]
+available: arch = "x86_64" & (os = "linux" | os = "macos" | os = "win32")
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.6.0/binaryen-archive-v0.6.0.tar.gz"
+  checksum: [
+    "md5=2b98cd022c3b7b105cdacc68f17ec739"
+    "sha512=304c139b088c504c33ea43671076d4d01403da5ebf01464ec53f279e084b9338af8b85755f308fd7e579294713a41d5754fe35f28a8b8c419ecd524390a34630"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.6.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---


### Features

* Allow signed narrow-width loads ([#62](https://www.github.com/grain-lang/binaryen.ml/issues/62)) ([6448aeb](https://www.github.com/grain-lang/binaryen.ml/commit/6448aeb4ae00a07c98b0386fc1a82f6b653ac2c0))


---
:camel: Pull-request generated by opam-publish v2.0.3