### PR TITLE
Package binaryen.0.7.0

### DIFF
--- a/packages/binaryen/binaryen.0.7.0/opam
+++ b/packages/binaryen/binaryen.0.7.0/opam
@@ -14,7 +14,7 @@ depends: [
 ]
 available: arch = "x86_64" & (os = "linux" | os = "macos" | os = "win32")
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"

--- a/packages/binaryen/binaryen.0.7.0/opam
+++ b/packages/binaryen/binaryen.0.7.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.09"}
+  "dune" {>= "2.7.1"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+]
+available: arch = "x86_64" & (os = "linux" | os = "macos" | os = "win32")
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.7.0/binaryen-archive-v0.7.0.tar.gz"
+  checksum: [
+    "md5=09491e1e654d1f3c825e15eff54b64ec"
+    "sha512=ab55ed73f3e07f3e1b7256e0122f8284b4b5b8c23fbcd3ecaa8fbb08939c6eb33fe99ae3549dd189b126b8ba2550d993b783b3aee6e86006921fc39c52d5a819"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.7.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---


### ⚠ BREAKING CHANGES

* memory_size and memory_grow are now toplevel functions in .
* removed , 
* removed  and 
* Bump to Binaryen 98

### Features

* Bump to Binaryen 98 ([9a52a07](https://www.github.com/grain-lang/binaryen.ml/commit/9a52a077051441f8b0999bad1d77a8d3a6357460))


### Continuous Integration

* add opam & npm releases to workflow ([#69](https://www.github.com/grain-lang/binaryen.ml/issues/69)) ([d339608](https://www.github.com/grain-lang/binaryen.ml/commit/d3396085565e478b31a5819628be08bae1e2be16))
* run opam build on ubuntu 18 instead of 20 ([#67](https://www.github.com/grain-lang/binaryen.ml/issues/67)) ([7ee2009](https://www.github.com/grain-lang/binaryen.ml/commit/7ee20092da341f927acf552abcbcf8bfcca90c0b))


### Miscellaneous Chores

* memory_size and memory_grow are now toplevel functions in . ([9a52a07](https://www.github.com/grain-lang/binaryen.ml/commit/9a52a077051441f8b0999bad1d77a8d3a6357460))
* removed  and  ([9a52a07](https://www.github.com/grain-lang/binaryen.ml/commit/9a52a077051441f8b0999bad1d77a8d3a6357460))
* removed ,  ([9a52a07](https://www.github.com/grain-lang/binaryen.ml/commit/9a52a077051441f8b0999bad1d77a8d3a6357460))


---
:camel: Pull-request generated by opam-publish v2.0.3