### PR TITLE
[new release] js_of_ocaml-lwt, js_of_ocaml-compiler, js_of_ocaml, js_of_ocaml-ppx_deriving_json, js_of_ocaml-toplevel, js_of_ocaml-ppx, js_of_ocaml-ocamlbuild and js_of_ocaml-tyxml (3.9.0)

### DIFF
--- a/packages/eliom/eliom.6.10.1/opam
+++ b/packages/eliom/eliom.6.10.1/opam
@@ -13,13 +13,13 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}
-  "js_of_ocaml-compiler" {>= "3.5.1"}
-  "js_of_ocaml" {>= "3.5.1"}
-  "js_of_ocaml-lwt" {>= "3.5.1"}
-  "js_of_ocaml-ocamlbuild" {build}
-  "js_of_ocaml-ppx" {>= "3.5.1"}
-  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1"}
-  "js_of_ocaml-tyxml" {>= "3.5.1"}
+  "js_of_ocaml-compiler" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-lwt" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-ocamlbuild" {build & < "3.9.0"}
+  "js_of_ocaml-ppx" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-tyxml" {>= "3.5.1" & < "3.9.0"}
   "lwt_log"
   "lwt_ppx"
   "ppx_tools_versioned"

--- a/packages/eliom/eliom.6.11.0/opam
+++ b/packages/eliom/eliom.6.11.0/opam
@@ -13,13 +13,13 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}
-  "js_of_ocaml-compiler" {>= "3.5.1"}
-  "js_of_ocaml" {>= "3.5.1"}
-  "js_of_ocaml-lwt" {>= "3.5.1"}
-  "js_of_ocaml-ocamlbuild" {build}
-  "js_of_ocaml-ppx" {>= "3.5.1"}
-  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1"}
-  "js_of_ocaml-tyxml" {>= "3.5.1"}
+  "js_of_ocaml-compiler" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-lwt" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-ocamlbuild" {build & < "3.9.0"}
+  "js_of_ocaml-ppx" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-tyxml" {>= "3.5.1" & < "3.9.0"}
   "lwt_log"
   "lwt_ppx"
   "ppx_tools_versioned"

--- a/packages/eliom/eliom.6.12.0/opam
+++ b/packages/eliom/eliom.6.12.0/opam
@@ -13,13 +13,13 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}
-  "js_of_ocaml-compiler" {>= "3.5.1"}
-  "js_of_ocaml" {>= "3.5.1"}
-  "js_of_ocaml-lwt" {>= "3.5.1"}
-  "js_of_ocaml-ocamlbuild" {build}
-  "js_of_ocaml-ppx" {>= "3.5.1"}
-  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1"}
-  "js_of_ocaml-tyxml" {>= "3.5.1"}
+  "js_of_ocaml-compiler" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-lwt" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-ocamlbuild" {build & < "3.9.0"}
+  "js_of_ocaml-ppx" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-tyxml" {>= "3.5.1" & < "3.9.0"}
   "lwt_log"
   "lwt_ppx"
   "ppx_tools_versioned"

--- a/packages/eliom/eliom.6.12.1/opam
+++ b/packages/eliom/eliom.6.12.1/opam
@@ -13,13 +13,13 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}
-  "js_of_ocaml-compiler" {>= "3.5.1"}
-  "js_of_ocaml" {>= "3.5.1"}
-  "js_of_ocaml-lwt" {>= "3.5.1"}
-  "js_of_ocaml-ocamlbuild" {build}
-  "js_of_ocaml-ppx" {>= "3.5.1"}
-  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1"}
-  "js_of_ocaml-tyxml" {>= "3.5.1"}
+  "js_of_ocaml-compiler" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-lwt" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-ocamlbuild" {build & < "3.9.0"}
+  "js_of_ocaml-ppx" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-tyxml" {>= "3.5.1" & < "3.9.0"}
   "lwt_log"
   "lwt_ppx"
   "ppx_tools_versioned"

