### PR TITLE
Create symlink for conf-bison and conf-flex in Mac homebrew

### DIFF
--- a/packages/conf-bison/conf-bison.2/opam
+++ b/packages/conf-bison/conf-bison.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+homepage: "https://www.gnu.org/software/bison/"
+bug-reports: "https://lists.gnu.org/mailman/listinfo/bug-bison"
+license: "GPL-3.0-or-later"
+authors: [
+  "Robert Corbett" 
+  "Richard Stallman"
+  "Wilfred Hansen"
+  "Akim Demaille"
+  "Paul Hilfinger" 
+  "Joel E. Denny"
+  "Paolo Bonzini"
+  "Alex Rozenman"
+  "Paul Eggert"
+]
+build: [ "bison" "--help" ]
+install: [
+  # Note: Mac homebrew installs bison to a path not in PATH, so symlink it in the opam switch bin folder.
+  # This affects only the current opam switch and is thus least invasive.
+  ["sh" "-c" "ln -s \"$(brew --prefix bison)/bin/bison\" \"%{bin}%/bison\""] {os-family = "homebrew"}
+  ["sh" "-c" "ln -s \"$(brew --prefix bison)/bin/yacc\" \"%{bin}%/yacc\""] {os-family = "homebrew"}
+]
+depexts: [
+  # The list of supported os-family names can be derived from the opam sources (thanks Enrico)
+  #   https://github.com/ocaml/opam/blob/6aefe95e60084e63d01b1c7c028b6b77de1f839f/src/state/opamSysInteract.ml#L84-L123
+  # The package name for many Linux/BSD/macOS/cygwin/msys platforms can be searched here (thanks Théo)
+  #   https://repology.org specifically https://repology.org/project/bison/versions
+  #   Not listed above but supported by opam are suse, oraclelinix, ol, rhel
+  # On macOS bison seems to be installed by default, but the homebrew and macports package is listed anyway
+  [ "bison" ] {os-family = "alpine"}
+  [ "bison" ] {os-family = "amzn"}
+  [ "bison" ] {os-family = "arch"}
+  [ "bison" ] {os-family = "archlinux"}
+  [ "bison" ] {os-family = "centos"}
+  [ "bison" ] {os-family = "debian"}
+  [ "bison" ] {os-family = "fedora"}
+  [ "sys-devel/bison" ] {os-family = "gentoo"}
+  [ "bison" ] {os-family = "homebrew"}
+  [ "bison" ] {os-family = "macports"}
+  [ "bison" ] {os-family = "mageia"}
+  [ "bison" ] {os-family = "opensuse"}
+  [ "devel/bison" ] {os-family = "bsd"}
+]
+synopsis: "Virtual package relying on GNU bison"
+description: "This package can only install if GNU bison is installed on the system."
+# Not technically a conf package for homebrew (has an install setp)
+# flags: conf

--- a/packages/conf-bison/conf-bison.2/opam
+++ b/packages/conf-bison/conf-bison.2/opam
@@ -14,7 +14,10 @@ authors: [
   "Alex Rozenman"
   "Paul Eggert"
 ]
