### PR TITLE
[new release] git, git-cohttp, git-cohttp-mirage, git-cohttp-unix, git-unix and git-mirage (3.3.1)

### DIFF
--- a/packages/carton-git/carton-git.0.3.0/opam
+++ b/packages/carton-git/carton-git.0.3.0/opam
@@ -12,7 +12,7 @@ doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6.0"}
+  "dune" {>= "2.8.0"}
   "carton" {= version}
   "carton-lwt" {= version}
   "bigstringaf"

--- a/packages/carton-lwt/carton-lwt.0.3.0/opam
+++ b/packages/carton-lwt/carton-lwt.0.3.0/opam
@@ -12,7 +12,7 @@ doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6.0"}
+  "dune" {>= "2.8.0"}
   "carton" {= version}
   "lwt"
   "decompress" {>= "1.3.0"}

--- a/packages/carton/carton.0.3.0/opam
+++ b/packages/carton/carton.0.3.0/opam
@@ -12,7 +12,7 @@ doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6.0"}
+  "dune" {>= "2.8.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
   "decompress" {>= "1.3.0"}

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.1/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.1/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6.0"}
+  "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic"
   "cohttp-mirage"

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.1/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "git" {= version}
+  "mimic"
+  "cohttp-mirage"
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "c5a3a245362a011d23573e4b1795f7d9c5234548"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.1/git-3.3.1.tbz"
+  checksum: [
+    "sha256=10375580a154a9af402dae39a8e96790a583fdd717d0542a7c3fe2d5d8e7dab8"
+    "sha512=1b7a6972cf7bd85464095419c636a3f195621e81dfd980aebb40ce283cf1177979b2d953915cf2401bf8827394071be55845ee76e86d67508bfff618660a1898"
+  ]
+}

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.3.1/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.3.1/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6.0"}
+  "dune" {>= "2.8.0"}
   "git" {= version}
   "git-cohttp" {= version}
   "cohttp-lwt-unix"

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.3.1/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.3.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "git" {= version}
+  "git-cohttp" {= version}
+  "cohttp-lwt-unix"
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "c5a3a245362a011d23573e4b1795f7d9c5234548"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.1/git-3.3.1.tbz"
+  checksum: [
+    "sha256=10375580a154a9af402dae39a8e96790a583fdd717d0542a7c3fe2d5d8e7dab8"
+    "sha512=1b7a6972cf7bd85464095419c636a3f195621e81dfd980aebb40ce283cf1177979b2d953915cf2401bf8827394071be55845ee76e86d67508bfff618660a1898"
+  ]
+}

--- a/packages/git-cohttp/git-cohttp.3.3.1/opam
+++ b/packages/git-cohttp/git-cohttp.3.3.1/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6.0"}
+  "dune" {>= "2.8.0"}
   "git" {= version}
   "cohttp"
   "cohttp-lwt"

--- a/packages/git-cohttp/git-cohttp.3.3.1/opam
+++ b/packages/git-cohttp/git-cohttp.3.3.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "git" {= version}
+  "cohttp"
+  "cohttp-lwt"
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "c5a3a245362a011d23573e4b1795f7d9c5234548"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.1/git-3.3.1.tbz"
+  checksum: [
+    "sha256=10375580a154a9af402dae39a8e96790a583fdd717d0542a7c3fe2d5d8e7dab8"
+    "sha512=1b7a6972cf7bd85464095419c636a3f195621e81dfd980aebb40ce283cf1177979b2d953915cf2401bf8827394071be55845ee76e86d67508bfff618660a1898"
+  ]
+}

--- a/packages/git-mirage/git-mirage.3.3.1/opam
+++ b/packages/git-mirage/git-mirage.3.3.1/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6.0"}
+  "dune" {>= "2.8.0"}
   "mimic"
   "mirage-stack"
   "git" {= version}

--- a/packages/git-mirage/git-mirage.3.3.1/opam
+++ b/packages/git-mirage/git-mirage.3.3.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A package to use ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "mimic"
+  "mirage-stack"
+  "git" {= version}
+  "awa"
+  "awa-mirage"
+  "dns-client" {>= "4.6.2"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "5.0.1"}
+  "lwt" {>= "5.3.0"}
+  "mirage-clock" {>= "3.1.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "mirage-protocols" {>= "5.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.1"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "c5a3a245362a011d23573e4b1795f7d9c5234548"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.1/git-3.3.1.tbz"
+  checksum: [
+    "sha256=10375580a154a9af402dae39a8e96790a583fdd717d0542a7c3fe2d5d8e7dab8"
+    "sha512=1b7a6972cf7bd85464095419c636a3f195621e81dfd980aebb40ce283cf1177979b2d953915cf2401bf8827394071be55845ee76e86d67508bfff618660a1898"
+  ]
+}

--- a/packages/git-unix/git-unix.3.3.1/opam
+++ b/packages/git-unix/git-unix.3.3.1/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6.0"}
+  "dune" {>= "2.8.0"}
   "mmap" {>= "1.1.0"}
   "git" {= version}
   "rresult"

