### PR TITLE
[new release] ocamlformat (0.17.0)

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.17.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.17.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-team@fb.com>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08" & < "4.13"}
+  "ocaml-version"
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune-build-info"
+  "fix"
+  "fpath"
+  "menhir" {>= "20180528"}
+  "menhirLib" {>= "20200624"}
+  "menhirSdk" {>= "20200624"}
+  "ocaml-migrate-parsetree" {>= "2.1.0"}
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "ppxlib" {>= "0.22.0"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+x-commit-hash: "e4b9547b48f7fbd56c3297822e38d983155bffa8"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.17.0/ocamlformat-0.17.0.tbz"
+  checksum: [
+    "sha256=b0b1356d49afa1b1efba9a68ec608efdc81861f2d33d637bf891ef1799ae0714"
+    "sha512=3776cf057d4b8d9a12c1f21c523bca3fbc9301f81b3b93a83d4d170e313c6e698937cda1d7e59623d4b93656c24de975b2233d2cd95067c2e6a9cbfa5e98a663"
+  ]
+}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### Removed

  + Remove the 'let-open' option, deprecated since 0.16.0 (ocaml-ppx/ocamlformat#1563, @gpetiot)

  + Remove support for OCaml 4.06 and 4.07, minimal version requirement bumped to OCaml 4.08 (ocaml-ppx/ocamlformat#1549, @gpetiot)

  + Remove the 'extension-sugar' option, deprecated since 0.14.0 (ocaml-ppx/ocamlformat#1588, @gpetiot)

#### Bug fixes

  + Fix parsing of invalid file wrt original source handling (ocaml-ppx/ocamlformat#1542, @hhugo)

  + Preserve the syntax of infix set/get operators (ocaml-ppx/ocamlformat#1528, @gpetiot)
    `String.get` and similar calls used to be automatically rewritten to their corresponding infix form `.()`, that was incorrect when using the `-unsafe` compilation flag. Now the concrete syntax of these calls is preserved.

  + Add location of invalid docstring in warning messages (ocaml-ppx/ocamlformat#1529, @gpetiot)

  + Fix comments on the same line as prev and next elements (ocaml-ppx/ocamlformat#1556, @gpetiot)

  + Break or-patterns after comments and preserve their position at the end of line (ocaml-ppx/ocamlformat#1555, @gpetiot)

  + Fix linebreak between signature items of the same group (ocaml-ppx/ocamlformat#1560, @gpetiot)

  + Fix stack overflow on large string constants (ocaml-ppx/ocamlformat#1562, @gpetiot)

  + Fix comment position around list cons operator (ocaml-ppx/ocamlformat#1567, @gpetiot)

  + Fix the vertical alignment test to break down comment groups (ocaml-ppx/ocamlformat#1575, @gpetiot)

  + Preserve spacing of toplevel comments (ocaml-ppx/ocamlformat#1554, @gpetiot)

  + Support more sugared extension points (ocaml-ppx/ocamlformat#1587, @gpetiot)

#### Changes

  + Add buffer filename in the logs when applying ocamlformat (ocaml-ppx/ocamlformat#1557, @dannywillems)

  + Improve comment position in pattern collection (ocaml-ppx/ocamlformat#1576, @gpetiot)

  + Consistent positioning of lambda return type annotations when no-break-infix-before-func and pre/post extensions (ocaml-ppx/ocamlformat#1581, @gpetiot)

#### New features

  + Support injectivity type annotations (OCaml 4.12 feature) (ocaml-ppx/ocamlformat#1523, @gpetiot)
