### PR TITLE
Package syslog.2.0.2

### DIFF
--- a/packages/syslog/syslog.2.0.2/opam
+++ b/packages/syslog/syslog.2.0.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+
+synopsis: "syslog(3) routines for ocaml (RFC 3164)"
+
+authors: [
+  "Shawn Wagner"
+  "Eric Stokes"
+]
+
+maintainer: [ "Julien Sagot <julien.sagot@geneanet.org>" ]
+
+homepage: "http://github.com/geneanet/ocaml-syslog"
+dev-repo: "git://github.com/geneanet/ocaml-syslog"
+bug-reports: "https://github.com/geneanet/ocaml-syslog/issues"
+
+license: "LGPL-2.1-or-later"
+
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.03.0"}
+]
+url {
+  src: "https://github.com/geneanet/ocaml-syslog/archive/v2.0.2.tar.gz"
+  checksum: [
+    "md5=5a961c4513d5eca6b7f442581a40f68a"
+    "sha512=fbc264dcc70c757f76d6978be78bdab63e083a03e00f0c43f0689ad182e90fabb67c35dbbdec82361a84e99818e6adf6f9ff76923dafec5a1a2e12b64c715ae8"
+  ]
+}


### PR DESCRIPTION
### `syslog.2.0.2`
syslog(3) routines for ocaml (RFC 3164)



---
* Homepage: http://github.com/geneanet/ocaml-syslog
* Source repo: git://github.com/geneanet/ocaml-syslog
* Bug tracker: https://github.com/geneanet/ocaml-syslog/issues

---
:camel: Pull-request generated by opam-publish v2.0.2