### PR TITLE
extlib.1.7.7-1: Add OCaml 4.12 compatibility to extlib < 1.7.8

### DIFF
--- a/packages/extlib/extlib.1.7.7-1/files/0001-Add-support-for-OCaml-4.12.patch
+++ b/packages/extlib/extlib.1.7.7-1/files/0001-Add-support-for-OCaml-4.12.patch
@@ -1,0 +1,25 @@
+From 3b2073701aed50cd768e0a4cd3c776c7a3a54d7e Mon Sep 17 00:00:00 2001
+From: Kate <kit.ty.kate@disroot.org>
+Date: Thu, 5 Nov 2020 22:17:24 +0000
+Subject: [PATCH 1/2] Add support for OCaml 4.12
+
+---
+ src/extList.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/extList.ml b/src/extList.ml
+index 4f0057f..a1435ee 100644
+--- a/src/extList.ml
++++ b/src/extList.ml
+@@ -380,7 +380,7 @@ let combine l1 l2 =
+   loop dummy l1 l2;
+   dummy.tl
+ 
+-let sort ?(cmp=compare) = List.sort cmp
++let sort ?(cmp=Pervasives.compare) = List.sort cmp
+ 
+ #if OCAML < 406
+ let rec init size f =
+-- 
+2.30.0
+

--- a/packages/extlib/extlib.1.7.7-1/files/0002-caml_hash_univ_param-was-removed-for-OCaml-pre-4.00-.patch
+++ b/packages/extlib/extlib.1.7.7-1/files/0002-caml_hash_univ_param-was-removed-for-OCaml-pre-4.00-.patch
@@ -1,0 +1,38 @@
+From 574e8eae2d358b6db62c2d062b194a7aa06ac02c Mon Sep 17 00:00:00 2001
+From: Kate <kit.ty.kate@disroot.org>
+Date: Fri, 6 Nov 2020 14:10:26 +0000
+Subject: [PATCH 2/2] caml_hash_univ_param was removed for OCaml (pre-4.00
+ function)
+
+---
+ src/extHashtbl.ml | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/extHashtbl.ml b/src/extHashtbl.ml
+index 140e9c2..3c69df4 100644
+--- a/src/extHashtbl.ml
++++ b/src/extHashtbl.ml
+@@ -22,7 +22,7 @@
+ module Hashtbl =
+   struct
+ 
+-#if OCAML >= 400
++#if OCAML >= 400 && OCAML < 412
+   external old_hash_param :
+     int -> int -> 'a -> int = "caml_hash_univ_param" "noalloc"
+ #endif
+@@ -114,7 +114,11 @@ module Hashtbl =
+     (* compatibility with old hash tables *)
+     if Obj.size (Obj.repr h) >= 3
+     then (seeded_hash_param 10 100 (h_conv h).seed key) land (Array.length (h_conv h).data - 1)
++  #if OCAML >= 412
++    else failwith "Old hash function not supported anymore"
++  #else
+     else (old_hash_param 10 100 key) mod (Array.length (h_conv h).data)
++  #endif
+ #else
+   let key_index h key = (hash key) mod (Array.length (h_conv h).data)
+ #endif
+-- 
+2.30.0
+

--- a/packages/extlib/extlib.1.7.7-1/opam
+++ b/packages/extlib/extlib.1.7.7-1/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer: "ygrek@autistici.org"
+homepage: "https://github.com/ygrek/ocaml-extlib"
+dev-repo: "git://github.com/ygrek/ocaml-extlib.git"
+bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
+doc: ["https://ygrek.org/p/extlib/doc/"]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+authors: [
+  "Nicolas Cannasse"
+  "Brian Hurt"
+  "Yamagata Yoriyuki"
+  "Markus Mottl"
+  "Jesse Guardiani"
+  "John Skaller"
+  "Bardur Arantsson"
+  "Janne Hellsten"
+  "Richard W.M. Jones"
+  "ygrek"
+  "Gabriel Scherer"
+  "Pietro Abate"
+]
+patches: [
+  "0001-Add-support-for-OCaml-4.12.patch"
+  "0002-caml_hash_univ_param-was-removed-for-OCaml-pre-4.00-.patch"
+]
+build: [
+  [make "minimal=1" "build"]
+  [make "minimal=1" "test"] {with-test}
+  [make "minimal=1" "doc"] {with-doc}
+]
+install: [ [make "minimal=1" "install"] ]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+  "cppo" {build}
+  "base-bytes" {build}
+]
+extra-files: [
+  ["0001-Add-support-for-OCaml-4.12.patch" "md5=816012e35353d76872ca56743d9fc71a"]
+  ["0002-caml_hash_univ_param-was-removed-for-OCaml-pre-4.00-.patch" "md5=4c3d4a6b1f66f4d913aef808c0ebc96b"]
+]
+synopsis:
+  "A complete yet small extension for OCaml standard library (reduced, recommended)"
+description: """
+The purpose of this library is to add new functions to OCaml standard library
+modules, to modify some functions in order to get better performances or
+safety (tail-recursive) and also to provide new modules which should be useful
+for day to day programming.
+
+Current goal is to maintain compatibility, new software is encouraged to not use extlib since stdlib
+is now seeing many additions and improvements which make many parts of extlib obsolete.
+For tail-recursion safety consider using other libraries e.g. containers.
+"""
+url {
+  src: "https://ygrek.org/p/release/ocaml-extlib/extlib-1.7.7.tar.gz"
+  checksum: [
+    "md5=2c620993aecd4b31b3a362b21b55dd94"
+    "sha256=4183abeca72efefc2513a440706c0e6e56d4676f60ae89a4306f8e5e03fbb5eb"
+    "sha512=4f3d6f5bc29c43254ad9f927213fca4afb8a74afbfbaca01ae7e540ea4509f2583aeedd91da8d5252843dd0998093e6e02801a4e95a70a04c6f7229b2b817bf3"
+  ]
+  mirrors: "https://github.com/ygrek/ocaml-extlib/releases/download/1.7.7/extlib-1.7.7.tar.gz"
+}


### PR DESCRIPTION
Patches taken from upstream.

Should solve issues from https://github.com/ocaml/opam-repository/pull/17998 / https://github.com/ocaml/opam-repository/pull/17999 without having to rely on extlib-compat.

cc @ygrek is that fine for you? I'll close your PR for `extlib-compat.1.7.8` if yes.