### PR TITLE
Flag deprecated packages as deprecated

### DIFF
--- a/packages/charrua-core/charrua-core.0.1/opam
+++ b/packages/charrua-core/charrua-core.0.1/opam
@@ -63,3 +63,4 @@ url {
   src: "https://github.com/haesbaert/charrua-core/archive/v0.1.tar.gz"
   checksum: "md5=e8fe482a9618cf82b785dabedb870f04"
 }
+flags: deprecated

--- a/packages/charrua-core/charrua-core.0.10/opam
+++ b/packages/charrua-core/charrua-core.0.10/opam
@@ -107,3 +107,4 @@ url {
     "https://github.com/mirage/charrua-core/releases/download/v0.10/charrua-core-0.10.tbz"
   checksum: "md5=3892074e768f32d2a4a5cff14e1d9f5a"
 }
+flags: deprecated

--- a/packages/charrua-core/charrua-core.0.11.0/opam
+++ b/packages/charrua-core/charrua-core.0.11.0/opam
@@ -59,3 +59,4 @@ url {
 archive: "https://github.com/mirage/charrua-core/releases/download/v0.11.0/charrua-core-0.11.0.tbz"
 checksum: "f4bb1ac3d1443a576982eae49d0eb7d8"
 }
+flags: deprecated

--- a/packages/charrua-core/charrua-core.0.11.1/opam
+++ b/packages/charrua-core/charrua-core.0.11.1/opam
@@ -60,3 +60,4 @@ url {
 archive: "https://github.com/mirage/charrua-core/releases/download/v0.11.1/charrua-core-0.11.1.tbz"
 checksum: "c9f82c844f78643cb05650a397acfb1c"
 }
+flags: deprecated

--- a/packages/charrua-core/charrua-core.0.11.2/opam
+++ b/packages/charrua-core/charrua-core.0.11.2/opam
@@ -62,3 +62,4 @@ url {
     "https://github.com/mirage/charrua-core/releases/download/v0.11.2/charrua-core-v0.11.2.tbz"
   checksum: "md5=c83ace0546e66ebe2b38e9685c7e9c55"
 }
+flags: deprecated

--- a/packages/charrua-core/charrua-core.0.12.0/opam
+++ b/packages/charrua-core/charrua-core.0.12.0/opam
@@ -61,3 +61,4 @@ url {
     "https://github.com/mirage/charrua-core/releases/download/v0.12.0/charrua-core-v0.12.0.tbz"
   checksum: "md5=a1edfeeaea6d9ed079efec4514f0e44c"
 }
+flags: deprecated

--- a/packages/charrua-core/charrua-core.0.3/opam
+++ b/packages/charrua-core/charrua-core.0.3/opam
@@ -65,3 +65,4 @@ url {
   src: "https://github.com/haesbaert/charrua-core/archive/v0.3.tar.gz"
   checksum: "md5=194813e9826e8a55d3a315d5f42364e2"
 }
+flags: deprecated

--- a/packages/charrua-core/charrua-core.0.4/opam
+++ b/packages/charrua-core/charrua-core.0.4/opam
@@ -65,3 +65,4 @@ url {
   src: "https://github.com/mirage/charrua-core/archive/v0.4.tar.gz"
   checksum: "md5=69f078e945c4a5a586db7cd7be08525e"
 }
+flags: deprecated

--- a/packages/charrua-core/charrua-core.0.5/opam
+++ b/packages/charrua-core/charrua-core.0.5/opam
@@ -73,3 +73,4 @@ url {
     "https://github.com/mirage/charrua-core/releases/download/v0.5/charrua-core-0.5.tbz"
   checksum: "md5=e722882d95dd898454bdb3d6c12048a4"
 }
+flags: deprecated

--- a/packages/charrua-core/charrua-core.0.6/opam
+++ b/packages/charrua-core/charrua-core.0.6/opam
@@ -57,3 +57,4 @@ url {
     "https://github.com/mirage/charrua-core/releases/download/v0.6/charrua-core-0.6.tbz"
   checksum: "md5=9d3dce29ca4f01060d8c6d4a8a66a457"
 }
