### PR TITLE
[new release] conduit, conduit-mirage, conduit-lwt, conduit-lwt-unix and conduit-async (2.3.0)

### DIFF
--- a/packages/bigstring/bigstring.0.2/opam
+++ b/packages/bigstring/bigstring.0.2/opam
@@ -7,6 +7,7 @@ tags: ["bigstring" "bigarray"]
 dev-repo: "git://github.com/c-cube/ocaml-bigstring"
 build: [
   ["jbuilder" "build" "-j" jobs "-p" name "@install"]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/bigstring/bigstring.0.2/opam
+++ b/packages/bigstring/bigstring.0.2/opam
@@ -7,7 +7,6 @@ tags: ["bigstring" "bigarray"]
 dev-repo: "git://github.com/c-cube/ocaml-bigstring"
 build: [
   ["jbuilder" "build" "-j" jobs "-p" name "@install"]
-  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/bigstring/bigstring.0.3/opam
+++ b/packages/bigstring/bigstring.0.3/opam
@@ -8,12 +8,15 @@ bug-reports: "https://github.com/c-cube/ocaml-bigstring/issues"
 dev-repo: "git://github.com/c-cube/ocaml-bigstring.git"
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 depends: [
   "dune" {>= "1.2"}
   "base-bigarray"
   "base-bytes"
   "ocaml" {>= "4.03.0"}
+  "alcotest" {with-test & < "1.2"}
+  "bigstring-unix" {with-test}
 ]
 url {
   src: "https://github.com/c-cube/ocaml-bigstring/archive/0.3.tar.gz"

--- a/packages/bigstring/bigstring.0.3/opam
+++ b/packages/bigstring/bigstring.0.3/opam
@@ -8,15 +8,12 @@ bug-reports: "https://github.com/c-cube/ocaml-bigstring/issues"
 dev-repo: "git://github.com/c-cube/ocaml-bigstring.git"
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 depends: [
   "dune" {>= "1.2"}
   "base-bigarray"
   "base-bytes"
   "ocaml" {>= "4.03.0"}
-  "alcotest" {with-test & < "1.2"}
-  "bigstring-unix" {with-test}
 ]
 url {
   src: "https://github.com/c-cube/ocaml-bigstring/archive/0.3.tar.gz"

--- a/packages/cohttp-mirage/cohttp-mirage.1.0.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.0.0/opam
@@ -22,12 +22,14 @@ depends: [
   "mirage-channel-lwt" {>= "3.0.0"}
   "mirage-kv-lwt" {<"2.0.0"}
   "conduit" {>= "0.99" & < "2.3.0"}
+  "conduit-lwt" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
-  "cohttp" {>= "1.0.0" & < "2.2"}
-  "cohttp-lwt" {>= "1.0.0" & < "2.2"}
+  "cohttp" {>= "1.0.0" & < "2.2.0"}
+  "cohttp-lwt" {>= "1.0.0" & < "2.2.0"}
   "astring"
   "magic-mime"
+  "sexplib"
 ]
 synopsis: "An OCaml library for HTTP clients and servers"
 description: """

--- a/packages/cohttp-mirage/cohttp-mirage.1.0.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
   "mirage-kv-lwt" {<"2.0.0"}
-  "conduit" {>= "0.99" & < "3.0.0"}
+  "conduit" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {>= "1.0.0" & < "2.2"}

--- a/packages/cohttp-mirage/cohttp-mirage.1.0.1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
   "mirage-kv-lwt" {<"2.0.0"}
-  "conduit" {>= "0.99" & < "3.0.0"}
+  "conduit" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {< "2.2"}

--- a/packages/cohttp-mirage/cohttp-mirage.1.0.1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.0.1/opam
@@ -22,12 +22,14 @@ depends: [
   "mirage-channel-lwt" {>= "3.0.0"}
   "mirage-kv-lwt" {<"2.0.0"}
   "conduit" {>= "0.99" & < "2.3.0"}
+  "conduit-lwt" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
-  "cohttp" {< "2.2"}
-  "cohttp-lwt" {< "2.2"}
+  "cohttp" {>= "1.0.0" & < "2.2.0"}
+  "cohttp-lwt" {>= "1.0.0" & < "2.2.0"}
   "astring"
   "magic-mime"
+  "sexplib"
 ]
 synopsis: "An OCaml library for HTTP clients and servers"
 description: """

--- a/packages/cohttp-mirage/cohttp-mirage.1.0.2/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.0.2/opam
@@ -22,12 +22,14 @@ depends: [
   "mirage-channel-lwt" {>= "3.0.0"}
   "mirage-kv-lwt" {<"2.0.0"}
   "conduit" {>= "0.99" & < "2.3.0"}
+  "conduit-lwt" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
-  "cohttp" {>= "1.0.0" & < "2.2"}
-  "cohttp-lwt" {>= "1.0.0" & < "2.2"}
+  "cohttp" {>= "1.0.0" & < "2.2.0"}
+  "cohttp-lwt" {>= "1.0.0" & < "2.2.0"}
   "astring"
   "magic-mime"
+  "sexplib"
 ]
 synopsis: "An OCaml library for HTTP clients and servers"
 description: """

--- a/packages/cohttp-mirage/cohttp-mirage.1.0.2/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.0.2/opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
   "mirage-kv-lwt" {<"2.0.0"}
-  "conduit" {>= "0.99" & < "3.0.0"}
+  "conduit" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {>= "1.0.0" & < "2.2"}

--- a/packages/cohttp-mirage/cohttp-mirage.1.1.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.1.0/opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
   "mirage-kv-lwt" {<"2.0.0"}
-  "conduit" {>= "0.99" & < "3.0.0"}
+  "conduit" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {< "2.2"}

--- a/packages/cohttp-mirage/cohttp-mirage.1.1.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.1.0/opam
@@ -22,12 +22,14 @@ depends: [
   "mirage-channel-lwt" {>= "3.0.0"}
   "mirage-kv-lwt" {<"2.0.0"}
   "conduit" {>= "0.99" & < "2.3.0"}
+  "conduit-lwt" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
-  "cohttp" {< "2.2"}
-  "cohttp-lwt" {< "2.2"}
+  "cohttp" {>= "1.0.0" & < "2.2.0"}
+  "cohttp-lwt" {>= "1.0.0" & < "2.2.0"}
   "astring"
   "magic-mime"
+  "sexplib"
 ]
 synopsis: "An OCaml library for HTTP clients and servers"
 description: """

--- a/packages/cohttp-mirage/cohttp-mirage.1.1.1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.1.1/opam
@@ -12,13 +12,15 @@ depends: [
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
   "conduit" {>= "0.99" & < "2.3.0"}
+  "conduit-lwt" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "mirage-kv-lwt" {<"2.0.0"}
   "lwt" {>= "2.4.3"}
-  "cohttp" {< "2.2"}
-  "cohttp-lwt" {< "2.2"}
+  "cohttp" {>= "1.0.0" & < "2.2.0"}
+  "cohttp-lwt" {>= "1.0.0" & < "2.2.0"}
   "astring"
   "magic-mime"
+  "sexplib"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/cohttp-mirage/cohttp-mirage.1.1.1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.1.1/opam
@@ -11,7 +11,7 @@ depends: [
   "result"
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
-  "conduit" {>= "0.99" & < "3.0.0"}
+  "conduit" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "mirage-kv-lwt" {<"2.0.0"}
   "lwt" {>= "2.4.3"}

--- a/packages/cohttp-mirage/cohttp-mirage.1.2.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.2.0/opam
@@ -39,13 +39,15 @@ depends: [
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
   "conduit" {>= "0.99" & < "2.3.0"}
+  "conduit-lwt" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "mirage-kv-lwt" {<"2.0.0"}
   "lwt" {>= "2.4.3"}
-  "cohttp" {< "2.2"}
-  "cohttp-lwt" {< "2.2"}
+  "cohttp" {>= "1.0.0" & < "2.2.0"}
+  "cohttp-lwt" {>= "1.0.0" & < "2.2.0"}
   "astring"
   "magic-mime"
+  "sexplib"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/cohttp-mirage/cohttp-mirage.1.2.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.1.2.0/opam
@@ -38,7 +38,7 @@ depends: [
   "result"
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
-  "conduit" {>= "0.99" & < "3.0.0"}
+  "conduit" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "mirage-kv-lwt" {<"2.0.0"}
   "lwt" {>= "2.4.3"}

--- a/packages/cohttp-mirage/cohttp-mirage.2.0.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-kv-lwt" {<"2.0.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
-  "conduit" {>= "0.99" & < "3.0.0"}
+  "conduit" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {< "2.2"}

--- a/packages/cohttp-mirage/cohttp-mirage.2.1.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "result"
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
-  "conduit" {>= "0.99" & < "3.0.0"}
+  "conduit" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "mirage-kv-lwt" {>= "2.0.0"}
   "lwt" {>= "2.4.3"}

--- a/packages/cohttp-mirage/cohttp-mirage.2.1.1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.1.1/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
-  "conduit" {>= "0.99" & < "3.0.0"}
+  "conduit" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "mirage-kv-lwt" {>= "2.0.0"}
   "lwt" {>= "2.4.3"}

--- a/packages/cohttp-mirage/cohttp-mirage.2.1.3/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.1.3/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
-  "conduit" {>= "0.99" & < "3.0.0"}
+  "conduit" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "mirage-kv-lwt" {>= "2.0.0"}
   "lwt" {>= "2.4.3"}

--- a/packages/cohttp-mirage/cohttp-mirage.2.2.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.2.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel-lwt" {>= "3.0.0"}
-  "conduit" {>= "0.99" & < "3.0.0"}
+  "conduit" {>= "0.99" & < "2.3.0"}
   "mirage-conduit" {>= "3.0.0"}
   "mirage-kv-lwt" {>= "2.0.0"}
   "lwt" {>= "2.4.3"}

--- a/packages/cohttp-mirage/cohttp-mirage.2.4.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.4.0/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "1.1.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2" & < "3.0.0"}
-  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
+  "conduit" {>= "2.0.2" & < "2.3.0"}
+  "conduit-mirage" {>= "2.0.2" & < "2.3.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {< "3.0.0"}

--- a/packages/cohttp-mirage/cohttp-mirage.2.5.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.5.0/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "1.1.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2" & < "3.0.0"}
-  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
+  "conduit" {>= "2.0.2" & < "2.3.0"}
+  "conduit-mirage" {>= "2.0.2" & < "2.3.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {< "3.0.0"}

--- a/packages/cohttp-mirage/cohttp-mirage.2.5.1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.5.1/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "1.1.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2" & < "3.0.0"}
-  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
+  "conduit" {>= "2.0.2" & < "2.3.0"}
+  "conduit-mirage" {>= "2.0.2" & < "2.3.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {< "3.0.0"}

--- a/packages/cohttp-mirage/cohttp-mirage.2.5.2-1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.5.2-1/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "1.1.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2" & < "3.0.0"}
-  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
+  "conduit" {>= "2.0.2" & < "2.3.0"}
+  "conduit-mirage" {>= "2.0.2" & < "2.3.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {< "3.0.0"}

--- a/packages/cohttp-mirage/cohttp-mirage.2.5.2/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.5.2/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "1.1.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2" & < "3.0.0"}
-  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
+  "conduit" {>= "2.0.2" & < "2.3.0"}
+  "conduit-mirage" {>= "2.0.2" & < "2.3.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {< "3.0.0"}

--- a/packages/cohttp-mirage/cohttp-mirage.2.5.3/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.5.3/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "1.1.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2" & < "3.0.0"}
-  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
+  "conduit" {>= "2.0.2" & < "2.3.0"}
+  "conduit-mirage" {>= "2.0.2" & < "2.3.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {< "3.0.0"}

--- a/packages/cohttp-mirage/cohttp-mirage.2.5.4/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.5.4/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "1.1.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2" & < "3.0.0"}
-  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
+  "conduit" {>= "2.0.2" & < "2.3.0"}
+  "conduit-mirage" {>= "2.0.2" & < "2.3.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {< "3.0.0"}

--- a/packages/conduit-async/conduit-async.2.3.0/opam
+++ b/packages/conduit-async/conduit-async.2.3.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "2.0.0"}
   "core"
   "uri" {>= "4.0.0"}
   "ppx_here" {>= "v0.9.0"}

--- a/packages/conduit-async/conduit-async.2.3.0/opam
+++ b/packages/conduit-async/conduit-async.2.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "core"
+  "uri" {>= "4.0.0"}
+  "ppx_here" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "conduit" {=version}
+  "async" {>= "v0.10.0"}
+  "ipaddr" {>= "3.0.0"}
+]
+depopts: ["async_ssl"]
+conflicts: [
+  "async_ssl" {< "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Async"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.3.0/conduit-v2.3.0.tbz"
+  checksum: [
+    "sha256=df52c4c0967ee8dfd044feca3cb90755132a5bc40e6b2884f64bf2d13755e72d"
+    "sha512=0783a6637035ed4c20dc96e995e73f978c9448b11d5caf6d1b351664c6ef0956261a0e44268dbd49953ac603b8b93b0e2b5f8ff4fd20e29ed20d317b10d36776"
+  ]
+}
+x-commit-hash: "d215061bff85153a2cefd55b213a93999f6637c6"

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.3.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.3.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune"
+  "dune" {>= "2.0.0"}
   "base-unix"
   "logs"
   "ppx_sexp_conv" {>="v0.13.0"}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.2.3.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.2.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "base-unix"
+  "logs"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "conduit-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+  "ca-certs"
+  "lwt_log" {with-test}
+  "ssl" {with-test}
+  "lwt_ssl" {with-test}
+]
+depopts: ["tls" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls" {< "0.11.0"}
+  "ssl" {< "0.5.9"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.3.0/conduit-v2.3.0.tbz"
+  checksum: [
+    "sha256=df52c4c0967ee8dfd044feca3cb90755132a5bc40e6b2884f64bf2d13755e72d"
+    "sha512=0783a6637035ed4c20dc96e995e73f978c9448b11d5caf6d1b351664c6ef0956261a0e44268dbd49953ac603b8b93b0e2b5f8ff4fd20e29ed20d317b10d36776"
+  ]
+}
+x-commit-hash: "d215061bff85153a2cefd55b213a93999f6637c6"

--- a/packages/conduit-lwt/conduit-lwt.2.3.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.2.3.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "2.0.0"}
   "base-unix"
   "ppx_sexp_conv" {>="v0.13.0"}
   "sexplib"

--- a/packages/conduit-lwt/conduit-lwt.2.3.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.2.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "conduit" {=version}
+  "lwt" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.3.0/conduit-v2.3.0.tbz"
+  checksum: [
+    "sha256=df52c4c0967ee8dfd044feca3cb90755132a5bc40e6b2884f64bf2d13755e72d"
+    "sha512=0783a6637035ed4c20dc96e995e73f978c9448b11d5caf6d1b351664c6ef0956261a0e44268dbd49953ac603b8b93b0e2b5f8ff4fd20e29ed20d317b10d36776"
+  ]
+}
+x-commit-hash: "d215061bff85153a2cefd55b213a93999f6637c6"

--- a/packages/conduit-mirage/conduit-mirage.2.3.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "dns-client" {>= "4.5.0"}
-  "conduit-lwt"
+  "conduit-lwt" {=version}
   "vchan" {>= "5.0.0"}
   "xenstore"
   "tls" {>= "0.11.0"}

--- a/packages/conduit-mirage/conduit-mirage.2.3.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.3.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "uri" {>= "4.0.0"}
+  "cstruct" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "dns-client" {>= "4.5.0"}
+  "conduit-lwt"
+  "vchan" {>= "5.0.0"}
+  "xenstore"
+  "tls" {>= "0.11.0"}
+  "tls-mirage" {>= "0.11.0"}
+  "ca-certs-nss"
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+  "tcpip" {with-test}
+]
+conflicts: [
+  "mirage-conduit"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.3.0/conduit-v2.3.0.tbz"
+  checksum: [
+    "sha256=df52c4c0967ee8dfd044feca3cb90755132a5bc40e6b2884f64bf2d13755e72d"
+    "sha512=0783a6637035ed4c20dc96e995e73f978c9448b11d5caf6d1b351664c6ef0956261a0e44268dbd49953ac603b8b93b0e2b5f8ff4fd20e29ed20d317b10d36776"
+  ]
+}
+x-commit-hash: "d215061bff85153a2cefd55b213a93999f6637c6"

--- a/packages/conduit-mirage/conduit-mirage.2.3.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.3.0/opam
@@ -6,8 +6,8 @@ tags: "org:mirage"
 homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
-  "ocaml" {>= "4.07.0"}
-  "dune"
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
   "ppx_sexp_conv" {>="v0.13.0"}
   "sexplib"
   "uri" {>= "4.0.0"}

--- a/packages/conduit/conduit.2.3.0/opam
+++ b/packages/conduit/conduit.2.3.0/opam
@@ -10,7 +10,7 @@ doc: "https://mirage.github.io/ocaml-conduit/"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>="2.0.0"}
   "ppx_sexp_conv" {>="v0.13.0"}
   "sexplib"
   "astring"

--- a/packages/conduit/conduit.2.3.0/opam
+++ b/packages/conduit/conduit.2.3.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "astring"
+  "uri"
+  "logs" {>= "0.5.0"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.3.0/conduit-v2.3.0.tbz"
+  checksum: [
+    "sha256=df52c4c0967ee8dfd044feca3cb90755132a5bc40e6b2884f64bf2d13755e72d"
+    "sha512=0783a6637035ed4c20dc96e995e73f978c9448b11d5caf6d1b351664c6ef0956261a0e44268dbd49953ac603b8b93b0e2b5f8ff4fd20e29ed20d317b10d36776"
+  ]
+}
+x-commit-hash: "d215061bff85153a2cefd55b213a93999f6637c6"

--- a/packages/fileutils/fileutils.0.6.0/opam
+++ b/packages/fileutils/fileutils.0.6.0/opam
@@ -12,7 +12,6 @@ depends: [
   "stdlib-shims"
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "oasis" {build}
   "ounit" {with-test & >= "2.0.0"}
 ]
 build: [

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.0.0/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.0.0/opam
@@ -11,6 +11,8 @@ depends: [
   "dune" {>= "2.6.0"}
   "git" {= version}
   "mimic"
+  "conduit" {< "2.3.0"}
+  "conduit-mirage" {< "2.3.0"}
   "cohttp-mirage"
   "cohttp" {>= "2.5.4"}
   "cohttp-lwt" {>= "2.5.4"}

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.1.0/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.1.0/opam
@@ -11,6 +11,8 @@ depends: [
   "dune" {>= "2.6.0"}
   "git" {= version}
   "mimic"
+  "conduit" {< "2.3.0"}
+  "conduit-mirage" {< "2.3.0"}
   "cohttp-mirage"
   "cohttp" {>= "2.5.4"}
   "cohttp-lwt" {>= "2.5.4"}

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.1.1/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.1.1/opam
@@ -11,6 +11,8 @@ depends: [
   "dune" {>= "2.6.0"}
   "git" {= version}
   "mimic"
+  "conduit" {< "2.3.0"}
+  "conduit-mirage" {< "2.3.0"}
   "cohttp-mirage"
   "cohttp" {>= "2.5.4"}
   "cohttp-lwt" {>= "2.5.4"}

--- a/packages/git-mirage/git-mirage.2.0.0/opam
+++ b/packages/git-mirage/git-mirage.2.0.0/opam
@@ -21,6 +21,7 @@ depends: [
   "cohttp-mirage"    {>= "1.0.0"}
   "mirage-flow-lwt"
   "mirage-channel-lwt"
+  "conduit"          {< "2.3.0"}
   "mirage-conduit"   {>= "3.0.0"}
   "git-http"         {>= "2.0.0"}
   "git"              {>= "2.0.0" & < "2.1.1"}

--- a/packages/git-mirage/git-mirage.2.1.0/opam
+++ b/packages/git-mirage/git-mirage.2.1.0/opam
@@ -21,6 +21,7 @@ depends: [
   "cohttp-mirage"    {>= "1.0.0"}
   "mirage-flow-lwt"
   "mirage-channel-lwt"
+  "conduit"          {< "2.3.0"}
   "mirage-conduit"   {>= "3.0.0"}
   "git-http"         {=version}
   "git"              {=version}

--- a/packages/git-mirage/git-mirage.2.1.1/opam
+++ b/packages/git-mirage/git-mirage.2.1.1/opam
@@ -21,7 +21,8 @@ depends: [
   "cohttp-mirage"    {>= "1.0.0"}
   "mirage-flow-lwt"
   "mirage-channel-lwt"
-  "conduit-mirage" {< "3.0.0"}
+  "conduit"          {< "2.3.0"}
+  "conduit-mirage"   {< "2.3.0"}
   "git-http"         {= version}
   "git"              {= version}
   "alcotest"         {with-test & >= "0.8.1"}

--- a/packages/git-mirage/git-mirage.2.1.3/opam
+++ b/packages/git-mirage/git-mirage.2.1.3/opam
@@ -21,7 +21,8 @@ depends: [
   "cohttp-mirage"     {>= "1.0.0"}
   "mirage-flow"       {>= "2.0.0"}
   "mirage-channel"    {>= "4.0.0"}
-  "conduit-mirage" {>= "2.2.0" & < "3.0.0"}
+  "conduit"           {< "2.3.0"}
+  "conduit-mirage"    {>= "2.2.0" & < "2.3.0"}
   "git-http"          {= version}
   "git"               {= version}
   "alcotest"          {with-test & >= "0.8.1"}

--- a/packages/gluten-mirage/gluten-mirage.0.2.1/opam
+++ b/packages/gluten-mirage/gluten-mirage.0.2.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "faraday-lwt"
   "gluten-lwt" {= version}
-  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
+  "conduit-mirage" {>= "2.0.2" & < "2.3.0"}
   "mirage-flow" {>= "2.0.0"}
   "cstruct"
   "dune" {>= "1.0"}

--- a/packages/h2-mirage/h2-mirage.0.1.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.1.0/opam
@@ -16,6 +16,7 @@ depends: [
   "h2-lwt" {< "0.5.0"}
   "dune"
   "lwt"
+  "conduit" {< "2.3.0"}
   "mirage-conduit"
   "cstruct"
 ]

--- a/packages/h2-mirage/h2-mirage.0.2.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.2.0/opam
@@ -12,12 +12,15 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04"}
+  "faraday"
   "faraday-lwt"
-  "h2-lwt" {>= "0.2.0" & < "0.3.0"}
+  "h2" {= version}
+  "h2-lwt" {= version}
   "dune"
   "lwt"
-  "conduit" {< "2.3.0"}
-  "mirage-conduit"
+  "conduit" {>= "1.0.0" & < "2.3.0"}
+  "conduit-lwt" {>= "1.0.0" & < "2.3.0"}
+  "mirage-conduit" {>= "3.0.0"}
   "cstruct"
 ]
 synopsis: "Mirage support for h2"

--- a/packages/h2-mirage/h2-mirage.0.2.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.2.0/opam
@@ -16,6 +16,7 @@ depends: [
   "h2-lwt" {>= "0.2.0" & < "0.3.0"}
   "dune"
   "lwt"
+  "conduit" {< "2.3.0"}
   "mirage-conduit"
   "cstruct"
 ]

--- a/packages/h2-mirage/h2-mirage.0.3.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.3.0/opam
@@ -15,6 +15,7 @@ depends: [
   "h2-lwt" {>= "0.3.0" & < "0.4.0"}
   "dune"
   "lwt"
+  "conduit" {< "2.3.0"}
   "mirage-conduit"
   "cstruct"
 ]

--- a/packages/h2-mirage/h2-mirage.0.4.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.4.0/opam
@@ -15,7 +15,8 @@ depends: [
   "h2-lwt" {= version}
   "dune" {>= "1.5"}
   "lwt"
-  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
+  "conduit" {< "2.3.0"}
+  "conduit-mirage" {>= "2.0.2" & < "2.3.0"}
   "mirage-flow" {>= "2.0.0"}
   "cstruct"
 ]

--- a/packages/h2-mirage/h2-mirage.0.6.1/opam
+++ b/packages/h2-mirage/h2-mirage.0.6.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.7"}
   "lwt"
   "gluten-mirage"
-  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
+  "conduit-mirage" {>= "2.0.2" & < "2.3.0"}
   "mirage-flow" {>= "2.0.0"}
   "cstruct"
 ]

--- a/packages/irmin-http/irmin-http.2.2.0/opam
+++ b/packages/irmin-http/irmin-http.2.2.0/opam
@@ -10,7 +10,6 @@ doc:          "https://mirage.github.io/irmin/"
 build: [
  ["dune" "subst"] {pinned}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
 ]
 
 depends: [
@@ -20,11 +19,6 @@ depends: [
   "webmachine" {>= "0.6.0"}
   "irmin" {>= "2.2.0" & < "2.3.0"}
   "cohttp-lwt" {>= "1.0.0"}
-  "irmin-git" {with-test & >= "2.2.0" & < "2.3.0"}
-  "irmin-mem" {with-test & >= "2.2.0" & < "2.3.0"}
-  "irmin-test" {with-test & >= "2.2.0" & < "2.3.0"}
-  "git-unix"   {with-test}
-  "digestif"   {with-test & >= "0.6.1"}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.0.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.0.0/opam
@@ -14,6 +14,7 @@ build: [
 
 depends: [
   "dune"       {>= "1.1.0"}
+  "conduit-mirage" {< "2.3.0"}
   "irmin-mirage" {< "2.2.0"}
   "irmin-git" {>= "2.0.0" & < "2.2.0"}
   "git-mirage" {>= "2.1.2" & < "3.0.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.2.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.2.0/opam
@@ -14,6 +14,7 @@ build: [
 
 depends: [
   "dune"       {>= "1.8.0"}
+  "conduit-mirage" {< "2.3.0"}
   "irmin-mirage" {>= "2.2.0" & < "2.3.0"}
   "irmin-git" {>= "2.2.0" & < "2.3.0"}
   "git-mirage" {>= "2.1.2" & < "3.0.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.4.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.4.0/opam
@@ -18,8 +18,8 @@ depends: [
   "irmin-git"    {= version}
   "mirage-kv"    {>= "3.0.0"}
   "cohttp"
-  "conduit-lwt"
-  "conduit-mirage"
+  "conduit-lwt" {< "2.3.0"}
+  "conduit-mirage" {< "2.3.0"}
   "git-cohttp-mirage" {>= "3.0.0" & < "3.3.0"}
   "fmt"
   "git"               {>= "3.0.0" & < "3.3.0"}

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.0.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.0.0/opam
@@ -14,6 +14,7 @@ build: [
 
 depends: [
   "dune"    {>= "1.1.0"}
+  "conduit-mirage" {< "2.3.0"}
   "irmin-mirage" {< "2.2.0"}
   "git-mirage" {>= "2.1.1" & < "3.0.0"}
   "irmin-graphql" {< "2.2.0"}

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.2.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.2.0/opam
@@ -14,6 +14,7 @@ build: [
 
 depends: [
   "dune"    {>= "1.8.0"}
+  "conduit-mirage" {< "2.3.0"}
   "irmin-mirage" {>= "2.2.0" & < "2.3.0"}
   "git-mirage" {>= "2.1.1" & < "3.0.0"}
   "irmin-graphql" {>= "2.2.0" & < "2.3.0"}

--- a/packages/mirage-conduit/mirage-conduit.3.1.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.1.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "3.1.0"
 maintainer: "anil@recoil.org"
 authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
 license: "ISC"

--- a/packages/mirage-conduit/mirage-conduit.3.1.0/opam
+++ b/packages/mirage-conduit/mirage-conduit.3.1.0/opam
@@ -6,6 +6,8 @@ license: "ISC"
 tags: "org:mirage"
 homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+synopsis: "A network connection establishment library for MirageOS"
+
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"

--- a/packages/yurt/yurt.0.5/opam
+++ b/packages/yurt/yurt.0.5/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "conduit-lwt-unix" {>= "1.0.0" & < "3.0.0"}
+  "conduit-lwt-unix" {>= "1.0.0" & < "2.3.0"}
   "cohttp-lwt-unix" {>= "1.0.0"}
   "lwt_log" {>= "1.0.0"}
   "ezjsonm" {>= "0.5.0"}

--- a/packages/yurt/yurt.0.6/opam
+++ b/packages/yurt/yurt.0.6/opam
@@ -10,7 +10,7 @@ doc: "https://zshipko.github.io/yurt/doc"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
-  "conduit-lwt-unix" {>= "1.0.0" & < "3.0.0"}
+  "conduit-lwt-unix" {>= "1.0.0" & < "2.3.0"}
   "cohttp-lwt-unix" {>= "1.0.0"}
   "lwt_log" {>= "1.0.0"}
   "ezjsonm" {>= "0.5.0"}


### PR DESCRIPTION
A network connection establishment library

- Project page: <a href="https://github.com/mirage/ocaml-conduit">https://github.com/mirage/ocaml-conduit</a>
- Documentation: <a href="https://mirage.github.io/ocaml-conduit/">https://mirage.github.io/ocaml-conduit/</a>

##### CHANGES:

* conduit-mirage: simplify the API to not mix functors and first-class
  modules anymore. We just use functors now and rely on the mirage tool
  to apply them properly (mirage/ocaml-conduit#376, @samoht)
* add client-side TLS certificate validation using OS trust anchors for
  `conduit-lwt-unix` and Mozilla's NSS for `conduit-mirage` (mirage/ocaml-conduit#375, @samoht)
