### PR TITLE
Package binaryen.0.8.0

### DIFF
--- a/packages/binaryen/binaryen.0.8.0/opam
+++ b/packages/binaryen/binaryen.0.8.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.09"}
+  "dune" {>= "2.7.1"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+]
+available: arch = "x86_64" & (os = "linux" | os = "macos" | os = "win32")
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.8.0/binaryen-archive-v0.8.0.tar.gz"
+  checksum: [
+    "md5=a7423434cd856d0d6956795a155de72c"
+    "sha512=d01e75adb7828d458605a6d8494aaf26f0781772ad67068ce422bea1fa0b28acec918ec82d5d1c42adda37b11a549c996beef8edafe023ba6fb33e85b958f548"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.8.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
$'\n\n### ⚠ BREAKING CHANGES\n\n* Table name must now be provided to the `Expression.call_indirect` and `Expression.return_call_indirect` instructions.\n\n### Features\n\n* Upgrade to Binaryen 100 ([#75](https://www.github.com/grain-lang/binaryen.ml/issues/75)) ([d59f5f9](https://www.github.com/grain-lang/binaryen.ml/commit/d59f5f9fb5356f4ccd7f4a7fefe15d5d4b721412))\n\n\n### Continuous Integration\n\n* fix markdown escaping for opam release ([#72](https://www.github.com/grain-lang/binaryen.ml/issues/72)) ([a2e6052](https://www.github.com/grain-lang/binaryen.ml/commit/a2e605241376ffdfcbba7ecd2e7a7ac52b53019f))\n\n\n### Miscellaneous Chores\n\n* fix dune misdocumentation ([#73](https://www.github.com/grain-lang/binaryen.ml/issues/73)) ([341e718](https://www.github.com/grain-lang/binaryen.ml/commit/341e71805078dae312171d5985dec7ebc689bdbe))\n'

---
:camel: Pull-request generated by opam-publish v2.0.3