### PR TITLE
[new release] omd (2.0.0~alpha1)

### DIFF
--- a/packages/omd/omd.2.0.0~alpha1/opam
+++ b/packages/omd/omd.2.0.0~alpha1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A Markdown frontend in pure OCaml"
+description: """
+This Markdown library is implemented using only pure OCaml (including
+I/O operations provided by the standard OCaml compiler distribution).
+OMD is meant to be as faithful as possible to the original Markdown.
+Additionally, OMD implements a few Github markdown features, an
+extension mechanism, and some other features. Note that the opam
+package installs both the OMD library and the command line tool `omd`."""
+maintainer: ["Nicolás Ojeda Bär <n.oje.bar@gmail.com>"]
+authors: [
+  "Philippe Wang <philippe.wang@gmail.com>"
+  "Nicolás Ojeda Bär <n.oje.bar@gmail.com>"
+]
+license: "ISC"
+tags: ["org:ocamllabs" "org:mirage"]
+homepage: "https://github.com/ocaml/omd"
+bug-reports: "https://github.com/ocaml/omd/issues"
+depends: [
+  "dune" {>= "2.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/omd.git"
+x-commit-hash: "a01807ec69c03781db9149d8a6759db049c936b8"
+url {
+  src:
+    "https://github.com/ocaml/omd/releases/download/v2.0.0_TILDE_alpha1/omd-v2.0.0~alpha1.tbz"
+  checksum: [
+    "sha256=6beae1370424de2d7b0fc6a7da3111cc5af595a7ec652d82198387b1e4a8b2b0"
+    "sha512=0ddc351a34e5ed835196680420b85820972592e99c8d87f9798b5431ba671d0991681ec49ee0c8789dabe54e187c9009b81d9360aaa70b54a38f5cacf3f5327f"
+  ]
+}


### PR DESCRIPTION
A Markdown frontend in pure OCaml

- Project page: <a href="https://github.com/ocaml/omd">https://github.com/ocaml/omd</a>

##### CHANGES:

- Lower OCaml requirement to 4.04.2  (ocaml/omd#213, @jfrolich)

- Big refactoring by @nojb. Changes in interface (simplification of code, might
  affect performance a little). To be tested!
