### PR TITLE
Package hack_parallel.1.0.1

### DIFF
--- a/packages/hack_parallel/hack_parallel.1.0.1/opam
+++ b/packages/hack_parallel/hack_parallel.1.0.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Rijnard van Tonder <rvantonder@gmail.com>"
+authors: "Facebook. Modifications by Rijnard van Tonder"
+homepage: "https://github.com/rvantonder/hack_parallel"
+bug-reports: "https://github.com/rvantonder/hack_parallel/issues"
+dev-repo: "git+https://github.com/rvantonder/hack_parallel.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install"]
+]
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.11"}
+  "conf-pkg-config"
+  "conf-sqlite3"
+  "core" {< "v0.15"}
+  "ppx_deriving"
+  "ppxlib" {< "0.9.0"}
+  "sexplib" {< "v0.15"}
+]
+synopsis: "Parallel and shared memory library"
+description: """
+Parallel and shared memory components used in Facebook's Hack, Flow, and Pyre
+projects.
+"""
+url {
+  src: "https://github.com/rvantonder/hack_parallel/archive/1.0.1.tar.gz"
+  checksum: [
+    "md5=ba7c72bc207e326b72e294fc76f6ad2c"
+    "sha512=5020d47f97bea2f88e2a40411894d03232a7f2282606926c93c7d4c96d72e94a966be852897a9b16f7e0893ba376512045abb9d93020a7c03c3def4f3d918f8e"
+  ]
+}


### PR DESCRIPTION
### `hack_parallel.1.0.1`
Parallel and shared memory library
Parallel and shared memory components used in Facebook's Hack, Flow, and Pyre
projects.



---
* Homepage: https://github.com/rvantonder/hack_parallel
* Source repo: git+https://github.com/rvantonder/hack_parallel.git
* Bug tracker: https://github.com/rvantonder/hack_parallel/issues

---
:camel: Pull-request generated by opam-publish v2.0.3