### PR TITLE
Fix package constraints after release Caqti 1.4.0.

### DIFF
--- a/packages/caqti-async/caqti-async.1.3.0/opam
+++ b/packages/caqti-async/caqti-async.1.3.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "async_kernel" {>= "v0.11.0"}
   "async_unix" {>= "v0.11.0"}
-  "caqti" {>= "1.3.0" & < "1.4.0~"}
+  "caqti" {>= "1.3.0" & < "1.5.0~"}
   "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
   "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
   "core_kernel"

--- a/packages/caqti-dynload/caqti-dynload.1.3.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.1.3.0/opam
@@ -7,7 +7,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "caqti" {>= "1.3.0" & < "1.4.0~"}
+  "caqti" {>= "1.3.0" & < "1.5.0~"}
   "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
   "dune" {>= "1.11"}
   "ocamlfind"

--- a/packages/caqti-lwt/caqti-lwt.1.3.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.1.3.0/opam
@@ -7,7 +7,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml"
-  "caqti" {>= "1.3.0" & < "1.4.0~"}
+  "caqti" {>= "1.3.0" & < "1.5.0~"}
   "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
   "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
   "dune" {>= "1.11"}


### PR DESCRIPTION
I forgot to update the constraints for subpackages which were not updated in #18318.  And thanks for fixing the mariadb dependencies.