### PR TITLE
Package ppx_cstubs.0.6.1.1

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.5.0.1/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.5.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+homepage: "https://fdopen.github.io/ppx_cstubs/"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+doc: "https://fdopen.github.io/ppx_cstubs/"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "bigarray-compat"
+  "ctypes" {>= "0.13.0" & < "0.19"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.02.3" & < "4.13.0"}
+  "ocaml-migrate-parsetree" {>= "1.7.0"}
+  "ocamlfind" {>= "1.7.2"} # not only a build dependency, it depends on findlib.top
+  "dune" {>= "1.6"}
+  "ppx_tools_versioned" {>= "5.4.0"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: """
+Preprocessor for easier stub generation with ctypes
+"""
+
+description: """
+ppx_cstubs is a ppx-based preprocessor for stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file
+with c stub code and an OCaml file with all additional boilerplate
+code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.5.0.1.tar.gz"
+  checksum: [
+    "md5=67bb32f020e268d1840c5edd6369da8b"
+    "sha512=4fab8a5c2558cbd5508aef19b1b13b65d2cd3e692f4805f796a6ae42f969b9a0c46b4eeeefe247cc259a16cc4b21ca09f9cbf8dd36940039aad4d36d4c310a88"
+  ]
+}

--- a/packages/ppx_cstubs/ppx_cstubs.0.6.0.1/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.6.0.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+homepage: "https://fdopen.github.io/ppx_cstubs/"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+doc: "https://fdopen.github.io/ppx_cstubs/"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "bigarray-compat"
+  "ctypes" {>= "0.13.0" & < "0.19"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.04.2" & < "4.13.0"}
+  "ppxlib" {>= "0.18.0" & < "0.22.0"}
+  "ocamlfind" {>= "1.7.2"} # not only a build dependency, it depends on findlib.top
+  "dune" {>= "1.6"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: """
+Preprocessor for easier stub generation with ctypes
+"""
+
+description: """
+ppx_cstubs is a ppx-based preprocessor for stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file
+with c stub code and an OCaml file with all additional boilerplate
+code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.6.0.1.tar.gz"
+  checksum: [
+    "md5=7af40c9f21d94d263a63eb7fb792c542"
+    "sha512=a407e8b6b2b87d750117a23efb3428a77f45941ea42138324aca1a45a86443a0133be059910b41821fa9621042d5b34d27991639b08610d1dc85eda7f907c643"
+  ]
+}

--- a/packages/ppx_cstubs/ppx_cstubs.0.6.1.1/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.6.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+homepage: "https://fdopen.github.io/ppx_cstubs/"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+doc: "https://fdopen.github.io/ppx_cstubs/"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "bigarray-compat"
+  "ctypes" {>= "0.13.0" & < "0.19"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.04.2" & < "4.13.0"}
+  "ppxlib" {>= "0.22.0"}
+  "ocamlfind" {>= "1.7.2"} # not only a build dependency, it depends on findlib.top
+  "dune" {>= "1.6"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: """
+Preprocessor for easier stub generation with ctypes
+"""
+
+description: """
+ppx_cstubs is a ppx-based preprocessor for stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file
+with c stub code and an OCaml file with all additional boilerplate
+code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.6.1.1.tar.gz"
+  checksum: [
+    "md5=33e520e369da5630c697318f6f4ed26d"
+    "sha512=77f28fd93ba476ccad089029fb7c7254a4525ea2d61f4d0a74c69b8c771e2657929c16cfa334671ccead1c02743804fc3db7726fd3e47772f50dc4a16270435c"
+  ]
+}


### PR DESCRIPTION
### `ppx_cstubs.0.6.1.1`
Preprocessor for easier stub generation with ctypes
ppx_cstubs is a ppx-based preprocessor for stub generation with
ctypes. ppx_cstubs creates two files from a single ml file: a file
with c stub code and an OCaml file with all additional boilerplate
code.



---
* Homepage: https://fdopen.github.io/ppx_cstubs/
* Source repo: git+https://github.com/fdopen/ppx_cstubs.git
* Bug tracker: https://github.com/fdopen/ppx_cstubs/issues

---
:camel: Pull-request generated by opam-publish v2.0.3