### PR TITLE
Package ppx_deriving_encoding.0.2.2

### DIFF
--- a/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2.2/opam
+++ b/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for json-encoding"
+maintainer: ["contact@origin-labs.com"]
+authors: ["Maxime Levillain <maxime.levillain@origin-labs.com"]
+license: "LGPL-2.1-or-later"
+homepage: "https://gitlab.com/o-labs/ppx_deriving_encoding"
+bug-reports: "https://gitlab.com/o-labs/ppx_deriving_encoding/-/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "json-data-encoding" {>= "0.9"}
+  "ppxlib" {>= "0.18.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://gitlab.com/o-labs/ppx_deriving_encoding"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/22769538/repository/archive?sha=b7ffd2c2aefd6133c6dec8fa03c31129069a8478"
+  checksum: [
+    "md5=ab0bcdebe068f18bae7819c69be7b79c"
+    "sha512=a01069233acb4f976c56b353720fcd16217fb92526b26740a6cd6c9befea0cb99ece676874aa60f85ede033e215764d822b9e75a9b17b975f0e4f8420df19d23"
+  ]
+}


### PR DESCRIPTION
### `ppx_deriving_encoding.0.2.2`
Ppx deriver for json-encoding



---
* Homepage: https://gitlab.com/o-labs/ppx_deriving_encoding
* Source repo: git://gitlab.com/o-labs/ppx_deriving_encoding
* Bug tracker: https://gitlab.com/o-labs/ppx_deriving_encoding/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.2