### PR TITLE
Add delimcc.2020.10.08

### DIFF
--- a/packages/delimcc/delimcc.2017.03.02/opam
+++ b/packages/delimcc/delimcc.2017.03.02/opam
@@ -9,7 +9,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "delimcc"]]
 depends: [
-  "ocaml" {>= "4.04.0" & < "4.12.0"}
+  "ocaml" {>= "4.04.0" & < "4.10.0"}
   "ocamlfind"
 ]
 install: [make "findlib-install"]

--- a/packages/delimcc/delimcc.2018.03.16/opam
+++ b/packages/delimcc/delimcc.2018.03.16/opam
@@ -8,7 +8,7 @@ build: [
   [make "opt"]
 ]
 depends: [
-  "ocaml" {>= "4.04.0" & < "4.12.0"}
+  "ocaml" {>= "4.04.0" & < "4.10.0"}
   "ocamlfind" {build}
 ]
 install: [make "findlib-install"]

--- a/packages/delimcc/delimcc.2020.10.08/opam
+++ b/packages/delimcc/delimcc.2020.10.08/opam
@@ -10,7 +10,9 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0" & < "4.12.0"}
   "ocamlfind" {build}
+  "conf-which" {build}
 ]
+available: arch != "ppc64"
 install: [make "findlib-install"]
 synopsis:
   "Oleg's delimited continuations library for byte-code and native OCaml"

--- a/packages/delimcc/delimcc.2020.10.08/opam
+++ b/packages/delimcc/delimcc.2020.10.08/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "yallop@gmail.com"
+authors: ["Oleg Kiselyov"]
+homepage: "http://okmij.org/ftp/continuations/implementations.html#caml-shift"
+license: "MIT"
+build: [
+  [make "all"]
+  [make "opt"]
+]
+depends: [
+  "ocaml" {>= "4.04.0" & < "4.12.0"}
+  "ocamlfind" {build}
+]
+install: [make "findlib-install"]
+synopsis:
+  "Oleg's delimited continuations library for byte-code and native OCaml"
+conflicts: ["ocaml-system"]
+url {
+  src: "http://okmij.org/ftp/continuations/caml-shift-20201008.tar.gz"
+  checksum: "md5=db0b649b012490d54f90a541f6b4e58e"
+}


### PR DESCRIPTION
Older versions of `delimcc` (2018.03.16 and earlier) don't work with recent versions of OCaml (4.10.0 onwards).  There's a [bug report on discuss.ocaml.org](https://discuss.ocaml.org/t/bug-in-delimcc-with-ocaml-4-10/6534) with a program that illustrates the problem.

This PR adds the latest version of `delimcc` (`2020.10.08`) and constrains older versions to OCaml versions below 4.10.0.

/cc @gasche, @rgrinberg (listed as maintainers of the earlier versions)