### PR TITLE
Bisect_ppx 2.6.0: code coverage analysis

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.2.6.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.6.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+
+synopsis: "Code coverage for OCaml"
+version: "2.6.0"
+license: "MIT"
+homepage: "https://github.com/aantron/bisect_ppx"
+doc: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+
+dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+
+depends: [
+  "base-unix"
+  "cmdliner" {>= "1.0.0"}
+  "dune" {>= "2.7.0"}
+  "ocaml" {>= "4.02.0"}
+  "ppxlib" {>= "0.21.0"}
+
+  "ocamlformat" {with-test & = "0.16.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@compatible"] {with-test}
+]
+
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+url {
+  src: "https://github.com/aantron/bisect_ppx/archive/2.6.0.tar.gz"
+  checksum: "md5=1e87162003525cd853631dae5b4aea66"
+}

--- a/packages/cuid/cuid.0.1/opam
+++ b/packages/cuid/cuid.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest" {with-test}
   "re" {with-test}
   "jbuilder"
-  "core" {< "v0.15"}
+  "core" {>= "v0.9.0" & < "v0.15"}
 ]
 synopsis: "CUID generator for OCaml."
 description: "For further information, please refer to http://usecuid.org"

--- a/packages/cuid/cuid.0.2/opam
+++ b/packages/cuid/cuid.0.2/opam
@@ -19,7 +19,7 @@ depends: [
     "alcotest" {with-test}
     "re"       {with-test}
     "dune" {>= "1.0"}
-    "core" {< "v0.15"}
+    "core" {>= "v0.9.0" & < "v0.15"}
     "nocrypto"
     "bisect_ppx" {< "2.6.0"}
 ]

--- a/packages/cuid/cuid.0.2/opam
+++ b/packages/cuid/cuid.0.2/opam
@@ -21,7 +21,7 @@ depends: [
     "dune" {>= "1.0"}
     "core" {< "v0.15"}
     "nocrypto"
-    "bisect_ppx"
+    "bisect_ppx" {< "2.6.0"}
 ]
 url {
   src: "https://github.com/marcoonroad/ocaml-cuid/archive/0.2.tar.gz"

--- a/packages/eigen/eigen.0.3.0/opam
+++ b/packages/eigen/eigen.0.3.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ctypes" {>= "0.14.0"}
   "dune" {>= "2.0.0"}
 ]
+available: arch != "ppc64"
 synopsis: "Owl's OCaml interface to Eigen3 C++ library"
 description:
 "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."

--- a/packages/exit/exit.0.0.1/opam
+++ b/packages/exit/exit.0.0.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://git.zapashcanon.fr/zapashcanon/exit/issues"
 depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "2.0"}
