### PR TITLE
[new release] earlybird (1.0.1)

### DIFF
--- a/packages/earlybird/earlybird.1.0.1/opam
+++ b/packages/earlybird/earlybird.1.0.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Debug adapter for OCaml 4.11"
+description: "Debug adapter for OCaml 4.11."
+maintainer: ["hackwaly@qq.com"]
+authors: ["hackwaly@qq.com"]
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0" & < "4.12.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "menhir" {>= "20201216" & build}
+  "menhirLib" {>= "20201216"}
+  "iter" {>= "1.2.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react" {>= "1.1.3"}
+  "cmdliner" {>= "1.0.4"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "path_glob" {>= "0.2"}
+  "sexplib" {>= "0.14.0"}
+  "csexp" {>= "1.3.2"}
+  "lru" {>= "0.3.0"}
+  "dap" {>= "1.0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hackwaly/ocamlearlybird.git"
+x-commit-hash: "8d3e11cdcb6112e3bf3690a9875baf598e632435"
+url {
+  src:
+    "https://github.com/hackwaly/ocamlearlybird/releases/download/1.0.1/earlybird-1.0.1.tbz"
+  checksum: [
+    "sha256=835419b442293e8f9348ca7a5547031cdffefbe35512562ef0df47e6a229c10c"
+    "sha512=94b16c6efbaab99ff800b0500709f2e1e81c2f62d218b7be3ac0293c6679c3cdb516bdf3ab88424d404d23c963fdfd5def6b6b18f2df6de7d5eb04fa5bd7bd34"
+  ]
+}


### PR DESCRIPTION
Debug adapter for OCaml 4.11

- Project page: <a href="https://github.com/hackwaly/ocamlearlybird">https://github.com/hackwaly/ocamlearlybird</a>

##### CHANGES:

Beta2 release.

## Added

* Allow to set breakpoints on files which has same digest of sources.

## Fixed

* Fix variables pane sometimes flooding by `Typenv__Envaux_hack.Error(...)`.
