### PR TITLE
Fix zarith compilation on arm64 homebrew

### DIFF
--- a/packages/zarith/zarith.1.12/opam
+++ b/packages/zarith/zarith.1.12/opam
@@ -19,7 +19,17 @@ build: [
     "sh"
     "-exc"
     "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"
-  ] {os = "macos"}
+  ] {os = "macos" & os-distribution != "homebrew"}
+  [
+    "sh"
+    "-exc"
+    "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"
+  ] {os = "macos" & os-distribution = "homebrew" & arch = "x86_64" }
+  [
+    "sh"
+    "-exc"
+    "LDFLAGS=\"$LDFLAGS -L/opt/homebrew/lib\" CFLAGS=\"$CFLAGS -I/opt/homebrew/include\" ./configure"
+  ] {os = "macos" & os-distribution = "homebrew" & arch = "arm64" }
   [make]
 ]
 install: [


### PR DESCRIPTION
Homebrew installs in /opt/homebrew by default on arm64.
This logic would ideally be baked into a configure script somewhere,
but for now it unblocks Zarith installation using opam on Mac M1s.