### PR TITLE
Cygwin builds in parallel since 4.09.0

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
@@ -22,8 +22,8 @@ build: [
     "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
   ]
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.1/opam
@@ -22,8 +22,8 @@ build: [
     "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
   ]
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.0/opam
@@ -22,8 +22,8 @@ build: [
     "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
   ]
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.1/opam
@@ -22,8 +22,8 @@ build: [
     "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
   ]
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/opam
@@ -22,8 +22,8 @@ build: [
     "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
   ]
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -35,8 +35,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.0/opam
@@ -22,8 +22,8 @@ build: [
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}
   ]
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.1/opam
@@ -22,8 +22,8 @@ build: [
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}
   ]
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.2/opam
@@ -22,8 +22,8 @@ build: [
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}
   ]
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0/opam
@@ -23,7 +23,7 @@ build: [
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}
   ]
-  [make "-j%{jobs}%" {os != "cygwin"}]
+  [make "-j%{jobs}%"]
 ]
 install: [make "install"]
 url {
@@ -35,8 +35,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+32bit/opam
@@ -36,8 +36,8 @@ build: [
     "ASPP=gcc -arch i386 -m32 -c"
     "--host" "i386-apple-darwin13.2.0"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -48,9 +48,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+afl/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+bytecode-only/opam
@@ -24,7 +24,7 @@ build: [
     "ASPP=cc -c"
     "--disable-native-compiler"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" "world"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+default-unsafe-string/opam
@@ -25,8 +25,8 @@ build: [
     "ASPP=cc -c"
     "DEFAULT_STRING=unsafe"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,9 +37,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+flambda+no-flat-float-array/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-flambda"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+force-safe-string/opam
@@ -25,8 +25,8 @@ build: [
     "ASPP=cc -c"
     "--enable-force-safe-string"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,9 +37,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+fp+flambda/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-frame-pointers"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+fp/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-frame-pointers"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+flambda/opam
@@ -31,8 +31,8 @@ build: [
     "ASPP=musl-gcc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -43,9 +43,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
@@ -34,8 +34,8 @@ build: [
     "--enable-flambda"
     "LIBS=-static"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -46,9 +46,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+no-flat-float-array/opam
@@ -25,8 +25,8 @@ build: [
     "ASPP=cc -c"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,9 +37,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+spacetime/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-spacetime"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+32bit/opam
@@ -36,8 +36,8 @@ build: [
     "ASPP=gcc -arch i386 -m32 -c"
     "--host" "i386-apple-darwin13.2.0"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -48,9 +48,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+afl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+afl+flambda/opam
@@ -25,8 +25,8 @@ build: [
     "--with-afl"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,9 +37,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+afl/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+bytecode-only/opam
@@ -24,7 +24,7 @@ build: [
     "ASPP=cc -c"
     "--disable-native-compiler"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" "world"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+default-unsafe-string/opam
@@ -25,8 +25,8 @@ build: [
     "ASPP=cc -c"
     "DEFAULT_STRING=unsafe"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,9 +37,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+flambda+no-flat-float-array/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-flambda"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+force-safe-string/opam
@@ -25,8 +25,8 @@ build: [
     "ASPP=cc -c"
     "--enable-force-safe-string"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,9 +37,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+fp+flambda/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-frame-pointers"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+fp/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-frame-pointers"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+musl+flambda/opam
@@ -31,8 +31,8 @@ build: [
     "ASPP=musl-gcc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -43,9 +43,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+musl+static+flambda/opam
@@ -34,8 +34,8 @@ build: [
     "--enable-flambda"
     "LIBS=-static"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -46,9 +46,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+no-flat-float-array/opam
@@ -25,8 +25,8 @@ build: [
     "ASPP=cc -c"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,9 +37,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+spacetime/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-spacetime"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+afl/opam
@@ -21,8 +21,8 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -32,9 +32,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+default-unsafe-string/opam
@@ -30,8 +30,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -41,9 +41,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+flambda/opam
@@ -21,8 +21,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -32,9 +32,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+fp+flambda/opam
@@ -30,8 +30,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -41,9 +41,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk+fp/opam
@@ -28,8 +28,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+trunk/opam
@@ -20,8 +20,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -31,9 +31,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+32bit/opam
@@ -36,8 +36,8 @@ build: [
     "ASPP=gcc -arch i386 -m32 -c"
     "--host" "i386-apple-darwin13.2.0"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -48,9 +48,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+afl/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+bytecode-only/opam
@@ -24,7 +24,7 @@ build: [
     "ASPP=cc -c"
     "--disable-native-compiler"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" "world"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+default-unsafe-string/opam
@@ -30,8 +30,8 @@ build: [
     "ASPP=cc -c"
     "DEFAULT_STRING=unsafe"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -42,9 +42,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+flambda+no-flat-float-array/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-flambda"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+fp+flambda/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-frame-pointers"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+fp/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-frame-pointers"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+musl+flambda/opam
@@ -31,8 +31,8 @@ build: [
     "ASPP=musl-gcc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -43,9 +43,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+musl+static+flambda/opam
@@ -34,8 +34,8 @@ build: [
     "--enable-flambda"
     "LIBS=-static"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -46,9 +46,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+nnpcheck/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+nnpcheck/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--disable-naked-pointers"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+no-flat-float-array/opam
@@ -25,8 +25,8 @@ build: [
     "ASPP=cc -c"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,9 +37,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+spacetime/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-spacetime"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+32bit/opam
@@ -36,8 +36,8 @@ build: [
     "ASPP=gcc -arch i386 -m32 -c"
     "--host" "i386-apple-darwin13.2.0"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -48,9 +48,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+afl/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+bytecode-only/opam
@@ -24,7 +24,7 @@ build: [
     "ASPP=cc -c"
     "--disable-native-compiler"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" "world"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+default-unsafe-string/opam
@@ -30,8 +30,8 @@ build: [
     "ASPP=cc -c"
     "DEFAULT_STRING=unsafe"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -42,9 +42,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+flambda+no-flat-float-array/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-flambda"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+fp+flambda/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-frame-pointers"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+fp/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-frame-pointers"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+musl+flambda/opam
@@ -31,8 +31,8 @@ build: [
     "ASPP=musl-gcc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -43,9 +43,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+musl+static+flambda/opam
@@ -34,8 +34,8 @@ build: [
     "--enable-flambda"
     "LIBS=-static"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -46,9 +46,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+no-flat-float-array/opam
@@ -25,8 +25,8 @@ build: [
     "ASPP=cc -c"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,9 +37,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+spacetime/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-spacetime"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+32bit/opam
@@ -36,8 +36,8 @@ build: [
     "ASPP=gcc -arch i386 -m32 -c"
     "--host" "i386-apple-darwin13.2.0"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -48,8 +48,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+afl/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,8 +36,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+bytecode-only/opam
@@ -24,7 +24,7 @@ build: [
     "ASPP=cc -c"
     "--disable-native-compiler"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" "world"]
 ]
 install: [make "install"]
 url {
@@ -35,8 +35,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+default-unsafe-string/opam
@@ -30,8 +30,8 @@ build: [
     "ASPP=cc -c"
     "DEFAULT_STRING=unsafe"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -42,8 +42,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+flambda+no-flat-float-array/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-flambda"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,8 +39,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,8 +36,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+fp+flambda/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-frame-pointers"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,8 +39,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+fp/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-frame-pointers"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,8 +36,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+musl+flambda/opam
@@ -31,8 +31,8 @@ build: [
     "ASPP=musl-gcc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -43,8 +43,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+musl+static+flambda/opam
@@ -34,8 +34,8 @@ build: [
     "--enable-flambda"
     "LIBS=-static"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -46,8 +46,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+no-flat-float-array/opam
@@ -25,8 +25,8 @@ build: [
     "ASPP=cc -c"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,8 +37,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+spacetime/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-spacetime"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,8 +36,8 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+32bit/opam
@@ -36,8 +36,8 @@ build: [
     "ASPP=gcc -arch i386 -m32 -c"
     "--host" "i386-apple-darwin13.2.0"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -48,9 +48,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+afl/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+bytecode-only/opam
@@ -24,7 +24,7 @@ build: [
     "ASPP=cc -c"
     "--disable-native-compiler"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" "world"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+default-unsafe-string/opam
@@ -30,8 +30,8 @@ build: [
     "ASPP=cc -c"
     "DEFAULT_STRING=unsafe"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -42,9 +42,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+flambda+no-flat-float-array/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-flambda"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+fp+flambda/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-frame-pointers"
     "--enable-flambda"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+fp/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-frame-pointers"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+musl+flambda/opam
@@ -31,8 +31,8 @@ build: [
     "ASPP=musl-gcc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -43,9 +43,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+musl+static+flambda/opam
@@ -34,8 +34,8 @@ build: [
     "--enable-flambda"
     "LIBS=-static"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -46,9 +46,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+no-flat-float-array/opam
@@ -25,8 +25,8 @@ build: [
     "ASPP=cc -c"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,9 +37,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+spacetime/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-spacetime"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+32bit/opam
@@ -36,8 +36,8 @@ build: [
     "ASPP=gcc -arch i386 -m32 -c"
     "--host" "i386-apple-darwin13.2.0"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -48,9 +48,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+BER/opam
@@ -31,9 +31,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+afl/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+bytecode-only/opam
@@ -24,7 +24,7 @@ build: [
     "ASPP=cc -c"
     "--disable-native-compiler"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" "world"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+default-unsafe-string/opam
@@ -30,8 +30,8 @@ build: [
     "ASPP=cc -c"
     "DEFAULT_STRING=unsafe"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -42,9 +42,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+flambda+no-flat-float-array/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-flambda"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+fp+flambda/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-frame-pointers"
     "--enable-flambda"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+fp/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-frame-pointers"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+musl+flambda/opam
@@ -31,8 +31,8 @@ build: [
     "ASPP=musl-gcc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -43,9 +43,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+musl+static+flambda/opam
@@ -34,8 +34,8 @@ build: [
     "--enable-flambda"
     "LIBS=-static"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -46,9 +46,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+no-flat-float-array/opam
@@ -25,8 +25,8 @@ build: [
     "ASPP=cc -c"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,9 +37,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+spacetime/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-spacetime"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+32bit/opam
@@ -36,8 +36,8 @@ build: [
     "ASPP=gcc -arch i386 -m32 -c"
     "--host" "i386-apple-darwin13.2.0"
   ] {os = "openbsd" | os = "freebsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -48,9 +48,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+afl/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+bytecode-only/opam
@@ -24,7 +24,7 @@ build: [
     "ASPP=cc -c"
     "--disable-native-compiler"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
+  [make "-j%{jobs}%" "world"]
 ]
 install: [make "install"]
 url {
@@ -35,9 +35,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+default-unsafe-string/opam
@@ -30,8 +30,8 @@ build: [
     "ASPP=cc -c"
     "DEFAULT_STRING=unsafe"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -42,9 +42,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+flambda+no-flat-float-array/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-flambda"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+flambda/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+fp+flambda/opam
@@ -27,8 +27,8 @@ build: [
     "--enable-frame-pointers"
     "--enable-flambda"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -39,9 +39,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+fp/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-frame-pointers"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+musl+flambda/opam
@@ -31,8 +31,8 @@ build: [
     "ASPP=musl-gcc -c"
     "--enable-flambda"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -43,9 +43,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+musl+static+flambda/opam
@@ -34,8 +34,8 @@ build: [
     "--enable-flambda"
     "LIBS=-static"
   ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -46,9 +46,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+no-flat-float-array/opam
@@ -25,8 +25,8 @@ build: [
     "ASPP=cc -c"
     "--disable-flat-float-array"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -37,9 +37,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+spacetime/opam
@@ -24,8 +24,8 @@ build: [
     "ASPP=cc -c"
     "--enable-spacetime"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -36,9 +36,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+afl/opam
@@ -21,8 +21,8 @@ build: [
     "ASPP=cc -c"
     "--with-afl"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -32,9 +32,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+flambda/opam
@@ -21,8 +21,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -32,9 +32,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+trunk+fp/opam
@@ -21,8 +21,8 @@ build: [
     "ASPP=cc -c"
     "--enable-frame-pointers"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -32,9 +32,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+trunk/opam
@@ -20,8 +20,8 @@ build: [
     "CC=cc"
     "ASPP=cc -c"
   ] {os = "openbsd" | os = "macos"}
-  [make "-j%{jobs}%" {os != "cygwin"} "world"]
-  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
 ]
 install: [make "install"]
 url {
@@ -31,9 +31,9 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+options/opam
@@ -45,7 +45,7 @@ build: [
     "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
     "LIBS=-static" {ocaml-option-static:installed}
   ]
-  [make "-j%{jobs}%" {os != "cygwin"}]
+  [make "-j%{jobs}%"]
 ]
 install: [make "install"]
 url {
@@ -57,10 +57,10 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    Please file a bug report at https://github.com/ocaml/ocaml/issues"
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 depopts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+trunk/opam
@@ -47,7 +47,7 @@ build: [
     "LIBS=-static" {ocaml-option-static:installed}
     "--disable-warn-error"
   ]
-  [make "-j%{jobs}%" {os != "cygwin"}]
+  [make "-j%{jobs}%"]
 ]
 install: [make "install"]
 url {
@@ -57,10 +57,10 @@ post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
+  {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
 depopts: [
   "ocaml-option-32bit"


### PR DESCRIPTION
#14257 enabled parallel builds for the compiler. It was necessary to exclude OCaml 4.07 and 4.08 on Cygwin, but in the discussion and rebases/re-runs it somehow got extended to all of the versions and has continued ever since!

Parallel builds on Cygwin should work in the same way as every other distro since 4.09.0 (https://github.com/ocaml/ocaml/pull/2267).