### PR TITLE
Fix incompatibility constraint with dune 2.8

### DIFF
--- a/packages/coq-of-ocaml/coq-of-ocaml.2.2.1/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.2.1/opam
@@ -14,7 +14,7 @@ install: [
   [make "-C" "OCaml" "install"] {coq:installed}
 ]
 depends: [
-  "dune" {>= "1.11"}
+  "dune" {>= "1.11" & < "2.8"}
   "ocaml" {>= "4.09" & < "4.10"}
   "ocamlfind" {>= "1.5.2"}
   "smart-print"

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.3.0/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.3.0/opam
@@ -14,7 +14,7 @@ install: [
   [make "-C" "OCaml" "install"] {coq:installed}
 ]
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.0" & < "2.8"}
   "ocaml" {>= "4.09" & < "4.10"}
   "ocamlfind" {>= "1.5.2"}
   "smart-print"


### PR DESCRIPTION
This incompatibility is due to the fact that dune >2.8 does not generate a `.merlin` file anymore. We will do a new release of coq-of-ocaml to work with the new dune version.