### PR TITLE
Package tezos-rust-libs.1.1

### DIFF
--- a/packages/tezos-rust-libs/tezos-rust-libs.1.1/opam
+++ b/packages/tezos-rust-libs/tezos-rust-libs.1.1/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+synopsis: "Tezos: all rust dependencies and their dependencies"
+maintainer: "contact@tezos.com"
+authors: "Tezos devteam"
+license: "multiple"
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos-rust-libs/issues"
+depends: ["conf-rust"]
+build: ["cargo" "build" "--target-dir" "target" "--release"]
+dev-repo: "git+https://gitlab.com/tezos/tezos-rust-libs.git"
+url {
+  src:
+    "https://gitlab.com/tezos/tezos-rust-libs/-/archive/v1.1/tezos-rust-libs-v1.1.zip"
+  checksum: [
+    "md5=a8a2720ba70306fdb6d0297f4d9bf95a"
+    "sha512=3aaf61288547df2ab6c9b7b092abe507316732da627bc76afda516becd36f02f029ddb96e85470bc58bf5ef703146a633fb0df21b705480dbf4f6f21b08d54eb"
+  ]
+}

--- a/packages/tezos-rust-libs/tezos-rust-libs.1.1/opam
+++ b/packages/tezos-rust-libs/tezos-rust-libs.1.1/opam
@@ -6,7 +6,11 @@ license: "multiple"
 homepage: "https://www.tezos.com/"
 bug-reports: "https://gitlab.com/tezos/tezos-rust-libs/issues"
 depends: ["conf-rust"]
-build: ["cargo" "build" "--target-dir" "target" "--release"]
+build: [
+  ["mkdir" ".cargo"]
+  ["mv" "cargo-config" ".cargo/config"]
+  ["cargo" "build" "--target-dir" "target" "--release"]
+]
 dev-repo: "git+https://gitlab.com/tezos/tezos-rust-libs.git"
 url {
   src:


### PR DESCRIPTION
### `tezos-rust-libs.1.1`

This is a new version of tezos-rust-libs which is going to be used by [bls12-381](https://gitlab.com/dannywillems/ocaml-bls12-381) for a JavaScript support using jsoo. The new version of bls12-381 (tagged 0.4.1) is coming right after.
The library is already pinned [here](https://gitlab.com/dannywillems/ocaml-bls12-381/-/blob/master/bls12-381-unix.opam#L30).
It doesn't change that much compared to 1.0, except it bumps up a dependency bls12-381 requires: rustc-bls12-381.

Released with @pirbo who can approve this PR.

**Something important**: the required rust version is 1.44.0 (`cargo vendor` has been used with rust 1.44.0). However, I am not sure the CI checks this. It is not possible yet to change to a specific rust version in OPAM.
I am not against adding a version check in the build (plus an additional error message). However, it might not pass the CI here. 


Tezos: all rust dependencies and their dependencies
---
* Homepage: https://www.tezos.com/
* Source repo: git+https://gitlab.com/tezos/tezos-rust-libs.git
* Bug tracker: https://gitlab.com/tezos/tezos-rust-libs/issues

---
:camel: Pull-request generated by opam-publish v2.0.2