### PR TITLE
[new release] irmin et al. (2.4.0)

### DIFF
--- a/packages/irmin-bench/irmin-bench.2.4.0/opam
+++ b/packages/irmin-bench/irmin-bench.2.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"         {>= "2.7.0"}
+  "irmin-pack"   {= version}
+  "irmin-layers" {= version}
+  "irmin-test"   {= version}
+  "cmdliner"
+  "logs"
+  "lwt"
+  "ppx_deriving_yojson"
+  "yojson"
+  "memtrace"
+  "repr"         {>= "0.2.0"}
+  "ppx_repr"
+  "re"           {>= "1.9.0"}
+  "fmt"
+]
+
+synopsis: "Irmin benchmarking suite"
+description: """
+`irmin-bench` provides access to the Irmin suite for benchmarking storage backend
+implementations.
+"""
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-chunk/irmin-chunk.2.4.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.2.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Mounir Nasr Allah" "Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "fmt"
+  "logs"
+  "lwt"
+  "irmin-test" {with-test & = version}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Irmin backend which allow to store values into chunks"
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-containers/irmin-containers.2.4.0/opam
+++ b/packages/irmin-containers/irmin-containers.2.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["KC Sivaramakrishnan" "Anirudh Sunder Raj"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "irmin-unix" {= version}
+  "irmin-git"  {= version}
+  "ppx_irmin"  {= version}
+  "lwt"
+  "mtime"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+
+synopsis: "Mergeable Irmin data structures"
+description: """
+A collection of simple, ready-to-use mergeable data structures built using
+Irmin. Each data structure works with an arbitrary Irmin backend and is
+customisable in a variety of ways.
+"""
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-fs/irmin-fs.2.4.0/opam
+++ b/packages/irmin-fs/irmin-fs.2.4.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "astring"
+  "logs"
+  "lwt"
+  "irmin-test" {with-test & = version}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Generic file-system backend for Irmin"
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-git/irmin-git.2.4.0/opam
+++ b/packages/irmin-git/irmin-git.2.4.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "ppx_irmin"  {= version}
+  "git"        {>= "3.0.0"}
+  "digestif"   {>= "0.9.0"}
+  "cstruct"
+  "fmt"
+  "astring"
+  "fpath"
+  "logs"
+  "lwt"
+  "uri"
+  "git-cohttp-unix" {with-test}
+  "irmin-test" {with-test & = version}
+  "git-unix"   {with-test}
+  "mtime"      {with-test & >= "1.0.0"}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Git backend for Irmin"
+description: """
+`Irmin_git` expose a bi-directional bridge between Git repositories and
+Irmin stores.
+"""
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-graphql/irmin-graphql.2.4.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors:      "Andreas Garnaes <andreas.garnaes@gmail.com>"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {>= "2.7.0"}
+  "irmin"          {= version}
+  "graphql"        {>= "0.13.0"}
+  "graphql-lwt"    {>= "0.13.0"}
+  "graphql-cohttp" {>= "0.13.0"}
+  "graphql_parser" {>= "0.13.0"}
+  "cohttp-lwt"
+  "cohttp"
+  "fmt"
+  "lwt"
+  "alcotest-lwt"    {with-test & >= "1.1.0"}
+  "yojson"          {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "alcotest"        {with-test & >= "1.2.3"}
+]
+
+
+synopsis: "GraphQL server for Irmin"
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-http/irmin-http.2.4.0/opam
+++ b/packages/irmin-http/irmin-http.2.4.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.7.0"}
+  "crunch"     {>= "2.2.0"}
+  "webmachine" {>= "0.6.0"}
+  "irmin"      {= version}
+  "ppx_irmin"  {= version}
+  "cohttp-lwt" {>= "1.0.0"}
+  "astring"
+  "cohttp"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt"
+  "uri"
+  "irmin-git"  {with-test & = version}
+  "irmin-test" {with-test & = version}
+  "git-unix"   {with-test & >= "3.0.0"}
+  "digestif"   {with-test & >= "0.9.0"}
+]
+
+synopsis: "HTTP client and server for Irmin"
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-layers/irmin-layers.2.4.0/opam
+++ b/packages/irmin-layers/irmin-layers.2.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.7.0"}
+  "mtime"      {>= "1.0.0"}
+  "irmin"      {= version}
+  "logs"
+  "lwt"
+  "irmin-test" {with-test & post & = version}
+]
+
+synopsis: "Combine different Irmin stores into a single, layered store"
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.4.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.4.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"         {>= "2.7.0"}
+  "irmin-mirage" {= version}
+  "irmin-git"    {= version}
+  "mirage-kv"    {>= "3.0.0"}
+  "cohttp"
+  "conduit-lwt"
+  "conduit-mirage"
+  "git-cohttp-mirage" {>= "3.0.0"}
+  "fmt"
+  "git"               {>= "3.0.0"}
+  "lwt"
+  "mirage-clock"
+  "uri"
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.4.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"          {>= "2.7.0"}
+  "irmin-mirage"  {= version}
+  "irmin-graphql" {= version}
+  "mirage-clock"
+  "cohttp-lwt"
+  "lwt"
+  "uri"
+  "git"           {>= "3.0.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-mirage/irmin-mirage.2.4.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.2.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "fmt"
+  "ptime"
+  "mirage-clock" {>= "3.0.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-pack/irmin-pack.2.4.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"        {>= "4.08.0"}
+  "dune"         {>= "2.7.0"}
+  "irmin"        {= version}
+  "irmin-layers" {= version}
+  "ppx_irmin"    {= version}
+  "index"        {>= "1.3.0"}
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime"
+  "cmdliner"
+  "irmin-test"   {with-test & = version}
+  "alcotest-lwt" {with-test}
+  "astring"      {with-test}
+  "fpath"        {with-test}
+  "alcotest"     {with-test}
+]
+
+synopsis: "Irmin backend which stores values in a pack file"
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-test/irmin-test.2.4.0/opam
+++ b/packages/irmin-test/irmin-test.2.4.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "irmin"        {= version}
+  "irmin-layers" {= version}
+  "ppx_irmin"    {= version}
+  "ocaml"        {>= "4.02.3"}
+  "dune"         {>= "2.7.0"}
+  "alcotest"     {>= "1.0.1"}
+  "mtime"        {>= "1.0.0"}
+  "astring"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt"
+  "metrics-unix"
+  "ocaml-syntax-shims"
+  "cmdliner"
+  "metrics" {>= "0.2.0"}
+]
+
+synopsis: "Irmin test suite"
+description: """
+`irmin-test` provides access to the Irmin test suite for testing storage backend
+implementations.
+"""
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-unix/irmin-unix.2.4.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.4.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.01.0"}
+  "dune"          {>= "2.7.0"}
+  "irmin"         {= version}
+  "irmin-git"     {= version}
+  "irmin-http"    {= version}
+  "irmin-fs"      {= version}
+  "irmin-pack"    {= version}
+  "irmin-graphql" {= version}
+  "irmin-layers"  {= version}
+  "git-unix"
+  "digestif"      {>= "0.9.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "yaml"          {>= "0.1.0"}
+  "astring"
+  "astring"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit"
+  "conduit-lwt"
+  "conduit-lwt-unix"
+  "logs"
+  "uri"
+  "cmdliner"
+  "cohttp-lwt-unix"
+  "fmt"
+  "git"             {>= "3.0.0"}
+  "git-cohttp-unix" {>= "3.0.0"}
+  "lwt"
+  "irmin-test"    {with-test & = version}
+  "alcotest"      {with-test}
+]
+
+synopsis: "Unix backends for Irmin"
+description: """
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.
+"""
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/irmin-unix/irmin-unix.2.4.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.4.0/opam
@@ -53,6 +53,9 @@ description: """
 as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
 stores.
 """
