### PR TITLE
Revive the pre 4.02.0 compilers

### DIFF
--- a/packages/aws/aws.0.0.2/opam
+++ b/packages/aws/aws.0.0.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlfind"
   "oasis"
   "cryptokit"
-  "calendar"
+  "calendar" {>= "2.00"}
   "lwt" {< "4.0.0"}
   "xmlm"
   "yojson"

--- a/packages/aws/aws.0.0.3/opam
+++ b/packages/aws/aws.0.0.3/opam
@@ -16,7 +16,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "calendar"
+  "calendar" {>= "2.00"}
   "cryptokit"
   "lwt" {< "4.0.0"}
   "oasis"

--- a/packages/aws/aws.1.0.0/opam
+++ b/packages/aws/aws.1.0.0/opam
@@ -35,7 +35,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "calendar"
+  "calendar" {>= "2.00"}
   "ezxmlm"
   "nocrypto"
   "ocamlfind" {build}

--- a/packages/aws/aws.1.0.1/opam
+++ b/packages/aws/aws.1.0.1/opam
@@ -35,7 +35,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.01"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "ezxmlm"
   "nocrypto"
   "ocamlfind" {build}

--- a/packages/aws/aws.1.0.2/opam
+++ b/packages/aws/aws.1.0.2/opam
@@ -35,7 +35,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.01"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "ezxmlm"
   "nocrypto"
   "ocamlfind" {build}

--- a/packages/bookaml/bookaml.2.0/opam
+++ b/packages/bookaml/bookaml.2.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "ocamlfind"
   "batteries"
-  "calendar"
+  "calendar" {>= "2.00"}
   "cryptokit"
   "ocamlnet" {< "4"}
   "tyxml" {< "4.3"}

--- a/packages/bookaml/bookaml.2.1/opam
+++ b/packages/bookaml/bookaml.2.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "ocamlfind"
   "batteries"
-  "calendar"
+  "calendar" {>= "2.00"}
   "cryptokit"
   "ocamlnet" {>= "4"}
   "tyxml" {< "4.3"}

--- a/packages/bookaml/bookaml.3.0/opam
+++ b/packages/bookaml/bookaml.3.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind"
   "batteries"
-  "calendar"
+  "calendar" {>= "2.00"}
   "cryptokit"
   "ocamlnet" {>= "4"}
   "tyxml" {< "4.3"}

--- a/packages/bookaml/bookaml.3.1/opam
+++ b/packages/bookaml/bookaml.3.1/opam
@@ -15,7 +15,7 @@ remove: [["ocamlfind" "remove" "bookaml"]]
 depends: [
   "ocaml" {>= "4.01.0"}
   "batteries"
-  "calendar"
+  "calendar" {>= "2.00"}
   "camlp4"
   "cryptokit"
   "ocamlbuild" {build}

--- a/packages/bookaml/bookaml.4.0/opam
+++ b/packages/bookaml/bookaml.4.0/opam
@@ -18,7 +18,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.01.0"}
   "batteries"
-  "calendar"
+  "calendar" {>= "2.00"}
   "camlp4"
   "cryptokit"
   "ocamlbuild" {build}

--- a/packages/calendar/calendar.1.10/opam
+++ b/packages/calendar/calendar.1.10/opam
@@ -6,19 +6,21 @@ bug-reports: "https://github.com/ocaml-community/calendar/issues"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml-community/calendar.git"
 build: [
+  ["autoconf"]
+  ["sed" "-ib" "-e" "s/include/-include/" "Makefile.in"]
   ["./configure"]
+  [make "depend"]
   [make]
 ]
-remove: [["ocamlfind" "remove" "calendar"]]
 depends: [
-  "ocaml" {>= "3.09"}
-  "ocamlfind" {build}
+  "ocaml"
+  "conf-autoconf"
+  "ocamlfind"
 ]
 install: [make "install"]
 synopsis: "Library for handling dates and times in your program"
-flags: light-uninstall
 url {
   src:
-    "https://download.ocamlcore.org/calendar/calendar/2.04/calendar-2.04.tar.gz"
-  checksum: "md5=625b4f32c9ff447501868fa1c44f4f4f"
+    "https://github.com/ocaml-community/calendar/archive/9efe464cbc2fa3c23cf92f0888b6fbc1fbc8cbb3.tar.gz"
+  checksum: "md5=e407374575ae599d5da63bda196c2b37"
 }

--- a/packages/calendar/calendar.2.03.1/opam
+++ b/packages/calendar/calendar.2.03.1/opam
@@ -1,5 +1,10 @@
 opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Julien Signoles"]
+homepage: "http://calendar.forge.ocamlcore.org/"
+bug-reports: "https://github.com/ocaml-community/calendar/issues"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocaml-community/calendar.git"
 build: [
   ["./configure"]
   [make]

--- a/packages/calendar/calendar.2.03.2/opam
+++ b/packages/calendar/calendar.2.03.2/opam
@@ -2,13 +2,15 @@ opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Julien Signoles"]
 homepage: "http://calendar.forge.ocamlcore.org/"
+bug-reports: "https://github.com/ocaml-community/calendar/issues"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocaml-community/calendar.git"
 build: [
   ["./configure"]
   [make]
 ]
 remove: [["ocamlfind" "remove" "calendar"]]
-depends: ["ocaml" "ocamlfind"]
+depends: ["ocaml" {>= "3.09"} "ocamlfind"]
 install: [make "install"]
 synopsis: "Library for handling dates and times in your program"
 flags: light-uninstall

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.10.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.10.0/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.10.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "jbuilder"
 ]
 synopsis: "Date and time field types using the calendar library."

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.10.1/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.10.1/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.10.1"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "jbuilder"
 ]
 synopsis: "Date and time field types using the calendar library."

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.10.2/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.10.2/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml"
   "caqti" {= "0.10.2"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "jbuilder" {>= "1.0+beta19"}
 ]
 synopsis: "Date and time field types using the calendar library."

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.11.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.11.0/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml"
   "caqti" {= "0.11.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "jbuilder" {>= "1.0+beta19"}
 ]
 synopsis: "Date and time field types using the calendar library."

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.9.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.9.0/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.9.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "jbuilder"
 ]
 synopsis: "Date and time field types using the calendar library."

