### PR TITLE
Package bastet.2.0.0

### DIFF
--- a/packages/bastet/bastet.2.0.0/opam
+++ b/packages/bastet/bastet.2.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "An OCaml library for category theory and abstract algebra"
+maintainer: ["me@risto.codes"]
+authors: ["Risto Stevcev"]
+license: "BSD-3-Clause"
+tags: ["category theory" "abstract algebra" "algebra" "cats"]
+homepage: "https://github.com/Risto-Stevcev/bastet"
+doc: "https://risto-stevcev.github.io/bastet"
+bug-reports: "https://github.com/Risto-Stevcev/bastet/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "qcheck" {>= "0.13" & with-test}
+  "qcheck-alcotest" {>= "0.13" & with-test}
+  "mdx" {>= "1.6.0" & with-test}
+  "bisect_ppx" {>= "2.1.0"}
+  "odoc" {>= "1.5.0" & with-doc}
+  "mustache" {>= "3.1.0" & with-doc}
+  "dune" {>= "2.0.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Risto-Stevcev/bastet.git"
+url {
+  src: "https://github.com/Risto-Stevcev/bastet/archive/2.0.0.tar.gz"
+  checksum: [
+    "md5=e9dcbc4e576d2c4622ac0cc9961f67b4"
+    "sha512=e2b891d23a2332368af801fd0d39f4ed0112162a962acba47b32e2ce7faf22ba6bf23549cf965184978966afbe08ea2e95ca09a05cffb0d780cf7e7af33b00b7"
+  ]
+}


### PR DESCRIPTION
### `bastet.2.0.0`
An OCaml library for category theory and abstract algebra



---
* Homepage: https://github.com/Risto-Stevcev/bastet
* Source repo: git+https://github.com/Risto-Stevcev/bastet.git
* Bug tracker: https://github.com/Risto-Stevcev/bastet/issues

---
:camel: Pull-request generated by opam-publish v2.0.3