### PR TITLE
Package speex.0.4.0

### DIFF
--- a/packages/speex/speex.0.4.0/opam
+++ b/packages/speex/speex.0.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Bindings to libspeex"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "GPL-2"
+homepage: "https://github.com/savonet/ocaml-speex"
+bug-reports: "https://github.com/savonet/ocaml-speex/issues"
+depends: [
+  "conf-libogg"
+  "conf-libspeex"
+  "conf-pkg-config"
+  "dune" {>= "2.0"}
+  "dune-configurator"
+  "ogg" {>= "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-speex.git"
+url {
+  src: "https://github.com/savonet/ocaml-speex/archive/v0.4.0.tar.gz"
+  checksum: [
+    "md5=463be522228a528894a000247823ac2c"
+    "sha512=812dcd25336729a6bcacd80f6a54ffc984c08961ffa1b151b7a4fd36b5c9c5f6429bf6cc0a698aae3efa630be029bf93d0e55f070f5db2de1b1efa7a692ef3d8"
+  ]
+}

--- a/packages/speex/speex.0.4.0/opam
+++ b/packages/speex/speex.0.4.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis: "Bindings to libspeex"
 maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
 authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
-license: "GPL-2"
+license: "GPL-2.0"
 homepage: "https://github.com/savonet/ocaml-speex"
 bug-reports: "https://github.com/savonet/ocaml-speex/issues"
 depends: [


### PR DESCRIPTION
### `speex.0.4.0`
Bindings to libspeex



---
* Homepage: https://github.com/savonet/ocaml-speex
* Source repo: git+https://github.com/savonet/ocaml-speex.git
* Bug tracker: https://github.com/savonet/ocaml-speex/issues

---
:camel: Pull-request generated by opam-publish v2.0.2