### PR TITLE
Package obelisk.0.6.0

### DIFF
--- a/packages/obelisk/obelisk.0.6.0/opam
+++ b/packages/obelisk/obelisk.0.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Pretty-printing for Menhir files"
+description: """
+Obelisk is a simple tool which produces pretty-printed output from a Menhir parser file (.mly).
+It is inspired from yacc2latex and is also written in OCaml, but is aimed at supporting features from Menhir instead of only those of ocamlyacc."""
+maintainer: ["Lélio Brun <lelio.brun@inria.fr>"]
+authors: ["Lélio Brun"]
+license: "MIT"
+homepage: "https://github.com/Lelio-Brun/Obelisk"
+doc: "https://github.com/Lelio-Brun/Obelisk/blob/master/README.md"
+bug-reports: "https://github.com/Lelio-Brun/obelisk/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.2.0"}
+  "re"
+  "menhir"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Lelio-Brun/obelisk.git"
+url {
+  src: "https://github.com/Lelio-Brun/Obelisk/archive/v0.6.0.tar.gz"
+  checksum: [
+    "md5=1494ac4b54ad165d2ddea26a0f54d2dc"
+    "sha512=a911070bb474e75c9332dac208c9916ef6be2f46148cafec9ce9c920f07e782d26796cb2f77ecb7f62247c6f56a53bc34aaf66d37ce5ab6d148e1459dd61a8e0"
+  ]
+}


### PR DESCRIPTION
### `obelisk.0.6.0`
Pretty-printing for Menhir files
Obelisk is a simple tool which produces pretty-printed output from a Menhir parser file (.mly).
It is inspired from yacc2latex and is also written in OCaml, but is aimed at supporting features from Menhir instead of only those of ocamlyacc.



---
* Homepage: https://github.com/Lelio-Brun/Obelisk
* Source repo: git+https://github.com/Lelio-Brun/obelisk.git
* Bug tracker: https://github.com/Lelio-Brun/obelisk/issues

---
:camel: Pull-request generated by opam-publish v2.0.3