### PR TITLE
Add: b0.0.0.2, odig.0.0.6

### DIFF
--- a/packages/b0/b0.0.0.2/opam
+++ b/packages/b0/b0.0.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: """Software construction and deployment kit"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The b0 programmers"]
+homepage: "https://erratique.ch/software/b0"
+doc: "https://erratique.ch/software/b0/doc"
+dev-repo: "git+https://erratique.ch/repos/b0.git"
+bug-reports: "https://github.com/b0-system/b0/issues"
+license: ["ISC" "BSD2"]
+tags: ["dev" "org:erratique" "org:b0-system" "build"]
+depends: ["ocaml" {>= "4.08.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}
+          "cmdliner" {build &>= "1.0.2"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/b0/releases/b0-0.0.2.tbz"
+  checksum: "sha512=78fd9e53b84cf5d6bf497adaf4b6d7d974134044318639cdfe5e01c7faaa8d987d04769abe3b3b1cbdb937132e21d8723dc185cd3c68433a793278907a8e757e"}
+description: """
+WARNING this package is unstable and work in progress, do not depend on it. 
+
+B0 describes software construction and deployments using modular and
+customizable definitions written in OCaml.
+
+B0 describes:
+
+* Build environments.
+* Software configuration, build and testing.
+* Source and binary deployments.
+* Software life-cycle procedures.
+
+B0 also provides the B00 build library which provides abitrary build
+abstraction with reliable and efficient incremental rebuilds. The B00
+library can be – and has been – used on its own to devise domain
+specific build systems.
+
+B0 is distributed under the ISC license. It depends on [cmdliner][cmdliner].
+
+[cmdliner]: https://erratique.ch/software/cmdliner"""

--- a/packages/odig/odig.0.0.6/opam
+++ b/packages/odig/odig.0.0.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: """Lookup documentation of installed OCaml packages"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The odig programmers"]
+homepage: "https://erratique.ch/software/odig"
+doc: "https://erratique.ch/software/odig/doc"
+dev-repo: "git+https://erratique.ch/repos/odig.git"
+bug-reports: "https://github.com/b0-system/odig/issues"
+license: ["ISC" "PT-Sans-fonts" "DejaVu-fonts"]
+tags: ["build" "dev" "doc" "meta" "packaging" "org:erratique"
+       "org:b0-system"]
+depends: ["ocaml" {>= "4.08"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}
+          "cmdliner" {>= "1.0.0"}
+          "odoc" {>= "1.5.0" & < "2.0.0"}
+          "b0" {= "0.0.2"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/odig/releases/odig-0.0.6.tbz"
+  checksum: "sha512=b0150e45e0522ba1eb661414cd9640e96f25648cc2636b6faa994a1af91562e39b5959dfd5ddf24ec36abbe7190e5af3b83aa9299507bc4ebb55f5c7f17abba0"}
+description: """
+odig is a command line tool to lookup documentation of installed OCaml
+packages. It shows package metadata, readmes, change logs, licenses,
+cross-referenced `odoc` API documentation and manuals.
+
+odig is distributed under the ISC license. The theme fonts have their
+own [licenses](LICENSE.md).
+
+Homepage: https://erratique.ch/software/odig"""


### PR DESCRIPTION
* Add: `b0.0.0.2` [home](https://erratique.ch/software/b0), [doc](https://erratique.ch/software/b0/doc), [issues](https://github.com/b0-system/b0/issues)  
  *Software construction and deployment kit*
* Add: `odig.0.0.6` [home](https://erratique.ch/software/odig), [doc](https://erratique.ch/software/odig/doc), [issues](https://github.com/b0-system/odig/issues)  
  *Lookup documentation of installed OCaml packages*


---

#### `b0` v0.0.2 2021-02-11 La Forclaz (VS)

Third release to support `odig`.

* OCaml 4.12 compatibility. 
  Thanks to Kate (@kit-ty-kate) for the patch.

---

#### `odig` v0.0.6 2021-02-11 La Forclaz (VS)

- Stylesheets. Change strategy to make code spans unbreakable.
  The previous way broke Chrome in-page search.
- Track `b0` changes.
- Update link to OCaml manual ([#59](https://github.com/b0-system/odig/issues/59)).
- Require OCaml >= 4.08.0

---

Use `b0 cmd -- .opam.publish b0.0.0.2 odig.0.0.6` to update the pull request.