### PR TITLE
Package theora.0.4.0

### DIFF
--- a/packages/theora/theora.0.4.0/opam
+++ b/packages/theora/theora.0.4.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Bindings to libtheora"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-theora"
+bug-reports: "https://github.com/savonet/ocaml-theora/issues"
+depends: [
+  "conf-libtheora"
+  "conf-pkg-config"
+  "dune" {>= "2.0"}
+  "dune-configurator"
+  "ogg" {>= "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-theora.git"
+url {
+  src: "https://github.com/savonet/ocaml-theora/archive/v0.4.0.tar.gz"
+  checksum: [
+    "md5=af6298d7edc8a82ed1a8c78eca588bcd"
+    "sha512=513765188edc36219df0fb4d9801d2483e53a545c5491a22eaf4274b4b9c8a950d1d58063ffa0ac02639af1362c4fd0ce56ea3d3dccfd6e330929de15b30ce0e"
+  ]
+}


### PR DESCRIPTION
### `theora.0.4.0`
Bindings to libtheora



---
* Homepage: https://github.com/savonet/ocaml-theora
* Source repo: git+https://github.com/savonet/ocaml-theora.git
* Bug tracker: https://github.com/savonet/ocaml-theora/issues

---
:camel: Pull-request generated by opam-publish v2.0.2