+available: [
+  arch != "x86_32" & arch != "arm32"
+]
 x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
 url {
   src:

--- a/packages/irmin/irmin.2.4.0/opam
+++ b/packages/irmin/irmin.2.4.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "repr"    {>= "0.2.0"}
+  "fmt"     {>= "0.8.0"}
+  "uri"     {>= "1.3.12"}
+  "uutf"
+  "jsonm"   {>= "1.0.0"}
+  "lwt"     {>= "2.4.7"}
+  "base64"  {>= "2.0.0"}
+  "digestif" {>= "0.9.0"}
+  "ocamlgraph"
+  "logs"    {>= "0.5.0"}
+  "bheap" {>= "2.0.0"}
+  "astring"
+  "ppx_irmin" {= version}
+  "hex"      {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "alcotest-lwt" {with-test}
+]
+synopsis: """
+Irmin, a distributed database that follows the same design principles as Git
+"""
+description: """
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.
+"""
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}

--- a/packages/ppx_irmin/ppx_irmin.2.4.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.2.4.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Craig Ferguson <craig@tarides.com>"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mirage/irmin.git"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {>= "2.7.0"}
+  "ppx_repr" {>= "0.2.0"}
+  "irmin" {with-test & post & = version}
+]
+
+synopsis: "PPX deriver for Irmin type representations"
+x-commit-hash: "a517b827b26ef4beffae1c2e145d1b5492ba403e"
+authors: "Craig Ferguson <craig@tarides.com>"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.4.0/irmin-2.4.0.tbz"
+  checksum: [
+    "sha256=abe7d504aaa4c8fd0f08a04bbfb2748bc23f714df20dd6381b6885bcca56d4ac"
+    "sha512=e3097e50ea3598b3c5da4d567a4d3d053a2cd70549afb9ced6fcec8f6faf0677f5d7f8c0541515e0dd3d5eb1d3990e3067d47014deaf93cd52b92bb9f7319968"
+  ]
+}


