### PR TITLE
Sundials/ML: fix build under OCaml 4.12.0

### DIFF
--- a/packages/conf-sundials/conf-sundials.1/files/test.c
+++ b/packages/conf-sundials/conf-sundials.1/files/test.c
@@ -1,0 +1,1 @@
+#include <sundials/sundials_config.h>

--- a/packages/conf-sundials/conf-sundials.1/opam
+++ b/packages/conf-sundials/conf-sundials.1/opam
@@ -6,8 +6,7 @@ authors: "Sundials dev team"
 license: "BSD-3-Clause"
 build: ["cc" "-E" "test.c"]
 depexts: [
-  ["libsundials-dev"] {os-family = "debian" & os-distribution != "debian"}
-  ["libsundials-dev"] {os-family = "ubuntu" & os-distribution != "ubuntu"}
+  ["libsundials-dev"] {(os-family = "debian" | os-family = "ubuntu") & os-distribution != "debian" & os-distribution != "ubuntu"}
   ["libsundials-dev"] {os-distribution = "debian" & os-version >= "10"}
   ["libsundials-dev"] {os-distribution = "ubuntu" & os-version >= "18.04"}
   ["libsundials-serial-dev"] {os-distribution = "debian" & os-version < "10"}

--- a/packages/conf-sundials/conf-sundials.1/opam
+++ b/packages/conf-sundials/conf-sundials.1/opam
@@ -6,8 +6,10 @@ authors: "Sundials dev team"
 license: "BSD-3-Clause"
 build: ["cc" "-E" "test.c"]
 depexts: [
-  ["libsundials-dev"] {os-family = "debian" & ! (os-distribution = "debian" & os-version < "10")}
-  ["libsundials-dev"] {os-family = "ubuntu" & ! (os-distribution = "ubuntu" & os-version < "18.04")}
+  ["libsundials-dev"] {os-family = "debian" & os-distribution != "debian"}
+  ["libsundials-dev"] {os-family = "ubuntu" & os-distribution != "ubuntu"}
+  ["libsundials-dev"] {os-distribution = "debian" & os-version >= "10"}
+  ["libsundials-dev"] {os-distribution = "ubuntu" & os-version >= "18.04"}
   ["libsundials-serial-dev"] {os-distribution = "debian" & os-version < "10"}
   ["libsundials-serial-dev"] {os-distribution = "ubuntu" & os-version < "18.04"}
   ["sundials-devel"] {os-distribution = "fedora"}

--- a/packages/conf-sundials/conf-sundials.1/opam
+++ b/packages/conf-sundials/conf-sundials.1/opam
@@ -6,8 +6,10 @@ authors: "Sundials dev team"
 license: "BSD-3-Clause"
 build: ["cc" "-E" "test.c"]
 depexts: [
-  ["libsundials-dev"] {os-family = "debian"}
-  ["libsundials-dev"] {os-family = "ubuntu"}
+  ["libsundials-dev"] {os-family = "debian" & ! (os-distribution = "debian" & os-version < "10")}
+  ["libsundials-dev"] {os-family = "ubuntu" & ! (os-distribution = "ubuntu" & os-version < "18.04")}
+  ["libsundials-serial-dev"] {os-distribution = "debian" & os-version < "10"}
+  ["libsundials-serial-dev"] {os-distribution = "ubuntu" & os-version < "18.04"}
   ["sundials-devel"] {os-distribution = "fedora"}
   ["epel-release" "sundials-devel"] {os-distribution = "centos"}
   ["sundials-devel"] {os-distribution = "rhel"}

--- a/packages/conf-sundials/conf-sundials.1/opam
+++ b/packages/conf-sundials/conf-sundials.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://computing.llnl.gov/projects/sundials"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "Sundials dev team"
+license: "BSD-3-Clause"
+build: ["cc" "-E" "test.c"]
+depexts: [
+  ["libsundials-dev"] {os-family = "debian"}
+  ["libsundials-dev"] {os-family = "ubuntu"}
+  ["sundials-devel"] {os-distribution = "fedora"}
+  ["epel-release" "sundials-devel"] {os-distribution = "centos"}
+  ["sundials-devel"] {os-distribution = "rhel"}
+  ["sundials-devel"] {os-distribution = "ol"}
+  ["sundials-devel"] {os-family = "suse"}
+  ["sundials"] {os-family = "arch"}
+  ["sci-libs/sundials"] {os-family = "gentoo"}
+  ["sundials"] {os = "macos" & os-distribution = "homebrew"}
+  ["sundials"] {os = "macos" & os-distribution = "macports"}
+  ["sundials"] {os = "freebsd"}
+  ["sundials"] {os = "openbsd"}
+  ["sundials"] {os = "netbsd"}
+]
+x-ci-accept-failures: [
+  "alpine-3.12" # package not available by default
+]
+extra-files: [
+  ["test.c" "md5=00a7c58d130f4aabfec5fe37aff9907e"]
+]
+synopsis: "Virtual package relying on sundials"
+description:
+  "This package can only install if the sundials library is installed on the system."
+flags: conf

--- a/packages/sundialsml/sundialsml.2.5.0p0/opam
+++ b/packages/sundialsml/sundialsml.2.5.0p0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "sundialsml"
 maintainer: "tim@tbrk.org"
 authors: [
     "Timothy Bourke <tim@tbrk.org>"
@@ -20,19 +19,14 @@ build: [
   [make "tests.opt.log"] {with-test}
   [make "doc"] {with-doc}
 ]
-remove: [["ocamlfind" "remove" "sundialsml"]]
 depends: [
   "ocaml" {>= "3.12.1"}
   "base-bigarray"
   "ocamlfind"
+  "conf-sundials" {build}
 ]
 depopts: [
     "mpi"
-]
-depexts: [
-  ["libsundials-serial-dev"] {os-family = "debian"}
-  ["sundials"] {os = "macos" & os-distribution = "homebrew"}
-  ["sundials"] {os = "macos" & os-distribution = "macports"}
 ]
 dev-repo: "git://github.com/inria-parkas/sundialsml"
 install: [
@@ -70,7 +64,6 @@ The OCaml documentation contains extensive cross-links to the original
 documentation. OCaml versions of the standard examples usually have an
 overhead of about 50% compared to the original C versions, and almost never
 more than 100%."""
-flags: light-uninstall
 url {
   src: "https://github.com/inria-parkas/sundialsml/archive/v2.5.0p0.zip"
   checksum: "md5=ee0c22de275b1f26cab4ecfb08315c02"

--- a/packages/sundialsml/sundialsml.2.5.0p0/opam
+++ b/packages/sundialsml/sundialsml.2.5.0p0/opam
@@ -6,6 +6,7 @@ authors: [
     "Marc Pouzet <Marc.Pouzet@ens.fr>"
 ]
 homepage: "http://inria-parkas.github.io/sundialsml/"
+bug-reports: "https://github.com/inria-parkas/sundialsml/issues"
 doc: "http://inria-parkas.github.io/sundialsml/"
 tags: [
     "numerical"
@@ -34,7 +35,7 @@ install: [
   [make "install-doc"] {with-doc}
 ]
 synopsis:
-  "Sundials/ML is an interface to the Sundials suite of numerical solvers."
+  "Sundials/ML is an interface to the Sundials suite of numerical solvers"
 description: """
 Sundials is a collection of five numerical solvers: CVODE, CVODES, IDA,
 IDAS, and KINSOL. This interface provides access to all features of the

--- a/packages/sundialsml/sundialsml.2.5.0p1/opam
+++ b/packages/sundialsml/sundialsml.2.5.0p1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "sundialsml"
 maintainer: "tim@tbrk.org"
 authors: [
     "Timothy Bourke <tim@tbrk.org>"
@@ -20,19 +19,14 @@ build: [
   [make "tests.opt.log"] {with-test}
   [make "doc"] {with-doc}
 ]
-remove: [["ocamlfind" "remove" "sundialsml"]]
 depends: [
   "ocaml" {>= "3.12.1"}
   "base-bigarray"
   "ocamlfind"
+  "conf-sundials" {build}
 ]
 depopts: [
     "mpi"
-]
-depexts: [
-  ["libsundials-serial-dev"] {os-family = "debian"}
-  ["sundials"] {os = "macos" & os-distribution = "homebrew"}
-  ["sundials"] {os = "macos" & os-distribution = "macports"}
 ]
 dev-repo: "git://github.com/inria-parkas/sundialsml"
 install: [
@@ -70,7 +64,6 @@ The OCaml documentation contains extensive cross-links to the original
 documentation. OCaml versions of the standard examples usually have an
 overhead of about 50% compared to the original C versions, and almost never
 more than 100%."""
-flags: light-uninstall
 url {
   src: "https://github.com/inria-parkas/sundialsml/archive/v2.5.0p1.zip"
   checksum: "md5=04454bd6b5278bcc65e8fe410dd33f1e"

--- a/packages/sundialsml/sundialsml.2.5.0p1/opam
+++ b/packages/sundialsml/sundialsml.2.5.0p1/opam
@@ -6,6 +6,7 @@ authors: [
     "Marc Pouzet <Marc.Pouzet@ens.fr>"
 ]
 homepage: "http://inria-parkas.github.io/sundialsml/"
+bug-reports: "https://github.com/inria-parkas/sundialsml/issues"
 doc: "http://inria-parkas.github.io/sundialsml/"
 tags: [
     "numerical"
@@ -34,7 +35,7 @@ install: [
   [make "install-doc"] {with-doc}
 ]
 synopsis:
-  "Sundials/ML is an interface to the Sundials suite of numerical solvers."
+  "Sundials/ML is an interface to the Sundials suite of numerical solvers"
 description: """
 Sundials is a collection of five numerical solvers: CVODE, CVODES, IDA,
 IDAS, and KINSOL. This interface provides access to all features of the

--- a/packages/sundialsml/sundialsml.2.5.0p2/opam
+++ b/packages/sundialsml/sundialsml.2.5.0p2/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "sundialsml"
 maintainer: "tim@tbrk.org"
 authors: [
     "Timothy Bourke <tim@tbrk.org>"
@@ -20,19 +19,14 @@ build: [
   [make "tests.opt.log"] {with-test}
   [make "doc"] {with-doc}
 ]
-remove: [["ocamlfind" "remove" "sundialsml"]]
 depends: [
   "ocaml" {>= "3.12.1"}
   "base-bigarray"
   "ocamlfind"
+  "conf-sundials" {build}
 ]
 depopts: [
     "mpi"
-]
-depexts: [
-  ["libsundials-serial-dev"] {os-family = "debian"}
-  ["homebrew/science/sundials"] {os = "macos" & os-distribution = "homebrew"}
-  ["sundials"] {os = "macos" & os-distribution = "macports"}
 ]
 dev-repo: "git://github.com/inria-parkas/sundialsml"
 install: [
@@ -70,7 +64,6 @@ The OCaml documentation contains extensive cross-links to the original
 documentation. OCaml versions of the standard examples usually have an
 overhead of about 50% compared to the original C versions, and almost never
 more than 100%."""
-flags: light-uninstall
 url {
   src: "https://github.com/inria-parkas/sundialsml/archive/v2.5.0p2.zip"
   checksum: "md5=479095cc1cd4d9988cfe2e4848496b98"

--- a/packages/sundialsml/sundialsml.2.5.0p2/opam
+++ b/packages/sundialsml/sundialsml.2.5.0p2/opam
@@ -6,6 +6,7 @@ authors: [
     "Marc Pouzet <Marc.Pouzet@ens.fr>"
 ]
 homepage: "http://inria-parkas.github.io/sundialsml/"
+bug-reports: "https://github.com/inria-parkas/sundialsml/issues"
 doc: "http://inria-parkas.github.io/sundialsml/"
 tags: [
     "numerical"
@@ -34,7 +35,7 @@ install: [
   [make "install-doc"] {with-doc}
 ]
 synopsis:
-  "Sundials/ML is an interface to the Sundials suite of numerical solvers."
+  "Sundials/ML is an interface to the Sundials suite of numerical solvers"
 description: """
 Sundials is a collection of five numerical solvers: CVODE, CVODES, IDA,
 IDAS, and KINSOL. This interface provides access to all features of the

--- a/packages/sundialsml/sundialsml.2.6.2p0/opam
+++ b/packages/sundialsml/sundialsml.2.6.2p0/opam
@@ -40,7 +40,7 @@ depopts: [
 ]
 dev-repo: "git://github.com/inria-parkas/sundialsml"
 synopsis:
-  "Sundials/ML is an interface to the Sundials suite of numerical solvers."
+  "Sundials/ML is an interface to the Sundials suite of numerical solvers"
 description: """
 Sundials is a collection of six numerical solvers: CVODE, CVODES, IDA, IDAS,
 ARKODE, and KINSOL. This interface provides access to all features of the

--- a/packages/sundialsml/sundialsml.2.6.2p0/opam
+++ b/packages/sundialsml/sundialsml.2.6.2p0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "sundialsml"
 maintainer: "tim@tbrk.org"
 authors: [
     "Timothy Bourke <tim@tbrk.org>"
@@ -30,22 +29,14 @@ install: [
   [make "install-findlib"]
   [make "install-doc"] {with-doc}
 ]
-remove: [["ocamlfind" "remove" "sundialsml"]]
 depends: [
   "ocaml" {>= "3.12.1"}
   "base-bigarray"
   "ocamlfind"
+  "conf-sundials" {build}
 ]
 depopts: [
     "mpi"
-]
-depexts: [
-  ["libsundials-serial-dev"] {os-family = "debian"}
-  ["lapack-devel" "sundials-devel"] {os-distribution = "fedora"}
-  ["epel-release" "lapack-devel" "sundials-devel"]
-    {os-distribution = "centos"}
-  ["homebrew/science/sundials"] {os = "macos" & os-distribution = "homebrew"}
-  ["sundials"] {os = "macos" & os-distribution = "macports"}
 ]
 dev-repo: "git://github.com/inria-parkas/sundialsml"
 synopsis:
@@ -79,7 +70,6 @@ The OCaml documentation contains extensive cross-links to the original
 documentation. OCaml versions of the standard examples usually have an
 overhead of about 30% compared to the original C versions, and almost never
 more than 50%."""
-flags: light-uninstall
 url {
   src: "https://github.com/inria-parkas/sundialsml/archive/v2.6.2p0.zip"
   checksum: "md5=91985c269fb326d758bef9db044a433a"

--- a/packages/sundialsml/sundialsml.2.6.2p1/opam
+++ b/packages/sundialsml/sundialsml.2.6.2p1/opam
@@ -40,7 +40,7 @@ depopts: [
 ]
 dev-repo: "git://github.com/inria-parkas/sundialsml"
 synopsis:
-  "Sundials/ML is an interface to the Sundials suite of numerical solvers."
+  "Sundials/ML is an interface to the Sundials suite of numerical solvers"
 description: """
 Sundials is a collection of six numerical solvers: CVODE, CVODES, IDA, IDAS,
 ARKODE, and KINSOL. This interface provides access to all features of the

--- a/packages/sundialsml/sundialsml.2.6.2p1/opam
+++ b/packages/sundialsml/sundialsml.2.6.2p1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "sundialsml"
 maintainer: "tim@tbrk.org"
 authors: [
     "Timothy Bourke <tim@tbrk.org>"
@@ -30,22 +29,14 @@ install: [
   [make "install-findlib"]
   [make "install-doc"] {with-doc}
 ]
-remove: [["ocamlfind" "remove" "sundialsml"]]
 depends: [
   "ocaml" {>= "3.12.1"}
   "base-bigarray"
   "ocamlfind"
+  "conf-sundials" {build}
 ]
 depopts: [
     "mpi"
-]
-depexts: [
-  ["libsundials-serial-dev"] {os-family = "debian"}
-  ["lapack-devel" "sundials-devel"] {os-distribution = "fedora"}
-  ["epel-release" "lapack-devel" "sundials-devel"]
-    {os-distribution = "centos"}
-  ["homebrew/science/sundials"] {os = "macos" & os-distribution = "homebrew"}
-  ["sundials"] {os = "macos" & os-distribution = "macports"}
 ]
 dev-repo: "git://github.com/inria-parkas/sundialsml"
 synopsis:
@@ -79,7 +70,6 @@ The OCaml documentation contains extensive cross-links to the original
 documentation. OCaml versions of the standard examples usually have an
 overhead of about 30% compared to the original C versions, and almost never
 more than 50%."""
-flags: light-uninstall
 url {
   src: "https://github.com/inria-parkas/sundialsml/archive/v2.6.2p1.zip"
   checksum: "md5=71fd10d67a87969d9fda2cbc188124f4"

--- a/packages/sundialsml/sundialsml.2.7.0p0/opam
+++ b/packages/sundialsml/sundialsml.2.7.0p0/opam
@@ -40,7 +40,7 @@ depopts: [
 ]
 dev-repo: "git://github.com/inria-parkas/sundialsml"
 synopsis:
-  "Sundials/ML is an interface to the Sundials suite of numerical solvers."
+  "Sundials/ML is an interface to the Sundials suite of numerical solvers"
 description: """
 Sundials is a collection of six numerical solvers: CVODE, CVODES, IDA, IDAS,
 ARKODE, and KINSOL. This interface provides access to all features of the

--- a/packages/sundialsml/sundialsml.2.7.0p0/opam
+++ b/packages/sundialsml/sundialsml.2.7.0p0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "sundialsml"
 maintainer: "tim@tbrk.org"
 authors: [
     "Timothy Bourke <tim@tbrk.org>"
@@ -30,22 +29,14 @@ install: [
   [make "install-findlib"]
   [make "install-doc"] {with-doc}
 ]
-remove: [["ocamlfind" "remove" "sundialsml"]]
 depends: [
   "ocaml" {>= "3.12.1"}
   "base-bigarray"
   "ocamlfind"
+  "conf-sundials" {build}
 ]
 depopts: [
     "mpi"
-]
-depexts: [
-  ["libsundials-serial-dev"] {os-family = "debian"}
-  ["lapack-devel" "sundials-devel"] {os-distribution = "fedora"}
-  ["epel-release" "lapack-devel" "sundials-devel"]
-    {os-distribution = "centos"}
-  ["homebrew/science/sundials"] {os = "macos" & os-distribution = "homebrew"}
-  ["sundials"] {os = "macos" & os-distribution = "macports"}
 ]
 dev-repo: "git://github.com/inria-parkas/sundialsml"
 synopsis:
@@ -79,7 +70,6 @@ The OCaml documentation contains extensive cross-links to the original
 documentation. OCaml versions of the standard examples usually have an
 overhead of about 30% compared to the original C versions, and almost never
 more than 50%."""
-flags: light-uninstall
 url {
   src: "https://github.com/inria-parkas/sundialsml/archive/v2.7.0p0.zip"
   checksum: "md5=bf22a8235c5ba25e4c3e5428ca876dbb"

--- a/packages/sundialsml/sundialsml.3.1.1p0-1/opam
+++ b/packages/sundialsml/sundialsml.3.1.1p0-1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "sundialsml"
 maintainer: "tim@tbrk.org"
 authors: [
     "Timothy Bourke <tim@tbrk.org>"
@@ -34,22 +33,10 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "base-bigarray"
   "ocamlfind" {build}
+  "conf-sundials" {build}
 ]
 depopts: [
     "mpi"
-]
-depexts: [
-  ["libsundials-dev"] {os-family = "debian"}
-  ["lapack-devel" "sundials-devel"] {os-distribution = "fedora"}
-  [
-    "epel-release"
-    "lapack-devel"
-    "suitesparse-devel"
-    "SuperLUMT-devel"
-    "sundials-devel"
-  ] {os-distribution = "centos"}
-  ["sundials"] {os = "macos" & os-distribution = "homebrew"}
-  ["sundials"] {os = "macos" & os-distribution = "macports"}
 ]
 synopsis: "Interface to the Sundials suite of numerical solvers"
 description: """

--- a/packages/sundialsml/sundialsml.3.1.1p0/opam
+++ b/packages/sundialsml/sundialsml.3.1.1p0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "sundialsml"
 maintainer: "tim@tbrk.org"
 authors: [
     "Timothy Bourke <tim@tbrk.org>"
@@ -30,27 +29,14 @@ install: [
   [make "install-findlib"]
   [make "install-doc"] {with-doc}
 ]
-remove: [["ocamlfind" "remove" "sundialsml"]]
 depends: [
   "ocaml" {>= "4.02.3"}
   "base-bigarray"
   "ocamlfind" {build}
+  "conf-sundials" {build}
 ]
 depopts: [
     "mpi"
-]
-depexts: [
-  ["libsundials-serial-dev"] {os-family = "debian"}
-  ["lapack-devel" "sundials-devel"] {os-distribution = "fedora"}
-  [
-    "epel-release"
-    "lapack-devel"
-    "suitesparse-devel"
-    "SuperLUMT-devel"
-    "sundials-devel"
-  ] {os-distribution = "centos"}
-  ["sundials"] {os = "macos" & os-distribution = "homebrew"}
-  ["sundials"] {os = "macos" & os-distribution = "macports"}
 ]
 synopsis: "Interface to the Sundials suite of numerical solvers"
 description: """
@@ -82,7 +68,6 @@ The detailed OCaml documentation contains cross-links to the original
 documentation. OCaml versions of the standard examples usually have an
 overhead of about 30% compared to the original C versions, and only rarely
 more than 50%."""
-flags: light-uninstall
 url {
   src: "https://github.com/inria-parkas/sundialsml/archive/v3.1.1p0.zip"
   checksum: "md5=0c35080ac75baf6ce1cd9e5056f5e639"

--- a/packages/sundialsml/sundialsml.3.1.1p1/opam
+++ b/packages/sundialsml/sundialsml.3.1.1p1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "sundialsml"
 maintainer: "tim@tbrk.org"
 authors: [
     "Timothy Bourke <tim@tbrk.org>"

--- a/packages/sundialsml/sundialsml.3.1.1p1/opam
+++ b/packages/sundialsml/sundialsml.3.1.1p1/opam
@@ -33,22 +33,10 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "base-bigarray"
   "ocamlfind" {build}
+  "conf-sundials" {build}
 ]
 depopts: [
     "mpi"
-]
-depexts: [
-  ["libsundials-dev"] {os-family = "debian"}
-  ["lapack-devel" "sundials-devel"] {os-distribution = "fedora"}
-  [
-    "epel-release"
-    "lapack-devel"
-    "suitesparse-devel"
-    "SuperLUMT-devel"
-    "sundials-devel"
-  ] {os-distribution = "centos"}
-  ["sundials"] {os = "macos" & os-distribution = "homebrew"}
-  ["sundials"] {os = "macos" & os-distribution = "macports"}
 ]
 synopsis: "Interface to the Sundials suite of numerical solvers"
 description: """

--- a/packages/sundialsml/sundialsml.3.1.1p1/opam
+++ b/packages/sundialsml/sundialsml.3.1.1p1/opam
@@ -1,0 +1,87 @@
+opam-version: "2.0"
+name: "sundialsml"
+maintainer: "tim@tbrk.org"
+authors: [
+    "Timothy Bourke <tim@tbrk.org>"
+    "Jun Inoue <Jun.Lambda@gmail.com>"
+    "Marc Pouzet <Marc.Pouzet@ens.fr>"
+]
+homepage: "http://inria-parkas.github.io/sundialsml/"
+bug-reports: "https://github.com/inria-parkas/sundialsml/issues"
+dev-repo: "git://github.com/inria-parkas/sundialsml"
+doc: "http://inria-parkas.github.io/sundialsml/"
+tags: [
+    "numerical"
+    "simulation"
+    "mathematics"
+    "science"
+]
+license: "BSD-3-Clause"
+build: [
+  [
+    "./configure"
+    "--stubdir=%{stublibs}%/"
+    "--libdir=%{lib}%/"
+    "--docdir=%{doc}%/"
+  ]
+  [make "doc"] {with-doc}
+]
+install: [
+  [make "install-findlib"]
+  [make "install-doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "base-bigarray"
+  "ocamlfind" {build}
+]
+depopts: [
+    "mpi"
+]
+depexts: [
+  ["libsundials-dev"] {os-family = "debian"}
+  ["lapack-devel" "sundials-devel"] {os-distribution = "fedora"}
+  [
+    "epel-release"
+    "lapack-devel"
+    "suitesparse-devel"
+    "SuperLUMT-devel"
+    "sundials-devel"
+  ] {os-distribution = "centos"}
+  ["sundials"] {os = "macos" & os-distribution = "homebrew"}
+  ["sundials"] {os = "macos" & os-distribution = "macports"}
+]
+synopsis: "Interface to the Sundials suite of numerical solvers"
+description: """
+Sundials is a collection of six numerical solvers: CVODE, CVODES, IDA, IDAS,
+ARKODE, and KINSOL. This interface provides access to all features of the
+underlying library except the Hypre and PETSC nvectors.
+
+The structure of the OCaml interface mostly follows that of the original
+library, both for ease of reading the existing documentation and for
+converting existing source code, but several changes have been made for
+programming convenience and to increase safety, namely:
+
+- solver sessions are mostly configured via algebraic data types rather than
+  multiple function calls;
+
+- errors are signalled by exceptions not return codes (also from
+  user-supplied callback routines);
+
+- user data is shared between callback routines via closures (partial
+  applications of functions);
+
+- vectors are checked for compatibility with a session (using a combination
+  of static and dynamic checks), and;
+
+- explicit free commands are not necessary since OCaml is a
+  garbage-collected language.
+
+The detailed OCaml documentation contains cross-links to the original
+documentation. OCaml versions of the standard examples usually have an
+overhead of about 30% compared to the original C versions, and only rarely
+more than 50%."""
+url {
+  src: "https://github.com/inria-parkas/sundialsml/archive/v3.1.1p1.zip"
+  checksum: "md5=64363f3bccec3c561fa56ed59e555361"
+}


### PR DESCRIPTION
Minor patches to fix build under OCaml 4.12.0. Still no major upgrade to the supported version of Sundials.