### PR TITLE
Various fixes

### DIFF
--- a/packages/delimcc/delimcc.2020.10.08/opam
+++ b/packages/delimcc/delimcc.2020.10.08/opam
@@ -8,7 +8,7 @@ build: [
   [make "opt"]
 ]
 depends: [
-  "ocaml" {>= "4.04.0" & < "4.12.0"}
+  "ocaml" {>= "4.07.0" & < "4.12.0"}
   "ocamlfind" {build}
   "conf-which" {build}
 ]

--- a/packages/dose3/dose3.4.3/opam
+++ b/packages/dose3/dose3.4.3/opam
@@ -29,6 +29,7 @@ depends: [
   "cudf" {>= "0.7"}
   ("extlib" {>= "1.7.0" & < "1.7.8"} | "extlib-compat" {>= "1.7.0"})
   "re" {>= "1.2.2"}
+  "ocamlfind" {build}
   "ocamlbuild" {build}
   "cppo" {build & >= "1.1.2"}
 ]

--- a/packages/dose3/dose3.5.0.1-1/opam
+++ b/packages/dose3/dose3.5.0.1-1/opam
@@ -26,6 +26,7 @@ depends: [
   "cudf" {>= "0.7"}
   ("extlib" {>= "1.7.0" & < "1.7.8"} | "extlib-compat" {>= "1.7.0"})
   "re" {>= "1.2.2"}
+  "ocamlfind" {build}
   "ocamlbuild" {build}
   "cppo" {build & >= "1.1.2"}
 ]

--- a/packages/dose3/dose3.5.0.1/opam
+++ b/packages/dose3/dose3.5.0.1/opam
@@ -30,6 +30,7 @@ depends: [
   "cudf" {>= "0.7"}
   ("extlib" {>= "1.7.0" & < "1.7.8"} | "extlib-compat" {>= "1.7.0"})
   "re" {>= "1.2.2"}
+  "ocamlfind" {build}
   "ocamlbuild" {build}
   "cppo" {build & >= "1.1.2"}
 ]

--- a/packages/dose3/dose3.5.0/opam
+++ b/packages/dose3/dose3.5.0/opam
@@ -29,6 +29,7 @@ depends: [
   "cudf" {>= "0.7"}
   ("extlib" {>= "1.7.0" & < "1.7.8"} | "extlib-compat" {>= "1.7.0"})
   "re" {>= "1.2.2"}
+  "ocamlfind" {build}
   "ocamlbuild" {build}
   "cppo" {build & >= "1.1.2"}
 ]

