### PR TITLE
[new release] duff (0.4)

### DIFF
--- a/packages/duff/duff.0.4/opam
+++ b/packages/duff/duff.0.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/duff"
+bug-reports:  "https://github.com/mirage/duff/issues"
+dev-repo:     "git+https://github.com/mirage/duff.git"
+doc:          "https://mirage.github.io/duff/"
+license:      "MIT"
+synopsis:     "Rabin's fingerprint and diff algorithm in OCaml"
+description: """
+This library provides a pure implementation of Rabin's fingerprint and diff algorithm in OCaml.
+
+It follows libXdiff C library. It is used by ocaml-git project.
+"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {>= "2.0.0"}
+  "fmt"
+  "bigarray-compat"
+  "stdlib-shims"
+  "alcotest"    {with-test}
+  "bigstringaf" {with-test}
+  "hxd"         {with-test & >= "0.3.1"}
+  "crowbar"     {with-test}
+]
+
+conflicts: [
+  "git" {<= "2.1.3"}
+]
+x-commit-hash: "7a124098e7bfe67322c05669ff049d61c86e353d"
+url {
+  src: "https://github.com/mirage/duff/releases/download/v0.4/duff-v0.4.tbz"
+  checksum: [
+    "sha256=4795e8344a2c2562e0ef6c44ab742334b5cd807637354715889741b20a461da4"
+    "sha512=a2771c2d045059eef991afcad5a6c8513c317bb928caf8c9c33d18c0df9a4b284da8f2b278d7e952605e74c3211a54ea683f107b0205719f5d19b0120b32b7e9"
+  ]
+}

--- a/packages/duff/duff.0.4/opam
+++ b/packages/duff/duff.0.4/opam
@@ -30,9 +30,6 @@ depends: [
   "crowbar"     {with-test}
 ]
 
-conflicts: [
-  "git" {<= "2.1.3"}
-]
 x-commit-hash: "7a124098e7bfe67322c05669ff049d61c86e353d"
 url {
   src: "https://github.com/mirage/duff/releases/download/v0.4/duff-v0.4.tbz"


### PR DESCRIPTION
Rabin's fingerprint and diff algorithm in OCaml

- Project page: <a href="https://github.com/mirage/duff">https://github.com/mirage/duff</a>
- Documentation: <a href="https://mirage.github.io/duff/">https://mirage.github.io/duff/</a>

##### CHANGES:

- Upgrade test to use `hxd.0.3.1`
- Upgrade to `ocamlformat.0.16.0`
