### PR TITLE
Package ppx_cstubs.0.6.0

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.6.0/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "https://fdopen.github.io/ppx_cstubs/"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+doc: "https://fdopen.github.io/ppx_cstubs/"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ctypes" {>= "0.13.0" & < "0.18"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.04.2" & < "4.13.0"}
+  "ppxlib" {>= "0.18.0" & < "0.22.0"}
+  "ocamlfind" {>= "1.7.2"} # not only a build dependency, it depends on findlib.top
+  "dune" {>= "1.6"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: """
+Preprocessor for easier stub generation with ctypes
+"""
+
+description: """
+ppx_cstubs is a ppx-based preprocessor for stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file
+with c stub code and an OCaml file with all additional boilerplate
+code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.6.0.tar.gz"
+  checksum: [
+    "md5=418ecd021b602cc51e16f2610fb6dff2"
+    "sha512=db0a8c1f3d9d4a0019f4533faaf7a10ac52dd8b9e7881e9ad4c8fc786ae57c860aec95fbaa42cd4c5acb3fbefb6162828c90e3fd7536692c80dce7f68e4410e4"
+  ]
+}


### PR DESCRIPTION
### `ppx_cstubs.0.6.0`
Preprocessor for easier stub generation with ctypes
ppx_cstubs is a ppx-based preprocessor for stub generation with
ctypes. ppx_cstubs creates two files from a single ml file: a file
with c stub code and an OCaml file with all additional boilerplate
code.



---
* Homepage: https://fdopen.github.io/ppx_cstubs/
* Source repo: git+https://github.com/fdopen/ppx_cstubs.git
* Bug tracker: https://github.com/fdopen/ppx_cstubs/issues

---
:camel: Pull-request generated by opam-publish v2.0.3