--- a/packages/iocaml/iocaml.0.4.3/opam
+++ b/packages/iocaml/iocaml.0.4.3/opam
@@ -15,7 +15,7 @@ depends: [
   "websocket" {>= "0.8"}
   "cohttp" {>= "0.10.0"}
   "crunch"
-  "ctypes" {>= "0.2.3"}
+  "ctypes" {>= "0.2.3" & < "0.18.0"}
   "ctypes-foreign"
   "iocaml-kernel" {= "0.4.3"}
   "iocamljs-kernel" {= "0.4.3"}

--- a/packages/iocaml/iocaml.0.4.4/opam
+++ b/packages/iocaml/iocaml.0.4.4/opam
@@ -15,7 +15,7 @@ depends: [
   "websocket" {>= "0.8"}
   "cohttp" {>= "0.10.0"}
   "crunch"
-  "ctypes" {>= "0.4"}
+  "ctypes" {>= "0.4" & < "0.18.0"}
   "ctypes-foreign"
   "iocaml-kernel" {= "0.4.4"}
   "iocamljs-kernel" {= "0.4.4"}

--- a/packages/iocaml/iocaml.0.4.5/opam
+++ b/packages/iocaml/iocaml.0.4.5/opam
@@ -15,7 +15,7 @@ depends: [
   "websocket" {>= "0.8"}
   "cohttp" {>= "0.10.0"}
   "crunch"
-  "ctypes" {>= "0.3"}
+  "ctypes" {>= "0.3" & < "0.18.0"}
   "ctypes-foreign"
   "iocaml-kernel" {= "0.4.4"}
   "iocamljs-kernel" {= "0.4.5"}

--- a/packages/iocaml/iocaml.0.4.6/opam
+++ b/packages/iocaml/iocaml.0.4.6/opam
@@ -19,7 +19,7 @@ depends: [
   "websocket" {= "0.8.1"}
   "cohttp" {>= "0.10.0"}
   "crunch"
-  "ctypes" {>= "0.3"}
+  "ctypes" {>= "0.3" & < "0.18.0"}
   "ctypes-foreign"
   "iocaml-kernel" {= "0.4.6"}
   "iocamljs-kernel" {= "0.4.6"}

--- a/packages/iocaml/iocaml.0.4.7/opam
+++ b/packages/iocaml/iocaml.0.4.7/opam
@@ -19,7 +19,7 @@ depends: [
   "websocket" {>= "0.9" & < "1.0"}
   "cohttp" {>= "0.15.0"}
   "crunch"
-  "ctypes" {>= "0.3"}
+  "ctypes" {>= "0.3" & < "0.18.0"}
   "ctypes-foreign"
   "iocaml-kernel" {= "0.4.6"}
   "iocamljs-kernel" {= "0.4.6"}

--- a/packages/iocaml/iocaml.0.4.8/opam
+++ b/packages/iocaml/iocaml.0.4.8/opam
@@ -18,7 +18,7 @@ depends: [
   "websocket" {>= "2.0" & <= "2.6"}
   "cohttp" {>= "0.15.0" & < "0.21.0"}
   "crunch"
-  "ctypes" {>= "0.3"}
+  "ctypes" {>= "0.3" & < "0.18.0"}
   "ctypes-foreign"
   "iocaml-kernel" {= "0.4.8"}
   "iocamljs-kernel" {= "0.4.8"}

--- a/packages/iocaml/iocaml.0.4.9/opam
+++ b/packages/iocaml/iocaml.0.4.9/opam
@@ -18,7 +18,7 @@ depends: [
   "websocket" {>= "2.0" & <= "2.6"}
   "cohttp" {>= "0.21.0" & < "0.99"}
   "crunch"
-  "ctypes" {>= "0.3"}
+  "ctypes" {>= "0.3" & < "0.18.0"}
   "ctypes-foreign"
   "iocaml-kernel" {= "0.4.8"}
   "iocamljs-kernel" {= "0.4.8"}

--- a/packages/mariadb/mariadb.0.10.0/opam
+++ b/packages/mariadb/mariadb.0.10.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "conf-mariadb"
 ]

--- a/packages/mariadb/mariadb.0.5.0/opam
+++ b/packages/mariadb/mariadb.0.5.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "async" {< "v0.15"}
   "lwt"

--- a/packages/mariadb/mariadb.0.5.1/opam
+++ b/packages/mariadb/mariadb.0.5.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "conf-mariadb"
 ]

--- a/packages/mariadb/mariadb.0.6.0/opam
+++ b/packages/mariadb/mariadb.0.6.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "conf-mariadb"
 ]

--- a/packages/mariadb/mariadb.0.7.0/opam
+++ b/packages/mariadb/mariadb.0.7.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "conf-mariadb"
 ]

--- a/packages/mariadb/mariadb.0.8.0/opam
+++ b/packages/mariadb/mariadb.0.8.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "conf-mariadb"
 ]

--- a/packages/mariadb/mariadb.0.8.1/opam
+++ b/packages/mariadb/mariadb.0.8.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "conf-mariadb"
 ]

--- a/packages/mariadb/mariadb.0.8.2/opam
+++ b/packages/mariadb/mariadb.0.8.2/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "conf-mariadb"
 ]

--- a/packages/mariadb/mariadb.0.9.0/opam
+++ b/packages/mariadb/mariadb.0.9.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "conf-mariadb"
 ]

--- a/packages/mariadb/mariadb.1.0.0/opam
+++ b/packages/mariadb/mariadb.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "conf-mariadb"
 ]

--- a/packages/mariadb/mariadb.1.0.1/opam
+++ b/packages/mariadb/mariadb.1.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "conf-mariadb"
 ]

--- a/packages/mariadb/mariadb.1.1.0/opam
+++ b/packages/mariadb/mariadb.1.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "conf-mariadb"
 ]

