### PR TITLE
Fix licenses for some conf packages

### DIFF
--- a/packages/conf-alsa/conf-alsa.1/opam
+++ b/packages/conf-alsa/conf-alsa.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.alsa-project.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "alsa dev team"
-license: "BSD-1-Clause"
+license: "LGPL-2.1-or-later"
 build: ["pkg-config" "--exists" "alsa"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-alsa/conf-alsa.1/opam
+++ b/packages/conf-alsa/conf-alsa.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.alsa-project.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "alsa dev team"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["pkg-config" "--exists" "alsa"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-ao/conf-ao.1/opam
+++ b/packages/conf-ao/conf-ao.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.xiph.org/ao/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "libao dev team"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["pkg-config" "--exists" "ao"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-ao/conf-ao.1/opam
+++ b/packages/conf-ao/conf-ao.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.xiph.org/ao/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "libao dev team"
-license: "BSD-1-Clause"
+license: "GPL-2.0-only"
 build: ["pkg-config" "--exists" "ao"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-dssi/conf-dssi.1/opam
+++ b/packages/conf-dssi/conf-dssi.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://dssi.sourceforge.net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "dssi dev team"
-license: "BSD"
+license: "BSD-1-Clause"
 depends: [
   "conf-alsa" {os = "linux"}
 ]

--- a/packages/conf-dssi/conf-dssi.1/opam
+++ b/packages/conf-dssi/conf-dssi.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://dssi.sourceforge.net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "dssi dev team"
-license: "BSD-1-Clause"
+license: "LGPL-2.1-or-later"
 depends: [
   "conf-alsa" {os = "linux"}
 ]

--- a/packages/conf-gstreamer/conf-gstreamer.1/opam
+++ b/packages/conf-gstreamer/conf-gstreamer.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://gstreamer.freedesktop.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "The GStreamer Project"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["pkg-config" "--exists" "gstreamer-1.0" "gstreamer-app-1.0"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-gstreamer/conf-gstreamer.1/opam
+++ b/packages/conf-gstreamer/conf-gstreamer.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://gstreamer.freedesktop.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "The GStreamer Project"
-license: "BSD-1-Clause"
+license: "LGPL-2.1-or-later"
 build: ["pkg-config" "--exists" "gstreamer-1.0" "gstreamer-app-1.0"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-jack/conf-jack.1/opam
+++ b/packages/conf-jack/conf-jack.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://jackaudio.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "jack dev team"
-license: "BSD-1-Clause"
+license: "LGPL-2.1-or-later"
 build: ["pkg-config" "--exists" "jack"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-jack/conf-jack.1/opam
+++ b/packages/conf-jack/conf-jack.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://jackaudio.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "jack dev team"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["pkg-config" "--exists" "jack"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-ladspa/conf-ladspa.1/opam
+++ b/packages/conf-ladspa/conf-ladspa.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.ladspa.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "ladspa dev team"
-license: "BSD"
+license: "BSD-1-Clause"
 depexts: [
   ["ladspa-dev"] {os-distribution = "alpine"}
   ["ladspa-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}

--- a/packages/conf-ladspa/conf-ladspa.1/opam
+++ b/packages/conf-ladspa/conf-ladspa.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.ladspa.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "ladspa dev team"
-license: "BSD-1-Clause"
+license: "LGPL-2.1-or-later"
 depexts: [
   ["ladspa-dev"] {os-distribution = "alpine"}
   ["ladspa-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}

--- a/packages/conf-libflac/conf-libflac.1/opam
+++ b/packages/conf-libflac/conf-libflac.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://xiph.org/flac/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "libFLAC dev team"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["pkg-config" "--exists" "flac"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libflac/conf-libflac.1/opam
+++ b/packages/conf-libflac/conf-libflac.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://xiph.org/flac/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "libFLAC dev team"
-license: "BSD-1-Clause"
+license: "LGPL-2.1-or-later"
 build: ["pkg-config" "--exists" "flac"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libogg/conf-libogg.1/opam
+++ b/packages/conf-libogg/conf-libogg.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://xiph.org/ogg/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Xiph.Org Foundation"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["pkg-config" "--exists" "ogg"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libogg/conf-libogg.1/opam
+++ b/packages/conf-libogg/conf-libogg.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://xiph.org/ogg/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Xiph.Org Foundation"
-license: "BSD-1-Clause"
+license: "BSD-3-Clause"
 build: ["pkg-config" "--exists" "ogg"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libopus/conf-libopus.1/opam
+++ b/packages/conf-libopus/conf-libopus.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://opus-codec.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Xiph.Org Foundation"
-license: "BSD"
+license: "BSD-1-Clause-1"
 build: ["pkg-config" "--exists" "opus"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libopus/conf-libopus.1/opam
+++ b/packages/conf-libopus/conf-libopus.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://opus-codec.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Xiph.Org Foundation"
-license: "BSD-1-Clause-1"
+license: "BSD-3-Clause"
 build: ["pkg-config" "--exists" "opus"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libsamplerate/conf-libsamplerate.1/opam
+++ b/packages/conf-libsamplerate/conf-libsamplerate.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.mega-nerd.com/SRC/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "libsamplerate dev team"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["pkg-config" "--exists" "samplerate"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libsamplerate/conf-libsamplerate.1/opam
+++ b/packages/conf-libsamplerate/conf-libsamplerate.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.mega-nerd.com/SRC/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "libsamplerate dev team"
-license: "BSD-1-Clause"
+license: "BSD-2-clause"
 build: ["pkg-config" "--exists" "samplerate"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libspeex/conf-libspeex.1/opam
+++ b/packages/conf-libspeex/conf-libspeex.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://xiph.org/speex/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Xiph.Org Foundation"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["pkg-config" "--exists" "speex"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libspeex/conf-libspeex.1/opam
+++ b/packages/conf-libspeex/conf-libspeex.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://xiph.org/speex/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Xiph.Org Foundation"
-license: "BSD-1-Clause"
+license: "BSD-3-Clause"
 build: ["pkg-config" "--exists" "speex"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libtheora/conf-libtheora.1/opam
+++ b/packages/conf-libtheora/conf-libtheora.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.theora.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Xiph.Org Foundation"
-license: "BSD-1-Clause"
+license: "BSD-3-Clause"
 build: ["pkg-config" "--exists" "theora"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libtheora/conf-libtheora.1/opam
+++ b/packages/conf-libtheora/conf-libtheora.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.theora.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Xiph.Org Foundation"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["pkg-config" "--exists" "theora"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libvorbis/conf-libvorbis.1/opam
+++ b/packages/conf-libvorbis/conf-libvorbis.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://xiph.org/vorbis/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Xiph.Org Foundation"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["pkg-config" "--exists" "vorbis"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-libvorbis/conf-libvorbis.1/opam
+++ b/packages/conf-libvorbis/conf-libvorbis.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://xiph.org/vorbis/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Xiph.Org Foundation"
-license: "BSD-1-Clause"
+license: "BSD-3-Clause"
 build: ["pkg-config" "--exists" "vorbis"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-portaudio/conf-portaudio.1/opam
+++ b/packages/conf-portaudio/conf-portaudio.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.portaudio.com/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "portaudio dev team"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["pkg-config" "--exists" "portaudio-2.0"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-pulseaudio/conf-pulseaudio.1/opam
+++ b/packages/conf-pulseaudio/conf-pulseaudio.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://gitlab.freedesktop.org/pulseaudio/pulseaudio"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "pulseaudio dev team"
-license: "BSD-1-Clause"
+license: "LGPL-2.1+"
 build: ["sh" "-c" "pkg-config --exists libpulse && pkg-config --exists libpulse-simple"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-pulseaudio/conf-pulseaudio.1/opam
+++ b/packages/conf-pulseaudio/conf-pulseaudio.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://gitlab.freedesktop.org/pulseaudio/pulseaudio"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "pulseaudio dev team"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["sh" "-c" "pkg-config --exists libpulse && pkg-config --exists libpulse-simple"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-soundtouch/conf-soundtouch.1/opam
+++ b/packages/conf-soundtouch/conf-soundtouch.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.mega-nerd.com/SRC/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "soundtouch dev team"
-license: "BSD-1-Clause"
+license: "LGPL-2.1+"
 build: ["sh" "-c" "pkg-config --exists soundtouch || pkg-config --exists libSoundTouch || pkg-config --exists soundtouch-1.4"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-soundtouch/conf-soundtouch.1/opam
+++ b/packages/conf-soundtouch/conf-soundtouch.1/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.mega-nerd.com/SRC/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "soundtouch dev team"
-license: "BSD"
+license: "BSD-1-Clause"
 build: ["sh" "-c" "pkg-config --exists soundtouch || pkg-config --exists libSoundTouch || pkg-config --exists soundtouch-1.4"]
 depends: [
   "conf-pkg-config" {build}


### PR DESCRIPTION
This fixes the licenses for the configuration packages created via the Savonet team. Couple of notes:
* There appear to be multiple other configuration packages with the invalid `BSD` license
* * Given the shallow nature of these packages, the mere presence of a license seems unnecessary. Perhaps it should be made optional or set to a very minimal one