### PR TITLE
[new release] bimage-unix, conf-openimageio, bimage, bimage-io, bimage-display and bimage-lwt (0.3.0)

### DIFF
--- a/packages/bimage-display/bimage-display.0.3.0/opam
+++ b/packages/bimage-display/bimage-display.0.3.0/opam
@@ -19,7 +19,6 @@ depends:
 
 build: [
     ["dune" "build" "-p" name "-j" jobs]
-    ["dune" "runtest" "-p" name] {with-test}
 ]
 
 synopsis: """

--- a/packages/bimage-display/bimage-display.0.3.0/opam
+++ b/packages/bimage-display/bimage-display.0.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "glfw-ocaml"
+    "conf-glew"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Window system for Bimage
+"""
+
+description: """
+Allows for Bimage Images to be displayed using OpenGL
+"""
+x-commit-hash: "683ba69b9a9c0406a85b4084da38c2dd604e390f"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.3.0/bimage-v0.3.0.tbz"
+  checksum: [
+    "sha256=d3c16024d56ad368dca87cdd09aac6d949e8834770942fd27175474f423569a4"
+    "sha512=946ddd44508356c99617f45d4c93eb7dc4eaee4e1d4e38dcce8e65a327fa90773f46c0f178afc1db550935bfbc44aed3340f4f1d12d2f851c14ba4a28e8a41c7"
+  ]
+}

--- a/packages/bimage-io/bimage-io.0.3.0/opam
+++ b/packages/bimage-io/bimage-io.0.3.0/opam
@@ -18,7 +18,6 @@ depends:
 
 build: [
     ["dune" "build" "-p" name "-j" jobs]
-    ["dune" "runtest" "-p" name] {with-test}
 ]
 
 synopsis: """

--- a/packages/bimage-io/bimage-io.0.3.0/opam
+++ b/packages/bimage-io/bimage-io.0.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "conf-openimageio"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Input/output for Bimage using OpenImageIO
+"""
+
+description: """
+Input/output for Bimage using OpenImageIO
+"""
+x-commit-hash: "683ba69b9a9c0406a85b4084da38c2dd604e390f"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.3.0/bimage-v0.3.0.tbz"
+  checksum: [
+    "sha256=d3c16024d56ad368dca87cdd09aac6d949e8834770942fd27175474f423569a4"
+    "sha512=946ddd44508356c99617f45d4c93eb7dc4eaee4e1d4e38dcce8e65a327fa90773f46c0f178afc1db550935bfbc44aed3340f4f1d12d2f851c14ba4a28e8a41c7"
+  ]
+}

--- a/packages/bimage-lwt/bimage-lwt.0.3.0/opam
+++ b/packages/bimage-lwt/bimage-lwt.0.3.0/opam
@@ -12,6 +12,7 @@ depends:
 [
     "ocaml" {>= "4.08.0"}
     "dune" {>= "2.0"}
+    "bimage" {= version}
     "lwt"
 ]
 

--- a/packages/bimage-lwt/bimage-lwt.0.3.0/opam
+++ b/packages/bimage-lwt/bimage-lwt.0.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "lwt"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library (LWT bindings)
+"""
+
+description: """
+LWT bindings for Bimage, an image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+x-commit-hash: "683ba69b9a9c0406a85b4084da38c2dd604e390f"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.3.0/bimage-v0.3.0.tbz"
+  checksum: [
+    "sha256=d3c16024d56ad368dca87cdd09aac6d949e8834770942fd27175474f423569a4"
+    "sha512=946ddd44508356c99617f45d4c93eb7dc4eaee4e1d4e38dcce8e65a327fa90773f46c0f178afc1db550935bfbc44aed3340f4f1d12d2f851c14ba4a28e8a41c7"
+  ]
+}

--- a/packages/bimage-unix/bimage-unix.0.3.0/opam
+++ b/packages/bimage-unix/bimage-unix.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "ctypes" {>= "0.14"}
+    "ctypes-foreign" {>= "0.4"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/stb_image
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+x-commit-hash: "683ba69b9a9c0406a85b4084da38c2dd604e390f"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.3.0/bimage-v0.3.0.tbz"
+  checksum: [
+    "sha256=d3c16024d56ad368dca87cdd09aac6d949e8834770942fd27175474f423569a4"
+    "sha512=946ddd44508356c99617f45d4c93eb7dc4eaee4e1d4e38dcce8e65a327fa90773f46c0f178afc1db550935bfbc44aed3340f4f1d12d2f851c14ba4a28e8a41c7"
+  ]
+}

