### PR TITLE
Change maximal OCaml version of camlp5.7.11 to 4.10.0

### DIFF
--- a/packages/camlp5/camlp5.7.11/opam
+++ b/packages/camlp5/camlp5.7.11/opam
@@ -30,7 +30,7 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 doc: "https://camlp5.github.io/doc/html"
 
 depends: [
-  "ocaml"       { >= "4.02" & < "4.11" }
+  "ocaml"       { >= "4.02" & <= "4.10.0" }
 ]
 
 build: [


### PR DESCRIPTION
For example with OCaml 4.10.2 the error is the following:
```
# 
# Sorry: the compatibility with ocaml version "4.10.2"
# is not yet implemented. Please report.
# 
# Information: directory ocaml_stuff/4.10.2 is missing.
# 
# Configuration failed.
```

It seems to me that camlp5 only supports OCaml up to version 4.10.0 exactly as there is one folder per version: https://github.com/camlp5/camlp5/tree/rel711/ocaml_stuff When the package was added only the 4.10.0 version of OCaml existed: https://github.com/ocaml/opam-repository/pull/15796 @chetmurthy 