### PR TITLE
[new release] coq-serapi (8.13.0+0.13.0)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.13.0+0.13.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.13.0+0.13.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.07.0"              }
+  "coq"                 {           >= "8.13.0" & < "8.14"   }
+  "cmdliner"            {           >= "1.0.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+x-commit-hash: "a22e3b7d6fb9956bea576f0f94d6bb294d7374fe"
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.13.0%2B0.13.0/coq-serapi-8.13.0.0.13.0.tbz"
+  checksum: [
+    "sha256=ddef1d7278021ce391f62e8e222e10962c7a308d6a2dfd8320382b4cf9a8cd75"
+    "sha512=8ee9cc09e5b8708b6cd7b0af8fccaa900413aa106cb47d99ca1fdd5b39c52676fa906204766f8f9e0964cc7e3ef987009de79f26b534b2021cf66f20c3d62bfe"
+  ]
+}


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

- [serapi] (!) support for Coq 8.13, see upstream changes; in
            particular there are changes in the kernel representation
            of terms [pattern matching, new caseinvert, primitive arrays]
