### PR TITLE
Package conformist.0.2.0

### DIFF
--- a/packages/conformist/conformist.0.2.0/opam
+++ b/packages/conformist/conformist.0.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Conformist allows you to define schemas to decode, validate and sanitize input data declaratively"
+description: """
+
+Conformist allows you to define schemas to decode, validate and sanitize input data declaratively.
+It comes with runtime types for primitive OCaml types such as `int`, `string`, `bool` and `float` but also `Ptime.date`, optional and custom types.
+Re-use business rules in validators and run it on the client side with js_of_ocaml.
+Arbitrary meta data can be stored in schemas which is useful to build functionality on top of conformist.
+"""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/conformist"
+doc: "https://oxidizing.github.io/conformist/"
+bug-reports: "https://github.com/oxidizing/conformist/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "ppx_deriving" {>= "4.5" & with-test}
+  "ppx_fields_conv" {>= "v0.14.1" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/conformist.git"
+url {
+  src: "https://github.com/oxidizing/conformist/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=7b09116430251ed48c7d21ac878cdcc3"
+    "sha512=8f562e8b54631bdcaab803348fa491b77cef95dff82ea0a01d9d0b88d9346261103123102aacd4fb1d7ab021b4f67ee602120239e08d09507a4247ecb5bce509"
+  ]
+}


### PR DESCRIPTION
### `conformist.0.2.0`
Conformist allows you to define schemas to decode, validate and sanitize input data declaratively
Conformist allows you to define schemas to decode, validate and sanitize input data declaratively.
It comes with runtime types for primitive OCaml types such as `int`, `string`, `bool` and `float` but also `Ptime.date`, optional and custom types.
Re-use business rules in validators and run it on the client side with js_of_ocaml.
Arbitrary meta data can be stored in schemas which is useful to build functionality on top of conformist.



---
* Homepage: https://github.com/oxidizing/conformist
* Source repo: git+https://github.com/oxidizing/conformist.git
* Bug tracker: https://github.com/oxidizing/conformist/issues

---
:camel: Pull-request generated by opam-publish v2.0.2