### PR TITLE
[new release] bimage-unix, bimage, bimage-io, bimage-display and bimage-lwt (0.3.1)

### DIFF
--- a/packages/bimage-display/bimage-display.0.3.1/opam
+++ b/packages/bimage-display/bimage-display.0.3.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "glfw-ocaml"
+    "conf-glew"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Window system for Bimage
+"""
+
+description: """
+Allows for Bimage Images to be displayed using OpenGL
+"""
+x-commit-hash: "533f72adba67ece8bd1a270eccdae85ccd87b44d"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.3.1/bimage-v0.3.1.tbz"
+  checksum: [
+    "sha256=9490a99848142a921ecb5da5b91b53682e7b372119dcf0ccf868d82f893b15d1"
+    "sha512=4e1d2a039931e014f319f54e73ed0cc7c1f819a4490d95693ce0d8797bc22e81027985f6bbbda3c3c6619dfd8f4bc01fe48b20cda2482ad279c9143d09c2a8c7"
+  ]
+}

--- a/packages/bimage-io/bimage-io.0.3.1/opam
+++ b/packages/bimage-io/bimage-io.0.3.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "conf-openimageio"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Input/output for Bimage using OpenImageIO
+"""
+
+description: """
+Input/output for Bimage using OpenImageIO
+"""
+x-commit-hash: "533f72adba67ece8bd1a270eccdae85ccd87b44d"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.3.1/bimage-v0.3.1.tbz"
+  checksum: [
+    "sha256=9490a99848142a921ecb5da5b91b53682e7b372119dcf0ccf868d82f893b15d1"
+    "sha512=4e1d2a039931e014f319f54e73ed0cc7c1f819a4490d95693ce0d8797bc22e81027985f6bbbda3c3c6619dfd8f4bc01fe48b20cda2482ad279c9143d09c2a8c7"
+  ]
+}

--- a/packages/bimage-lwt/bimage-lwt.0.3.1/opam
+++ b/packages/bimage-lwt/bimage-lwt.0.3.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "lwt"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library (LWT bindings)
+"""
+
+description: """
+LWT bindings for Bimage, an image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+x-commit-hash: "533f72adba67ece8bd1a270eccdae85ccd87b44d"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.3.1/bimage-v0.3.1.tbz"
+  checksum: [
+    "sha256=9490a99848142a921ecb5da5b91b53682e7b372119dcf0ccf868d82f893b15d1"
+    "sha512=4e1d2a039931e014f319f54e73ed0cc7c1f819a4490d95693ce0d8797bc22e81027985f6bbbda3c3c6619dfd8f4bc01fe48b20cda2482ad279c9143d09c2a8c7"
+  ]
+}

--- a/packages/bimage-unix/bimage-unix.0.3.1/opam
+++ b/packages/bimage-unix/bimage-unix.0.3.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "ctypes" {>= "0.14"}
+    "ctypes-foreign" {>= "0.4"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/stb_image
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+x-commit-hash: "533f72adba67ece8bd1a270eccdae85ccd87b44d"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.3.1/bimage-v0.3.1.tbz"
+  checksum: [
+    "sha256=9490a99848142a921ecb5da5b91b53682e7b372119dcf0ccf868d82f893b15d1"
+    "sha512=4e1d2a039931e014f319f54e73ed0cc7c1f819a4490d95693ce0d8797bc22e81027985f6bbbda3c3c6619dfd8f4bc01fe48b20cda2482ad279c9143d09c2a8c7"
+  ]
+}

--- a/packages/bimage/bimage.0.3.1/opam
+++ b/packages/bimage/bimage.0.3.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+x-commit-hash: "533f72adba67ece8bd1a270eccdae85ccd87b44d"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.3.1/bimage-v0.3.1.tbz"
+  checksum: [
+    "sha256=9490a99848142a921ecb5da5b91b53682e7b372119dcf0ccf868d82f893b15d1"
+    "sha512=4e1d2a039931e014f319f54e73ed0cc7c1f819a4490d95693ce0d8797bc22e81027985f6bbbda3c3c6619dfd8f4bc01fe48b20cda2482ad279c9143d09c2a8c7"
+  ]
+}


### PR DESCRIPTION
Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/stb_image

- Project page: <a href="https://github.com/zshipko/ocaml-bimage">https://github.com/zshipko/ocaml-bimage</a>
- Documentation: <a href="https://zshipko.github.io/ocaml-bimage/doc">https://zshipko.github.io/ocaml-bimage/doc</a>

##### CHANGES:

- More aggressive image type checking in `bimage-display` to fix possible
  segmentation faults
