### PR TITLE
[new release] albatross (1.1.0)

### DIFF
--- a/packages/albatross/albatross.1.1.0/opam
+++ b/packages/albatross/albatross.1.1.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "cstruct"
+  "logs"
+  "rresult"
+  "bos"
+  "ptime"
+  "cmdliner" {>= "1.0.0"}
+  "fmt"
+  "astring"
+  "jsonm"
+  "x509" {>= "0.11.0"}
+  "tls" {>= "0.12.2"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "1.2.0"}
+  "bigstringaf"
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "hex"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+available: [
+  arch != "ppc64" & arch != "x86_32" & arch != "arm32"
+]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+x-commit-hash: "3db6b8f6e3f3bf32ad94fac3d6c3466a8226a5cf"
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v1.1.0/albatross-v1.1.0.tbz"
+  checksum: [
+    "sha256=b91813e5562deca97b1c2795b4239db5a857eddbd9845ce8cea6bb2d92c9b58e"
+    "sha512=df1fc60881e1deb48aa675ded3e796a207110c28f40f56345112ecaa5ba7def19f77e4f91b2755b2cef2f473941183ce92bb8ed0d6db446881df66f7154b8077"
+  ]
+}

--- a/packages/conf-libnl3/conf-libnl3.1/opam
+++ b/packages/conf-libnl3/conf-libnl3.1/opam
@@ -11,12 +11,16 @@ depends: ["conf-pkg-config"]
 depexts: [
   ["libnl-3-dev" "libnl-route-3-dev"] {os-family = "debian"}
   ["libnl-3-dev" "libnl-route-3-dev"] {os-family = "ubuntu"}
-  ["libnl3" "libnl3-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
+  ["libnl3" "libnl3-devel"] {os-distribution = "centos" | os-distribution = "fedora"}
+  ["libnl3" "libnl3-devel"] {os-distribution = "ol" & os-version >= "8"}
   ["libnl3-devel"] {os-family = "suse"}
   ["libnl"] {os-family = "arch"}
   ["libnl3-dev"] {os-family = "alpine"}
 ]
 available: [ os = "linux" ]
+x-ci-accept-failures: [
+  "oraclelinux-7" # Not available by default
+]
 synopsis: "Virtual package relying on a libnl system installation"
 description:
   "This package can only install if libnl is installed on the system."


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

- fix and improve block device handling (roburio/albatross#67 @hannesm)
- unikernel_info now includes a SHA256 digest of the unikernel image (fixes roburio/albatross#61,
  roburio/albatross#64 @hannesm)
- unikernel_get returns only the image, and a boolean value whether it is
  compressed or not (roburio/albatross#64 @hannesm)
- allow naming of block devices (roburio/albatross#64 @hannesm) similar to network devices
- albatrossd: wait 3 seconds between socket connection retries, default to 2
  retries (previously was 0) (roburio/albatross#64 @hannesm)
- infer dbdir and tmpdir from uname before processing (roburio/albatross#60 @hannesm)
- statistics: adapt to FreeBSD 13 (roburio/albatross#62 @sg2342)
- use binaries with '-' instead of '_' in FreeBSD packaging (to be the same as
  on Linux)
- extend PATH with /usr/local/bin and /usr/local/sbin in FreeBSD RC scripts,
  allowing solo5 utilities installed in PATH (roburio/albatross#64 @hannesm)
- use latest version of decompress (>= 1.2.0 roburio/albatross#68 @dinosaure)
- add test for ASN grammar (roburio/albatross#65 @reynir)
