### PR TITLE
[new release] git, git-cohttp, git-cohttp-unix, git-cohttp-mirage, git-unix and git-mirage (3.3.0)

### DIFF
--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.0/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "git" {= version}
+  "mimic"
+  "cohttp-mirage"
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "363613ebab82a2730216816def653547c8a9e848"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.0/git-3.3.0.tbz"
+  checksum: [
+    "sha256=090b67e8f8a02fb52b4d0c7aa445b5ff7353fdb2da00fb37b908f089c6776cd0"
+    "sha512=b3beedffc9ec7f85d0c503f9d5f4115ce84bb75a6d1df8ed0fae214acec6922959be603e9ae869fb5ce6bd9da266973911889e2a4cd10b4c254d83a0f21bbaf4"
+  ]
+}

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.3.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "git" {= version}
+  "git-cohttp" {= version}
+  "cohttp-lwt-unix"
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "363613ebab82a2730216816def653547c8a9e848"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.0/git-3.3.0.tbz"
+  checksum: [
+    "sha256=090b67e8f8a02fb52b4d0c7aa445b5ff7353fdb2da00fb37b908f089c6776cd0"
+    "sha512=b3beedffc9ec7f85d0c503f9d5f4115ce84bb75a6d1df8ed0fae214acec6922959be603e9ae869fb5ce6bd9da266973911889e2a4cd10b4c254d83a0f21bbaf4"
+  ]
+}

--- a/packages/git-cohttp/git-cohttp.3.3.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "git" {= version}
+  "cohttp"
+  "cohttp-lwt"
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "363613ebab82a2730216816def653547c8a9e848"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.0/git-3.3.0.tbz"
+  checksum: [
+    "sha256=090b67e8f8a02fb52b4d0c7aa445b5ff7353fdb2da00fb37b908f089c6776cd0"
+    "sha512=b3beedffc9ec7f85d0c503f9d5f4115ce84bb75a6d1df8ed0fae214acec6922959be603e9ae869fb5ce6bd9da266973911889e2a4cd10b4c254d83a0f21bbaf4"
+  ]
+}

--- a/packages/git-mirage/git-mirage.3.3.0/opam
+++ b/packages/git-mirage/git-mirage.3.3.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A package to use ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "mimic"
+  "mirage-stack"
+  "git" {= version}
+  "awa"
+  "awa-mirage"
+  "dns-client" {>= "4.6.2"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "5.0.1"}
+  "lwt" {>= "5.3.0"}
+  "mirage-clock" {>= "3.1.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "mirage-protocols" {>= "5.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.1"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "363613ebab82a2730216816def653547c8a9e848"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.0/git-3.3.0.tbz"
+  checksum: [
+    "sha256=090b67e8f8a02fb52b4d0c7aa445b5ff7353fdb2da00fb37b908f089c6776cd0"
+    "sha512=b3beedffc9ec7f85d0c503f9d5f4115ce84bb75a6d1df8ed0fae214acec6922959be603e9ae869fb5ce6bd9da266973911889e2a4cd10b4c254d83a0f21bbaf4"
+  ]
+}

