### PR TITLE
[new release] path_glob (0.2)

### DIFF
--- a/packages/path_glob/path_glob.0.2/opam
+++ b/packages/path_glob/path_glob.0.2/opam
@@ -6,15 +6,16 @@ extracted from ocamlbuild.
 """
 
 homepage: "https://gitlab.com/gasche/path_glob"
-bug-reports: "https://gitlab.com/gasche/path_glob"
+bug-reports: "https://gitlab.com/gasche/path_glob/-/issues"
 doc: "https://gasche.gitlab.io/path_glob/doc/path_glob"
+dev-repo: "git+https://gitlab.com/gasche/path_glob.git"
 
 maintainer: ["Gabriel Scherer <gabriel.scherer@gmail.com>"]
 authors: [
   "Berke Durak"
 ]
 
-license: "LGPL2 + linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 
 depends: [
   "ocaml" {>= "4.03"}

--- a/packages/path_glob/path_glob.0.2/opam
+++ b/packages/path_glob/path_glob.0.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Globbing file paths"
+description: """
+An implementation of 'glob' patterns for file paths,
+extracted from ocamlbuild.
+"""
+
+homepage: "https://gitlab.com/gasche/path_glob"
+bug-reports: "https://gitlab.com/gasche/path_glob"
+doc: "https://gasche.gitlab.io/path_glob/doc/path_glob"
+
+maintainer: ["Gabriel Scherer <gabriel.scherer@gmail.com>"]
+authors: [
+  "Berke Durak"
+]
+
+license: "LGPL2 + linking exception"
+
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune" {>= "2.7"}
+  "odoc" {with-doc}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "2cc5714fbe0439af7ba36eeff8b6d1acd437474b"
+url {
+  src: "https://gasche.gitlab.io/path_glob/releases/path_glob-0.2.tbz"
+  checksum: [
+    "sha256=5e09a2148876b68ac8fb315679ba69b1e207ced55d91a3ea5b3046f917102a07"
+    "sha512=f55775c694e4b66acdfc9210cccc4af505ecbce3101b638495623d7f18a169e4c904e1b86c1c13ec3af9ae765acd6eedfa6cb7059a0c8a4a1aff375b7e9114ab"
+  ]
+}


### PR DESCRIPTION
CHANGES:

Initial publication of the package, extracted from the ocamlbuild sources.
The library is named 'path_glob'.