### PR TITLE
[new release] travesty (0.7.0)

### DIFF
--- a/packages/travesty/travesty.0.7.0/opam
+++ b/packages/travesty/travesty.0.7.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Traversable containers, monad extensions, and more"
+description: """
+'Travesty' is a library for defining containers with applicative
+or monadic traversals, inspired by Haskell's Traversable typeclass; it also
+contains various helpers for monadic code, such as state transformers and
+extension functions for common monads and containers.  It sits on top of Jane
+Street's Base library and ecosystem."""
+maintainer: ["Matt Windsor <mattwindsor91@gmail.com>"]
+authors: ["Matt Windsor <mattwindsor91@gmail.com>"]
+license: "MIT"
+homepage: "https://MattWindsor91.github.io/travesty/"
+doc: "https://MattWindsor91.github.io/travesty/"
+bug-reports: "https://github.com/MattWindsor91/travesty/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "ppx_jane" {>= "v0.12.0" & < "v0.15.0"}
+  "ppx_expect" {with-test & >= "v0.12.0" & < "v0.15.0"}
+  "base" {>= "v0.12.0" & < "v0.15.0"}
+]
+conflicts: [
+  "bisect_ppx" {>= "2.6.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/MattWindsor91/travesty.git"
+x-commit-hash: "07608cd7ecc670b0f8b0f77565a7f313c15aabde"
+url {
+  src:
+    "https://github.com/MattWindsor91/travesty/releases/download/v0.7.0/travesty-v0.7.0.tbz"
+  checksum: [
+    "sha256=01661918f73f33b0e6d0cf3851c2d5d6ef76b86332a3e76a4958689ff1a6fd3a"
+    "sha512=14e9b0e9ae39055c386c5e996055ce59edf57b9bf9b0055722632520f9c9b0270af571576950be982ed2b86e859361c7344166a38a85fa7d28d45be8f3e18c77"
+  ]
+}

--- a/packages/travesty/travesty.0.7.0/opam
+++ b/packages/travesty/travesty.0.7.0/opam
@@ -19,11 +19,8 @@ depends: [
   "ppx_expect" {with-test & >= "v0.12.0" & < "v0.15.0"}
   "base" {>= "v0.12.0" & < "v0.15.0"}
 ]
-conflicts: [
-  "bisect_ppx" {>= "2.6.0"}
-]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
**Note:** `travesty` currently has a `conflicts` against `bisect_ppx`, which is a quick-fix for issue
#18134 - this will likely become unnecessary when PR #18125 is merged.


CHANGES:

Major release with large breaking changes, and added and removed features.

## Breaking changes

- `Traversable` and `Bi_traversable` now encode applicative traversals, not
  monadic traversals.  This means that every use of a `Make` functor needs
  changing such that, instead of an `On_monad` functor over `Monad.S`, they
  expose an `On` functor over `Applicative.S`.  No function names have changed
  (they remain `map_m`, `iter_m` etc. for backwards compatibility), and the
  various `Make` functors generate both `On` (applicative) and `On_monad`
  (monadic) functors, so most code that _consumes_ traversals should be fine.
- Some traversal implementations in `Base_exts` have changed; this may subtly
  affect side effect processing order.

## Added

- `Monad_exts.App` is `Base.Applicative.Of_monad`, but keeps the original
  monad type around; this is useful for passing monads to things that expect
  applicatives.
- `Monad_exts.Let` produces OCaml 4.08-style `let+` and `let*` bindings for
  monads.  It is included in `Monad_exts.Make`.

## Removed

- The `Traversable.Helpers` module; in practice this doesn't seem to be very
  useful compared to writing the traversable boilerplate manually, and it
  doesn't gel particularly well with the planned monad to applicative change.
- Support for OCaml v4.07.  This has effectively been broken since v0.6.2 when
  building on Jane Street libraries v0.14.