### PR TITLE
Package apronext.1.0.4

### DIFF
--- a/packages/apronext/apronext.1.0.4/opam
+++ b/packages/apronext/apronext.1.0.4/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Ghiles Ziat <ghiles.ziat@isae-supaero.fr"
+authors: ["Ghiles Ziat <ghiles.ziat@isae-supaero.fr"]
+homepage: "https://github.com/ghilesZ/apronext"
+bug-reports: "https://github.com/ghilesZ/apronext/issues"
+dev-repo: "git+https://github.com/ghilesZ/apronext"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "dune"  {>= "2.1"}
+  "ocaml" {>= "4.08"}
+  "apron"
+]
+synopsis: "Apron extension"
+description: "An extension for the OCaml interface of the Apron library"
+url {
+  src: "https://github.com/ghilesZ/apronext/archive/1.0.4.tar.gz"
+  checksum: [
+    "md5=1a61e232befa7e50becb03d116c883e8"
+    "sha512=6886bc6f09584b5b9e1e48f0ef2ddafdf0de9c42498d9f8c5293adfbec363706a37e4334a2b0852d1b95cb08f41c511b5a41889b94f178f46b8815f264c740a0"
+  ]
+}


### PR DESCRIPTION
### `apronext.1.0.4`
Apron extension
An extension for the OCaml interface of the Apron library



---
* Homepage: https://github.com/ghilesZ/apronext
* Source repo: git+https://github.com/ghilesZ/apronext
* Bug tracker: https://github.com/ghilesZ/apronext/issues

---
:camel: Pull-request generated by opam-publish v2.0.2