### PR TITLE
[new release] ppx_import (1.8.0)

### DIFF
--- a/packages/ppx_import/ppx_import.1.8.0/opam
+++ b/packages/ppx_import/ppx_import.1.8.0/opam
@@ -1,6 +1,5 @@
-description: "A syntax extension for importing declarations from interface files"
-synopsis: "A syntax extension for importing declarations from interface files"
 opam-version: "2.0"
+synopsis: "A syntax extension for importing declarations from interface files"
 maintainer: "whitequark <whitequark@whitequark.org>"
 authors: [ "whitequark <whitequark@whitequark.org>" ]
 homepage: "https://github.com/ocaml-ppx/ppx_import"

--- a/packages/ppx_import/ppx_import.1.8.0/opam
+++ b/packages/ppx_import/ppx_import.1.8.0/opam
@@ -1,0 +1,33 @@
+description: "A syntax extension for importing declarations from interface files"
+synopsis: "A syntax extension for importing declarations from interface files"
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_import"
+doc: "https://ocaml-ppx.github.io/ppx_import/"
+license: "MIT"
+bug-reports: "https://github.com/ocaml-ppx/ppx_import/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
+tags: [ "syntax" ]
+
+depends: [
+  "ocaml"                   {              >= "4.04.2" & < "4.12" }
+  "dune"                    {              >= "1.2.0"  }
+  "ppx_tools_versioned"     {              >= "5.4.0"  }
+  "ocaml-migrate-parsetree" {              >= "1.7.0"  }
+  "ounit"                   { with-test                }
+  "ppx_deriving"            { with-test  & >= "4.2.1"  }
+]
+
+build:      [["dune" "build"   "-p" name "-j" jobs]
+             ["dune" "runtest" "-p" name "-j" jobs] { with-test }
+            ]
+x-commit-hash: "29423cd1fe0acd558eb13969435c5292989391ea"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_import/releases/download/v1.8.0/ppx_import-1.8.0.tbz"
+  checksum: [
+    "sha256=fb0d4627125379561a9031616f58df242dd885c6e34bc32499915cefc1910c7f"
+    "sha512=48f882d36ce80c90cb24bf54e76540890b571a9c6eb16747e9e27257d29c2686daf535039fbf14c71da2c6427145181db007a2ee2c993a2569e29e4f8408b311"
+  ]
+}


### PR DESCRIPTION
A syntax extension for importing declarations from interface files

- Project page: <a href="https://github.com/ocaml-ppx/ppx_import">https://github.com/ocaml-ppx/ppx_import</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_import/">https://ocaml-ppx.github.io/ppx_import/</a>

##### CHANGES:

  * Upgrade the internal AST from 4.07 to 4.11
    ocaml-ppx/ppx_import#52
    (Gabriel Scherer, review by Emilio J. Gallego Arias)

  * Update lower bound for `ppx_tools_versioned` and
    `ocaml-migrate-parsetree` to 4.11 capable versions
    (Emilio J. Gallego Arias)
