### PR TITLE
+mparser.1.3, +mparser-re.1.3, +mparser-pcre.1.3

### DIFF
--- a/packages/anthill/anthill.0.1/opam
+++ b/packages/anthill/anthill.0.1/opam
@@ -7,7 +7,7 @@ depends: [
   "dune" {>= "1.0"}
   "core" {< "v0.15"}
   "pcre"
-  "mparser"
+  "mparser" {< "1.3"}
   "lwt"
   "lwt_ppx"
   "lambda-term"

--- a/packages/mparser-pcre/mparser-pcre.1.3/opam
+++ b/packages/mparser-pcre/mparser-pcre.1.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+version: "1.3"
+synopsis: "MParser plugin: PCRE-based regular expressions"
+maintainer: ["Max Mouratov <mmouratov@gmail.com>"]
+authors: [
+  "Holger Arnold <holger@harnold.org>" "Max Mouratov <mmouratov@gmail.com>"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/murmour/mparser"
+bug-reports: "https://github.com/murmour/mparser/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.02"}
+  "mparser"
+  "pcre"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/murmour/mparser.git"
+url {
+  src: "https://github.com/murmour/mparser/archive/1.3.tar.gz"
+  checksum: "md5=3180cb522747aac876cc93e50ccd8d78"
+}

--- a/packages/mparser-pcre/mparser-pcre.1.3/opam
+++ b/packages/mparser-pcre/mparser-pcre.1.3/opam
@@ -1,11 +1,10 @@
 opam-version: "2.0"
-version: "1.3"
 synopsis: "MParser plugin: PCRE-based regular expressions"
 maintainer: ["Max Mouratov <mmouratov@gmail.com>"]
 authors: [
   "Holger Arnold <holger@harnold.org>" "Max Mouratov <mmouratov@gmail.com>"
 ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/murmour/mparser"
 bug-reports: "https://github.com/murmour/mparser/issues"
 depends: [

--- a/packages/mparser-re/mparser-re.1.3/opam
+++ b/packages/mparser-re/mparser-re.1.3/opam
@@ -1,11 +1,10 @@
 opam-version: "2.0"
-version: "1.3"
 synopsis: "MParser plugin: RE-based regular expressions"
 maintainer: ["Max Mouratov <mmouratov@gmail.com>"]
 authors: [
   "Holger Arnold <holger@harnold.org>" "Max Mouratov <mmouratov@gmail.com>"
 ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/murmour/mparser"
 bug-reports: "https://github.com/murmour/mparser/issues"
 depends: [

--- a/packages/mparser-re/mparser-re.1.3/opam
+++ b/packages/mparser-re/mparser-re.1.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+version: "1.3"
+synopsis: "MParser plugin: RE-based regular expressions"
+maintainer: ["Max Mouratov <mmouratov@gmail.com>"]
+authors: [
+  "Holger Arnold <holger@harnold.org>" "Max Mouratov <mmouratov@gmail.com>"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/murmour/mparser"
+bug-reports: "https://github.com/murmour/mparser/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.02"}
+  "mparser"
+  "re" {>= "1.7.2"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/murmour/mparser.git"
+url {
+  src: "https://github.com/murmour/mparser/archive/1.3.tar.gz"
+  checksum: "md5=3180cb522747aac876cc93e50ccd8d78"
+}

--- a/packages/mparser/mparser.1.3/opam
+++ b/packages/mparser/mparser.1.3/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "1.3"
 synopsis: "A simple monadic parser combinator library"
 description: """
 This library implements a rather complete and efficient monadic parser
@@ -9,7 +8,7 @@ maintainer: ["Max Mouratov <mmouratov@gmail.com>"]
 authors: [
   "Holger Arnold <holger@harnold.org>" "Max Mouratov <mmouratov@gmail.com>"
 ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/murmour/mparser"
 bug-reports: "https://github.com/murmour/mparser/issues"
 depends: [

--- a/packages/mparser/mparser.1.3/opam
+++ b/packages/mparser/mparser.1.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+version: "1.3"
+synopsis: "A simple monadic parser combinator library"
+description: """
+This library implements a rather complete and efficient monadic parser
+combinator library similar to the Parsec library for Haskell by Daan Leijen and
+the FParsec library for FSharp by Stephan Tolksdorf."""
+maintainer: ["Max Mouratov <mmouratov@gmail.com>"]
+authors: [
+  "Holger Arnold <holger@harnold.org>" "Max Mouratov <mmouratov@gmail.com>"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/murmour/mparser"
+bug-reports: "https://github.com/murmour/mparser/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.02"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/murmour/mparser.git"
+url {
+  src: "https://github.com/murmour/mparser/archive/1.3.tar.gz"
+  checksum: "md5=3180cb522747aac876cc93e50ccd8d78"
+}

--- a/packages/netkat/netkat.0.1/opam
+++ b/packages/netkat/netkat.0.1/opam
@@ -35,7 +35,7 @@ depends: [
   "ppx_jane" {>= "v0.12.0" & < "v0.14"}
   "printbox" {>= "0.2"}
   "tyxml" {>= "4.3.0"}
-  "mparser" {>= "1.2.3"}
+  "mparser" {>= "1.2.3" & < "1.3"}
 ]
 url {
   src:


### PR DESCRIPTION
- **New**: Build system is changed from OASIS to Dune.
- **Break**: Support for RE and PCRE was moved to separate OPAM packages: mparser-re, mparser-pcre. Findlib packages were renamed accordingly: mparser.re -> mparser-re, mparser.pcre -> mparser-pcre.
- **New**: `MParser_RE.wrap`, `MParser_PCRE.wrap`.
- **Fix**: Cleaned up deprecation warnings.
- **Drop**: Support for OCaml < 4.02.
- **Drop**: Support for `ocaml-re` < 1.7.2.
