### PR TITLE
LablTk 8.06.10 and OCamlBrowser 4.12.0

### DIFF
--- a/packages/labltk/labltk.8.06.10/opam
+++ b/packages/labltk/labltk.8.06.10/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/labltk/"
+bug-reports: "https://github.com/garrigue/labltk/issues"
+dev-repo: "git+https://github.com/garrigue/labltk.git"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "-use-findlib" "-verbose" "-installbindir" bin]
+  [make "library" "opt"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "ocamlfind" {build}
+  "conf-tcl"
+  "conf-tk"
+]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]
+synopsis: "OCaml interface to Tcl/Tk"
+description: "ocamlbrowser is now a separate package.\n\
+             For details, see https://garrigue.github.io/labltk/"
+url {
+  src: "https://github.com/garrigue/labltk/archive/8.06.10.tar.gz"
+  checksum: "md5=d6b4691bb03b114d45411158143883d7"
+}

--- a/packages/ocamlbrowser/ocamlbrowser.4.12.0/opam
+++ b/packages/ocamlbrowser/ocamlbrowser.4.12.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/labltk/"
+bug-reports: "https://github.com/garrigue/labltk/issues"
+dev-repo: "git+https://github.com/garrigue/labltk.git"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "-use-findlib" "-installbindir" bin]
+  [make "all"]
+]
+install: [
+  [make "install-browser"]
+]
+depends: [
+  "ocaml" {>= "4.12" & < "4.13"}
+  "labltk" {= "8.06.10"}
+  "ocamlfind" {build}
+  "conf-tcl"
+  "conf-tk"
+]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]
+synopsis: "OCamlBrowser Library Explorer"
+description: "Require LablTk. For details, see https://garrigue.github.io/labltk/"
+url {
+  src: "https://github.com/garrigue/labltk/archive/8.06.10.tar.gz"
+  checksum: "md5=d6b4691bb03b114d45411158143883d7"
+}


### PR DESCRIPTION
This is a bug fix release of LablTk and OCamlBrowser.
It also makes OCamlBrowser work on OCaml 4.12 (and only this version).