### PR TITLE
ppx_irmin: remove cycles with tests

### DIFF
--- a/packages/ppx_irmin/ppx_irmin.2.2.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.2.2.0/opam
@@ -8,7 +8,6 @@ dev-repo: "git+https://github.com/mirage/irmin.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
@@ -16,7 +15,6 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "ocaml-syntax-shims"
   "ppxlib" {>= "0.12.0" & < "0.18.0"}
-  "irmin" {with-test & >= "2.2.0" & < "2.3.0"}
 ]
 
 synopsis: "PPX deriver for Irmin generics"

--- a/packages/ppx_irmin/ppx_irmin.2.3.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.2.3.0/opam
@@ -8,7 +8,6 @@ dev-repo: "git+https://github.com/mirage/irmin.git"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
@@ -16,7 +15,6 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "ppxlib" {>= "0.12.0" & < "0.18.0"}
   "ppx_repr" {>= "0.2.0"}
-  "irmin" {with-test & post & = version}
 ]
 
 synopsis: "PPX deriver for Irmin type representations"

--- a/packages/ppx_irmin/ppx_irmin.2.4.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.2.4.0/opam
@@ -8,13 +8,11 @@ dev-repo: "git+https://github.com/mirage/irmin.git"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
   "dune" {>= "2.7.0"}
   "ppx_repr" {>= "0.2.0"}
-  "irmin" {with-test & post & = version}
 ]
 
 synopsis: "PPX deriver for Irmin type representations"


### PR DESCRIPTION
This fixes stuff like:

```
opam list --readonly '--resolve=ppx_irmin.2.2.0' --rec --with-test
# Packages matching: (installed | available) & solution(ppx_irmin.2.2.0)
[ERROR] No solution for ppx_irmin.2.2.0: The actions to process have cyclic dependencies:
          - install irmin.2.2.0 -> install ppx_irmin.2.2.0 -> install irmin.2.2.0
```