### PR TITLE
[new release] earlybird (1.0.3)

### DIFF
--- a/packages/earlybird/earlybird.1.0.3/opam
+++ b/packages/earlybird/earlybird.1.0.3/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Debug adapter for OCaml 4.11"
+description: "Debug adapter for OCaml 4.11."
+maintainer: ["hackwaly@qq.com"]
+authors: ["hackwaly@qq.com"]
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0" & < "4.12.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "menhir" {>= "20201216" & build}
+  "menhirLib" {>= "20201216"}
+  "iter" {>= "1.2.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react" {>= "1.1.3"}
+  "cmdliner" {>= "1.0.4"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "path_glob" {>= "0.2"}
+  "sexplib" {>= "0.14.0"}
+  "csexp" {>= "1.3.2"}
+  "lru" {>= "0.3.0"}
+  "dap" {>= "1.0.6"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hackwaly/ocamlearlybird.git"
+x-commit-hash: "7bd4fb0275da4b2b08eeb7cd51668299ae46c6ab"
+url {
+  src:
+    "https://github.com/hackwaly/ocamlearlybird/releases/download/1.0.3/earlybird-1.0.3.tbz"
+  checksum: [
+    "sha256=f1a4de803d308eb2cb61bf9f8b0b77211d7526edd4a10753fc11dc3be754795f"
+    "sha512=335b431a94777d34dfccc619701521ddeb2df1af7de60273594b5d58a72121093189b711896a7d3580e55f26034a67d664ceb4b1386bbbfd4c1d8f1b5bf2b807"
+  ]
+}


### PR DESCRIPTION
Debug adapter for OCaml 4.11

- Project page: <a href="https://github.com/hackwaly/ocamlearlybird">https://github.com/hackwaly/ocamlearlybird</a>

##### CHANGES:

### Fixed

* Fix breakpoints resolution algorithm.
* Fix variables pane sometimes flooding by `Assertion_failure(...)` raised at Env_hack.ml.
* Fix incorrectly inspect 'a type as int.
* Output to debug console when uncaught_exc occurs.
