### PR TITLE
[new release] earlybird-411 (1.0.0-beta.0)

### DIFF
--- a/packages/earlybird-411/earlybird-411.1.0.0-beta.0/opam
+++ b/packages/earlybird-411/earlybird-411.1.0.0-beta.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Debug adapter for OCaml 4.11"
+description: "Debug adapter for OCaml 4.11."
+maintainer: ["hackwaly@qq.com"]
+authors: ["hackwaly@qq.com"]
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0" & < "4.12.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "menhir" {>= "20201216" & build}
+  "menhirLib" {>= "20201216"}
+  "iter" {>= "1.2.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react" {>= "1.1.3"}
+  "cmdliner" {>= "1.0.4"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "path_glob" {>= "0.2"}
+  "dap" {>= "1.0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hackwaly/ocamlearlybird.git"
+x-commit-hash: "e90cea0a24bcdb244f93143d2737444b79ae9de6"
+url {
+  src:
+    "https://github.com/hackwaly/ocamlearlybird/releases/download/1.0.0-beta.0/earlybird-411-1.0.0-beta.0.tbz"
+  checksum: [
+    "sha256=8404df07db43dd30104b13545d79086602fa0993e1c94dc41be2b0fee4445f64"
+    "sha512=2536095a0417d594f9f1699c46df302c1935572f20be3c61ab598a10b4cc19356366d7352a50fac2f0d4dfdf54ce3aa17712afd6f67caf28f5c98df2ebce5760"
+  ]
+}


### PR DESCRIPTION
Debug adapter for OCaml 4.11

- Project page: <a href="https://github.com/hackwaly/ocamlearlybird">https://github.com/hackwaly/ocamlearlybird</a>

##### CHANGES:

Initial release.
