### PR TITLE
[new release] omd (2.0.0+alpha1)

### DIFF
--- a/packages/omd/omd.2.0.0+alpha1/opam
+++ b/packages/omd/omd.2.0.0+alpha1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A Markdown frontend in pure OCaml"
+description: """
+This Markdown library is implemented using only pure OCaml (including
+I/O operations provided by the standard OCaml compiler distribution).
+OMD is meant to be as faithful as possible to the original Markdown.
+Additionally, OMD implements a few Github markdown features, an
+extension mechanism, and some other features. Note that the opam
+package installs both the OMD library and the command line tool `omd`."""
+maintainer: ["Nicolás Ojeda Bär <n.oje.bar@gmail.com>"]
+authors: [
+  "Philippe Wang <philippe.wang@gmail.com>"
+  "Nicolás Ojeda Bär <n.oje.bar@gmail.com>"
+]
+license: "ISC"
+tags: ["org:ocamllabs" "org:mirage"]
+homepage: "https://github.com/ocaml/omd"
+bug-reports: "https://github.com/ocaml/omd/issues"
+depends: [
+  "dune" {>= "2.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/omd.git"
+x-commit-hash: "a00c3ba699ebae148948e96ab290fc0d508522b5"
+url {
+  src:
+    "https://github.com/ocaml/omd/releases/download/v2.0.0%2Balpha1/omd-v2.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=400dadec2805519786dd74c9c78df04130878d4cf4595fdf7d1f3dabf2489cbe"
+    "sha512=9f5ab62c93dfec4c1256a78d57e43ae72eb3555a82e290ac9a61b76b9f6b4329f0ea0805e04991171f997f9fd15568b903036d2edc679bbcf8bb1965284a6f75"
+  ]
+}


### PR DESCRIPTION
A Markdown frontend in pure OCaml

- Project page: <a href="https://github.com/ocaml/omd">https://github.com/ocaml/omd</a>

##### CHANGES:

- Lower OCaml requirement to 4.04.2  (ocaml/omd#213, @jfrolich)

- Big refactoring by @nojb. Changes in interface (simplification of code, might
  affect performance a little). To be tested!
