### PR TITLE
[new release] hxd (0.3.1)

### DIFF
--- a/packages/hxd/hxd.0.3.1/opam
+++ b/packages/hxd/hxd.0.3.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/hxd"
+bug-reports:  "https://github.com/dinosaure/hxd/issues"
+dev-repo:     "git+https://github.com/dinosaure/hxd.git"
+doc:          "https://dinosaure.github.io/hxd/"
+license:      "MIT"
+synopsis:     "Hexdump in OCaml"
+description: """Please, help me to debug ocaml-git
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.06.0"}
+  "dune"              {>= "2.7"}
+  "dune-configurator" {>= "2.7"}
+  "cmdliner"
+]
+
+depopts: [
+  "lwt"
+]
+x-commit-hash: "cee4cc97391634d4c4cb15250946dfc5782e335e"
+url {
+  src:
+    "https://github.com/dinosaure/hxd/releases/download/v0.3.1/hxd-v0.3.1.tbz"
+  checksum: [
+    "sha256=1c226c91e17cd329dec0c287bfd20f36302aa533069ff9c6ced32721f96b29bc"
+    "sha512=93ff909eb519f750794684dcb050bdf51d271652dcea5501654e63b6ac17b79a85981f984a2e1a6db963240de594f21dde4dc541ef8e5873b906fa50d4ef803b"
+  ]
+}


### PR DESCRIPTION
Hexdump in OCaml

- Project page: <a href="https://github.com/dinosaure/hxd">https://github.com/dinosaure/hxd</a>
- Documentation: <a href="https://dinosaure.github.io/hxd/">https://dinosaure.github.io/hxd/</a>

##### CHANGES:

- Fix the array printer (dinosaure/hxd#9, @dinosaure)
