### PR TITLE
[new release] merlin and dot-merlin-reader (4.0)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.0/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {> "4.11.1" }
+  "dune" {>= "1.8.0"}
+  "yojson" {>= "1.6.0"}
+  "ocamlfind" {>= "1.6.0"}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+]
+x-commit-hash: "e990d420f5d74ba8da9b34a4f45dc821043d57fa"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.0/dot-merlin-reader-v4.0.tbz"
+  checksum: [
+    "sha256=d51ab1a48055a1d587ccbf8c63b9a21e27b31ddcbdd10d8166badc0facf42d1f"
+    "sha512=dee9038d9033e29c80c10f6cc6d674652633ab77b0e4f49c2488b4ae08a5af5892e287024b0b3f0cb09aec915ea91f12e1519de8c72504abceaf3624bcdf8658"
+  ]
+}

--- a/packages/dot-merlin-reader/dot-merlin-reader.4.0/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {> "4.11.1" }
+  "ocaml" {>= "4.11.0"}
   "dune" {>= "1.8.0"}
   "yojson" {>= "1.6.0"}
   "ocamlfind" {>= "1.6.0"}

--- a/packages/merlin/merlin.4.0-411/opam
+++ b/packages/merlin/merlin.4.0-411/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" "1"] {with-test & ocaml:version >= "4.03"}
+]
+depends: [
+  "ocaml" {>= "4.11.0" & < "4.12"}
+  "dune" {>= "2.7.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "1.6.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+x-commit-hash: "70559abf8c567c902a36aabbb7017b97e4c830ac"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.0-411/merlin-v4.0-411.tbz"
+  checksum: [
+    "sha256=a5188480979625b1d9adfab581dc2f142a81850c22fd618ef78e386d6ef8ea54"
+    "sha512=e44b994e66f48dc93d5fa4551d6b6c7d69919a83d9b7571ff799fced08fa4b79dd046b88c9f83ba8637fa7fdde02a4907c081facbe07e0ee849556a95a34f8ad"
+  ]
+}

--- a/packages/merlin/merlin.4.0-411/opam
+++ b/packages/merlin/merlin.4.0-411/opam
@@ -5,9 +5,9 @@ homepage:     "https://github.com/ocaml/merlin"
 bug-reports:  "https://github.com/ocaml/merlin/issues"
 dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" "1"] {with-test & ocaml:version >= "4.03"}
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.11.0" & < "4.12"}

--- a/packages/merlin/merlin.4.0-412/opam
+++ b/packages/merlin/merlin.4.0-412/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" "1"] {with-test & ocaml:version >= "4.03"}
 ]
 depends: [
-  "ocaml" {> "4.11.1" }
+  "ocaml" {>= "4.12.0" & < "4.13"}
   "dune" {>= "2.7.0"}
   "dot-merlin-reader" {>= "4.0"}
   "yojson" {>= "1.6.0"}

--- a/packages/merlin/merlin.4.0-412/opam
+++ b/packages/merlin/merlin.4.0-412/opam
@@ -5,9 +5,9 @@ homepage:     "https://github.com/ocaml/merlin"
 bug-reports:  "https://github.com/ocaml/merlin/issues"
 dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" "1"] {with-test & ocaml:version >= "4.03"}
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.12.0" & < "4.13"}

--- a/packages/merlin/merlin.4.0-412/opam
+++ b/packages/merlin/merlin.4.0-412/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" "1"] {with-test & ocaml:version >= "4.03"}
+]
+depends: [
+  "ocaml" {> "4.11.1" }
+  "dune" {>= "2.7.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "1.6.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+x-commit-hash: "e990d420f5d74ba8da9b34a4f45dc821043d57fa"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.0-412/merlin-v4.0-412.tbz"
+  checksum: [
+    "sha256=e69204dc51b5a33563000b87a67055b13374e9fc93d442599a7122c28fcbc058"
+    "sha512=55690e19f0e656d3e68cbc7f094f6583576e9b18e1df87a3937ba650be163b57a62c4b9fe69c786bed566529242c261de4af35c63b31adb67e253e33368d3561"
+  ]
+}


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

*    Project page: https://github.com/ocaml/merlin

##### CHANGES:

Tue Feb  2 03:13:37 PM CET 2021

  + ocaml support
    Detailled list of changes on
    https://tarides.com/blog/2021-01-26-recent-and-upcoming-changes-to-merlin#dropping-support-for-old-versions-of-ocaml
    Summary:
    - any revision of Merlin now only supports one version of OCaml. Support for
      other versions will be found in other branches
    - stopped actively supporting version older than 4.11
    - add support for 4.12
  + merlin binary
    - add keyword completion (disabled by default) (#1243)
    - fix a bug which caused type-enclosing to sometimes look at an incorrect
      node (#1232, fixes #1226)
    - properly report leaked parsing error (#1223, fixes #1222)
    - wrap `merlin_analysis` and `merlin_utils` library
  + editor modes
    - emacs: add missing mandatory argument for define-obsolete-function-alias
      (#1250, by Atharva Shukla, fixes #1234)
    - emacs: use "opam var" instead of "opam config var" (#1249, by Raja Boujbel)
    - vim: fix CursorMoved semantics (#1213, by Daniel Dickstein)
    - vim: add :MerlinLocateImpl and :MerlinLocateIntf (#1208 by Matthew Ryan)
  + test suite
    - replace mdx usage by dune's cram mechanism