### PR TITLE
ppx_repr: conflict with ocaml-migrate-parsetree.1.7.1

### DIFF
--- a/packages/ppx_repr/ppx_repr.0.1.0/opam
+++ b/packages/ppx_repr/ppx_repr.0.1.0/opam
@@ -15,6 +15,9 @@ depends: [
   "alcotest" {>= "1.1.0" & with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "ocaml-migrate-parsetree" {= "1.7.1"}
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/ppx_repr/ppx_repr.0.2.0/opam
+++ b/packages/ppx_repr/ppx_repr.0.2.0/opam
@@ -14,6 +14,9 @@ depends: [
   "hex" {with-test}
   "alcotest" {>= "1.1.0" & with-test}
 ]
+conflicts: [
+  "ocaml-migrate-parsetree" {= "1.7.1"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ppx_repr/ppx_repr.0.2.1/opam
+++ b/packages/ppx_repr/ppx_repr.0.2.1/opam
@@ -15,6 +15,9 @@ depends: [
   "alcotest" {>= "1.1.0" & with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "ocaml-migrate-parsetree" {= "1.7.1"}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
`ppx_repr` is affected by a bug with this version of OMP. See https://github.com/mirage/repr/issues/48 for details.