### PR TITLE
Package ocaml-protoc-plugin.4.2.0

### DIFF
--- a/packages/conf-protoc/conf-protoc.1.0.0/opam
+++ b/packages/conf-protoc/conf-protoc.1.0.0/opam
@@ -14,12 +14,15 @@ depexts: [
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "centos"}
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "fedora"}
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "rhel"}
-  ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "ol"}
   ["protobuf" "protobuf-dev"]               {os-family = "alpine"}
   ["protobuf"]                              {os-family = "arch"}
   ["protobuf-devel"]                        {os-family = "suse"}
   ["protobuf"]                              {os = "freebsd"}
   ["protobuf"]                              {os = "macos" & os-distribution = "homebrew"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7" # Package not available by default
+  "oraclelinux-8" # Package not available by default
 ]
 
 available: (os-distribution != "ubuntu" | os-version >= "18.04") & (os-distribution != "centos" | os-version >= "8")

--- a/packages/conf-protoc/conf-protoc.1.0.0/opam
+++ b/packages/conf-protoc/conf-protoc.1.0.0/opam
@@ -9,12 +9,14 @@ build: [ "protoc" "--version" ]
 
 depexts: [
   ["libprotobuf-dev" "protobuf-compiler"]   {os-family = "debian"}
+  ["libprotobuf-dev" "protobuf-compiler"]   {os-family = "ubuntu"}
   ["libprotobuf-devel" "protobuf-compiler"] {os-distribution = "mageia"}
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "centos"}
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "fedora"}
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "rhel"}
-  ["protobuf" "protobuf-dev"]               {os-distribution = "alpine"}
-  ["protobuf"]                              {os-distribution = "arch"}
+  ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "ol"}
+  ["protobuf" "protobuf-dev"]               {os-family = "alpine"}
+  ["protobuf"]                              {os-family = "arch"}
   ["protobuf-devel"]                        {os-family = "suse"}
   ["protobuf"]                              {os = "freebsd"}
   ["protobuf"]                              {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.2.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.2.0/opam
@@ -27,9 +27,9 @@ depends: [
   "ppx_deriving" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
 ]
 dev-repo: "git+https://github.com/issuu/ocaml-protoc-plugin"
 url {

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.2.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file"
+description: """\
+The plugin generates ocaml type definitions,
+serialization and deserialization functions from a protobuf file.
+The types generated aims to create ocaml idiomatic types;
+- messages are mapped into modules
+- oneof constructs are mapped to polymorphic variants
+- enums are mapped to adt's
+- map types are mapped to assoc lists
+- all integer types are mapped to int by default (exact mapping is also possible)
+- all floating point types are mapped to float.
+- packages are mapped to nested modules"""
+maintainer: "Issuu"
+authors: "Anders Fugmann <af@issuu.com>"
+license: "APACHE-2.0"
+homepage: "https://github.com/issuu/ocaml-protoc-plugin"
+doc: "https://issuu.github.io/ocaml-protoc-plugin/"
+bug-reports: "https://github.com/issuu/ocaml-protoc-plugin/issues"
+depends: [
+  "conf-protoc" {>= "1.0.0"}
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.06.0"}
+  "ppx_expect" {with-test}
+  "ppx_inline_test" {with-test}
+  "ppx_deriving" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/issuu/ocaml-protoc-plugin"
+url {
+  src:
+    "https://github.com/issuu/ocaml-protoc-plugin/releases/download/4.2.0/ocaml-protoc-plugin-4.2.0.tbz"
+  checksum: [
+    "md5=7837774e6637afdbd5e3b1066c01d3b1"
+    "sha512=3d96bbdf8a391b8e7903ca07d28507e7568b063521be84f62e9e0e30728ada4cae3553a9239254fb4f2bde480e6cfeb05ec4a2bab699c755a6890108b8f889e6"
+  ]
+}


### PR DESCRIPTION
### `ocaml-protoc-plugin.4.2.0`
Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file
The plugin generates ocaml type definitions,
serialization and deserialization functions from a protobuf file.
The types generated aims to create ocaml idiomatic types;
- messages are mapped into modules
- oneof constructs are mapped to polymorphic variants
- enums are mapped to adt's
- map types are mapped to assoc lists
- all integer types are mapped to int by default (exact mapping is also possible)
- all floating point types are mapped to float.
- packages are mapped to nested modules



---
* Homepage: https://github.com/issuu/ocaml-protoc-plugin
* Source repo: git+https://github.com/issuu/ocaml-protoc-plugin
* Bug tracker: https://github.com/issuu/ocaml-protoc-plugin/issues

---
:camel: Pull-request generated by opam-publish v2.0.3