### PR TITLE
[new release] bitv (1.6)

### DIFF
--- a/packages/bitv/bitv.1.6/opam
+++ b/packages/bitv/bitv.1.6/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "filliatr@lri.fr"
+authors: "Jean-Christophe Filliâtre"
+license: "LGPL v2"
+synopsis: "A bit vector library for OCaml"
+description: "A bit vector library for OCaml"
+homepage: "https://github.com/backtracking/bitv"
+bug-reports: "https://github.com/backtracking/bitv/issues"
+doc: "https://backtracking.github.io/bitv"
+depends: [
+  "ocaml"
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/backtracking/bitv.git"
+x-commit-hash: "399c05ca24a65b22b8e48cde198e25addb617d89"
+url {
+  src:
+    "https://github.com/backtracking/bitv/releases/download/1.6/bitv-1.6.tbz"
+  checksum: [
+    "sha256=222ba9d8d518880a27e83d4a0ca564c2bdaf46423b7302bed675b947dde3e449"
+    "sha512=c67efe637a6c7a93f8e82e40e137122a1125073350ae3a397c10e85b40e748cfcd20df0e8fe8d700886770d68185f6615d7199d500d1b8bcf98e4a57ddab5df6"
+  ]
+}


### PR DESCRIPTION
A bit vector library for OCaml

- Project page: <a href="https://github.com/backtracking/bitv">https://github.com/backtracking/bitv</a>
- Documentation: <a href="https://backtracking.github.io/bitv">https://backtracking.github.io/bitv</a>

##### CHANGES:

- fixed build on 32-bit platforms e.g. js_of_ocaml (patch from Tim Bourke)
  - added `exceeds_max_length` to replace `max_length` (deprecated)
