### PR TITLE
[new release] earlybird (1.0.2)

### DIFF
--- a/packages/earlybird/earlybird.1.0.2/opam
+++ b/packages/earlybird/earlybird.1.0.2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Debug adapter for OCaml 4.11"
+description: "Debug adapter for OCaml 4.11."
+maintainer: ["hackwaly@qq.com"]
+authors: ["hackwaly@qq.com"]
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0" & < "4.12.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "menhir" {>= "20201216" & build}
+  "menhirLib" {>= "20201216"}
+  "iter" {>= "1.2.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react" {>= "1.1.3"}
+  "cmdliner" {>= "1.0.4"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "path_glob" {>= "0.2"}
+  "sexplib" {>= "0.14.0"}
+  "csexp" {>= "1.3.2"}
+  "lru" {>= "0.3.0"}
+  "dap" {>= "1.0.6"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hackwaly/ocamlearlybird.git"
+x-commit-hash: "06f4b2931725eaee40d03640aeffdff227541f5d"
+url {
+  src:
+    "https://github.com/hackwaly/ocamlearlybird/releases/download/1.0.2/earlybird-1.0.2.tbz"
+  checksum: [
+    "sha256=c370e2e6d1d33960e9c34d95bbf5d730a1ad0e4daab57980aadaa6e8697b225a"
+    "sha512=e5e11a422bb8a04705be7e563bd7c15a1a7a106e713a58291292c5754a8a3f196155593a21c2137b40466415dd0076f04b7eb8a2e0b9f58fa8763641021922e6"
+  ]
+}


### PR DESCRIPTION
Debug adapter for OCaml 4.11

- Project page: <a href="https://github.com/hackwaly/ocamlearlybird">https://github.com/hackwaly/ocamlearlybird</a>

##### CHANGES:

### Added

* Show %accu pseudo variable at Event_after event.
* Added variable context menu "Goto Closure Code Location".

### Fixed

* Respect linesStartAt1 and columnsStartAt1 options.
* Fix occasional breakpointLocations command exception.
* Fix stopped at first event in main module cannot display stack frames when using onlyDebugGlob option.