-build: [ "bison" "--help" ]
+build: [
+  ["bison" "--version"] {os-family != "homebrew"}
+  ["sh" "-c" "\"$(brew --prefix bison)/bin/bison\" --version"] {os-family = "homebrew"}
+]
 install: [
   # Note: Mac homebrew installs bison to a path not in PATH, so symlink it in the opam switch bin folder.
   # This affects only the current opam switch and is thus least invasive.
@@ -44,5 +47,5 @@ depexts: [
 ]
 synopsis: "Virtual package relying on GNU bison"
 description: "This package can only install if GNU bison is installed on the system."
-# Not technically a conf package for homebrew (has an install setp)
+# Not technically a conf package for homebrew (has an install step)
 # flags: conf

--- a/packages/conf-flex/conf-flex.2/opam
+++ b/packages/conf-flex/conf-flex.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+homepage: "https://github.com/westes/flex"
+bug-reports: "https://github.com/westes/flex/issues"
+license: "https://github.com/westes/flex/blob/master/COPYING"
+authors: "The Flex Project"
+build: [ "flex" "--help" ]
+install: [
+  # Note: Mac homebrew installs flex to a path not in PATH, so symlink it in the opam switch bin folder
+  # This affects only the current opam switch and is thus least invasive.
+  ["sh" "-c" "ln -s \"$(brew --prefix flex)/bin/flex\" \"%{bin}%/flex\""] {os-family = "homebrew"}
+]
+depexts: [
+  # The list of supported os-family names can be derived from the opam sources (thanks Enrico)
+  #   https://github.com/ocaml/opam/blob/6aefe95e60084e63d01b1c7c028b6b77de1f839f/src/state/opamSysInteract.ml#L84-L123
+  # The package name for many Linux/BSD/macOS/cygwin/msys platforms can be searched here (thanks Théo)
+  #   https://repology.org specifically https://repology.org/project/flex/versions
+  #   Not listed above but supported by opam are suse, oraclelinix, ol, rhel
+  # On macOS flex seems to be installed by default, but the homebrew and macports package is listed anyway
+  [ "flex" ] {os-family = "alpine"}
+  [ "flex" ] {os-family = "amzn"}
+  [ "flex" ] {os-family = "arch"}
+  [ "flex" ] {os-family = "archlinux"}
+  [ "flex" ] {os-family = "centos"}
+  [ "flex" ] {os-family = "debian"}
+  [ "flex" ] {os-family = "fedora"}
+  [ "sys-devel/flex" ] {os-family = "gentoo"}
+  [ "flex" ] {os-family = "homebrew"}
+  [ "flex" ] {os-family = "macports"}
+  [ "flex" ] {os-family = "mageia"}
+  [ "flex" ] {os-family = "opensuse"}
+  [ "textproc/flex" ] {os-family = "bsd" & os-distribution = "freebsd"}
+]
+synopsis: "Virtual package relying on GNU flex"
+description: "This package can only install if GNU flex is installed on the system."
+# Not technically a conf package for homebrew (has an install setp)
+# flags: conf

--- a/packages/conf-flex/conf-flex.2/opam
+++ b/packages/conf-flex/conf-flex.2/opam
@@ -4,7 +4,10 @@ homepage: "https://github.com/westes/flex"
 bug-reports: "https://github.com/westes/flex/issues"
 license: "https://github.com/westes/flex/blob/master/COPYING"
 authors: "The Flex Project"
-build: [ "flex" "--help" ]
+build: [
+  ["flex" "--version"] {os-family != "homebrew"}
+  ["sh" "-c" "\"$(brew --prefix flex)/bin/flex\" --version"] {os-family = "homebrew"}
+]
 install: [
   # Note: Mac homebrew installs flex to a path not in PATH, so symlink it in the opam switch bin folder
   # This affects only the current opam switch and is thus least invasive.
@@ -33,5 +36,5 @@ depexts: [
 ]
 synopsis: "Virtual package relying on GNU flex"
 description: "This package can only install if GNU flex is installed on the system."
-# Not technically a conf package for homebrew (has an install setp)
+# Not technically a conf package for homebrew (has an install step)
 # flags: conf


### PR DESCRIPTION
Mac Homebrew installs bison and flex to folders which are not in the usual PATH, because they would hide the macOS supplied (old) versions of bison and flex. Since packages depending on these conf packages can be assumed to require the provided tools and not the system supplied tools, the conf packages are changed to include an install step which creates a symlink in the switch bin folder.

I don't know how agreeable this method is - technically the package is no longer a conf package for homebrew, but I think this is the most reasonable solution. I also thought about using `setenv`, but then there is no way to call brew to get the proper path with `setenv`. Also cluttering PATH is not that nice. So in the end I found the symlink solution most reasonable.

I increased the package version because for macOS with homebrew it does make a difference - the package did install before - without the symlinks.

Other OSes (notably macOS MacPorts) don't have a similar issue - this is homebrew specific.

This is required to fix (https://gitlab.inria.fr/gappa/gappa/-/issues/7).