### PR TITLE
[new release] flex-array (1.1.0)

### DIFF
--- a/packages/flex-array/flex-array.1.1.0/opam
+++ b/packages/flex-array/flex-array.1.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jean-Christophe.Filliatre@lri.fr"
+authors: "Jean-Christophe Filliâtre"
+synopsis: "Flexible arrays"
+description: "Flexible arrays are arrays whose size can be changed by adding or
+removing elements at either end (one at a time)."
+license: "LGPL-2.1"
+homepage: "https://github.com/backtracking/flex-array"
+doc: "https://backtracking.github.io/flex-array"
+bug-reports: "https://github.com/backtracking/flex-array/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/backtracking/flex-array.git"
+x-commit-hash: "184df263a4cf7812d4c7adf684c6835cdbd89676"
+url {
+  src:
+    "https://github.com/backtracking/flex-array/releases/download/1.1.0/flex-array-1.1.0.tbz"
+  checksum: [
+    "sha256=067b0598b0134342b219735e839a9b7cecd4584573d1dc41ba4ed0e3e5141331"
+    "sha512=423b2125eb9ed7816d2e838e74a83250f1284ac7bcb037d7616cf0b5732328ed0023a2277a268919897c1a736da79b859b32c91a1cbc7f33d81c081484830031"
+  ]
+}


### PR DESCRIPTION
Flexible arrays

- Project page: <a href="https://github.com/backtracking/flex-array">https://github.com/backtracking/flex-array</a>
- Documentation: <a href="https://backtracking.github.io/flex-array">https://backtracking.github.io/flex-array</a>

##### CHANGES:

- improved `make` (now O(log n))
  - added `init`, `of_array`, `map`, `of_list`
