### PR TITLE
pa_ppx requires exact versions of the compiler

### DIFF
--- a/packages/pa_ppx/pa_ppx.0.07.02/opam
+++ b/packages/pa_ppx/pa_ppx.0.07.02/opam
@@ -35,7 +35,7 @@ dev-repo: "git+https://github.com/camlp5/pa_ppx.git"
 doc: "https://github.com/camlp5/pa_ppx/doc"
 
 depends: [
-  "ocaml"       { >= "4.10.0" & < "4.13.0" }
+  "ocaml"       { = "4.10.0" | = "4.10.1" | = "4.10.2" | = "4.11.0" | = "4.11.1" | = "4.12.0" }
   "conf-perl"
   "conf-perl-ipc-system-simple"
   "conf-perl-string-shellquote"

--- a/packages/pa_ppx/pa_ppx.0.07/opam
+++ b/packages/pa_ppx/pa_ppx.0.07/opam
@@ -35,7 +35,7 @@ dev-repo: "git+https://github.com/camlp5/pa_ppx.git"
 doc: "https://github.com/camlp5/pa_ppx/doc"
 
 depends: [
-  "ocaml"       { >= "4.10.0" & < "4.13.0" }
+  "ocaml"       { = "4.10.0" | = "4.10.1" | = "4.10.2" | = "4.11.0" | = "4.11.1" | = "4.12.0" }
   "conf-perl"
   "conf-perl-ipc-system-simple"
   "conf-perl-string-shellquote"

--- a/packages/pa_ppx/pa_ppx.0.07/opam
+++ b/packages/pa_ppx/pa_ppx.0.07/opam
@@ -35,7 +35,7 @@ dev-repo: "git+https://github.com/camlp5/pa_ppx.git"
 doc: "https://github.com/camlp5/pa_ppx/doc"
 
 depends: [
-  "ocaml"       { = "4.10.0" | = "4.10.1" | = "4.10.2" | = "4.11.0" | = "4.11.1" | = "4.12.0" }
+  "ocaml"       { = "4.10.0" | = "4.10.1" | = "4.11.0" | = "4.11.1" | = "4.12.0" }
   "conf-perl"
   "conf-perl-ipc-system-simple"
   "conf-perl-string-shellquote"


### PR DESCRIPTION
@chetmurthy pa_ppx broke with the release of ocaml 4.11.2.
Could you return this fix to the opam file upstream? It's not the first time this type of error appears in your software stack.