### PR TITLE
remove some constraints on qcheck that are too strong

### DIFF
--- a/packages/gen/gen.0.5.3/opam
+++ b/packages/gen/gen.0.5.3/opam
@@ -11,7 +11,7 @@ depends: [
   "dune-configurator"
   "base-bytes"
   "odoc" {with-doc}
-  "qcheck" {with-test & < "0.14"}
+  "qcheck" {with-test}
   "qtest" {with-test}
   "ocaml" { >= "4.03.0" }
 ]

--- a/packages/iter/iter.1.2.1/opam
+++ b/packages/iter/iter.1.2.1/opam
@@ -15,7 +15,7 @@ depends: [
   "result"
   "dune"
   "dune-configurator"
-  "qcheck" {with-test & < "0.14"}
+  "qcheck" {with-test}
   "qtest" {with-test}
   "mdx" {with-test}
   "odoc" {with-doc}

--- a/packages/oseq/oseq.0.3/opam
+++ b/packages/oseq/oseq.0.3/opam
@@ -12,7 +12,7 @@ doc: "https://c-cube.github.io/oseq/"
 bug-reports: "https://github.com/c-cube/oseq/issues"
 depends: [
   "dune" {>= "1.0"}
-  "qcheck" {with-test & < "0.14"}
+  "qcheck" {with-test}
   "qtest" {with-test}
   "gen" {with-test}
   "containers" {with-test}

--- a/packages/sqlite3_utils/sqlite3_utils.0.3.1/opam
+++ b/packages/sqlite3_utils/sqlite3_utils.0.3.1/opam
@@ -14,7 +14,7 @@ depends: [
   "sqlite3"
   "seq"
   "qtest" {with-test & >= "2.10.1" }
-  "qcheck" {with-test & < "0.14"}
+  "qcheck" {with-test}
   "odoc" {with-doc}
 ]
 tags: [ "sqlite3" "gadt" "typed" "sql" ]


### PR DESCRIPTION
cannot install a modern qcheck along with these packages, even though
they work with 0.16 at least