### PR TITLE
10 packages from gitlab.com/nomadic-labs/resto/-/archive/v0.6/resto-v0.6.tar.gz

### DIFF
--- a/packages/ezresto-directory/ezresto-directory.0.6/opam
+++ b/packages/ezresto-directory/ezresto-directory.0.6/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.11" }
+  "ezresto" {= version }
+  "resto-directory" {= version }
+  "resto" {= version }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.6/resto-v0.6.tar.gz"
+  checksum: [
+    "md5=2420b4f53c0ebe56baa2731c036d720a"
+    "sha512=7654d928d0a666b96e88ae1a3b4338a11bcc9694e4d521f3a8b7b086da33092caaa0b1936b5661067ecd7b8045c7c3c4b735a9bf2398987d44dcd3c294caae48"
+  ]
+}

--- a/packages/ezresto/ezresto.0.6/opam
+++ b/packages/ezresto/ezresto.0.6/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto" {= version }
+  "resto-json" {= version }
+  "lwt" {with-test}
+  "base-unix" {with-test}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.6/resto-v0.6.tar.gz"
+  checksum: [
+    "md5=2420b4f53c0ebe56baa2731c036d720a"
+    "sha512=7654d928d0a666b96e88ae1a3b4338a11bcc9694e4d521f3a8b7b086da33092caaa0b1936b5661067ecd7b8045c7c3c4b735a9bf2398987d44dcd3c294caae48"
+  ]
+}

--- a/packages/resto-acl/resto-acl.0.6/opam
+++ b/packages/resto-acl/resto-acl.0.6/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "Access Control Lists for Resto"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto" {= version }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.6/resto-v0.6.tar.gz"
+  checksum: [
+    "md5=2420b4f53c0ebe56baa2731c036d720a"
+    "sha512=7654d928d0a666b96e88ae1a3b4338a11bcc9694e4d521f3a8b7b086da33092caaa0b1936b5661067ecd7b8045c7c3c4b735a9bf2398987d44dcd3c294caae48"
+  ]
+}

--- a/packages/resto-cohttp-client/resto-cohttp-client.0.6/opam
+++ b/packages/resto-cohttp-client/resto-cohttp-client.0.6/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto-cohttp" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.6/resto-v0.6.tar.gz"
+  checksum: [
+    "md5=2420b4f53c0ebe56baa2731c036d720a"
+    "sha512=7654d928d0a666b96e88ae1a3b4338a11bcc9694e4d521f3a8b7b086da33092caaa0b1936b5661067ecd7b8045c7c3c4b735a9bf2398987d44dcd3c294caae48"
+  ]
+}

--- a/packages/resto-cohttp-self-serving-client/resto-cohttp-self-serving-client.0.6/opam
+++ b/packages/resto-cohttp-self-serving-client/resto-cohttp-self-serving-client.0.6/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto-cohttp-client" {= version }
+  "resto-cohttp-server" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.6/resto-v0.6.tar.gz"
+  checksum: [
+    "md5=2420b4f53c0ebe56baa2731c036d720a"
+    "sha512=7654d928d0a666b96e88ae1a3b4338a11bcc9694e4d521f3a8b7b086da33092caaa0b1936b5661067ecd7b8045c7c3c4b735a9bf2398987d44dcd3c294caae48"
+  ]
+}

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.6/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs - server library"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.11" }
+  "resto-directory" {= version }
+  "resto-cohttp" {= version }
+  "resto-acl" {= version }
+  "cohttp-lwt-unix" { >= "2.0.0" & < "3.0.0" }
+  "conduit-lwt-unix" { >= "2.0.0" & < "3.0.0" }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.6/resto-v0.6.tar.gz"
+  checksum: [
+    "md5=2420b4f53c0ebe56baa2731c036d720a"
+    "sha512=7654d928d0a666b96e88ae1a3b4338a11bcc9694e4d521f3a8b7b086da33092caaa0b1936b5661067ecd7b8045c7c3c4b735a9bf2398987d44dcd3c294caae48"
+  ]
+}

--- a/packages/resto-cohttp/resto-cohttp.0.6/opam
+++ b/packages/resto-cohttp/resto-cohttp.0.6/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.11" }
+  "resto-directory" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.6/resto-v0.6.tar.gz"
+  checksum: [
+    "md5=2420b4f53c0ebe56baa2731c036d720a"
+    "sha512=7654d928d0a666b96e88ae1a3b4338a11bcc9694e4d521f3a8b7b086da33092caaa0b1936b5661067ecd7b8045c7c3c4b735a9bf2398987d44dcd3c294caae48"
+  ]
+}