--- a/packages/eliom/eliom.6.12.4/opam
+++ b/packages/eliom/eliom.6.12.4/opam
@@ -13,13 +13,13 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}
-  "js_of_ocaml-compiler" {>= "3.5.1"}
-  "js_of_ocaml" {>= "3.5.1"}
-  "js_of_ocaml-lwt" {>= "3.5.1"}
-  "js_of_ocaml-ocamlbuild" {build}
-  "js_of_ocaml-ppx" {>= "3.5.1"}
-  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1"}
-  "js_of_ocaml-tyxml" {>= "3.5.1"}
+  "js_of_ocaml-compiler" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-lwt" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-ocamlbuild" {build & < "3.9.0"}
+  "js_of_ocaml-ppx" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-tyxml" {>= "3.5.1" & < "3.9.0"}
   "lwt_log"
   "lwt_ppx"
   "ppx_tools_versioned"

--- a/packages/eliom/eliom.6.13.1/opam
+++ b/packages/eliom/eliom.6.13.1/opam
@@ -13,13 +13,13 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}
-  "js_of_ocaml-compiler" {>= "3.5.1"}
-  "js_of_ocaml" {>= "3.5.1"}
-  "js_of_ocaml-lwt" {>= "3.5.1"}
-  "js_of_ocaml-ocamlbuild" {build}
-  "js_of_ocaml-ppx" {>= "3.5.1"}
-  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1"}
-  "js_of_ocaml-tyxml" {>= "3.5.1"}
+  "js_of_ocaml-compiler" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-lwt" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-ocamlbuild" {build & < "3.9.0"}
+  "js_of_ocaml-ppx" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1" & < "3.9.0"}
+  "js_of_ocaml-tyxml" {>= "3.5.1" & < "3.9.0"}
   "lwt_log"
   "lwt_ppx"
   "tyxml" {>= "4.4.0" & < "5.0.0"}

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "ppx_expect" {with-test & >= "v0.12.0"}
+  "cmdliner"
+  "menhir"
+  "ppxlib" {>= "0.15.0"}
+  "yojson" # It's optional, but we want users to be able to use source-map without pain.
+]
+
+depopts: [ "ocamlfind" ]
+
+conflicts: [
+  "ocamlfind"   {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+x-commit-hash: "95bc95d31122bae5764022f878d8a6dd95ceb169"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.9.0/js_of_ocaml-3.9.0.tbz"
+  checksum: [
+    "sha256=74d3b17b089af04cde29173c9e7a1154b9a784ba415aeef5026440aeb907cb54"
+    "sha512=affc91ed58d71e79752595345fcb2afe0d86378a73030ce64ef5624b9fef31925a2c2bb5e772fea017a508da292c351ad89b77e28361ff6f8ed345fecb78b31d"
+  ]
+}

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.9.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.9.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "lwt" {>= "2.4.4"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+]
+depopts: [ "graphics" "lwt_log" ]
+x-commit-hash: "95bc95d31122bae5764022f878d8a6dd95ceb169"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.9.0/js_of_ocaml-3.9.0.tbz"
+  checksum: [
+    "sha256=74d3b17b089af04cde29173c9e7a1154b9a784ba415aeef5026440aeb907cb54"
+    "sha512=affc91ed58d71e79752595345fcb2afe0d86378a73030ce64ef5624b9fef31925a2c2bb5e772fea017a508da292c351ad89b77e28361ff6f8ed345fecb78b31d"
+  ]
+}

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.9.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.9.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.5"}
+  "ocamlbuild"
+]
+x-commit-hash: "95bc95d31122bae5764022f878d8a6dd95ceb169"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.9.0/js_of_ocaml-3.9.0.tbz"
+  checksum: [
+    "sha256=74d3b17b089af04cde29173c9e7a1154b9a784ba415aeef5026440aeb907cb54"
+    "sha512=affc91ed58d71e79752595345fcb2afe0d86378a73030ce64ef5624b9fef31925a2c2bb5e772fea017a508da292c351ad89b77e28361ff6f8ed345fecb78b31d"
+  ]
+}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.9.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.9.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "ppxlib" {>= "0.15.0"}
+  "js_of_ocaml" {= version}
+]
+x-commit-hash: "95bc95d31122bae5764022f878d8a6dd95ceb169"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.9.0/js_of_ocaml-3.9.0.tbz"
+  checksum: [
+    "sha256=74d3b17b089af04cde29173c9e7a1154b9a784ba415aeef5026440aeb907cb54"
+    "sha512=affc91ed58d71e79752595345fcb2afe0d86378a73030ce64ef5624b9fef31925a2c2bb5e772fea017a508da292c351ad89b77e28361ff6f8ed345fecb78b31d"
+  ]
+}

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.9.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.9.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "2.5"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+]
+x-commit-hash: "95bc95d31122bae5764022f878d8a6dd95ceb169"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.9.0/js_of_ocaml-3.9.0.tbz"
+  checksum: [
+    "sha256=74d3b17b089af04cde29173c9e7a1154b9a784ba415aeef5026440aeb907cb54"
+    "sha512=affc91ed58d71e79752595345fcb2afe0d86378a73030ce64ef5624b9fef31925a2c2bb5e772fea017a508da292c351ad89b77e28361ff6f8ed345fecb78b31d"
+  ]
+}

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.9.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.9.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "ocamlfind" {>= "1.5.1"}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "js_of_ocaml" {= version}
+]
+x-commit-hash: "95bc95d31122bae5764022f878d8a6dd95ceb169"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.9.0/js_of_ocaml-3.9.0.tbz"
+  checksum: [
+    "sha256=74d3b17b089af04cde29173c9e7a1154b9a784ba415aeef5026440aeb907cb54"
+    "sha512=affc91ed58d71e79752595345fcb2afe0d86378a73030ce64ef5624b9fef31925a2c2bb5e772fea017a508da292c351ad89b77e28361ff6f8ed345fecb78b31d"
+  ]
+}

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.9.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.9.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "tyxml" {>= "4.3"}
+  "reactiveData" {>= "0.2"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+]
+x-commit-hash: "95bc95d31122bae5764022f878d8a6dd95ceb169"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.9.0/js_of_ocaml-3.9.0.tbz"
+  checksum: [
+    "sha256=74d3b17b089af04cde29173c9e7a1154b9a784ba415aeef5026440aeb907cb54"
+    "sha512=affc91ed58d71e79752595345fcb2afe0d86378a73030ce64ef5624b9fef31925a2c2bb5e772fea017a508da292c351ad89b77e28361ff6f8ed345fecb78b31d"
+  ]
+}