--- a/packages/git-unix/git-unix.3.3.1/opam
+++ b/packages/git-unix/git-unix.3.3.1/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install and configure ocaml-git's Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "mmap" {>= "1.1.0"}
+  "git" {= version}
+  "rresult"
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "fmt" {>= "0.8.7"}
+  "bos"
+  "fpath"
+  "uri" {with-test}
+  "digestif" {>= "0.8.1"}
+  "logs"
+  "lwt"
+  "base-unix"
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "git-cohttp-unix" {= version}
+  "mirage-clock"
+  "mirage-clock-unix"
+  "astring" {>= "0.8.5"}
+  "awa"
+  "cmdliner" {>= "1.0.4"}
+  "cohttp-lwt-unix" {>= "2.5.4"}
+  "decompress" {>= "1.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "5.0.1"}
+  "mtime" {>= "1.2.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "tcpip" {>= "6.0.0"}
+  "cstruct" {>= "6.0.0" & with-test}
+  "awa-mirage"
+  "mirage-flow" {>= "2.0.1"}
+  "ke" {>= "0.4" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "ocurl" {>= "0.9.1" & with-test}
+  "ptime" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "c5a3a245362a011d23573e4b1795f7d9c5234548"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.1/git-3.3.1.tbz"
+  checksum: [
+    "sha256=10375580a154a9af402dae39a8e96790a583fdd717d0542a7c3fe2d5d8e7dab8"
+    "sha512=1b7a6972cf7bd85464095419c636a3f195621e81dfd980aebb40ce283cf1177979b2d953915cf2401bf8827394071be55845ee76e86d67508bfff618660a1898"
+  ]
+}

--- a/packages/git/git.3.3.1/opam
+++ b/packages/git/git.3.3.1/opam
@@ -30,9 +30,9 @@ depends: [
   "mimic"
   "cstruct" {>= "5.0.0"}
   "angstrom" {>= "0.14.0"}
-  "carton" {>= "0.2.0"}
-  "carton-lwt" {>= "0.2.0"}
-  "carton-git" {>= "0.2.0"}
+  "carton" {>= "0.3.0"}
+  "carton-lwt" {>= "0.3.0"}
+  "carton-git" {>= "0.3.0"}
   "ke" {>= "0.4"}
   "fmt" {>= "0.8.7"}
   "checkseum" {>= "0.2.1"}

--- a/packages/git/git.3.3.1/opam
+++ b/packages/git/git.3.3.1/opam
@@ -16,7 +16,7 @@ doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6.0"}
+  "dune" {>= "2.8.0"}
   "digestif" {>= "0.8.1"}
   "rresult"
   "base64" {>= "3.0.0"}

--- a/packages/git/git.3.3.1/opam
+++ b/packages/git/git.3.3.1/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "Git format and protocol in pure OCaml"
+description: """\
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "digestif" {>= "0.8.1"}
+  "rresult"
+  "base64" {>= "3.0.0"}
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "optint"
+  "decompress" {>= "1.3.0"}
+  "logs"
+  "lwt"
+  "mimic"
+  "cstruct" {>= "5.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "carton" {>= "0.2.0"}
+  "carton-lwt" {>= "0.2.0"}
+  "carton-git" {>= "0.2.0"}
+  "ke" {>= "0.4"}
+  "fmt" {>= "0.8.7"}
+  "checkseum" {>= "0.2.1"}
+  "ocamlgraph" {>= "1.8.8"}
+  "astring"
+  "fpath"
+  "encore" {>= "0.7"}
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng" {with-test & >= "0.8.0"}
+  "cmdliner" {with-test}
+  "base-unix" {with-test}
+  "fpath"
+  "mirage-flow" {>= "2.0.1"}
+  "domain-name" {>= "0.3.0"}
+  "emile" {>= "1.1"}
+  "ipaddr" {>= "5.0.1"}
+  "psq" {>= "0.2.0"}
+  "uri" {>= "4.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "c5a3a245362a011d23573e4b1795f7d9c5234548"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.1/git-3.3.1.tbz"
+  checksum: [
+    "sha256=10375580a154a9af402dae39a8e96790a583fdd717d0542a7c3fe2d5d8e7dab8"
+    "sha512=1b7a6972cf7bd85464095419c636a3f195621e81dfd980aebb40ce283cf1177979b2d953915cf2401bf8827394071be55845ee76e86d67508bfff618660a1898"
+  ]
+}


### PR DESCRIPTION
Git format and protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Fix tests on NixOS (@sternenseemann, mirage/ocaml-git#472)
- Fix report status over git://, ssh:// and http(s):// with
  side-band-64k and report-status capabilities (@dinosaure, @hannesm, mirage/ocaml-git#474)
- Be sure that creation of a tree is tail-rec (@dinosaure, @zshipko, mirage/ocaml-git#476)
- Update to decompress.1.3.0 (@dinosaure, mirage/ocaml-git#477)
