### PR TITLE
Luv 0.5.7 — concurrent I/O through libuv

### DIFF
--- a/packages/luv/luv.0.5.7/opam
+++ b/packages/luv/luv.0.5.7/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+
+synopsis: "Binding to libuv: cross-platform asynchronous I/O"
+
+version: "0.5.7"
+license: "MIT"
+homepage: "https://github.com/aantron/luv"
+doc: "https://aantron.github.io/luv"
+bug-reports: "https://github.com/aantron/luv/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/luv.git"
+
+depends: [
+  "base-unix" {build}
+  "ctypes" {>= "0.13.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.02.0"}
+  "result"
+
+  "alcotest" {with-test & >= "0.8.1"}
+  "base-unix" {with-test}
+  "odoc" {with-doc & = "1.5.2"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Luv is a binding to libuv, the cross-platform C library that does
+asynchronous I/O in Node.js and runs its main loop.
+
+Besides asynchronous I/O, libuv also supports multiprocessing and
+multithreading. Multiple event loops can be run in different threads. libuv also
+exposes a lot of other functionality, amounting to a full OS API, and an
+alternative to the standard module Unix."
+
+url {
+  src: "https://github.com/aantron/luv/releases/download/0.5.7/luv-0.5.7.tar.gz"
+  checksum: "md5=ca1a2de9a100a8d2f2d9fcf2e1b5bd8c"
+}

--- a/packages/luv/luv.0.5.7/opam
+++ b/packages/luv/luv.0.5.7/opam
@@ -2,7 +2,6 @@ opam-version: "2.0"
 
 synopsis: "Binding to libuv: cross-platform asynchronous I/O"
 
-version: "0.5.7"
 license: "MIT"
 homepage: "https://github.com/aantron/luv"
 doc: "https://aantron.github.io/luv"


### PR DESCRIPTION
Repo: https://github.com/aantron/luv
Docs: https://aantron.github.io/luv/
Changelog:

Additions

- Upgrade vendored libuv to [1.41.0](https://github.com/libuv/libuv/releases/tag/v1.41.0) (aantron/luv#100).
- Expose [`uv_pipe`](http://docs.libuv.org/en/v1.x/pipe.html#c.uv_pipe) as [`Luv.Pipe.pipe`](https://aantron.github.io/luv/luv/Luv/Pipe/index.html#val-pipe) (aantron/luv#100).
- Expose [`uv_socketpair`](http://docs.libuv.org/en/v1.x/tcp.html#c.uv_socketpair) as [`Luv.TCP.socketpair`](https://aantron.github.io/luv/luv/Luv/TCP/index.html#val-socketpair) (aantron/luv#100).
- Expose [`UV_PRIORITY_*`](http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_setpriority) constants in module [`Luv.Resource.Priority`](https://aantron.github.io/luv/luv/Luv/Resource/Priority/index.html) (aantron/luv#98).
- Install headers for the vendored libuv in the opam switch (aantron/luv#83).
- Ability to link with a system or other external libuv (aantron/luv#94, Andy Li).
- Ability to link against older versions of libuv than the vendored one; the minimum libuv version is 1.3.0, though several functions will return `ENOSYS`; see notes in [README](https://github.com/aantron/luv#external-libuv) (aantron/luv#97).

Bugs fixed

- `SOMAXCONN` might not fit into an OCaml (31-bit) integer on 32-bit platforms (aantron/luv#85, reported by Aleksandr Kuzmenko).
- During [`Luv.Process.spawn`](https://aantron.github.io/luv/luv/Luv/Process/index.html#val-spawn), the OCaml GC was collecting [`uv_spawn`](http://docs.libuv.org/en/v1.x/process.html#c.uv_spawn) arguments before they were used (aantron/luv#87, Bryan Phelps).
- Write outside bounds of data structure during [`Luv.Thread_pool.queue_c_work`](https://aantron.github.io/luv/luv/Luv/Thread_pool/index.html#val-queue_c_work) (aantron/luv#93, Jerry James).
