### PR TITLE
Remove doc and test dependency cycles

### DIFF
--- a/packages/alcotest/alcotest.0.4.6/opam
+++ b/packages/alcotest/alcotest.0.4.6/opam
@@ -19,7 +19,8 @@ depends: [
   "result"
   "cmdliner"
 ]
-synopsis: "Alcotest is a lightweight and colourful test framework."
+conflicts:["odoc"]
+synopsis: "Alcotest is a lightweight and colourful test framework"
 description: """
 Alcotest exposes simple interface to perform unit tests. It exposes
 a simple `TESTABLE` module type, a `check` function to assert test

--- a/packages/alcotest/alcotest.0.4.7/opam
+++ b/packages/alcotest/alcotest.0.4.7/opam
@@ -19,7 +19,8 @@ depends: [
   "result"
   "cmdliner"
 ]
-synopsis: "Alcotest is a lightweight and colourful test framework."
+conflicts:["odoc"]
+synopsis: "Alcotest is a lightweight and colourful test framework"
 description: """
 Alcotest exposes simple interface to perform unit tests. It exposes
 a simple `TESTABLE` module type, a `check` function to assert test

--- a/packages/alcotest/alcotest.1.1.0/opam
+++ b/packages/alcotest/alcotest.1.1.0/opam
@@ -26,7 +26,6 @@ depends: [
   "uuidm"
   "re"
   "stdlib-shims"
-  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {pinned}
@@ -38,8 +37,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
-    "@doc" {with-doc}
   ]
 ]
 dev-repo: "git+https://github.com/mirage/alcotest.git"

--- a/packages/atd/atd.1.12.0/opam
+++ b/packages/atd/atd.1.12.0/opam
@@ -14,7 +14,6 @@ depends: [
   "jbuilder" {>= "1.0+beta7"}
   "menhir" {build}
   "easy-format"
-  "atdgen" {with-test}
 ]
 synopsis: "Parser for the ATD data format description language"
 description: """

--- a/packages/base64/base64.2.1.2/opam
+++ b/packages/base64/base64.2.1.2/opam
@@ -14,15 +14,9 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "bos" {with-test}
-  "rresult" {with-test}
-  "alcotest" {with-test & >= "0.4.0"}
 ]
 build: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"]
-  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
-    {with-test}
-  ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 synopsis: "For OCaml"
 description: """

