### PR TITLE
Package lilac.v0.1.0

### DIFF
--- a/packages/lilac/lilac.v0.1.0/opam
+++ b/packages/lilac/lilac.v0.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Shea Newton <lilac@shnewto.dev>"
+authors: ["Shea Newton <lilac@shnewto.dev>"]
+synopsis: "Get the value of any field in a YAML file as a string."
+homepage: "https://github.com/shnewto/lilac"
+dev-repo: "git+https://github.com/shnewto/lilac"
+bug-reports: "https://github.com/shnewto/lilac/issues"
+tags: [ "library" "lib" "lilac" "yaml" ]
+license: "MIT"
+depends: [ 
+  "cmdliner" 
+  "stdio" 
+  "base" 
+  "ounit" 
+  "yaml" 
+  "dune" {>= "2.7.0"}
+  "ocaml" {>= "4.10.0"}
+  "bisect_ppx" {dev & >= "2.5.0"} 
+]
+build: [
+  [ "dune" "build" ]
+]
+install: [ "dune" "install" ]
+url {
+  src: "https://github.com/shnewto/lilac/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=64b45390195d3944d36ef2e375dac1a0"
+    "sha512=a851dcd0c21ec8473118cc0df3b122b134cafc55674fce2c1f92598f26696dc754682177fad153c222f6ac1e8f9b68138bc66c395d92b65e17c3abfcc24d4aa6"
+  ]
+}


### PR DESCRIPTION
### `lilac.v0.1.0`
Get the value of any field in a YAML file as a string.



---
* Homepage: https://github.com/shnewto/lilac
* Source repo: git+https://github.com/shnewto/lilac
* Bug tracker: https://github.com/shnewto/lilac/issues

---
:camel: Pull-request generated by opam-publish v2.0.3