### PR TITLE
[new release] ppxlib (0.22.0)

### DIFF
--- a/packages/OCanren-ppx/OCanren-ppx.0.1.0/opam
+++ b/packages/OCanren-ppx/OCanren-ppx.0.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "2.5"}
   "dune-configurator"
   "base" { >= "v0.14.0" }
-  "ppxlib"
+  "ppxlib" {< "0.22.0"}
 ]
 
 build: [

--- a/packages/base_quickcheck/base_quickcheck.v0.14.0/opam
+++ b/packages/base_quickcheck/base_quickcheck.v0.14.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_sexp_value"    {>= "v0.14" & < "v0.15"}
   "splittable_random" {>= "v0.14" & < "v0.15"}
   "dune"              {>= "2.0.0"}
-  "ppxlib"            {>= "0.11.0"}
+  "ppxlib"            {>= "0.11.0" & < "0.22.0"}
 ]
 synopsis: "Randomized testing framework, designed for compatibility with Base"
 description: "

--- a/packages/ocamlformat/ocamlformat.0.15.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.15.1/opam
@@ -22,7 +22,7 @@ depends: [
   "menhir"
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
-  "ppxlib" {>= "0.18.0"}
+  "ppxlib" {>= "0.18.0" & < "0.22.0"}
   "re"
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}

--- a/packages/ocamlformat/ocamlformat.0.16.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.16.0/opam
@@ -22,7 +22,7 @@ depends: [
   "menhir"
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
-  "ppxlib" {>= "0.18.0"}
+  "ppxlib" {>= "0.18.0" & < "0.22.0"}
   "re"
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.2/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.2/opam
@@ -14,7 +14,7 @@ depends: [
   "base"     {>= "v0.14" & < "v0.15"}
   "sexplib0" {>= "v0.14" & < "v0.15"}
   "dune"     {>= "2.0.0"}
-  "ppxlib"   {>= "0.18.0"}
+  "ppxlib"   {>= "0.18.0" & < "0.22.0"}
 ]
 synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
 description: "

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.14.1/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.14.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base"    {>= "v0.14" & < "v0.15"}
   "typerep" {>= "v0.14" & < "v0.15"}
   "dune"    {>= "2.0.0"}
-  "ppxlib"  {>= "0.14.0"}
+  "ppxlib"  {>= "0.14.0" & < "0.22.0"}
 ]
 synopsis: "Generation of runtime types from type declarations"
 description: "

--- a/packages/ppxlib/ppxlib.0.22.0/opam
+++ b/packages/ppxlib/ppxlib.0.22.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Standard library for ppx rewriters"
+description: """
+Ppxlib is the standard library for ppx rewriters and other programs
+that manipulate the in-memory reprensation of OCaml programs, a.k.a
+the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1" & < "4.13"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "2.1.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0"
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "base" {with-test}
+  "stdio" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-commit-hash: "06a2c9bdad8c1d3361a3d9430e9bf58476b08590"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.22.0/ppxlib-0.22.0.tbz"
+  checksum: [
+    "sha256=3eeb91e03966662284a3222e612dee7f4fa2b7637c53d9572d2a74134bb96d7a"
+    "sha512=425051dff9df53579a6edd17369d66c10f87a78daeddf1691e50997990ed643e874fcc6a30112a4dacbfd2d0097a19445354e04cd920d9522f76c51cdbc7f1db"
+  ]
+}

--- a/packages/visitors/visitors.20210127/opam
+++ b/packages/visitors/visitors.20210127/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.07.0"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.22.0"}
   "ppx_deriving" {>= "5.0"}
   "result"
   "dune" {>= "2.0"}


### PR DESCRIPTION
Standard library for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Bump ppxlib's AST to 4.12 (ocaml-ppx/ppxlib#193, @NathanReb)
