### PR TITLE
Package vorbis.0.8.0

### DIFF
--- a/packages/conf-libvorbis/conf-libvorbis.1/opam
+++ b/packages/conf-libvorbis/conf-libvorbis.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://xiph.org/vorbis/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "Xiph.Org Foundation"
+license: "BSD"
+build: ["pkg-config" "--exists" "vorbis"]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["libvorbis-dev"] {os-family = "debian" | os-family = "ubuntu" | os-family = "alpine"}
+  ["libvorbis"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
+  ["libvorbis-devel"] {os-distribution="centos" | os-family = "fedora" | os-family = "suse"}
+]
+synopsis: "Virtual package relying on libvorbis"
+description:
+  "This package can only install if the vorbis library is installed on the system."
+flags: conf

--- a/packages/vorbis/vorbis.0.8.0/opam
+++ b/packages/vorbis/vorbis.0.8.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Bindings to libvorbis"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-vorbis"
+bug-reports: "https://github.com/savonet/ocaml-vorbis/issues"
+depends: [
+  "conf-libvorbis"
+  "conf-pkg-config"
+  "dune" {>= "2.0"}
+  "dune-configurator"
+  "ogg" {>= "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-vorbis.git"
+url {
+  src: "https://github.com/savonet/ocaml-vorbis/archive/v0.8.0.tar.gz"
+  checksum: [
+    "md5=46b59a02b000aa34e97ce537e346f8e6"
+    "sha512=b2d3940492552fdda27785623cc563758aca061fedfdf577ab1ef22fb1958c27af9fe68c1ed7bd5cf323e1a1b7b42cc53ae6d2c09dc6cae7ead37f740d106ba8"
+  ]
+}

--- a/packages/vorbis/vorbis.0.8.0/opam
+++ b/packages/vorbis/vorbis.0.8.0/opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.0"}
   "dune-configurator"
   "ogg" {>= "0.7.0"}
+  "ocaml" {>= "4.03.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
### `vorbis.0.8.0`
Bindings to libvorbis



---
* Homepage: https://github.com/savonet/ocaml-vorbis
* Source repo: git+https://github.com/savonet/ocaml-vorbis.git
* Bug tracker: https://github.com/savonet/ocaml-vorbis/issues

---
:camel: Pull-request generated by opam-publish v2.0.2