### PR TITLE
[new release] graphics (5.1.1)

### DIFF
--- a/packages/graphics/graphics.5.1.1/opam
+++ b/packages/graphics/graphics.5.1.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "The OCaml graphics library"
+description: """
+The graphics library provides a set of portable drawing
+primitives. Drawing takes place in a separate window that is created
+when Graphics.open_graph is called.
+
+This library used to be distributed with OCaml up to OCaml 4.08.
+"""
+maintainer: ["jeremie@dimino.org" "david.allsopp@metastack.com"]
+authors: [
+  "Xavier Leroy" "Jun Furuse" "J-M Geffroy" "Jacob Navia" "Pierre Weis"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/ocaml/graphics"
+doc: "https://ocaml.github.io/graphics/"
+bug-reports: "https://github.com/ocaml/graphics/issues"
+depends: [
+  "dune" {>= "2.1"}
+  "dune-configurator"
+  "conf-libX11" {os != "win32"}
+  "conf-pkg-config" {os != "win32"}
+  "ocaml" {>= "4.09.0~~"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/graphics.git"
+x-commit-hash: "9a869c5e1b366353a4e56423a562e78bdcc4de74"
+url {
+  src:
+    "https://github.com/ocaml/graphics/releases/download/5.1.1/graphics-5.1.1.tbz"
+  checksum: [
+    "sha256=286c83e3ded9287036c5e5c77b39a1dcfd73a1296b7b587937dce3900166328e"
+    "sha512=15adbe03211e7392a2fded2d9fd5e0cc2c532b4a1de3b6c90945e9e99cc4f419583a204f357f8c9fd92d1ffce48e13e1f146da1f009eb4645150b7394f799e0a"
+  ]
+}


### PR DESCRIPTION
The OCaml graphics library

- Project page: <a href="https://github.com/ocaml/graphics">https://github.com/ocaml/graphics</a>
- Documentation: <a href="https://ocaml.github.io/graphics/">https://ocaml.github.io/graphics/</a>

##### CHANGES:

- Fix configurator detection on native Windows (ocaml/graphics#19, @fdopen)
- Use caml_alloc_custom_mem when available (ocaml/graphics#23, @hhugo)
- Fix windows dependencies (ocaml/graphics#20, @jeremiedimino)
- Safe-string updates for native Windows (ocaml/graphics#28, fixes ocaml/graphics#27, @dra27)
