### PR TITLE
Package ocsigen-start.4.0.1

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.4.0.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+authors: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"
+description: "Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom). It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users. Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management. This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users. The goal is to enable the programmer to concentrate on the core of the app, and not on user management."
+homepage: "https://ocsigen.org/ocsigen-start/"
+bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "pgocaml" {>= "4.0"}
+  "pgocaml_ppx" {>= "4.0"}
+  "safepass" {>= "3.0"}
+  "ocsigen-i18n" {>= "3.7.0"}
+  "eliom" {>= "6.12.4"}
+  "ocsigen-toolkit" {>= "2.7.0"}
+  "ocsigen-i18n" {>= "3.7.0"}
+  "yojson" {>= "1.4.1"}
+  "resource-pooling" {>= "1.0" & < "2.0"}
+  "cohttp-lwt-unix"
+  "conf-npm" {>= "1"}
+  "ocamlnet"
+]
+depexts: [
+	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}
+  ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-start/archive/4.0.1.tar.gz"
+  checksum: [
+    "md5=6973e51377ea651317b9816276dd1a24"
+    "sha512=e334a4b4b23380064a5bc58c41412a8a0d2f2be28899f7ee077ba7f51be319cc6beb3a8660711fec574321e1621d626f689a9897863b9f6703b80903cc822f39"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-start.4.0.1`
An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc
Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom). It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users. Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management. This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users. The goal is to enable the programmer to concentrate on the core of the app, and not on user management.



---
* Homepage: https://ocsigen.org/ocsigen-start/
* Source repo: git+https://github.com/ocsigen/ocsigen-start.git
* Bug tracker: https://github.com/ocsigen/ocsigen-start/issues

---
:camel: Pull-request generated by opam-publish v2.0.2