### PR TITLE
7 packages from oxidizing/sihl at 0.3.0

### DIFF
--- a/packages/sihl-cache/sihl-cache.0.3.0/opam
+++ b/packages/sihl-cache/sihl-cache.0.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "A module that provides services to store and retrieve data with key-value semantics"
+description:
+  "Depending on the backend the cache service can be used to improve performance or to persist arbitrary data."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=3265ccfac470edc97a524259ec98e15b"
+    "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"
+  ]
+}

--- a/packages/sihl-email/sihl-email.0.3.0/opam
+++ b/packages/sihl-email/sihl-email.0.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Sihl service to deal with sending emails"
+description: """
+
+Modules for sending emails using Lwt. Various email transports are provided that can be used in production or testing such as SMTP, Sendgrid, in-memory and console printing."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "letters" {>= "0.2.1"}
+  "sihl" {= version}
+  "cohttp-lwt-unix" {>= "2.5.4"}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=3265ccfac470edc97a524259ec98e15b"
+    "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"
+  ]
+}

--- a/packages/sihl-queue/sihl-queue.0.3.0/opam
+++ b/packages/sihl-queue/sihl-queue.0.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Sihl service to deal with queuing jobs"
+description: """
+
+Modules for putting and working jobs on queues. Various queue backends are provided."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=3265ccfac470edc97a524259ec98e15b"
+    "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"
+  ]
+}

--- a/packages/sihl-storage/sihl-storage.0.3.0/opam
+++ b/packages/sihl-storage/sihl-storage.0.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Sihl service to deal with storage of large files"
+description: """
+
+This service can be used to handle large binary blobs that are typically not stored in relational databases. Various storage backends are provided."""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=3265ccfac470edc97a524259ec98e15b"
+    "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"
+  ]
+}

--- a/packages/sihl-token/sihl-token.0.3.0/opam
+++ b/packages/sihl-token/sihl-token.0.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Sihl service to deal with tokens"
+description:
+  "Modules for token handling with support for JWT blacklisting and database-based tokens."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=3265ccfac470edc97a524259ec98e15b"
+    "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"
+  ]
+}

--- a/packages/sihl-user/sihl-user.0.3.0/opam
+++ b/packages/sihl-user/sihl-user.0.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Sihl services to deal with users"
+description: "Modules for user handling and password reset workflows."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "sihl-token" {= version & with-test}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=3265ccfac470edc97a524259ec98e15b"
+    "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"
+  ]
+}

--- a/packages/sihl/sihl.0.3.0/opam
+++ b/packages/sihl/sihl.0.3.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "The Sihl web framework"
+description:
+  "Modules for dealing with configuration, service lifecycle, app, CLI commands, logging, random number generation, middlewares and database."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "conformist" {>= "0.1.0"}
+  "tsort" {>= "2.0.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.8"}
+  "sexplib" {>= "v0.13.0"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.5.2"}
+  "tls" {>= "0.11.1"}
+  "ssl" {>= "0.5.9"}
+  "uuidm" {>= "0.9.7"}
+  "lwt_ssl" {>= "1.1.3"}
+  "caqti" {>= "1.2.1"}
+  "safepass" {>= "3.0"}
+  "jwto" {>= "0.3.0"}
+  "uuidm" {>= "0.9.7"}
+  "ppx_fields_conv" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "opium" {>= "0.20.0"}
+  "caqti" {>= "1.2.1"}
+  "caqti-lwt" {>= "1.2.0"}
+  "cohttp-lwt-unix" {>= "2.5.4" & with-test}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=3265ccfac470edc97a524259ec98e15b"
+    "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`sihl.0.3.0`: The Sihl web framework
-`sihl-cache.0.3.0`: A module that provides services to store and retrieve data with key-value semantics
-`sihl-email.0.3.0`: Sihl service to deal with sending emails
-`sihl-queue.0.3.0`: Sihl service to deal with queuing jobs
-`sihl-storage.0.3.0`: Sihl service to deal with storage of large files
-`sihl-token.0.3.0`: Sihl service to deal with tokens
-`sihl-user.0.3.0`: Sihl services to deal with users



---
* Homepage: https://github.com/oxidizing/sihl
* Source repo: git+https://github.com/oxidizing/sihl.git
* Bug tracker: https://github.com/oxidizing/sihl/issues

---
:camel: Pull-request generated by opam-publish v2.0.2