### PR TITLE
[new release] carton, carton-lwt and carton-git (carton-v0.2.0)

### DIFF
--- a/packages/carton-git/carton-git.carton-v0.2.0/opam
+++ b/packages/carton-git/carton-git.carton-v0.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "carton"
+  "carton-lwt"
+  "bigstringaf"
+  "bigarray-compat"
+  "lwt"
+  "fpath"
+  "result"
+  "mmap"
+  "fmt" {>= "0.8.7"}
+  "base-unix"
+  "decompress" {>= "1.2.0"}
+  "astring" {>= "0.8.5"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "ed21e77636b61daf74d8f323533399709a07904a"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.2.0/carton-carton-v0.2.0.tbz"
+  checksum: [
+    "sha256=904c52f2ff658de6349e8e4e43cfd28c920f72013439e29c677d1d7cb4346f67"
+    "sha512=831d0a30ee81e5fbba4a66276b60582e8d2c0ea35b826db106e2d97d186a434a8c4a65cf8e5f8b0c33d18bd5da337e2c8c5d736d13ba79de027d87343586192b"
+  ]
+}

--- a/packages/carton-lwt/carton-lwt.carton-v0.2.0/opam
+++ b/packages/carton-lwt/carton-lwt.carton-v0.2.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "carton"
+  "lwt"
+  "decompress" {>= "1.2.0"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf"
+  "bigarray-compat" {with-test}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "fmt" {>= "0.8.9" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "result" {>= "1.5" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+  "base64" {>= "3.4.0" & with-test}
+  "bos" {>= "0.2.0" & with-test}
+  "checkseum" {>= "0.3.0" & with-test}
+  "digestif" {>= "1.0.0" & with-test}
+  "fpath" {>= "0.7.3" & with-test}
+  "mmap" {>= "1.1.0" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "ed21e77636b61daf74d8f323533399709a07904a"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.2.0/carton-carton-v0.2.0.tbz"
+  checksum: [
+    "sha256=904c52f2ff658de6349e8e4e43cfd28c920f72013439e29c677d1d7cb4346f67"
+    "sha512=831d0a30ee81e5fbba4a66276b60582e8d2c0ea35b826db106e2d97d186a434a8c4a65cf8e5f8b0c33d18bd5da337e2c8c5d736d13ba79de027d87343586192b"
+  ]
+}

--- a/packages/carton/carton.carton-v0.2.0/opam
+++ b/packages/carton/carton.carton-v0.2.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACKv2 file in OCaml"
+description: """\
+Carton is an implementation of the PACKv2 file
+in OCaml. PACKv2 file is used by Git to store Git objects.
+Carton is more abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "ke" {>= "0.4"}
+  "duff" {>= "0.3"}
+  "decompress" {>= "1.2.0"}
+  "cstruct" {>= "5.0.0"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf"
+  "checkseum" {>= "0.2.1"}
+  "logs"
+  "bigstringaf"
+  "bigarray-compat"
+  "bos"
+  "cmdliner" {>= "1.0.4"}
+  "digestif"
+  "fpath"
+  "mmap"
+  "result"
+  "rresult"
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.7"}
+  "result"
+  "rresult"
+  "fpath"
+  "base64" {with-test & >= "3.0.0"}
+  "bos"
+  "digestif" {>= "0.8.1"}
+  "mmap"
+  "base-unix" {with-test}
+  "base-threads" {with-test}
+  "alcotest" {with-test}
+  "crowbar" {with-test & >= "0.2"}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "lwt" {>= "5.3.0" & with-test}
+  "ocamlfind" {>= "1.8.1" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "ed21e77636b61daf74d8f323533399709a07904a"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.2.0/carton-carton-v0.2.0.tbz"
+  checksum: [
+    "sha256=904c52f2ff658de6349e8e4e43cfd28c920f72013439e29c677d1d7cb4346f67"
+    "sha512=831d0a30ee81e5fbba4a66276b60582e8d2c0ea35b826db106e2d97d186a434a8c4a65cf8e5f8b0c33d18bd5da337e2c8c5d736d13ba79de027d87343586192b"
+  ]
+}


### PR DESCRIPTION
Implementation of PACKv2 file in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Fix `git-unix` and PACK files location (@dinosaure, mirage/ocaml-git#444, mirage/ocaml-git#443)
- Initialise (as `git`) correctly (add an `HEAD` reference, at least) (@dinosaure, mirage/ocaml-git#443)
