### PR TITLE
[new release] memtrace (0.2.1.1)

### DIFF
--- a/packages/memtrace/memtrace.0.2.1.1/opam
+++ b/packages/memtrace/memtrace.0.2.1.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Streaming client for Memprof"
+description: "Generates compact traces of a program's memory use."
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/janestreet/memtrace"
+bug-reports: "https://github.com/janestreet/memtrace/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/janestreet/memtrace.git"
+x-commit-hash: "101588953bf9dbe896af11748d056b1d482e53bb"
+url {
+  src:
+    "https://github.com/janestreet/memtrace/releases/download/v0.2.1.1/memtrace-v0.2.1.1.tbz"
+  checksum: [
+    "sha256=2016c67cb9e1a2f3c15a032f3ef1d04e0aed514c906cba4526ddff1c9b7a2cf5"
+    "sha512=3434b95973e09384223d2349a309bdc26e5167d33bdc3c104c58dfbeabdc3e9a28e55ceb51b366b59bebac5c5cf2eab820c819806db44024c55c04089e8fe3b2"
+  ]
+}


### PR DESCRIPTION
Streaming client for Memprof

- Project page: <a href="https://github.com/janestreet/memtrace">https://github.com/janestreet/memtrace</a>

##### CHANGES:

Fix compilation on 32-bit platforms.
