### PR TITLE
relax ppxlib constraint on hack_parallel.1.0.1

### DIFF
--- a/packages/hack_parallel/hack_parallel.1.0.1/opam
+++ b/packages/hack_parallel/hack_parallel.1.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "conf-sqlite3"
   "core" {< "v0.15"}
   "ppx_deriving"
-  "ppxlib" {< "0.9.0"}
+  "ppxlib"
   "sexplib" {< "v0.15"}
 ]
 synopsis: "Parallel and shared memory library"

--- a/packages/hack_parallel/hack_parallel.1.0.1/opam
+++ b/packages/hack_parallel/hack_parallel.1.0.1/opam
@@ -18,6 +18,7 @@ depends: [
   "ppxlib"
   "sexplib" {< "v0.15"}
 ]
+available: arch != "arm32"
 synopsis: "Parallel and shared memory library"
 description: """
 Parallel and shared memory components used in Facebook's Hack, Flow, and Pyre


### PR DESCRIPTION
I think this constraint can be relaxed but missed removing it in https://github.com/ocaml/opam-repository/pull/18222. Let's see.