### PR TITLE
2 packages from LexiFi/gen_js_api at 1.0.7

### DIFF
--- a/packages/conf-npm/conf-npm.1/opam
+++ b/packages/conf-npm/conf-npm.1/opam
@@ -10,7 +10,8 @@ build: [
 depexts: [
   ["npm"] {os-distribution = "alpine"}
   ["npm"] {os-distribution = "arch"}
-  ["npm"] {os-distribution = "centos"}
+  ["epel-release" "npm"] {os-distribution = "centos"}
+  ["npm"] {os-distribution = "ol" & os-version >= "8"}
   ["npm"] {os-family = "debian"}
   ["npm"] {os-distribution = "fedora"}
   ["npm"] {os = "freebsd"}
@@ -20,6 +21,9 @@ depexts: [
   ["nodejs"] {os = "netbsd"}
   ["node"] {os = "openbsd"}
   ["npm"] {os-family = "suse"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7" # not available
 ]
 synopsis: "Virtual package relying on npm installation"
 flags: conf

--- a/packages/cordova-plugin-background-mode/cordova-plugin-background-mode.1.0/opam
+++ b/packages/cordova-plugin-background-mode/cordova-plugin-background-mode.1.0/opam
@@ -14,6 +14,7 @@ remove: ["ocamlfind" "remove" "cordova-plugin-background-mode"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "gen_js_api"
+  "js_of_ocaml"
   "ocamlfind" {build}
 ]
 synopsis: "Binding to cordova-plugin-background-mode using gen_js_api."

--- a/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.1.0/opam
+++ b/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.1.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
   "gen_js_api"
+  "js_of_ocaml"
 ]
 synopsis: "Binding OCaml to cordova-plugin-battery-status using gen_js_api."
 description: """

--- a/packages/cordova-plugin-local-notifications/cordova-plugin-local-notifications.1.0/opam
+++ b/packages/cordova-plugin-local-notifications/cordova-plugin-local-notifications.1.0/opam
@@ -13,6 +13,7 @@ remove: ["ocamlfind" "remove" "cordova-plugin-local-notifications"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "gen_js_api"
+  "js_of_ocaml"
   "ocamlfind" {build}
 ]
 synopsis: "Binding to cordova-plugin-local-notifications using gen_js_api."

--- a/packages/cordova-plugin-sim-card/cordova-plugin-sim-card.1.0/opam
+++ b/packages/cordova-plugin-sim-card/cordova-plugin-sim-card.1.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
   "gen_js_api"
+  "js_of_ocaml"
   "cordova"
 ]
 synopsis: "Binding OCaml to cordova-plugin-sim-card using gen_js_api."

--- a/packages/cordova/cordova.1.0/opam
+++ b/packages/cordova/cordova.1.0/opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
   "gen_js_api"
+  "js_of_ocaml"
 ]
 synopsis: "Binding OCaml to cordova Javascript object."
 description: """

--- a/packages/gen_js_api/gen_js_api.1.0.7/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.7/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Easy OCaml bindings for JavaScript libraries"
+description: """
+
+gen_js_api aims at simplifying the creation of OCaml bindings for
+JavaScript libraries.  Authors of bindings write OCaml signatures for
+JavaScript libraries and the tool generates the actual binding code
+with a combination of implicit conventions and explicit annotations.
+
+gen_js_api is to be used with the js_of_ocaml compiler.
+ """
+maintainer: ["Alain Frisch <alain.frisch@lexifi.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Sebastien Briais <sebastien.briais@lexifi.com>"
+]
+license: "MIT"
+homepage: "https://github.com/LexiFi/gen_js_api"
+bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.9"}
+  "ocaml-migrate-parsetree" {>= "1.6.0" & < "2.0.0"}
+  "js_of_ocaml-compiler" {with-test}
+  "conf-npm" {with-test}
+  "ojs"
+]
+conflicts: [
+  "js_of_ocaml-compiler" {< "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/LexiFi/gen_js_api.git"
+url {
+  src: "https://github.com/LexiFi/gen_js_api/archive/v1.0.7.tar.gz"
+  checksum: [
+    "md5=a9e7bf3e65a7b3e6ebefd2bee35d4adf"
+    "sha512=cacb5bbdfb255aa2dae498b8168d7e18ade890b0c63fc29684b1493531ba671cac981f59ac86991783b75c117c86900241669bf92070ca9c4749947a243018d5"
+  ]
+}

--- a/packages/gen_js_api/gen_js_api.1.0.7/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.7/opam
@@ -29,6 +29,9 @@ depends: [
 conflicts: [
   "js_of_ocaml-compiler" {< "3.0.0"}
 ]
+x-ci-accept-failures: [
+  "ubuntu-16.04" # npm is too old for the tests
+]
 build: [
   ["dune" "subst"] {pinned}
   [

--- a/packages/ocaml-js-stdlib/ocaml-js-stdlib.1.0/opam
+++ b/packages/ocaml-js-stdlib/ocaml-js-stdlib.1.0/opam
@@ -15,6 +15,9 @@ depends: [
   "ocamlfind" {build}
   "gen_js_api"
 ]
+conflicts: [
+  "gen_js_api" {> "1.0.6"}
+]
 synopsis: "Binding OCaml to JavaScript standard library"
 description: "Binding OCaml to JavaScript standard library"
 url {

--- a/packages/ojs/ojs.1.0.7/opam
+++ b/packages/ojs/ojs.1.0.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Runtime Library for gen_js_api generated libraries"
+description: "To be used in conjunction with gen_js_api"
+maintainer: ["Alain Frisch <alain.frisch@lexifi.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Sebastien Briais <sebastien.briais@lexifi.com>"
+]
+license: "MIT"
+homepage: "https://github.com/LexiFi/gen_js_api"
+bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+]
+conflicts: [
+  "js_of_ocaml-compiler" {< "3.0.0"}
+]
+dev-repo: "git+https://github.com/LexiFi/gen_js_api.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+url {
+  src: "https://github.com/LexiFi/gen_js_api/archive/v1.0.7.tar.gz"
+  checksum: [
+    "md5=a9e7bf3e65a7b3e6ebefd2bee35d4adf"
+    "sha512=cacb5bbdfb255aa2dae498b8168d7e18ade890b0c63fc29684b1493531ba671cac981f59ac86991783b75c117c86900241669bf92070ca9c4749947a243018d5"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`gen_js_api.1.0.7`: Easy OCaml bindings for JavaScript libraries
-`ojs.1.0.7`: Runtime Library for gen_js_api generated libraries



---
* Homepage: https://github.com/LexiFi/gen_js_api
* Source repo: git+https://github.com/LexiFi/gen_js_api.git
* Bug tracker: https://github.com/LexiFi/gen_js_api/issues

---
:camel: Pull-request generated by opam-publish v2.0.3