### PR TITLE
8 packages from ocaml/opam at 2.0.8

### DIFF
--- a/packages/opam-client/opam-client.2.0.8/opam
+++ b/packages/opam-client/opam-client.2.0.8/opam
@@ -23,7 +23,7 @@ depends: [
   "opam-solver" {= version}
   "re" {>= "1.7.2"}
   "cmdliner" {>= "0.9.8"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-client/opam-client.2.0.8/opam
+++ b/packages/opam-client/opam-client.2.0.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "opam 2.0 development libraries (client)"
+description:
+  "Actions on the opam root, switches, installations, and front-end."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-state" {= version}
+  "opam-solver" {= version}
+  "re" {>= "1.7.2"}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.8.tar.gz"
+  checksum: [
+    "md5=0b798434a6275212ec58922068cde186"
+    "sha512=14737dc994be2c54dfeaf2658d3713178033e1bc2b4b845a58b4bfc118bbbf12b502924add0ae32b4b2b6c1944462e5ee7143df3de362d9ee39573249d013bc9"
+  ]
+}

--- a/packages/opam-core/opam-core.2.0.8/opam
+++ b/packages/opam-core/opam-core.2.0.8/opam
@@ -23,7 +23,7 @@ depends: [
   "base-bigarray"
   "ocamlgraph"
   "re" {>= "1.5.0"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
   "cppo" {build}
 ]
 conflicts: ["extlib-compat"]

--- a/packages/opam-core/opam-core.2.0.8/opam
+++ b/packages/opam-core/opam-core.2.0.8/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "opam 2.0 development libraries (core)"
+description:
+  "Small standard library extensions, and generic system interaction modules used by opam."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.5.0"}
+  "dune" {build & >= "1.2.1"}
+  "cppo" {build}
+]
+conflicts: ["extlib-compat"]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.8.tar.gz"
+  checksum: [
+    "md5=0b798434a6275212ec58922068cde186"
+    "sha512=14737dc994be2c54dfeaf2658d3713178033e1bc2b4b845a58b4bfc118bbbf12b502924add0ae32b4b2b6c1944462e5ee7143df3de362d9ee39573249d013bc9"
+  ]
+}

--- a/packages/opam-devel/opam-devel.2.0.8/opam
+++ b/packages/opam-devel/opam-devel.2.0.8/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
   "cmdliner" {>= "0.9.8"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-devel/opam-devel.2.0.8/opam
+++ b/packages/opam-devel/opam-devel.2.0.8/opam
@@ -26,7 +26,7 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test & os-distribution = "debian" & arch = "x86_64"}
+  [make "tests"] {with-test & os-distribution = "debian" & arch = "x86_64" & opam-version < "2.1"}
 ]
 post-messages:
   """\

--- a/packages/opam-devel/opam-devel.2.0.8/opam
+++ b/packages/opam-devel/opam-devel.2.0.8/opam
@@ -26,7 +26,7 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
+  [make "tests"] {with-test & os-distribution = "debian" & arch = "x86_64"}
 ]
 post-messages:
   """\

--- a/packages/opam-devel/opam-devel.2.0.8/opam
+++ b/packages/opam-devel/opam-devel.2.0.8/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "opam 2.0 bootstrapped binary"
+description:
+  "This package compiles (bootstraps) opam. For consistency and safety of the installation, the binaries are not installed into the PATH, but into lib/opam-devel, from where the user can manually install them system-wide."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-client" {= version}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+  [make "tests"] {with-test}
+]
+post-messages:
+  """\
+The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/opam /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2="OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""""
+    {success}
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.8.tar.gz"
+  checksum: [
+    "md5=0b798434a6275212ec58922068cde186"
+    "sha512=14737dc994be2c54dfeaf2658d3713178033e1bc2b4b845a58b4bfc118bbbf12b502924add0ae32b4b2b6c1944462e5ee7143df3de362d9ee39573249d013bc9"
+  ]
+}

--- a/packages/opam-format/opam-format.2.0.8/opam
+++ b/packages/opam-format/opam-format.2.0.8/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "opam 2.0 development libraries (format)"
+description: "Definition of opam datastructures and its file interface."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-core" {= version}
+  "opam-file-format" {>= "2.0.0~rc2" & <= "2.1.0"}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.8.tar.gz"
+  checksum: [
+    "md5=0b798434a6275212ec58922068cde186"
+    "sha512=14737dc994be2c54dfeaf2658d3713178033e1bc2b4b845a58b4bfc118bbbf12b502924add0ae32b4b2b6c1944462e5ee7143df3de362d9ee39573249d013bc9"
+  ]
+}

