### PR TITLE
[new release] optint (0.0.5)

### DIFF
--- a/packages/checkseum/checkseum.0.0.1/opam
+++ b/packages/checkseum/checkseum.0.0.1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "checkseum"
 maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 homepage:     "https://github.com/dinosaure/checkseum"

--- a/packages/checkseum/checkseum.0.0.1/opam
+++ b/packages/checkseum/checkseum.0.0.1/opam
@@ -13,7 +13,7 @@ build: [ "jbuilder" "build" "-p" name "-j" jobs ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.12"}
   "jbuilder"
-  "optint"
+  "optint" {< "0.0.5"}
   "base-bytes"
 ]
 synopsis: "Checkseum"

--- a/packages/checkseum/checkseum.0.0.1/opam
+++ b/packages/checkseum/checkseum.0.0.1/opam
@@ -16,6 +16,7 @@ depends: [
   "optint" {< "0.0.5"}
   "base-bytes"
 ]
+available: arch = "x86_64"
 synopsis: "Checkseum"
 description: """
 =========

--- a/packages/checkseum/checkseum.0.0.2/opam
+++ b/packages/checkseum/checkseum.0.0.2/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "checkseum"
 maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 homepage:     "https://github.com/dinosaure/checkseum"

--- a/packages/checkseum/checkseum.0.0.2/opam
+++ b/packages/checkseum/checkseum.0.0.2/opam
@@ -13,7 +13,7 @@ build: [ "jbuilder" "build" "-p" name "-j" jobs ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.12"}
   "jbuilder"
-  "optint"
+  "optint" {< "0.0.5"}
   "base-bytes"
   "base-bigarray"
   "fmt"

--- a/packages/checkseum/checkseum.0.0.2/opam
+++ b/packages/checkseum/checkseum.0.0.2/opam
@@ -20,6 +20,7 @@ depends: [
   "rresult"
   "cmdliner"
 ]
+available: arch = "x86_64"
 synopsis: "Checkseum"
 description: """
 =========

--- a/packages/checkseum/checkseum.0.0.3/opam
+++ b/packages/checkseum/checkseum.0.0.3/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "checkseum"
 maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 homepage:     "https://github.com/dinosaure/checkseum"

--- a/packages/checkseum/checkseum.0.0.3/opam
+++ b/packages/checkseum/checkseum.0.0.3/opam
@@ -32,6 +32,7 @@ depends: [
   "cmdliner"
   "alcotest"      {with-test}
 ]
