### PR TITLE
Package opus.0.2.0

### DIFF
--- a/packages/conf-libopus/conf-libopus.1/opam
+++ b/packages/conf-libopus/conf-libopus.1/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://opus-codec.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "Xiph.Org Foundation"
+license: "BSD"
+build: ["pkg-config" "--exists" "opus"]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["libopus-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["opus-dev"] {os-family = "alpine"}
+  ["opus"] {os-family = "arch"}
+  ["libopus"] {os = "freebsd" | os-distribution = "nixos" | os-family = "suse" | os = "macos" & os-distribution = "homebrew"}
+  ["opus-devel"] {os-distribution="centos" | os-family = "fedora"}
+]
+synopsis: "Virtual package relying on libopus"
+description:
+  "This package can only install if the opus library is installed on the system."
+flags: conf

--- a/packages/opus/opus.0.2.0/opam
+++ b/packages/opus/opus.0.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Bindings to libopus"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-opus"
+bug-reports: "https://github.com/savonet/ocaml-opus/issues"
+depends: [
+  "conf-libogg"
+  "conf-libopus"
+  "conf-pkg-config"
+  "dune" {>= "2.0"}
+  "dune-configurator"
+  "ogg" {>= "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-opus.git"
+url {
+  src: "https://github.com/savonet/ocaml-opus/archive/v0.2.0.tar.gz"
+  checksum: [
+    "md5=0fcc34b008d9b92c0c726a5f8e11f01a"
+    "sha512=93cf9c676221aee3a09fcc27cbd157b18b65f4b5e6e25f8daa1ebc50a2f4cd7addc29aae88ffc844c4a93119e2736ba5a0d30cac2b38f38b5fb5b129348b5928"
+  ]
+}


### PR DESCRIPTION
### `opus.0.2.0`
Bindings to libopus



---
* Homepage: https://github.com/savonet/ocaml-opus
* Source repo: git+https://github.com/savonet/ocaml-opus.git
* Bug tracker: https://github.com/savonet/ocaml-opus/issues

---
:camel: Pull-request generated by opam-publish v2.0.2