### PR TITLE
[new release] rfc1951 and decompress (1.3.0)

### DIFF
--- a/packages/albatross/albatross.1.1.0/opam
+++ b/packages/albatross/albatross.1.1.0/opam
@@ -30,7 +30,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "asn1-combinators" {>= "0.2.0"}
   "duration"
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "bigstringaf"
   "checkseum"
   "metrics" {>= "0.2.0"}

--- a/packages/carton-git/carton-git.0.1.0/opam
+++ b/packages/carton-git/carton-git.0.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mmap"
   "fmt" {>= "0.8.7"}
   "base-unix"
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0" }
   "astring" {>= "0.8.5"}
   "alcotest" {>= "1.2.3" & with-test}
   "alcotest-lwt" {>= "1.2.3" & with-test}

--- a/packages/carton-git/carton-git.0.2.0/opam
+++ b/packages/carton-git/carton-git.0.2.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mmap"
   "fmt" {>= "0.8.7"}
   "base-unix"
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "astring" {>= "0.8.5"}
   "alcotest" {>= "1.2.3" & with-test}
   "alcotest-lwt" {>= "1.2.3" & with-test}

--- a/packages/carton-lwt/carton-lwt.0.1.0/opam
+++ b/packages/carton-lwt/carton-lwt.0.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.6.0"}
   "carton" {= version}
   "lwt"
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "optint" {>= "0.0.4"}
   "bigstringaf"
   "alcotest" {>= "1.2.3" & with-test}

--- a/packages/carton-lwt/carton-lwt.0.2.0/opam
+++ b/packages/carton-lwt/carton-lwt.0.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.6.0"}
   "carton" {= version}
   "lwt"
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "optint" {>= "0.0.4"}
   "bigstringaf"
   "bigarray-compat" {with-test}

--- a/packages/carton/carton.0.1.0/opam
+++ b/packages/carton/carton.0.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.6.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "cstruct" {>= "5.0.0"}
   "optint" {>= "0.0.4"}
   "bigstringaf"

--- a/packages/carton/carton.0.2.0/opam
+++ b/packages/carton/carton.0.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.6.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "cstruct" {>= "5.0.0"}
   "optint" {>= "0.0.4"}
   "bigstringaf"

--- a/packages/decompress/decompress.1.3.0/opam
+++ b/packages/decompress/decompress.1.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "base-bytes"
+  "bigarray-compat"
+  "cmdliner"
+  "optint"      {>= "0.0.4"}
+  "checkseum"   {>= "0.2.0"}
+  "bigstringaf" {with-test}
+  "alcotest"    {with-test}
+  "ctypes"      {with-test & >= "0.18.0"}
+  "fmt"         {with-test}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+]
+x-commit-hash: "78635883950afd9c1b0b84977fda07301a07679a"
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.3.0/decompress-v1.3.0.tbz"
+  checksum: [
+    "sha256=de149896939be13fedec46a4581121d5ab74850a2241d08e6aa8ae4bb18c52c4"
+    "sha512=324b4c2daef6ddaae2d28edcdadec8e29ebcc408eed2fed3fe4a3cb298cd78864d9ac939ae794c6ff8d9f5233a7cfa6feee62aa683ed3eb73f53ab8ea74cbffb"
+  ]
+}

--- a/packages/git-unix/git-unix.3.0.0/opam
+++ b/packages/git-unix/git-unix.3.0.0/opam
@@ -34,7 +34,7 @@ depends: [
   "awa"
   "cmdliner" {>= "1.0.4"}
   "cohttp-lwt-unix" {>= "2.5.4"}
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "5.0.1"}
   "mtime" {>= "1.2.0"}

--- a/packages/git-unix/git-unix.3.1.1/opam
+++ b/packages/git-unix/git-unix.3.1.1/opam
@@ -34,7 +34,7 @@ depends: [
   "awa"
   "cmdliner" {>= "1.0.4"}
   "cohttp-lwt-unix" {>= "2.5.4"}
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "5.0.1"}
   "mtime" {>= "1.2.0"}

--- a/packages/git-unix/git-unix.3.2.0/opam
+++ b/packages/git-unix/git-unix.3.2.0/opam
@@ -33,7 +33,7 @@ depends: [
   "awa"
   "cmdliner" {>= "1.0.4"}
   "cohttp-lwt-unix" {>= "2.5.4"}
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "5.0.1"}
   "mtime" {>= "1.2.0"}

--- a/packages/git-unix/git-unix.3.3.0/opam
+++ b/packages/git-unix/git-unix.3.3.0/opam
@@ -33,7 +33,7 @@ depends: [
   "awa"
   "cmdliner" {>= "1.0.4"}
   "cohttp-lwt-unix" {>= "2.5.4"}
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "5.0.1"}
   "mtime" {>= "1.2.0"}

