### PR TITLE
[new release] opasswd (1.3.1)

### DIFF
--- a/packages/opasswd/opasswd.1.3.1/opam
+++ b/packages/opasswd/opasswd.1.3.1/opam
@@ -16,7 +16,6 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/xapi-project/ocaml-opasswd.git"
 url {

--- a/packages/opasswd/opasswd.1.3.1/opam
+++ b/packages/opasswd/opasswd.1.3.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis:
+  "OCaml bindings to the glibc passwd file and shadow password file interface"
+maintainer: "xen-api@lists.xen.org"
+authors: "Mike McClurg"
+license: "ISC"
+tags: "org:xapi-project"
+homepage: "https://github.com/xapi-project/ocaml-opasswd"
+bug-reports: "https://github.com/xapi-project/ocaml-opasswd/issues"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "dune" {>= "1.4"}
+  "ctypes" {>= "0.2.2"}
+  "ctypes-foreign"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/xapi-project/ocaml-opasswd.git"
+url {
+  src:
+    "https://github.com/xapi-project/ocaml-opasswd/archive/v1.3.1/ocaml-opasswd-1.3.1.tar.gz"
+  checksum: "sha256=18a24a9b1467796fa73bc939f14d15807cc6dc8995f56530f6b908b174837235"
+}


### PR DESCRIPTION
CHANGES:
  + Port to dune.
  + Fixed quite a few memory safety issues
  + Make the types of to_*_t and of_*_t be more symmetrical
  + Update string fields to char ptrs


This version is a couple years old and has some memory safety fixes, I thought it was about time it got published here.