### PR TITLE
[new release] piaf (0.1.0)

### DIFF
--- a/packages/piaf/piaf.0.1.0/opam
+++ b/packages/piaf/piaf.0.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/piaf"
+bug-reports: "https://github.com/anmonteiro/piaf/issues"
+dev-repo: "git+https://github.com/anmonteiro/piaf.git"
+doc: "https://anmonteiro.github.io/piaf/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.5"}
+  "angstrom"
+  "faraday"
+  "bigstringaf" {>= "0.5.0"}
+  "logs"
+  "lwt"
+  "conf-libssl"
+  "ssl" {>= "0.5.10"}
+  "lwt_ssl"
+  "mrmime"
+  "pecu"
+  "psq"
+  "uri"
+  "magic-mime"
+  "gluten-lwt-unix"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+synopsis:
+  "An HTTP library with HTTP/2 support written entirely in OCaml"
+description:
+  "Piaf is an HTTP library and webserver written entirely in OCaml."
+x-commit-hash: "0552d0423c194da90c4692dd2e18e177012adcb5"
+url {
+  src:
+    "https://github.com/anmonteiro/piaf/releases/download/0.1.0/piaf-0.1.0.tbz"
+  checksum: [
+    "sha256=00c3bea6d1a8c77dc18bbbbf1f449a78253cf17391ad153751b2e87f71307265"
+    "sha512=0f35e88b78ec1f1cd06a972ee69e29a8983b4c07dbc0268cc9764d8df5d9c2402cc3710874f54a111095fb57a08fe582d99d1b7e070e141e260af6ced50172aa"
+  ]
+}


### PR DESCRIPTION
An HTTP library with HTTP/2 support written entirely in OCaml

- Project page: <a href="https://github.com/anmonteiro/piaf">https://github.com/anmonteiro/piaf</a>
- Documentation: <a href="https://anmonteiro.github.io/piaf/">https://anmonteiro.github.io/piaf/</a>

##### CHANGES:

- Initial public release
