### PR TITLE
Package ssl.0.5.10

### DIFF
--- a/packages/ssl/ssl.0.5.10/opam
+++ b/packages/ssl/ssl.0.5.10/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+homepage: "https://github.com/savonet/ocaml-ssl"
+dev-repo: "git+https://github.com/savonet/ocaml-ssl.git"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.0.0"}
+  "dune-configurator"
+  "base-unix"
+  "conf-libssl"
+]
+synopsis: "Bindings for OpenSSL"
+authors: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+url {
+  src: "https://github.com/savonet/ocaml-ssl/archive/v0.5.10.tar.gz"
+  checksum: [
+    "md5=afebbdc3130c1addf1da31e3b92c1dcd"
+    "sha512=f2d0acc8dcdb0a36c8ad236f60c6e9d7f8f76ea25183017218953dbe3432a19de5b0be8214714add71b88b211ac78318f09429d4df7ecba1e19dc94d4414f0e1"
+  ]
+}


### PR DESCRIPTION
### `ssl.0.5.10`
Bindings for OpenSSL



---
* Homepage: https://github.com/savonet/ocaml-ssl
* Source repo: git+https://github.com/savonet/ocaml-ssl.git
* Bug tracker: https://github.com/savonet/ocaml-ssl/issues

---
:camel: Pull-request generated by opam-publish v2.0.3