+flags: deprecated

--- a/packages/charrua-core/charrua-core.0.7/opam
+++ b/packages/charrua-core/charrua-core.0.7/opam
@@ -57,3 +57,4 @@ url {
     "https://github.com/mirage/charrua-core/releases/download/v0.7/charrua-core-0.7.tbz"
   checksum: "md5=8dc296dd688e9cea29bfb131774a7b41"
 }
+flags: deprecated

--- a/packages/charrua-core/charrua-core.0.8/opam
+++ b/packages/charrua-core/charrua-core.0.8/opam
@@ -76,3 +76,4 @@ url {
     "https://github.com/mirage/charrua-core/releases/download/v0.8/charrua-core-0.8.tbz"
   checksum: "md5=cefcd421a63a0d4dc255a0bf22d20b04"
 }
+flags: deprecated

--- a/packages/charrua-core/charrua-core.0.9/opam
+++ b/packages/charrua-core/charrua-core.0.9/opam
@@ -107,3 +107,4 @@ url {
     "https://github.com/mirage/charrua-core/releases/download/v0.9/charrua-core-0.9.tbz"
   checksum: "md5=015e5795d03f9a57deff04c424027efd"
 }
+flags: deprecated

--- a/packages/configurator/configurator.v0.10.0/opam
+++ b/packages/configurator/configurator.v0.10.0/opam
@@ -31,3 +31,4 @@ url {
   checksum: "md5=d02f66dd5dc4dbc3017f78c51209ba6b"
 }
 post-messages: [ "configurator is deprecated. Please use dune-configurator in new code and consider switching to it in existing projects." ]
+flags: deprecated

--- a/packages/configurator/configurator.v0.11.0/opam
+++ b/packages/configurator/configurator.v0.11.0/opam
@@ -32,3 +32,4 @@ url {
   checksum: "md5=55511f3ea8e3d66439910b3324701218"
 }
 post-messages: [ "configurator is deprecated. Please use dune-configurator in new code and consider switching to it in existing projects." ]
+flags: deprecated

--- a/packages/configurator/configurator.v0.9.0/opam
+++ b/packages/configurator/configurator.v0.9.0/opam
@@ -34,3 +34,4 @@ url {
   checksum: "md5=857aed0fda772fd2c1632affb0d3bcb6"
 }
 post-messages: [ "configurator is deprecated. Please use dune-configurator in new code and consider switching to it in existing projects." ]
+flags: deprecated

--- a/packages/configurator/configurator.v0.9.1/opam
+++ b/packages/configurator/configurator.v0.9.1/opam
@@ -33,3 +33,4 @@ url {
   checksum: "md5=3152504ee8f08667e385fe36bd058cf5"
 }
 post-messages: [ "configurator is deprecated. Please use dune-configurator in new code and consider switching to it in existing projects." ]
+flags: deprecated

--- a/packages/expect_test_helpers/expect_test_helpers.v0.10.0/opam
+++ b/packages/expect_test_helpers/expect_test_helpers.v0.10.0/opam
@@ -30,3 +30,4 @@ url {
     "https://ocaml.janestreet.com/ocaml-core/v0.10/files/expect_test_helpers-v0.10.0.tar.gz"
   checksum: "md5=390587b0825681dcdbf80aede0411129"
 }
+flags: deprecated

--- a/packages/expect_test_helpers/expect_test_helpers.v0.11.0/opam
+++ b/packages/expect_test_helpers/expect_test_helpers.v0.11.0/opam
@@ -29,3 +29,4 @@ url {
     "https://ocaml.janestreet.com/ocaml-core/v0.11/files/expect_test_helpers-v0.11.0.tar.gz"
   checksum: "md5=3c07c2e493f3b891e2d9dc9640e91b95"
 }
+flags: deprecated

--- a/packages/expect_test_helpers/expect_test_helpers.v0.12.0/opam
+++ b/packages/expect_test_helpers/expect_test_helpers.v0.12.0/opam
@@ -29,3 +29,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/expect_test_helpers-v0.12.0.tar.gz"
   checksum: "md5=6f7a0e74897cc15303fe3fbee1645079"
 }
