### PR TITLE
[new release] earlybird (1.0.0)

### DIFF
--- a/packages/earlybird/earlybird.1.0.0/opam
+++ b/packages/earlybird/earlybird.1.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Debug adapter for OCaml 4.11"
+description: "Debug adapter for OCaml 4.11."
+maintainer: ["hackwaly@qq.com"]
+authors: ["hackwaly@qq.com"]
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0" & < "4.12.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "menhir" {>= "20201216" & build}
+  "menhirLib" {>= "20201216"}
+  "iter" {>= "1.2.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react" {>= "1.1.3"}
+  "cmdliner" {>= "1.0.4"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "path_glob" {>= "0.2"}
+  "dap" {>= "1.0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hackwaly/ocamlearlybird.git"
+x-commit-hash: "380f339fdd264cc3567f14d3dc1981e7fadc5a20"
+url {
+  src:
+    "https://github.com/hackwaly/ocamlearlybird/releases/download/1.0.0/earlybird-1.0.0.tbz"
+  checksum: [
+    "sha256=454c743a086fc4f94f7a1e686324bb8b6b46450972e94f671d8e28f413dc6d87"
+    "sha512=26f9fa36cef21a2981eaeb18cb5c824f5879f69101e4128432d54c9ae63faddafbf204c69ed7a3ddd440161d25c0c212899c61a14a124c150d0629939f6af89f"
+  ]
+}


### PR DESCRIPTION
Debug adapter for OCaml 4.11

- Project page: <a href="https://github.com/hackwaly/ocamlearlybird">https://github.com/hackwaly/ocamlearlybird</a>

##### CHANGES:

Initial release.