-  "bisect_ppx" {>= "1.4"}
+  "bisect_ppx" {>= "1.4" & < "2.6.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/gobba/gobba.0.4.1/opam
+++ b/packages/gobba/gobba.0.4.1/opam
@@ -11,7 +11,7 @@ doc: "https://0x0f0f0f.github.io/gobba"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["sh" "-c" "GOBBA_EXAMPLES=$(realpath ./examples/) dune runtest -p %{name}% -j %{jobs}%"] {with-test}
+  ["sh" "-c" "GOBBA_EXAMPLES=$(realpath ./examples/) dune runtest -p %{name}% -j %{jobs}%"] {with-test & arch != "x86_32" & arch != "arm32"}
 ]
 
 depends: [

--- a/packages/gobba/gobba.0.4.1/opam
+++ b/packages/gobba/gobba.0.4.1/opam
@@ -23,7 +23,7 @@ depends: [
     "ppx_deriving"
     "cmdliner"
     "alcotest" {with-test & >= "0.8.5"}
-    "bisect_ppx" {with-test >= "1.4.1"}
+    "bisect_ppx" {with-test >= "1.4.1" & < "2.6.0"}
 ]
 url {
   src:

--- a/packages/gobba/gobba.0.4.2/opam
+++ b/packages/gobba/gobba.0.4.2/opam
@@ -27,7 +27,7 @@ depends: [
     "owl"
     "owl-base"
     "alcotest" {with-test & >= "0.8.5"}
-    "bisect_ppx" {>= "1.4.1"}
+    "bisect_ppx" {>= "1.4.1" & < "2.6.0"}
 ]
 url {
   src: "https://github.com/0x0f0f0f/gobba/archive/0.4.2.tar.gz"

--- a/packages/hc/hc.0.0.1/opam
+++ b/packages/hc/hc.0.0.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://git.zapashcanon.fr/zapashcanon/hc/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.11.0"}
-  "bisect_ppx" {>= "1.4.1"}
+  "bisect_ppx" {>= "1.4.1" & < "2.6.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/memo/memo.0.0.1/opam
+++ b/packages/memo/memo.0.0.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://git.zapashcanon.fr/zapashcanon/memo/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.11.0"}
-  "bisect_ppx" {>= "1.4.1"}
+  "bisect_ppx" {>= "1.4.1" & < "2.6.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/omg/omg.0.0.1/opam
+++ b/packages/omg/omg.0.0.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://git.zapashcanon.fr/zapashcanon/omg/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.11.0"}
-  "bisect_ppx"
+  "bisect_ppx" {< "2.6.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/opazl/opazl.0.0.1/opam
+++ b/packages/opazl/opazl.0.0.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://git.zapashcanon.fr/zapashcanon/opazl/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.11.0"}
-  "bisect_ppx" {>= "1.4.1"}
+  "bisect_ppx" {>= "1.4.1" & < "2.6.0"}
   "sedlex" {>= "2.1"}
 ]
 build: [

--- a/packages/owl/owl.1.0.0/opam
+++ b/packages/owl/owl.1.0.0/opam
@@ -35,6 +35,7 @@ depends: [
   "stdio" {build}
   "npy"
 ]
+available: arch != "arm64" & arch != "arm32"
 x-commit-hash: "f164864baf68f94a19a09b19ed377db433d7aa2a"
 url {
   src: "https://github.com/owlbarn/owl/releases/download/1.0.0/owl-1.0.0.tbz"

--- a/packages/partition_map/partition_map.0.9.0/opam
+++ b/packages/partition_map/partition_map.0.9.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "jbuilder" {>= "1.0+beta19"}
   "bisect_ppx"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 synopsis: "Partition maps"
 description: """

--- a/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.1/opam
+++ b/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "jbuilder"
   "cppo" {build}
-  "bisect_ppx" {build}
+  "bisect_ppx" {build & < "2.6.0"}
   "core_kernel" {< "v0.15"}
   "ctypes"
   "ctypes-foreign"

--- a/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.2/opam
+++ b/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.2/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "dune"
   "cppo" {build}
-  "bisect_ppx" {build}
+  "bisect_ppx" {build & < "2.6.0"}
   "core_kernel" {< "v0.15"}
   "ctypes"
   "ctypes-foreign"

--- a/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.2/opam
+++ b/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.2/opam
@@ -5,7 +5,7 @@ homepage: "https://gitlab.com/darrenldl/ocaml-reed-solomon-erasure"
 bug-reports: "https://gitlab.com/darrenldl/ocaml-reed-solomon-erasure/issues"
 license: "MIT"
 dev-repo: "git+https://gitlab.com/darrenldl/ocaml-reed-solomon-erasure.git"
-build: ["dune" "build"]
+build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.06"}
   "dune"
@@ -15,6 +15,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
+available: arch != "ppc64"
 synopsis: "OCaml implementation of Reed-Solomon erasure coding"
 description: """
 This library provides an encoder/decoder for Reed-Solomon erasure code.

--- a/packages/so/so.0.0.1/opam
+++ b/packages/so/so.0.0.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://git.zapashcanon.fr/zapashcanon/so/issues"
 depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "2.0"}
-  "bisect_ppx" {>= "1.4"}
+  "bisect_ppx" {>= "1.4" & < "2.6.0"}
   "ocaml-xdg-basedir" {>= "0.0.3"}
 ]
 build: [


### PR DESCRIPTION
[Changelog](https://github.com/aantron/bisect_ppx/releases/tag/2.6.0):

<br/>

> Changes
>
> - Port to ppxlib (aantron/bisect_ppx#327, Sonja Heinze).
> - CSS: use ligature fonts, if installed (aantron/bisect_ppx#339).
> - Internal: switch to Dune cram tests, finding lots of bugs in the process (aantron/bisect_ppx@beb80b3, aantron/bisect_ppx@593a7c2, aantron/bisect_ppx#352).
>
> Bugs fixed
>
> - Workaround for typing issue with instrumentation of or-patterns under GADTs; includes a new `match` instrumenter (aantron/bisect_ppx#325, reported by Mehdi Bouaziz).
> - The second subexpression of `(||)` and `(&&)` is in tail position iff the whole expression is in tail position; Bisect was unconditionally wrapping the second expression in successor code (aantron/bisect_ppx#359, reported by Benjamin Monate).
> - HTML: words that have an instrumentation point on one of their characters were not searchable (aantron/bisect_ppx#346).
> - Don't clobber the global random number generator (aantron/bisect_ppx#344).
> - `(or)` nested inside `(||)` not properly instrumented (aantron/bisect_ppx#347).
> - Subexpressions of `Pexp_newtype` were always treated as if they were in tail position (aantron/bisect_ppx#348).
> - `assert` instrumentation was placed at the wrong point in the generated code (aantron/bisect_ppx#349).
> - `assert false` should not be instrumented; the point is unreachable (aantron/bisect_ppx#355).
> - Instrumentation of or-patterns inside local `open` patterns could trigger unused `open` warning (aantron/bisect_ppx#350).
>
> Removed
>
> *These removals were planned and announced in the 2.0.0 release.*
>
> - PPX option `--mode` (aantron/bisect_ppx#200).
> - PPX option `--no-comment-parsing` (aantron/bisect_ppx#202).
> - PPX option `--exclude` (aantron/bisect_ppx#244).
> - PPX option `--exclude-file`, which has been renamed to `--exclusions` (aantron/bisect_ppx#245).
> - Reporter options `--html`, `--text`, `--coveralls`, which have been replaced by `html`, `summary`, `send-to` subcommands, respectively (aantron/bisect_ppx#145).
> - Support for discovering `.out` files. Bisect switched to extension `.coverage` in 2.0.0 (aantron/bisect_ppx#110).
> - `--dump`, `--csv`, and the old-style text report (aantron/bisect_ppx#251).
> - The old command line, including single-dashed (`-`) multi-character options, and usage of `bisect-ppx-report` without a subcommand (such as `bisect-ppx-report html`) (aantron/bisect_ppx#145).
