### PR TITLE
Various fixes (OCaml 4.13 edition)

### DIFF
--- a/packages/camelot/camelot.0.5/opam
+++ b/packages/camelot/camelot.0.5/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/upenn-cis1xx/camelot"
 bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.09.0" & < "4.13"}
   "ANSITerminal" {>= "0.8"}
 ]
 build: [

--- a/packages/camelot/camelot.1.0.1/opam
+++ b/packages/camelot/camelot.1.0.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/upenn-cis1xx/camelot"
 bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "4.13"}
   "ANSITerminal" {>= "0.8"}
 ]
 build: [

--- a/packages/camelot/camelot.1.1.0/opam
+++ b/packages/camelot/camelot.1.1.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/upenn-cis1xx/camelot"
 bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "4.13"}
   "ANSITerminal" {>= "0.8"}
 ]
 build: [

--- a/packages/camelot/camelot.1.1.1/opam
+++ b/packages/camelot/camelot.1.1.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/upenn-cis1xx/camelot"
 bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "4.13"}
   "ANSITerminal" {>= "0.8"}
 ]
 build: [

--- a/packages/camelot/camelot.1.2.0/opam
+++ b/packages/camelot/camelot.1.2.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/upenn-cis1xx/camelot"
 bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "4.13"}
   "ANSITerminal" {>= "0.8"}
 ]
 build: [

--- a/packages/camelot/camelot.1.4.3/opam
+++ b/packages/camelot/camelot.1.4.3/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/upenn-cis1xx/camelot"
 bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "4.13"}
   "ANSITerminal" {>= "0.8"}
   "yojson" {>= "1.7.0"}
   "ppx_expect" {with-test & >= "v0.13.0"}

--- a/packages/camelot/camelot.1.4.4/opam
+++ b/packages/camelot/camelot.1.4.4/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/upenn-cis1xx/camelot"
 bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "4.13"}
   "ANSITerminal" {>= "0.8"}
   "yojson" {>= "1.7.0"}
   "ppx_expect" {with-test & >= "v0.13.0"}

--- a/packages/camelot/camelot.1.5.0/opam
+++ b/packages/camelot/camelot.1.5.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/upenn-cis1xx/camelot"
 bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "4.13"}
   "ANSITerminal" {>= "0.8"}
   "yojson" {>= "1.7.0"}
   "ppx_expect" {with-test & >= "v0.13.0"}

--- a/packages/camelot/camelot.1.6.0/opam
+++ b/packages/camelot/camelot.1.6.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/upenn-cis1xx/camelot"
 bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "4.13"}
   "ANSITerminal" {>= "0.8"}
   "yojson" {>= "1.7.0"}
   "ppx_expect" {with-test & >= "v0.13.0"}

--- a/packages/camelot/camelot.1.6.1/opam
+++ b/packages/camelot/camelot.1.6.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/upenn-cis1xx/camelot"
 bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "4.13"}
   "ANSITerminal" {>= "0.8"}
   "yojson" {>= "1.7.0"}
   "ppx_expect" {with-test & >= "v0.13.0"}

--- a/packages/camelot/camelot.1.6.2/opam
+++ b/packages/camelot/camelot.1.6.2/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/upenn-cis1xx/camelot"
 bug-reports: "https://github.com/upenn-cis1xx/camelot/issues"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "4.13"}
   "ANSITerminal" {>= "0.8"}
   "yojson" {>= "1.7.0"}
   "ppx_expect" {with-test & >= "v0.13.0"}

--- a/packages/ocp-index/ocp-index.1.2.2/opam
+++ b/packages/ocp-index/ocp-index.1.2.2/opam
@@ -21,7 +21,7 @@ tags: [ "org:ocamlpro" "org:typerex" ]
 dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.13"}
   "cppo" {build}
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}

--- a/packages/odoc/odoc.1.5.2/opam
+++ b/packages/odoc/odoc.1.5.2/opam
@@ -27,7 +27,7 @@ depends: [
   "cppo" {build}
   "dune"
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.13"}
   "result"
   "tyxml" {>= "4.3.0"}
 

--- a/packages/owl-symbolic/owl-symbolic.0.1.0/opam
+++ b/packages/owl-symbolic/owl-symbolic.0.1.0/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "4.13"}
   "dune" {>= "2.0.0"}
   "owl-base" {>= "0.7.0" & < "0.10.0"}
   "ocaml-protoc" {build}

--- a/packages/owl-symbolic/owl-symbolic.0.2.0/opam
+++ b/packages/owl-symbolic/owl-symbolic.0.2.0/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "4.13"}
   "dune" {>= "2.0.0"}
   "owl-base" {>= "0.7.0" & < "0.10.0"}
   "ocaml-protoc" {build}


### PR DESCRIPTION
cc @jzstark for `owl-symbolic`
cc @KeenWill for `camelot` (oops i forgot to specify why in the commit message. It's the type of the pattern matching parsetree that changed in compiler-libs)

The rest will be fixed in due time