### PR TITLE
[new release] ppx_deriving_protobuf (3.0.0)

### DIFF
--- a/packages/pa_ppx/pa_ppx.0.03/opam
+++ b/packages/pa_ppx/pa_ppx.0.03/opam
@@ -43,6 +43,7 @@ depends: [
   "ounit2" { >= "2.2.3" }
   "bos" { >= "0.2.0" }
   "base"
+  "sexplib"
   "ppx_deriving_protobuf" { >= "2.7" }
   "uint" { >= "2.0.1" }
   "ppx_import" { with-test & >= "1.7.1" }

--- a/packages/pa_ppx/pa_ppx.0.03/opam
+++ b/packages/pa_ppx/pa_ppx.0.03/opam
@@ -36,7 +36,7 @@ doc: "https://github.com/camlp5/pa_ppx/doc"
 
 depends: [
   "ocaml"       { >= "4.10.0" & < "4.12.0" }
-  "camlp5"      { >= "8.00~alpha03" }
+  "camlp5"      { >= "8.00~alpha03" & < "8.00" }
   "not-ocamlfind" { >= "0.01" }
   "pcre" { >= "7.4.3" }
   "yojson" { >= "1.7.0" }
@@ -45,7 +45,6 @@ depends: [
   "base"
   "sexplib"
   "ppx_deriving_protobuf" { >= "2.7" }
-  "ocaml-migrate-parsetree" {< "2.0.0"}
   "uint" { >= "2.0.1" }
   "ppx_import" { with-test & >= "1.7.1" }
   "ppx_deriving_yojson" { with-test & >= "3.5.2" }

--- a/packages/pa_ppx/pa_ppx.0.03/opam
+++ b/packages/pa_ppx/pa_ppx.0.03/opam
@@ -45,6 +45,7 @@ depends: [
   "base"
   "sexplib"
   "ppx_deriving_protobuf" { >= "2.7" }
+  "ocaml-migrate-parsetree" {< "2.0.0"}
   "uint" { >= "2.0.1" }
   "ppx_import" { with-test & >= "1.7.1" }
   "ppx_deriving_yojson" { with-test & >= "3.5.2" }

--- a/packages/pa_ppx/pa_ppx.0.03/opam
+++ b/packages/pa_ppx/pa_ppx.0.03/opam
@@ -42,6 +42,7 @@ depends: [
   "yojson" { >= "1.7.0" }
   "ounit2" { >= "2.2.3" }
   "bos" { >= "0.2.0" }
+  "base"
   "ppx_deriving_protobuf" { >= "2.7" }
   "uint" { >= "2.0.1" }
   "ppx_import" { with-test & >= "1.7.1" }

--- a/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.3.0.0/opam
+++ b/packages/ppx_deriving_protobuf/ppx_deriving_protobuf.3.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving_protobuf"
+doc: "https://ocaml-ppx.github.io/ppx_deriving_protobuf"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving_protobuf/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving_protobuf.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"        {>= "4.05"}
+  "dune"         {>= "1.0"}
+  "cppo"         {build}
+  "ppx_deriving" {>= "5.2.1"}
+  "ppxlib"       {>= "0.20.0"}
+  "ounit2"       {with-test}
+  "uint"         {with-test}
+]
+synopsis: "A Protocol Buffers codec generator for OCaml"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving_protobuf/releases/download/v3.0.0/ppx_deriving_protobuf-v3.0.0.tbz"
+  checksum: [
+    "sha256=5287ef0db8d4f7a62b0bb7a21010172d602aa45a7fecc2d4cb9681366ddf81b5"
+    "sha512=6bc04d10c2448a35c9c2404be01aab616d51cdda563f6f3b8d213db18614233746c6bf2190a3f12881f544e91c18aa01d56f9aeeb7b01eddfe68123b88703625"
+  ]
+}
+x-commit-hash: "5b602831d6df6e47412c96e93368d0068aeb6027"


### PR DESCRIPTION
A Protocol Buffers codec generator for OCaml

- Project page: <a href="https://github.com/ocaml-ppx/ppx_deriving_protobuf">https://github.com/ocaml-ppx/ppx_deriving_protobuf</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_deriving_protobuf">https://ocaml-ppx.github.io/ppx_deriving_protobuf</a>

##### CHANGES:

  * Add support for OCaml 4.11 (ocaml-ppx/ppx_deriving_protobuf#36)
    (Thierry Martinez, review by Gabriel Scherer)
  * Add support for OCaml 4.12 (ocaml-ppx/ppx_deriving_protobuf#39)
    (Kate Deplaix, review by Gabriel Scherer)
  * Port to ppx_deriving 5.0 and ppxlib (ocaml-ppx/ppx_deriving_protobuf#39)
    (Kate Deplaix, review by Gabriel Scherer)
  * Upgrade the tests from ounit to ounit2 (ocaml-ppx/ppx_deriving_protobuf#39)
    (Kate Deplaix, review by Gabriel Scherer)
