### PR TITLE
[new release] memtrace (0.2.1)

### DIFF
--- a/packages/memtrace/memtrace.0.2.1/opam
+++ b/packages/memtrace/memtrace.0.2.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Streaming client for Memprof"
+description: "Generates compact traces of a program's memory use."
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/janestreet/memtrace"
+bug-reports: "https://github.com/janestreet/memtrace/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/janestreet/memtrace.git"
+x-commit-hash: "6d23d15f460b401ac28172764fb42eb773c34534"
+url {
+  src:
+    "https://github.com/janestreet/memtrace/releases/download/v0.2.1/memtrace-v0.2.1.tbz"
+  checksum: [
+    "sha256=9d34599cea0c57ce6470fb09901038332d0df91bdeafda487695077367098a24"
+    "sha512=b033f26130034c8dbde674badc24dd27ad1f5aa6184ba5668de2592a580df245494057361aeb1a6c582d3a4cd1b4d748ac511b5024152da227980efb6812ba66"
+  ]
+}


### PR DESCRIPTION
Streaming client for Memprof

- Project page: <a href="https://github.com/janestreet/memtrace">https://github.com/janestreet/memtrace</a>

##### CHANGES:

Packaging fixes.
