### PR TITLE
[new release] base64 (3.5.0)

### DIFF
--- a/packages/base64/base64.3.5.0/opam
+++ b/packages/base64/base64.3.5.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: [ "Thomas Gazagnaire"
+           "Anil Madhavapeddy" "Calascibetta Romain"
+           "Peter Zotov" ]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-base64"
+doc: "http://mirage.github.io/ocaml-base64/"
+bug-reports: "https://github.com/mirage/ocaml-base64/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-base64.git"
+synopsis: "Base64 encoding for OCaml"
+description: """
+Base64 is a group of similar binary-to-text encoding schemes that represent
+binary data in an ASCII string format by translating it into a radix-64
+representation.  It is specified in RFC 4648.
+"""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "bos" {with-test}
+  "rresult" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+x-commit-hash: "3a5e259895acef979a0fab8bb59d396e1bccead0"
+url {
+  src:
+    "https://github.com/mirage/ocaml-base64/releases/download/v3.5.0/base64-v3.5.0.tbz"
+  checksum: [
+    "sha256=589de9c00578ebfe784198ac9818d3586c474b2316b6cd3e1c46ccb1f62ae3a4"
+    "sha512=82efc76ca75717dbd533eac20845ca8731f535233f6a3e6081114d7e3dc7ee8367ded16f402ef05ad0bf1217a3a6224161c92b9467023e44fc7f3598a314a432"
+  ]
+}


### PR DESCRIPTION
Base64 encoding for OCaml

- Project page: <a href="https://github.com/mirage/ocaml-base64">https://github.com/mirage/ocaml-base64</a>
- Documentation: <a href="http://mirage.github.io/ocaml-base64/">http://mirage.github.io/ocaml-base64/</a>

##### CHANGES:

- Fix support for `x-compilation` (@samoht, mirage/ocaml-base64#44)
- Update to `dune.2.0` and apply `ocamlformat` (@samoht, mirage/ocaml-base64#45)
- Select `unsafe.ml` only with `dune` (@emillon, mirage/ocaml-base64#46)
- Remove indirect dependecy to `ocamlfind` (@kit-ty-kate, mirage/ocaml-base64#49)
- Hide internals of `base64` and return a `string` as the alphabet (@reynir, mirage/ocaml-base64#48)
  **breaking chnages** `Base64.alphabet` is updated and return a simple `string` now
