### PR TITLE
Improve pkg-config and improve the conf-libssl experience with Homebrew

### DIFF
--- a/packages/conf-libssl/conf-libssl.3/files/homebrew.sh
+++ b/packages/conf-libssl/conf-libssl.3/files/homebrew.sh
@@ -16,7 +16,7 @@ install)
     exit 1
   fi
   for file in $(ls "$brew_pkg_config"/*.pc); do
-    ln -s "$brew_pkg_config/$file" "$2/pkgconfig/$file"
+    ln -s "$file" "$2/pkgconfig/$file"
   done;;
 *)
   echo "Usage: $0 <check|install>"

--- a/packages/conf-libssl/conf-libssl.3/files/homebrew.sh
+++ b/packages/conf-libssl/conf-libssl.3/files/homebrew.sh
@@ -1,0 +1,24 @@
+#!/bin/sh -ex
+
+brew_pkg_config=$(brew --prefix openssl)/lib/pkgconfig
+
+case "$1" in
+check)
+  if test "$#" != 1; then
+    echo "Usage: $0 check"
+    exit 1
+  fi
+  export PKG_CONFIG_PATH=$brew_pkg_config:$PKG_CONFIG_PATH
+  pkg-config --print-errors --exists openssl;;
+install)
+  if test "$#" != 2; then
+    echo "Usage: $0 install <libdir>"
+    exit 1
+  fi
+  for file in $(ls "$brew_pkg_config"/*.pc); do
+    ln -s "$brew_pkg_config/$file" "$2/pkgconfig/$file"
+  done;;
+*)
+  echo "Usage: $0 <check|install>"
+  exit 1;;
+esac

--- a/packages/conf-libssl/conf-libssl.3/files/homebrew.sh
+++ b/packages/conf-libssl/conf-libssl.3/files/homebrew.sh
@@ -15,8 +15,11 @@ install)
     echo "Usage: $0 install <libdir>"
     exit 1
   fi
-  for file in $(ls "$brew_pkg_config"/*.pc); do
-    ln -s "$file" "$2/pkgconfig/$file"
+  cd "$brew_pkg_config"
+  for file in $(ls *.pc); do
+    if test -f "$file"; then
+      ln -s "$brew_pkg_config/$file" "$2/pkgconfig/$file"
+    fi
   done;;
 *)
   echo "Usage: $0 <check|install>"

--- a/packages/conf-libssl/conf-libssl.3/files/homebrew.sh
+++ b/packages/conf-libssl/conf-libssl.3/files/homebrew.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -ex
 
+# check the openssl installation
+# and symlink the homebrew pkg-config files for openssl to the opam local pkgconfig directory
+
 brew_pkg_config=$(brew --prefix openssl)/lib/pkgconfig
 
 case "$1" in

--- a/packages/conf-libssl/conf-libssl.3/opam
+++ b/packages/conf-libssl/conf-libssl.3/opam
@@ -4,6 +4,7 @@ authors: ["The OpenSSL Project"]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.openssl.org/"
 license: "Apache-1.0"
+setenv: [PKG_CONFIG_PATH = "%{lib}%/pkgconfig"]
 build: [
   ["pkg-config" "--print-errors" "--exists" "openssl"]
     {os != "freebsd" & os != "openbsd" & os != "netbsd" # libssl is provided by base system on BSDs

--- a/packages/conf-libssl/conf-libssl.3/opam
+++ b/packages/conf-libssl/conf-libssl.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "David Sheets <sheets@alum.mit.edu>"
+authors: ["The OpenSSL Project"]
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://www.openssl.org/"
+license: "Apache-1.0"
+build: [
+  ["pkg-config" "--print-errors" "--exists" "openssl"]
+    {os != "freebsd" & os != "openbsd" & os != "netbsd" # libssl is provided by base system on BSDs
+     os-distribution != "homebrew" & os-distribution != "macports" & os-distribution != "nixos"}
+  ["sh" "-c" "env \"PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --print-errors --exists openssl"] {os-distribution = "homebrew"}
+  ["sh" "-c" "env \"PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --print-errors --exists openssl"] {os-distribution = "nixos"}
+  ["sh" "-c" "env \"PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --print-errors --exists openssl"] {os-distribution = "macports"}
+]
+install: [
+  ["mkdir" "-p" "%{lib}%/pkgconfig"]
+  ["sh" "-c" "ln -s \"$(brew --prefix openssl)/lib/pkgconfig/openssl.pc" '%{lib}%/pkgconfig/openssl.pc'"] {os-distribution = "homebrew"}
+  ["sh" "-c" "ln -s \"$HOME/.nix-profile/lib/pkgconfig/openssl.pc" '%{lib}%/pkgconfig/openssl.pc'"] {os-distribution = "nixos"}
+  ["ln" "-s" "/opt/local/lib/pkgconfig/openssl.pc" "%{lib}%/pkgconfig/openssl.pc"] {os-distribution = "macports"}
+]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["libssl-dev"] {os-family = "debian"}
+  ["libssl-dev"] {os-family = "ubuntu"}
+  ["openssl-devel"] {os-distribution = "centos"}
+  ["openssl-devel"] {os-distribution = "ol"}
+  ["openssl-devel"] {os-distribution = "fedora"}
+  ["libopenssl-devel"] {os-family = "suse"}
+  ["libressl-dev"] {os-family = "alpine"}
+  ["openssl"] {os-family = "arch"}
+  ["openssl"] {os-distribution = "homebrew"}
+  ["openssl"] {os-distribution = "macports"}
+  ["openssl"] {os-distribution = "nixos"}
+]
+synopsis: "Virtual package relying on an OpenSSL library system installation"
+description:
+  "This package can only install if the OpenSSL library is installed on the system."
+flags: conf

--- a/packages/conf-libssl/conf-libssl.3/opam
+++ b/packages/conf-libssl/conf-libssl.3/opam
@@ -9,14 +9,14 @@ build: [
   ["pkg-config" "--print-errors" "--exists" "openssl"]
     {os != "freebsd" & os != "openbsd" & os != "netbsd" # libssl is provided by base system on BSDs
      os-distribution != "homebrew" & os-distribution != "macports" & os-distribution != "nixos"}
-  ["sh" "-c" "env \"PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --print-errors --exists openssl"] {os-distribution = "homebrew"}
-  ["sh" "-c" "env \"PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --print-errors --exists openssl"] {os-distribution = "nixos"}
-  ["sh" "-c" "env \"PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --print-errors --exists openssl"] {os-distribution = "macports"}
+  ["sh" "-c" "env \"PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --print-errors --exists openssl"] {os-distribution = "homebrew"}
+  ["sh" "-c" "env \"PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --print-errors --exists openssl"] {os-distribution = "nixos"}
+  ["sh" "-c" "env \"PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --print-errors --exists openssl"] {os-distribution = "macports"}
 ]
 install: [
   ["mkdir" "-p" "%{lib}%/pkgconfig"]
-  ["sh" "-c" "ln -s \"$(brew --prefix openssl)/lib/pkgconfig/openssl.pc" '%{lib}%/pkgconfig/openssl.pc'"] {os-distribution = "homebrew"}
-  ["sh" "-c" "ln -s \"$HOME/.nix-profile/lib/pkgconfig/openssl.pc" '%{lib}%/pkgconfig/openssl.pc'"] {os-distribution = "nixos"}
+  ["sh" "-c" "ln -s \"$(brew --prefix openssl)/lib/pkgconfig/openssl.pc\" '%{lib}%/pkgconfig/openssl.pc'"] {os-distribution = "homebrew"}
+  ["sh" "-c" "ln -s \"$HOME/.nix-profile/lib/pkgconfig/openssl.pc\" '%{lib}%/pkgconfig/openssl.pc'"] {os-distribution = "nixos"}
   ["ln" "-s" "/opt/local/lib/pkgconfig/openssl.pc" "%{lib}%/pkgconfig/openssl.pc"] {os-distribution = "macports"}
 ]
 depends: [

--- a/packages/conf-libssl/conf-libssl.3/opam
+++ b/packages/conf-libssl/conf-libssl.3/opam
@@ -7,15 +7,11 @@ license: "Apache-1.0"
 build: [
   ["pkg-config" "--print-errors" "--exists" "openssl"]
     {os != "freebsd" & os != "openbsd" & os != "netbsd" & # libssl is provided by base system on BSDs
-     os-distribution != "homebrew" & os-distribution != "macports" & os-distribution != "nixos"}
-  ["sh" "-c" "env \"PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --print-errors --exists openssl"] {os-distribution = "homebrew"}
-  ["sh" "-c" "env \"PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --print-errors --exists openssl"] {os-distribution = "nixos"}
-  ["sh" "-c" "env \"PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --print-errors --exists openssl"] {os-distribution = "macports"}
+     os-distribution != "homebrew"}
+  ["./homebrew.sh" "check"] {os-distribution = "homebrew"}
 ]
 install: [
-  ["sh" "-c" "ln -s \"$(brew --prefix openssl)/lib/pkgconfig/openssl.pc\" '%{lib}%/pkgconfig/openssl.pc'"] {os-distribution = "homebrew"}
-  ["sh" "-c" "ln -s \"$HOME/.nix-profile/lib/pkgconfig/openssl.pc\" '%{lib}%/pkgconfig/openssl.pc'"] {os-distribution = "nixos"}
-  ["ln" "-s" "/opt/local/lib/pkgconfig/openssl.pc" "%{lib}%/pkgconfig/openssl.pc"] {os-distribution = "macports"}
+  ["./homebrew.sh" "install" lib] {os-distribution = "homebrew"}
 ]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libssl/conf-libssl.3/opam
+++ b/packages/conf-libssl/conf-libssl.3/opam
@@ -6,7 +6,7 @@ homepage: "https://www.openssl.org/"
 license: "Apache-1.0"
 build: [
   ["pkg-config" "--print-errors" "--exists" "openssl"]
-    {os != "freebsd" & os != "openbsd" & os != "netbsd" # libssl is provided by base system on BSDs
+    {os != "freebsd" & os != "openbsd" & os != "netbsd" & # libssl is provided by base system on BSDs
      os-distribution != "homebrew" & os-distribution != "macports" & os-distribution != "nixos"}
   ["sh" "-c" "env \"PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --print-errors --exists openssl"] {os-distribution = "homebrew"}
   ["sh" "-c" "env \"PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --print-errors --exists openssl"] {os-distribution = "nixos"}

--- a/packages/conf-libssl/conf-libssl.3/opam
+++ b/packages/conf-libssl/conf-libssl.3/opam
@@ -4,7 +4,6 @@ authors: ["The OpenSSL Project"]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.openssl.org/"
 license: "Apache-1.0"
-setenv: [PKG_CONFIG_PATH = "%{lib}%/pkgconfig"]
 build: [
   ["pkg-config" "--print-errors" "--exists" "openssl"]
     {os != "freebsd" & os != "openbsd" & os != "netbsd" # libssl is provided by base system on BSDs
@@ -14,7 +13,6 @@ build: [
   ["sh" "-c" "env \"PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --print-errors --exists openssl"] {os-distribution = "macports"}
 ]
 install: [
-  ["mkdir" "-p" "%{lib}%/pkgconfig"]
   ["sh" "-c" "ln -s \"$(brew --prefix openssl)/lib/pkgconfig/openssl.pc\" '%{lib}%/pkgconfig/openssl.pc'"] {os-distribution = "homebrew"}
   ["sh" "-c" "ln -s \"$HOME/.nix-profile/lib/pkgconfig/openssl.pc\" '%{lib}%/pkgconfig/openssl.pc'"] {os-distribution = "nixos"}
   ["ln" "-s" "/opt/local/lib/pkgconfig/openssl.pc" "%{lib}%/pkgconfig/openssl.pc"] {os-distribution = "macports"}

--- a/packages/conf-pkg-config/conf-pkg-config.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.2/opam
@@ -34,7 +34,7 @@ depexts: [
   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
   ["pkg-config"] {os-distribution = "cygwinports"}
 ]
-synopsis: "Virtual package relying on pkg-config installation"
+synopsis: "Check if pkg-config is installed and create an opam switch local pkgconfig folder"
 description: """
 This package can only install if the pkg-config package is installed
 on the system."""

--- a/packages/conf-pkg-config/conf-pkg-config.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: ["Francois Berenger"]
+homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+setenv: [PKG_CONFIG_PATH = "%{lib}%/pkgconfig"]
+build: [
+  ["pkg-config" "--help"] {os != "openbsd"}
+  ["/usr/local/bin/pkgconf" "--help"] {os = "openbsd"}
+]
+install: [
+  ["mkdir" "-p" "%{lib}%/pkgconfig"]
+  ["ln" "-s" "/usr/local/bin/pkgconf" "%{bin}%/pkg-config"] {os = "openbsd"}
+]
+post-messages: [
+  "conf-pkg-config: A symlink to /usr/local/bin/pkgconf has been installed in the OPAM bin directory (%{bin}%) on your PATH as 'pkg-config'. This is necessary for correct operation." {os = "openbsd"}
+]
+depexts: [
+  ["pkg-config"] {os-family = "debian"}
+  ["pkgconf"] {os-distribution = "arch"}
+  ["pkgconfig"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "mageia"}
+  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "ol"}
+  ["pkgconf"] {os-distribution = "alpine"}
+  ["pkgconfig"] {os-distribution = "nixos"}
+  ["devel/pkgconf"] {os = "openbsd"}
+  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
+  ["pkgconf"] {os = "freebsd"}
+  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  ["pkg-config"] {os-distribution = "cygwinports"}
+]
+synopsis: "Virtual package relying on pkg-config installation"
+description: """
+This package can only install if the pkg-config package is installed
+on the system."""
+flags: conf

--- a/packages/conf-pkg-config/conf-pkg-config.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.2/opam
@@ -4,7 +4,7 @@ authors: ["Francois Berenger"]
 homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
-setenv: [PKG_CONFIG_PATH = "%{lib}%/pkgconfig"]
+setenv: [PKG_CONFIG_PATH += "%{lib}%/pkgconfig"]
 build: [
   ["pkg-config" "--help"] {os != "openbsd"}
   ["/usr/local/bin/pkgconf" "--help"] {os = "openbsd"}


### PR DESCRIPTION
This PR tries to improve the opam experience for people using macOS and NixOS and well as the general `pkg-config` experience.
The `conf-libssl` package would previously ask the user to change their `PKG_CONFIG_PATH` by hand to be able to locate openssl.pc.
The change to `conf-pkg-config` makes it so that `%{lib}%/pkgconfig` is always created and prepended to the global `PKG_CONFIG_PATH`.

This is a draft for the moment as it is just a PoC for the moment and a few questions remain unanswered, such as:
* Is the implementation for NixOS correct? Does it not have the path in the environment by default? (cc @timbertson)
* Is it correct for Macports? (cc @mseri)
* Should we symlink all the `.pc` files from those directories? With homebrew the directory contains:
  - libcrypto.pc
  - libssl.pc
  - openssl.pc

*Big thanks to @MSoegtropIMC for the original idea for bison & flex in https://github.com/ocaml/opam-repository/pull/18059*