### PR TITLE
[new release] sha (1.14)

### DIFF
--- a/packages/sha/sha.1.14/opam
+++ b/packages/sha/sha.1.14/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Binding to the SHA cryptographic functions"
+description: """
+This is the binding for SHA interface code in OCaml. Offering the same
+interface than the MD5 digest included in the OCaml standard library.
+It's currently providing SHA1, SHA256 and SHA512 hash functions."""
+maintainer: ["dave@recoil.org"]
+authors: [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Goswin von Brederlow"
+  "Eric Cooper"
+  "Florent Monnier"
+  "Forrest L Norvell"
+  "Vincent Bernadoff"
+  "David Scott"
+  "Olaf Hering"
+  "Arthur Teisseire"
+  "Nicolás Ojeda Bär"
+  "Christopher Zimmermann"
+  "Thomas Leonard"
+]
+license: "ISC"
+homepage: "https://github.com/djs55/ocaml-sha"
+bug-reports: "https://github.com/djs55/ocaml-sha/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "stdlib-shims" {>= "0.3.0"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/djs55/ocaml-sha.git"
+x-commit-hash: "c86a4c76b23a6bd3ae700ea054dc4b6e4d4feef7"
+url {
+  src:
+    "https://github.com/djs55/ocaml-sha/releases/download/v1.14/sha-v1.14.tbz"
+  checksum: [
+    "sha256=29d051bf35f30132d11e45069688257002bfe26463befda257eedce672f39b84"
+    "sha512=029a86e1aab43bc496f7cd285f056f0d5b192e0e90ce989d628b2e64ae1dc03860f91d382337a6a772635fe746cc63fe283e1857fa6ab2f51019c3adb3f19108"
+  ]
+}


### PR DESCRIPTION
Binding to the SHA cryptographic functions

- Project page: <a href="https://github.com/djs55/ocaml-sha">https://github.com/djs55/ocaml-sha</a>

##### CHANGES:

- Handle `safe-string` by @olafhering, reviewed by @nojb (djs55/ocaml-sha#47)
- Remove `--dev` option from `dune` invocation by @arthurteisseire (djs55/ocaml-sha#48)