--- a/packages/js_of_ocaml/js_of_ocaml.3.9.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.9.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.github.io/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+synopsis:     "Compiler from OCaml bytecode to Javascript"
+description: """
+Js_of_ocaml is a compiler from OCaml bytecode to JavaScript.
+It makes it possible to run pure OCaml programs in JavaScript
+environment like browsers and Node.js
+"""
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.5"}
+  "ppxlib" {>= "0.15.0" }
+  "uchar"
+  "js_of_ocaml-compiler" {= version}
+]
+x-commit-hash: "95bc95d31122bae5764022f878d8a6dd95ceb169"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.9.0/js_of_ocaml-3.9.0.tbz"
+  checksum: [
+    "sha256=74d3b17b089af04cde29173c9e7a1154b9a784ba415aeef5026440aeb907cb54"
+    "sha512=affc91ed58d71e79752595345fcb2afe0d86378a73030ce64ef5624b9fef31925a2c2bb5e772fea017a508da292c351ad89b77e28361ff6f8ed345fecb78b31d"
+  ]
+}


### PR DESCRIPTION
Compiler from OCaml bytecode to Javascript

- Project page: <a href="http://ocsigen.github.io/js_of_ocaml">http://ocsigen.github.io/js_of_ocaml</a>

##### CHANGES:

## Features/Changes
* Lib: add clipboardEvent to Dom_html and update appropriate function signatures
* Lib: add submitEvent to Dom_html and update appropriate function signatures
* Compiler: complete support for OCaml 4.12
* Lib: expose API to attached and retrieve js errors to/from ocaml exceptions
* Lib: intersection observer API fixes

## Bug fixes
* Compiler: fix a segmentation fault when `flat-float-array` mode is disabled.
