### PR TITLE
Package pruvendo-base.0.1.0

### DIFF
--- a/packages/pruvendo-base/pruvendo-base.0.1.0/opam
+++ b/packages/pruvendo-base/pruvendo-base.0.1.0/opam
@@ -1,0 +1,18 @@
+synopsis:     "Pruvendo base coq theory"
+description:  "Pruvendo base coq theory"
+opam-version: "2.0"
+maintainer:   "team@pruvendo.com"
+authors:      "Pruvendo Team"
+homepage:     "git@vcs.modus-ponens.com:ton/coq-finproof-base.git"
+dev-repo:     "git://git@github.com:AndronovN/test-opam-repo.git"
+bug-reports:  "git@vcs.modus-ponens.com:ton/coq-finproof-base.git"
+doc:          "https://pruvendo.github.io/pruvendo-base"
+
+license:      "GPL 3"
+
+depends: [
+  "coq"           { >= "8.11.0" }
+  "dune"          { >= "2.8.0"  }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]


### PR DESCRIPTION
### `pruvendo-base.0.1.0`
Pruvendo base coq theory
Pruvendo base coq theory



---
* Homepage: git@vcs.modus-ponens.com:ton/coq-finproof-base.git
* Source repo: git+ssh://git@github.com/AndronovN/test-opam-repo.git
* Bug tracker: git@vcs.modus-ponens.com:ton/coq-finproof-base.git

---
:camel: Pull-request generated by opam-publish v2.0.3