### PR DESCRIPTION
- Project page: <a href="https://github.com/mirage/irmin">https://github.com/mirage/irmin</a>
- Documentation: <a href="https://mirage.github.io/irmin/">https://mirage.github.io/irmin/</a>

##### CHANGES:

### Fixed
- **irmin-pack**
  - Fix a bug in `inode` where the `remove` function could cause hashing
    instabilities. No user-facing change since this function is not being used
    yet. (mirage/irmin#1247, @Ngoguey42, @icristescu)

- **irmin**
  - Ensure that `Tree.add_tree t k v` complexity does not depend on `v` size.
    (mirage/irmin#1267, @samoht @Ngoguey42 and @CraigFe)

### Added

- **irmin**
  - Added a `Perms` module containing helper types for using phantom-typed
    capabilities as used by the store backends. (mirage/irmin#1262, @CraigFe)

  - Added an `Exported_for_stores` module containing miscellaneous helper types
    for building backends. (mirage/irmin#1262, @CraigFe)

  - Added new operations `Tree.update` and `Tree.update_tree` for efficient
    read-and-set on trees. (mirage/irmin#1274, @CraigFe)
    
- **irmin-pack**:
  - Added `integrity-check-inodes` command to `irmin-fsck` for checking the
    integrity of inodes. (mirage/irmin#1253, @icristescu, @Ngoguey42)

- **irmin-bench**
  - Added benchmarks for tree operations. (mirage/irmin#1237, @icristescu, @Ngoguey42,
    @Craigfe)

#### Changed

- The `irmin-mem` package is now included with the `irmin` package under the
  library name `irmin.mem`. It keeps the same top-level module name of
  `Irmin_mem`. (mirage/irmin#1276, @CraigFe)

#### Removed

- `Irmin_mem` no longer provides the layered in-memory store `Make_layered`.
  This can be constructed manually via `Irmin_layers.Make`. (mirage/irmin#1276, @CraigFe)
