### PR TITLE
ppx_protocol_conv: Works with ppxlib > 0.18.0

### DIFF
--- a/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.3/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.3/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.04"}
   "base" {>= "v0.14.0" }
   "dune" {>= "1.2"}
-  "ppxlib" {>= "0.9.0" & < "0.18.0"}
+  "ppxlib" {>= "0.9.0" & != "0.18.0"}
   "ppx_sexp_conv" {with-test}
   "sexplib" {with-test}
   "alcotest" {with-test & >= "0.8.0"}

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.3/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.3/opam
@@ -5,15 +5,15 @@ homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
 dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
 bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.04"}
-  "base" {>= "v0.14.0" }
+  "base" {>= "v0.14.0"}
   "dune" {>= "1.2"}
-  "ppxlib" {>= "0.9.0" & != "0.18.0"}
+  "ppxlib" {>= "0.9.0"}
   "ppx_sexp_conv" {with-test}
   "sexplib" {with-test}
   "alcotest" {with-test & >= "0.8.0"}


### PR DESCRIPTION
The constraint `ppxlib < 0.18` was added in https://github.com/ocaml/opam-repository/pull/17360, however ppx_protocol_conv is already compatible with ppxlib 0.21. It's unclear whether the problem was spurious. I opted to change the constraint to `ppxlib != 0.18`.