--- a/packages/bimage/bimage.0.3.0/opam
+++ b/packages/bimage/bimage.0.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+x-commit-hash: "683ba69b9a9c0406a85b4084da38c2dd604e390f"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.3.0/bimage-v0.3.0.tbz"
+  checksum: [
+    "sha256=d3c16024d56ad368dca87cdd09aac6d949e8834770942fd27175474f423569a4"
+    "sha512=946ddd44508356c99617f45d4c93eb7dc4eaee4e1d4e38dcce8e65a327fa90773f46c0f178afc1db550935bfbc44aed3340f4f1d12d2f851c14ba4a28e8a41c7"
+  ]
+}

--- a/packages/conf-glew/conf-glew.1/opam
+++ b/packages/conf-glew/conf-glew.1/opam
@@ -18,8 +18,7 @@ depexts: [
   ["libglew-devel"] {os-distribution = "mageia"}
   ["glew-devel"] {os-distribution = "fedora"}
   ["glew-devel"] {os-distribution = "centos"}
-  ["glew-devel"] {os-distribution = "ol"}
-  ["glew-devel"] {os-family = "suse"}
+  ["glu-devel" "glew-devel"] {os-family = "suse"}
   ["glew-dev"] {os-family = "alpine"}
   ["glew"] {os-family = "arch"}
   ["glew"] {os-family = "freebsd"}
@@ -27,6 +26,10 @@ depexts: [
   ["glew"] {os-family = "netbsd"}
   ["glew"] {os = "macos" & os-distribution = "homebrew"}
   ["glew"] {os = "macos" & os-distribution = "macports"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7" # not available
+  "oraclelinux-8" # not available
 ]
 synopsis: "Virtual package relying on a GLEW system installation"
 description:

--- a/packages/conf-glew/conf-glew.1/opam
+++ b/packages/conf-glew/conf-glew.1/opam
@@ -8,12 +8,25 @@ authors: [
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://glew.sourceforge.net/"
 license: "modified BSD"
-build: [["pkg-config" "glew"]]
-depends: ["conf-pkg-config" {build}]
+build: ["pkg-config" "--print-errors" "--exists" "glew"]
+depends: [
+  "conf-pkg-config" {build}
+]
 depexts: [
   ["libglew-dev"] {os-family = "debian"}
+  ["libglew-dev"] {os-family = "ubuntu"}
   ["libglew-devel"] {os-distribution = "mageia"}
   ["glew-devel"] {os-distribution = "fedora"}
+  ["glew-devel"] {os-distribution = "centos"}
+  ["glew-devel"] {os-distribution = "ol"}
+  ["glew-devel"] {os-family = "suse"}
+  ["glew-dev"] {os-family = "alpine"}
+  ["glew"] {os-family = "arch"}
+  ["glew"] {os-family = "freebsd"}
+  ["glew"] {os-family = "openbsd"}
+  ["glew"] {os-family = "netbsd"}
+  ["glew"] {os = "macos" & os-distribution = "homebrew"}
+  ["glew"] {os = "macos" & os-distribution = "macports"}
 ]
 synopsis: "Virtual package relying on a GLEW system installation"
 description:

--- a/packages/conf-glfw3/conf-glfw3.2/opam
+++ b/packages/conf-glfw3/conf-glfw3.2/opam
@@ -7,16 +7,20 @@ homepage: "http://www.glfw.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Zlib"
 flags: conf
-build: [["pkg-config" "glfw3"]]
-depends: ["conf-pkg-config" {build}]
+build: ["pkg-config" "--print-errors" "--exists" "glfw3"]
+depends: [
+  "conf-pkg-config" {build}
+]
 depexts: [
   ["libglfw3-dev"] {os-family = "debian"}
+  ["libglfw3-dev"] {os-family = "ubuntu"}
   ["glfw-devel" "epel-release" "mesa-libGL-devel"]
     {os-distribution = "centos"}
   ["glfw-devel" "mesa-libGL-devel"] {os-distribution = "rhel"}
   ["glfw-devel" "mesa-libGL-devel"] {os-distribution = "fedora"}
-  ["glfw-dev"] {os-distribution = "alpine"}
-  ["libglfw-devel" "Mesa-libGL-devel"] {os-family = "suse"}
   ["libglfw-devel" "mesagl-devel"] {os-distribution = "mageia"}
+  ["libglfw-devel" "Mesa-libGL-devel"] {os-family = "suse"}
+  ["glfw-dev"] {os-family = "alpine"}
+  ["glfw"] {os-family = "arch"}
   ["glfw"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-glfw3/conf-glfw3.2/opam
+++ b/packages/conf-glfw3/conf-glfw3.2/opam
@@ -24,3 +24,7 @@ depexts: [
   ["glfw"] {os-family = "arch"}
   ["glfw"] {os = "macos" & os-distribution = "homebrew"}
 ]
+x-ci-accept-failures: [
+  "oraclelinux-7"
+  "oraclelinux-8"
+]

--- a/packages/conf-openimageio/conf-openimageio.0.3.0/opam
+++ b/packages/conf-openimageio/conf-openimageio.0.3.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "zachshipko@gmail.com"
+homepage: "https://www.openimageio.org"
+authors: "OpenImageIO"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "MIT"
+build: [
+  ["pkg-config" "--atleast-version=2" "OpenImageIO"]
+]
+depends: ["conf-pkg-config" {build}]
+depexts: [
+  ["libopenimageio-dev"] {os-family = "debian"}
+  ["openimageio-devel"] {os-distribution = "fedora"}
+  ["openimageio-devel" "epel-release"] {os-distribution = "centos"}
+  ["openimageio-devel"] {os-family = "suse"}
+  ["openimageio-dev"] {os-distribution = "alpine"}
+  ["openimageio"] {os = "macos" & os-distribution = "homebrew"}
+  ["openimageio"] {os = "macos" & os-distribution = "macports"}
+]
+synopsis: "Virtual package relying on OpenImageIO development package installation"
+description: """
+This package can only install if OpenImageIO is available on the system.
+"""
+flags: conf
+x-commit-hash: "683ba69b9a9c0406a85b4084da38c2dd604e390f"
+url {
+  src: "https://www.openimageio.org/releases/bimage-v0.3.0.tbz"
+  checksum: [
+    "sha256=d3c16024d56ad368dca87cdd09aac6d949e8834770942fd27175474f423569a4"
+    "sha512=946ddd44508356c99617f45d4c93eb7dc4eaee4e1d4e38dcce8e65a327fa90773f46c0f178afc1db550935bfbc44aed3340f4f1d12d2f851c14ba4a28e8a41c7"
+  ]
+}

--- a/packages/conf-openimageio/conf-openimageio.0.3.0/opam
+++ b/packages/conf-openimageio/conf-openimageio.0.3.0/opam
@@ -10,9 +10,9 @@ build: [
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libopenimageio-dev"] {os-family = "debian"}
-  ["openimageio-devel"] {os-distribution = "fedora"}
-  ["openimageio-devel" "epel-release"] {os-distribution = "centos"}
-  ["openimageio-devel"] {os-family = "suse"}
+  ["OpenImageIO-devel"] {os-distribution = "fedora"}
+  ["OpenImageIO-devel" "epel-release"] {os-distribution = "centos"}
+  ["OpenImageIO-devel"] {os-family = "suse"}
   ["openimageio-dev"] {os-distribution = "alpine"}
   ["openimageio"] {os = "macos" & os-distribution = "homebrew"}
   ["openimageio"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-openimageio/conf-openimageio.0.3.0/opam
+++ b/packages/conf-openimageio/conf-openimageio.0.3.0/opam
@@ -22,11 +22,3 @@ description: """
 This package can only install if OpenImageIO is available on the system.
 """
 flags: conf
-x-commit-hash: "683ba69b9a9c0406a85b4084da38c2dd604e390f"
-url {
-  src: "https://www.openimageio.org/releases/bimage-v0.3.0.tbz"
-  checksum: [
-    "sha256=d3c16024d56ad368dca87cdd09aac6d949e8834770942fd27175474f423569a4"
-    "sha512=946ddd44508356c99617f45d4c93eb7dc4eaee4e1d4e38dcce8e65a327fa90773f46c0f178afc1db550935bfbc44aed3340f4f1d12d2f851c14ba4a28e8a41c7"
-  ]
-}

--- a/packages/conf-openimageio/conf-openimageio.1/files/test.cpp
+++ b/packages/conf-openimageio/conf-openimageio.1/files/test.cpp
@@ -1,0 +1,5 @@
+#include <OpenImageIO/version.h>
+
+#if OIIO_VERSION_MAJOR >= 2
+#error "OpenImageIO (>= 2.0) is not accessible"
+#endif

--- a/packages/conf-openimageio/conf-openimageio.1/files/test.cpp
+++ b/packages/conf-openimageio/conf-openimageio.1/files/test.cpp
@@ -1,5 +1,5 @@
 #include <OpenImageIO/version.h>
 
-#if OIIO_VERSION_MAJOR >= 2
+#if OIIO_VERSION_MAJOR < 2
 #error "OpenImageIO (>= 2.0) is not accessible"
 #endif

--- a/packages/conf-openimageio/conf-openimageio.1/opam
+++ b/packages/conf-openimageio/conf-openimageio.1/opam
@@ -15,15 +15,22 @@ depexts: [
   ["libopenimageio-dev"] {os-family = "ubuntu"}
   ["OpenImageIO-devel"] {os-distribution = "fedora"}
   ["OpenImageIO-devel" "epel-release"] {os-distribution = "centos"}
-  ["OpenImageIO-devel"] {os-distribution = "ol"}
   ["OpenImageIO-devel"] {os-family = "suse"}
-  ["openimageio-dev"] {os-family = "alpine"}
+  ["openimageio-dev@testing"] {os-family = "alpine"}
   ["openimageio"] {os-family = "arch"}
   ["openimageio"] {os = "macos" & os-distribution = "homebrew"}
   ["openimageio"] {os = "macos" & os-distribution = "macports"}
   ["openimageio"] {os = "freebsd"}
   ["openimageio"] {os = "openbsd"}
   ["openimageio"] {os = "netbsd"}
+]
+x-ci-accept-failures: [
+  "centos-7" # too old
+  "opensuse-15.2" # too old
+  "ubuntu-16.04" # too old
+  "ubuntu-18.04" # too old
+  "oraclelinux-7" # not available
+  "oraclelinux-8" # not available
 ]
 synopsis: "Virtual package relying on OpenImageIO development package installation"
 description: """

--- a/packages/conf-openimageio/conf-openimageio.1/opam
+++ b/packages/conf-openimageio/conf-openimageio.1/opam
@@ -11,6 +11,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
+  ["libopenexr-dev"] {os-distribution = "debian" & os-version >= "11"}
   ["libopenimageio-dev"] {os-family = "debian"}
   ["libopenimageio-dev"] {os-family = "ubuntu"}
   ["OpenImageIO-devel"] {os-distribution = "fedora"}

--- a/packages/conf-openimageio/conf-openimageio.1/opam
+++ b/packages/conf-openimageio/conf-openimageio.1/opam
@@ -1,24 +1,32 @@
 opam-version: "2.0"
 maintainer: "zachshipko@gmail.com"
 homepage: "https://www.openimageio.org"
-authors: "OpenImageIO"
+authors: "OpenImageIO devs"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-license: "MIT"
+license: "BSD 3-Clause"
 build: [
-  ["pkg-config" "--atleast-version=2" "OpenImageIO"]
+  ["sh" "-c" "pkg-config --atleast-version=2 --print-errors OpenImageIO || c++ -E test.cpp"]
 ]
-depends: ["conf-pkg-config" {build}]
+depends: [
+  "conf-pkg-config" {build}
+]
 depexts: [
   ["libopenimageio-dev"] {os-family = "debian"}
+  ["libopenimageio-dev"] {os-family = "ubuntu"}
   ["OpenImageIO-devel"] {os-distribution = "fedora"}
   ["OpenImageIO-devel" "epel-release"] {os-distribution = "centos"}
+  ["OpenImageIO-devel"] {os-distribution = "ol"}
   ["OpenImageIO-devel"] {os-family = "suse"}
-  ["openimageio-dev"] {os-distribution = "alpine"}
+  ["openimageio-dev"] {os-family = "alpine"}
+  ["openimageio"] {os-family = "arch"}
   ["openimageio"] {os = "macos" & os-distribution = "homebrew"}
   ["openimageio"] {os = "macos" & os-distribution = "macports"}
+  ["openimageio"] {os = "freebsd"}
+  ["openimageio"] {os = "openbsd"}
+  ["openimageio"] {os = "netbsd"}
 ]
 synopsis: "Virtual package relying on OpenImageIO development package installation"
 description: """
-This package can only install if OpenImageIO is available on the system.
+This package can only install if the OpenImageIO library is available on the system.
 """
 flags: conf

--- a/packages/conf-openimageio/conf-openimageio.1/opam
+++ b/packages/conf-openimageio/conf-openimageio.1/opam
@@ -16,7 +16,6 @@ depexts: [
   ["OpenImageIO-devel"] {os-distribution = "fedora"}
   ["OpenImageIO-devel" "epel-release"] {os-distribution = "centos"}
   ["OpenImageIO-devel"] {os-family = "suse"}
-  ["openimageio-dev@testing"] {os-family = "alpine"}
   ["openimageio"] {os-family = "arch"}
   ["openimageio"] {os = "macos" & os-distribution = "homebrew"}
   ["openimageio"] {os = "macos" & os-distribution = "macports"}
@@ -25,6 +24,7 @@ depexts: [
   ["openimageio"] {os = "netbsd"}
 ]
 x-ci-accept-failures: [
+  "alpine-3.12" # openimageio-dev@testing has missing dependencies (unable to install)
   "centos-7" # too old
   "opensuse-15.2" # too old
   "ubuntu-16.04" # too old

--- a/packages/glfw-ocaml/glfw-ocaml.3.3/opam
+++ b/packages/glfw-ocaml/glfw-ocaml.3.3/opam
@@ -13,6 +13,12 @@ depends: [
   "conf-pkg-config" {build}
   "ocaml" {>= "4.02.0"}
 ]
+x-ci-accept-failures: [
+  "debian-10" # default version of this library is too old
+  "ubuntu-16.04" # default version of this library is too old
+  "ubuntu-18.04" # default version of this library is too old
+  "centos-7" # default version of this library is too old
+]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/SylvainBoilard/GLFW-OCaml.git"
 url {

--- a/packages/glfw-ocaml/glfw-ocaml.3.3~rc1/opam
+++ b/packages/glfw-ocaml/glfw-ocaml.3.3~rc1/opam
@@ -13,6 +13,12 @@ depends: [
   "conf-pkg-config" {build}
   "ocaml" {>= "4.02.0"}
 ]
+x-ci-accept-failures: [
+  "debian-10" # default version of this library is too old
+  "ubuntu-16.04" # default version of this library is too old
+  "ubuntu-18.04" # default version of this library is too old
+  "centos-7" # default version of this library is too old
+]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/SylvainBoilard/GLFW-OCaml.git"
 url {

--- a/packages/glfw-ocaml/glfw-ocaml.3.3~rc2/opam
+++ b/packages/glfw-ocaml/glfw-ocaml.3.3~rc2/opam
@@ -13,6 +13,12 @@ depends: [
   "conf-pkg-config" {build}
   "ocaml" {>= "4.02.0"}
 ]
+x-ci-accept-failures: [
+  "debian-10" # default version of this library is too old
+  "ubuntu-16.04" # default version of this library is too old
+  "ubuntu-18.04" # default version of this library is too old
+  "centos-7" # default version of this library is too old
+]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/SylvainBoilard/GLFW-OCaml.git"
 url {


### PR DESCRIPTION
Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/stb_image

- Project page: <a href="https://github.com/zshipko/ocaml-bimage">https://github.com/zshipko/ocaml-bimage</a>
- Documentation: <a href="https://zshipko.github.io/ocaml-bimage/doc">https://zshipko.github.io/ocaml-bimage/doc</a>

##### CHANGES:

- Overhaul of `Color` and `Type`
- Added `FILTER`/`Filter`
- Added `Bimage_io` and `Bimage_lwt`
