### PR TITLE
Add extprot.1.7.0.

### DIFF
--- a/packages/extprot/extprot.1.7.0/opam
+++ b/packages/extprot/extprot.1.7.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "base64" {with-test}
   "camlp4" {build}
-  ("extlib" {>= "1.7.7"} | "extlib-compat" {>="1.7.7"})
+  "extlib" {>= "1.7.8"}
   "base-bytes"
 ]
 synopsis:

--- a/packages/extprot/extprot.1.7.0/opam
+++ b/packages/extprot/extprot.1.7.0/opam
@@ -30,7 +30,6 @@ extprot allows you to create compact, efficient, extensible, binary protocols th
 be used for cross-language communication and long-term data serialization.
 extprot supports protocols with rich, composable types, whose definition can evolve
 while keeping both forward and backward compatibility."""
-flags: light-uninstall
 url {
   src: "https://github.com/mfp/extprot/releases/download/v1.7.0/extprot-1.7.0.tar.gz"
   checksum: "md5=12acd1466af6feaced5f2836b703b33d"

--- a/packages/extprot/extprot.1.7.0/opam
+++ b/packages/extprot/extprot.1.7.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "ygrek@autistici.org"
+homepage: "https://github.com/mfp/extprot"
+license: "MIT"
+authors: ["Mauricio Fernandez <mfp@acm.org>"]
+doc: ["https://github.com/mfp/extprot/blob/master/README.md"]
+dev-repo: "git://github.com/mfp/extprot.git"
+bug-reports: "https://github.com/mfp/extprot/issues"
+build: [
+  ["omake"]
+  ["omake" "test"] {with-test}
+]
+install: [
+  ["omake" "install" "prefix=%{prefix}%"]
+]
+remove: [
+  ["ocamlfind" "remove" "extprot"]
+  ["rm" "-f" "%{bin}%/extprotc" "%{bin}%/extprotc.exe"]
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "omake" {build}
+  "ocamlfind" {build}
+  "ounit" {with-test}
+  "base64" {with-test}
+  "camlp4" {build}
+  ("extlib" {>= "1.7.7"} | "extlib-compat" {>="1.7.7"})
+  "base-bytes"
+]
+synopsis:
+  "Extensible binary protocols for cross-language communication and long-term serialization"
+description: """
+extprot allows you to create compact, efficient, extensible, binary protocols that can
+be used for cross-language communication and long-term data serialization.
+extprot supports protocols with rich, composable types, whose definition can evolve
+while keeping both forward and backward compatibility."""
+flags: light-uninstall
+url {
+  src: "https://github.com/mfp/extprot/releases/download/v1.7.0/extprot-1.7.0.tar.gz"
+  checksum: "md5=12acd1466af6feaced5f2836b703b33d"
+}

--- a/packages/extprot/extprot.1.7.0/opam
+++ b/packages/extprot/extprot.1.7.0/opam
@@ -13,12 +13,8 @@ build: [
 install: [
   ["omake" "install" "prefix=%{prefix}%"]
 ]
-remove: [
-  ["ocamlfind" "remove" "extprot"]
-  ["rm" "-f" "%{bin}%/extprotc" "%{bin}%/extprotc.exe"]
-]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.03.0"}
   "omake" {build}
   "ocamlfind" {build}
   "ounit" {with-test}


### PR DESCRIPTION
* lazy deserialization regime for message fields and associated option `-fieldmod`
  Refer to "Evaluation regime" section in `doc/language-mapping.md`
* improved codegen for monomorphic record types
* `-mli` option to generate `.mli` signatures
* `-export-type-io` option to export monomorphic record type
  (de)serialization functions and allow to reference the type in other
  protocols
* `-assume-subsets` option to enable cross-protocol subsets of messages
  (use in proto for whose messages subsets will be created)
* support for `extlib` 1.7.8
