### PR TITLE
Add the libtorch 1.8 packages.

### DIFF
--- a/packages/libtorch/libtorch.1.8.0+linux-x86_64/opam
+++ b/packages/libtorch/libtorch.1.8.0+linux-x86_64/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+homepage: "https://github.com/LaurentMazare/ocaml-torch"
+maintainer: "lmazare@gmail.com"
+bug-reports: "https://github.com/LaurentMazare/ocaml-torch/issues"
+authors: [
+  "Laurent Mazare"
+]
+install: [
+  [
+    "sh"
+    "-c"
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-linux.zip && mv -f libtorch %{lib}%/ )"
+  ]
+]
+synopsis: "LibTorch library package"
+description: """
+This is used by the torch package to trigger the install of the
+libtorch library."""
+extra-source "libtorch-linux.zip" {
+  src: "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.8.0%2Bcpu.zip"
+  checksum: "md5=82969e58ae8cabee16746711850d6fd9"
+}
+available: arch = "x86_64" & os = "linux"

--- a/packages/libtorch/libtorch.1.8.0+macos-x86_64/opam
+++ b/packages/libtorch/libtorch.1.8.0+macos-x86_64/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+homepage: "https://github.com/LaurentMazare/ocaml-torch"
+maintainer: "lmazare@gmail.com"
+bug-reports: "https://github.com/LaurentMazare/ocaml-torch/issues"
+authors: [
+  "Laurent Mazare"
+]
+install: [
+  [
+    "sh"
+    "-c"
+    "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-macos.zip && mv -f libtorch %{lib}%/ && tar xzf mklml-macos.tgz && mv -f mklml_mac_2019.0.1.20181227/lib/libmklml.dylib %{lib}%/libtorch/lib/ && mv -f mklml_mac_2019.0.1.20181227/lib/libiomp5.dylib %{lib}%/libtorch/lib/ )"
+  ]
+]
+depexts: [
+  ["libomp"] {os-distribution = "homebrew"}
+]
+synopsis: "LibTorch library package"
+description: """
+This is used by the torch package to trigger the install of the
+libtorch library."""
+extra-source "libtorch-macos.zip" {
+  src: "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.8.0.zip"
+  checksum: "md5=23f07569e0c942260c8b13fa8c3289b8"
+}
+extra-source "mklml-macos.tgz" {
+  src: "https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_mac_2019.0.1.20181227.tgz"
+  checksum: "md5=a8b4b158dc8e7aad13c0d594a9a8d241"
+}
+available: arch = "x86_64" & os = "macos"


### PR DESCRIPTION
Update the libtorch linux and macos packages to use the newly released PyTorch 1.8 binaries.