### PR TITLE
new file:   packages/parany/parany.12.0.3/opam

### DIFF
--- a/packages/parany/parany.12.0.3/opam
+++ b/packages/parany/parany.12.0.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: "Francois Berenger"
+license: "LGPL-2.0-or-later"
+homepage: "https://github.com/UnixJunkie/parany"
+bug-reports: "https://github.com/UnixJunkie/parany/issues"
+dev-repo: "git+https://github.com/UnixJunkie/parany.git"
+depends: [
+  "base-unix"
+  "cpu"
+  "dune" {>= "1.6.0"}
+  "ocaml" {>= "4.03.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "src/test.exe"] {with-test}
+  ["./test.sh"] {with-test}
+]
+synopsis: "Parallelize any computation"
+description: """
+Generalized map reduce for parallel computers (not distributed computing).
+Can process in parallel an infinite stream of elements.
+
+Can process a very large file in parallel on a multicore computer;
+provided there is a way to cut your file into independent blocks
+(the 'demux' function).
+The processing function is called 'work'.
+The function gathering the results is called 'mux'.
+The number of processors running your computation in parallel is called
+'nprocs'.
+The chunk size (number of items) processed by one call to the 'work' function
+is called 'csize'.
+
+There is a minimalist Parmap module, if you want to switch
+to/from Parmap easily.
+
+Read the corresponding ocamldoc before using.
+
+USING THIS LIBRARY IN A MISSION CRITICAL, LONG-RUNNING SOFTWARE
+THAT IS NEVER SUPPOSED TO CRASH IS NOT ADVIZED.
+WHILE THIS LIBRARY IS HIGH PERFORMANCE, IT IS ALSO DANGEROUS.
+USE AT YOUR OWN RISKS.
+"""
+url {
+  src: "https://github.com/UnixJunkie/parany/archive/v12.0.3.tar.gz"
+  checksum: "md5=da39a0ab633fd224cb1b4682786ba0e8"
+}


### PR DESCRIPTION
corrected the duplicated I/O problem.
Not a parany bug per se, just something that might annoy/surprise some users.