### PR TITLE
add an ocaml-options-only-nnpchecker package

### DIFF
--- a/packages/ocaml-options-only-nnpchecker/ocaml-options-only-nnpchecker.1/opam
+++ b/packages/ocaml-options-only-nnpchecker/ocaml-options-only-nnpchecker.1/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+synopsis: "Ensure that OCaml is compiled with enable-naked-pointers-checker, and no other custom options"
+depends: ["ocaml-option-nnpchecker"]
+conflicts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-spacetime"
+  "ocaml-option-static"
+  "ocaml-option-nnp"
+]
+maintainer: "platform@lists.ocaml.org"
+flags: compiler


### PR DESCRIPTION
Strictly speaking we shouldn't need this package, since a package
should never conflict with nnp-checker (only with nnp).

However, this makes life easier for CI running the nnp checker,
since we want to avoid any situation where something might trigger
a base compiler changing under our feet to turn off nnp.

Follows up https://github.com/ocurrent/opam-repo-ci/pull/79