+available: arch = "x86_64"
 url {
   src:
     "https://github.com/dinosaure/checkseum/releases/download/v0.0.3/checkseum-v0.0.3.tbz"

--- a/packages/checkseum/checkseum.0.0.3/opam
+++ b/packages/checkseum/checkseum.0.0.3/opam
@@ -24,7 +24,7 @@ build: [
 depends: [
   "ocaml"         {>= "4.03.0"}
   "dune"
-  "optint"
+  "optint"        {< "0.0.5"}
   "base-bytes"
   "base-bigarray"
   "fmt"

--- a/packages/checkseum/checkseum.0.0.9/opam
+++ b/packages/checkseum/checkseum.0.0.9/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "checkseum"
 maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 homepage:     "https://github.com/dinosaure/checkseum"

--- a/packages/checkseum/checkseum.0.0.9/opam
+++ b/packages/checkseum/checkseum.0.0.9/opam
@@ -21,7 +21,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 depends: [
   "ocaml"         {>= "4.03.0"}
   "dune"          {>= "1.9.2" & < "2.6"}
-  "optint"
+  "optint"        {< "0.0.5"}
   "base-bytes"
   "bigarray-compat"
   "fmt"

--- a/packages/checkseum/checkseum.0.0.9/opam
+++ b/packages/checkseum/checkseum.0.0.9/opam
@@ -29,6 +29,7 @@ depends: [
   "cmdliner"
   "alcotest"      {with-test}
 ]
+available: arch = "x86_64"
 
 depopts: [
   "ocaml-freestanding"

--- a/packages/checkseum/checkseum.0.1.0/opam
+++ b/packages/checkseum/checkseum.0.1.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "checkseum"
 maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 homepage:     "https://github.com/dinosaure/checkseum"

--- a/packages/checkseum/checkseum.0.1.0/opam
+++ b/packages/checkseum/checkseum.0.1.0/opam
@@ -32,6 +32,7 @@ depends: [
   "cmdliner"
   "alcotest"      {with-test}
 ]
+available: arch = "x86_64"
 
 depopts: [
   "ocaml-freestanding"

--- a/packages/checkseum/checkseum.0.1.0/opam
+++ b/packages/checkseum/checkseum.0.1.0/opam
@@ -24,7 +24,7 @@ build: [
 depends: [
   "ocaml"         {>= "4.03.0"}
   "dune"          {>= "1.9.2" & < "2.6"}
-  "optint"
+  "optint"        {< "0.0.5"}
   "base-bytes"
   "base-bigarray"
   "fmt"

--- a/packages/checkseum/checkseum.0.1.1-1/opam
+++ b/packages/checkseum/checkseum.0.1.1-1/opam
@@ -27,7 +27,7 @@ extra-files: [
 depends: [
   "ocaml"         {>= "4.07.0"}
   "dune"          {>= "1.9.2" & < "2.6"}
-  "optint"        {>= "0.0.3"}
+  "optint"        {>= "0.0.3" & < "0.0.5"}
   "base-bytes"
   "bigarray-compat"
   "fmt"

--- a/packages/checkseum/checkseum.0.1.1/opam
+++ b/packages/checkseum/checkseum.0.1.1/opam
@@ -20,7 +20,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 depends: [
   "ocaml"         {>= "4.07.0"}
   "dune"          {>= "1.9.2" & < "2.6"}
-  "optint"        {>= "0.0.3"}
+  "optint"        {>= "0.0.3" & < "0.0.5"}
   "base-bytes"
   "bigarray-compat"
   "fmt"

--- a/packages/checkseum/checkseum.0.2.0/opam
+++ b/packages/checkseum/checkseum.0.2.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "checkseum"
 maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 homepage:     "https://github.com/mirage/checkseum"

--- a/packages/checkseum/checkseum.0.2.0/opam
+++ b/packages/checkseum/checkseum.0.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml"         {>= "4.07.0"}
   "dune"          {>= "2.0.0" & < "2.6"}
   "dune-configurator"
-  "optint"        {>= "0.0.4"}
+  "optint"        {>= "0.0.4" & < "0.0.5"}
   "base-bytes"
   "bigarray-compat"
   "alcotest"      {with-test}

--- a/packages/checkseum/checkseum.0.2.1/opam
+++ b/packages/checkseum/checkseum.0.2.1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "checkseum"
 maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 homepage:     "https://github.com/mirage/checkseum"

--- a/packages/checkseum/checkseum.0.2.1/opam
+++ b/packages/checkseum/checkseum.0.2.1/opam
@@ -31,7 +31,7 @@ depends: [
   "ocaml"         {>= "4.07.0"}
   "dune"          {>= "2.6.0"}
   "dune-configurator"
-  "optint"        {>= "0.0.3"}
+  "optint"        {>= "0.0.3" & < "0.0.5"}
   "base-bytes"
   "bigarray-compat"
   "alcotest"      {with-test}

--- a/packages/checkseum/checkseum.0.3.0/opam
+++ b/packages/checkseum/checkseum.0.3.0/opam
@@ -26,7 +26,7 @@ depends: [
   "dune"          {>= "2.6.0"}
   "conf-pkg-config" {build}
   "dune-configurator"
-  "optint"        {>= "0.0.3"}
+  "optint"        {>= "0.0.3" & < "0.0.5"}
   "base-bytes"
   "bigarray-compat"
   "alcotest"      {with-test}

--- a/packages/decompress/decompress.0.9.0/opam
+++ b/packages/decompress/decompress.0.9.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "decompress"
 maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
 authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
 homepage:     "https://github.com/mirage/decompress"

--- a/packages/decompress/decompress.0.9.0/opam
+++ b/packages/decompress/decompress.0.9.0/opam
@@ -23,7 +23,7 @@ depends: [
   "base-bigarray"
   "mmap"
   "optint"
-  "checkseum"
+  "checkseum"  {>= "0.0.3"}
   "camlzip"    {with-test & >= "1.07"}
   "re"         {with-test & >= "1.7.2"}
   "alcotest"   {with-test}

--- a/packages/decompress/decompress.0.9.1/opam
+++ b/packages/decompress/decompress.0.9.1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "decompress"
 maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
 authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
 homepage:     "https://github.com/mirage/decompress"

--- a/packages/decompress/decompress.0.9.1/opam
+++ b/packages/decompress/decompress.0.9.1/opam
@@ -23,7 +23,7 @@ depends: [
   "bigarray-compat"
   "mmap"
   "optint"
-  "checkseum"
+  "checkseum"  {>= "0.0.3"}
   "camlzip"    {with-test & >= "1.07"}
   "re"         {with-test & >= "1.7.2"}
   "alcotest"   {with-test}

--- a/packages/optint/optint.0.0.5/opam
+++ b/packages/optint/optint.0.0.5/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   [ "romain.calascibetta@gmail.com" ]
+authors:      "Romain Calascibetta"
+license:      "ISC"
+homepage:     "https://github.com/mirage/optint"
+bug-reports:  "https://github.com/mirage/optint/issues"
+dev-repo:     "git+https://github.com/mirage/optint.git"
+doc:          "https://mirage.github.io/optint/"
+synopsis:     "Abstract type on integer between x64 and x86 architecture"
+description: """
+This library provide an abstract type which represents at least a 32-bits integer.
+On x64, this library use a native unboxed integer (63 bits).
+On x86, this library use a boxed int32.
+
+Implementation depends on target architecture.
+"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "crowbar" {with-test & >= "0.2"}
+  "monolith" {with-test}
+  "fmt" {with-test}
+]
+x-commit-hash: "ae1bb20d25d9638001f3f1388e24f6ee2fd6aba1"
+url {
+  src:
+    "https://github.com/mirage/optint/releases/download/v0.0.5/optint-v0.0.5.tbz"
+  checksum: [
+    "sha256=774901af130eacc08e30ae43e9a18c926f284c22e3c66c2ff95e74648fbedf26"
+    "sha512=fe5762ee7a1a08c7b389fbef9188f8a59c40bb8e19535cec1661a789f973338d5b6d4b30c1869e089282242efa63bfc86c1fb15224b47c05cb5277971aa14a35"
+  ]
+}

--- a/packages/rfc1951/rfc1951.0.9.0/opam
+++ b/packages/rfc1951/rfc1951.0.9.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "rfc1951"
 maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
 authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
 homepage:     "https://github.com/mirage/decompress"

--- a/packages/rfc1951/rfc1951.0.9.0/opam
+++ b/packages/rfc1951/rfc1951.0.9.0/opam
@@ -22,7 +22,7 @@ depends: [
   "base-bytes"
   "base-bigarray"
   "optint"
-  "checkseum"
+  "checkseum"  {>= "0.0.3"}
   "decompress" {= version}
   "camlzip"    {with-test}
   "re"         {with-test & >= "1.7.2"}

--- a/packages/rfc1951/rfc1951.0.9.1/opam
+++ b/packages/rfc1951/rfc1951.0.9.1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "rfc1951"
 maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
 authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
 homepage:     "https://github.com/mirage/decompress"

--- a/packages/rfc1951/rfc1951.0.9.1/opam
+++ b/packages/rfc1951/rfc1951.0.9.1/opam
@@ -22,7 +22,7 @@ depends: [
   "base-bytes"
   "bigarray-compat"
   "optint"
-  "checkseum"
+  "checkseum"  {>= "0.0.3"}
   "decompress" {= version}
   "camlzip"    {with-test}
   "re"         {with-test & >= "1.7.2"}


### PR DESCRIPTION
Abstract type on integer between x64 and x86 architecture

- Project page: <a href="https://github.com/mirage/optint">https://github.com/mirage/optint</a>
- Documentation: <a href="https://mirage.github.io/optint/">https://mirage.github.io/optint/</a>

##### CHANGES:

- Update the README.md (@CraigFe, mirage/optint#9)
- Add a representation of 63-bit integers (@CraigFe, mirage/optint#9)
- Allow to compile fuzzers on 32-bit architectures (@dinosaure, mirage/optint#9)
- Add encode / decode functions for integers (@CraigFe, mirage/optint#9)
- Fix `optint` about sign and cast on all architectures (@dinosaure, mirage/optint#9)
