### PR TITLE
gmp-freestanding 6.2.1

### DIFF
--- a/packages/gmp-freestanding/gmp-freestanding.6.2.1/files/gmp-freestanding.pc
+++ b/packages/gmp-freestanding/gmp-freestanding.6.2.1/files/gmp-freestanding.pc
@@ -1,0 +1,9 @@
+libdir=${pcfiledir}/../gmp-freestanding
+includedir=${libdir}/include
+
+Name: gmp-freestanding
+Version: 6.2.1
+URL: https://gmplib.org
+Description: The GNU Multiple Precision Arithmetic Library
+Cflags: -I${includedir}
+Libs: -L${libdir} -lgmp-freestanding

--- a/packages/gmp-freestanding/gmp-freestanding.6.2.1/files/mirage-build.sh
+++ b/packages/gmp-freestanding/gmp-freestanding.6.2.1/files/mirage-build.sh
@@ -1,0 +1,43 @@
+#!/bin/sh -ex
+if [ -z "$PREFIX" ]; then
+	PREFIX="`opam config var prefix`/lib/gmp-freestanding"
+fi
+
+PKG_CONFIG_DEPS="ocaml-freestanding"
+check_deps () {
+  pkg-config --print-errors --exists ${PKG_CONFIG_DEPS}
+}
+
+if ! check_deps 2>/dev/null; then
+  # rely on `opam` if deps are unavailable
+  export PKG_CONFIG_PATH="`opam config var prefix`/lib/pkgconfig"
+fi
+check_deps || exit 1
+
+#
+# ocaml-freestanding does not provide a real cross compiler, so we fake it:
+# 
+# - set CC to stop configure trying to find a host compiler
+# - set CPPFLAGS to ocaml-freestanding CFLAGS, this prevents inclusion of
+#   system headers
+# - manually override tests for missing functions
+# - manually trim the components (SUBDIRS) of libgmp we build to the subset
+#   actually used by zarith-freestanding (our sole dependency)
+# - set -Werror=implicit-function-declaration at *build* time to catch any
+#   undefined symbols
+#
+# Further, with the introduction of -fstack-protector-strong in Solo5, override
+# this during './configure' to prevent it complaining that the compiler does not
+# work, and reinstate it again during 'make'.
+#
+FREESTANDING_CFLAGS="$(pkg-config --cflags ${PKG_CONFIG_DEPS})"
+ac_cv_func_obstack_vprintf=no \
+ac_cv_func_localeconv=no \
+./configure \
+    --host=$(uname -m)-unknown-none --enable-fat --disable-shared --with-pic=no \
+    CC=cc "CPPFLAGS=${FREESTANDING_CFLAGS} -fno-stack-protector"
+
+make SUBDIRS="mpn mpz mpq mpf" \
+    PRINTF_OBJECTS= SCANF_OBJECTS= \
+    CPPFLAGS="${FREESTANDING_CFLAGS}" \
+    CFLAGS+=-Werror=implicit-function-declaration

--- a/packages/gmp-freestanding/gmp-freestanding.6.2.1/files/mirage-install.sh
+++ b/packages/gmp-freestanding/gmp-freestanding.6.2.1/files/mirage-install.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -ex
+if [ -z "$PREFIX" ]; then
+	PREFIX=`opam config var prefix`
+fi
+PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
+LIBDIR=${PREFIX}/lib/gmp-freestanding
+
+mkdir -p ${PKG_CONFIG_PATH}
+cp gmp-freestanding.pc ${PKG_CONFIG_PATH}
+mkdir -p ${LIBDIR}
+cp .libs/libgmp.a ${LIBDIR}/libgmp-freestanding.a
+touch ${LIBDIR}/META
+mkdir -p ${LIBDIR}/include
+cp gmp.h ${LIBDIR}/include

--- a/packages/gmp-freestanding/gmp-freestanding.6.2.1/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.2.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "Martin Lucina <martin@lucina.net>"
+homepage:     "https://gmplib.org/"
+license:      ["LGPL-3.0-only" "LGPL-2.0-only"]
+authors:      "Torbjörn Granlund and contributors"
+bug-reports:  "mirageos-devel@lists.xenproject.org"
+
+build:   ["sh" "-ex" "./mirage-build.sh"]
+install: ["sh" "-ex" "./mirage-install.sh"]
+remove: [
+  "rm" "-rf"
+    "%{prefix}%/lib/pkgconfig/gmp-freestanding.pc"
+    "%{prefix}%/lib/gmp-freestanding"
+]
+depends: [
+  "ocaml"
+  "ocaml-freestanding" {>= "0.4.1"}
+]
+synopsis: "The GNU Multiple Precision Arithmetic Library"
+description: "Freestanding build of GNU GMP."
+flags: light-uninstall
+extra-files: [
+  ["mirage-install.sh" "md5=aca9a1c985326f95daa51aedef55b318"]
+  ["mirage-build.sh" "md5=c4b411f29867c13595470011d3b77f6c"]
+  ["gmp-freestanding.pc" "md5=314f83a7d574bb4d1afe0dabffa5fbe0"]
+]
+url {
+  src: "https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz"
+  checksum: "sha512=c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a99895a3b2f9a0856cd17887738fa51cf7499781b65c049769271cbcb77d057d2e9f1ec52e07dd84"
+}


### PR DESCRIPTION
gmp released 6.2.1 in November 2020, adapt to this release.

From their changelog:
```
Changes in GMP 6.2.1

BUGS FIXED

    A possible overflow of type int is avoided for mpz_cmp on huge operands.
    Overflows are more carefully detected and reported for mpz_pow_ui.
    A bug in longlong.h for aarch64 sub_ddmmss, not affecting GMP, was healed.
    Mini-GMP: mpz_out_str and mpq_out_str now correctly handle out of range bases.

FEATURES

    C90 compliance.
    Initial support for Darwin on arm64, and improved portability.
    Support for more processors.

SPEEDUPS

    None, except indirectly through recognition of new CPUs.
```