### PR TITLE
Backport the fix for GCC 10 to ocaml-base-compiler 4.09.0

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/files/fix-gcc10.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/files/fix-gcc10.patch
@@ -1,0 +1,34 @@
+commit 3f10a16153308f967149917585d2bc0b9c06492c
+Author: Anil Madhavapeddy <anil@recoil.org>
+Date:   Sun Jun 21 18:40:27 2020 +0100
+
+    Add `-fcommon` unconditionally to CFLAGS to fix gcc10 build
+    
+    Signed-off-by: Anil Madhavapeddy <anil@recoil.org>
+
+diff --git a/configure b/configure
+index 9a78a4554..0c54b560b 100755
+--- a/configure
++++ b/configure
+@@ -12412,7 +12412,7 @@ $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
+ -fno-builtin-memcmp";
+       internal_cflags="$gcc_warnings" ;; #(
+   gcc-*) :
+-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++    common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+       internal_cflags="$gcc_warnings" ;; #(
+   msvc-*) :
+     common_cflags="-nologo -O2 -Gy- -MD"
+diff --git a/configure.ac b/configure.ac
+index f5d8a2687..775e0e2db 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -540,7 +540,7 @@ AS_CASE([$host],
+ -fno-builtin-memcmp";
+       internal_cflags="$gcc_warnings"],
+     [gcc-*],
+-      [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
++      [common_cflags="-O2 -fno-strict-aliasing -fwrapv -fcommon";
+       internal_cflags="$gcc_warnings"],
+     [msvc-*],
+       [common_cflags="-nologo -O2 -Gy- -MD"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
@@ -30,7 +30,11 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.09.0.tar.gz"
   checksum: "md5=76ac39570fc88b16fda2a94db7cd5cf3"
 }
-extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+patches: ["fix-gcc10.patch"]
+extra-files: [
+  ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"]
+  ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).


### PR DESCRIPTION
It seems that https://github.com/ocaml/opam-repository/pull/16583 missed 4.09.0 (one minor version below the official fix)

Should fix #18250 