### PR TITLE
[new release] dockerfile-opam, dockerfile and dockerfile-cmd (7.1.0)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.7.1.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.7.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL - generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "2.0.0"}
+  "dockerfile-opam" {= version}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+x-commit-hash: "054dc07bf0cc196708357905e3b8ec8b4d84993d"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v7.1.0/dockerfile-v7.1.0.tbz"
+  checksum: [
+    "sha256=471ee833f127d091d61280ed7cb29dd55d0dc63b2cb03b7b767f9f658214eda4"
+    "sha512=ae4146e1747a82f28095e6e02a74ca8f645530cbe571953208ab15645733a77aac321d83bd62b5a9c8e71b73a98cf1ee9d3eb13b206c32a88d68ae017112b82f"
+  ]
+}

--- a/packages/dockerfile-opam/dockerfile-opam.7.1.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.7.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution
+support for generating dockerfiles."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "2.0.0"}
+  "dockerfile" {= version}
+  "ocaml-version" {>= "1.0.0"}
+  "cmdliner"
+  "astring"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+x-commit-hash: "054dc07bf0cc196708357905e3b8ec8b4d84993d"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v7.1.0/dockerfile-v7.1.0.tbz"
+  checksum: [
+    "sha256=471ee833f127d091d61280ed7cb29dd55d0dc63b2cb03b7b767f9f658214eda4"
+    "sha512=ae4146e1747a82f28095e6e02a74ca8f645530cbe571953208ab15645733a77aac321d83bd62b5a9c8e71b73a98cf1ee9d3eb13b206c32a88d68ae017112b82f"
+  ]
+}

--- a/packages/dockerfile/dockerfile.7.1.0/opam
+++ b/packages/dockerfile/dockerfile.7.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-dockerfile"
+doc: "https://avsm.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/avsm/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "2.0.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/avsm/ocaml-dockerfile.git"
+x-commit-hash: "054dc07bf0cc196708357905e3b8ec8b4d84993d"
+url {
+  src:
+    "https://github.com/avsm/ocaml-dockerfile/releases/download/v7.1.0/dockerfile-v7.1.0.tbz"
+  checksum: [
+    "sha256=471ee833f127d091d61280ed7cb29dd55d0dc63b2cb03b7b767f9f658214eda4"
+    "sha512=ae4146e1747a82f28095e6e02a74ca8f645530cbe571953208ab15645733a77aac321d83bd62b5a9c8e71b73a98cf1ee9d3eb13b206c32a88d68ae017112b82f"
+  ]
+}


### PR DESCRIPTION
Dockerfile eDSL -- opam support

- Project page: <a href="https://github.com/avsm/ocaml-dockerfile">https://github.com/avsm/ocaml-dockerfile</a>
- Documentation: <a href="https://avsm.github.io/ocaml-dockerfile/doc">https://avsm.github.io/ocaml-dockerfile/doc</a>

##### CHANGES:

- Add ArchLinux support (@kit-ty-kate avsm/ocaml-dockerfile#23)
- Move Alpine 3.11 to deprecated (@kit-ty-kate avsm/ocaml-dockerfile#23).
- Add OracleLinux v8 (@kit-ty-kate avsm/ocaml-dockerfile#24)
- Add Ubuntu 20.10 and Fedora 33 (@avsm)
- Make Alpine 3.13 and Fedora 33 the latest versions.
- Update the latest versions of Ubuntu LTS to 20.04
  and CentOS to 8 and OracleLinux to 8 (@avsm)
- Activate Powertools for CentOS 8 (@kit-ty-kate avsm/ocaml-dockerfile#26)
- Build aarch64 images for Fedora 33 and higher as well (@avsm).
- Remove outdated bulk-build and archive functions from
  `Dockerfile_opam` (@avsm)
- Create a Tier 3 for distros for things we do not want
  to test in the opam repository (@avsm @kit-ty-kate)
