### PR TITLE
Package visitors.20210127

### DIFF
--- a/packages/visitors/visitors.20210127/opam
+++ b/packages/visitors/visitors.20210127/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/visitors"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/visitors.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "ppxlib" {>= "0.9.0"}
+  "ppx_deriving" {>= "5.0"}
+  "result"
+  "dune" {>= "2.0"}
+]
+synopsis: "An OCaml syntax extension for generating visitor classes"
+description: """
+Annotating an algebraic data type definition with [@@deriving visitors { ... }]
+causes visitor classes to be automatically generated. A visitor is an object
+that knows how to traverse and transform a data structure."""
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/visitors/repository/20210127/archive.tar.gz"
+  checksum: [
+    "md5=b9e69f4f8f896a8c916e18551a4a4a95"
+    "sha512=2aa6aef225feedb790f3e89341ecf796b29e76604b0c2f2f9bea71ff5cd83c2cfcd0a496e60117e158ac78ae009002daa57df0b016b6bf7b08cd6d305a3fe7b6"
+  ]
+}


### PR DESCRIPTION
### `visitors.20210127`
An OCaml syntax extension for generating visitor classes
Annotating an algebraic data type definition with [@@deriving visitors { ... }]
causes visitor classes to be automatically generated. A visitor is an object
that knows how to traverse and transform a data structure.



---
* Homepage: https://gitlab.inria.fr/fpottier/visitors
* Source repo: git+https://gitlab.inria.fr/fpottier/visitors.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.3