### PR TITLE
Package satyrographos.0.0.2.9

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.2.9/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.9/opam
@@ -8,12 +8,12 @@ dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
 bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
 license: "LGPL-3.0-or-later"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["sed" "-i.bak" "-e" "s/%%%%VERSION_NUM%%%%/%{version}%/" "bin/main.ml"]
   ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [
-  ["dune" "runtest"]
+  ["dune" "runtest" "-p" name "-j" jobs]
 ]
 
 depends: [
@@ -29,6 +29,7 @@ depends: [
   "opam-state" {>= "2.0" & < "2.1"}
   "re"
   "stringext" {with-test}
+  "conf-diffutils" {with-test}
   "uri" {>= "3.0.0"}
   "uri-sexp" {>= "3.0.0"}
   "yaml" {>= "2.0" & < "3.0"}
@@ -38,9 +39,6 @@ depends: [
   "core" {>= "v0.14" & < "v0.15"}
   "ppx_jane"
   "shexp"
-]
-depexts: [
-  [ "diffutils" ] {with-test}
 ]
 synopsis: "A package manager for SATySFi"
 description: """

--- a/packages/satyrographos/satyrographos.0.0.2.9/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.9/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  ["dune" "subst"] {pinned}
+  ["sed" "-i.bak" "-e" "s/%%%%VERSION_NUM%%%%/%{version}%/" "bin/main.ml"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest"]
+]
+
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "dune" {>= "2.7"}
+  "fileutils"
+  "json-derivers"
+  "menhir"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ocamlgraph"
+  "opam-format" {>= "2.0" & < "2.1"}
+  "opam-state" {>= "2.0" & < "2.1"}
+  "re"
+  "stringext" {with-test}
+  "uri" {>= "3.0.0"}
+  "uri-sexp" {>= "3.0.0"}
+  "yaml" {>= "2.0" & < "3.0"}
+  "yojson"
+
+  # Janestreet Libs
+  "core" {>= "v0.14" & < "v0.15"}
+  "ppx_jane"
+  "shexp"
+]
+depexts: [
+  [ "diffutils" ] {with-test}
+]
+synopsis: "A package manager for SATySFi"
+description: """
+Satyrographos is a package manager for [SATySFi].
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src: "https://github.com/na4zagin3/satyrographos/archive/v0.0.2.9.tar.gz"
+  checksum: [
+    "md5=296637620c59d96149dd7d6159f4160e"
+    "sha512=63349a15159ad3899cfc00d6357df530f651c9b995c8ddf43a6972fde8ff1ff9245f88dad9f79a3f3f7b88a1304ef6ffb0651e86ddbb11d580178df084da8a30"
+  ]
+}


### PR DESCRIPTION
### `satyrographos.0.0.2.9`
A package manager for SATySFi
Satyrographos is a package manager for [SATySFi].

Satyrographos is distributed under the LGPL-3.0 license.


  [SATySFi]: https://github.com/gfngfn/SATySFi
  [Satyrographos]: https://github.com/na4zagin3/satyrographos



---
* Homepage: https://github.com/na4zagin3/satyrographos
* Source repo: git+https://github.com/na4zagin3/satyrographos.git
* Bug tracker: https://github.com/na4zagin3/satyrographos/issues

---
:camel: Pull-request generated by opam-publish v2.0.2