+flags: deprecated

--- a/packages/expect_test_helpers/expect_test_helpers.v0.13.0/opam
+++ b/packages/expect_test_helpers/expect_test_helpers.v0.13.0/opam
@@ -29,3 +29,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.13/files/expect_test_helpers-v0.13.0.tar.gz"
   checksum: "md5=fc3572d962d1afcbe437910e736c6b3f"
 }
+flags: deprecated

--- a/packages/expect_test_helpers/expect_test_helpers.v0.9.0/opam
+++ b/packages/expect_test_helpers/expect_test_helpers.v0.9.0/opam
@@ -30,3 +30,4 @@ url {
     "https://ocaml.janestreet.com/ocaml-core/v0.9/files/expect_test_helpers-v0.9.0.tar.gz"
   checksum: "md5=754cedf41cb1c12fff6d784b889f1aee"
 }
+flags: deprecated

--- a/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.10.0/opam
+++ b/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.10.0/opam
@@ -29,3 +29,4 @@ url {
     "https://ocaml.janestreet.com/ocaml-core/v0.10/files/expect_test_helpers_kernel-v0.10.0.tar.gz"
   checksum: "md5=8a430de23c0224ad48ccbdbfc3059b01"
 }
+flags: deprecated

--- a/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.11.0/opam
+++ b/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.11.0/opam
@@ -28,3 +28,4 @@ url {
     "https://ocaml.janestreet.com/ocaml-core/v0.11/files/expect_test_helpers_kernel-v0.11.0.tar.gz"
   checksum: "md5=90b44210c535b8883abff13bdbf49bce"
 }
+flags: deprecated

--- a/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.12.0/opam
+++ b/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.12.0/opam
@@ -31,3 +31,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/expect_test_helpers_kernel-v0.12.0.tar.gz"
   checksum: "md5=2970600eef2cd693ab5773a33a9a4a88"
 }
+flags: deprecated

--- a/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.13.0/opam
+++ b/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.13.0/opam
@@ -31,3 +31,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.13/files/expect_test_helpers_kernel-v0.13.0.tar.gz"
   checksum: "md5=5d51328bcaff8e2086fed560b1826790"
 }
+flags: deprecated

--- a/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.9.0/opam
+++ b/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.9.0/opam
@@ -29,3 +29,4 @@ url {
     "https://ocaml.janestreet.com/ocaml-core/v0.9/files/expect_test_helpers_kernel-v0.9.0.tar.gz"
   checksum: "md5=ea02d33c168ae2a282feff2cb53b0fd1"
 }
+flags: deprecated

--- a/packages/io-page-xen/io-page-xen.0.1.0/opam
+++ b/packages/io-page-xen/io-page-xen.0.1.0/opam
@@ -5,7 +5,6 @@ tags: [
   "org:xapi-project"
 ]
 build: [make "xen-build"]
