### PR TITLE
pardi.3.2.0: upper bound on dolog is not needed

### DIFF
--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -20,6 +20,7 @@ depexts: [
   ["epel-release" "zeromq-devel"] {os-distribution = "centos"}
   ["zeromq"] {os-distribution = "arch"}
   ["zeromq-devel"] {os-distribution = "fedora"}
+  ["zeromq-devel"] {os-distribution = "ol"}
   ["zeromq-devel"] {os-family = "suse"}
   ["libzmq4"] {os = "freebsd"}
 ]

--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -20,9 +20,12 @@ depexts: [
   ["epel-release" "zeromq-devel"] {os-distribution = "centos"}
   ["zeromq"] {os-distribution = "arch"}
   ["zeromq-devel"] {os-distribution = "fedora"}
-  ["zeromq-devel"] {os-distribution = "ol"}
   ["zeromq-devel"] {os-family = "suse"}
   ["libzmq4"] {os = "freebsd"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7" # package not available
+  "oraclelinux-8" # package not available
 ]
 synopsis: "Virtual package relying on zmq library installation"
 description: """

--- a/packages/pardi/pardi.3.2.0/opam
+++ b/packages/pardi/pardi.3.2.0/opam
@@ -9,7 +9,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "1.11"}
   "batteries"
-  "dolog" {>= "4.0.0" & < "5.0.0"}
+  "dolog" {>= "4.0.0"}
   "parany" {>= "11.0.0"}
   "minicli" {>= "5.0.0"}
   "lz4"


### PR DESCRIPTION
pardi compiles fine with dolog.6.0.0, for example