--- a/packages/base64/base64.2.2.0/opam
+++ b/packages/base64/base64.2.2.0/opam
@@ -12,14 +12,10 @@ depends: [
   "ocaml"
   "base-bytes"
   "jbuilder" {>= "1.0+beta10"}
-  "bos" {with-test}
-  "rresult" {with-test}
-  "alcotest" {with-test & >= "0.4.0"}
 ]
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 synopsis: "Base64 encoding for OCaml"
 description: """

--- a/packages/base64/base64.2.3.0/opam
+++ b/packages/base64/base64.2.3.0/opam
@@ -17,14 +17,10 @@ representation.  It is specified in RFC 4648.
 depends: [
   "base-bytes"
   "dune" {>= "1.0.1"}
-  "bos" {with-test}
-  "rresult" {with-test}
-  "alcotest" {with-test}
 ]
 build: [
   ["dune" "subst"]
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
 ]
 url {
   src:

--- a/packages/bigstring/bigstring.0.3/opam
+++ b/packages/bigstring/bigstring.0.3/opam
@@ -8,15 +8,12 @@ bug-reports: "https://github.com/c-cube/ocaml-bigstring/issues"
 dev-repo: "git://github.com/c-cube/ocaml-bigstring.git"
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 depends: [
   "dune" {>= "1.2"}
   "base-bigarray"
   "base-bytes"
   "ocaml" {>= "4.03.0"}
-  "alcotest" {with-test & < "1.2"}
-  "bigstring-unix" {with-test}
 ]
 url {
   src: "https://github.com/c-cube/ocaml-bigstring/archive/0.3.tar.gz"

--- a/packages/expect/expect.0.0.2/opam
+++ b/packages/expect/expect.0.0.2/opam
@@ -5,19 +5,16 @@ homepage: "https://github.com/gildor478/ocaml-expect"
 bug-reports: "https://github.com/gildor478/ocaml-expect/issues"
 dev-repo: "git+https://github.com/gildor478/ocaml-expect.git"
 build: [
-  ["rm" "setup.ml"] {ocaml:version >= "4.00.0"}
-  ["oasis" "setup"] {ocaml:version >= "4.00.0"}
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
 remove: [["ocamlfind" "remove" "expect"]]
 depends: [
-  "ocaml" {< "4.06.0"}
+  "ocaml" {!= "4.00.0" & < "4.06.0"}
   "ocamlfind"
   "extlib" {= "1.5.3"}
   "ounit"
   "pcre"
-  "oasis" {>= "0.3.0" & < "0.4.2"}
   "ocamlbuild" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/oasis/oasis.0.2.0/opam
+++ b/packages/oasis/oasis.0.2.0/opam
@@ -1,5 +1,10 @@
 opam-version: "2.0"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "Sylvain Le Gall <sylvain@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "http://oasis.forge.ocamlcore.org/"
+dev-repo: "git://github.com/ocaml/oasis.git#opam/testing"
+bug-reports: "https://forge.ocamlcore.org/tracker/?func=add&group_id=54&atid=291"
 build: [
   ["rm" "test/TestMETA.ml"]
   ["touch" "test/TestMETA.ml"]
@@ -18,7 +23,7 @@ depends: [
   "ounit"
   "ocaml-data-notation"
   "pcre"
-  "expect"
+  "expect" {<= "0.0.2"}
   "ocamlbuild"
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/odoc/odoc.1.0.0/opam
+++ b/packages/odoc/odoc.1.0.0/opam
@@ -23,6 +23,10 @@ depends: [
   "xmlm"
   "cmdliner"
 ]
+conflicts:[
+  "dune-configurator" {>= "2.7.0"}
+  "alcotest" {>= "0.4.3" | <"0.4.6"}
+]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pinned" "%{pinned}%"

--- a/packages/odoc/odoc.1.1.0/opam
+++ b/packages/odoc/odoc.1.1.0/opam
@@ -23,6 +23,10 @@ depends: [
   "xmlm"
   "cmdliner"
 ]
+conflicts:[
+  "dune-configurator" {>= "2.7.0"}
+  "alcotest" {>= "0.4.3" | <"0.4.6"}
+]
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}
   ["ocaml" "bin/set-etc" "bin/odoc_etc.ml" odoc:etc]

--- a/packages/odoc/odoc.1.1.1/opam
+++ b/packages/odoc/odoc.1.1.1/opam
@@ -22,6 +22,10 @@ depends: [
   "xmlm"
   "cmdliner"
 ]
+conflicts:[
+  "dune-configurator" {>= "2.7.0"}
+  "alcotest" {>= "0.4.3" | <"0.4.6"}
+]
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}
   ["ocaml" "bin/set-etc" "bin/odoc_etc.ml" odoc:etc]

--- a/packages/odoc/odoc.1.2.0/opam
+++ b/packages/odoc/odoc.1.2.0/opam
@@ -23,6 +23,10 @@ depends: [
   "xmlm"
   "cmdliner"
 ]
+conflicts:[
+  "dune-configurator" {>= "2.7.0"}
+  "alcotest" {>= "0.4.3" | <"0.4.6"}
+]
 build: [
   ["jbuilder" "subst" "-p" name] {pinned}
   ["ocaml" "bin/set-etc" "bin/odoc_etc.ml" odoc:etc]

--- a/packages/odoc/odoc.1.3.0/opam
+++ b/packages/odoc/odoc.1.3.0/opam
@@ -26,6 +26,10 @@ depends: [
   "result" {build}
   "tyxml" {build & >= "4.0.0"}
 ]
+conflicts:[
+  "dune-configurator" {>= "2.7.0"}
+  "alcotest" {>= "0.4.3" | < "0.4.8"}
+]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/odoc/odoc.1.4.0/opam
+++ b/packages/odoc/odoc.1.4.0/opam
@@ -29,8 +29,6 @@ depends: [
   "markup" {dev & >= "0.8.0"}
   "ocamlfind" {dev}
   "sexplib" {dev & >= "113.33.00" & < "v0.15"}
-
-  "bisect_ppx" {with-test & >= "1.3.0"}
 ]
 
 build: [

--- a/packages/odoc/odoc.1.4.1/opam
+++ b/packages/odoc/odoc.1.4.1/opam
@@ -29,8 +29,6 @@ depends: [
   "markup" {dev & >= "0.8.0"}
   "ocamlfind" {dev}
   "sexplib" {dev & >= "113.33.00" & < "v0.15"}
-
-  "bisect_ppx" {with-test & >= "1.3.0"}
 ]
 
 build: [

--- a/packages/odoc/odoc.1.4.2/opam
+++ b/packages/odoc/odoc.1.4.2/opam
@@ -30,8 +30,6 @@ depends: [
   "markup" {dev & >= "0.8.0"}
   "ocamlfind" {dev}
   "sexplib" {dev & >= "113.33.00" & < "v0.15"}
-
-  "bisect_ppx" {with-test & >= "1.3.0"}
 ]
 
 build: [

--- a/packages/odoc/odoc.1.5.0/opam
+++ b/packages/odoc/odoc.1.5.0/opam
@@ -35,8 +35,6 @@ depends: [
   "markup" {dev & >= "0.8.0"}
   "ocamlfind" {dev}
   "sexplib" {dev & >= "113.33.00" & < "v0.15"}
-
-  "bisect_ppx" {with-test & >= "1.3.0"}
 ]
 
 build: [

--- a/packages/odoc/odoc.1.5.1/opam
+++ b/packages/odoc/odoc.1.5.1/opam
@@ -35,8 +35,6 @@ depends: [
   "markup" {dev & >= "0.8.0"}
   "ocamlfind" {dev}
   "sexplib" {dev & >= "113.33.00"}
-
-  "bisect_ppx" {with-test & >= "1.3.0"}
 ]
 
 build: [

--- a/packages/odoc/odoc.1.5.2/opam
+++ b/packages/odoc/odoc.1.5.2/opam
@@ -35,8 +35,6 @@ depends: [
   "markup" {dev & >= "1.0.0"}
   "ocamlfind" {dev}
   "sexplib" {dev & >= "113.33.00"}
-
-  "bisect_ppx" {with-test & >= "1.3.0"}
 ]
 
 build: [

--- a/packages/ppxlib/ppxlib.0.22.0/opam
+++ b/packages/ppxlib/ppxlib.0.22.0/opam
@@ -31,7 +31,6 @@ depends: [
   "cinaps" {with-test & >= "v0.12.1"}
   "base" {with-test}
   "stdio" {with-test}
-  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -44,7 +43,6 @@ build: [
     jobs
     "@install"
     "@runtest" {with-test}
-    "@doc" {with-doc}
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"


### PR DESCRIPTION
And here the remaining cycle fixes to complement https://github.com/ocaml/opam-repository/pull/18124.

With these 2 PRs, `opam admin check --cycle` returns no errors.