### PR TITLE
[new release] carton, carton-lwt and carton-git (0.3.0)

### DIFF
--- a/packages/carton-git/carton-git.0.3.0/opam
+++ b/packages/carton-git/carton-git.0.3.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "carton" {= version}
+  "carton-lwt" {= version}
+  "bigstringaf"
+  "bigarray-compat"
+  "lwt"
+  "fpath"
+  "result"
+  "mmap"
+  "fmt" {>= "0.8.7"}
+  "base-unix"
+  "decompress" {>= "1.3.0"}
+  "astring" {>= "0.8.5"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "169c7b552c3462a34d98ae614048ea327529b144"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.3.0/carton-carton-v0.3.0.tbz"
+  checksum: [
+    "sha256=41872e18fe0c9ceac1053af95ab4cafecc33bc705a27c0f798ddaa8c35c885ac"
+    "sha512=98d2b4db6daaa08a652f9400924bad6418e8fbfb76a662e2d9249441dcfc3ff3ffcfe9f6fd41b6d97d47998ea84b164b10fb156f70cb74f4b989eebfb6f9e64b"
+  ]
+}

--- a/packages/carton-lwt/carton-lwt.0.3.0/opam
+++ b/packages/carton-lwt/carton-lwt.0.3.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "carton" {= version}
+  "lwt"
+  "decompress" {>= "1.3.0"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf"
+  "bigarray-compat" {with-test}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "fmt" {>= "0.8.9" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "result" {>= "1.5" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+  "base64" {>= "3.4.0" & with-test}
+  "bos" {>= "0.2.0" & with-test}
+  "checkseum" {>= "0.3.0" & with-test}
+  "digestif" {>= "1.0.0" & with-test}
+  "fpath" {>= "0.7.3" & with-test}
+  "mmap" {>= "1.1.0" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "169c7b552c3462a34d98ae614048ea327529b144"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.3.0/carton-carton-v0.3.0.tbz"
+  checksum: [
+    "sha256=41872e18fe0c9ceac1053af95ab4cafecc33bc705a27c0f798ddaa8c35c885ac"
+    "sha512=98d2b4db6daaa08a652f9400924bad6418e8fbfb76a662e2d9249441dcfc3ff3ffcfe9f6fd41b6d97d47998ea84b164b10fb156f70cb74f4b989eebfb6f9e64b"
+  ]
+}

--- a/packages/carton/carton.0.3.0/opam
+++ b/packages/carton/carton.0.3.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACKv2 file in OCaml"
+description: """\
+Carton is an implementation of the PACKv2 file
+in OCaml. PACKv2 file is used by Git to store Git objects.
+Carton is more abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "ke" {>= "0.4"}
+  "duff" {>= "0.3"}
+  "decompress" {>= "1.3.0"}
+  "cstruct" {>= "5.0.0"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf"
+  "checkseum" {>= "0.2.1"}
+  "logs"
+  "bigstringaf"
+  "bigarray-compat"
+  "bos"
+  "cmdliner" {>= "1.0.4"}
+  "digestif"
+  "fpath"
+  "mmap"
+  "result"
+  "rresult"
+  "hxd" {>= "0.3.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.7"}
+  "result"
+  "rresult"
+  "fpath"
+  "base64" {with-test & >= "3.0.0"}
+  "bos"
+  "digestif" {>= "0.8.1"}
+  "mmap"
+  "base-unix" {with-test}
+  "base-threads" {with-test}
+  "alcotest" {with-test}
+  "crowbar" {with-test & >= "0.2"}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "lwt" {>= "5.3.0" & with-test}
+  "ocamlfind" {>= "1.8.1" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "169c7b552c3462a34d98ae614048ea327529b144"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.3.0/carton-carton-v0.3.0.tbz"
+  checksum: [
+    "sha256=41872e18fe0c9ceac1053af95ab4cafecc33bc705a27c0f798ddaa8c35c885ac"
+    "sha512=98d2b4db6daaa08a652f9400924bad6418e8fbfb76a662e2d9249441dcfc3ff3ffcfe9f6fd41b6d97d47998ea84b164b10fb156f70cb74f4b989eebfb6f9e64b"
+  ]
+}

--- a/packages/carton/carton.0.3.0/opam
+++ b/packages/carton/carton.0.3.0/opam
@@ -23,18 +23,12 @@ depends: [
   "logs"
   "bigstringaf"
   "bigarray-compat"
-  "bos"
   "cmdliner" {>= "1.0.4"}
-  "digestif"
-  "fpath"
-  "mmap"
   "result"
   "rresult"
   "hxd" {>= "0.3.0"}
   "psq" {>= "0.2.0"}
   "fmt" {>= "0.8.7"}
-  "result"
-  "rresult"
   "fpath"
   "base64" {with-test & >= "3.0.0"}
   "bos"

--- a/packages/git/git.3.3.0/opam
+++ b/packages/git/git.3.3.0/opam
@@ -30,9 +30,9 @@ depends: [
   "mimic"
   "cstruct" {>= "5.0.0"}
   "angstrom" {>= "0.14.0"}
-  "carton" {>= "0.2.0"}
-  "carton-lwt" {>= "0.2.0"}
-  "carton-git" {>= "0.2.0"}
+  "carton" {>= "0.2.0" & < "0.3.0"}
+  "carton-lwt" {>= "0.2.0" < "0.3.0"}
+  "carton-git" {>= "0.2.0" < "0.3.0"}
   "ke" {>= "0.4"}
   "fmt" {>= "0.8.7"}
   "checkseum" {>= "0.2.1"}


### PR DESCRIPTION
Implementation of PACKv2 file in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Provides binaries to manipulate PACK files (@dinosaure, mirage/ocaml-git#475)
  **breaking changes**
  A transitive breaking changes from decompress.1.3.0 when
  the compressor expects a `De.Lz77.window` instead of
  `De.window`
- Update to decompress.1.3.0 (@dinosaure, mirage/ocaml-git#477)
