### PR TITLE
[new release] asn1-combinators (0.2.5)

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.2.5/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.5/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+authors: "David Kaloper Meršinjak"
+maintainer: "David Kaloper Meršinjak <dk505@cam.ac.uk>"
+homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
+doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+synopsis: "Embed typed ASN.1 grammars in OCaml"
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+depends: [
+  "ocaml" {>="4.05.0"}
+  "dune" {>= "1.2.0"}
+  "cstruct" {>= "1.6.0"}
+  "zarith"
+  "bigarray-compat"
+  "stdlib-shims"
+  "ptime"
+  "alcotest" {with-test}
+]
+description: """
+asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
+part of ASN.1, and embed the abstract syntax directly in the language. These
+abstract syntax representations can be used for parsing, serialization, or
+random testing.
+
+The only ASN.1 encodings currently supported are BER and DER.
+"""
+x-commit-hash: "c15f6901c89466dda7d1b48ca5b099b7970153dd"
+url {
+  src:
+    "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.2.5/asn1-combinators-v0.2.5.tbz"
+  checksum: [
+    "sha256=96f2590a518aa3a57d43f989db83812717399d6467892d43bbce42112a6f6cdd"
+    "sha512=49767d04129bb842215e57e4efeb79f6fba025ddd67e474d9a3f51625c5101e583208cc0ff6dd69bcbcd4ab415c83b410125c1b9eb66c8cde60132b243b06158"
+  ]
+}


### PR DESCRIPTION
Embed typed ASN.1 grammars in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-asn1-combinators">https://github.com/mirleft/ocaml-asn1-combinators</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-asn1-combinators/doc">https://mirleft.github.io/ocaml-asn1-combinators/doc</a>

##### CHANGES:

* Fix an integer overflow in the length field on 32 bit architectures
  (mirleft/ocaml-asn1-combinators#36 by @hannesm)
