### PR TITLE
Package archetype.1.2.2

### DIFF
--- a/packages/archetype/archetype.1.2.2/opam
+++ b/packages/archetype/archetype.1.2.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["The Archetype development team <archetype-dev@edukera.com>"]
+authors: [
+  "Benoit Rognier <benoit.rognier@edukera.com>"
+  "Guillaume Duhamel <guillaume.duhamel@edukera.com>"
+  "Pierre-Yves Strub <pierre-yves.strub@polytechnique.edu>"
+]
+bug-reports: "https://github.com/edukera/archetype-lang/issues"
+homepage: "https://github.com/edukera/archetype-lang"
+doc: "https://docs.archetype-lang.org/"
+license: "MIT"
+dev-repo: "git+https://github.com/edukera/archetype-lang.git"
+synopsis: "Archetype language compiler"
+description: """
+Archetype is a domain-specific language (DSL) to develop smart contracts
+on the Tezos blockchain, with a specific focus on contract security
+"""
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.10.0"}
+  "menhir"
+  "num"
+  "yojson"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "visitors"
+  "hex"
+]
+url {
+  src: "https://github.com/edukera/archetype-lang/archive/1.2.2.tar.gz"
+  checksum: [
+    "md5=492ba7d0e131579f7bce426fcdb87d25"
+    "sha512=5ea4f3c1ff277052a4d5b744dd2b3d54b2dc6910cabc1018a26b3f694e8362c122c270b66de341a80ab2df4ef0414c0685b8ecba901ef6a2636b129842bf56c1"
+  ]
+}


### PR DESCRIPTION
### `archetype.1.2.2`
Archetype language compiler
Archetype is a domain-specific language (DSL) to develop smart contracts
on the Tezos blockchain, with a specific focus on contract security



---
* Homepage: https://github.com/edukera/archetype-lang
* Source repo: git+https://github.com/edukera/archetype-lang.git
* Bug tracker: https://github.com/edukera/archetype-lang/issues

---
:camel: Pull-request generated by opam-publish v2.0.0