### PR TITLE
[new release] earlybird (1.0.2)

### DIFF
--- a/packages/earlybird/earlybird.1.0.2/opam
+++ b/packages/earlybird/earlybird.1.0.2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Debug adapter for OCaml 4.11"
+description: "Debug adapter for OCaml 4.11."
+maintainer: ["hackwaly@qq.com"]
+authors: ["hackwaly@qq.com"]
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0" & < "4.12.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "menhir" {>= "20201216" & build}
+  "menhirLib" {>= "20201216"}
+  "iter" {>= "1.2.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react" {>= "1.1.3"}
+  "cmdliner" {>= "1.0.4"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "path_glob" {>= "0.2"}
+  "sexplib" {>= "0.14.0"}
+  "csexp" {>= "1.3.2"}
+  "lru" {>= "0.3.0"}
+  "dap" {>= "1.0.6"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hackwaly/ocamlearlybird.git"
+x-commit-hash: "e3ad8fb670d399537995fe80dbfa88862a4188a0"
+url {
+  src:
+    "https://github.com/hackwaly/ocamlearlybird/releases/download/1.0.2/earlybird-1.0.2.tbz"
+  checksum: [
+    "sha256=bf1bc40854212665f1fa8370ef2a8eceb9c696e638a7013484fc6359a6d386f1"
+    "sha512=210e2312d3caffbea4db5f3c1d5636b4bf0b3093c1c4d0d112d312e41d2b7ebc285e7764623acd3bd33ae8346615fb8df2ff6277b7fc1a55165ec19b9580f040"
+  ]
+}


### PR DESCRIPTION
Debug adapter for OCaml 4.11

- Project page: <a href="https://github.com/hackwaly/ocamlearlybird">https://github.com/hackwaly/ocamlearlybird</a>

##### CHANGES:

### Added

* Show %accu pseudo variable at Event_after event.
* Added variable context menu "Goto Closure Code Location".

### Fixed

* Respect linesStartAt1 and columnsStartAt1 options.
* Fix occasional breakpointLocations command exception.
* Fix stopped at first event in main module cannot display stack frames when using onlyDebugGlob option.