--- a/packages/git/git.3.1.1/opam
+++ b/packages/git/git.3.1.1/opam
@@ -24,7 +24,7 @@ depends: [
   "bigarray-compat"
   "bigstringaf"
   "optint"
-  "decompress"
+  "decompress" {< "1.3.0"}
   "logs"
   "lwt"
   "mimic"

--- a/packages/git/git.3.2.0/opam
+++ b/packages/git/git.3.2.0/opam
@@ -23,7 +23,7 @@ depends: [
   "bigstringaf"
   "bigarray-compat"
   "optint"
-  "decompress"
+  "decompress" {< "1.3.0"}
   "logs"
   "lwt"
   "mimic"

--- a/packages/git/git.3.3.0/opam
+++ b/packages/git/git.3.3.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bigstringaf"
   "bigarray-compat"
   "optint"
-  "decompress"
+  "decompress" {< "1.3.0"}
   "logs"
   "lwt"
   "mimic"

--- a/packages/imagelib/imagelib.20200929/opam
+++ b/packages/imagelib/imagelib.20200929/opam
@@ -35,7 +35,7 @@ depends: [
   "ocaml"        { >= "4.07.0" }
   "base-unix"
   "dune"         { >= "2.3.0"  }
-  "decompress"   { >= "1.2.0" }
+  "decompress"   { >= "1.2.0" & < "1.3.0" }
   "stdlib-shims"
   "alcotest"     { with-test }
 ]

--- a/packages/imagelib/imagelib.20210116/opam
+++ b/packages/imagelib/imagelib.20210116/opam
@@ -35,7 +35,7 @@ depends: [
   "ocaml"        { >= "4.07.0" }
   "base-unix"
   "dune"         { >= "2.3.0"  }
-  "decompress"   { >= "1.2.0" }
+  "decompress"   { >= "1.2.0" & < "1.3.0" }
   "stdlib-shims"
   "alcotest"     { with-test }
 ]

--- a/packages/rfc1951/rfc1951.1.3.0/opam
+++ b/packages/rfc1951/rfc1951.1.3.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "dune"       {>= "1.0"}
+  "decompress" {= version}
+  "bigarray-compat"
+  "checkseum"
+  "optint"
+  "ctypes"     {with-test & >= "0.18.0"}
+]
+x-commit-hash: "78635883950afd9c1b0b84977fda07301a07679a"
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.3.0/decompress-v1.3.0.tbz"
+  checksum: [
+    "sha256=de149896939be13fedec46a4581121d5ab74850a2241d08e6aa8ae4bb18c52c4"
+    "sha512=324b4c2daef6ddaae2d28edcdadec8e29ebcc408eed2fed3fe4a3cb298cd78864d9ac939ae794c6ff8d9f5233a7cfa6feee62aa683ed3eb73f53ab8ea74cbffb"
+  ]
+}

--- a/packages/rfc1951/rfc1951.1.3.0/opam
+++ b/packages/rfc1951/rfc1951.1.3.0/opam
@@ -17,11 +17,11 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"      {>= "4.07.0"}
-  "dune"       {>= "1.0"}
+  "dune"       {>= "2.8"}
   "decompress" {= version}
   "bigarray-compat"
-  "checkseum"
-  "optint"
+  "checkseum"  {>= "0.2.0"}
+  "optint"     {>= "0.0.4"}
   "ctypes"     {with-test & >= "0.18.0"}
 ]
 x-commit-hash: "78635883950afd9c1b0b84977fda07301a07679a"


### PR DESCRIPTION
Implementation of RFC1951 in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- Add a little executable to benchmark inflation into the distribution (@dinosaure, mirage/decompress#93)
- Add instructions for running benchmark (@gs0510, mirage/decompress#94)
- Clarify the description (@XVilka, mirage/decompress#96)
- Improve the benchmark and outputs (@dinosaure, @gs0510, mirage/decompress#95)
- Avoid allocation of distance table (@Engil, @dinosaure, mirage/decompress#97)
- Swapping from arithmetic to logical bitshifts on `d.hold` (@clecat, mirage/decompress#99)
- Make the use of all `Higher.compress` arguments (@vect0r-vicall, mirage/decompress#103)
- Apply ocamlformat.0.16.0 (@dinosaure, mirage/decompress#105, mirage/decompress#107)
- Improve Lz77 algorithms (@dinosaure, mirage/decompress#108)
  **breaking changes** the deflation expects a new window: `De.Lz77.make_window`
  instead of `De.make_window` (which is twice larger to improve the compression
  algorithm)

  Depending on the level and your corpus, we did not observe performance
  regression on deflation (and mirage/decompress#97 improves a lot performances). An higher level
  is slower (but the compression ratio is better). We advise, by default, to use
  the level 6.

  Note that the user is able to make its own compression algorithm according to
  his corpus. An example of such implementation is available on the new
  `decompress.lz` libraries which fills a queue and compress the input.

  **breaking changes** decompress expects a level between 0 and 9 (inclusive)
  (instead of 0 and 3).
- Add tests about level compression (@dinosaure, mirage/decompress#109)
- Add level on GZip layer (@dinosaure, mirage/decompress#110)
- Provide a `ctypes` reverse binding (@dinosaure, mirage/decompress#98)
- Provide a binary `decompress.pipe` which can compress/uncompress with
  deflate, zlib or gzip format.
