### PR TITLE
[new release] carton, carton-lwt and carton-git (0.4.0)

### DIFF
--- a/packages/carton-git/carton-git.0.4.0/opam
+++ b/packages/carton-git/carton-git.0.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "carton" {= version}
+  "carton-lwt" {= version}
+  "bigstringaf"
+  "bigarray-compat"
+  "lwt"
+  "fpath"
+  "result"
+  "mmap"
+  "fmt" {>= "0.8.7"}
+  "base-unix"
+  "decompress" {>= "1.3.0"}
+  "astring" {>= "0.8.5"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "6cb4962c8b2e9a18312c0599f659eb64bc3c2445"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.4.0/carton-carton-v0.4.0.tbz"
+  checksum: [
+    "sha256=777f9692b83cd63570c17527a32c5045818ab9242d923cbbde72fc23d0da0140"
+    "sha512=d148c1a77a67e25dd1871fa222f64ecb8dfac92c8c038c436b385fb7e2fe5eba29c9f415187aa030da05e794d0cab6484c1fa99bffe339a52efeed0672979fb8"
+  ]
+}

--- a/packages/carton-lwt/carton-lwt.0.4.0/opam
+++ b/packages/carton-lwt/carton-lwt.0.4.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "carton" {= version}
+  "lwt"
+  "decompress" {>= "1.3.0"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf"
+  "bigarray-compat" {with-test}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "fmt" {>= "0.8.9" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "result" {>= "1.5" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+  "base64" {>= "3.4.0" & with-test}
+  "bos" {>= "0.2.0" & with-test}
+  "checkseum" {>= "0.3.0" & with-test}
+  "digestif" {>= "1.0.0" & with-test}
+  "fpath" {>= "0.7.3" & with-test}
+  "mmap" {>= "1.1.0" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "6cb4962c8b2e9a18312c0599f659eb64bc3c2445"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.4.0/carton-carton-v0.4.0.tbz"
+  checksum: [
+    "sha256=777f9692b83cd63570c17527a32c5045818ab9242d923cbbde72fc23d0da0140"
+    "sha512=d148c1a77a67e25dd1871fa222f64ecb8dfac92c8c038c436b385fb7e2fe5eba29c9f415187aa030da05e794d0cab6484c1fa99bffe339a52efeed0672979fb8"
+  ]
+}

--- a/packages/carton/carton.0.4.0/opam
+++ b/packages/carton/carton.0.4.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACKv2 file in OCaml"
+description: """\
+Carton is an implementation of the PACKv2 file
+in OCaml. PACKv2 file is used by Git to store Git objects.
+Carton is more abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "ke" {>= "0.4"}
+  "duff" {>= "0.3"}
+  "decompress" {>= "1.3.0"}
+  "cstruct" {>= "5.0.0"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf"
+  "checkseum" {>= "0.2.1"}
+  "logs"
+  "bigstringaf"
+  "bigarray-compat"
+  "cmdliner" {>= "1.0.4"}
+  "hxd" {>= "0.3.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.7"}
+  "result"
+  "rresult"
+  "fpath"
+  "base64" {with-test & >= "3.0.0"}
+  "bos"
+  "digestif" {>= "0.8.1"}
+  "mmap"
+  "base-unix" {with-test}
+  "base-threads" {with-test}
+  "alcotest" {with-test}
+  "crowbar" {with-test & >= "0.2"}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "lwt" {>= "5.3.0" & with-test}
+  "ocamlfind" {>= "1.8.1" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "6cb4962c8b2e9a18312c0599f659eb64bc3c2445"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.4.0/carton-carton-v0.4.0.tbz"
+  checksum: [
+    "sha256=777f9692b83cd63570c17527a32c5045818ab9242d923cbbde72fc23d0da0140"
+    "sha512=d148c1a77a67e25dd1871fa222f64ecb8dfac92c8c038c436b385fb7e2fe5eba29c9f415187aa030da05e794d0cab6484c1fa99bffe339a52efeed0672979fb8"
+  ]
+}

--- a/packages/git/git.3.3.1/opam
+++ b/packages/git/git.3.3.1/opam
@@ -30,9 +30,9 @@ depends: [
   "mimic"
   "cstruct" {>= "5.0.0"}
   "angstrom" {>= "0.14.0"}
-  "carton" {>= "0.3.0"}
-  "carton-lwt" {>= "0.3.0"}
-  "carton-git" {>= "0.3.0"}
+  "carton" {>= "0.3.0" & < "0.4.0"}
+  "carton-lwt" {>= "0.3.0" & < "0.4.0"}
+  "carton-git" {>= "0.3.0" & < "0.4.0"}
   "ke" {>= "0.4"}
   "fmt" {>= "0.8.7"}
   "checkseum" {>= "0.2.1"}


### PR DESCRIPTION
Implementation of PACKv2 file in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Handle `trunc` argument when we process a `thin` PACK file
  **breaking changes**
  An optional argument is added on the record which abstract the file-system.
  It should be correctly handled by underlying implementation of the
  file-system. It appears that, at top, we need to figure out such option,
  specially for Git and `Cstruct_append` to correctly access to memories.
