### PR TITLE
Add new version drom.0.3.0

### DIFF
--- a/packages/drom/drom.0.3.0/opam
+++ b/packages/drom/drom.0.3.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:
+  "The drom tool is a wrapper over opam/dune in an attempt to provide a cargo-like user experience"
+description: """
+
+The drom tool is a wrapper over opam/dune in an attempt to provide a cargo-like
+user experience. It can be used to create full OCaml projects with
+sphinx and odoc documentation. It has specific knowledge of Github and
+will generate files for Github Actions CI and Github pages.
+"""
+authors: [
+  "Fabrice Le Fessant <fabrice.le_fessant@origin-labs.com>"
+  "Léo Andrès <leo.andres@ocamlpro.com>"
+]
+maintainer: [
+  "Fabrice Le Fessant <fabrice.le_fessant@origin-labs.com>"
+  "Léo Andrès <leo.andres@ocamlpro.com>"
+]
+homepage: "https://ocamlpro.github.io/drom"
+doc: "https://ocamlpro.github.io/drom/sphinx"
+bug-reports: "https://github.com/ocamlpro/drom/issues"
+dev-repo: "git+https://github.com/ocamlpro/drom.git"
+tags: "org:ocamlpro"
+build: [
+  ["dune" "subst"] {dev}
+  ["sh" "-c" "./scripts/before.sh build '%{name}%'"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["sh" "-c" "./scripts/after.sh build '%{name}%'"]
+]
+install: [
+  ["sh" "-c" "./scripts/before.sh install '%{name}%'"]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.6.0"}
+  "drom_lib" {= version}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {with-test}
+]
+
+url {
+    src: "https://github.com/ocamlpro/drom/archive/v0.3.0.tar.gz"
+    checksum: [ "sha256=32cd759497fb31d9a12a0d1c95a0dcbb21ea74e5a242ffde428b4286dc906452" ]
+}

--- a/packages/drom_lib/drom_lib.0.3.0/opam
+++ b/packages/drom_lib/drom_lib.0.3.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:
+  "The drom tool is a wrapper over opam/dune in an attempt to provide a cargo-like user experience"
+description: """
+
+The drom tool is a wrapper over opam/dune in an attempt to provide a cargo-like
+user experience. It can be used to create full OCaml projects with
+sphinx and odoc documentation. It has specific knowledge of Github and
+will generate files for Github Actions CI and Github pages.
+"""
+authors: [
+  "Fabrice Le Fessant <fabrice.le_fessant@origin-labs.com>"
+  "Léo Andrès <leo.andres@ocamlpro.com>"
+]
+maintainer: [
+  "Fabrice Le Fessant <fabrice.le_fessant@origin-labs.com>"
+  "Léo Andrès <leo.andres@ocamlpro.com>"
+]
+homepage: "https://ocamlpro.github.io/drom"
+doc: "https://ocamlpro.github.io/drom/sphinx"
+bug-reports: "https://github.com/ocamlpro/drom/issues"
+dev-repo: "git+https://github.com/ocamlpro/drom.git"
+tags: "org:ocamlpro"
+build: [
+  ["dune" "subst"] {dev}
+  ["sh" "-c" "./scripts/before.sh build '%{name}%'"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["sh" "-c" "./scripts/after.sh build '%{name}%'"]
+]
+install: [
+  ["sh" "-c" "./scripts/before.sh install '%{name}%'"]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.6.0"}
+  "toml" {>= "6.0.0" & < "7.0.0"}
+  "ez_subst" {>= "0.1"}
+  "ez_opam_file" {>= "0.1.0" & < "1.0.0"}
+  "ez_file" {>= "0.2.0" & < "1.0.0"}
+  "ez_config" {>= "0.1.0" & < "1.0.0"}
+  "ez_cmdliner" {>= "0.2.0" & < "1.0.0"}
+  "directories" {>= "0.2"}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {with-test}
+]
+
+url {
+    src: "https://github.com/ocamlpro/drom/archive/v0.3.0.tar.gz"
+    checksum: [ "sha256=32cd759497fb31d9a12a0d1c95a0dcbb21ea74e5a242ffde428b4286dc906452" ]
+}


### PR DESCRIPTION
New version 0.3.0 of drom, the OCaml project creator:
* New command `drom top` to start utop with all the project libraries
* Many new skeletons (ppx, menhir, C bindings, JS projects, WASM, etc.)