### PR TITLE
[new release] earlybird-411 (1.0.0-beta.0)

### DIFF
--- a/packages/earlybird-411/earlybird-411.1.0.0-beta.0/opam
+++ b/packages/earlybird-411/earlybird-411.1.0.0-beta.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Debug adapter for OCaml 4.11"
+description: "Debug adapter for OCaml 4.11."
+maintainer: ["hackwaly@qq.com"]
+authors: ["hackwaly@qq.com"]
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0" & < "4.12.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "menhir" {>= "20201216" & build}
+  "menhirLib" {>= "20201216"}
+  "iter" {>= "1.2.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react" {>= "1.1.3"}
+  "cmdliner" {>= "1.0.4"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "dap" {>= "1.0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hackwaly/ocamlearlybird.git"
+x-commit-hash: "3ac59e9213688a1bc0e9bf0a8222d51839ce6b81"
+url {
+  src:
+    "https://github.com/hackwaly/ocamlearlybird/releases/download/1.0.0-beta.0/earlybird-411-1.0.0-beta.0.tbz"
+  checksum: [
+    "sha256=12e1600338abff63417fcda99e6229b851da3ce2576c6b4630d04f28c37ea383"
+    "sha512=1615244140275b15ff7b0d3019ed38dff36ca20f4bf933e3a6dc4b210484c61950f5c1a08ca36df2fd69f412766b039e63d17c75bb16460713534a1c14e6261b"
+  ]
+}


### PR DESCRIPTION
Debug adapter for OCaml 4.11

- Project page: <a href="https://github.com/hackwaly/ocamlearlybird">https://github.com/hackwaly/ocamlearlybird</a>

##### CHANGES:

Initial release.