--- a/packages/caqti-type-calendar/caqti-type-calendar.1.0.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.1.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml"
   "caqti" {>= "1.0.0" & < "2.0.0~"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "dune"
 ]
 build: [

--- a/packages/caqti-type-calendar/caqti-type-calendar.1.2.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.1.2.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml"
   "caqti" {>= "1.0.0" & < "2.0.0~"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "dune" {>= "1.11"}
 ]
 build: [

--- a/packages/caqti/caqti.0.10.0/opam
+++ b/packages/caqti/caqti.0.10.0/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder"
-  "calendar"
+  "calendar" {>= "2.00"}
   "ocamlfind" {build}
   "ptime"
   "uri" {>= "1.9.0"}

--- a/packages/caqti/caqti.0.10.1/opam
+++ b/packages/caqti/caqti.0.10.1/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder"
-  "calendar"
+  "calendar" {>= "2.00"}
   "ocamlfind" {build}
   "ptime"
   "uri" {>= "1.9.0"}

--- a/packages/caqti/caqti.0.10.2/opam
+++ b/packages/caqti/caqti.0.10.2/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder" {>= "1.0+beta19"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "ocamlfind" {build}
   "ptime"
   "uri" {>= "1.9.0"}

--- a/packages/caqti/caqti.0.9.0/opam
+++ b/packages/caqti/caqti.0.9.0/opam
@@ -12,7 +12,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder"
-  "calendar"
+  "calendar" {>= "2.00"}
   "ocamlfind" {build}
   "ptime"
   "uri" {>= "1.9.0"}

--- a/packages/crowbar/crowbar.0.1/opam
+++ b/packages/crowbar/crowbar.0.1/opam
@@ -35,7 +35,7 @@ depends: [
   "ocplib-endian"
   "cmdliner"
   "afl-persistent" {>= "1.1"}
-  "calendar" {with-test}
+  "calendar" {with-test & >= "2.00"}
   "xmldiff" {with-test}
   "fpath" {with-test}
   "uucp" {with-test}

--- a/packages/crowbar/crowbar.0.2/opam
+++ b/packages/crowbar/crowbar.0.2/opam
@@ -22,7 +22,7 @@ depends: [
   "ocplib-endian"
   "cmdliner"
   "afl-persistent" {>= "1.1"}
-  "calendar" {with-test}
+  "calendar" {with-test & >= "2.00"}
   "fpath" {with-test}
   "uucp" {with-test}
   "uunf" {with-test}

--- a/packages/eliom/eliom.2.2.2/opam
+++ b/packages/eliom/eliom.2.2.2/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind"
   "deriving-ocsigen"
   "js_of_ocaml" {< "2.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "tyxml" {< "3.2"}
   "ocsigenserver" {< "2.3.0"}
   "camlp4"

--- a/packages/eliom/eliom.3.0.0/opam
+++ b/packages/eliom/eliom.3.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind"
   "deriving-ocsigen"
   "js_of_ocaml" {>= "1.3" & < "2.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "tyxml" {< "3.2"}
   "ocsigenserver" {>= "2.2" & < "2.3.0"}
   "camlp4"

--- a/packages/eliom/eliom.3.0.1/opam
+++ b/packages/eliom/eliom.3.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind"
   "deriving-ocsigen"
   "js_of_ocaml" {>= "1.3" & < "2.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "tyxml" {< "3.2"}
   "ocsigenserver" {>= "2.2" & < "2.3.0"}
   "camlp4"

--- a/packages/eliom/eliom.3.0.2/opam
+++ b/packages/eliom/eliom.3.0.2/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind"
   "deriving-ocsigen"
   "js_of_ocaml" {>= "1.3" & < "2.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "tyxml" {< "3.2"}
   "ocsigenserver" {>= "2.2" & < "2.3.0"}
   "camlp4"

--- a/packages/eliom/eliom.3.0.3/opam
+++ b/packages/eliom/eliom.3.0.3/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind"
   "deriving-ocsigen"
   "js_of_ocaml" {>= "1.3" & < "2.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "tyxml" {< "3.2"}
   "ocsigenserver" {>= "2.2" & < "2.3.0"}
   "camlp4"

--- a/packages/eliom/eliom.4.0.0/opam
+++ b/packages/eliom/eliom.4.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"
   "deriving"
   "js_of_ocaml" {>= "2.2" & < "3.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "tyxml" {< "3.2"}
   "ocsigenserver" {>= "2.4.0" & < "2.6"}
   "camlp4" {<= "4.02+6"}

--- a/packages/eliom/eliom.4.1.0/opam
+++ b/packages/eliom/eliom.4.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "deriving" {>= "0.6"}
   "js_of_ocaml" {>= "2.5" & < "3.0"}
   "tyxml" {>= "3.3.0" & < "3.6.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "camlp4" {<= "4.02+6"}
   "ocsigenserver" {= "2.5"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.4.2.0/opam
+++ b/packages/eliom/eliom.4.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "deriving" {>= "0.6"}
   "js_of_ocaml" {>= "2.5" & < "3.0"}
   "tyxml" {>= "3.3.0" & < "3.6.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "ocsigenserver" {>= "2.6"}
   "ipaddr" {>= "2.1"}
   "reactiveData"

--- a/packages/eliom/eliom.5.0.0/opam
+++ b/packages/eliom/eliom.5.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   ("base-no-ppx" | "ppx_tools" {>= "0.99.3"})
   "js_of_ocaml" {> "2.6" & < "3.0"}
   "tyxml" {= "3.6.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "ocsigenserver" {>= "2.6"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {= "0.2"}

--- a/packages/eliom/eliom.6.0.0/opam
+++ b/packages/eliom/eliom.6.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_tools" {>= "0.99.3"}
   "js_of_ocaml" {>= "2.8.2" & < "3.0"}
   "tyxml" {>= "4.0.0" & < "4.3"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "ocsigenserver" {>= "2.8"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}

--- a/packages/facebook-sdk/facebook-sdk.0.2.12/opam
+++ b/packages/facebook-sdk/facebook-sdk.0.2.12/opam
@@ -20,7 +20,7 @@ depends: [
   "atd" {= "1.0.3"}
   "atdgen"
   "bolt"
-  "calendar"
+  "calendar" {>= "2.00"}
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "lwt" {< "3.0.0"}
   "oasis"

--- a/packages/facebook-sdk/facebook-sdk.0.3.1/opam
+++ b/packages/facebook-sdk/facebook-sdk.0.3.1/opam
@@ -18,7 +18,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.01.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "core" {< "v0.15"}
   "csv"

--- a/packages/facebook-sdk/facebook-sdk.0.3.3/opam
+++ b/packages/facebook-sdk/facebook-sdk.0.3.3/opam
@@ -18,7 +18,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.01.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "core" {< "v0.15"}
   "csv"

--- a/packages/facebook-sdk/facebook-sdk.0.3.4/opam
+++ b/packages/facebook-sdk/facebook-sdk.0.3.4/opam
@@ -18,7 +18,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.01.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "core" {< "v0.15"}
   "csv"

--- a/packages/facebook-sdk/facebook-sdk.0.3.5/opam
+++ b/packages/facebook-sdk/facebook-sdk.0.3.5/opam
@@ -18,7 +18,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.01.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "cohttp" {>= "0.10.0" & < "0.12.0"}
   "core" {< "v0.15"}
   "csv"

--- a/packages/oasis2debian/oasis2debian.0.1.3/opam
+++ b/packages/oasis2debian/oasis2debian.0.1.3/opam
@@ -19,7 +19,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "3.12.1"}
-  "calendar" {build}
+  "calendar" {build & >= "2.00"}
   "debian-formats" {build & >= "0.0.1"}
   "fileutils" {build & >= "0.4.2"}
   "oasis" {build & >= "0.4.7"}

--- a/packages/oasis2debian/oasis2debian.0.1.4/opam
+++ b/packages/oasis2debian/oasis2debian.0.1.4/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml" {>= "3.12.1"}
   "base-unix" {with-test}
-  "calendar" {build}
+  "calendar" {build & >= "2.00"}
   "debian-formats" {build & >= "0.0.1"}
   "fileutils" {build & >= "0.4.2"}
   "oasis" {build & >= "0.4.7"}

--- a/packages/oasis2debian/oasis2debian.0.1.5/opam
+++ b/packages/oasis2debian/oasis2debian.0.1.5/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml" {>= "3.12.1"}
   "base-unix" {with-test}
-  "calendar" {build}
+  "calendar" {build & >= "2.00"}
   "debian-formats" {build & >= "0.0.1"}
   "fileutils" {build & >= "0.4.2"}
   "oasis" {build & >= "0.4.7"}

--- a/packages/ocal/ocal.0.1.1/opam
+++ b/packages/ocal/ocal.0.1.1/opam
@@ -13,7 +13,7 @@ install: [make "install"]
 depends: [
   "ocaml"
   "astring" {build}
-  "calendar" {build}
+  "calendar" {build & >= "2.00"}
   "cmdliner" {build}
   "ocamlfind" {build}
 ]

--- a/packages/ocal/ocal.0.1.2/opam
+++ b/packages/ocal/ocal.0.1.2/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml"
   "astring" {build}
-  "calendar" {build}
+  "calendar" {build & >= "2.00"}
   "cmdliner" {build}
   "ocamlfind" {build}
 ]

--- a/packages/ocal/ocal.0.1.3/opam
+++ b/packages/ocal/ocal.0.1.3/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {>= "1.0+beta11"}
   "astring" {build}
-  "calendar" {build}
+  "calendar" {build & >= "2.00"}
   "cmdliner" {build}
 ]
 synopsis: "An improved Unix `cal` utility"

--- a/packages/ocal/ocal.0.2.0/opam
+++ b/packages/ocal/ocal.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {>= "1.0+beta11"}
   "astring" {build}
-  "calendar" {build}
+  "calendar" {build & >= "2.00"}
   "cmdliner" {build}
   "notty" {build & < "0.2.0"}
 ]

--- a/packages/ocal/ocal.0.2.1/opam
+++ b/packages/ocal/ocal.0.2.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {>= "1.0+beta11"}
   "astring" {build}
-  "calendar" {build}
+  "calendar" {build & >= "2.00"}
   "cmdliner" {build}
   "notty" {build & >= "0.2.0"}
 ]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/files/PIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/files/PIC.patch
@@ -1,0 +1,210 @@
+From 3d664fd9695159460337bf0764808aefc8fb5cdf Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Sat, 17 Dec 2005 17:05:26 +0000
+Subject: [PATCH] Back-port PIC related changes from 3.09-3.11
+
+ - x86_64: do not define ARCH_CODE32 if compiling for a shared library (PR#3869)
+ - Ajout production de code relogeable (option -fPIC)
+ - Produce position-independent code by default.  This makes it easier to embed Caml code in a shared library.
+ - Lswitch did not generate relocatable code with -fPIC option (PR#3924)
+ - Non-PC-relative reference (PR#3924)
+ - PR#4867, PR#4760: make Lswitch generate PIC code acceptable for MacOS X
+---
+ asmcomp/amd64/arch.ml      |  8 +++++++-
+ asmcomp/amd64/emit.mlp     | 38 +++++++++++++++++++++++++++++++-------
+ asmcomp/amd64/proc.ml      |  1 +
+ asmcomp/amd64/reload.ml    |  9 +++++++--
+ asmcomp/amd64/selection.ml |  2 +-
+ asmrun/amd64.S             |  2 +-
+ configure                  |  5 ++++-
+ 7 files changed, 52 insertions(+), 13 deletions(-)
+
+diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
+index 5d3005349..3e8f4b111 100644
+--- a/asmcomp/amd64/arch.ml
++++ b/asmcomp/amd64/arch.ml
+@@ -14,7 +14,13 @@
+ 
+ (* Machine-specific command-line options *)
+ 
+-let command_line_options = []
++let pic_code = ref true
++
++let command_line_options =
++  [ "-fPIC", Arg.Set pic_code,
++      " Generate position-independent machine code (default)";
++    "-fno-PIC", Arg.Clear pic_code,
++      " Generate position-dependent machine code" ]
+ 
+ (* Specific operations for the AMD64 processor *)
+ 
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index a3ceedadc..e3049aa8d 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -12,7 +12,7 @@
+ 
+ (* $Id$ *)
+ 
+-(* Emission of Intel 386 assembly code *)
++(* Emission of x86-64 (AMD 64) assembly code *)
+ 
+ open Misc
+ open Cmm
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -312,7 +318,10 @@ let emit_instr fallthrough i =
+           `	movlpd	{emit_label lbl}(%rip), {emit_reg i.res.(0)}\n`
+         end
+     | Lop(Iconst_symbol s) ->
+-        `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
++        if !pic_code then
++          `	leaq	{emit_symbol s}(%rip), {emit_reg i.res.(0)}\n`
++        else
++          `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
+     | Lop(Icall_ind) ->
+         `	call	*{emit_reg i.arg.(0)}\n`;
+         record_frame i.live
+@@ -331,7 +340,7 @@ let emit_instr fallthrough i =
+         end
+     | Lop(Iextcall(s, alloc)) ->
+         if alloc then begin
+-          `	movq	${emit_symbol s}, %rax\n`;
++          `	leaq	{emit_symbol s}(%rip), %rax\n`;
+           `	call	{emit_symbol "caml_c_call"}\n`;
+           record_frame i.live
+         end else begin
+@@ -471,6 +480,7 @@ let emit_instr fallthrough i =
+     | Lop(Ispecific(Istore_int(n, addr))) ->
+         `	movq	${emit_nativeint n}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Istore_symbol(s, addr))) ->
++        assert (not !pic_code);
+         `	movq	${emit_symbol s}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Ioffset_loc(n, addr))) ->
+         `	addq	${emit_int n}, {emit_addressing addr i.arg 0}\n`
+@@ -531,12 +541,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 856e4655a..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -169,6 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+diff --git a/asmcomp/amd64/reload.ml b/asmcomp/amd64/reload.ml
+index f18604442..44c1d97fb 100644
+--- a/asmcomp/amd64/reload.ml
++++ b/asmcomp/amd64/reload.ml
+@@ -26,7 +26,8 @@ open Mach
+                              or S       R
+      Iconst_int                 S
+      Iconst_float               R
+-     Iconst_symbol              S
++     Iconst_symbol (not PIC)    S
++     Iconst_symbol (PIC)        R
+      Icall_ind                          R
+      Itailcall_ind                      R
+      Iload                      R       R       R
+@@ -72,7 +73,11 @@ method reload_operation op arg res =
+       (* This add will be turned into a lea; args and results must be
+          in registers *)
+       super#reload_operation op arg res
+-  | Iconst_int _ | Iconst_symbol _
++  | Iconst_symbol _ ->
++      if !pic_code
++      then super#reload_operation op arg res
++      else (arg, res)
++  | Iconst_int _
+   | Iintop(Idiv | Imod | Ilsl | Ilsr | Iasr)
+   | Iintop_imm(_, _) ->
+       (* The argument(s) and results can be either in register or on stack *)
+diff --git a/asmcomp/amd64/selection.ml b/asmcomp/amd64/selection.ml
+index acd79f141..b38a1b8cd 100644
+--- a/asmcomp/amd64/selection.ml
++++ b/asmcomp/amd64/selection.ml
+@@ -144,7 +144,7 @@ method select_store addr exp =
+       (Ispecific(Istore_int(Nativeint.of_int n, addr)), Ctuple [])
+   | Cconst_natpointer n when self#is_immediate_natint n ->
+       (Ispecific(Istore_int(n, addr)), Ctuple [])
+-  | Cconst_symbol s ->
++  | Cconst_symbol s when not !pic_code ->
+       (Ispecific(Istore_symbol(s, addr)), Ctuple [])
+   | _ ->
+       super#select_store addr exp
+diff --git a/asmrun/amd64.S b/asmrun/amd64.S
+index b1f204f44..5fd5440cf 100644
+--- a/asmrun/amd64.S
++++ b/asmrun/amd64.S
+@@ -52,7 +52,7 @@ FUNCTION(caml_call_gc)
+         pushq   %rdi
+         pushq   %rbx
+         pushq   %rax
+-        movq    %rsp, caml_gc_regs
++        movq    %rsp, caml_gc_regs(%rip)
+     /* Save floating-point registers */
+         subq    $(16*8), %rsp
+         movlpd  %xmm0, 0*8(%rsp)
+diff --git a/configure b/configure
+index a387a6780..1c219e0d0 100755
+--- a/configure
++++ b/configure
+@@ -296,7 +296,10 @@ case "$bytecc,$host" in
+   gcc*,x86_64-*-linux*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings"
+     # Tell gcc that we can use 32-bit code addresses for threaded code
+-    echo "#define ARCH_CODE32" >> m.h;;
++    # unless we are compiled for a shared library (-fPIC option)
++    echo "#ifndef __PIC__" >> m.h
++    echo "#  define ARCH_CODE32" >> m.h
++    echo "#endif" >> m.h;;
+   gcc*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings";;
+ esac
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/files/pr2061.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/files/pr2061.patch
@@ -1,0 +1,23 @@
+From 0d27aeebb4086175b5c46a6612d9275ed8a08f9c Mon Sep 17 00:00:00 2001
+From: Damien Doligez <damien.doligez-inria.fr>
+Date: Mon, 2 Feb 2004 22:33:27 +0000
+Subject: [PATCH 1/7] PR#2061 probleme de locale
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/trunk@6106 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ ocamldoc/remove_DEBUG | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ocamldoc/remove_DEBUG b/ocamldoc/remove_DEBUG
+index 99ab8972f..6dd7ad0b0 100755
+--- a/ocamldoc/remove_DEBUG
++++ b/ocamldoc/remove_DEBUG
+@@ -5,4 +5,4 @@
+ # respecting the cpp # line annotation conventions
+ 
+ echo "# 1 \"$1\""
+-sed -e '/DEBUG/s/.*//' "$1"
++LC_ALL=C sed -e '/DEBUG/s/.*//' "$1"
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
@@ -32,7 +32,11 @@ install: [
   ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
   ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
-patches: "ocaml-3.07-patch1.diffs"
+patches: [
+  "ocaml-3.07-patch1.diffs"
+  "PIC.patch"
+  "pr2061.patch"
+]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
   checksum: "md5=2dd038055f5e1350078ad81270411b78"
@@ -41,4 +45,8 @@ extra-source "ocaml-3.07-patch1.diffs" {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch1.diffs"
   checksum: "md5=50e158dee599e00a4b9b93041ea9d21f"
 }
+extra-files: [
+  ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
+  ["pr2061.patch" "md5=015cc44bb737dccd8cb63d4c37ce9371"]
+]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
@@ -53,4 +53,4 @@ extra-files: [
   ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
   ["pr2061.patch" "md5=015cc44bb737dccd8cb63d4c37ce9371"]
 ]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.07+1 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.07"
 depends: [
   "ocaml" {= "3.07+1" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
@@ -53,4 +53,4 @@ extra-files: [
   ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
   ["pr2061.patch" "md5=015cc44bb737dccd8cb63d4c37ce9371"]
 ]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/files/PIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/files/PIC.patch
@@ -1,0 +1,210 @@
+From 3d664fd9695159460337bf0764808aefc8fb5cdf Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Sat, 17 Dec 2005 17:05:26 +0000
+Subject: [PATCH] Back-port PIC related changes from 3.09-3.11
+
+ - x86_64: do not define ARCH_CODE32 if compiling for a shared library (PR#3869)
+ - Ajout production de code relogeable (option -fPIC)
+ - Produce position-independent code by default.  This makes it easier to embed Caml code in a shared library.
+ - Lswitch did not generate relocatable code with -fPIC option (PR#3924)
+ - Non-PC-relative reference (PR#3924)
+ - PR#4867, PR#4760: make Lswitch generate PIC code acceptable for MacOS X
+---
+ asmcomp/amd64/arch.ml      |  8 +++++++-
+ asmcomp/amd64/emit.mlp     | 38 +++++++++++++++++++++++++++++++-------
+ asmcomp/amd64/proc.ml      |  1 +
+ asmcomp/amd64/reload.ml    |  9 +++++++--
+ asmcomp/amd64/selection.ml |  2 +-
+ asmrun/amd64.S             |  2 +-
+ configure                  |  5 ++++-
+ 7 files changed, 52 insertions(+), 13 deletions(-)
+
+diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
+index 5d3005349..3e8f4b111 100644
+--- a/asmcomp/amd64/arch.ml
++++ b/asmcomp/amd64/arch.ml
+@@ -14,7 +14,13 @@
+ 
+ (* Machine-specific command-line options *)
+ 
+-let command_line_options = []
++let pic_code = ref true
++
++let command_line_options =
++  [ "-fPIC", Arg.Set pic_code,
++      " Generate position-independent machine code (default)";
++    "-fno-PIC", Arg.Clear pic_code,
++      " Generate position-dependent machine code" ]
+ 
+ (* Specific operations for the AMD64 processor *)
+ 
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index a3ceedadc..e3049aa8d 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -12,7 +12,7 @@
+ 
+ (* $Id$ *)
+ 
+-(* Emission of Intel 386 assembly code *)
++(* Emission of x86-64 (AMD 64) assembly code *)
+ 
+ open Misc
+ open Cmm
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -312,7 +318,10 @@ let emit_instr fallthrough i =
+           `	movlpd	{emit_label lbl}(%rip), {emit_reg i.res.(0)}\n`
+         end
+     | Lop(Iconst_symbol s) ->
+-        `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
++        if !pic_code then
++          `	leaq	{emit_symbol s}(%rip), {emit_reg i.res.(0)}\n`
++        else
++          `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
+     | Lop(Icall_ind) ->
+         `	call	*{emit_reg i.arg.(0)}\n`;
+         record_frame i.live
+@@ -331,7 +340,7 @@ let emit_instr fallthrough i =
+         end
+     | Lop(Iextcall(s, alloc)) ->
+         if alloc then begin
+-          `	movq	${emit_symbol s}, %rax\n`;
++          `	leaq	{emit_symbol s}(%rip), %rax\n`;
+           `	call	{emit_symbol "caml_c_call"}\n`;
+           record_frame i.live
+         end else begin
+@@ -471,6 +480,7 @@ let emit_instr fallthrough i =
+     | Lop(Ispecific(Istore_int(n, addr))) ->
+         `	movq	${emit_nativeint n}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Istore_symbol(s, addr))) ->
++        assert (not !pic_code);
+         `	movq	${emit_symbol s}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Ioffset_loc(n, addr))) ->
+         `	addq	${emit_int n}, {emit_addressing addr i.arg 0}\n`
+@@ -531,12 +541,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 856e4655a..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -169,6 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+diff --git a/asmcomp/amd64/reload.ml b/asmcomp/amd64/reload.ml
+index f18604442..44c1d97fb 100644
+--- a/asmcomp/amd64/reload.ml
++++ b/asmcomp/amd64/reload.ml
+@@ -26,7 +26,8 @@ open Mach
+                              or S       R
+      Iconst_int                 S
+      Iconst_float               R
+-     Iconst_symbol              S
++     Iconst_symbol (not PIC)    S
++     Iconst_symbol (PIC)        R
+      Icall_ind                          R
+      Itailcall_ind                      R
+      Iload                      R       R       R
+@@ -72,7 +73,11 @@ method reload_operation op arg res =
+       (* This add will be turned into a lea; args and results must be
+          in registers *)
+       super#reload_operation op arg res
+-  | Iconst_int _ | Iconst_symbol _
++  | Iconst_symbol _ ->
++      if !pic_code
++      then super#reload_operation op arg res
++      else (arg, res)
++  | Iconst_int _
+   | Iintop(Idiv | Imod | Ilsl | Ilsr | Iasr)
+   | Iintop_imm(_, _) ->
+       (* The argument(s) and results can be either in register or on stack *)
+diff --git a/asmcomp/amd64/selection.ml b/asmcomp/amd64/selection.ml
+index acd79f141..b38a1b8cd 100644
+--- a/asmcomp/amd64/selection.ml
++++ b/asmcomp/amd64/selection.ml
+@@ -144,7 +144,7 @@ method select_store addr exp =
+       (Ispecific(Istore_int(Nativeint.of_int n, addr)), Ctuple [])
+   | Cconst_natpointer n when self#is_immediate_natint n ->
+       (Ispecific(Istore_int(n, addr)), Ctuple [])
+-  | Cconst_symbol s ->
++  | Cconst_symbol s when not !pic_code ->
+       (Ispecific(Istore_symbol(s, addr)), Ctuple [])
+   | _ ->
+       super#select_store addr exp
+diff --git a/asmrun/amd64.S b/asmrun/amd64.S
+index b1f204f44..5fd5440cf 100644
+--- a/asmrun/amd64.S
++++ b/asmrun/amd64.S
+@@ -52,7 +52,7 @@ FUNCTION(caml_call_gc)
+         pushq   %rdi
+         pushq   %rbx
+         pushq   %rax
+-        movq    %rsp, caml_gc_regs
++        movq    %rsp, caml_gc_regs(%rip)
+     /* Save floating-point registers */
+         subq    $(16*8), %rsp
+         movlpd  %xmm0, 0*8(%rsp)
+diff --git a/configure b/configure
+index a387a6780..1c219e0d0 100755
+--- a/configure
++++ b/configure
+@@ -296,7 +296,10 @@ case "$bytecc,$host" in
+   gcc*,x86_64-*-linux*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings"
+     # Tell gcc that we can use 32-bit code addresses for threaded code
+-    echo "#define ARCH_CODE32" >> m.h;;
++    # unless we are compiled for a shared library (-fPIC option)
++    echo "#ifndef __PIC__" >> m.h
++    echo "#  define ARCH_CODE32" >> m.h
++    echo "#endif" >> m.h;;
+   gcc*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings";;
+ esac
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/files/pr2061.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/files/pr2061.patch
@@ -1,0 +1,23 @@
+From 0d27aeebb4086175b5c46a6612d9275ed8a08f9c Mon Sep 17 00:00:00 2001
+From: Damien Doligez <damien.doligez-inria.fr>
+Date: Mon, 2 Feb 2004 22:33:27 +0000
+Subject: [PATCH 1/7] PR#2061 probleme de locale
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/trunk@6106 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ ocamldoc/remove_DEBUG | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ocamldoc/remove_DEBUG b/ocamldoc/remove_DEBUG
+index 99ab8972f..6dd7ad0b0 100755
+--- a/ocamldoc/remove_DEBUG
++++ b/ocamldoc/remove_DEBUG
+@@ -5,4 +5,4 @@
+ # respecting the cpp # line annotation conventions
+ 
+ echo "# 1 \"$1\""
+-sed -e '/DEBUG/s/.*//' "$1"
++LC_ALL=C sed -e '/DEBUG/s/.*//' "$1"
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
@@ -53,4 +53,4 @@ extra-files: [
   ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
   ["pr2061.patch" "md5=015cc44bb737dccd8cb63d4c37ce9371"]
 ]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
@@ -53,4 +53,4 @@ extra-files: [
   ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
   ["pr2061.patch" "md5=015cc44bb737dccd8cb63d4c37ce9371"]
 ]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
@@ -32,7 +32,11 @@ install: [
   ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
   ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
-patches: "ocaml-3.07-patch2.diffs"
+patches: [
+  "ocaml-3.07-patch2.diffs"
+  "PIC.patch"
+  "pr2061.patch"
+]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
   checksum: "md5=2dd038055f5e1350078ad81270411b78"
@@ -41,4 +45,8 @@ extra-source "ocaml-3.07-patch2.diffs" {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07-patch2.diffs"
   checksum: "md5=f91d1f1e531f77011bd554817dbbc12a"
 }
+extra-files: [
+  ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
+  ["pr2061.patch" "md5=015cc44bb737dccd8cb63d4c37ce9371"]
+]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.07+2 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.07"
 depends: [
   "ocaml" {= "3.07+2" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/files/PIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/files/PIC.patch
@@ -1,0 +1,210 @@
+From 3d664fd9695159460337bf0764808aefc8fb5cdf Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Sat, 17 Dec 2005 17:05:26 +0000
+Subject: [PATCH] Back-port PIC related changes from 3.09-3.11
+
+ - x86_64: do not define ARCH_CODE32 if compiling for a shared library (PR#3869)
+ - Ajout production de code relogeable (option -fPIC)
+ - Produce position-independent code by default.  This makes it easier to embed Caml code in a shared library.
+ - Lswitch did not generate relocatable code with -fPIC option (PR#3924)
+ - Non-PC-relative reference (PR#3924)
+ - PR#4867, PR#4760: make Lswitch generate PIC code acceptable for MacOS X
+---
+ asmcomp/amd64/arch.ml      |  8 +++++++-
+ asmcomp/amd64/emit.mlp     | 38 +++++++++++++++++++++++++++++++-------
+ asmcomp/amd64/proc.ml      |  1 +
+ asmcomp/amd64/reload.ml    |  9 +++++++--
+ asmcomp/amd64/selection.ml |  2 +-
+ asmrun/amd64.S             |  2 +-
+ configure                  |  5 ++++-
+ 7 files changed, 52 insertions(+), 13 deletions(-)
+
+diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
+index 5d3005349..3e8f4b111 100644
+--- a/asmcomp/amd64/arch.ml
++++ b/asmcomp/amd64/arch.ml
+@@ -14,7 +14,13 @@
+ 
+ (* Machine-specific command-line options *)
+ 
+-let command_line_options = []
++let pic_code = ref true
++
++let command_line_options =
++  [ "-fPIC", Arg.Set pic_code,
++      " Generate position-independent machine code (default)";
++    "-fno-PIC", Arg.Clear pic_code,
++      " Generate position-dependent machine code" ]
+ 
+ (* Specific operations for the AMD64 processor *)
+ 
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index a3ceedadc..e3049aa8d 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -12,7 +12,7 @@
+ 
+ (* $Id$ *)
+ 
+-(* Emission of Intel 386 assembly code *)
++(* Emission of x86-64 (AMD 64) assembly code *)
+ 
+ open Misc
+ open Cmm
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -312,7 +318,10 @@ let emit_instr fallthrough i =
+           `	movlpd	{emit_label lbl}(%rip), {emit_reg i.res.(0)}\n`
+         end
+     | Lop(Iconst_symbol s) ->
+-        `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
++        if !pic_code then
++          `	leaq	{emit_symbol s}(%rip), {emit_reg i.res.(0)}\n`
++        else
++          `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
+     | Lop(Icall_ind) ->
+         `	call	*{emit_reg i.arg.(0)}\n`;
+         record_frame i.live
+@@ -331,7 +340,7 @@ let emit_instr fallthrough i =
+         end
+     | Lop(Iextcall(s, alloc)) ->
+         if alloc then begin
+-          `	movq	${emit_symbol s}, %rax\n`;
++          `	leaq	{emit_symbol s}(%rip), %rax\n`;
+           `	call	{emit_symbol "caml_c_call"}\n`;
+           record_frame i.live
+         end else begin
+@@ -471,6 +480,7 @@ let emit_instr fallthrough i =
+     | Lop(Ispecific(Istore_int(n, addr))) ->
+         `	movq	${emit_nativeint n}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Istore_symbol(s, addr))) ->
++        assert (not !pic_code);
+         `	movq	${emit_symbol s}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Ioffset_loc(n, addr))) ->
+         `	addq	${emit_int n}, {emit_addressing addr i.arg 0}\n`
+@@ -531,12 +541,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 856e4655a..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -169,6 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+diff --git a/asmcomp/amd64/reload.ml b/asmcomp/amd64/reload.ml
+index f18604442..44c1d97fb 100644
+--- a/asmcomp/amd64/reload.ml
++++ b/asmcomp/amd64/reload.ml
+@@ -26,7 +26,8 @@ open Mach
+                              or S       R
+      Iconst_int                 S
+      Iconst_float               R
+-     Iconst_symbol              S
++     Iconst_symbol (not PIC)    S
++     Iconst_symbol (PIC)        R
+      Icall_ind                          R
+      Itailcall_ind                      R
+      Iload                      R       R       R
+@@ -72,7 +73,11 @@ method reload_operation op arg res =
+       (* This add will be turned into a lea; args and results must be
+          in registers *)
+       super#reload_operation op arg res
+-  | Iconst_int _ | Iconst_symbol _
++  | Iconst_symbol _ ->
++      if !pic_code
++      then super#reload_operation op arg res
++      else (arg, res)
++  | Iconst_int _
+   | Iintop(Idiv | Imod | Ilsl | Ilsr | Iasr)
+   | Iintop_imm(_, _) ->
+       (* The argument(s) and results can be either in register or on stack *)
+diff --git a/asmcomp/amd64/selection.ml b/asmcomp/amd64/selection.ml
+index acd79f141..b38a1b8cd 100644
+--- a/asmcomp/amd64/selection.ml
++++ b/asmcomp/amd64/selection.ml
+@@ -144,7 +144,7 @@ method select_store addr exp =
+       (Ispecific(Istore_int(Nativeint.of_int n, addr)), Ctuple [])
+   | Cconst_natpointer n when self#is_immediate_natint n ->
+       (Ispecific(Istore_int(n, addr)), Ctuple [])
+-  | Cconst_symbol s ->
++  | Cconst_symbol s when not !pic_code ->
+       (Ispecific(Istore_symbol(s, addr)), Ctuple [])
+   | _ ->
+       super#select_store addr exp
+diff --git a/asmrun/amd64.S b/asmrun/amd64.S
+index b1f204f44..5fd5440cf 100644
+--- a/asmrun/amd64.S
++++ b/asmrun/amd64.S
+@@ -52,7 +52,7 @@ FUNCTION(caml_call_gc)
+         pushq   %rdi
+         pushq   %rbx
+         pushq   %rax
+-        movq    %rsp, caml_gc_regs
++        movq    %rsp, caml_gc_regs(%rip)
+     /* Save floating-point registers */
+         subq    $(16*8), %rsp
+         movlpd  %xmm0, 0*8(%rsp)
+diff --git a/configure b/configure
+index a387a6780..1c219e0d0 100755
+--- a/configure
++++ b/configure
+@@ -296,7 +296,10 @@ case "$bytecc,$host" in
+   gcc*,x86_64-*-linux*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings"
+     # Tell gcc that we can use 32-bit code addresses for threaded code
+-    echo "#define ARCH_CODE32" >> m.h;;
++    # unless we are compiled for a shared library (-fPIC option)
++    echo "#ifndef __PIC__" >> m.h
++    echo "#  define ARCH_CODE32" >> m.h
++    echo "#endif" >> m.h;;
+   gcc*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings";;
+ esac
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/files/pr2061.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/files/pr2061.patch
@@ -1,0 +1,23 @@
+From 0d27aeebb4086175b5c46a6612d9275ed8a08f9c Mon Sep 17 00:00:00 2001
+From: Damien Doligez <damien.doligez-inria.fr>
+Date: Mon, 2 Feb 2004 22:33:27 +0000
+Subject: [PATCH 1/7] PR#2061 probleme de locale
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/trunk@6106 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ ocamldoc/remove_DEBUG | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ocamldoc/remove_DEBUG b/ocamldoc/remove_DEBUG
+index 99ab8972f..6dd7ad0b0 100755
+--- a/ocamldoc/remove_DEBUG
++++ b/ocamldoc/remove_DEBUG
+@@ -5,4 +5,4 @@
+ # respecting the cpp # line annotation conventions
+ 
+ echo "# 1 \"$1\""
+-sed -e '/DEBUG/s/.*//' "$1"
++LC_ALL=C sed -e '/DEBUG/s/.*//' "$1"
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
@@ -32,8 +32,16 @@ install: [
   ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
   ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
+patches: [
+  "PIC.patch"
+  "pr2061.patch"
+]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.07/ocaml-3.07.tar.gz"
   checksum: "md5=2dd038055f5e1350078ad81270411b78"
 }
+extra-files: [
+  ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
+  ["pr2061.patch" "md5=015cc44bb737dccd8cb63d4c37ce9371"]
+]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
@@ -48,4 +48,4 @@ extra-files: [
   ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
   ["pr2061.patch" "md5=015cc44bb737dccd8cb63d4c37ce9371"]
 ]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
@@ -48,4 +48,4 @@ extra-files: [
   ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
   ["pr2061.patch" "md5=015cc44bb737dccd8cb63d4c37ce9371"]
 ]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.07 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.07"
 depends: [
   "ocaml" {= "3.07" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/files/PIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/files/PIC.patch
@@ -1,0 +1,210 @@
+From 3d664fd9695159460337bf0764808aefc8fb5cdf Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Sat, 17 Dec 2005 17:05:26 +0000
+Subject: [PATCH] Back-port PIC related changes from 3.09-3.11
+
+ - x86_64: do not define ARCH_CODE32 if compiling for a shared library (PR#3869)
+ - Ajout production de code relogeable (option -fPIC)
+ - Produce position-independent code by default.  This makes it easier to embed Caml code in a shared library.
+ - Lswitch did not generate relocatable code with -fPIC option (PR#3924)
+ - Non-PC-relative reference (PR#3924)
+ - PR#4867, PR#4760: make Lswitch generate PIC code acceptable for MacOS X
+---
+ asmcomp/amd64/arch.ml      |  8 +++++++-
+ asmcomp/amd64/emit.mlp     | 38 +++++++++++++++++++++++++++++++-------
+ asmcomp/amd64/proc.ml      |  1 +
+ asmcomp/amd64/reload.ml    |  9 +++++++--
+ asmcomp/amd64/selection.ml |  2 +-
+ asmrun/amd64.S             |  2 +-
+ configure                  |  5 ++++-
+ 7 files changed, 52 insertions(+), 13 deletions(-)
+
+diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
+index 5d3005349..3e8f4b111 100644
+--- a/asmcomp/amd64/arch.ml
++++ b/asmcomp/amd64/arch.ml
+@@ -14,7 +14,13 @@
+ 
+ (* Machine-specific command-line options *)
+ 
+-let command_line_options = []
++let pic_code = ref true
++
++let command_line_options =
++  [ "-fPIC", Arg.Set pic_code,
++      " Generate position-independent machine code (default)";
++    "-fno-PIC", Arg.Clear pic_code,
++      " Generate position-dependent machine code" ]
+ 
+ (* Specific operations for the AMD64 processor *)
+ 
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index a3ceedadc..e3049aa8d 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -12,7 +12,7 @@
+ 
+ (* $Id$ *)
+ 
+-(* Emission of Intel 386 assembly code *)
++(* Emission of x86-64 (AMD 64) assembly code *)
+ 
+ open Misc
+ open Cmm
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -312,7 +318,10 @@ let emit_instr fallthrough i =
+           `	movlpd	{emit_label lbl}(%rip), {emit_reg i.res.(0)}\n`
+         end
+     | Lop(Iconst_symbol s) ->
+-        `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
++        if !pic_code then
++          `	leaq	{emit_symbol s}(%rip), {emit_reg i.res.(0)}\n`
++        else
++          `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
+     | Lop(Icall_ind) ->
+         `	call	*{emit_reg i.arg.(0)}\n`;
+         record_frame i.live
+@@ -331,7 +340,7 @@ let emit_instr fallthrough i =
+         end
+     | Lop(Iextcall(s, alloc)) ->
+         if alloc then begin
+-          `	movq	${emit_symbol s}, %rax\n`;
++          `	leaq	{emit_symbol s}(%rip), %rax\n`;
+           `	call	{emit_symbol "caml_c_call"}\n`;
+           record_frame i.live
+         end else begin
+@@ -471,6 +480,7 @@ let emit_instr fallthrough i =
+     | Lop(Ispecific(Istore_int(n, addr))) ->
+         `	movq	${emit_nativeint n}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Istore_symbol(s, addr))) ->
++        assert (not !pic_code);
+         `	movq	${emit_symbol s}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Ioffset_loc(n, addr))) ->
+         `	addq	${emit_int n}, {emit_addressing addr i.arg 0}\n`
+@@ -531,12 +541,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 856e4655a..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -169,6 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+diff --git a/asmcomp/amd64/reload.ml b/asmcomp/amd64/reload.ml
+index f18604442..44c1d97fb 100644
+--- a/asmcomp/amd64/reload.ml
++++ b/asmcomp/amd64/reload.ml
+@@ -26,7 +26,8 @@ open Mach
+                              or S       R
+      Iconst_int                 S
+      Iconst_float               R
+-     Iconst_symbol              S
++     Iconst_symbol (not PIC)    S
++     Iconst_symbol (PIC)        R
+      Icall_ind                          R
+      Itailcall_ind                      R
+      Iload                      R       R       R
+@@ -72,7 +73,11 @@ method reload_operation op arg res =
+       (* This add will be turned into a lea; args and results must be
+          in registers *)
+       super#reload_operation op arg res
+-  | Iconst_int _ | Iconst_symbol _
++  | Iconst_symbol _ ->
++      if !pic_code
++      then super#reload_operation op arg res
++      else (arg, res)
++  | Iconst_int _
+   | Iintop(Idiv | Imod | Ilsl | Ilsr | Iasr)
+   | Iintop_imm(_, _) ->
+       (* The argument(s) and results can be either in register or on stack *)
+diff --git a/asmcomp/amd64/selection.ml b/asmcomp/amd64/selection.ml
+index acd79f141..b38a1b8cd 100644
+--- a/asmcomp/amd64/selection.ml
++++ b/asmcomp/amd64/selection.ml
+@@ -144,7 +144,7 @@ method select_store addr exp =
+       (Ispecific(Istore_int(Nativeint.of_int n, addr)), Ctuple [])
+   | Cconst_natpointer n when self#is_immediate_natint n ->
+       (Ispecific(Istore_int(n, addr)), Ctuple [])
+-  | Cconst_symbol s ->
++  | Cconst_symbol s when not !pic_code ->
+       (Ispecific(Istore_symbol(s, addr)), Ctuple [])
+   | _ ->
+       super#select_store addr exp
+diff --git a/asmrun/amd64.S b/asmrun/amd64.S
+index b1f204f44..5fd5440cf 100644
+--- a/asmrun/amd64.S
++++ b/asmrun/amd64.S
+@@ -52,7 +52,7 @@ FUNCTION(caml_call_gc)
+         pushq   %rdi
+         pushq   %rbx
+         pushq   %rax
+-        movq    %rsp, caml_gc_regs
++        movq    %rsp, caml_gc_regs(%rip)
+     /* Save floating-point registers */
+         subq    $(16*8), %rsp
+         movlpd  %xmm0, 0*8(%rsp)
+diff --git a/configure b/configure
+index a387a6780..1c219e0d0 100755
+--- a/configure
++++ b/configure
+@@ -296,7 +296,10 @@ case "$bytecc,$host" in
+   gcc*,x86_64-*-linux*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings"
+     # Tell gcc that we can use 32-bit code addresses for threaded code
+-    echo "#define ARCH_CODE32" >> m.h;;
++    # unless we are compiled for a shared library (-fPIC option)
++    echo "#ifndef __PIC__" >> m.h
++    echo "#  define ARCH_CODE32" >> m.h
++    echo "#endif" >> m.h;;
+   gcc*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings";;
+ esac
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["PIC.patch"]
 extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.08.0 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.08"
 depends: [
   "ocaml" {= "3.08.0" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["PIC.patch"]
 extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
@@ -35,4 +35,6 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.0.tar.gz"
   checksum: "md5=c6ef478362295c150101cdd2efcd38e0"
 }
+patches: ["PIC.patch"]
+extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/files/PIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/files/PIC.patch
@@ -1,0 +1,210 @@
+From 3d664fd9695159460337bf0764808aefc8fb5cdf Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Sat, 17 Dec 2005 17:05:26 +0000
+Subject: [PATCH] Back-port PIC related changes from 3.09-3.11
+
+ - x86_64: do not define ARCH_CODE32 if compiling for a shared library (PR#3869)
+ - Ajout production de code relogeable (option -fPIC)
+ - Produce position-independent code by default.  This makes it easier to embed Caml code in a shared library.
+ - Lswitch did not generate relocatable code with -fPIC option (PR#3924)
+ - Non-PC-relative reference (PR#3924)
+ - PR#4867, PR#4760: make Lswitch generate PIC code acceptable for MacOS X
+---
+ asmcomp/amd64/arch.ml      |  8 +++++++-
+ asmcomp/amd64/emit.mlp     | 38 +++++++++++++++++++++++++++++++-------
+ asmcomp/amd64/proc.ml      |  1 +
+ asmcomp/amd64/reload.ml    |  9 +++++++--
+ asmcomp/amd64/selection.ml |  2 +-
+ asmrun/amd64.S             |  2 +-
+ configure                  |  5 ++++-
+ 7 files changed, 52 insertions(+), 13 deletions(-)
+
+diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
+index 5d3005349..3e8f4b111 100644
+--- a/asmcomp/amd64/arch.ml
++++ b/asmcomp/amd64/arch.ml
+@@ -14,7 +14,13 @@
+ 
+ (* Machine-specific command-line options *)
+ 
+-let command_line_options = []
++let pic_code = ref true
++
++let command_line_options =
++  [ "-fPIC", Arg.Set pic_code,
++      " Generate position-independent machine code (default)";
++    "-fno-PIC", Arg.Clear pic_code,
++      " Generate position-dependent machine code" ]
+ 
+ (* Specific operations for the AMD64 processor *)
+ 
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index a3ceedadc..e3049aa8d 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -12,7 +12,7 @@
+ 
+ (* $Id$ *)
+ 
+-(* Emission of Intel 386 assembly code *)
++(* Emission of x86-64 (AMD 64) assembly code *)
+ 
+ open Misc
+ open Cmm
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -312,7 +318,10 @@ let emit_instr fallthrough i =
+           `	movlpd	{emit_label lbl}(%rip), {emit_reg i.res.(0)}\n`
+         end
+     | Lop(Iconst_symbol s) ->
+-        `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
++        if !pic_code then
++          `	leaq	{emit_symbol s}(%rip), {emit_reg i.res.(0)}\n`
++        else
++          `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
+     | Lop(Icall_ind) ->
+         `	call	*{emit_reg i.arg.(0)}\n`;
+         record_frame i.live
+@@ -331,7 +340,7 @@ let emit_instr fallthrough i =
+         end
+     | Lop(Iextcall(s, alloc)) ->
+         if alloc then begin
+-          `	movq	${emit_symbol s}, %rax\n`;
++          `	leaq	{emit_symbol s}(%rip), %rax\n`;
+           `	call	{emit_symbol "caml_c_call"}\n`;
+           record_frame i.live
+         end else begin
+@@ -471,6 +480,7 @@ let emit_instr fallthrough i =
+     | Lop(Ispecific(Istore_int(n, addr))) ->
+         `	movq	${emit_nativeint n}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Istore_symbol(s, addr))) ->
++        assert (not !pic_code);
+         `	movq	${emit_symbol s}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Ioffset_loc(n, addr))) ->
+         `	addq	${emit_int n}, {emit_addressing addr i.arg 0}\n`
+@@ -531,12 +541,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 856e4655a..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -169,6 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+diff --git a/asmcomp/amd64/reload.ml b/asmcomp/amd64/reload.ml
+index f18604442..44c1d97fb 100644
+--- a/asmcomp/amd64/reload.ml
++++ b/asmcomp/amd64/reload.ml
+@@ -26,7 +26,8 @@ open Mach
+                              or S       R
+      Iconst_int                 S
+      Iconst_float               R
+-     Iconst_symbol              S
++     Iconst_symbol (not PIC)    S
++     Iconst_symbol (PIC)        R
+      Icall_ind                          R
+      Itailcall_ind                      R
+      Iload                      R       R       R
+@@ -72,7 +73,11 @@ method reload_operation op arg res =
+       (* This add will be turned into a lea; args and results must be
+          in registers *)
+       super#reload_operation op arg res
+-  | Iconst_int _ | Iconst_symbol _
++  | Iconst_symbol _ ->
++      if !pic_code
++      then super#reload_operation op arg res
++      else (arg, res)
++  | Iconst_int _
+   | Iintop(Idiv | Imod | Ilsl | Ilsr | Iasr)
+   | Iintop_imm(_, _) ->
+       (* The argument(s) and results can be either in register or on stack *)
+diff --git a/asmcomp/amd64/selection.ml b/asmcomp/amd64/selection.ml
+index acd79f141..b38a1b8cd 100644
+--- a/asmcomp/amd64/selection.ml
++++ b/asmcomp/amd64/selection.ml
+@@ -144,7 +144,7 @@ method select_store addr exp =
+       (Ispecific(Istore_int(Nativeint.of_int n, addr)), Ctuple [])
+   | Cconst_natpointer n when self#is_immediate_natint n ->
+       (Ispecific(Istore_int(n, addr)), Ctuple [])
+-  | Cconst_symbol s ->
++  | Cconst_symbol s when not !pic_code ->
+       (Ispecific(Istore_symbol(s, addr)), Ctuple [])
+   | _ ->
+       super#select_store addr exp
+diff --git a/asmrun/amd64.S b/asmrun/amd64.S
+index b1f204f44..5fd5440cf 100644
+--- a/asmrun/amd64.S
++++ b/asmrun/amd64.S
+@@ -52,7 +52,7 @@ FUNCTION(caml_call_gc)
+         pushq   %rdi
+         pushq   %rbx
+         pushq   %rax
+-        movq    %rsp, caml_gc_regs
++        movq    %rsp, caml_gc_regs(%rip)
+     /* Save floating-point registers */
+         subq    $(16*8), %rsp
+         movlpd  %xmm0, 0*8(%rsp)
+diff --git a/configure b/configure
+index a387a6780..1c219e0d0 100755
+--- a/configure
++++ b/configure
+@@ -296,7 +296,10 @@ case "$bytecc,$host" in
+   gcc*,x86_64-*-linux*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings"
+     # Tell gcc that we can use 32-bit code addresses for threaded code
+-    echo "#define ARCH_CODE32" >> m.h;;
++    # unless we are compiled for a shared library (-fPIC option)
++    echo "#ifndef __PIC__" >> m.h
++    echo "#  define ARCH_CODE32" >> m.h
++    echo "#endif" >> m.h;;
+   gcc*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings";;
+ esac
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["PIC.patch"]
 extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["PIC.patch"]
 extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
@@ -35,4 +35,6 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.1.tar.gz"
   checksum: "md5=8a32dd665d0d8fc08a027e1b8f68a001"
 }
+patches: ["PIC.patch"]
+extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.08.1 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.08"
 depends: [
   "ocaml" {= "3.08.1" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/files/PIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/files/PIC.patch
@@ -1,0 +1,210 @@
+From 3d664fd9695159460337bf0764808aefc8fb5cdf Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Sat, 17 Dec 2005 17:05:26 +0000
+Subject: [PATCH] Back-port PIC related changes from 3.09-3.11
+
+ - x86_64: do not define ARCH_CODE32 if compiling for a shared library (PR#3869)
+ - Ajout production de code relogeable (option -fPIC)
+ - Produce position-independent code by default.  This makes it easier to embed Caml code in a shared library.
+ - Lswitch did not generate relocatable code with -fPIC option (PR#3924)
+ - Non-PC-relative reference (PR#3924)
+ - PR#4867, PR#4760: make Lswitch generate PIC code acceptable for MacOS X
+---
+ asmcomp/amd64/arch.ml      |  8 +++++++-
+ asmcomp/amd64/emit.mlp     | 38 +++++++++++++++++++++++++++++++-------
+ asmcomp/amd64/proc.ml      |  1 +
+ asmcomp/amd64/reload.ml    |  9 +++++++--
+ asmcomp/amd64/selection.ml |  2 +-
+ asmrun/amd64.S             |  2 +-
+ configure                  |  5 ++++-
+ 7 files changed, 52 insertions(+), 13 deletions(-)
+
+diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
+index 5d3005349..3e8f4b111 100644
+--- a/asmcomp/amd64/arch.ml
++++ b/asmcomp/amd64/arch.ml
+@@ -14,7 +14,13 @@
+ 
+ (* Machine-specific command-line options *)
+ 
+-let command_line_options = []
++let pic_code = ref true
++
++let command_line_options =
++  [ "-fPIC", Arg.Set pic_code,
++      " Generate position-independent machine code (default)";
++    "-fno-PIC", Arg.Clear pic_code,
++      " Generate position-dependent machine code" ]
+ 
+ (* Specific operations for the AMD64 processor *)
+ 
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index a3ceedadc..e3049aa8d 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -12,7 +12,7 @@
+ 
+ (* $Id$ *)
+ 
+-(* Emission of Intel 386 assembly code *)
++(* Emission of x86-64 (AMD 64) assembly code *)
+ 
+ open Misc
+ open Cmm
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -312,7 +318,10 @@ let emit_instr fallthrough i =
+           `	movlpd	{emit_label lbl}(%rip), {emit_reg i.res.(0)}\n`
+         end
+     | Lop(Iconst_symbol s) ->
+-        `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
++        if !pic_code then
++          `	leaq	{emit_symbol s}(%rip), {emit_reg i.res.(0)}\n`
++        else
++          `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
+     | Lop(Icall_ind) ->
+         `	call	*{emit_reg i.arg.(0)}\n`;
+         record_frame i.live
+@@ -331,7 +340,7 @@ let emit_instr fallthrough i =
+         end
+     | Lop(Iextcall(s, alloc)) ->
+         if alloc then begin
+-          `	movq	${emit_symbol s}, %rax\n`;
++          `	leaq	{emit_symbol s}(%rip), %rax\n`;
+           `	call	{emit_symbol "caml_c_call"}\n`;
+           record_frame i.live
+         end else begin
+@@ -471,6 +480,7 @@ let emit_instr fallthrough i =
+     | Lop(Ispecific(Istore_int(n, addr))) ->
+         `	movq	${emit_nativeint n}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Istore_symbol(s, addr))) ->
++        assert (not !pic_code);
+         `	movq	${emit_symbol s}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Ioffset_loc(n, addr))) ->
+         `	addq	${emit_int n}, {emit_addressing addr i.arg 0}\n`
+@@ -531,12 +541,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 856e4655a..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -169,6 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+diff --git a/asmcomp/amd64/reload.ml b/asmcomp/amd64/reload.ml
+index f18604442..44c1d97fb 100644
+--- a/asmcomp/amd64/reload.ml
++++ b/asmcomp/amd64/reload.ml
+@@ -26,7 +26,8 @@ open Mach
+                              or S       R
+      Iconst_int                 S
+      Iconst_float               R
+-     Iconst_symbol              S
++     Iconst_symbol (not PIC)    S
++     Iconst_symbol (PIC)        R
+      Icall_ind                          R
+      Itailcall_ind                      R
+      Iload                      R       R       R
+@@ -72,7 +73,11 @@ method reload_operation op arg res =
+       (* This add will be turned into a lea; args and results must be
+          in registers *)
+       super#reload_operation op arg res
+-  | Iconst_int _ | Iconst_symbol _
++  | Iconst_symbol _ ->
++      if !pic_code
++      then super#reload_operation op arg res
++      else (arg, res)
++  | Iconst_int _
+   | Iintop(Idiv | Imod | Ilsl | Ilsr | Iasr)
+   | Iintop_imm(_, _) ->
+       (* The argument(s) and results can be either in register or on stack *)
+diff --git a/asmcomp/amd64/selection.ml b/asmcomp/amd64/selection.ml
+index acd79f141..b38a1b8cd 100644
+--- a/asmcomp/amd64/selection.ml
++++ b/asmcomp/amd64/selection.ml
+@@ -144,7 +144,7 @@ method select_store addr exp =
+       (Ispecific(Istore_int(Nativeint.of_int n, addr)), Ctuple [])
+   | Cconst_natpointer n when self#is_immediate_natint n ->
+       (Ispecific(Istore_int(n, addr)), Ctuple [])
+-  | Cconst_symbol s ->
++  | Cconst_symbol s when not !pic_code ->
+       (Ispecific(Istore_symbol(s, addr)), Ctuple [])
+   | _ ->
+       super#select_store addr exp
+diff --git a/asmrun/amd64.S b/asmrun/amd64.S
+index b1f204f44..5fd5440cf 100644
+--- a/asmrun/amd64.S
++++ b/asmrun/amd64.S
+@@ -52,7 +52,7 @@ FUNCTION(caml_call_gc)
+         pushq   %rdi
+         pushq   %rbx
+         pushq   %rax
+-        movq    %rsp, caml_gc_regs
++        movq    %rsp, caml_gc_regs(%rip)
+     /* Save floating-point registers */
+         subq    $(16*8), %rsp
+         movlpd  %xmm0, 0*8(%rsp)
+diff --git a/configure b/configure
+index a387a6780..1c219e0d0 100755
+--- a/configure
++++ b/configure
+@@ -296,7 +296,10 @@ case "$bytecc,$host" in
+   gcc*,x86_64-*-linux*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings"
+     # Tell gcc that we can use 32-bit code addresses for threaded code
+-    echo "#define ARCH_CODE32" >> m.h;;
++    # unless we are compiled for a shared library (-fPIC option)
++    echo "#ifndef __PIC__" >> m.h
++    echo "#  define ARCH_CODE32" >> m.h
++    echo "#endif" >> m.h;;
+   gcc*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings";;
+ esac
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["PIC.patch"]
 extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.08.2 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.08"
 depends: [
   "ocaml" {= "3.08.2" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
@@ -35,4 +35,6 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.2.tar.gz"
   checksum: "md5=b79358a09884f5e679433cce284de43e"
 }
+patches: ["PIC.patch"]
+extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["PIC.patch"]
 extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/files/PIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/files/PIC.patch
@@ -1,0 +1,210 @@
+From 3d664fd9695159460337bf0764808aefc8fb5cdf Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Sat, 17 Dec 2005 17:05:26 +0000
+Subject: [PATCH] Back-port PIC related changes from 3.09-3.11
+
+ - x86_64: do not define ARCH_CODE32 if compiling for a shared library (PR#3869)
+ - Ajout production de code relogeable (option -fPIC)
+ - Produce position-independent code by default.  This makes it easier to embed Caml code in a shared library.
+ - Lswitch did not generate relocatable code with -fPIC option (PR#3924)
+ - Non-PC-relative reference (PR#3924)
+ - PR#4867, PR#4760: make Lswitch generate PIC code acceptable for MacOS X
+---
+ asmcomp/amd64/arch.ml      |  8 +++++++-
+ asmcomp/amd64/emit.mlp     | 38 +++++++++++++++++++++++++++++++-------
+ asmcomp/amd64/proc.ml      |  1 +
+ asmcomp/amd64/reload.ml    |  9 +++++++--
+ asmcomp/amd64/selection.ml |  2 +-
+ asmrun/amd64.S             |  2 +-
+ configure                  |  5 ++++-
+ 7 files changed, 52 insertions(+), 13 deletions(-)
+
+diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
+index 5d3005349..3e8f4b111 100644
+--- a/asmcomp/amd64/arch.ml
++++ b/asmcomp/amd64/arch.ml
+@@ -14,7 +14,13 @@
+ 
+ (* Machine-specific command-line options *)
+ 
+-let command_line_options = []
++let pic_code = ref true
++
++let command_line_options =
++  [ "-fPIC", Arg.Set pic_code,
++      " Generate position-independent machine code (default)";
++    "-fno-PIC", Arg.Clear pic_code,
++      " Generate position-dependent machine code" ]
+ 
+ (* Specific operations for the AMD64 processor *)
+ 
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index a3ceedadc..e3049aa8d 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -12,7 +12,7 @@
+ 
+ (* $Id$ *)
+ 
+-(* Emission of Intel 386 assembly code *)
++(* Emission of x86-64 (AMD 64) assembly code *)
+ 
+ open Misc
+ open Cmm
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -312,7 +318,10 @@ let emit_instr fallthrough i =
+           `	movlpd	{emit_label lbl}(%rip), {emit_reg i.res.(0)}\n`
+         end
+     | Lop(Iconst_symbol s) ->
+-        `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
++        if !pic_code then
++          `	leaq	{emit_symbol s}(%rip), {emit_reg i.res.(0)}\n`
++        else
++          `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
+     | Lop(Icall_ind) ->
+         `	call	*{emit_reg i.arg.(0)}\n`;
+         record_frame i.live
+@@ -331,7 +340,7 @@ let emit_instr fallthrough i =
+         end
+     | Lop(Iextcall(s, alloc)) ->
+         if alloc then begin
+-          `	movq	${emit_symbol s}, %rax\n`;
++          `	leaq	{emit_symbol s}(%rip), %rax\n`;
+           `	call	{emit_symbol "caml_c_call"}\n`;
+           record_frame i.live
+         end else begin
+@@ -471,6 +480,7 @@ let emit_instr fallthrough i =
+     | Lop(Ispecific(Istore_int(n, addr))) ->
+         `	movq	${emit_nativeint n}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Istore_symbol(s, addr))) ->
++        assert (not !pic_code);
+         `	movq	${emit_symbol s}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Ioffset_loc(n, addr))) ->
+         `	addq	${emit_int n}, {emit_addressing addr i.arg 0}\n`
+@@ -531,12 +541,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 856e4655a..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -169,6 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+diff --git a/asmcomp/amd64/reload.ml b/asmcomp/amd64/reload.ml
+index f18604442..44c1d97fb 100644
+--- a/asmcomp/amd64/reload.ml
++++ b/asmcomp/amd64/reload.ml
+@@ -26,7 +26,8 @@ open Mach
+                              or S       R
+      Iconst_int                 S
+      Iconst_float               R
+-     Iconst_symbol              S
++     Iconst_symbol (not PIC)    S
++     Iconst_symbol (PIC)        R
+      Icall_ind                          R
+      Itailcall_ind                      R
+      Iload                      R       R       R
+@@ -72,7 +73,11 @@ method reload_operation op arg res =
+       (* This add will be turned into a lea; args and results must be
+          in registers *)
+       super#reload_operation op arg res
+-  | Iconst_int _ | Iconst_symbol _
++  | Iconst_symbol _ ->
++      if !pic_code
++      then super#reload_operation op arg res
++      else (arg, res)
++  | Iconst_int _
+   | Iintop(Idiv | Imod | Ilsl | Ilsr | Iasr)
+   | Iintop_imm(_, _) ->
+       (* The argument(s) and results can be either in register or on stack *)
+diff --git a/asmcomp/amd64/selection.ml b/asmcomp/amd64/selection.ml
+index acd79f141..b38a1b8cd 100644
+--- a/asmcomp/amd64/selection.ml
++++ b/asmcomp/amd64/selection.ml
+@@ -144,7 +144,7 @@ method select_store addr exp =
+       (Ispecific(Istore_int(Nativeint.of_int n, addr)), Ctuple [])
+   | Cconst_natpointer n when self#is_immediate_natint n ->
+       (Ispecific(Istore_int(n, addr)), Ctuple [])
+-  | Cconst_symbol s ->
++  | Cconst_symbol s when not !pic_code ->
+       (Ispecific(Istore_symbol(s, addr)), Ctuple [])
+   | _ ->
+       super#select_store addr exp
+diff --git a/asmrun/amd64.S b/asmrun/amd64.S
+index b1f204f44..5fd5440cf 100644
+--- a/asmrun/amd64.S
++++ b/asmrun/amd64.S
+@@ -52,7 +52,7 @@ FUNCTION(caml_call_gc)
+         pushq   %rdi
+         pushq   %rbx
+         pushq   %rax
+-        movq    %rsp, caml_gc_regs
++        movq    %rsp, caml_gc_regs(%rip)
+     /* Save floating-point registers */
+         subq    $(16*8), %rsp
+         movlpd  %xmm0, 0*8(%rsp)
+diff --git a/configure b/configure
+index a387a6780..1c219e0d0 100755
+--- a/configure
++++ b/configure
+@@ -296,7 +296,10 @@ case "$bytecc,$host" in
+   gcc*,x86_64-*-linux*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings"
+     # Tell gcc that we can use 32-bit code addresses for threaded code
+-    echo "#define ARCH_CODE32" >> m.h;;
++    # unless we are compiled for a shared library (-fPIC option)
++    echo "#ifndef __PIC__" >> m.h
++    echo "#  define ARCH_CODE32" >> m.h
++    echo "#endif" >> m.h;;
+   gcc*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings";;
+ esac
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["PIC.patch"]
 extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.08.3 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.08"
 depends: [
   "ocaml" {= "3.08.3" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
@@ -35,4 +35,6 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.3.tar.gz"
   checksum: "md5=b1fc455aca6980e02e8cce8a3cbb4c81"
 }
+patches: ["PIC.patch"]
+extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["PIC.patch"]
 extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/files/PIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/files/PIC.patch
@@ -1,0 +1,210 @@
+From 3d664fd9695159460337bf0764808aefc8fb5cdf Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Sat, 17 Dec 2005 17:05:26 +0000
+Subject: [PATCH] Back-port PIC related changes from 3.09-3.11
+
+ - x86_64: do not define ARCH_CODE32 if compiling for a shared library (PR#3869)
+ - Ajout production de code relogeable (option -fPIC)
+ - Produce position-independent code by default.  This makes it easier to embed Caml code in a shared library.
+ - Lswitch did not generate relocatable code with -fPIC option (PR#3924)
+ - Non-PC-relative reference (PR#3924)
+ - PR#4867, PR#4760: make Lswitch generate PIC code acceptable for MacOS X
+---
+ asmcomp/amd64/arch.ml      |  8 +++++++-
+ asmcomp/amd64/emit.mlp     | 38 +++++++++++++++++++++++++++++++-------
+ asmcomp/amd64/proc.ml      |  1 +
+ asmcomp/amd64/reload.ml    |  9 +++++++--
+ asmcomp/amd64/selection.ml |  2 +-
+ asmrun/amd64.S             |  2 +-
+ configure                  |  5 ++++-
+ 7 files changed, 52 insertions(+), 13 deletions(-)
+
+diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
+index 5d3005349..3e8f4b111 100644
+--- a/asmcomp/amd64/arch.ml
++++ b/asmcomp/amd64/arch.ml
+@@ -14,7 +14,13 @@
+ 
+ (* Machine-specific command-line options *)
+ 
+-let command_line_options = []
++let pic_code = ref true
++
++let command_line_options =
++  [ "-fPIC", Arg.Set pic_code,
++      " Generate position-independent machine code (default)";
++    "-fno-PIC", Arg.Clear pic_code,
++      " Generate position-dependent machine code" ]
+ 
+ (* Specific operations for the AMD64 processor *)
+ 
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index a3ceedadc..e3049aa8d 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -12,7 +12,7 @@
+ 
+ (* $Id$ *)
+ 
+-(* Emission of Intel 386 assembly code *)
++(* Emission of x86-64 (AMD 64) assembly code *)
+ 
+ open Misc
+ open Cmm
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -312,7 +318,10 @@ let emit_instr fallthrough i =
+           `	movlpd	{emit_label lbl}(%rip), {emit_reg i.res.(0)}\n`
+         end
+     | Lop(Iconst_symbol s) ->
+-        `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
++        if !pic_code then
++          `	leaq	{emit_symbol s}(%rip), {emit_reg i.res.(0)}\n`
++        else
++          `	movq	${emit_symbol s}, {emit_reg i.res.(0)}\n`
+     | Lop(Icall_ind) ->
+         `	call	*{emit_reg i.arg.(0)}\n`;
+         record_frame i.live
+@@ -331,7 +340,7 @@ let emit_instr fallthrough i =
+         end
+     | Lop(Iextcall(s, alloc)) ->
+         if alloc then begin
+-          `	movq	${emit_symbol s}, %rax\n`;
++          `	leaq	{emit_symbol s}(%rip), %rax\n`;
+           `	call	{emit_symbol "caml_c_call"}\n`;
+           record_frame i.live
+         end else begin
+@@ -471,6 +480,7 @@ let emit_instr fallthrough i =
+     | Lop(Ispecific(Istore_int(n, addr))) ->
+         `	movq	${emit_nativeint n}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Istore_symbol(s, addr))) ->
++        assert (not !pic_code);
+         `	movq	${emit_symbol s}, {emit_addressing addr i.arg 0}\n`
+     | Lop(Ispecific(Ioffset_loc(n, addr))) ->
+         `	addq	${emit_int n}, {emit_addressing addr i.arg 0}\n`
+@@ -531,12 +541,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 856e4655a..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -169,6 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+diff --git a/asmcomp/amd64/reload.ml b/asmcomp/amd64/reload.ml
+index f18604442..44c1d97fb 100644
+--- a/asmcomp/amd64/reload.ml
++++ b/asmcomp/amd64/reload.ml
+@@ -26,7 +26,8 @@ open Mach
+                              or S       R
+      Iconst_int                 S
+      Iconst_float               R
+-     Iconst_symbol              S
++     Iconst_symbol (not PIC)    S
++     Iconst_symbol (PIC)        R
+      Icall_ind                          R
+      Itailcall_ind                      R
+      Iload                      R       R       R
+@@ -72,7 +73,11 @@ method reload_operation op arg res =
+       (* This add will be turned into a lea; args and results must be
+          in registers *)
+       super#reload_operation op arg res
+-  | Iconst_int _ | Iconst_symbol _
++  | Iconst_symbol _ ->
++      if !pic_code
++      then super#reload_operation op arg res
++      else (arg, res)
++  | Iconst_int _
+   | Iintop(Idiv | Imod | Ilsl | Ilsr | Iasr)
+   | Iintop_imm(_, _) ->
+       (* The argument(s) and results can be either in register or on stack *)
+diff --git a/asmcomp/amd64/selection.ml b/asmcomp/amd64/selection.ml
+index acd79f141..b38a1b8cd 100644
+--- a/asmcomp/amd64/selection.ml
++++ b/asmcomp/amd64/selection.ml
+@@ -144,7 +144,7 @@ method select_store addr exp =
+       (Ispecific(Istore_int(Nativeint.of_int n, addr)), Ctuple [])
+   | Cconst_natpointer n when self#is_immediate_natint n ->
+       (Ispecific(Istore_int(n, addr)), Ctuple [])
+-  | Cconst_symbol s ->
++  | Cconst_symbol s when not !pic_code ->
+       (Ispecific(Istore_symbol(s, addr)), Ctuple [])
+   | _ ->
+       super#select_store addr exp
+diff --git a/asmrun/amd64.S b/asmrun/amd64.S
+index b1f204f44..5fd5440cf 100644
+--- a/asmrun/amd64.S
++++ b/asmrun/amd64.S
+@@ -52,7 +52,7 @@ FUNCTION(caml_call_gc)
+         pushq   %rdi
+         pushq   %rbx
+         pushq   %rax
+-        movq    %rsp, caml_gc_regs
++        movq    %rsp, caml_gc_regs(%rip)
+     /* Save floating-point registers */
+         subq    $(16*8), %rsp
+         movlpd  %xmm0, 0*8(%rsp)
+diff --git a/configure b/configure
+index a387a6780..1c219e0d0 100755
+--- a/configure
++++ b/configure
+@@ -296,7 +296,10 @@ case "$bytecc,$host" in
+   gcc*,x86_64-*-linux*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings"
+     # Tell gcc that we can use 32-bit code addresses for threaded code
+-    echo "#define ARCH_CODE32" >> m.h;;
++    # unless we are compiled for a shared library (-fPIC option)
++    echo "#ifndef __PIC__" >> m.h
++    echo "#  define ARCH_CODE32" >> m.h
++    echo "#endif" >> m.h;;
+   gcc*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings";;
+ esac
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["PIC.patch"]
 extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.08.4 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.08"
 depends: [
   "ocaml" {= "3.08.4" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
@@ -35,4 +35,6 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.08/ocaml-3.08.4.tar.gz"
   checksum: "md5=105d192896bf945b660c4fb1ee486f57"
 }
+patches: ["PIC.patch"]
+extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["PIC.patch"]
 extra-files: ["PIC.patch" "md5=53aa5accaa1308e7b9eb434f47068a24"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/files/PIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/files/PIC.patch
@@ -1,0 +1,44 @@
+From 74e79341aaaacea4399c76b8ad9798e2187c7ec9 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Sat, 17 Dec 2005 17:05:26 +0000
+Subject: [PATCH] Back-port PIC related changes from 3.09.1
+
+ - x86_64: do not define ARCH_CODE32 if compiling for a shared library (PR#3869)
+ - Non-PC-relative reference (PR#3924)
+---
+ asmrun/amd64.S | 2 +-
+ configure      | 5 ++++-
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/asmrun/amd64.S b/asmrun/amd64.S
+index b1f204f44..5fd5440cf 100644
+--- a/asmrun/amd64.S
++++ b/asmrun/amd64.S
+@@ -52,7 +52,7 @@ FUNCTION(caml_call_gc)
+         pushq   %rdi
+         pushq   %rbx
+         pushq   %rax
+-        movq    %rsp, caml_gc_regs
++        movq    %rsp, caml_gc_regs(%rip)
+     /* Save floating-point registers */
+         subq    $(16*8), %rsp
+         movlpd  %xmm0, 0*8(%rsp)
+diff --git a/configure b/configure
+index b68154a01..ccafdf57f 100755
+--- a/configure
++++ b/configure
+@@ -293,7 +293,10 @@ case "$bytecc,$host" in
+   gcc*,x86_64-*-linux*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings"
+     # Tell gcc that we can use 32-bit code addresses for threaded code
+-    echo "#define ARCH_CODE32" >> m.h;;
++    # unless we are compiled for a shared library (-fPIC option)
++    echo "#ifndef __PIC__" >> m.h
++    echo "#  define ARCH_CODE32" >> m.h
++    echo "#endif" >> m.h;;
+   gcc*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings";;
+ esac
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/files/ocamlopt-fPIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/files/ocamlopt-fPIC.patch
@@ -1,0 +1,34 @@
+From a61bcb0f6c4863e3f6cb184d1a620413cf71ac05 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Mon, 1 Jan 2007 13:07:35 +0000
+Subject: [PATCH 2/3] Produce position-independent code by default.  This makes
+ it easier to embed Caml code in a shared library.
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/trunk@7784 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/arch.ml | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
+index d9b174bc0..3e8f4b111 100644
+--- a/asmcomp/amd64/arch.ml
++++ b/asmcomp/amd64/arch.ml
+@@ -14,11 +14,13 @@
+ 
+ (* Machine-specific command-line options *)
+ 
+-let pic_code = ref false
++let pic_code = ref true
+ 
+ let command_line_options =
+   [ "-fPIC", Arg.Set pic_code,
+-      " Generate position-independent machine code" ]
++      " Generate position-independent machine code (default)";
++    "-fno-PIC", Arg.Clear pic_code,
++      " Generate position-dependent machine code" ]
+ 
+ (* Specific operations for the AMD64 processor *)
+ 
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/files/pr4439.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/files/pr4439.patch
@@ -1,0 +1,25 @@
+From b50c588e661c6679e4ffd4c42ac2155d826d7bb4 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Sat, 27 Feb 2021 15:54:19 +0000
+Subject: [PATCH 1/3] Back-port part of PR#4439/PR#4433
+
+---
+ asmrun/signals.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/asmrun/signals.c b/asmrun/signals.c
+index 000360d25..061a381e5 100644
+--- a/asmrun/signals.c
++++ b/asmrun/signals.c
+@@ -466,7 +466,7 @@ void caml_init_signals(void)
+   /* Stack overflow handling */
+ #ifdef HAS_STACK_OVERFLOW_DETECTION
+   {
+-    struct sigaltstack stk;
++    stack_t stk;
+     struct sigaction act;
+     stk.ss_sp = sig_alt_stack;
+     stk.ss_size = SIGSTKSZ;
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/files/pr4867.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/files/pr4867.patch
@@ -1,0 +1,75 @@
+From 02ac5a0e93a72c61397ab7c74817083da871ea82 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Fri, 18 Sep 2009 13:49:21 +0000
+Subject: [PATCH] PR#4867, PR#4760: make Lswitch generate PIC code acceptable
+ for MacOS X
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/version/3.11@9342 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/emit.mlp | 28 ++++++++++++++++++++++++----
+ asmcomp/amd64/proc.ml  |  1 +
+ 2 files changed, 25 insertions(+), 4 deletions(-)
+
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index a5ef1dcdd..b6f3dc4af 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -534,12 +540,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 856e4655a..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -169,6 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
@@ -35,4 +35,16 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.0.tar.gz"
   checksum: "md5=5445b3fba28291fe789797d10cef3431"
 }
+patches: [
+  "pr4439.patch"
+  "ocamlopt-fPIC.patch"
+  "pr4867.patch"
+  "PIC.patch"
+]
+extra-files: [
+  ["pr4439.patch" "md5=da2ef48cb1b5f33f4328dbaf522d8af1"]
+  ["ocamlopt-fPIC.patch" "md5=faa0d816425f8fcbf8a8c3458bc6ed3f"]
+  ["pr4867.patch" "md5=c54f0a0098c136e8a9100d38b12767b3"]
+  ["PIC.patch" "md5=d7d634a6e9943582b16414124f054f0f"]
+]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.09.0 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.09"
 depends: [
   "ocaml" {= "3.09.0" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
@@ -51,4 +51,4 @@ extra-files: [
   ["pr4867.patch" "md5=c54f0a0098c136e8a9100d38b12767b3"]
   ["PIC.patch" "md5=d7d634a6e9943582b16414124f054f0f"]
 ]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
@@ -51,4 +51,4 @@ extra-files: [
   ["pr4867.patch" "md5=c54f0a0098c136e8a9100d38b12767b3"]
   ["PIC.patch" "md5=d7d634a6e9943582b16414124f054f0f"]
 ]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/files/ocamlopt-fPIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/files/ocamlopt-fPIC.patch
@@ -1,0 +1,34 @@
+From a61bcb0f6c4863e3f6cb184d1a620413cf71ac05 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Mon, 1 Jan 2007 13:07:35 +0000
+Subject: [PATCH 2/3] Produce position-independent code by default.  This makes
+ it easier to embed Caml code in a shared library.
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/trunk@7784 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/arch.ml | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
+index d9b174bc0..3e8f4b111 100644
+--- a/asmcomp/amd64/arch.ml
++++ b/asmcomp/amd64/arch.ml
+@@ -14,11 +14,13 @@
+ 
+ (* Machine-specific command-line options *)
+ 
+-let pic_code = ref false
++let pic_code = ref true
+ 
+ let command_line_options =
+   [ "-fPIC", Arg.Set pic_code,
+-      " Generate position-independent machine code" ]
++      " Generate position-independent machine code (default)";
++    "-fno-PIC", Arg.Clear pic_code,
++      " Generate position-dependent machine code" ]
+ 
+ (* Specific operations for the AMD64 processor *)
+ 
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/files/pr4439.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/files/pr4439.patch
@@ -1,0 +1,25 @@
+From b50c588e661c6679e4ffd4c42ac2155d826d7bb4 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Sat, 27 Feb 2021 15:54:19 +0000
+Subject: [PATCH 1/3] Back-port part of PR#4439/PR#4433
+
+---
+ asmrun/signals.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/asmrun/signals.c b/asmrun/signals.c
+index 000360d25..061a381e5 100644
+--- a/asmrun/signals.c
++++ b/asmrun/signals.c
+@@ -466,7 +466,7 @@ void caml_init_signals(void)
+   /* Stack overflow handling */
+ #ifdef HAS_STACK_OVERFLOW_DETECTION
+   {
+-    struct sigaltstack stk;
++    stack_t stk;
+     struct sigaction act;
+     stk.ss_sp = sig_alt_stack;
+     stk.ss_size = SIGSTKSZ;
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/files/pr4867.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/files/pr4867.patch
@@ -1,0 +1,89 @@
+From 484d170309a82f2dd1d7430b0cb7611964620588 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Fri, 18 Sep 2009 13:49:21 +0000
+Subject: [PATCH 3/3] PR#4867, PR#4760: make Lswitch generate PIC code
+ acceptable for MacOS X
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/version/3.11@9342 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/emit.mlp | 33 ++++++++++++++++++++++++---------
+ asmcomp/amd64/proc.ml  |  3 +--
+ 2 files changed, 25 insertions(+), 11 deletions(-)
+
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index b57b308a1..7dd081f18 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -534,17 +540,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        if !pic_code then begin
+-          `	leaq	{emit_label lbl}(%rip), %r11\n`;
+-          `	jmp	*(%r11, {emit_reg i.arg.(0)}, 8)\n`
+-        end else begin
+-          `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`
+-        end;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 0e274b4f4..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -92,7 +92,6 @@ let phys_reg n =
+ let rax = phys_reg 0
+ let rcx = phys_reg 5
+ let rdx = phys_reg 4
+-let r11 = phys_reg 9
+ let rxmm15 = phys_reg 115
+ 
+ let stack_slot slot ty =
+@@ -170,7 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
+-  | Iswitch(_, _) when !pic_code -> [| r11 |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.09.1 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.09"
 depends: [
   "ocaml" {= "3.09.1" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
@@ -49,4 +49,4 @@ extra-files: [
   ["ocamlopt-fPIC.patch" "md5=faa0d816425f8fcbf8a8c3458bc6ed3f"]
   ["pr4867.patch" "md5=ca6675db25c2cde402301cf7b0bec8d6"]
 ]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
@@ -35,4 +35,14 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.1.tar.gz"
   checksum: "md5=c73f4b093e27ba5bf13d62923f89befc"
 }
+patches: [
+  "pr4439.patch"
+  "ocamlopt-fPIC.patch"
+  "pr4867.patch"
+]
+extra-files: [
+  ["pr4439.patch" "md5=da2ef48cb1b5f33f4328dbaf522d8af1"]
+  ["ocamlopt-fPIC.patch" "md5=faa0d816425f8fcbf8a8c3458bc6ed3f"]
+  ["pr4867.patch" "md5=ca6675db25c2cde402301cf7b0bec8d6"]
+]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
@@ -49,4 +49,4 @@ extra-files: [
   ["ocamlopt-fPIC.patch" "md5=faa0d816425f8fcbf8a8c3458bc6ed3f"]
   ["pr4867.patch" "md5=ca6675db25c2cde402301cf7b0bec8d6"]
 ]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/files/ocamlopt-fPIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/files/ocamlopt-fPIC.patch
@@ -1,0 +1,34 @@
+From a61bcb0f6c4863e3f6cb184d1a620413cf71ac05 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Mon, 1 Jan 2007 13:07:35 +0000
+Subject: [PATCH 2/3] Produce position-independent code by default.  This makes
+ it easier to embed Caml code in a shared library.
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/trunk@7784 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/arch.ml | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
+index d9b174bc0..3e8f4b111 100644
+--- a/asmcomp/amd64/arch.ml
++++ b/asmcomp/amd64/arch.ml
+@@ -14,11 +14,13 @@
+ 
+ (* Machine-specific command-line options *)
+ 
+-let pic_code = ref false
++let pic_code = ref true
+ 
+ let command_line_options =
+   [ "-fPIC", Arg.Set pic_code,
+-      " Generate position-independent machine code" ]
++      " Generate position-independent machine code (default)";
++    "-fno-PIC", Arg.Clear pic_code,
++      " Generate position-dependent machine code" ]
+ 
+ (* Specific operations for the AMD64 processor *)
+ 
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/files/pr4439.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/files/pr4439.patch
@@ -1,0 +1,25 @@
+From b50c588e661c6679e4ffd4c42ac2155d826d7bb4 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Sat, 27 Feb 2021 15:54:19 +0000
+Subject: [PATCH 1/3] Back-port part of PR#4439/PR#4433
+
+---
+ asmrun/signals.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/asmrun/signals.c b/asmrun/signals.c
+index 000360d25..061a381e5 100644
+--- a/asmrun/signals.c
++++ b/asmrun/signals.c
+@@ -466,7 +466,7 @@ void caml_init_signals(void)
+   /* Stack overflow handling */
+ #ifdef HAS_STACK_OVERFLOW_DETECTION
+   {
+-    struct sigaltstack stk;
++    stack_t stk;
+     struct sigaction act;
+     stk.ss_sp = sig_alt_stack;
+     stk.ss_size = SIGSTKSZ;
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/files/pr4867.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/files/pr4867.patch
@@ -1,0 +1,89 @@
+From 484d170309a82f2dd1d7430b0cb7611964620588 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Fri, 18 Sep 2009 13:49:21 +0000
+Subject: [PATCH 3/3] PR#4867, PR#4760: make Lswitch generate PIC code
+ acceptable for MacOS X
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/version/3.11@9342 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/emit.mlp | 33 ++++++++++++++++++++++++---------
+ asmcomp/amd64/proc.ml  |  3 +--
+ 2 files changed, 25 insertions(+), 11 deletions(-)
+
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index b57b308a1..7dd081f18 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -534,17 +540,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        if !pic_code then begin
+-          `	leaq	{emit_label lbl}(%rip), %r11\n`;
+-          `	jmp	*(%r11, {emit_reg i.arg.(0)}, 8)\n`
+-        end else begin
+-          `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`
+-        end;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 0e274b4f4..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -92,7 +92,6 @@ let phys_reg n =
+ let rax = phys_reg 0
+ let rcx = phys_reg 5
+ let rdx = phys_reg 4
+-let r11 = phys_reg 9
+ let rxmm15 = phys_reg 115
+ 
+ let stack_slot slot ty =
+@@ -170,7 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
+-  | Iswitch(_, _) when !pic_code -> [| r11 |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
@@ -49,4 +49,4 @@ extra-files: [
   ["ocamlopt-fPIC.patch" "md5=faa0d816425f8fcbf8a8c3458bc6ed3f"]
   ["pr4867.patch" "md5=ca6675db25c2cde402301cf7b0bec8d6"]
 ]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
@@ -35,4 +35,14 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.2.tar.gz"
   checksum: "md5=dc4a298cfa8c65fe4e506a06fe514ccd"
 }
+patches: [
+  "pr4439.patch"
+  "ocamlopt-fPIC.patch"
+  "pr4867.patch"
+]
+extra-files: [
+  ["pr4439.patch" "md5=da2ef48cb1b5f33f4328dbaf522d8af1"]
+  ["ocamlopt-fPIC.patch" "md5=faa0d816425f8fcbf8a8c3458bc6ed3f"]
+  ["pr4867.patch" "md5=ca6675db25c2cde402301cf7b0bec8d6"]
+]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
@@ -49,4 +49,4 @@ extra-files: [
   ["ocamlopt-fPIC.patch" "md5=faa0d816425f8fcbf8a8c3458bc6ed3f"]
   ["pr4867.patch" "md5=ca6675db25c2cde402301cf7b0bec8d6"]
 ]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.09.2 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.09"
 depends: [
   "ocaml" {= "3.09.2" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/files/ocamlopt-fPIC.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/files/ocamlopt-fPIC.patch
@@ -1,0 +1,34 @@
+From a61bcb0f6c4863e3f6cb184d1a620413cf71ac05 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Mon, 1 Jan 2007 13:07:35 +0000
+Subject: [PATCH 2/3] Produce position-independent code by default.  This makes
+ it easier to embed Caml code in a shared library.
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/trunk@7784 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/arch.ml | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
+index d9b174bc0..3e8f4b111 100644
+--- a/asmcomp/amd64/arch.ml
++++ b/asmcomp/amd64/arch.ml
+@@ -14,11 +14,13 @@
+ 
+ (* Machine-specific command-line options *)
+ 
+-let pic_code = ref false
++let pic_code = ref true
+ 
+ let command_line_options =
+   [ "-fPIC", Arg.Set pic_code,
+-      " Generate position-independent machine code" ]
++      " Generate position-independent machine code (default)";
++    "-fno-PIC", Arg.Clear pic_code,
++      " Generate position-dependent machine code" ]
+ 
+ (* Specific operations for the AMD64 processor *)
+ 
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/files/pr4439.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/files/pr4439.patch
@@ -1,0 +1,25 @@
+From b50c588e661c6679e4ffd4c42ac2155d826d7bb4 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Sat, 27 Feb 2021 15:54:19 +0000
+Subject: [PATCH 1/3] Back-port part of PR#4439/PR#4433
+
+---
+ asmrun/signals.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/asmrun/signals.c b/asmrun/signals.c
+index 000360d25..061a381e5 100644
+--- a/asmrun/signals.c
++++ b/asmrun/signals.c
+@@ -466,7 +466,7 @@ void caml_init_signals(void)
+   /* Stack overflow handling */
+ #ifdef HAS_STACK_OVERFLOW_DETECTION
+   {
+-    struct sigaltstack stk;
++    stack_t stk;
+     struct sigaction act;
+     stk.ss_sp = sig_alt_stack;
+     stk.ss_size = SIGSTKSZ;
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/files/pr4867.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/files/pr4867.patch
@@ -1,0 +1,89 @@
+From 484d170309a82f2dd1d7430b0cb7611964620588 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Fri, 18 Sep 2009 13:49:21 +0000
+Subject: [PATCH 3/3] PR#4867, PR#4760: make Lswitch generate PIC code
+ acceptable for MacOS X
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/version/3.11@9342 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/emit.mlp | 33 ++++++++++++++++++++++++---------
+ asmcomp/amd64/proc.ml  |  3 +--
+ 2 files changed, 25 insertions(+), 11 deletions(-)
+
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index b57b308a1..7dd081f18 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -534,17 +540,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        if !pic_code then begin
+-          `	leaq	{emit_label lbl}(%rip), %r11\n`;
+-          `	jmp	*(%r11, {emit_reg i.arg.(0)}, 8)\n`
+-        end else begin
+-          `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`
+-        end;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 0e274b4f4..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -92,7 +92,6 @@ let phys_reg n =
+ let rax = phys_reg 0
+ let rcx = phys_reg 5
+ let rdx = phys_reg 4
+-let r11 = phys_reg 9
+ let rxmm15 = phys_reg 115
+ 
+ let stack_slot slot ty =
+@@ -170,7 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
+-  | Iswitch(_, _) when !pic_code -> [| r11 |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
@@ -49,4 +49,4 @@ extra-files: [
   ["ocamlopt-fPIC.patch" "md5=faa0d816425f8fcbf8a8c3458bc6ed3f"]
   ["pr4867.patch" "md5=ca6675db25c2cde402301cf7b0bec8d6"]
 ]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
@@ -49,4 +49,4 @@ extra-files: [
   ["ocamlopt-fPIC.patch" "md5=faa0d816425f8fcbf8a8c3458bc6ed3f"]
   ["pr4867.patch" "md5=ca6675db25c2cde402301cf7b0bec8d6"]
 ]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.09.3 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.09"
 depends: [
   "ocaml" {= "3.09.3" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
@@ -35,4 +35,14 @@ url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.09/ocaml-3.09.3.tar.gz"
   checksum: "md5=11a91651007f70a2cb4d5ecfe20fab89"
 }
+patches: [
+  "pr4439.patch"
+  "ocamlopt-fPIC.patch"
+  "pr4867.patch"
+]
+extra-files: [
+  ["pr4439.patch" "md5=da2ef48cb1b5f33f4328dbaf522d8af1"]
+  ["ocamlopt-fPIC.patch" "md5=faa0d816425f8fcbf8a8c3458bc6ed3f"]
+  ["pr4867.patch" "md5=ca6675db25c2cde402301cf7b0bec8d6"]
+]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/files/pr4867.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/files/pr4867.patch
@@ -1,0 +1,89 @@
+From f8f3b251bbf20f163be7752f7dab0b36da7286a2 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Fri, 18 Sep 2009 13:49:21 +0000
+Subject: [PATCH] PR#4867, PR#4760: make Lswitch generate PIC code acceptable
+ for MacOS X
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/version/3.11@9342 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/emit.mlp | 33 ++++++++++++++++++++++++---------
+ asmcomp/amd64/proc.ml  |  3 +--
+ 2 files changed, 25 insertions(+), 11 deletions(-)
+
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index 4f2d54d17..96be4a559 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -548,17 +554,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        if !pic_code then begin
+-          `	leaq	{emit_label lbl}(%rip), %r11\n`;
+-          `	jmp	*(%r11, {emit_reg i.arg.(0)}, 8)\n`
+-        end else begin
+-          `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`
+-        end;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 0e274b4f4..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -92,7 +92,6 @@ let phys_reg n =
+ let rax = phys_reg 0
+ let rcx = phys_reg 5
+ let rdx = phys_reg 4
+-let r11 = phys_reg 9
+ let rxmm15 = phys_reg 115
+ 
+ let stack_slot slot ty =
+@@ -170,7 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
+-  | Iswitch(_, _) when !pic_code -> [| r11 |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
@@ -32,8 +32,10 @@ install: [
   ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
   ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
+patches: ["pr4867.patch"]
 url {
   src: "https://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.0.tar.gz"
   checksum: "md5=5ec0b860730925f738d91ca96d692406"
 }
+extra-files: ["pr4867.patch" "md5=eb67f1923baa030938c7331ec44faa9b"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
@@ -42,4 +42,4 @@ url {
   checksum: "md5=5ec0b860730925f738d91ca96d692406"
 }
 extra-files: ["pr4867.patch" "md5=eb67f1923baa030938c7331ec44faa9b"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.10.0 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.10"
 depends: [
   "ocaml" {= "3.10.0" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
@@ -42,4 +42,4 @@ url {
   checksum: "md5=5ec0b860730925f738d91ca96d692406"
 }
 extra-files: ["pr4867.patch" "md5=eb67f1923baa030938c7331ec44faa9b"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/files/pr4867.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/files/pr4867.patch
@@ -1,0 +1,103 @@
+From 1e0307ff682b106adbbf7c6df967de205fb96760 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Fri, 18 Sep 2009 13:49:21 +0000
+Subject: [PATCH] PR#4867, PR#4760: make Lswitch generate PIC code acceptable
+ for MacOS X
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/version/3.11@9342 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/emit.mlp | 47 +++++++++++++++++++++---------------------
+ asmcomp/amd64/proc.ml  |  3 +--
+ 2 files changed, 25 insertions(+), 25 deletions(-)
+
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index 7b5565b49..1084b3241 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -548,31 +554,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        if !pic_code then begin
+-          (* PR#4424: r11 is known to be clobbered by the Lswitch,
+-             meaning that no variable that is live across the Lswitch
+-             is assigned to r11.  However, the argument to Lswitch
+-             can still be assigned to r11, so we need to special-case 
+-             this situation. *)
+-          if i.arg.(0).loc = Reg 9 (* ie r11, cf amd64/proc.ml *) then begin
+-            `	salq	$3, %r11\n`;
+-            `	pushq	%r11\n`;
+-            `	leaq	{emit_label lbl}(%rip), %r11\n`;
+-            `	addq	0(%rsp), %r11\n`;
+-            `	addq	$8, %rsp\n`;
+-            `	jmp	*(%r11)\n`
+-          end else begin
+-            `	leaq	{emit_label lbl}(%rip), %r11\n`;
+-            `	jmp	*(%r11, {emit_reg i.arg.(0)}, 8)\n`
+-          end
+-        end else begin
+-          `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`
+-        end;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 0e274b4f4..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -92,7 +92,6 @@ let phys_reg n =
+ let rax = phys_reg 0
+ let rcx = phys_reg 5
+ let rdx = phys_reg 4
+-let r11 = phys_reg 9
+ let rxmm15 = phys_reg 115
+ 
+ let stack_slot slot ty =
+@@ -170,7 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
+-  | Iswitch(_, _) when !pic_code -> [| r11 |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
@@ -31,8 +31,10 @@ install: [
   ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
   ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
+patches: ["pr4867.patch"]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.1.tar.gz"
   checksum: "md5=04fbe476b7f633a910429106e02d9948"
 }
+extra-files: ["pr4867.patch" "md5=3875e5e32cfa8b639785e0963e9eb7c4"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.10.1 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.10"
 depends: [
   "ocaml" {= "3.10.1" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
@@ -41,4 +41,4 @@ url {
   checksum: "md5=04fbe476b7f633a910429106e02d9948"
 }
 extra-files: ["pr4867.patch" "md5=3875e5e32cfa8b639785e0963e9eb7c4"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
@@ -41,4 +41,4 @@ url {
   checksum: "md5=04fbe476b7f633a910429106e02d9948"
 }
 extra-files: ["pr4867.patch" "md5=3875e5e32cfa8b639785e0963e9eb7c4"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/files/pr4867.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/files/pr4867.patch
@@ -1,0 +1,103 @@
+From 1e0307ff682b106adbbf7c6df967de205fb96760 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Fri, 18 Sep 2009 13:49:21 +0000
+Subject: [PATCH] PR#4867, PR#4760: make Lswitch generate PIC code acceptable
+ for MacOS X
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/version/3.11@9342 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/emit.mlp | 47 +++++++++++++++++++++---------------------
+ asmcomp/amd64/proc.ml  |  3 +--
+ 2 files changed, 25 insertions(+), 25 deletions(-)
+
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index 7b5565b49..1084b3241 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -23,6 +23,12 @@ open Mach
+ open Linearize
+ open Emitaux
+ 
++let macosx =
++  match Config.system with
++  | "macosx" -> true
++  | _ -> false
++
++
+ (* Tradeoff between code size and code speed *)
+ 
+ let fastcode_flag = ref true
+@@ -548,31 +554,26 @@ let emit_instr fallthrough i =
+             end
+     | Lswitch jumptbl ->
+         let lbl = new_label() in
+-        if !pic_code then begin
+-          (* PR#4424: r11 is known to be clobbered by the Lswitch,
+-             meaning that no variable that is live across the Lswitch
+-             is assigned to r11.  However, the argument to Lswitch
+-             can still be assigned to r11, so we need to special-case 
+-             this situation. *)
+-          if i.arg.(0).loc = Reg 9 (* ie r11, cf amd64/proc.ml *) then begin
+-            `	salq	$3, %r11\n`;
+-            `	pushq	%r11\n`;
+-            `	leaq	{emit_label lbl}(%rip), %r11\n`;
+-            `	addq	0(%rsp), %r11\n`;
+-            `	addq	$8, %rsp\n`;
+-            `	jmp	*(%r11)\n`
+-          end else begin
+-            `	leaq	{emit_label lbl}(%rip), %r11\n`;
+-            `	jmp	*(%r11, {emit_reg i.arg.(0)}, 8)\n`
+-          end
+-        end else begin
+-          `	jmp	*{emit_label lbl}(, {emit_reg i.arg.(0)}, 8)\n`
+-        end;
+-        `	.section .rodata\n`;
+-        emit_align 8;
++        (* rax and rdx are clobbered by the Lswitch,
++           meaning that no variable that is live across the Lswitch
++           is assigned to rax or rdx.  However, the argument to Lswitch
++           can still be assigned to one of these two registers, so
++           we must be careful not to clobber it before use. *)
++        let (tmp1, tmp2) =
++          if i.arg.(0).loc = Reg 0 (* rax *)
++          then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
++          else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
++        `	leaq	{emit_label lbl}(%rip), {emit_reg tmp1}\n`;
++        `	movslq	({emit_reg tmp1}, {emit_reg i.arg.(0)}, 4), {emit_reg tmp2}\n`;
++        `	addq	{emit_reg tmp2}, {emit_reg tmp1}\n`;
++        `	jmp	*{emit_reg tmp1}\n`;
++        if macosx
++        then `	.const\n`
++        else `	.section .rodata\n`;
++        emit_align 4;
+         `{emit_label lbl}:`;
+         for i = 0 to Array.length jumptbl - 1 do
+-          `	.quad	{emit_label jumptbl.(i)}\n`
++          `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
+         done;
+         `	.text\n`
+     | Lsetuptrap lbl ->
+diff --git a/asmcomp/amd64/proc.ml b/asmcomp/amd64/proc.ml
+index 0e274b4f4..bda821f8a 100644
+--- a/asmcomp/amd64/proc.ml
++++ b/asmcomp/amd64/proc.ml
+@@ -92,7 +92,6 @@ let phys_reg n =
+ let rax = phys_reg 0
+ let rcx = phys_reg 5
+ let rdx = phys_reg 4
+-let r11 = phys_reg 9
+ let rxmm15 = phys_reg 115
+ 
+ let stack_slot slot ty =
+@@ -170,7 +169,7 @@ let destroyed_at_oper = function
+   | Iop(Istore(Single, _)) -> [| rxmm15 |]
+   | Iop(Ialloc _ | Iintop(Icomp _) | Iintop_imm((Idiv|Imod|Icomp _), _))
+         -> [| rax |]
+-  | Iswitch(_, _) when !pic_code -> [| r11 |]
++  | Iswitch(_, _) -> [| rax; rdx |]
+   | _ -> [||]
+ 
+ let destroyed_at_raise = all_phys_regs
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
@@ -41,4 +41,4 @@ url {
   checksum: "md5=52c795592c90ecb15c2c4754f04eeff4"
 }
 extra-files: ["pr4867.patch" "md5=3875e5e32cfa8b639785e0963e9eb7c4"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.10.2 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.10"
 depends: [
   "ocaml" {= "3.10.2" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
@@ -31,8 +31,10 @@ install: [
   ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
   ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
+patches: ["pr4867.patch"]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.10/ocaml-3.10.2.tar.gz"
   checksum: "md5=52c795592c90ecb15c2c4754f04eeff4"
 }
+extra-files: ["pr4867.patch" "md5=3875e5e32cfa8b639785e0963e9eb7c4"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
@@ -41,4 +41,4 @@ url {
   checksum: "md5=52c795592c90ecb15c2c4754f04eeff4"
 }
 extra-files: ["pr4867.patch" "md5=3875e5e32cfa8b639785e0963e9eb7c4"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/files/pr5237.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/files/pr5237.patch
@@ -1,0 +1,64 @@
+From d7d13be2aa34a4812e56a3b2ef3ec60bfc4341c0 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Sun, 13 Mar 2011 13:33:17 +0000
+Subject: [PATCH] PR#5237: incorrect .size directives generated for x86-32 and
+ x86-64
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/version/3.12@10980 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/emit.mlp | 13 +++++++------
+ asmcomp/i386/emit.mlp  |  6 +++---
+ 2 files changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index 08745799b..80e71cce1 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -679,17 +679,18 @@ let fundecl fundecl =
+   emit_all true fundecl.fun_body;
+   List.iter emit_call_gc !call_gc_sites;
+   emit_call_bound_errors ();
++  begin match Config.system with
++    "linux" | "gnu" ->
++      `	.type	{emit_symbol fundecl.fun_name},@function\n`;
++      `	.size	{emit_symbol fundecl.fun_name},.-{emit_symbol fundecl.fun_name}\n`
++    | _ -> ()
++  end;
+   if !float_constants <> [] then begin
+     if macosx
+     then `	.literal8\n`
+     else `	.section	.rodata.cst8,\"a\",@progbits\n`;
+     List.iter emit_float_constant !float_constants
+-  end;
+-  match Config.system with
+-    "linux" | "gnu" ->
+-      `	.type	{emit_symbol fundecl.fun_name},@function\n`;
+-      `	.size	{emit_symbol fundecl.fun_name},.-{emit_symbol fundecl.fun_name}\n`
+-  | _ -> ()
++  end
+ 
+ (* Emission of data *)
+ 
+diff --git a/asmcomp/i386/emit.mlp b/asmcomp/i386/emit.mlp
+index 75881201e..d78a28a82 100644
+--- a/asmcomp/i386/emit.mlp
++++ b/asmcomp/i386/emit.mlp
+@@ -905,12 +905,12 @@ let fundecl fundecl =
+   emit_all true fundecl.fun_body;
+   List.iter emit_call_gc !call_gc_sites;
+   emit_call_bound_errors ();
+-  List.iter emit_float_constant !float_constants;
+-  match Config.system with
++  begin match Config.system with
+     "linux_elf" | "bsd_elf" | "gnu" ->
+       `	.type	{emit_symbol fundecl.fun_name},@function\n`;
+       `	.size	{emit_symbol fundecl.fun_name},.-{emit_symbol fundecl.fun_name}\n`
+-  | _ -> ()
++  | _ -> () end;
++  List.iter emit_float_constant !float_constants
+ 
+ 
+ (* Emission of data *)
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
@@ -41,4 +41,4 @@ url {
   checksum: "md5=be152066bdf09761ddf1c31291e5cb90"
 }
 extra-files: ["pr5237.patch" "md5=ed296f21546aaea6cf62e6dc4ac2e28f"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
@@ -41,4 +41,4 @@ url {
   checksum: "md5=be152066bdf09761ddf1c31291e5cb90"
 }
 extra-files: ["pr5237.patch" "md5=ed296f21546aaea6cf62e6dc4ac2e28f"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.11.0 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.11"
 depends: [
   "ocaml" {= "3.11.0" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
@@ -31,8 +31,10 @@ install: [
   ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
   ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
+patches: ["pr5237.patch"]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.0.tar.gz"
   checksum: "md5=be152066bdf09761ddf1c31291e5cb90"
 }
+extra-files: ["pr5237.patch" "md5=ed296f21546aaea6cf62e6dc4ac2e28f"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/files/pr5237.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/files/pr5237.patch
@@ -1,0 +1,64 @@
+From d7d13be2aa34a4812e56a3b2ef3ec60bfc4341c0 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Sun, 13 Mar 2011 13:33:17 +0000
+Subject: [PATCH] PR#5237: incorrect .size directives generated for x86-32 and
+ x86-64
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/version/3.12@10980 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/emit.mlp | 13 +++++++------
+ asmcomp/i386/emit.mlp  |  6 +++---
+ 2 files changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index 08745799b..80e71cce1 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -679,17 +679,18 @@ let fundecl fundecl =
+   emit_all true fundecl.fun_body;
+   List.iter emit_call_gc !call_gc_sites;
+   emit_call_bound_errors ();
++  begin match Config.system with
++    "linux" | "gnu" ->
++      `	.type	{emit_symbol fundecl.fun_name},@function\n`;
++      `	.size	{emit_symbol fundecl.fun_name},.-{emit_symbol fundecl.fun_name}\n`
++    | _ -> ()
++  end;
+   if !float_constants <> [] then begin
+     if macosx
+     then `	.literal8\n`
+     else `	.section	.rodata.cst8,\"a\",@progbits\n`;
+     List.iter emit_float_constant !float_constants
+-  end;
+-  match Config.system with
+-    "linux" | "gnu" ->
+-      `	.type	{emit_symbol fundecl.fun_name},@function\n`;
+-      `	.size	{emit_symbol fundecl.fun_name},.-{emit_symbol fundecl.fun_name}\n`
+-  | _ -> ()
++  end
+ 
+ (* Emission of data *)
+ 
+diff --git a/asmcomp/i386/emit.mlp b/asmcomp/i386/emit.mlp
+index 75881201e..d78a28a82 100644
+--- a/asmcomp/i386/emit.mlp
++++ b/asmcomp/i386/emit.mlp
+@@ -905,12 +905,12 @@ let fundecl fundecl =
+   emit_all true fundecl.fun_body;
+   List.iter emit_call_gc !call_gc_sites;
+   emit_call_bound_errors ();
+-  List.iter emit_float_constant !float_constants;
+-  match Config.system with
++  begin match Config.system with
+     "linux_elf" | "bsd_elf" | "gnu" ->
+       `	.type	{emit_symbol fundecl.fun_name},@function\n`;
+       `	.size	{emit_symbol fundecl.fun_name},.-{emit_symbol fundecl.fun_name}\n`
+-  | _ -> ()
++  | _ -> () end;
++  List.iter emit_float_constant !float_constants
+ 
+ 
+ (* Emission of data *)
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
@@ -41,4 +41,4 @@ url {
   checksum: "md5=069aa55d40e548280f92af693f6c625a"
 }
 extra-files: ["pr5237.patch" "md5=ed296f21546aaea6cf62e6dc4ac2e28f"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.11.1 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.11"
 depends: [
   "ocaml" {= "3.11.1" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
@@ -31,8 +31,10 @@ install: [
   ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
   ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
+patches: ["pr5237.patch"]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.1.tar.gz"
   checksum: "md5=069aa55d40e548280f92af693f6c625a"
 }
+extra-files: ["pr5237.patch" "md5=ed296f21546aaea6cf62e6dc4ac2e28f"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
@@ -41,4 +41,4 @@ url {
   checksum: "md5=069aa55d40e548280f92af693f6c625a"
 }
 extra-files: ["pr5237.patch" "md5=ed296f21546aaea6cf62e6dc4ac2e28f"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/files/pr5237.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/files/pr5237.patch
@@ -1,0 +1,64 @@
+From d7d13be2aa34a4812e56a3b2ef3ec60bfc4341c0 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@inria.fr>
+Date: Sun, 13 Mar 2011 13:33:17 +0000
+Subject: [PATCH] PR#5237: incorrect .size directives generated for x86-32 and
+ x86-64
+
+git-svn-id: http://caml.inria.fr/svn/ocaml/version/3.12@10980 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+---
+ asmcomp/amd64/emit.mlp | 13 +++++++------
+ asmcomp/i386/emit.mlp  |  6 +++---
+ 2 files changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/asmcomp/amd64/emit.mlp b/asmcomp/amd64/emit.mlp
+index 08745799b..80e71cce1 100644
+--- a/asmcomp/amd64/emit.mlp
++++ b/asmcomp/amd64/emit.mlp
+@@ -679,17 +679,18 @@ let fundecl fundecl =
+   emit_all true fundecl.fun_body;
+   List.iter emit_call_gc !call_gc_sites;
+   emit_call_bound_errors ();
++  begin match Config.system with
++    "linux" | "gnu" ->
++      `	.type	{emit_symbol fundecl.fun_name},@function\n`;
++      `	.size	{emit_symbol fundecl.fun_name},.-{emit_symbol fundecl.fun_name}\n`
++    | _ -> ()
++  end;
+   if !float_constants <> [] then begin
+     if macosx
+     then `	.literal8\n`
+     else `	.section	.rodata.cst8,\"a\",@progbits\n`;
+     List.iter emit_float_constant !float_constants
+-  end;
+-  match Config.system with
+-    "linux" | "gnu" ->
+-      `	.type	{emit_symbol fundecl.fun_name},@function\n`;
+-      `	.size	{emit_symbol fundecl.fun_name},.-{emit_symbol fundecl.fun_name}\n`
+-  | _ -> ()
++  end
+ 
+ (* Emission of data *)
+ 
+diff --git a/asmcomp/i386/emit.mlp b/asmcomp/i386/emit.mlp
+index 75881201e..d78a28a82 100644
+--- a/asmcomp/i386/emit.mlp
++++ b/asmcomp/i386/emit.mlp
+@@ -905,12 +905,12 @@ let fundecl fundecl =
+   emit_all true fundecl.fun_body;
+   List.iter emit_call_gc !call_gc_sites;
+   emit_call_bound_errors ();
+-  List.iter emit_float_constant !float_constants;
+-  match Config.system with
++  begin match Config.system with
+     "linux_elf" | "bsd_elf" | "gnu" ->
+       `	.type	{emit_symbol fundecl.fun_name},@function\n`;
+       `	.size	{emit_symbol fundecl.fun_name},.-{emit_symbol fundecl.fun_name}\n`
+-  | _ -> ()
++  | _ -> () end;
++  List.iter emit_float_constant !float_constants
+ 
+ 
+ (* Emission of data *)
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
@@ -31,13 +31,10 @@ install: [
   ["mkdir" "-p" "%{prefix}%/lib/ocaml/compiler-libs"]
   ["cp" "-r" "typing" "parsing" "utils" "%{prefix}%/lib/ocaml/compiler-libs/"]
 ]
-patches: "3.11.2_binutils.patch"
+patches: ["pr5237.patch"]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.2.tar.gz"
   checksum: "md5=9d0611245122ffbc8263735cae1da7fb"
 }
-extra-source "3.11.2_binutils.patch" {
-  src: "http://www.ocamlpro.com/patches/3.11.2_binutils.patch"
-  checksum: "md5=041f12c823520d687a7bbbce10cd57e3"
-}
+extra-files: ["pr5237.patch" "md5=ed296f21546aaea6cf62e6dc4ac2e28f"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.11.2 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.11"
 depends: [
   "ocaml" {= "3.11.2" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
@@ -41,4 +41,4 @@ url {
   checksum: "md5=9d0611245122ffbc8263735cae1da7fb"
 }
 extra-files: ["pr5237.patch" "md5=ed296f21546aaea6cf62e6dc4ac2e28f"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
@@ -41,4 +41,4 @@ url {
   checksum: "md5=9d0611245122ffbc8263735cae1da7fb"
 }
 extra-files: ["pr5237.patch" "md5=ed296f21546aaea6cf62e6dc4ac2e28f"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
@@ -44,4 +44,4 @@ extra-source "file_download.php?file_id=418&type=bug" {
   src: "https://gist.githubusercontent.com/vicuna/864c7c8a5c03917ca1482d8fbba12d36/raw/fa7664cecc98d7d5d97ee6d8fb035c2e229bff57/0007-Fix-ocamlopt-w.r.t.-binutils-2.21.patch"
   checksum: "md5=8c664a0a346424ea2ec6fc6f713170c6"
 }
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
@@ -44,4 +44,4 @@ extra-source "file_download.php?file_id=418&type=bug" {
   src: "https://gist.githubusercontent.com/vicuna/864c7c8a5c03917ca1482d8fbba12d36/raw/fa7664cecc98d7d5d97ee6d8fb035c2e229bff57/0007-Fix-ocamlopt-w.r.t.-binutils-2.21.patch"
   checksum: "md5=8c664a0a346424ea2ec6fc6f713170c6"
 }
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
@@ -37,7 +37,7 @@ url {
   checksum: "md5=3ba7cc65123c3579f14e7c726d3ee782"
 }
 extra-source "file_download.php?file_id=418&type=bug" {
-  src: "http://caml.inria.fr/mantis/file_download.php?file_id=418&type=bug"
+  src: "https://gist.githubusercontent.com/vicuna/864c7c8a5c03917ca1482d8fbba12d36/raw/fa7664cecc98d7d5d97ee6d8fb035c2e229bff57/0007-Fix-ocamlopt-w.r.t.-binutils-2.21.patch"
   checksum: "md5=8c664a0a346424ea2ec6fc6f713170c6"
 }
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.12.0 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.12"
 depends: [
   "ocaml" {= "3.12.0" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
@@ -39,4 +39,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1.tar.gz"
   checksum: "md5=814a047085f0f901ab7d8e3a4b7a9e65"
 }
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
@@ -39,4 +39,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1.tar.gz"
   checksum: "md5=814a047085f0f901ab7d8e3a4b7a9e65"
 }
-available: arch != "arm64"
+available: arch != "arm64" & arch != "arm32" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 3.12.1 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#3.12"
 depends: [
   "ocaml" {= "3.12.1" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/files/fix-gcc10.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/files/fix-gcc10.patch
@@ -1,0 +1,33 @@
+From 4a8630f83ce70396d5fdcc812ed912a7df771787 Mon Sep 17 00:00:00 2001
+From: Anil Madhavapeddy <anil@recoil.org>
+Date: Sun, 21 Jun 2020 22:56:47 +0100
+Subject: [PATCH] add `-fcommon` unconditionally to fix build on gcc10
+
+---
+ configure | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/configure b/configure
+index a9a4068ee..54607bfb9 100755
+--- a/configure
++++ b/configure
+@@ -345,6 +345,8 @@ case "$bytecc,$host" in
+     bytecccompopts="-fno-defer-pop $gcc_warnings";;
+ esac
+ 
++bytecccompopts="-fcommon $bytecccompopts"
++
+ # Configure compiler to use in further tests
+ 
+ cc="$bytecc -O $bytecclinkopts"
+@@ -740,6 +742,7 @@ case "$arch,$nativecc,$system,$host_type" in
+   *,gcc*,*,*)          nativecccompopts="$gcc_warnings";;
+ esac
+ 
++nativecccompopts="-fcommon $nativecccompopts"
+ asppprofflags='-DPROFILING'
+ 
+ case "$arch,$model,$system" in
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 4.00.0 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.00"
 depends: [
   "ocaml" {= "4.00.0" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
@@ -33,4 +33,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: ["fix-gcc10.patch" "md5=eb8555e57846757138861e14d2665ed1"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
@@ -33,4 +33,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: ["fix-gcc10.patch" "md5=eb8555e57846757138861e14d2665ed1"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
@@ -27,4 +27,6 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.0.tar.gz"
   checksum: "md5=fa11560a45793bd9fa45c1295a6f4a91"
 }
+patches: ["fix-gcc10.patch"]
+extra-files: ["fix-gcc10.patch" "md5=eb8555e57846757138861e14d2665ed1"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/files/fix-gcc10.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/files/fix-gcc10.patch
@@ -1,0 +1,33 @@
+From 4a8630f83ce70396d5fdcc812ed912a7df771787 Mon Sep 17 00:00:00 2001
+From: Anil Madhavapeddy <anil@recoil.org>
+Date: Sun, 21 Jun 2020 22:56:47 +0100
+Subject: [PATCH] add `-fcommon` unconditionally to fix build on gcc10
+
+---
+ configure | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/configure b/configure
+index a9a4068ee..54607bfb9 100755
+--- a/configure
++++ b/configure
+@@ -345,6 +345,8 @@ case "$bytecc,$host" in
+     bytecccompopts="-fno-defer-pop $gcc_warnings";;
+ esac
+ 
++bytecccompopts="-fcommon $bytecccompopts"
++
+ # Configure compiler to use in further tests
+ 
+ cc="$bytecc -O $bytecclinkopts"
+@@ -740,6 +742,7 @@ case "$arch,$nativecc,$system,$host_type" in
+   *,gcc*,*,*)          nativecccompopts="$gcc_warnings";;
+ esac
+ 
++nativecccompopts="-fcommon $nativecccompopts"
+ asppprofflags='-DPROFILING'
+ 
+ case "$arch,$model,$system" in
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
@@ -23,7 +23,10 @@ build: [
   [make "world" "opt" "opt.opt"]
 ]
 install: [make "install"]
-patches: "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
+patches: [
+  "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
+  "fix-gcc10.patch"
+]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
   checksum: "md5=91124a8eb12a57f1e56c02fe3db0f9e7"
@@ -33,4 +36,5 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
     "https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   checksum: "md5=faccda3b3ab092fa9ac7d5d4d8beb004"
 }
+extra-files: ["fix-gcc10.patch" "md5=eb8555e57846757138861e14d2665ed1"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
@@ -41,4 +41,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
   checksum: "md5=faccda3b3ab092fa9ac7d5d4d8beb004"
 }
 extra-files: ["fix-gcc10.patch" "md5=eb8555e57846757138861e14d2665ed1"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
@@ -41,4 +41,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
   checksum: "md5=faccda3b3ab092fa9ac7d5d4d8beb004"
 }
 extra-files: ["fix-gcc10.patch" "md5=eb8555e57846757138861e14d2665ed1"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 4.00.1 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.00"
 depends: [
   "ocaml" {= "4.00.1" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/files/fix-gcc10.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/files/fix-gcc10.patch
@@ -1,0 +1,33 @@
+From de6f4ab737b0f83f945845967ac4be867650a44c Mon Sep 17 00:00:00 2001
+From: Anil Madhavapeddy <anil@recoil.org>
+Date: Sun, 21 Jun 2020 22:56:47 +0100
+Subject: [PATCH] add `-fcommon` unconditionally to fix build on gcc10
+
+---
+ configure | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/configure b/configure
+index 07b1c3503..3210157f3 100755
+--- a/configure
++++ b/configure
+@@ -350,6 +350,8 @@ case "$bytecc,$host" in
+     bytecccompopts="-fno-defer-pop $gcc_warnings";;
+ esac
+ 
++bytecccompopts="-fcommon $bytecccompopts"
++
+ # Configure compiler to use in further tests
+ 
+ cc="$bytecc -O $bytecclinkopts"
+@@ -752,6 +754,7 @@ case "$arch,$nativecc,$system,$host_type" in
+   *,gcc*,*,*)          nativecccompopts="$gcc_warnings";;
+ esac
+ 
++nativecccompopts="-fcommon $nativecccompopts"
+ asppprofflags='-DPROFILING'
+ 
+ case "$arch,$model,$system" in
+-- 
+2.27.0
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
@@ -53,4 +53,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
   checksum: "md5=faccda3b3ab092fa9ac7d5d4d8beb004"
 }
 extra-files: ["fix-gcc10.patch" "md5=a5ee5f90499987223ca8c13896fa2c4c"]
-available: arch != "arm64"
+available: arch != "arm64" & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
@@ -53,4 +53,4 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
   checksum: "md5=faccda3b3ab092fa9ac7d5d4d8beb004"
 }
 extra-files: ["fix-gcc10.patch" "md5=a5ee5f90499987223ca8c13896fa2c4c"]
-available: !(os = "macos" & arch = "arm64")
+available: arch != "arm64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 4.01.0 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.01"
 depends: [
   "ocaml" {= "4.01.0" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
@@ -35,7 +35,10 @@ build: [
   [make "world.opt"]
 ]
 install: [make "install"]
-patches: "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
+patches: [
+  "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
+  "fix-gcc10.patch"
+]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
   checksum: "md5=04dfdd7da189462a4f10ec6530359cef"
@@ -45,4 +48,5 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
     "https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   checksum: "md5=faccda3b3ab092fa9ac7d5d4d8beb004"
 }
+extra-files: ["fix-gcc10.patch" "md5=a5ee5f90499987223ca8c13896fa2c4c"]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=91a4a258611302bc57f4d9fadb7fc14d"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64") & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64") & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=d40cd243f53876ba0b7e181ac16836a9"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64") & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64") & arch != "ppc64"

--- a/packages/ocaml-config/ocaml-config.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-config/ocaml-config.0/files/gen_ocaml_config.ml.in
@@ -1,0 +1,48 @@
+let () =
+  if Sys.ocaml_version <> Sys.argv.(1) then
+    (Printf.eprintf
+       "OCaml version mismatch: %%s, expected %s"
+       Sys.ocaml_version Sys.argv.(1);
+     exit 1)
+  else
+  let oc = open_out (Sys.argv.(2) ^ ".config") in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
+  let libdir =
+    if Sys.command (ocamlc^" -where > where") = 0 then
+      (* Must be opened in text mode for Windows *)
+      let ic = open_in "where" in
+      let r = input_line ic in
+      close_in ic; r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let stubsdir =
+    let ic = open_in (Filename.concat libdir "ld.conf") in
+    let rec r acc = try r (input_line ic::acc) with End_of_file -> acc in
+    let lines = List.rev (r []) in
+    close_in ic;
+    String.concat ":" lines
+  in
+  let p fmt = Printf.fprintf oc (fmt ^^ "\n") in
+  p "opam-version: \"2.0\"";
+  p "variables {";
+  p "  native: %%b"
+    (Sys.file_exists (ocaml^"opt"^suffix));
+  p "  native-tools: %%b"
+    (Sys.file_exists (ocamlc^".opt"^suffix));
+  p "  native-dynlink: %%b"
+    (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
+  p "  stubsdir: %%S"
+    stubsdir;
+  p "  preinstalled: %{ocaml-system:installed}%";
+  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{ocaml-variants:version}%\"";
+  p "}";
+  close_out oc

--- a/packages/ocaml-config/ocaml-config.0/files/ocaml-config.install
+++ b/packages/ocaml-config/ocaml-config.0/files/ocaml-config.install
@@ -1,0 +1,1 @@
+share: ["gen_ocaml_config.ml"]

--- a/packages/ocaml-config/ocaml-config.0/opam
+++ b/packages/ocaml-config/ocaml-config.0/opam
@@ -10,13 +10,13 @@ authors: [
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml-base-compiler" {>= "3.08.0~"} |
-  "ocaml-variants" {>= "3.08.0~"} |
-  "ocaml-system" {>= "3.08.0~"}
+  "ocaml-base-compiler" {< "3.08"} |
+  "ocaml-variants" {< "3.08"} |
+  "ocaml-system" {< "3.08"}
 ]
 substs: "gen_ocaml_config.ml"
 extra-files: [
-  ["gen_ocaml_config.ml.in" "md5=71f88c92be191cf4a0547f3c6196ef00"]
+  ["gen_ocaml_config.ml.in" "md5=6209d629171ad6ce6677de1aff759ac5"]
   ["ocaml-config.install" "md5=8e50c5e2517d3463b3aad649748cafd7"]
 ]
 

--- a/packages/ocaml-r/ocaml-r.0.0.1/opam
+++ b/packages/ocaml-r/ocaml-r.0.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {< "4.06.0"}
   "camlp4" {build}
   "ocamlfind"
-  "calendar"
+  "calendar" {>= "2.00"}
   "oasis" {>= "0.4.0"}
   "menhir"
 ]

--- a/packages/ocamlfind/ocamlfind.1.0.4/files/no-awk-check.patch
+++ b/packages/ocamlfind/ocamlfind.1.0.4/files/no-awk-check.patch
@@ -1,0 +1,19 @@
+commit 78fdec4547038f65e7d8401035dacdc7052f7ff2
+Author: Kate <kit.ty.kate@disroot.org>
+Date:   Tue Mar 19 16:29:06 2019 +0000
+
+    Remove awk from the set of checked unix tools as it's not used anywhere
+
+diff --git a/configure b/configure
+index 4376bb9..ab70488 100755
+--- a/configure
++++ b/configure
+@@ -170,7 +170,7 @@ echo "Configuring core..."
+ 
+ # Some standard Unix tools must be available:
+ 
+-for tool in sed awk ocamlc uname rm make cat m4 dirname basename; do
++for tool in sed ocamlc uname rm make cat m4 dirname basename; do
+     if in_path $tool; then true; else
+ 	echo "configure: $tool not in PATH; this is required" 1>&2
+ 	exit 1

--- a/packages/ocamlfind/ocamlfind.1.0.4/files/ocamlfind.install
+++ b/packages/ocamlfind/ocamlfind.1.0.4/files/ocamlfind.install
@@ -1,0 +1,4 @@
+bin: [
+  "src/findlib/ocamlfind"
+]
+toplevel: ["src/findlib/topfind"]

--- a/packages/ocamlfind/ocamlfind.1.0.4/opam
+++ b/packages/ocamlfind/ocamlfind.1.0.4/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+patches: ["no-awk-check.patch"]
+build: [
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-sitelib"
+    lib
+    "-mandir"
+    man
+    "-config"
+    "%{lib}%/findlib.conf"
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "all"]
+  [make "opt"]
+]
+depends: [
+  "ocaml" {< "4.00.0~"}
+  "conf-m4" {build}
+  "num" {= "0"}
+]
+install: [
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-sitelib"
+    lib
+    "-mandir"
+    man
+    "-config"
+    "%{lib}%/findlib.conf"
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "install"]
+]
+synopsis: "A library manager for OCaml"
+description: """
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts."""
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+extra-files: [
+  ["ocamlfind.install" "md5=2a7365fc4b6af4531babaefb5226e080"]
+  ["no-awk-check.patch" "md5=628377ab781f705cc6f468165bad47cb"]
+]
+url {
+  src: "http://download.camlcity.org/download/findlib-1.0.4.tar.gz"
+  checksum: "md5=dbfabe1b3677a03bcf238ecccb36d84f"
+  mirrors: "http://download2.camlcity.org/download/findlib-1.0.4.tar.gz"
+}
+depopts: ["graphics"]

--- a/packages/ocamlnet/ocamlnet.3.2.1/opam
+++ b/packages/ocamlnet/ocamlnet.3.2.1/opam
@@ -1,5 +1,9 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   ["./configure" "-bindir" bin]
   [make "all"]
@@ -25,7 +29,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocaml" {< "4.00.0"}
+  "ocaml" {>= "3.11" < "4.00.0"}
   "ocamlfind"
   "pcre"
   "camlp4"

--- a/packages/ocamlnet/ocamlnet.3.5.1/opam
+++ b/packages/ocamlnet/ocamlnet.3.5.1/opam
@@ -1,5 +1,9 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"
@@ -41,7 +45,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocaml" {< "4.00.0"}
+  "ocaml" {>= "3.12" & < "4.00.0"}
   "ocamlfind"
   "pcre"
   "camlp4"

--- a/packages/ocamlnet/ocamlnet.3.6.0/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.0/opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.6.0/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"
@@ -45,7 +48,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocaml" {< "4.01.0"}
+  "ocaml" {>= "3.12" & < "4.01.0"}
   "ocamlfind"
   "camlp4"
 ]

--- a/packages/ocamlnet/ocamlnet.3.6.3/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.3/opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.6.3/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"
@@ -45,7 +48,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocaml" {< "4.01.0"}
+  "ocaml" {>= "3.12" & < "4.01.0"}
   "ocamlfind"
   "camlp4"
 ]

--- a/packages/ocamlnet/ocamlnet.3.6.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.5/opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.6.5/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"
@@ -45,7 +48,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocaml" {< "4.02.0"}
+  "ocaml" {>= "3.12" & < "4.02.0"}
   "ocamlfind"
   "camlp4"
 ]

--- a/packages/ocamlnet/ocamlnet.3.7.3/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.3/opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.3/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"
@@ -45,7 +48,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocaml" {< "4.02.0"}
+  "ocaml" {>= "4.00" & < "4.02.0"}
   "ocamlfind"
   "camlp4"
 ]

--- a/packages/ocamlnet/ocamlnet.3.7.4-1/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.4-1/opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.4/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"
@@ -45,7 +48,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocaml" {< "4.02.0"}
+  "ocaml" {>= "4.00" & < "4.02.0"}
   "ocamlfind"
   "camlp4"
 ]

--- a/packages/ocamlnet/ocamlnet.3.7.4/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.4/opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.4/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"
@@ -45,7 +48,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocaml" {< "4.02.0"}
+  "ocaml" {>= "4.00" & < "4.02.0"}
   "ocamlfind"
   "camlp4"
 ]

--- a/packages/ocamlnet/ocamlnet.3.7.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.5/opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.5/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"
@@ -45,7 +48,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocaml" {< "4.03.0"}
+  "ocaml" {>= "3.12" & < "4.03.0"}
   "ocamlfind"
   "ocamlbuild"
 ]

--- a/packages/ocamlnet/ocamlnet.3.7.6/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.6/opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.6/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"
@@ -45,7 +48,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocaml" {< "4.03.0"}
+  "ocaml" {>= "3.12" & < "4.03.0"}
   "ocamlfind"
   "ocamlbuild"
 ]

--- a/packages/ocamlnet/ocamlnet.3.7.7/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.7/opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.7/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"
@@ -45,7 +48,7 @@ remove: [
   ["ocamlfind" "remove" "smtp"]
 ]
 depends: [
-  "ocaml" {< "4.03.0"}
+  "ocaml" {>= "3.12" & < "4.03.0"}
   "ocamlfind"
   "ocamlbuild"
 ]

--- a/packages/ocamlnet/ocamlnet.4.0.1/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.1/opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.0.1/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.0.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.2/opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
+authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.0.2/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.0.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.4/opam
@@ -2,6 +2,8 @@ opam-version: "2.0"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.0.4/doc/html-main/index.html"]
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.1.7/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.7/opam
@@ -21,7 +21,7 @@ build: [
   [make "opt"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0" & < "4.11.0"}
+  "ocaml" {>= "4.02" & < "4.11.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/ocamlnet/ocamlnet.4.1.8/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.8/opam
@@ -21,7 +21,7 @@ build: [
   [make "opt"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.02"}
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.0.99/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.0.99/opam
@@ -9,7 +9,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.02"}
   "eliom" {>= "6.0.0" & <= "6.2.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
 ]
 synopsis:
   "Reusable UI components for Eliom applications (client only, or client-server)"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.1.0.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.1.0.0/opam
@@ -9,7 +9,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.02"}
   "eliom" {>= "6.0.0" & <= "6.2.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
 ]
 synopsis:
   "Reusable UI components for Eliom applications (client only, or client-server)"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.1.1.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.1.1.0/opam
@@ -9,7 +9,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.03"}
   "eliom" {>= "6.3"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "lwt" {< "4.0.0"}
 ]
 synopsis:

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.0.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.0.0/opam
@@ -13,7 +13,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.06.1"}
   "eliom" {>= "6.4"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "js_of_ocaml" {< "3.4.0"}
   "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.1.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.1.0/opam
@@ -13,7 +13,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.06.1"}
   "eliom" {>= "6.7.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 available: false

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.2.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.2.0/opam
@@ -13,7 +13,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.06.1"}
   "eliom" {>= "6.7.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 available: false

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.2.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.2.1/opam
@@ -15,7 +15,7 @@ depends: [
   "js_of_ocaml-lwt" {< "3.5.0"}
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 url {

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.1/opam
@@ -14,7 +14,7 @@ depends: [
   "js_of_ocaml-lwt" {< "3.5.0"}
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 url {

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.2/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.2/opam
@@ -15,7 +15,7 @@ depends: [
   "js_of_ocaml-lwt" {< "3.5.0"}
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 url {

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.3/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.3.3/opam
@@ -15,7 +15,7 @@ depends: [
   "js_of_ocaml-lwt" {< "3.5.0"}
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 url {

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.4.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.4.1/opam
@@ -13,7 +13,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.7.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "js_of_ocaml-ppx_deriving_json" {< "3.5"}
 ]
 url {

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.4.3/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.4.3/opam
@@ -13,7 +13,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.10.1"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "js_of_ocaml-ppx_deriving_json" {< "3.6"}
 ]
 url {

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.5.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.5.0/opam
@@ -13,7 +13,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.10.1"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "js_of_ocaml-ppx_deriving_json" {< "3.6"}
 ]
 url {

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.7.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.7.0/opam
@@ -13,7 +13,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.10.1"}
-  "calendar"
+  "calendar" {>= "2.00"}
 ]
 url {
   src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.7.0.tar.gz"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.8.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.8.0/opam
@@ -13,7 +13,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.12.1"}
-  "calendar"
+  "calendar" {>= "2.00"}
 ]
 url {
   src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.8.0.tar.gz"

--- a/packages/opam-depext/opam-depext.1.1.1/opam
+++ b/packages/opam-depext/opam-depext.1.1.1/opam
@@ -20,7 +20,7 @@ OPAM packages and the host package management system. It can perform OS and
 distribution detection, query OPAM for the right external dependencies on a set
 of packages, and call the OS's package manager in the appropriate way to install
 them."""
-depends: ["ocaml"]
+depends: ["ocaml" {>= "4.00"}]
 flags: plugin
 url {
   src:

--- a/packages/opam-depext/opam-depext.1.1.4/opam
+++ b/packages/opam-depext/opam-depext.1.1.4/opam
@@ -10,7 +10,7 @@ authors: [
 license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-depext"
 bug-reports: "https://github.com/ocaml/opam-depext/issues"
-depends: ["ocaml"]
+depends: ["ocaml" {>= "4.00"}]
 available: opam-version >= "2.0.0~beta5"
 flags: plugin
 build: make

--- a/packages/opam-depext/opam-depext.1.1.5/opam
+++ b/packages/opam-depext/opam-depext.1.1.5/opam
@@ -10,7 +10,7 @@ authors: [
 license: "LGPL-2.1 with OCaml linking exception"
 homepage: "https://github.com/ocaml/opam-depext"
 bug-reports: "https://github.com/ocaml/opam-depext/issues"
-depends: ["ocaml"]
+depends: ["ocaml" {>= "4.00"}]
 available: opam-version >= "2.0.0~beta5"
 flags: plugin
 build: make

--- a/packages/pcre/pcre.6.2.5/opam
+++ b/packages/pcre/pcre.6.2.5/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "markus.mottl@gmail.com"
+authors: [ "Markus Mottl <markus.mottl@gmail.com>" ]
+homepage: "http://mmottl.github.io/pcre-ocaml"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+build: make
+depends: [
+  "ocaml" {>= "3.08" & < "4.06.0"}
+  "ocamlfind"
+  "conf-libpcre"
+]
+dev-repo: "git://github.com/mmottl/pcre-ocaml"
+install: [make "install"]
+synopsis:
+  "Interface to the PCRE (Perl-compatibility regular expressions) library"
+description: """
+This OCaml-library interfaces the C-library PCRE (Perl-compatibility
+Regular Expressions). It can be used for matching regular expressions
+which are written in "PERL"-style."""
+url {
+  src: "https://github.com/mmottl/pcre-ocaml/archive/v6.2.5.tar.gz"
+  checksum: "md5=6b15ccd734db50a9abb9ebaa7c14e1f4"
+}

--- a/packages/pgocaml/pgocaml.1.6/opam
+++ b/packages/pgocaml/pgocaml.1.6/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind" {build}
   "extlib" {= "1.5.3"}
   "pcre"
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "camlp4"
 ]

--- a/packages/pgocaml/pgocaml.1.7.1/opam
+++ b/packages/pgocaml/pgocaml.1.7.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind" {build}
   "batteries" {>= "2.0.0"}
   "pcre"
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "camlp4"
   "ocamlbuild" {build}

--- a/packages/pgocaml/pgocaml.1.7/opam
+++ b/packages/pgocaml/pgocaml.1.7/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind" {build}
   "batteries" {>= "2.0.0"}
   "pcre"
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "camlp4"
   "ocamlbuild" {build}

--- a/packages/pgocaml/pgocaml.2.0/opam
+++ b/packages/pgocaml/pgocaml.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.00.0" & < "4.06.0"}
   "ocamlfind" {build}
   "pcre"
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "camlp4"
   "ocamlbuild" {build}

--- a/packages/pgocaml/pgocaml.2.1/opam
+++ b/packages/pgocaml/pgocaml.2.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {< "4.06.0"}
   "ocamlfind"
   "pcre"
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "camlp4"
   "ocamlbuild" {build}

--- a/packages/pgocaml/pgocaml.2.2/opam
+++ b/packages/pgocaml/pgocaml.2.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "base-bytes"
   "pcre"
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "camlp4"
   "ocamlbuild" {build}

--- a/packages/pgocaml/pgocaml.2.3/opam
+++ b/packages/pgocaml/pgocaml.2.3/opam
@@ -15,7 +15,7 @@ remove: [["ocamlfind" "remove" "pgocaml"]]
 depends: [
   "ocaml" {>= "4.01.0"}
   "base-bytes"
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "ocamlbuild" {build}
   "ocamlfind" {build}

--- a/packages/pgocaml/pgocaml.3.0/opam
+++ b/packages/pgocaml/pgocaml.3.0/opam
@@ -17,7 +17,7 @@ remove: [["ocamlfind" "remove" "pgocaml"]]
 depends: [
   "ocaml" {>= "4.01"}
   "base-bytes"
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "hex"
   "ocamlbuild" {build}

--- a/packages/pgocaml/pgocaml.3.1/opam
+++ b/packages/pgocaml/pgocaml.3.1/opam
@@ -16,7 +16,7 @@ install: [[make "install"]]
 depends: [
   "ocaml" {>= "4.05" & < "4.12"}
   "base-bytes"
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "hex"
   "ocamlbuild" {build}

--- a/packages/pgocaml/pgocaml.3.2/opam
+++ b/packages/pgocaml/pgocaml.3.2/opam
@@ -17,7 +17,7 @@ remove: [["ocamlfind" "remove" "pgocaml"]]
 depends: [
   "ocaml" {>= "4.05" & < "4.08.0"}
   "base-bytes"
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "hex"
   "ocamlbuild" {build}

--- a/packages/pgocaml/pgocaml.4.0/opam
+++ b/packages/pgocaml/pgocaml.4.0/opam
@@ -15,7 +15,7 @@ dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
 license: "LGPL-2.0 with OCaml linking exception"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "dune" {>= "1.10"}
   "hex"

--- a/packages/pgocaml/pgocaml.4.2.2/opam
+++ b/packages/pgocaml/pgocaml.4.2.2/opam
@@ -15,7 +15,7 @@ dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
 license: "LGPL-2.0 with OCaml linking exception"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "dune" {>= "1.10"}
   "hex"

--- a/packages/pgocaml/pgocaml.4.2/opam
+++ b/packages/pgocaml/pgocaml.4.2/opam
@@ -15,7 +15,7 @@ dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
 license: "LGPL-2.0 with OCaml linking exception"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "calendar"
+  "calendar" {>= "2.00"}
   "csv"
   "dune" {>= "1.10"}
   "hex"

--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.0/opam
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.0/opam
@@ -20,7 +20,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.01.0"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "cohttp" {>= "0.12.0" & < "0.18.0"}
   "core_kernel" {< "v0.15"}
   "csv"

--- a/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/opam
+++ b/packages/sociaml-facebook-api/sociaml-facebook-api.0.4.1/opam
@@ -22,7 +22,7 @@ remove: [
 ]
 depends: [
   "ocaml" {= "4.02.1"}
-  "calendar"
+  "calendar" {>= "2.00"}
   "cohttp" {>= "0.18.0"}
   "core_kernel" {< "v0.15"}
   "csv"

--- a/packages/sociaml-tumblr-api/sociaml-tumblr-api.0.1.0/opam
+++ b/packages/sociaml-tumblr-api/sociaml-tumblr-api.0.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "tiny_json_conv"
   "uri"
   "csv"
-  "calendar"
+  "calendar" {>= "2.00"}
   "sociaml-oauth-client" {< "0.5.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/sociaml-tumblr-api/sociaml-tumblr-api.0.2.0/opam
+++ b/packages/sociaml-tumblr-api/sociaml-tumblr-api.0.2.0/opam
@@ -25,7 +25,7 @@ depends: [
   "tiny_json_conv"
   "uri"
   "csv"
-  "calendar"
+  "calendar" {>= "2.00"}
   "sociaml-oauth-client" {>= "0.5.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/soupault/soupault.1.10.0/opam
+++ b/packages/soupault/soupault.1.10.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ezjsonm"
   "containers"
   "stringext"
-  "calendar"
+  "calendar" {>= "2.00"}
   "spelll"
   "mustache"
   "tsort" {< "2.0.0"}

--- a/packages/soupault/soupault.1.11.0/opam
+++ b/packages/soupault/soupault.1.11.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ezjsonm"
   "containers"
   "stringext"
-  "calendar"
+  "calendar" {>= "2.00"}
   "spelll"
   "mustache"
   "tsort" {< "2.0.0"}

--- a/packages/soupault/soupault.1.12.0/opam
+++ b/packages/soupault/soupault.1.12.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ezjsonm"
   "containers"
   "stringext"
-  "calendar"
+  "calendar" {>= "2.00"}
   "spelll"
   "mustache"
   "tsort" {>= "2.0.0"}

--- a/packages/soupault/soupault.1.13.0/opam
+++ b/packages/soupault/soupault.1.13.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ezjsonm"
   "containers"
   "stringext"
-  "calendar"
+  "calendar" {>= "2.00"}
   "spelll"
   "mustache"
   "tsort" {>= "2.0.0"}

--- a/packages/soupault/soupault.1.6/opam
+++ b/packages/soupault/soupault.1.6/opam
@@ -30,7 +30,7 @@ depends: [
   "ocaml-monadic" {build & >= "0.4.0"}
   "containers"
   "stringext"
-  "calendar"
+  "calendar" {>= "2.00"}
   "spelll"
   "mustache"
   "tsort" {< "2.0.0"}

--- a/packages/soupault/soupault.1.7.0/opam
+++ b/packages/soupault/soupault.1.7.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ezjsonm"
   "containers"
   "stringext"
-  "calendar"
+  "calendar" {>= "2.00"}
   "spelll"
   "mustache"
   "tsort" {< "2.0.0"}

--- a/packages/soupault/soupault.1.8.0/opam
+++ b/packages/soupault/soupault.1.8.0/opam
@@ -36,7 +36,7 @@ depends: [
   "ezjsonm"
   "containers"
   "stringext"
-  "calendar"
+  "calendar" {>= "2.00"}
   "spelll"
   "mustache"
   "tsort" {< "2.0.0"}

--- a/packages/soupault/soupault.1.9.0/opam
+++ b/packages/soupault/soupault.1.9.0/opam
@@ -36,7 +36,7 @@ depends: [
   "ezjsonm"
   "containers"
   "stringext"
-  "calendar"
+  "calendar" {>= "2.00"}
   "spelll"
   "mustache"
   "tsort" {< "2.0.0"}

--- a/packages/soupault/soupault.2.0.0/opam
+++ b/packages/soupault/soupault.2.0.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ezjsonm"
   "containers"
   "stringext"
-  "calendar"
+  "calendar" {>= "2.00"}
   "spelll"
   "jingoo"
   "tsort" {>= "2.0.0"}

--- a/packages/soupault/soupault.2.1.0/opam
+++ b/packages/soupault/soupault.2.1.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ezjsonm"
   "containers"
   "stringext"
-  "calendar"
+  "calendar" {>= "2.00"}
   "spelll"
   "jingoo"
   "tsort" {>= "2.0.0"}


### PR DESCRIPTION
The old OCaml compilers are of interest to ~a few people~at least me and @herbelin (see #5260)! I recall noticing several years ago that 3.07 and 3.08 had stopped building on anything later than Ubuntu 14.04 (IIRC!), but my lazy solution on the very rare occasions that I've "needed" them is to fire up that old VM. It's been gradually spreading, though as gcc and, more relevantly, the linker have evolved. I can't visit actual care homes at the moment, so I spent a little time with some old compilers instead.

As always, the patches carried here are strictly ones required to build an old OCaml with a new C compiler. For 3.07-3.09, this necessitates back-porting the 3.09 addition of `-fPIC` to ocamlopt to 3.07 and 3.08 and the 3.10.0 adjustment to use it by default to all three of those.

- It turns out OCaml 3 is not affected by the `-fcommon` fix (I wasn't interested enough to check why!) so the patches in #16583 are extended to 4.00.0, 4.00.1 and 4.01.0
- `ocaml-base-compiler.3.11.2` contained an external reference to a patch on the OCamlPRO website which is no longer there. This patch is required for any modern binutils and so I've replaced it with the actual commit from the OCaml repo and extended it to 3.11.0 and 3.11.1
- `ocaml-config.1` has never worked on 3.07... I've simply inserted `ocaml-config.0` to handle the change in version number scheme 😂 Note that the change to `ocaml-config.1` will trigger a switch rebuild in opam 2.1 but because `ocaml-config` is a base package, it won't trigger that in opam 2.0. On that basis, I've amended its constraints, rather than a slightly more weird adjustment to `ocaml-base-compiler.3.07*/opam`.

If we're going to have these packages (and, even as we end up splitting opam-repository, they should still be kept) then we should periodically check that they still build. To that end, I've adjusted 3 packages:
- `ocamlfind.1.0.4` is the last version which supported 3.07, so adding it allows `ocamlfind` to be installed in _any_ ocaml switch
- `pcre.6.2.5` allows a library with C stubs to be installed in 3.08+
- `calendar.1.10` - at least at present - allows a single package at a single version to be installed on _all_ supported versions of OCaml

As usual, while touching `ocaml-base-compiler` packages and others, I've updated metadata.