--- a/packages/resto-directory/resto-directory.0.6/opam
+++ b/packages/resto-directory/resto-directory.0.6/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.11" }
+  "resto" {= version }
+  "resto-json" {= version & with-test }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.6/resto-v0.6.tar.gz"
+  checksum: [
+    "md5=2420b4f53c0ebe56baa2731c036d720a"
+    "sha512=7654d928d0a666b96e88ae1a3b4338a11bcc9694e4d521f3a8b7b086da33092caaa0b1936b5661067ecd7b8045c7c3c4b735a9bf2398987d44dcd3c294caae48"
+  ]
+}

--- a/packages/resto-json/resto-json.0.6/opam
+++ b/packages/resto-json/resto-json.0.6/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.11" }
+  "resto" {= version }
+  "json-data-encoding" {= "0.9.1" }
+  "json-data-encoding-bson" {= "0.9.1" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.6/resto-v0.6.tar.gz"
+  checksum: [
+    "md5=2420b4f53c0ebe56baa2731c036d720a"
+    "sha512=7654d928d0a666b96e88ae1a3b4338a11bcc9694e4d521f3a8b7b086da33092caaa0b1936b5661067ecd7b8045c7c3c4b735a9bf2398987d44dcd3c294caae48"
+  ]
+}

--- a/packages/resto/resto.0.6/opam
+++ b/packages/resto/resto.0.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "LGPL-2.1-with-OCaml-exception"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "json-data-encoding" {= "0.9.1" & with-test }
+  "json-data-encoding-bson" {= "0.9.1" & with-test }
+  "ezjsonm" {with-test}
+  "lwt" {with-test}
+  "base-unix"{with-test}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.6/resto-v0.6.tar.gz"
+  checksum: [
+    "md5=2420b4f53c0ebe56baa2731c036d720a"
+    "sha512=7654d928d0a666b96e88ae1a3b4338a11bcc9694e4d521f3a8b7b086da33092caaa0b1936b5661067ecd7b8045c7c3c4b735a9bf2398987d44dcd3c294caae48"
+  ]
+}

