### PR TITLE
[new release] decoders-yojson, decoders-cbor, decoders, decoders-jsonm, decoders-ezjsonm, decoders-sexplib, decoders-bencode and decoders-msgpck (0.6.0)

### DIFF
--- a/packages/decoders-bencode/decoders-bencode.0.6.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Bencode backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Simon Cruanes <simon@imandra.ai>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders"
+  "bencode"
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "aab49f578fc39d9e53090c104a3918ac2ef20c68"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.6.0/decoders-v0.6.0.tbz"
+  checksum: [
+    "sha256=e7e3d43685e01aabf8c285c228a3bee9d601feff4fa065fe177860f16f3bed9e"
+    "sha512=d9774df8145367eb078016c9cdd3a80208b7c92ce6412e8bbb1c3b0fab370cac9a105014c996c7eeb2c32997fa9e4f94884ea897a435ba0785eff20e135b67bd"
+  ]
+}

--- a/packages/decoders-cbor/decoders-cbor.0.6.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.0.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "CBOR backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders"
+  "cbor"
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "aab49f578fc39d9e53090c104a3918ac2ef20c68"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.6.0/decoders-v0.6.0.tbz"
+  checksum: [
+    "sha256=e7e3d43685e01aabf8c285c228a3bee9d601feff4fa065fe177860f16f3bed9e"
+    "sha512=d9774df8145367eb078016c9cdd3a80208b7c92ce6412e8bbb1c3b0fab370cac9a105014c996c7eeb2c32997fa9e4f94884ea897a435ba0785eff20e135b67bd"
+  ]
+}

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.6.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Ezjsonm backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders"
+  "ezjsonm" {>= "0.4.0"}
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "aab49f578fc39d9e53090c104a3918ac2ef20c68"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.6.0/decoders-v0.6.0.tbz"
+  checksum: [
+    "sha256=e7e3d43685e01aabf8c285c228a3bee9d601feff4fa065fe177860f16f3bed9e"
+    "sha512=d9774df8145367eb078016c9cdd3a80208b7c92ce6412e8bbb1c3b0fab370cac9a105014c996c7eeb2c32997fa9e4f94884ea897a435ba0785eff20e135b67bd"
+  ]
+}

--- a/packages/decoders-jsonm/decoders-jsonm.0.6.0/opam
+++ b/packages/decoders-jsonm/decoders-jsonm.0.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Jsonm backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders"
+  "jsonm"
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "aab49f578fc39d9e53090c104a3918ac2ef20c68"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.6.0/decoders-v0.6.0.tbz"
+  checksum: [
+    "sha256=e7e3d43685e01aabf8c285c228a3bee9d601feff4fa065fe177860f16f3bed9e"
+    "sha512=d9774df8145367eb078016c9cdd3a80208b7c92ce6412e8bbb1c3b0fab370cac9a105014c996c7eeb2c32997fa9e4f94884ea897a435ba0785eff20e135b67bd"
+  ]
+}

--- a/packages/decoders-msgpck/decoders-msgpck.0.6.0/opam
+++ b/packages/decoders-msgpck/decoders-msgpck.0.6.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Msgpck backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: [
+  "Matt Bray <mattjbray@gmail.com>" "Simon Cruanes <simon@imandra.ai>"
+]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders"
+  "msgpck"
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "aab49f578fc39d9e53090c104a3918ac2ef20c68"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.6.0/decoders-v0.6.0.tbz"
+  checksum: [
+    "sha256=e7e3d43685e01aabf8c285c228a3bee9d601feff4fa065fe177860f16f3bed9e"
+    "sha512=d9774df8145367eb078016c9cdd3a80208b7c92ce6412e8bbb1c3b0fab370cac9a105014c996c7eeb2c32997fa9e4f94884ea897a435ba0785eff20e135b67bd"
+  ]
+}

--- a/packages/decoders-sexplib/decoders-sexplib.0.6.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.0.6.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Sexplib backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders"
+  "sexplib0"
+  "sexplib"
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "aab49f578fc39d9e53090c104a3918ac2ef20c68"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.6.0/decoders-v0.6.0.tbz"
+  checksum: [
+    "sha256=e7e3d43685e01aabf8c285c228a3bee9d601feff4fa065fe177860f16f3bed9e"
+    "sha512=d9774df8145367eb078016c9cdd3a80208b7c92ce6412e8bbb1c3b0fab370cac9a105014c996c7eeb2c32997fa9e4f94884ea897a435ba0785eff20e135b67bd"
+  ]
+}

--- a/packages/decoders-yojson/decoders-yojson.0.6.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Yojson backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders"
+  "yojson"
+  "odoc" {with-doc}
+  "containers" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "aab49f578fc39d9e53090c104a3918ac2ef20c68"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.6.0/decoders-v0.6.0.tbz"
+  checksum: [
+    "sha256=e7e3d43685e01aabf8c285c228a3bee9d601feff4fa065fe177860f16f3bed9e"
+    "sha512=d9774df8145367eb078016c9cdd3a80208b7c92ce6412e8bbb1c3b0fab370cac9a105014c996c7eeb2c32997fa9e4f94884ea897a435ba0785eff20e135b67bd"
+  ]
+}

--- a/packages/decoders/decoders.0.6.0/opam
+++ b/packages/decoders/decoders.0.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Elm-inspired decoders for Ocaml"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+  "containers" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+x-commit-hash: "aab49f578fc39d9e53090c104a3918ac2ef20c68"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.6.0/decoders-v0.6.0.tbz"
+  checksum: [
+    "sha256=e7e3d43685e01aabf8c285c228a3bee9d601feff4fa065fe177860f16f3bed9e"
+    "sha512=d9774df8145367eb078016c9cdd3a80208b7c92ce6412e8bbb1c3b0fab370cac9a105014c996c7eeb2c32997fa9e4f94884ea897a435ba0785eff20e135b67bd"
+  ]
+}


### PR DESCRIPTION
Yojson backend for decoders

- Project page: <a href="https://github.com/mattjbray/ocaml-decoders">https://github.com/mattjbray/ocaml-decoders</a>
- Documentation: <a href="https://mattjbray.github.io/ocaml-decoders/">https://mattjbray.github.io/ocaml-decoders/</a>

##### CHANGES:

* Add `Decode.of_of_string` and `Encode.of_to_string` (@mattjbray)
* Add `Decode.array` with bs-specific impl (mattjbray/ocaml-decoders#28, mattjbray/ocaml-decoders#30, @actionshrimp)