--- a/packages/mariadb/mariadb.1.1.1/opam
+++ b/packages/mariadb/mariadb.1.1.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.7.0" & < "0.18.0"}
   "ctypes-foreign" {>= "0.4.0"}
   "conf-mariadb"
 ]

--- a/packages/opasswd/opasswd.1.0.1/opam
+++ b/packages/opasswd/opasswd.1.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "4.03.0"}
   "oasis" {build}
   "ocamlfind" {build}
-  "ctypes" {>= "0.2.2"}
+  "ctypes" {>= "0.2.2" & < "0.18.0"}
   "ctypes-foreign"
 ]
 tags: [ "org:xapi-project" ]

--- a/packages/oplay/oplay.1.0.0/opam
+++ b/packages/oplay/oplay.1.0.0/opam
@@ -8,6 +8,7 @@ depends: [
   "ocaml"
   "ocamlfind"
   "tsdl" {< "0.9.0"}
+  "ctypes" {< "0.18.0"} # used implicitly through tsdl
   "ocamlbuild" {build}
 ]
 dev-repo: "git://github.com/ujamjar/oplay"

--- a/packages/sodium/sodium.0.6.0/opam
+++ b/packages/sodium/sodium.0.6.0/opam
@@ -26,7 +26,7 @@ depends: [
   "base-bytes"
   "ocamlfind" {build}
   "conf-libsodium"
-  "ctypes" {>= "0.6.0"}
+  "ctypes" {>= "0.6.0" & < "0.18.0"}
   "ocamlbuild" {build}
   "ounit" {with-test}
 ]

--- a/packages/tsdl-ttf/tsdl-ttf.0.2/opam
+++ b/packages/tsdl-ttf/tsdl-ttf.0.2/opam
@@ -17,7 +17,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "tsdl_ttf"]
 depends: [
   "ocaml"
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0" & < "0.18.0"}
   "ctypes-foreign"
   "tsdl" {>= "0.9.0"}
   "result"


### PR DESCRIPTION
cc @yallop for `delimcc` I'm not sure how our CI here didn't get the issue but opam-health-check got the following failures on OCaml < 4.07:
```
#=== ERROR while compiling delimcc.2020.10.08 =================================#
# context              2.1.0~beta4 | linux/x86_64 | ocaml-base-compiler.4.06.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.06.1/.opam-switch/build/delimcc.2020.10.08
# command              /usr/bin/make all
# exit-code            2
# env-file             ~/.opam/log/delimcc-7-2fc21c.env
# output-file          ~/.opam/log/delimcc-7-2fc21c.out
### output ###
# /home/opam/.opam/4.06.1/bin/ocamlc -c delimcc.mli
# /home/opam/.opam/4.06.1/bin/ocamlc -c delimcc.ml
# gcc -fPIC -Wall  -I/home/opam/.opam/4.06.1/lib/ocaml/caml -O2 -D_FILE_OFFSET_BITS=64 -D_REENTRANT -DCAML_NAME_SPACE   -c -o stacks.o stacks.c
# gcc -fPIC -Wall  -I/home/opam/.opam/4.06.1/lib/ocaml/caml -O2 -D_FILE_OFFSET_BITS=64 -D_REENTRANT -DCAML_NAME_SPACE   -c -o delim_serialize.o delim_serialize.c
# /home/opam/.opam/4.06.1/bin/ocamlmklib -v -o delimcc -oc delimcc \
# delimcc.cmo stacks.o delim_serialize.o
# + gcc -shared  -o ./dlldelimcc.so stacks.o delim_serialize.o     
# /usr/bin/ld: delim_serialize.o:(.bss+0x10): multiple definition of `caml_major_work_credit'; stacks.o:(.bss+0x0): first defined here
# /usr/bin/ld: delim_serialize.o:(.bss+0x18): multiple definition of `caml_major_ring_index'; stacks.o:(.bss+0x8): first defined here
# /usr/bin/ld: delim_serialize.o:(.bss+0x20): multiple definition of `caml_major_ring'; stacks.o:(.bss+0x20): first defined here
# collect2: error: ld returned 1 exit status
# make: *** [Makefile:89: delimcc.cma] Error 2
```
cc @andrewray for `iocaml` and `oplay`
cc @psafont for `opasswd`
cc @tokenrove for `tsdl-ttf`
cc @dsheets for `sodium`