### PR TITLE
[new release] earlybird (1.0.3)

### DIFF
--- a/packages/earlybird/earlybird.1.0.3/opam
+++ b/packages/earlybird/earlybird.1.0.3/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Debug adapter for OCaml 4.11"
+description: "Debug adapter for OCaml 4.11."
+maintainer: ["hackwaly@qq.com"]
+authors: ["hackwaly@qq.com"]
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0" & < "4.12.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "menhir" {>= "20201216" & build}
+  "menhirLib" {>= "20201216"}
+  "iter" {>= "1.2.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react" {>= "1.1.3"}
+  "cmdliner" {>= "1.0.4"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "path_glob" {>= "0.2"}
+  "sexplib" {>= "0.14.0"}
+  "csexp" {>= "1.3.2"}
+  "lru" {>= "0.3.0"}
+  "dap" {>= "1.0.6"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hackwaly/ocamlearlybird.git"
+x-commit-hash: "a27bb72ec014d9dcdd2685bd81f2eaef922b399a"
+url {
+  src:
+    "https://github.com/hackwaly/ocamlearlybird/releases/download/1.0.3/earlybird-1.0.3.tbz"
+  checksum: [
+    "sha256=5866be8c56633cfb088f36f0fc943f10e807ef22b062cbb1afe436aea2d294a2"
+    "sha512=2296e7ea9b7643222dacd6d8b73be152faeafdc2caff5c0a199f2ae3b3a07f35ff2382ca31c0fd62c9f35ce9b0d0d65e9b80007b541439c8ea68eee5cb79c2e5"
+  ]
+}


### PR DESCRIPTION
Debug adapter for OCaml 4.11

- Project page: <a href="https://github.com/hackwaly/ocamlearlybird">https://github.com/hackwaly/ocamlearlybird</a>

##### CHANGES:

### Fixed

* Fix breakpoints resolution algorithm.
* Fix variables pane sometimes flooding by `Assertion_failure(...)` raised at Env_hack.ml.
* Fix incorrectly inspect 'a type as int.
