### PR TITLE
[new release] coq-serapi (8.12.0+0.12.1)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.12.0+0.12.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.12.0+0.12.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.07.0"              }
+  "coq"                 {           >= "8.12.0" & < "8.13"   }
+  "cmdliner"            {           >= "1.0.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+x-commit-hash: "5c29d2f7a8f2a806bcec983402a3b931dffe733d"
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.12.0%2B0.12.1/coq-serapi-8.12.0.0.12.1.tbz"
+  checksum: [
+    "sha256=08a12e8e8766c2e6a6a7394b0df48989c081367fa7d4d8dd8cdcd026575b4859"
+    "sha512=80267021f065f04543f72f16827fc7642ce98ed93940b0f780e83b0c751ac1a8df0e27018326315726c1b7b029015da31eec8322fda15a3a23c57850d53ef358"
+  ]
+}


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

* [serapi]  (!) Bump public library versioning [breaking change]
 * [opam]    Bump upper bound on ppx_sexp_conv to 0.15, allowing SerAPI
             to work with the 0.14 set of Jane Street packages.
 * [serapi]  Fix goal printing anomaly (ejgallego/coq-serapi#230, fixes ejgallego/coq-serapi#228 @corwin-of-amber)
 * [sertop ] New `(Fork (fifo_in file) (fifo_out file))` command, that
             will (hard) fork a new SerAPI process and redirect the
             input / output towards the given Unix FIFOs. This API is
             experimental but should allow quite a few advantages to
             some users willing to perform speculative execution.
             (ejgallego/coq-serapi#210 , improves ejgallego/coq-serapi#202 , @ejgallego)
 - [serapi]  Fix missing newline to separate goals (ejgallego/coq-serapi#235, fixes ejgallego/coq-serapi#231, @ejgallego)
