### PR TITLE
[new release] earlybird (1.0.1)

### DIFF
--- a/packages/earlybird/earlybird.1.0.1/opam
+++ b/packages/earlybird/earlybird.1.0.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Debug adapter for OCaml 4.11"
+description: "Debug adapter for OCaml 4.11."
+maintainer: ["hackwaly@qq.com"]
+authors: ["hackwaly@qq.com"]
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0" & < "4.12.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "menhir" {>= "20201216" & build}
+  "menhirLib" {>= "20201216"}
+  "iter" {>= "1.2.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react" {>= "1.1.3"}
+  "cmdliner" {>= "1.0.4"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "path_glob" {>= "0.2"}
+  "sexplib" {>= "0.14.0"}
+  "csexp" {>= "1.3.2"}
+  "lru" {>= "0.3.0"}
+  "dap" {>= "1.0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hackwaly/ocamlearlybird.git"
+x-commit-hash: "9068e314043d3a4eaf598c0a82a05d67a0e902e5"
+url {
+  src:
+    "https://github.com/hackwaly/ocamlearlybird/releases/download/1.0.1/earlybird-1.0.1.tbz"
+  checksum: [
+    "sha256=ec03f862f14a78b395710f93fde7d8e0470ac0c4689f4011bb3a74697da2a699"
+    "sha512=33a5ac6d4426f5ba59da49919910a1ba3bf7bd54beffac5076677c8c37518e229f08afbee9e6a0fecd48fd3ca94a16d698165c6c1f869a22f17df7e3b9d7afae"
+  ]
+}


### PR DESCRIPTION
Debug adapter for OCaml 4.11

- Project page: <a href="https://github.com/hackwaly/ocamlearlybird">https://github.com/hackwaly/ocamlearlybird</a>

##### CHANGES:

Beta2 release.

## Added

* Allow to set breakpoints on files which has same digest of sources.

## Fixed

* Fix variables pane sometimes flooding by `Typenv__Envaux_hack.Error(...)`.
* Fix inspect array variables cause infinite loading.