--- a/packages/opam-format/opam-format.2.0.8/opam
+++ b/packages/opam-format/opam-format.2.0.8/opam
@@ -19,8 +19,8 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= version}
-  "opam-file-format" {>= "2.0.0~rc2" & <= "2.1.0"}
-  "dune" {build & >= "1.2.1"}
+  "opam-file-format" {>= "2.0.0~rc2" & < "2.1.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-installer/opam-installer.2.0.8/opam
+++ b/packages/opam-installer/opam-installer.2.0.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Installation of files to a prefix, following opam conventions"
+description: """\
+opam-installer is a small tool that can read *.install files, as defined by opam [1], and execute them to install or remove package files without going through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.8.tar.gz"
+  checksum: [
+    "md5=0b798434a6275212ec58922068cde186"
+    "sha512=14737dc994be2c54dfeaf2658d3713178033e1bc2b4b845a58b4bfc118bbbf12b502924add0ae32b4b2b6c1944462e5ee7143df3de362d9ee39573249d013bc9"
+  ]
+}

--- a/packages/opam-installer/opam-installer.2.0.8/opam
+++ b/packages/opam-installer/opam-installer.2.0.8/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
   "cmdliner" {>= "0.9.8"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-repository/opam-repository.2.0.8/opam
+++ b/packages/opam-repository/opam-repository.2.0.8/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "opam 2.0 development libraries (repository)"
+description:
+  "This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.8.tar.gz"
+  checksum: [
+    "md5=0b798434a6275212ec58922068cde186"
+    "sha512=14737dc994be2c54dfeaf2658d3713178033e1bc2b4b845a58b4bfc118bbbf12b502924add0ae32b4b2b6c1944462e5ee7143df3de362d9ee39573249d013bc9"
+  ]
+}

--- a/packages/opam-repository/opam-repository.2.0.8/opam
+++ b/packages/opam-repository/opam-repository.2.0.8/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-solver/opam-solver.2.0.8/opam
+++ b/packages/opam-solver/opam-solver.2.0.8/opam
@@ -23,7 +23,7 @@ depends: [
   "mccs" {>= "1.1+9"}
   "dose3" {>= "5"}
   "cudf" {>= "0.7"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-solver/opam-solver.2.0.8/opam
+++ b/packages/opam-solver/opam-solver.2.0.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "opam 2.0 development libraries (solver)"
+description:
+  "Solver and Cudf interaction. This library is based on the Cudf and Dose libraries, and handles calls to the external solver from opam."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "mccs" {>= "1.1+9"}
+  "dose3" {>= "5"}
+  "cudf" {>= "0.7"}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.8.tar.gz"
+  checksum: [
+    "md5=0b798434a6275212ec58922068cde186"
+    "sha512=14737dc994be2c54dfeaf2658d3713178033e1bc2b4b845a58b4bfc118bbbf12b502924add0ae32b4b2b6c1944462e5ee7143df3de362d9ee39573249d013bc9"
+  ]
+}

--- a/packages/opam-state/opam-state.2.0.8/opam
+++ b/packages/opam-state/opam-state.2.0.8/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-repository" {= version}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-state/opam-state.2.0.8/opam
+++ b/packages/opam-state/opam-state.2.0.8/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "opam 2.0 development libraries (state)"
+description:
+  "Handling of the ~/.opam hierarchy, repository and switch states."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-repository" {= version}
+  "dune" {build & >= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.8.tar.gz"
+  checksum: [
+    "md5=0b798434a6275212ec58922068cde186"
+    "sha512=14737dc994be2c54dfeaf2658d3713178033e1bc2b4b845a58b4bfc118bbbf12b502924add0ae32b4b2b6c1944462e5ee7143df3de362d9ee39573249d013bc9"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`opam-client.2.0.8`: opam 2.0 development libraries (client)
-`opam-core.2.0.8`: opam 2.0 development libraries (core)
-`opam-devel.2.0.8`: opam 2.0 bootstrapped binary
-`opam-format.2.0.8`: opam 2.0 development libraries (format)
-`opam-installer.2.0.8`: Installation of files to a prefix, following opam conventions
-`opam-repository.2.0.8`: opam 2.0 development libraries (repository)
-`opam-solver.2.0.8`: opam 2.0 development libraries (solver)
-`opam-state.2.0.8`: opam 2.0 development libraries (state)



---
* Source repo: git+https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---
:camel: Pull-request generated by opam-publish v2.0.3