### PR TITLE
Update source hash code for gappa

### DIFF
--- a/packages/gappa/gappa.1.3.5/opam
+++ b/packages/gappa/gappa.1.3.5/opam
@@ -36,6 +36,6 @@ depends: [
 ]
 synopsis: "Tool intended for formally proving properties on numerical programs dealing with floating-point or fixed-point arithmetic"
 url {
-  src: "https://gitlab.inria.fr/gappa/gappa/-/archive/f53e105cd73484fc76eb58ba24ead73be502c608.tar.gz"
-  checksum: "sha512=22b82333d0e135578843dcb0740a68a364a21c24dc061e9645ace2353fb8a9141722e5b4691d32d6c433064e3a393ee7ee44435ecd3de936ecb4901498f539de"
+  src: "https://gitlab.inria.fr/gappa/gappa/-/archive/gappa-1.3.5.tar.gz"
+  checksum: "sha512=29ce59af97e6d60547a193b43538f4812ff74fb01a812cda7109855219457fa7a47f59ea39aff2a5e03fd70181e024a3296b4f48300818a81f62fd2d8629c389"
 }

--- a/packages/gappa/gappa.1.3.5/opam
+++ b/packages/gappa/gappa.1.3.5/opam
@@ -36,5 +36,5 @@ depends: [
 synopsis: "Tool intended for formally proving properties on numerical programs dealing with floating-point or fixed-point arithmetic"
 url {
   src: "https://gitlab.inria.fr/gappa/gappa/-/archive/f53e105cd73484fc76eb58ba24ead73be502c608.tar.gz"
-  checksum: "sha512=b2c04d87b502fcab24573b6030e1ba3e2bd9cc7ae719367d12785e8bd91e43001f8d64e70d5ae515ddd9ec636d9c1ce89b54b18ae0796955b5c97b71fee5c957"
+  checksum: "sha512=22b82333d0e135578843dcb0740a68a364a21c24dc061e9645ace2353fb8a9141722e5b4691d32d6c433064e3a393ee7ee44435ecd3de936ecb4901498f539de"
 }

--- a/packages/gappa/gappa.1.3.5/opam
+++ b/packages/gappa/gappa.1.3.5/opam
@@ -3,6 +3,7 @@ maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
 authors: "Guillaume Melquiond"
 bug-reports: "https://gitlab.inria.fr/gappa/gappa/-/issues"
 homepage: "https://gitlab.inria.fr/gappa/gappa"
+dev-repo: "git+https://gitlab.inria.fr/gappa/gappa.git"
 license: "CeCILL"
 patches: [
   "remake.patch"
@@ -30,8 +31,8 @@ depends: [
   "conf-gmp"
   "conf-mpfr"
   "conf-boost"
-  "conf-bison"
-  "conf-flex"
+  "conf-bison" {build}
+  "conf-flex" {build}
 ]
 synopsis: "Tool intended for formally proving properties on numerical programs dealing with floating-point or fixed-point arithmetic"
 url {


### PR DESCRIPTION
Interestingly the source hash code for gappa changed (the source URL is a commit reference, so the commit did for sure not change).

We had a discussion on Coq Zulip how this can be possible - apparently the contents of a .gitattributes file on the master branch can influence the contents of tar balls for an old commit with gitlab. The difference between the old and new tar ball for the same commit are that the .gitignore files are removed - in line with a .giattributes file modification in a later commit.

Anyway - the hash code needs to be adjusted.

@silene : FYI.