### PR TITLE
Add avoid-version to existing packages with hidden-version

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler avoid-version hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler avoid-version hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler avoid-version hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler avoid-version hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler avoid-version hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~rc1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler hidden-version avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+trunk/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler avoid-version hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler avoid-version hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler avoid-version hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler avoid-version hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler avoid-version hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler avoid-version hidden-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~rc1+options/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version ]
+flags: [ compiler hidden-version avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [


### PR DESCRIPTION
See ocaml/opam#4527 - this PR would be merged after that one.

We'd want to do the same pattern of `avoid-version` and `hidden-version` just until opam 2.1 is released. After that - i.e. for OCaml 4.13 - we'd just use `avoid-version` since there'd be no version of opam around using `hidden-version` (recall that opam ignores flags it doesn't understand).