### PR TITLE
merlin: fix ocaml version contraints

### DIFF
--- a/packages/merlin/merlin.4.1-411/opam
+++ b/packages/merlin/merlin.4.1-411/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.11.0" & < "4.12"}
+  "ocaml" {>= "4.11" & < "4.12"}
   "dune" {>= "2.7.0"}
   "dot-merlin-reader" {>= "4.0"}
   "yojson" {>= "1.6.0"}

--- a/packages/merlin/merlin.4.1-412/opam
+++ b/packages/merlin/merlin.4.1-412/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
 ]
 depends: [
-  "ocaml" {> "4.11.1" }
+  "ocaml" {>= "4.12" & < "4.13"}
   "dune" {>= "2.7.0"}
   "dot-merlin-reader" {>= "4.0"}
   "yojson" {>= "1.6.0"}


### PR DESCRIPTION
If working in an OCaml 4.11.2 switch (release forthcoming) merlin
would be upgraded from 411 to 412.
This also helps with beta switches, if my calculations are correct we have 4.11 <= 4.11.0~x.
@trefis 