--- a/packages/git-unix/git-unix.3.3.0/opam
+++ b/packages/git-unix/git-unix.3.3.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install and configure ocaml-git's Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "mmap" {>= "1.1.0"}
+  "git" {= version}
+  "rresult"
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "fmt" {>= "0.8.7"}
+  "bos"
+  "fpath"
+  "uri" {with-test}
+  "digestif" {>= "0.8.1"}
+  "logs"
+  "lwt"
+  "base-unix"
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "git-cohttp-unix" {= version}
+  "mirage-clock"
+  "mirage-clock-unix"
+  "astring" {>= "0.8.5"}
+  "awa"
+  "cmdliner" {>= "1.0.4"}
+  "cohttp-lwt-unix" {>= "2.5.4"}
+  "decompress" {>= "1.2.0"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "5.0.1"}
+  "mtime" {>= "1.2.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "tcpip" {>= "6.0.0"}
+  "cstruct" {>= "6.0.0" & with-test}
+  "awa-mirage"
+  "mirage-flow" {>= "2.0.1"}
+  "ke" {>= "0.4" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "ocurl" {>= "0.9.1" & with-test}
+  "ptime" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "363613ebab82a2730216816def653547c8a9e848"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.0/git-3.3.0.tbz"
+  checksum: [
+    "sha256=090b67e8f8a02fb52b4d0c7aa445b5ff7353fdb2da00fb37b908f089c6776cd0"
+    "sha512=b3beedffc9ec7f85d0c503f9d5f4115ce84bb75a6d1df8ed0fae214acec6922959be603e9ae869fb5ce6bd9da266973911889e2a4cd10b4c254d83a0f21bbaf4"
+  ]
+}

--- a/packages/git/git.3.3.0/opam
+++ b/packages/git/git.3.3.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "Git format and protocol in pure OCaml"
+description: """\
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "digestif" {>= "0.8.1"}
+  "rresult"
+  "base64" {>= "3.0.0"}
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "optint"
+  "decompress"
+  "logs"
+  "lwt"
+  "mimic"
+  "cstruct" {>= "5.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "carton" {>= "0.2.0"}
+  "carton-lwt" {>= "0.2.0"}
+  "carton-git" {>= "0.2.0"}
+  "ke" {>= "0.4"}
+  "fmt" {>= "0.8.7"}
+  "checkseum" {>= "0.2.1"}
+  "ocamlgraph" {>= "1.8.8"}
+  "astring"
+  "fpath"
+  "encore" {>= "0.7"}
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng" {with-test & >= "0.8.0"}
+  "cmdliner" {with-test}
+  "base-unix" {with-test}
+  "fpath"
+  "mirage-flow" {>= "2.0.1"}
+  "domain-name" {>= "0.3.0"}
+  "emile" {>= "1.1"}
+  "ipaddr" {>= "5.0.1"}
+  "psq" {>= "0.2.0"}
+  "uri" {>= "4.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "363613ebab82a2730216816def653547c8a9e848"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.0/git-3.3.0.tbz"
+  checksum: [
+    "sha256=090b67e8f8a02fb52b4d0c7aa445b5ff7353fdb2da00fb37b908f089c6776cd0"
+    "sha512=b3beedffc9ec7f85d0c503f9d5f4115ce84bb75a6d1df8ed0fae214acec6922959be603e9ae869fb5ce6bd9da266973911889e2a4cd10b4c254d83a0f21bbaf4"
+  ]
+}

--- a/packages/irmin-git/irmin-git.2.3.0/opam
+++ b/packages/irmin-git/irmin-git.2.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"       {>= "2.7.0"}
   "irmin"      {= version}
   "ppx_irmin"  {= version}
-  "git"        {>= "3.0.0"}
+  "git"        {>= "3.0.0" & < "3.3.0"}
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"

--- a/packages/irmin-git/irmin-git.2.4.0/opam
+++ b/packages/irmin-git/irmin-git.2.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"       {>= "2.7.0"}
   "irmin"      {= version}
   "ppx_irmin"  {= version}
-  "git"        {>= "3.0.0"}
+  "git"        {>= "3.0.0" & < "3.3.0"}
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"

--- a/packages/irmin-git/irmin-git.2.5.0/opam
+++ b/packages/irmin-git/irmin-git.2.5.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"       {>= "2.7.0"}
   "irmin"      {= version}
   "ppx_irmin"  {= version}
-  "git"        {>= "3.0.0"}
+  "git"        {>= "3.0.0" & < "3.3.0"}
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.3.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.3.0/opam
@@ -20,9 +20,9 @@ depends: [
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"
-  "git-cohttp-mirage" {>= "3.0.0"}
+  "git-cohttp-mirage" {>= "3.0.0" & < "3.3.0"}
   "fmt"
-  "git"               {>= "3.0.0"}
+  "git"               {>= "3.0.0" & < "3.3.0"}
   "lwt"
   "mirage-clock"
   "uri"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.4.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.4.0/opam
@@ -20,9 +20,9 @@ depends: [
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"
-  "git-cohttp-mirage" {>= "3.0.0"}
+  "git-cohttp-mirage" {>= "3.0.0" & < "3.3.0"}
   "fmt"
-  "git"               {>= "3.0.0"}
+  "git"               {>= "3.0.0" & < "3.3.0"}
   "lwt"
   "mirage-clock"
   "uri"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.5.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.5.0/opam
@@ -20,9 +20,9 @@ depends: [
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"
-  "git-cohttp-mirage" {>= "3.0.0"}
+  "git-cohttp-mirage" {>= "3.0.0" & < "3.3.0"}
   "fmt"
-  "git"               {>= "3.0.0"}
+  "git"               {>= "3.0.0" & < "3.3.0"}
   "lwt"
   "mirage-clock"
   "uri"

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.3.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.3.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp-lwt"
   "lwt"
   "uri"
-  "git"           {>= "3.0.0"}
+  "git"           {>= "3.0.0" & < "3.3.0"}
 ]
 
 synopsis: "MirageOS-compatible Irmin stores"

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.4.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp-lwt"
   "lwt"
   "uri"
-  "git"           {>= "3.0.0"}
+  "git"           {>= "3.0.0" & < "3.3.0"}
 ]
 
 synopsis: "MirageOS-compatible Irmin stores"

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.5.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.5.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp-lwt"
   "lwt"
   "uri"
-  "git"           {>= "3.0.0"}
+  "git"           {>= "3.0.0" & < "3.3.0"}
 ]
 
 synopsis: "MirageOS-compatible Irmin stores"

--- a/packages/irmin-unix/irmin-unix.2.3.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.3.0/opam
@@ -40,8 +40,8 @@ depends: [
   "cmdliner"
   "cohttp-lwt-unix"
   "fmt"
-  "git"             {>= "3.0.0"}
-  "git-cohttp-unix" {>= "3.0.0"}
+  "git"             {>= "3.0.0" & < "3.3.0"}
+  "git-cohttp-unix" {>= "3.0.0" & < "3.3.0"}
   "lwt"
 ]
 

--- a/packages/irmin-unix/irmin-unix.2.4.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.4.0/opam
@@ -40,8 +40,8 @@ depends: [
   "cmdliner"
   "cohttp-lwt-unix"
   "fmt"
-  "git"             {>= "3.0.0"}
-  "git-cohttp-unix" {>= "3.0.0"}
+  "git"             {>= "3.0.0" & < "3.3.0"}
+  "git-cohttp-unix" {>= "3.0.0" & < "3.3.0"}
   "lwt"
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}

--- a/packages/irmin-unix/irmin-unix.2.5.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.5.0/opam
@@ -42,8 +42,8 @@ depends: [
   "cmdliner"
   "cohttp-lwt-unix"
   "fmt"
-  "git"             {>= "3.0.0"}
-  "git-cohttp-unix" {>= "3.0.0"}
+  "git"             {>= "3.0.0" & < "3.3.0"}
+  "git-cohttp-unix" {>= "3.0.0" & < "3.3.0"}
   "lwt"
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}


### PR DESCRIPTION
Git format and protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Fix tests when we push to an empty repository (mirage/ocaml-git#462, @dinosaure, @ulugbekna)
- Fix new smart tests without a global git config (mirage/ocaml-git#463, @sternenseemann, @dinosaure)
- Refactor tests (mirage/ocaml-git#464, @ulugbekna, @dinosaure)
- Refactor `find_common.ml` (mirage/ocaml-git#465, @ulugbekna, @dinosaure)
- Some preparation about Git protocol v2 (mirage/ocaml-git#466, @ulugbekna, @dinosaure)
- Add HTTP/HTTPS support on the unikernel example (mirage/ocaml-git#467, @dinosaure)
- Fix bug about push and capabilities (mirage/ocaml-git#468, @dinosaure, @hannesm, @ulugbekna)
- Implement HTTP push and handle username & password in the given `Uri.t` (mirage/ocaml-git#469, @dinosaure)
- **breaking changes**
  Commit object must have a double LF to separate the header and the body. This format changes
  hashes of commit and invalid old commits generated by `ocaml-git`. It seems that on the Git
  side, the format is not fully respected - and it's why Git did not complain about that on our
  tests for a long time.

  However, `git fsck` does this check and an HTTP push to GitHub run `git fsck` at the end. To
  be able to push (or run our _unikernel_ over HTTP/S), we must generate right commits.

  So, we advise users to make a fake commit with Git (`git commit --allow-empty -m.`) on
  repositories used by `ocaml-git` and fetch it with `depth:1`. Otherwise, this new version
  of `ocaml-git` will refute older commits - due to the inherent isomorphism between
  decoder/encoder in `ocaml-git`.

  For Irmin users, this breaking changes does not change anything when `irmin` reformats correctly
  the message to put the second LF. However, a breaking change exists on the API level when the
  Git commit (and a Git tag) expects a `string option` now (instead of a simple `string).

  For more details and tests, see mirage/ocaml-git#470 (@dinosaure)
