### PR TITLE
[new release] hxd (0.3.0)

### DIFF
--- a/packages/colombe/colombe.0.1.0/opam
+++ b/packages/colombe/colombe.0.1.0/opam
@@ -24,7 +24,7 @@ depends: [
   "logs"
   "base64"
   "rresult"
-  "hxd"
+  "hxd" {< "0.3.0"}
   "domain-name" {>= "0.2.1"}
   "alcotest" {with-test & < "1.0.0"}
   "crowbar" {with-test}

--- a/packages/decompress/decompress.1.0.0/opam
+++ b/packages/decompress/decompress.1.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "checkseum"   {>= "0.1.1"}
   "bigstringaf" {with-test}
   "alcotest"    {with-test}
-  "hxd"         {with-test}
+  "hxd"         {with-test & < "0.3.0"}
   "fmt"
 ]
 url {

--- a/packages/decompress/decompress.1.1.0/opam
+++ b/packages/decompress/decompress.1.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "checkseum"   {>= "0.2.0"}
   "bigstringaf" {with-test}
   "alcotest"    {with-test}
-  "hxd"         {with-test}
+  "hxd"         {with-test & < "0.3.0"}
   "camlzip"     {>= "1.10" & with-test}
   "base64"      {>= "3.0.0" & with-test}
 ]

--- a/packages/decompress/decompress.1.2.0/opam
+++ b/packages/decompress/decompress.1.2.0/opam
@@ -25,7 +25,7 @@ depends: [
   "checkseum"   {>= "0.2.0"}
   "bigstringaf" {with-test}
   "alcotest"    {with-test}
-  "hxd"         {with-test}
+  "hxd"         {with-test & < "0.3.0"}
   "camlzip"     {>= "1.10" & with-test}
   "base64"      {>= "3.0.0" & with-test}
 ]

--- a/packages/duff/duff.0.3/opam
+++ b/packages/duff/duff.0.3/opam
@@ -26,7 +26,7 @@ depends: [
   "stdlib-shims"
   "alcotest"    {with-test}
   "bigstringaf" {with-test}
-  "hxd"         {with-test}
+  "hxd"         {with-test & < "0.3.0"}
   "crowbar"     {with-test}
 ]
 

--- a/packages/hxd/hxd.0.3.0/opam
+++ b/packages/hxd/hxd.0.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/hxd"
+bug-reports:  "https://github.com/dinosaure/hxd/issues"
+dev-repo:     "git+https://github.com/dinosaure/hxd.git"
+doc:          "https://dinosaure.github.io/hxd/"
+license:      "MIT"
+synopsis:     "Hexdump in OCaml"
+description: """Please, help me to debug ocaml-git
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.06.0"}
+  "dune"              {>= "2.0"}
+  "dune-configurator" {>= "2.0.1"}
+  "cmdliner"
+]
+
+depopts: [
+  "lwt"
+]
+x-commit-hash: "af93473a18700b26b2081662c4cb5df420c2a3a5"
+url {
+  src:
+    "https://github.com/dinosaure/hxd/releases/download/v0.3.0/hxd-v0.3.0.tbz"
+  checksum: [
+    "sha256=238b86af6cb7c540b08f9da436cedafc07677e4c6492b7ba9bf5892a55a862a2"
+    "sha512=55e9e149460d26fe62b7fee21c0c905d0f1efa89f0c48cc9098d20614b96315cdbfeb3305db3894c52e1d745901c9e049ba0d8c07da501e5e627630f1b972910"
+  ]
+}

--- a/packages/hxd/hxd.0.3.0/opam
+++ b/packages/hxd/hxd.0.3.0/opam
@@ -17,8 +17,8 @@ build: [
 
 depends: [
   "ocaml"             {>= "4.06.0"}
-  "dune"              {>= "2.0"}
-  "dune-configurator" {>= "2.0.1"}
+  "dune"              {>= "2.7"}
+  "dune-configurator" {>= "2.7"}
   "cmdliner"
 ]
 

--- a/packages/mrmime/mrmime.0.1.0/opam
+++ b/packages/mrmime/mrmime.0.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "pecu" {>= "0.3" & < "0.5"}
   "rresult"
   "fmt"
-  "hxd" {with-test}
+  "hxd" {with-test & < "0.3.0"}
   "angstrom" {>= "0.11.0" & < "0.14.0"}
   "alcotest" {with-test & < "1.0.0"}
   "jsonm" {with-test}

--- a/packages/mrmime/mrmime.0.3.0/opam
+++ b/packages/mrmime/mrmime.0.3.0/opam
@@ -32,7 +32,7 @@ depends: [
   "bigarray-compat"
   "bigarray-overlap" {>= "0.2.0"}
   "angstrom"         {>= "0.14.0"}
-  "hxd"              {with-test}
+  "hxd"              {with-test & < "0.3.0"}
   "alcotest"         {with-test}
   "jsonm"            {with-test}
 ]

--- a/packages/mrmime/mrmime.0.3.1/opam
+++ b/packages/mrmime/mrmime.0.3.1/opam
@@ -32,7 +32,7 @@ depends: [
   "bigarray-compat"
   "bigarray-overlap" {>= "0.2.0"}
   "angstrom"         {>= "0.14.0"}
-  "hxd"              {with-test}
+  "hxd"              {with-test & < "0.3.0"}
   "alcotest"         {with-test}
   "jsonm"            {with-test}
 ]

--- a/packages/mrmime/mrmime.0.3.2/opam
+++ b/packages/mrmime/mrmime.0.3.2/opam
@@ -32,7 +32,7 @@ depends: [
   "bigarray-compat"
   "bigarray-overlap" {>= "0.2.0"}
   "angstrom"         {>= "0.14.0"}
-  "hxd"              {with-test}
+  "hxd"              {with-test & < "0.3.0"}
   "alcotest"         {with-test}
   "jsonm"            {with-test}
 ]

--- a/packages/paf/paf.0.0.1/opam
+++ b/packages/paf/paf.0.0.1/opam
@@ -24,7 +24,7 @@ depends: [
   "mimic"
   "cohttp-lwt"
   "letsencrypt"
-  "emile"
+  "emile"             {>= "1.0"}
   "ke"                {>= "0.4"}
   "lwt"               {with-test}
   "base-unix"         {with-test}

--- a/packages/piaf/piaf.0.1.0/opam
+++ b/packages/piaf/piaf.0.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "conf-libssl"
   "ssl" {>= "0.5.10"}
   "lwt_ssl"
-  "mrmime"
+  "mrmime" {>= "0.3.2"}
   "pecu"
   "psq"
   "uri"

--- a/packages/unstrctrd/unstrctrd.0.2/opam
+++ b/packages/unstrctrd/unstrctrd.0.2/opam
@@ -23,7 +23,7 @@ depends: [
   "alcotest"    {with-test}
   "ke"          {with-test}
   "bigstringaf" {with-test}
-  "hxd"         {with-test}
+  "hxd"         {with-test & < "0.3.0"}
   "fmt"         {with-test}
 ]
 url {


### PR DESCRIPTION
Hexdump in OCaml

- Project page: <a href="https://github.com/dinosaure/hxd">https://github.com/dinosaure/hxd</a>
- Documentation: <a href="https://dinosaure.github.io/hxd/">https://dinosaure.github.io/hxd/</a>

##### CHANGES:

- Add LICENSE.md
- Keep compatibility with 4.06
- Big improvement on the produced tool
- Lint dependencies
