### PR TITLE
Package apronext.1.0.3

### DIFF
--- a/packages/apronext/apronext.1.0.3/opam
+++ b/packages/apronext/apronext.1.0.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Ghiles Ziat <ghiles.ziat@isae-supaero.fr"
+authors: ["Ghiles Ziat <ghiles.ziat@isae-supaero.fr"]
+homepage: "https://github.com/ghilesZ/apronext"
+bug-reports: "https://github.com/ghilesZ/apronext/issues"
+dev-repo: "git+https://github.com/ghilesZ/apronext"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "dune"  {>= "2.1"}
+  "ocaml" {>= "4.08"}
+  "apron"
+]
+synopsis: "Apron extension"
+description: "An extension for the OCaml interface of the Apron library"
+url {
+  src: "https://github.com/ghilesZ/apronext/archive/1.0.3.tar.gz"
+  checksum: [
+    "md5=4cead2ba877bbcb5f5aff1e4323ea730"
+    "sha512=86b3329fcf609e9da16b9441f317e097b2a4fec7ce8f7f68113b4b6e55f379519ab55edf3ad5cd32ad600632a3127f0d58af140e619cc0cc467d6d96a6225b18"
+  ]
+}

--- a/packages/conf-mpfr/conf-mpfr.2/opam
+++ b/packages/conf-mpfr/conf-mpfr.2/opam
@@ -11,6 +11,7 @@ build: [
 depexts: [
   ["libmpfr-dev"] {os-family = "debian"}
   ["mpfr-devel"] {os-distribution = "fedora"}
+  ["mpfr-devel"] {os-distribution = "ol"}
   ["mpfr"] {os = "macos" & os-distribution = "homebrew"}
   ["mpfr"] {os = "macos" & os-distribution = "macports"}
   ["mpfr"] {os = "freebsd"}

--- a/packages/picasso/picasso.0.1/opam
+++ b/packages/picasso/picasso.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dune"  {>= "2.1"}
   "ocaml" {>= "4.08"}
   "lablgtk"
-  "apronext" {>= "1.0.1"}
+  "apronext" {>= "1.0.1" & < "1.0.3"}
   "apron"
 ]
 synopsis: "Abstract elements drawing library"


### PR DESCRIPTION
### `apronext.1.0.3`
Apron extension
An extension for the OCaml interface of the Apron library



---
* Homepage: https://github.com/ghilesZ/apronext
* Source repo: git+https://github.com/ghilesZ/apronext
* Bug tracker: https://github.com/ghilesZ/apronext/issues

---
:camel: Pull-request generated by opam-publish v2.0.2