### PR TITLE
Release Caqti 1.4.0.

### DIFF
--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.4.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.4.0" & < "1.5.0~"}
+  "dune" {>= "1.11"}
+  "mariadb" {>= "1.1.1"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MariaDB driver for Caqti using C bindings"
+x-commit-hash: "c65b8d6094b00eb8de615f0b3459ad5c2718d52b"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.4.0/caqti-v1.4.0.tbz"
+  checksum: [
+    "sha256=9501f0bed11ae4c134824a1cfd2072614de46d56ee30c84245c040ef53e9dc46"
+    "sha512=56bfd42ab4f85d369b3a317047d8172172239ee7b2989b2b9c4a8d39349c5bd504cca54180a526c23486613ebe57c89f8be143007f6873089dc7d48bd03267f1"
+  ]
+}

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.4.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.4.0" & < "1.5.0~"}
+  "dune" {>= "1.11"}
+  "postgresql" {>= "5.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+x-commit-hash: "c65b8d6094b00eb8de615f0b3459ad5c2718d52b"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.4.0/caqti-v1.4.0.tbz"
+  checksum: [
+    "sha256=9501f0bed11ae4c134824a1cfd2072614de46d56ee30c84245c040ef53e9dc46"
+    "sha512=56bfd42ab4f85d369b3a317047d8172172239ee7b2989b2b9c4a8d39349c5bd504cca54180a526c23486613ebe57c89f8be143007f6873089dc7d48bd03267f1"
+  ]
+}

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.4.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.4.0" & < "1.5.0~"}
+  "dune" {>= "1.11"}
+  "sqlite3"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Sqlite3 driver for Caqti using C bindings"
+x-commit-hash: "c65b8d6094b00eb8de615f0b3459ad5c2718d52b"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.4.0/caqti-v1.4.0.tbz"
+  checksum: [
+    "sha256=9501f0bed11ae4c134824a1cfd2072614de46d56ee30c84245c040ef53e9dc46"
+    "sha512=56bfd42ab4f85d369b3a317047d8172172239ee7b2989b2b9c4a8d39349c5bd504cca54180a526c23486613ebe57c89f8be143007f6873089dc7d48bd03267f1"
+  ]
+}

--- a/packages/caqti/caqti.1.4.0/opam
+++ b/packages/caqti/caqti.1.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "Nathan Rebours <nathan@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "cppo" {build}
+  "dune" {>= "1.11"}
+  "logs"
+  "ocaml" {>= "4.04.0"}
+  "ptime"
+  "uri" {>= "1.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Unified interface to relational database libraries"
+description: """
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators."""
+x-commit-hash: "c65b8d6094b00eb8de615f0b3459ad5c2718d52b"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.4.0/caqti-v1.4.0.tbz"
+  checksum: [
+    "sha256=9501f0bed11ae4c134824a1cfd2072614de46d56ee30c84245c040ef53e9dc46"
+    "sha512=56bfd42ab4f85d369b3a317047d8172172239ee7b2989b2b9c4a8d39349c5bd504cca54180a526c23486613ebe57c89f8be143007f6873089dc7d48bd03267f1"
+  ]
+}

--- a/packages/conf-mariadb/conf-mariadb.2/opam
+++ b/packages/conf-mariadb/conf-mariadb.2/opam
@@ -14,7 +14,8 @@ depends: [
 depexts: [
   ["libmariadb-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["libmariadb-dev"] {os-family = "ubuntu"}
-  ["libmariadb-dev"] {os-distribution = "ubuntu" & os-version >= "18.04"}
+  ["libmariadb-dev"] {os-distribution = "ubuntu" & os-version >= "19.04"}
+  ["libmariadbclient-dev"] {os-distribution = "ubuntu" & os-version >= "18.04" & os-version < "19.04"}
   ["mariadb-connector-c-dev"] {os-family = "alpine"}
   ["mariadb-connector-c-devel"] {os-distribution = "centos" & os-version >= "8"}
   ["mariadb-connector-c-devel"] {os-distribution = "fedora"}

--- a/packages/conf-mariadb/conf-mariadb.2/opam
+++ b/packages/conf-mariadb/conf-mariadb.2/opam
@@ -12,9 +12,9 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libmariadbclient-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
-  ["libmariadbclient-dev"] {os-family = "ubuntu"}
-  ["libmariadbclient-dev"] {os-distribution = "ubuntu" & os-version >= "18.04"}
+  ["libmariadb-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
+  ["libmariadb-dev"] {os-family = "ubuntu"}
+  ["libmariadb-dev"] {os-distribution = "ubuntu" & os-version >= "18.04"}
   ["mariadb-connector-c-dev"] {os-family = "alpine"}
   ["mariadb-connector-c-devel"] {os-distribution = "centos" & os-version >= "8"}
   ["mariadb-connector-c-devel"] {os-distribution = "fedora"}


### PR DESCRIPTION
This release is first of all motivated by a bug in the sqlite3 driver (paurkedal/ocaml-caqti#63). The full change log:

- Fix infinite loop when deserializing an optional tuple (GPR#63 mefyl).
- Add `Caqti_connect_sig.S.with_connection` (GPR#61 Anton Bachin).
- Pass parameter types to PostgreSQL prepare and query functions. This
  avoids the need to CAST parameters on the SQL side in some cases.
- Add `?post_connect` callback to `connect_pool`.
- Documentation fixes and improvements (Aaron L. Zeng, Anton Bachin, Petter
  A. Urkedal).