### PR TITLE
cinaps: break cyclic test dependency

### DIFF
--- a/packages/cinaps/cinaps.v0.15.0/opam
+++ b/packages/cinaps/cinaps.v0.15.0/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml" {>= "4.04"}
   "dune" {>= "2.0.0"}
   "re"   {>= "1.8.0"}
-  "ppx_jane" {with-test}
   "base-unix"
 ]
 synopsis: "Trivial metaprogramming tool"


### PR DESCRIPTION
Otherwise:

```
[ERROR] No solution for irmin-indexeddb.2.0: The actions to process have cyclic dependencies:
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_variants_conv.v0.14.1 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_typerep_conv.v0.14.1 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_stable.v0.14.1 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_pipebang.v0.14.0 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_optional.v0.14.0 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_optcomp.v0.14.1 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_let.v0.14.0 -> install ppx_jane.v0.14.0
          - install base_quickcheck.v0.14.0 -> install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_let.v0.14.0 -> install base_quickcheck.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_here.v0.14.0 -> install ppx_sexp_value.v0.14.0 -> install ppx_jane.v0.14.0
          - install base_quickcheck.v0.14.0 -> install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_here.v0.14.0 -> install ppx_sexp_value.v0.14.0 -> install base_quickcheck.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_here.v0.14.0 -> install ppx_sexp_message.v0.14.1 -> install ppx_jane.v0.14.0
          - install base_quickcheck.v0.14.0 -> install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_here.v0.14.0 -> install ppx_sexp_message.v0.14.1 -> install base_quickcheck.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_here.v0.14.0 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_fixed_literal.v0.14.0 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_fields_conv.v0.14.2 -> install ppx_jane.v0.14.0
          - install base_quickcheck.v0.14.0 -> install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_fields_conv.v0.14.2 -> install base_quickcheck.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_custom_printf.v0.14.1 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_bin_prot.v0.14.0 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_base.v0.14.0 -> install ppx_string.v0.14.1 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_base.v0.14.0 -> install ppx_jane.v0.14.0
          - install base_quickcheck.v0.14.0 -> install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_base.v0.14.0 -> install base_quickcheck.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_assert.v0.14.0 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_assert.v0.14.0 -> install jst-config.v0.14.0 -> install time_now.v0.14.0 -> install ppx_module_timer.v0.14.0 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_assert.v0.14.0 -> install jst-config.v0.14.0 -> install time_now.v0.14.0 -> install ppx_inline_test.v0.14.1 -> install ppx_jane.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_assert.v0.14.0 -> install jst-config.v0.14.0 -> install time_now.v0.14.0 -> install ppx_inline_test.v0.14.1 -> install ppx_expect.v0.14.1 -> install ppx_jane.v0.14.0
          - install base_quickcheck.v0.14.0 -> install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_assert.v0.14.0 -> install jst-config.v0.14.0 -> install time_now.v0.14.0 -> install ppx_inline_test.v0.14.1 -> install ppx_bench.v0.14.1 -> install splittable_random.v0.14.0 -> install base_quickcheck.v0.14.0
          - install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install ppx_assert.v0.14.0 -> install jst-config.v0.14.0 -> install time_now.v0.14.0 -> install ppx_inline_test.v0.14.1 -> install ppx_bench.v0.14.1 -> install ppx_jane.v0.14.0
          - install base_quickcheck.v0.14.0 -> install ppx_jane.v0.14.0 -> install cinaps.v0.15.0 -> install ppxlib.0.21.0 -> install base_quickcheck.v0.14.0
```