### PR TITLE
Restore ARM64 support for 4.02-4.05

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/files/gpr1330.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/files/gpr1330.patch
@@ -1,0 +1,58 @@
+From 475c2dc0c7ae197772bfcdf0dd5a17ffc5d4fb3b Mon Sep 17 00:00:00 2001
+From: Mark Shinwell <mshinwell@gmail.com>
+Date: Wed, 13 Sep 2017 10:23:16 +0100
+Subject: [PATCH] AArch64 GOT fixed
+
+---
+ asmcomp/arm64/emit.mlp     | 12 ++++++++++--
+ asmcomp/arm64/selection.ml |  4 ++--
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/asmcomp/arm64/emit.mlp b/asmcomp/arm64/emit.mlp
+index 9cca60b26..6b9f0274a 100644
+--- a/asmcomp/arm64/emit.mlp
++++ b/asmcomp/arm64/emit.mlp
+@@ -325,7 +325,7 @@ let emit_literals() =
+ (* Emit code to load the address of a symbol *)
+ 
+ let emit_load_symbol_addr dst s =
+-  if (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit s then begin
++  if not !Clflags.dlcode then begin
+     `	adrp	{emit_reg dst}, {emit_symbol s}\n`;
+     `	add	{emit_reg dst}, {emit_reg dst}, #:lo12:{emit_symbol s}\n`
+   end else begin
+@@ -923,7 +923,15 @@ let fundecl fundecl =
+ 
+ let emit_item = function
+   | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
+-  | Cdefine_symbol s -> `{emit_symbol s}:\n`
++  | Cdefine_symbol s ->
++    if !Clflags.dlcode then begin
++      (* GOT relocations against non-global symbols don't seem to work
++         properly: GOT entries are not created for the symbols and the
++         relocations evaluate to random other GOT entries.  For the moment
++         force all symbols to be global. *)
++      `	.globl	{emit_symbol s}\n`;
++    end;
++    `{emit_symbol s}:\n`
+   | Cdefine_label lbl -> `{emit_data_label lbl}:\n`
+   | Cint8 n -> `	.byte	{emit_int n}\n`
+   | Cint16 n -> `	.short	{emit_int n}\n`
+diff --git a/asmcomp/arm64/selection.ml b/asmcomp/arm64/selection.ml
+index d7d55a938..849cd0896 100644
+--- a/asmcomp/arm64/selection.ml
++++ b/asmcomp/arm64/selection.ml
+@@ -84,8 +84,8 @@ let inline_ops =
+   [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
+     "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
+ 
+-let use_direct_addressing symb =
+-  (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit symb
++let use_direct_addressing _symb =
++  not !Clflags.dlcode
+ 
+ (* Instruction selection *)
+ 
+-- 
+2.17.1
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
@@ -43,6 +43,9 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz"
   checksum: "md5=8bba7e7d872083af1723dd450e07a5f4"
 }
-patches: ["fix-gcc10.patch"]
-extra-files: [ ["fix-gcc10.patch" "md5=91a4a258611302bc57f4d9fadb7fc14d"] ]
+patches: ["fix-gcc10.patch" "gpr1330.patch"]
+extra-files: [
+  ["fix-gcc10.patch" "md5=91a4a258611302bc57f4d9fadb7fc14d"]
+  ["gpr1330.patch" "md5=f6e2574d7b63d3de281f6c48984e2c71"]
+]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 4.02.0 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 depends: [
   "ocaml" {= "4.02.0" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/files/gpr1330.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/files/gpr1330.patch
@@ -1,0 +1,58 @@
+From 475c2dc0c7ae197772bfcdf0dd5a17ffc5d4fb3b Mon Sep 17 00:00:00 2001
+From: Mark Shinwell <mshinwell@gmail.com>
+Date: Wed, 13 Sep 2017 10:23:16 +0100
+Subject: [PATCH] AArch64 GOT fixed
+
+---
+ asmcomp/arm64/emit.mlp     | 12 ++++++++++--
+ asmcomp/arm64/selection.ml |  4 ++--
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/asmcomp/arm64/emit.mlp b/asmcomp/arm64/emit.mlp
+index 9cca60b26..6b9f0274a 100644
+--- a/asmcomp/arm64/emit.mlp
++++ b/asmcomp/arm64/emit.mlp
+@@ -325,7 +325,7 @@ let emit_literals() =
+ (* Emit code to load the address of a symbol *)
+ 
+ let emit_load_symbol_addr dst s =
+-  if (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit s then begin
++  if not !Clflags.dlcode then begin
+     `	adrp	{emit_reg dst}, {emit_symbol s}\n`;
+     `	add	{emit_reg dst}, {emit_reg dst}, #:lo12:{emit_symbol s}\n`
+   end else begin
+@@ -923,7 +923,15 @@ let fundecl fundecl =
+ 
+ let emit_item = function
+   | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
+-  | Cdefine_symbol s -> `{emit_symbol s}:\n`
++  | Cdefine_symbol s ->
++    if !Clflags.dlcode then begin
++      (* GOT relocations against non-global symbols don't seem to work
++         properly: GOT entries are not created for the symbols and the
++         relocations evaluate to random other GOT entries.  For the moment
++         force all symbols to be global. *)
++      `	.globl	{emit_symbol s}\n`;
++    end;
++    `{emit_symbol s}:\n`
+   | Cdefine_label lbl -> `{emit_data_label lbl}:\n`
+   | Cint8 n -> `	.byte	{emit_int n}\n`
+   | Cint16 n -> `	.short	{emit_int n}\n`
+diff --git a/asmcomp/arm64/selection.ml b/asmcomp/arm64/selection.ml
+index d7d55a938..849cd0896 100644
+--- a/asmcomp/arm64/selection.ml
++++ b/asmcomp/arm64/selection.ml
+@@ -84,8 +84,8 @@ let inline_ops =
+   [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
+     "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
+ 
+-let use_direct_addressing symb =
+-  (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit symb
++let use_direct_addressing _symb =
++  not !Clflags.dlcode
+ 
+ (* Instruction selection *)
+ 
+-- 
+2.17.1
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 4.02.1 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 depends: [
   "ocaml" {= "4.02.1" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
@@ -43,6 +43,9 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
   checksum: "md5=3c35318eefd201f96797c093c920b343"
 }
-patches: ["fix-gcc10.patch"]
-extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
+patches: ["fix-gcc10.patch" "gpr1330.patch"]
+extra-files: [
+  ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"]
+  ["gpr1330.patch" "md5=f6e2574d7b63d3de281f6c48984e2c71"]
+]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/files/gpr1330.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/files/gpr1330.patch
@@ -1,0 +1,58 @@
+From 475c2dc0c7ae197772bfcdf0dd5a17ffc5d4fb3b Mon Sep 17 00:00:00 2001
+From: Mark Shinwell <mshinwell@gmail.com>
+Date: Wed, 13 Sep 2017 10:23:16 +0100
+Subject: [PATCH] AArch64 GOT fixed
+
+---
+ asmcomp/arm64/emit.mlp     | 12 ++++++++++--
+ asmcomp/arm64/selection.ml |  4 ++--
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/asmcomp/arm64/emit.mlp b/asmcomp/arm64/emit.mlp
+index 9cca60b26..6b9f0274a 100644
+--- a/asmcomp/arm64/emit.mlp
++++ b/asmcomp/arm64/emit.mlp
+@@ -325,7 +325,7 @@ let emit_literals() =
+ (* Emit code to load the address of a symbol *)
+ 
+ let emit_load_symbol_addr dst s =
+-  if (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit s then begin
++  if not !Clflags.dlcode then begin
+     `	adrp	{emit_reg dst}, {emit_symbol s}\n`;
+     `	add	{emit_reg dst}, {emit_reg dst}, #:lo12:{emit_symbol s}\n`
+   end else begin
+@@ -923,7 +923,15 @@ let fundecl fundecl =
+ 
+ let emit_item = function
+   | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
+-  | Cdefine_symbol s -> `{emit_symbol s}:\n`
++  | Cdefine_symbol s ->
++    if !Clflags.dlcode then begin
++      (* GOT relocations against non-global symbols don't seem to work
++         properly: GOT entries are not created for the symbols and the
++         relocations evaluate to random other GOT entries.  For the moment
++         force all symbols to be global. *)
++      `	.globl	{emit_symbol s}\n`;
++    end;
++    `{emit_symbol s}:\n`
+   | Cdefine_label lbl -> `{emit_data_label lbl}:\n`
+   | Cint8 n -> `	.byte	{emit_int n}\n`
+   | Cint16 n -> `	.short	{emit_int n}\n`
+diff --git a/asmcomp/arm64/selection.ml b/asmcomp/arm64/selection.ml
+index d7d55a938..849cd0896 100644
+--- a/asmcomp/arm64/selection.ml
++++ b/asmcomp/arm64/selection.ml
+@@ -84,8 +84,8 @@ let inline_ops =
+   [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
+     "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
+ 
+-let use_direct_addressing symb =
+-  (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit symb
++let use_direct_addressing _symb =
++  not !Clflags.dlcode
+ 
+ (* Instruction selection *)
+ 
+-- 
+2.17.1
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 4.02.2 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 depends: [
   "ocaml" {= "4.02.2" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
@@ -43,6 +43,9 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.2.tar.gz"
   checksum: "md5=359ad0ef89717341767142f2a4d050b2"
 }
-patches: ["fix-gcc10.patch"]
-extra-files: [ ["fix-gcc10.patch" "md5=d40cd243f53876ba0b7e181ac16836a9"] ]
+patches: ["fix-gcc10.patch" "gpr1330.patch"]
+extra-files: [
+  ["fix-gcc10.patch" "md5=d40cd243f53876ba0b7e181ac16836a9"]
+  ["gpr1330.patch" "md5=f6e2574d7b63d3de281f6c48984e2c71"]
+]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/files/gpr1330.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/files/gpr1330.patch
@@ -1,0 +1,58 @@
+From 475c2dc0c7ae197772bfcdf0dd5a17ffc5d4fb3b Mon Sep 17 00:00:00 2001
+From: Mark Shinwell <mshinwell@gmail.com>
+Date: Wed, 13 Sep 2017 10:23:16 +0100
+Subject: [PATCH] AArch64 GOT fixed
+
+---
+ asmcomp/arm64/emit.mlp     | 12 ++++++++++--
+ asmcomp/arm64/selection.ml |  4 ++--
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/asmcomp/arm64/emit.mlp b/asmcomp/arm64/emit.mlp
+index 9cca60b26..6b9f0274a 100644
+--- a/asmcomp/arm64/emit.mlp
++++ b/asmcomp/arm64/emit.mlp
+@@ -325,7 +325,7 @@ let emit_literals() =
+ (* Emit code to load the address of a symbol *)
+ 
+ let emit_load_symbol_addr dst s =
+-  if (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit s then begin
++  if not !Clflags.dlcode then begin
+     `	adrp	{emit_reg dst}, {emit_symbol s}\n`;
+     `	add	{emit_reg dst}, {emit_reg dst}, #:lo12:{emit_symbol s}\n`
+   end else begin
+@@ -923,7 +923,15 @@ let fundecl fundecl =
+ 
+ let emit_item = function
+   | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
+-  | Cdefine_symbol s -> `{emit_symbol s}:\n`
++  | Cdefine_symbol s ->
++    if !Clflags.dlcode then begin
++      (* GOT relocations against non-global symbols don't seem to work
++         properly: GOT entries are not created for the symbols and the
++         relocations evaluate to random other GOT entries.  For the moment
++         force all symbols to be global. *)
++      `	.globl	{emit_symbol s}\n`;
++    end;
++    `{emit_symbol s}:\n`
+   | Cdefine_label lbl -> `{emit_data_label lbl}:\n`
+   | Cint8 n -> `	.byte	{emit_int n}\n`
+   | Cint16 n -> `	.short	{emit_int n}\n`
+diff --git a/asmcomp/arm64/selection.ml b/asmcomp/arm64/selection.ml
+index d7d55a938..849cd0896 100644
+--- a/asmcomp/arm64/selection.ml
++++ b/asmcomp/arm64/selection.ml
+@@ -84,8 +84,8 @@ let inline_ops =
+   [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
+     "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
+ 
+-let use_direct_addressing symb =
+-  (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit symb
++let use_direct_addressing _symb =
++  not !Clflags.dlcode
+ 
+ (* Instruction selection *)
+ 
+-- 
+2.17.1
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
@@ -42,6 +42,9 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
   checksum: "md5=ef1a324608c97031cbd92a442d685ab7"
 }
-patches: ["fix-gcc10.patch"]
-extra-files: [ ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"] ]
+patches: ["fix-gcc10.patch" "gpr1330.patch"]
+extra-files: [
+  ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"]
+  ["gpr1330.patch" "md5=f6e2574d7b63d3de281f6c48984e2c71"]
+]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 4.02.3 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 depends: [
   "ocaml" {= "4.02.3" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/files/gpr1330.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/files/gpr1330.patch
@@ -1,0 +1,58 @@
+From 475c2dc0c7ae197772bfcdf0dd5a17ffc5d4fb3b Mon Sep 17 00:00:00 2001
+From: Mark Shinwell <mshinwell@gmail.com>
+Date: Wed, 13 Sep 2017 10:23:16 +0100
+Subject: [PATCH] AArch64 GOT fixed
+
+---
+ asmcomp/arm64/emit.mlp     | 12 ++++++++++--
+ asmcomp/arm64/selection.ml |  4 ++--
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/asmcomp/arm64/emit.mlp b/asmcomp/arm64/emit.mlp
+index 9cca60b26..6b9f0274a 100644
+--- a/asmcomp/arm64/emit.mlp
++++ b/asmcomp/arm64/emit.mlp
+@@ -325,7 +325,7 @@ let emit_literals() =
+ (* Emit code to load the address of a symbol *)
+ 
+ let emit_load_symbol_addr dst s =
+-  if (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit s then begin
++  if not !Clflags.dlcode then begin
+     `	adrp	{emit_reg dst}, {emit_symbol s}\n`;
+     `	add	{emit_reg dst}, {emit_reg dst}, #:lo12:{emit_symbol s}\n`
+   end else begin
+@@ -923,7 +923,15 @@ let fundecl fundecl =
+ 
+ let emit_item = function
+   | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
+-  | Cdefine_symbol s -> `{emit_symbol s}:\n`
++  | Cdefine_symbol s ->
++    if !Clflags.dlcode then begin
++      (* GOT relocations against non-global symbols don't seem to work
++         properly: GOT entries are not created for the symbols and the
++         relocations evaluate to random other GOT entries.  For the moment
++         force all symbols to be global. *)
++      `	.globl	{emit_symbol s}\n`;
++    end;
++    `{emit_symbol s}:\n`
+   | Cdefine_label lbl -> `{emit_data_label lbl}:\n`
+   | Cint8 n -> `	.byte	{emit_int n}\n`
+   | Cint16 n -> `	.short	{emit_int n}\n`
+diff --git a/asmcomp/arm64/selection.ml b/asmcomp/arm64/selection.ml
+index d7d55a938..849cd0896 100644
+--- a/asmcomp/arm64/selection.ml
++++ b/asmcomp/arm64/selection.ml
+@@ -84,8 +84,8 @@ let inline_ops =
+   [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
+     "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
+ 
+-let use_direct_addressing symb =
+-  (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit symb
++let use_direct_addressing _symb =
++  not !Clflags.dlcode
+ 
+ (* Instruction selection *)
+ 
+-- 
+2.17.1
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 4.03.0 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.03"
 depends: [
   "ocaml" {= "4.03.0" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
@@ -42,6 +42,9 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz"
   checksum: "md5=4ddf4977de7708f11adad692c63e87ec"
 }
-patches: ["fix-gcc10.patch"]
-extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
+patches: ["fix-gcc10.patch" "gpr1330.patch"]
+extra-files: [
+  ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"]
+  ["gpr1330.patch" "md5=f6e2574d7b63d3de281f6c48984e2c71"]
+]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/files/gpr1330.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/files/gpr1330.patch
@@ -1,0 +1,58 @@
+From 978726fd2f3921bcfad9d54d7f8d1e6cb4621699 Mon Sep 17 00:00:00 2001
+From: Mark Shinwell <mshinwell@gmail.com>
+Date: Wed, 13 Sep 2017 10:23:16 +0100
+Subject: [PATCH] AArch64 GOT fixed
+
+---
+ asmcomp/arm64/emit.mlp     | 12 ++++++++++--
+ asmcomp/arm64/selection.ml |  4 ++--
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/asmcomp/arm64/emit.mlp b/asmcomp/arm64/emit.mlp
+index f75646e12..5e56600f7 100644
+--- a/asmcomp/arm64/emit.mlp
++++ b/asmcomp/arm64/emit.mlp
+@@ -323,7 +323,7 @@ let emit_literals() =
+ (* Emit code to load the address of a symbol *)
+ 
+ let emit_load_symbol_addr dst s =
+-  if (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit s then begin
++  if not !Clflags.dlcode then begin
+     `	adrp	{emit_reg dst}, {emit_symbol s}\n`;
+     `	add	{emit_reg dst}, {emit_reg dst}, #:lo12:{emit_symbol s}\n`
+   end else begin
+@@ -924,7 +924,15 @@ let fundecl fundecl =
+ 
+ let emit_item = function
+   | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
+-  | Cdefine_symbol s -> `{emit_symbol s}:\n`
++  | Cdefine_symbol s ->
++    if !Clflags.dlcode then begin
++      (* GOT relocations against non-global symbols don't seem to work
++         properly: GOT entries are not created for the symbols and the
++         relocations evaluate to random other GOT entries.  For the moment
++         force all symbols to be global. *)
++      `	.globl	{emit_symbol s}\n`;
++    end;
++    `{emit_symbol s}:\n`
+   | Cint8 n -> `	.byte	{emit_int n}\n`
+   | Cint16 n -> `	.short	{emit_int n}\n`
+   | Cint32 n -> `	.long	{emit_nativeint n}\n`
+diff --git a/asmcomp/arm64/selection.ml b/asmcomp/arm64/selection.ml
+index d8ea7f83b..b714d0032 100644
+--- a/asmcomp/arm64/selection.ml
++++ b/asmcomp/arm64/selection.ml
+@@ -82,8 +82,8 @@ let inline_ops =
+   [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
+     "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
+ 
+-let use_direct_addressing symb =
+-  (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit symb
++let use_direct_addressing _symb =
++  not !Clflags.dlcode
+ 
+ (* Instruction selection *)
+ 
+-- 
+2.17.1
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 4.04.0 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 depends: [
   "ocaml" {= "4.04.0" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
@@ -42,6 +42,9 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz"
   checksum: "md5=dbf5f869bf0621d2922547b671b36566"
 }
-patches: ["fix-gcc10.patch"]
-extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
+patches: ["fix-gcc10.patch" "gpr1330.patch"]
+extra-files: [
+  ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"]
+  ["gpr1330.patch" "md5=f3c23cc64175211d1b13a71560dc5a97"]
+]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/files/gpr1330.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/files/gpr1330.patch
@@ -1,0 +1,58 @@
+From 978726fd2f3921bcfad9d54d7f8d1e6cb4621699 Mon Sep 17 00:00:00 2001
+From: Mark Shinwell <mshinwell@gmail.com>
+Date: Wed, 13 Sep 2017 10:23:16 +0100
+Subject: [PATCH] AArch64 GOT fixed
+
+---
+ asmcomp/arm64/emit.mlp     | 12 ++++++++++--
+ asmcomp/arm64/selection.ml |  4 ++--
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/asmcomp/arm64/emit.mlp b/asmcomp/arm64/emit.mlp
+index f75646e12..5e56600f7 100644
+--- a/asmcomp/arm64/emit.mlp
++++ b/asmcomp/arm64/emit.mlp
+@@ -323,7 +323,7 @@ let emit_literals() =
+ (* Emit code to load the address of a symbol *)
+ 
+ let emit_load_symbol_addr dst s =
+-  if (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit s then begin
++  if not !Clflags.dlcode then begin
+     `	adrp	{emit_reg dst}, {emit_symbol s}\n`;
+     `	add	{emit_reg dst}, {emit_reg dst}, #:lo12:{emit_symbol s}\n`
+   end else begin
+@@ -924,7 +924,15 @@ let fundecl fundecl =
+ 
+ let emit_item = function
+   | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
+-  | Cdefine_symbol s -> `{emit_symbol s}:\n`
++  | Cdefine_symbol s ->
++    if !Clflags.dlcode then begin
++      (* GOT relocations against non-global symbols don't seem to work
++         properly: GOT entries are not created for the symbols and the
++         relocations evaluate to random other GOT entries.  For the moment
++         force all symbols to be global. *)
++      `	.globl	{emit_symbol s}\n`;
++    end;
++    `{emit_symbol s}:\n`
+   | Cint8 n -> `	.byte	{emit_int n}\n`
+   | Cint16 n -> `	.short	{emit_int n}\n`
+   | Cint32 n -> `	.long	{emit_nativeint n}\n`
+diff --git a/asmcomp/arm64/selection.ml b/asmcomp/arm64/selection.ml
+index d8ea7f83b..b714d0032 100644
+--- a/asmcomp/arm64/selection.ml
++++ b/asmcomp/arm64/selection.ml
+@@ -82,8 +82,8 @@ let inline_ops =
+   [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
+     "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
+ 
+-let use_direct_addressing symb =
+-  (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit symb
++let use_direct_addressing _symb =
++  not !Clflags.dlcode
+ 
+ (* Instruction selection *)
+ 
+-- 
+2.17.1
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
@@ -42,6 +42,9 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz"
   checksum: "md5=ca6f8d941c4c86c43cccb29ae2a9cd0e"
 }
-patches: ["fix-gcc10.patch"]
-extra-files: [ ["fix-gcc10.patch" "md5=c59d1ac3de4c892f4aa74d8d1112de00"] ]
+patches: ["fix-gcc10.patch" "gpr1330.patch"]
+extra-files: [
+  ["fix-gcc10.patch" "md5=c59d1ac3de4c892f4aa74d8d1112de00"]
+  ["gpr1330.patch" "md5=f3c23cc64175211d1b13a71560dc5a97"]
+]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 4.04.1 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 depends: [
   "ocaml" {= "4.04.1" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/files/gpr1330.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/files/gpr1330.patch
@@ -1,0 +1,58 @@
+From 978726fd2f3921bcfad9d54d7f8d1e6cb4621699 Mon Sep 17 00:00:00 2001
+From: Mark Shinwell <mshinwell@gmail.com>
+Date: Wed, 13 Sep 2017 10:23:16 +0100
+Subject: [PATCH] AArch64 GOT fixed
+
+---
+ asmcomp/arm64/emit.mlp     | 12 ++++++++++--
+ asmcomp/arm64/selection.ml |  4 ++--
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/asmcomp/arm64/emit.mlp b/asmcomp/arm64/emit.mlp
+index f75646e12..5e56600f7 100644
+--- a/asmcomp/arm64/emit.mlp
++++ b/asmcomp/arm64/emit.mlp
+@@ -323,7 +323,7 @@ let emit_literals() =
+ (* Emit code to load the address of a symbol *)
+ 
+ let emit_load_symbol_addr dst s =
+-  if (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit s then begin
++  if not !Clflags.dlcode then begin
+     `	adrp	{emit_reg dst}, {emit_symbol s}\n`;
+     `	add	{emit_reg dst}, {emit_reg dst}, #:lo12:{emit_symbol s}\n`
+   end else begin
+@@ -924,7 +924,15 @@ let fundecl fundecl =
+ 
+ let emit_item = function
+   | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
+-  | Cdefine_symbol s -> `{emit_symbol s}:\n`
++  | Cdefine_symbol s ->
++    if !Clflags.dlcode then begin
++      (* GOT relocations against non-global symbols don't seem to work
++         properly: GOT entries are not created for the symbols and the
++         relocations evaluate to random other GOT entries.  For the moment
++         force all symbols to be global. *)
++      `	.globl	{emit_symbol s}\n`;
++    end;
++    `{emit_symbol s}:\n`
+   | Cint8 n -> `	.byte	{emit_int n}\n`
+   | Cint16 n -> `	.short	{emit_int n}\n`
+   | Cint32 n -> `	.long	{emit_nativeint n}\n`
+diff --git a/asmcomp/arm64/selection.ml b/asmcomp/arm64/selection.ml
+index d8ea7f83b..b714d0032 100644
+--- a/asmcomp/arm64/selection.ml
++++ b/asmcomp/arm64/selection.ml
+@@ -82,8 +82,8 @@ let inline_ops =
+   [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
+     "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
+ 
+-let use_direct_addressing symb =
+-  (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit symb
++let use_direct_addressing _symb =
++  not !Clflags.dlcode
+ 
+ (* Instruction selection *)
+ 
+-- 
+2.17.1
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
@@ -42,6 +42,9 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.04.2.tar.gz"
   checksum: "md5=5ce661a2d8b760dc77c2facf46ccddd1"
 }
-patches: ["fix-gcc10.patch"]
-extra-files: [ ["fix-gcc10.patch" "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"] ]
+patches: ["fix-gcc10.patch" "gpr1330.patch"]
+extra-files: [
+  ["fix-gcc10.patch" "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"]
+  ["gpr1330.patch" "md5=f3c23cc64175211d1b13a71560dc5a97"]
+]
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 4.04.2 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 depends: [
   "ocaml" {= "4.04.2" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/files/gpr1330.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/files/gpr1330.patch
@@ -1,0 +1,58 @@
+From 978726fd2f3921bcfad9d54d7f8d1e6cb4621699 Mon Sep 17 00:00:00 2001
+From: Mark Shinwell <mshinwell@gmail.com>
+Date: Wed, 13 Sep 2017 10:23:16 +0100
+Subject: [PATCH] AArch64 GOT fixed
+
+---
+ asmcomp/arm64/emit.mlp     | 12 ++++++++++--
+ asmcomp/arm64/selection.ml |  4 ++--
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/asmcomp/arm64/emit.mlp b/asmcomp/arm64/emit.mlp
+index f75646e12..5e56600f7 100644
+--- a/asmcomp/arm64/emit.mlp
++++ b/asmcomp/arm64/emit.mlp
+@@ -323,7 +323,7 @@ let emit_literals() =
+ (* Emit code to load the address of a symbol *)
+ 
+ let emit_load_symbol_addr dst s =
+-  if (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit s then begin
++  if not !Clflags.dlcode then begin
+     `	adrp	{emit_reg dst}, {emit_symbol s}\n`;
+     `	add	{emit_reg dst}, {emit_reg dst}, #:lo12:{emit_symbol s}\n`
+   end else begin
+@@ -924,7 +924,15 @@ let fundecl fundecl =
+ 
+ let emit_item = function
+   | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
+-  | Cdefine_symbol s -> `{emit_symbol s}:\n`
++  | Cdefine_symbol s ->
++    if !Clflags.dlcode then begin
++      (* GOT relocations against non-global symbols don't seem to work
++         properly: GOT entries are not created for the symbols and the
++         relocations evaluate to random other GOT entries.  For the moment
++         force all symbols to be global. *)
++      `	.globl	{emit_symbol s}\n`;
++    end;
++    `{emit_symbol s}:\n`
+   | Cint8 n -> `	.byte	{emit_int n}\n`
+   | Cint16 n -> `	.short	{emit_int n}\n`
+   | Cint32 n -> `	.long	{emit_nativeint n}\n`
+diff --git a/asmcomp/arm64/selection.ml b/asmcomp/arm64/selection.ml
+index d8ea7f83b..b714d0032 100644
+--- a/asmcomp/arm64/selection.ml
++++ b/asmcomp/arm64/selection.ml
+@@ -82,8 +82,8 @@ let inline_ops =
+   [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
+     "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
+ 
+-let use_direct_addressing symb =
+-  (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit symb
++let use_direct_addressing _symb =
++  not !Clflags.dlcode
+ 
+ (* Instruction selection *)
+ 
+-- 
+2.17.1
+

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 synopsis: "Official 4.05.0 release"
 maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 depends: [
   "ocaml" {= "4.05.0" & post}
   "base-unix" {post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
@@ -42,6 +42,9 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.05.0.tar.gz"
   checksum: "md5=7e0079162134336a24b9028349c756bb"
 }
-patches: ["fix-gcc10.patch"]
-extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
+patches: ["fix-gcc10.patch" "gpr1330.patch"]
+extra-files: [
+  ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"]
+  ["gpr1330.patch" "md5=f3c23cc64175211d1b13a71560dc5a97"]
+]
 available: !(os = "macos" & arch = "arm64")


### PR DESCRIPTION
Further to https://github.com/ocaml/opam-repository/pull/18240#issuecomment-788052388

I haven't constrained the patches at all, as they only apply to files in the ARM64 backend.