-remove: [["ocamlfind" "remove" "io-page-xen"]]
 depends: [
   "ocaml" {< "4.06.0"}
   "ocamlfind"
@@ -15,7 +14,7 @@ depends: [
 dev-repo: "git://github.com/mirage/io-page"
 install: [make "xen-install"]
 synopsis: "Allocate OS memory pages suitable for aligned I/O"
-flags: light-uninstall
+flags: deprecated
 url {
   src: "https://github.com/mirage/io-page/archive/0.1.0.tar.gz"
   checksum: "md5=e1558627dd05d438befa14165f7df896"

--- a/packages/io-page-xen/io-page-xen.0.9.9/opam
+++ b/packages/io-page-xen/io-page-xen.0.9.9/opam
@@ -5,7 +5,6 @@ tags: [
   "org:xapi-project"
 ]
 build: [make "xen-build"]
-remove: [["ocamlfind" "remove" "io-page-xen"]]
 depends: [
   "ocaml" {< "4.06.0"}
   "ocamlfind"
@@ -15,7 +14,7 @@ depends: [
 dev-repo: "git://github.com/mirage/io-page"
 install: [make "xen-install"]
 synopsis: "Allocate OS memory pages suitable for aligned I/O"
-flags: light-uninstall
+flags: deprecated
 url {
   src: "https://github.com/mirage/io-page/archive/v0.9.9.tar.gz"
   checksum: "md5=3001aeec835ba4c9aad77c307696c3be"

--- a/packages/io-page-xen/io-page-xen.2.0.0/opam
+++ b/packages/io-page-xen/io-page-xen.2.0.0/opam
@@ -24,6 +24,7 @@ depends: [
   "mirage-xen-ocaml"
 ]
 synopsis: "Allocate memory pages suitable for aligned I/O"
+flags: deprecated
 url {
   src:
     "https://github.com/mirage/io-page/releases/download/2.0.0/io-page-2.0.0.tbz"

--- a/packages/io-page-xen/io-page-xen.2.0.1/opam
+++ b/packages/io-page-xen/io-page-xen.2.0.1/opam
@@ -24,6 +24,7 @@ depends: [
   "mirage-xen-ocaml"
 ]
 synopsis: "Allocate memory pages suitable for aligned I/O"
+flags: deprecated
 url {
   src:
     "https://github.com/mirage/io-page/releases/download/2.0.1/io-page-2.0.1.tbz"

--- a/packages/io-page-xen/io-page-xen.2.1.0/opam
+++ b/packages/io-page-xen/io-page-xen.2.1.0/opam
@@ -25,6 +25,7 @@ description: """
 IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
 copying the data contained within the page.
 """
+flags: deprecated
 url {
   src:
     "https://github.com/mirage/io-page/releases/download/v2.1.0/io-page-v2.1.0.tbz"

--- a/packages/io-page-xen/io-page-xen.2.2.0/opam
+++ b/packages/io-page-xen/io-page-xen.2.2.0/opam
@@ -25,6 +25,7 @@ description: """
 IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
 copying the data contained within the page.
 """
+flags: deprecated
 url {
   src:
     "https://github.com/mirage/io-page/releases/download/v2.2.0/io-page-v2.2.0.tbz"

--- a/packages/io-page-xen/io-page-xen.2.3.0/opam
+++ b/packages/io-page-xen/io-page-xen.2.3.0/opam
@@ -25,6 +25,7 @@ description: """
 IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
 copying the data contained within the page.
 """
+flags: deprecated
 url {
   src:
     "https://github.com/mirage/io-page/releases/download/v2.3.0/io-page-v2.3.0.tbz"

--- a/packages/lwt-zmq/lwt-zmq.1.0-beta3/opam
+++ b/packages/lwt-zmq/lwt-zmq.1.0-beta3/opam
@@ -5,7 +5,6 @@ build: [
   ["oasis" "setup"]
   [make]
 ]
-remove: [["ocamlfind" "remove" "lwt-zmq"]]
 depends: [
   "ocaml"
   "ocamlfind"
@@ -20,7 +19,7 @@ depexts: [
 dev-repo: "git://github.com/hcarty/lwt-zmq"
 install: [make "install"]
 synopsis: "Lwt-friendly wrapping around ZeroMQ sockets"
-flags: light-uninstall
+flags: deprecated
 url {
   src: "https://github.com/hcarty/lwt-zmq/archive/v1.0-beta3.tar.gz"
   checksum: "md5=0ef8e4ee309ae816fc9fe31884b6daaa"

--- a/packages/lwt-zmq/lwt-zmq.1.0-beta4/opam
+++ b/packages/lwt-zmq/lwt-zmq.1.0-beta4/opam
@@ -2,7 +2,6 @@ opam-version: "2.0"
 maintainer: "hez@0ok.org"
 homepage: "https://github.com/hcarty/lwt-zmq"
 build: make
-remove: [["ocamlfind" "remove" "lwt-zmq"]]
 depends: [
   "ocaml"
   "ocamlfind"
@@ -16,7 +15,7 @@ depexts: [
 dev-repo: "git://github.com/hcarty/lwt-zmq"
 install: [make "install"]
 synopsis: "Lwt-friendly wrapping around ZeroMQ sockets"
-flags: light-uninstall
+flags: deprecated
 url {
   src: "https://github.com/hcarty/lwt-zmq/archive/v1.0-beta4.tar.gz"
   checksum: "md5=29338d125a545daf45df9e3d7631d01d"

--- a/packages/lwt-zmq/lwt-zmq.1.0.0/opam
+++ b/packages/lwt-zmq/lwt-zmq.1.0.0/opam
@@ -7,9 +7,6 @@ build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
-remove: [
-  ["ocamlfind" "remove" "lwt-zmq"]
-]
 depends: [
   "ocaml"
   "lwt" {< "4.0.0"}
@@ -21,7 +18,7 @@ depends: [
 dev-repo: "git://github.com/hcarty/lwt-zmq"
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Lwt-friendly interface to ZeroMQ"
-flags: light-uninstall
+flags: deprecated
 url {
   src: "https://github.com/hcarty/lwt-zmq/archive/v1.0.0.tar.gz"
   checksum: "md5=17967607c74f9b809f135bf0561fd30a"

--- a/packages/lwt-zmq/lwt-zmq.2.0.0/opam
+++ b/packages/lwt-zmq/lwt-zmq.2.0.0/opam
@@ -7,9 +7,6 @@ build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
-remove: [
-  ["ocamlfind" "remove" "lwt-zmq"]
-]
 depends: [
   "ocaml"
   "lwt" {< "4.0.0"}
@@ -21,7 +18,7 @@ depends: [
 dev-repo: "git://github.com/hcarty/lwt-zmq"
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Lwt-friendly interface to ZeroMQ"
-flags: light-uninstall
+flags: deprecated
 url {
   src: "https://github.com/hcarty/lwt-zmq/archive/v2.0.0.tar.gz"
   checksum: "md5=4b6fa7947ccbc14a3597c80f84f1fe74"

--- a/packages/lwt-zmq/lwt-zmq.2.0.1/opam
+++ b/packages/lwt-zmq/lwt-zmq.2.0.1/opam
@@ -12,9 +12,6 @@ build: [
 install:[
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [
-  ["ocamlfind" "remove" "lwt-zmq"]
-]
 depends: [
   "ocaml" {>= "3.12.1"}
   "lwt" {< "5.0.0"}
@@ -23,7 +20,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 synopsis: "Lwt-friendly interface to ZeroMQ"
-flags: light-uninstall
+flags: deprecated
 url {
   src: "https://github.com/hcarty/lwt-zmq/archive/v2.0.1.tar.gz"
   checksum: "md5=e5321d12d3d5cab74577c0669d31fe7c"

--- a/packages/lwt-zmq/lwt-zmq.2.1.0/opam
+++ b/packages/lwt-zmq/lwt-zmq.2.1.0/opam
@@ -12,9 +12,6 @@ build: [
 install:[
   ["ocaml" "setup.ml" "-install"]
 ]
-remove: [
-  ["ocamlfind" "remove" "lwt-zmq"]
-]
 depends: [
   "ocaml" {>= "3.12.1"}
   "lwt" {< "5.0.0"}
@@ -23,7 +20,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 synopsis: "Lwt-friendly interface to ZeroMQ"
-flags: light-uninstall
+flags: deprecated
 url {
   src: "https://github.com/hcarty/lwt-zmq/archive/v2.1.0.tar.gz"
   checksum: "md5=9183f16aed74035ac75c5c24271ffc66"

--- a/packages/mirage-conduit/mirage-conduit.1.0.3/opam
+++ b/packages/mirage-conduit/mirage-conduit.1.0.3/opam
@@ -68,3 +68,4 @@ url {
     "https://github.com/mirage/ocaml-conduit/releases/download/v1.0.3/conduit-1.0.3.tbz"
   checksum: "md5=e1ec0cbd3478ea572f43491fab69db44"
 }
+flags: deprecated

--- a/packages/mirage-conduit/mirage-conduit.1.3.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.1.3.0/opam
@@ -69,3 +69,4 @@ url {
     "https://github.com/mirage/ocaml-conduit/releases/download/v1.3.0/conduit-v1.3.0.tbz"
   checksum: "md5=df1c271a56537f8176eba811ab40ec19"
 }
+flags: deprecated

--- a/packages/mirage-conduit/mirage-conduit.2.0.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.2.0.0/opam
@@ -14,3 +14,4 @@ depends: [
   "conduit" {= "0.7.2"}
 ]
 synopsis: "Virtual package for the MirageOS Conduit transports"
+flags: deprecated

--- a/packages/mirage-conduit/mirage-conduit.2.1.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.2.1.0/opam
@@ -18,3 +18,4 @@ depends: [
   "tls" {>= "0.4.0" & < "0.11.0"}
 ]
 synopsis: "Virtual package for the MirageOS Conduit transports"
+flags: deprecated

--- a/packages/mirage-conduit/mirage-conduit.2.2.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.2.2.0/opam
@@ -20,3 +20,4 @@ conflicts: [
   "vchan" {>="2.3.0"}
 ]
 synopsis: "Virtual package for the MirageOS Conduit transports"
+flags: deprecated

--- a/packages/mirage-conduit/mirage-conduit.2.3.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.2.3.0/opam
@@ -28,3 +28,4 @@ url {
   src: "https://github.com/mirage/ocaml-conduit/archive/v0.15.0.tar.gz"
   checksum: "md5=20f8016d86a0571df37d79f701b250cb"
 }
+flags: deprecated

--- a/packages/mirage-conduit/mirage-conduit.2.3.1/opam
+++ b/packages/mirage-conduit/mirage-conduit.2.3.1/opam
@@ -29,3 +29,4 @@ url {
   src: "https://github.com/mirage/ocaml-conduit/archive/v0.15.2.tar.gz"
   checksum: "md5=c62120ab9d6ae02256d8ec13032bac00"
 }
+flags: deprecated

--- a/packages/mirage-conduit/mirage-conduit.3.0.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.0.0/opam
@@ -67,3 +67,4 @@ url {
     "https://github.com/mirage/ocaml-conduit/releases/download/v1.0.0/conduit-1.0.0.tbz"
   checksum: "md5=4656f150b9f98603c21d00c8f0aa1a9b"
 }
+flags: deprecated

--- a/packages/mirage-conduit/mirage-conduit.3.0.1/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.0.1/opam
@@ -65,3 +65,4 @@ url {
     "https://github.com/mirage/ocaml-conduit/releases/download/v1.0.1/conduit-1.0.1.tbz"
   checksum: "md5=ef2095d59d93303697c944f9d404e64d"
 }
+flags: deprecated

--- a/packages/mirage-conduit/mirage-conduit.3.1.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.1.0/opam
@@ -33,3 +33,4 @@ url {
     "https://github.com/mirage/ocaml-conduit/releases/download/v1.4.0/conduit-v1.4.0.tbz"
   checksum: "md5=204222b8a61692083b79c67c8967fb28"
 }
+flags: deprecated

--- a/packages/mirage-conduit/mirage-conduit.3.2.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.2.0/opam
@@ -41,3 +41,4 @@ url {
     "sha512=8bddae1a238d58d1b59520afb4f627c4beaf9b5355cacc4087e6667e678392cbc681777e32874ee033ffe40da8a7f0d3bab38eed64f25d201294a9c3e3476978"
   ]
 }
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.0/opam
@@ -26,3 +26,4 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v2.3.0.tar.gz"
   checksum: "md5=4bae08a22f8260f764646620ce83d084"
 }
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.1/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.1/opam
@@ -27,3 +27,4 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v2.3.1.tar.gz"
   checksum: "md5=4d2918daafd0dc192d537f8422bf43cb"
 }
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.3.4/opam
@@ -27,3 +27,4 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v2.3.4.tar.gz"
   checksum: "md5=00402709acf64d7405091c587a81e4eb"
 }
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.6.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.2.6.0/opam
@@ -27,3 +27,4 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v2.6.0.tar.gz"
   checksum: "md5=e9d5ec80ae06b42658e48af130aea7c1"
 }
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.0/opam
@@ -28,3 +28,4 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.0.0.tar.gz"
   checksum: "md5=ad80c57c36e8aec9c623d1fc4441ec49"
 }
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/opam
@@ -27,3 +27,4 @@ url {
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
 ]
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/opam
@@ -27,3 +27,4 @@ url {
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
 ]
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.6/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.6/opam
@@ -28,3 +28,4 @@ url {
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
 ]
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.1.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.1.0/opam
@@ -27,3 +27,4 @@ url {
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
 ]
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.2.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.2.0/opam
@@ -27,3 +27,4 @@ url {
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
 ]
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.0/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.0/opam
@@ -31,3 +31,4 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.3.0.tar.gz"
   checksum: "md5=25b42ec49cdd2c4503eb994d0279ef35"
 }
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.1/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.1/opam
@@ -31,3 +31,4 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.3.1.tar.gz"
   checksum: "md5=ef287658f37ec55bf80ff3f1d2541db5"
 }
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.2/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.2/opam
@@ -31,3 +31,4 @@ url {
   src: "https://github.com/mirage/mirage-platform/archive/v3.3.2.tar.gz"
   checksum: "md5=7e7f95542bcb07605c2b99ff8f8965c4"
 }
+flags: deprecated

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.3/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.3.3/opam
@@ -27,3 +27,4 @@ url {
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
 ]
+flags: deprecated

--- a/packages/named-pipe/named-pipe.0.2/opam
+++ b/packages/named-pipe/named-pipe.0.2/opam
@@ -14,7 +14,6 @@ build: [
   [make "test"] {with-test}
 ]
 install: [make "install"]
-remove: ["ocamlfind" "remove" "named-pipe"]
 
 depends: [
   "ocaml" {>= "3.12.1"}
@@ -31,7 +30,7 @@ description: """
 Named pipe bindings for Windows systems. Note this code will compile on
 non-Windows platforms but will raise a dynamic `Not_available` error
 if you try to use the functions."""
-flags: light-uninstall
+flags: deprecated
 url {
   src: "https://github.com/djs55/ocaml-named-pipe/archive/v0.2.tar.gz"
   checksum: "md5=0e7af39e956ff67d96a5bb2d7b05aa06"

--- a/packages/named-pipe/named-pipe.0.3/opam
+++ b/packages/named-pipe/named-pipe.0.3/opam
@@ -12,7 +12,6 @@ build: [
   [make "test"] {with-test}
 ]
 install: [make "install"]
-remove: ["ocamlfind" "remove" "named-pipe"]
 
 depends: [
   "ocaml" {>= "3.12.1"}
@@ -29,7 +28,7 @@ description: """
 Named pipe bindings for Windows systems. Note this code will compile on
 non-Windows platforms but will raise a dynamic `Not_available` error
 if you try to use the functions."""
-flags: light-uninstall
+flags: deprecated
 url {
   src: "https://github.com/djs55/ocaml-named-pipe/archive/v0.3.tar.gz"
   checksum: "md5=33a003c2041225f5de6fdde94cb84cbd"

--- a/packages/named-pipe/named-pipe.0.4.0/opam
+++ b/packages/named-pipe/named-pipe.0.4.0/opam
@@ -35,3 +35,4 @@ url {
     "https://github.com/mirage/ocaml-named-pipe/releases/download/0.4.0/named-pipe-0.4.0.tbz"
   checksum: "md5=ec3a7aaec3cc0efd6560dd1668da6def"
 }
+flags: deprecated


### PR DESCRIPTION
Discussed in:
- https://github.com/ocurrent/opam-health-check/issues/8
- https://github.com/ocaml/opam/issues/4522

Implemented as a builtin flag in opam in: https://github.com/ocaml/opam/pull/4523

This PR should not have any effect on any of the packages from opam 2.0 to opam 2.1.0~beta4 and is just there for external tools support for the moment. If https://github.com/ocaml/opam/pull/4523 gets merged, these packages will still be available, just avoided, if possible, by the solver.