--- a/packages/tezos-rpc-http-client/tezos-rpc-http-client.7.1/opam
+++ b/packages/tezos-rpc-http-client/tezos-rpc-http-client.7.1/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-rpc-http" { = version }
-  "resto-cohttp-client"
+  "resto-cohttp-client" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc-http-client/tezos-rpc-http-client.7.2/opam
+++ b/packages/tezos-rpc-http-client/tezos-rpc-http-client.7.2/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-rpc-http" { = version }
-  "resto-cohttp-client"
+  "resto-cohttp-client" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc-http-client/tezos-rpc-http-client.7.3/opam
+++ b/packages/tezos-rpc-http-client/tezos-rpc-http-client.7.3/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-rpc-http" { = version }
-  "resto-cohttp-client"
+  "resto-cohttp-client" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc-http-client/tezos-rpc-http-client.7.4/opam
+++ b/packages/tezos-rpc-http-client/tezos-rpc-http-client.7.4/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-rpc-http" { = version }
-  "resto-cohttp-client"
+  "resto-cohttp-client" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.0/opam
+++ b/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.0/opam
@@ -8,7 +8,7 @@ license: "MIT"
 depends: [
   "dune" { >= "1.11" }
   "tezos-rpc-http" { = version }
-  "resto-cohttp-server"
+  "resto-cohttp-server" { = "0.4" }
   "tezos-tooling" {with-test}
 ]
 build: [

--- a/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.1/opam
+++ b/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.1/opam
@@ -8,7 +8,7 @@ license: "MIT"
 depends: [
   "dune" { >= "1.11" }
   "tezos-rpc-http" { = version }
-  "resto-cohttp-server"
+  "resto-cohttp-server" { = "0.4" }
   "tezos-tooling" {with-test}
 ]
 build: [

--- a/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.2/opam
+++ b/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.2/opam
@@ -8,7 +8,7 @@ license: "MIT"
 depends: [
   "dune" { >= "1.11" }
   "tezos-rpc-http" { = version }
-  "resto-cohttp-server"
+  "resto-cohttp-server" { = "0.4" }
   "tezos-tooling" {with-test}
 ]
 build: [

--- a/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.3/opam
+++ b/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.3/opam
@@ -8,7 +8,7 @@ license: "MIT"
 depends: [
   "dune" { >= "1.11" }
   "tezos-rpc-http" { = version }
-  "resto-cohttp-server"
+  "resto-cohttp-server" { = "0.4" }
   "tezos-tooling" {with-test}
 ]
 build: [

--- a/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.4/opam
+++ b/packages/tezos-rpc-http-server/tezos-rpc-http-server.7.4/opam
@@ -8,7 +8,7 @@ license: "MIT"
 depends: [
   "dune" { >= "1.11" }
   "tezos-rpc-http" { = version }
-  "resto-cohttp-server"
+  "resto-cohttp-server" { = "0.4" }
   "tezos-tooling" {with-test}
 ]
 build: [

--- a/packages/tezos-rpc-http/tezos-rpc-http.7.0/opam
+++ b/packages/tezos-rpc-http/tezos-rpc-http.7.0/opam
@@ -9,8 +9,8 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-base" { = version }
-  "resto-directory"
-  "resto-cohttp"
+  "resto-directory" { = "0.4" }
+  "resto-cohttp" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc-http/tezos-rpc-http.7.1/opam
+++ b/packages/tezos-rpc-http/tezos-rpc-http.7.1/opam
@@ -9,8 +9,8 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-base" { = version }
-  "resto-directory"
-  "resto-cohttp"
+  "resto-directory" { = "0.4" }
+  "resto-cohttp" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc-http/tezos-rpc-http.7.2/opam
+++ b/packages/tezos-rpc-http/tezos-rpc-http.7.2/opam
@@ -9,8 +9,8 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-base" { = version }
-  "resto-directory"
-  "resto-cohttp"
+  "resto-directory" { = "0.4" }
+  "resto-cohttp" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc-http/tezos-rpc-http.7.3/opam
+++ b/packages/tezos-rpc-http/tezos-rpc-http.7.3/opam
@@ -9,8 +9,8 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-base" { = version }
-  "resto-directory"
-  "resto-cohttp"
+  "resto-directory" { = "0.4" }
+  "resto-cohttp" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc-http/tezos-rpc-http.7.4/opam
+++ b/packages/tezos-rpc-http/tezos-rpc-http.7.4/opam
@@ -9,8 +9,8 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-base" { = version }
-  "resto-directory"
-  "resto-cohttp"
+  "resto-directory" { = "0.4" }
+  "resto-cohttp" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc/tezos-rpc.7.0/opam
+++ b/packages/tezos-rpc/tezos-rpc.7.0/opam
@@ -9,8 +9,8 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-error-monad" { = version }
-  "resto"
-  "resto-directory"
+  "resto" { = "0.4" }
+  "resto-directory" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc/tezos-rpc.7.1/opam
+++ b/packages/tezos-rpc/tezos-rpc.7.1/opam
@@ -9,8 +9,8 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-error-monad" { = version }
-  "resto"
-  "resto-directory"
+  "resto" { = "0.4" }
+  "resto-directory" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc/tezos-rpc.7.2/opam
+++ b/packages/tezos-rpc/tezos-rpc.7.2/opam
@@ -9,8 +9,8 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-error-monad" { = version }
-  "resto"
-  "resto-directory"
+  "resto" { = "0.4" }
+  "resto-directory" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc/tezos-rpc.7.3/opam
+++ b/packages/tezos-rpc/tezos-rpc.7.3/opam
@@ -9,8 +9,8 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-error-monad" { = version }
-  "resto"
-  "resto-directory"
+  "resto" { = "0.4" }
+  "resto-directory" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc/tezos-rpc.7.4/opam
+++ b/packages/tezos-rpc/tezos-rpc.7.4/opam
@@ -9,8 +9,8 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-error-monad" { = version }
-  "resto"
-  "resto-directory"
+  "resto" { = "0.4" }
+  "resto-directory" { = "0.4" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc/tezos-rpc.8.0/opam
+++ b/packages/tezos-rpc/tezos-rpc.8.0/opam
@@ -8,8 +8,8 @@ license: "MIT"
 depends: [
   "dune" { >= "2.0" }
   "tezos-error-monad" { = version }
-  "resto" { >= "0.5" }
-  "resto-directory" { >= "0.5" }
+  "resto" { >= "0.5" & < "0.6" }
+  "resto-directory" { >= "0.5" & < "0.6" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-rpc/tezos-rpc.8.1/opam
+++ b/packages/tezos-rpc/tezos-rpc.8.1/opam
@@ -8,8 +8,8 @@ license: "MIT"
 depends: [
   "dune" { >= "2.0" }
   "tezos-error-monad" { = version }
-  "resto" { >= "0.5" }
-  "resto-directory" { >= "0.5" }
+  "resto" { >= "0.5" & < "0.6" }
+  "resto-directory" { >= "0.5" & < "0.6" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
This pull-request concerns:
-`ezresto.0.6`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`ezresto-directory.0.6`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto.0.6`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-acl.0.6`: Access Control Lists for Resto
-`resto-cohttp.0.6`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-client.0.6`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-self-serving-client.0.6`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-server.0.6`: A minimal OCaml library for type-safe HTTP/JSON RPCs - server library
-`resto-directory.0.6`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-json.0.6`: A minimal OCaml library for type-safe HTTP/JSON RPCs



---
* Homepage: https://gitlab.com/nomadic-labs/resto
* Source repo: git+https://gitlab.com/nomadic-labs/resto
* Bug tracker: https://gitlab.com/nomadic-labs/resto/issues

---
:camel: Pull-request generated by opam-publish v2.0.2