### PR TITLE
[new release] bloomf (0.2.0)

### DIFF
--- a/packages/bloomf/bloomf.0.2.0/opam
+++ b/packages/bloomf/bloomf.0.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Clément Pascutto"
+authors:      ["Clément Pascutto"]
+license:      "MIT"
+homepage:     "https://github.com/mirage/bloomf"
+bug-reports:  "https://github.com/mirage/bloomf/issues"
+dev-repo:     "git+https://github.com/mirage/bloomf.git"
+doc:          "https://mirage.github.io/bloomf/"
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+  name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+  "@doc" {with-doc}
+  ]
+]
+
+depends: [
+  "ocaml"   {>= "4.06.0"}
+  "dune"    {>= "2.0"}
+  "bitv"    {>= "1.4"}
+  "alcotest" {with-test}
+]
+synopsis: "Efficient Bloom filters for OCaml"
+description: "Efficient Bloom filters for OCaml"
+x-commit-hash: "4464d8e4df27560a59000b784e9b26c214fc344e"
+url {
+  src:
+    "https://github.com/mirage/bloomf/releases/download/v0.2.0/bloomf-v0.2.0.tbz"
+  checksum: [
+    "sha256=16409a1221e1d05a3d6b64ec0e5b302a60b6802cc573fdc243662e2fc85bd561"
+    "sha512=bc18e79cc782004edef88b24bc6ca586701294bd91c81ffc3de450df19f050e9e52b480980b74a5c38b7c70a3e9b4e94feca02007f1b661855868acf9cbdb245"
+  ]
+}


### PR DESCRIPTION
Benchmarking package for `bloomf`

- Project page: <a href="https://github.com/mirage/bloomf">https://github.com/mirage/bloomf</a>
- Documentation: <a href="https://mirage.github.io/bloomf/">https://mirage.github.io/bloomf/</a>

##### CHANGES:

- Added `to_bytes` and `of_bytes`.
- Added `union` and `inter`.
