### PR TITLE
OCaml 4.12.0 second beta release

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Second beta release of OCaml 4.12.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml#4.12"
+depends: [
+  "ocaml" {= "4.12.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler hidden-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%" {os != "cygwin"}]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.12.0-beta2.tar.gz"
+  checksum: "sha256=bfb1cfdfe86736fd03e1985d0d1eb1d624fab947f04456b64f58eeaf93b4fc6d"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
@@ -1,0 +1,79 @@
+opam-version: "2.0"
+synopsis: "Second beta release of OCaml 4.12.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml#4.12"
+depends: [
+  "ocaml" {= "4.12.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta" {opam-version < "2.1"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler hidden-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--enable-spacetime" {ocaml-option-spacetime:installed}
+    "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+  ]
+  [make "-j%{jobs}%" {os != "cygwin"}]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.12.0-beta2.tar.gz"
+  checksum: "sha256=bfb1cfdfe86736fd03e1985d0d1eb1d624fab947f04456b64f58eeaf93b4fc6d"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+  "ocaml-option-spacetime"
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]


### PR DESCRIPTION
This is a quiet release with a race condition fix on windows, and a new experimental support for illumos and Solaris (in the form of various documentation fix). Both changes should be pretty safe, but some testing in the wild would not hurt.

There is also a handful of documentation changes, in order to prepare the 4.12 version of the manual (with notably a new format for the ocaml.org version of the manual)

### Thread library

* [*additional fixes*] [9757](https://github.com/ocaml/ocaml/issues/9757), [9846](https://github.com/ocaml/ocaml/issues/9846), +[10161](https://github.com/ocaml/ocaml/issues/10161): check proper ownership when operating over mutexes.
  Now, unlocking a mutex held by another thread or not locked at all
  reliably raises a Sys_error exception.  Before, it was undefined
  behavior, but the documentation did not say so.
  Likewise, locking a mutex already locked by the current thread
  reliably raises a Sys_error exception.  Before, it could
  deadlock or succeed (and do recursive locking), depending on the OS.
  (Xavier Leroy, report by Guillaume Munch-Maccagnoni, review by
  Guillaume Munch-Maccagnoni, David Allsopp, and Stephen Dolan)

### Build system

- [10063](https://github.com/ocaml/ocaml/issues/10063): (Re-)enable building on illumos (SmartOS, OmniOS, ...) and
  Oracle Solaris; x86_64/GCC and 64-bit SPARC/Sun PRO C compilers.
  (partially revert [2024](https://github.com/ocaml/ocaml/issues/2024)).
  (Tõivo Leedjärv and Konstantin Romanov,
   review by Gabriel Scherer, Sébastien Hinderer and Xavier Leroy)


### Documentation

- [9755](https://github.com/ocaml/ocaml/issues/9755): Manual: post-processing the html generated by ocamldoc and
   hevea. Improvements on design and navigation, including a mobile
   version, and a quick-search functionality for the API.
   (San Vũ Ngọc, review by David Allsopp and Florian Angeletti)

- [10142](https://github.com/ocaml/ocaml/issues/10142), [10154](https://github.com/ocaml/ocaml/issues/10154): improved rendering and latex code for toplevel code examples.
  (Florian Angeletti, report by John Whitington, review by Gabriel Scherer)
