### PR TITLE
[new release] pyml.20210226

### DIFF
--- a/packages/conf-python-3-dev/conf-python-3-dev.1/opam
+++ b/packages/conf-python-3-dev/conf-python-3-dev.1/opam
@@ -9,10 +9,13 @@ build: [
 ]
 depexts: [
   ["python3-dev"] {os-family = "debian"}
+  ["python3-dev"] {os-family = "ubuntu"}
   ["python3-devel"] {os-distribution = "fedora"}
   ["python3-devel" "epel-release"] {os-distribution = "centos"}
+  ["python3-devel"] {os-distribution = "ol"}
   ["python3-devel"] {os-family = "suse"}
-  ["python3-dev"] {os-distribution = "alpine"}
+  ["python3-dev"] {os-family = "alpine"}
+  ["python"] {os-family = "arch"}
   ["python3"] {os = "macos" & os-distribution = "homebrew"}
   ["python38"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/conf-python-3-dev/conf-python-3-dev.1/opam
+++ b/packages/conf-python-3-dev/conf-python-3-dev.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["python3-devel"] {os-distribution = "ol"}
   ["python3-devel"] {os-family = "suse"}
   ["python3-dev"] {os-family = "alpine"}
-  ["glibc=2.33" "python"] {os-family = "arch"}
+  ["python"] {os-family = "arch"}
   ["python3"] {os = "macos" & os-distribution = "homebrew"}
   ["python38"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/conf-python-3-dev/conf-python-3-dev.1/opam
+++ b/packages/conf-python-3-dev/conf-python-3-dev.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["python3-devel"] {os-distribution = "ol"}
   ["python3-devel"] {os-family = "suse"}
   ["python3-dev"] {os-family = "alpine"}
-  ["python"] {os-family = "arch"}
+  ["glibc=2.33" "python"] {os-family = "arch"}
   ["python3"] {os = "macos" & os-distribution = "homebrew"}
   ["python38"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/pyml/pyml.20210226/opam
+++ b/packages/pyml/pyml.20210226/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "http://github.com/thierry-martinez/pyml"
+bug-reports: "http://github.com/thierry-martinez/pyml/issues"
+license: "BSD"
+dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
+build: [make "all" "pymltop" "pymlutop" {utop:installed} "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%"]
+run-test: [make "test"]
+synopsis: "OCaml bindings for Python"
+description: "OCaml bindings for Python 2 and Python 3"
+depends: [
+  "ocaml" {>= "3.12.1"}
+  "ocamlfind" {build}
+  "stdcompat" {>= "13"}
+  "conf-python-3-dev" {with-test}
+]
+depopts: ["utop"]
+url {
+  src: "https://github.com/thierry-martinez/pyml/archive/20210226.tar.gz"
+  checksum: "sha512=f2d583433a36c91dbdae28798254c949f43018a377eda30b3eeefb6e0c17738d24ea3b65014c209a53078fcb787ff77efad32f004540aacbab214f59c62ae23d"
+}

--- a/packages/pyml/pyml.20210226/opam
+++ b/packages/pyml/pyml.20210226/opam
@@ -19,5 +19,5 @@ depends: [
 depopts: ["utop"]
 url {
   src: "https://github.com/thierry-martinez/pyml/archive/20210226.tar.gz"
-  checksum: "sha512=f2d583433a36c91dbdae28798254c949f43018a377eda30b3eeefb6e0c17738d24ea3b65014c209a53078fcb787ff77efad32f004540aacbab214f59c62ae23d"
+  checksum: "sha512=90164642ddc0d75bf958e417a0ab90daab08146ee79c02943d97e288584e7197773f8c5e6e8d671efe8ba3a35e87a92c6dca2ca878c50df005d19afcffdbc141"
 }

--- a/packages/pyml/pyml.20210226/opam
+++ b/packages/pyml/pyml.20210226/opam
@@ -3,7 +3,7 @@ maintainer: "Thierry Martinez <martinez@nsup.org>"
 authors: "Thierry Martinez <martinez@nsup.org>"
 homepage: "http://github.com/thierry-martinez/pyml"
 bug-reports: "http://github.com/thierry-martinez/pyml/issues"
-license: "BSD"
+license: "BSD-2-Clause"
 dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
 build: [make "all" "pymltop" "pymlutop" {utop:installed} "PREFIX=%{prefix}%"]
 install: [make "install" "PREFIX=%{prefix}%"]


### PR DESCRIPTION
- Compatibility with Python 3.10 (reported by Richard W.M. Jones)

    - `PyObject_AsCharBuffer`, `PyObject_AsReadBuffer`,
      `PyObject_AsWriteBuffer` bindings are marked optional as they have
      been removed in Python 3.10.

    - `Py_fopen` is optional and `Py_wfopen` is used instead if available.

- More general handling of Unix architectures.
  (Fixed by Pino Toscano, https://github.com/thierry-martinez/pyml/pull/57)

- Add `Py.Set` module for Python sets.
  (Added by Laurent Mazare, https://github.com/thierry-martinez/pyml/pull/58)

- Fix #61: `Numpy.to_bigarray` raises an exception if source value is
  not a Numpy array instead of segfaulting.
  (Reported by Jonathan Laurent,
   https://github.com/thierry-martinez/pyml/issues/61)

- Fix #56, #59: Add `python-config` heuristics to find Python library.
  (Reported by Anders Thuné and Nils Becker,
   https://github.com/thierry-martinez/pyml/issues/56
   https://github.com/thierry-martinez/pyml/issues/59)