### PR TITLE
[new release] memtrace (0.2.1.2)

### DIFF
--- a/packages/memtrace/memtrace.0.2.1.2/opam
+++ b/packages/memtrace/memtrace.0.2.1.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Streaming client for Memprof"
+description: "Generates compact traces of a program's memory use."
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/janestreet/memtrace"
+bug-reports: "https://github.com/janestreet/memtrace/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/janestreet/memtrace.git"
+x-commit-hash: "ecbb163de228f53cc86463d70acc220b0e681719"
+url {
+  src:
+    "https://github.com/janestreet/memtrace/releases/download/v0.2.1.2/memtrace-v0.2.1.2.tbz"
+  checksum: [
+    "sha256=c86f09e79d48bcd0852ab94b11766408c3a10d77df7640b88841271d5bfa5932"
+    "sha512=d9465d1bcbd5d35e66456c0b1b37b4efd097696aaac1b8fc8472ad477d96ef982551d73d72b98213d266013f40528ed6e7834e22d66d6edd321bccc1b8c08051"
+  ]
+}

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
@@ -30,7 +30,7 @@ depends: [
   "lambdasoup" {>= "0.7.1"}
   "logs" {>= "0.7.0"}
   "magic-mime" {>= "1.1.2"}
-  "memtrace" {>= "0.1.1"}
+  "memtrace" {>= "0.1.1" & < "0.2.0"}
   "ocaml-migrate-parsetree" {>= "0.4" & < "2.0.0"}
   "octavius" {>= "1.2.2"}
   "ppxlib" {>= "0.15.0" & < "0.18.0"}

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
@@ -30,7 +30,7 @@ depends: [
   "lambdasoup" {>= "0.7.1"}
   "logs" {>= "0.7.0"}
   "magic-mime" {>= "1.1.2"}
-  "memtrace" {>= "0.1.1"}
+  "memtrace" {>= "0.1.1" & < "0.2.0"}
   "ocaml-migrate-parsetree" {>= "0.4" & < "2.0.0"}
   "octavius" {>= "1.2.2"}
   "ppxlib" {>= "0.15.0" & < "0.18.0"}


### PR DESCRIPTION
Streaming client for Memprof

- Project page: <a href="https://github.com/janestreet/memtrace">https://github.com/janestreet/memtrace</a>

##### CHANGES:

More fixes for 32-bit platforms.
