### PR TITLE
Tezos-crypto should depend on 0.3.15, not 0.3.14.

### DIFF
--- a/packages/bls12-381/bls12-381.0.3.15/opam
+++ b/packages/bls12-381/bls12-381.0.3.15/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "OCaml binding for bls12-381 from librustzcash"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "conf-rust" {build}
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "dune-configurator" {build}
+  "ff" {>= "0.4.0" & < "0.5.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "ctypes" {>= "0.17.1" & < "0.18.0"}
+  "ctypes-foreign"
+  "tezos-rust-libs" {= "1.0"}
+  "alcotest" {with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.3.15/ocaml-bls12-381-0.3.15.tar.gz"
+  checksum: [
+    "md5=bc2be5f59fbdabc1faf64f4c7be79aff"
+    "sha512=88282ebaf59aa722ce7499e71e24e5313c7933a137c15f95cce58becd50ed30c4df8ca5eb6b00ee98ed4af6aa4412f6e620e23328b381a4372b2d516122464cc"
+  ]
+}

--- a/packages/tezos-crypto/tezos-crypto.8.0/opam
+++ b/packages/tezos-crypto/tezos-crypto.8.0/opam
@@ -9,7 +9,7 @@ depends: [
   "dune" { >= "2.0" }
   "tezos-clic" { = version }
   "tezos-rpc" { = version }
-  "bls12-381" { = "0.3.14" }
+  "bls12-381" { = "0.3.15" }
   "hacl-star" { >= "0.3.0" }
   "secp256k1-internal"
   "uecc" { >= "0.3" }

--- a/packages/tezos-crypto/tezos-crypto.8.1/opam
+++ b/packages/tezos-crypto/tezos-crypto.8.1/opam
@@ -9,7 +9,7 @@ depends: [
   "dune" { >= "2.0" }
   "tezos-clic" { = version }
   "tezos-rpc" { = version }
-  "bls12-381" { = "0.3.14" }
+  "bls12-381" { = "0.3.15" }
   "hacl-star" { >= "0.3.0" }
   "secp256k1-internal"
   "uecc" { >= "0.3" }


### PR DESCRIPTION
Contains https://github.com/ocaml/opam-repository/pull/18047.
The previous version of tezos-crypto does not use the correct version of bls12-381. @pirbo can confirm.