### PR TITLE
2 packages from project-everest/hacl-star at 0.3.2

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.3.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.2/opam
@@ -1,4 +1,3 @@
-x-ci-accept-failures: ["centos-7" "oraclelinux-7"]
 opam-version: "2.0"
 synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
 description: """\
@@ -19,6 +18,10 @@ depends: [
   "conf-which" {build}
 ]
 available: os-family != "bsd"
+x-ci-accept-failures: [
+  "centos-7" # GCC is too old
+  "oraclelinux-7" # GCC is too old
+]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.3.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.2/opam
@@ -1,0 +1,35 @@
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]
+opam-version: "2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """\
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `hacl-star` package, of
+which `hacl-star-raw` is a dependency."""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ctypes"
+  "ctypes-foreign"
+  "conf-which" {build}
+]
+available: os-family != "bsd"
+build: [
+  ["sh" "-exc" "cd raw && ./configure"]
+  [make "-C" "raw"]
+]
+install: [make "-C" "raw" "install-hacl-star-raw"]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.3.2/hacl-star.0.3.2.tar.gz"
+  checksum: [
+    "md5=5b3cb04bdcd3ede759ac9e31125dffde"
+    "sha512=272070750040651742f81ee7ef64e4aab5421e65e5e66030341fb60cf134273f79f8cf81d75cc62056d523b184e75866e01a40d332b418c3a9071c4f87d21710"
+  ]
+}

--- a/packages/hacl-star/hacl-star.0.3.2/opam
+++ b/packages/hacl-star/hacl-star.0.3.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "OCaml API for EverCrypt/HACL*"
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.2"}
+  "hacl-star-raw" {= version}
+  "zarith"
+  "cppo" {build}
+]
+available: os-family != "bsd"
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.3.2/hacl-star.0.3.2.tar.gz"
+  checksum: [
+    "md5=5b3cb04bdcd3ede759ac9e31125dffde"
+    "sha512=272070750040651742f81ee7ef64e4aab5421e65e5e66030341fb60cf134273f79f8cf81d75cc62056d523b184e75866e01a40d332b418c3a9071c4f87d21710"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`hacl-star.0.3.2`: OCaml API for EverCrypt/HACL*
-`hacl-star-raw.0.3.2`: Auto-generated low-level OCaml bindings for EverCrypt/HACL*



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.3