### PR TITLE
All cohttp-*.3.0.0 packages need to be unavailable

### DIFF
--- a/packages/cohttp-async/cohttp-async.3.0.0/opam
+++ b/packages/cohttp-async/cohttp-async.3.0.0/opam
@@ -44,6 +44,7 @@ depends: [
   "uri-sexp"
   "ipaddr"
 ]
+available: false
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.3.0.0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.3.0.0/opam
@@ -31,6 +31,7 @@ depends: [
   "js_of_ocaml-ppx" {>= "3.3.0"}
   "js_of_ocaml-lwt" {>= "3.5.0"}
 ]
+available: false
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/cohttp-lwt-unix-nossl/cohttp-lwt-unix-nossl.3.0.0/opam
+++ b/packages/cohttp-lwt-unix-nossl/cohttp-lwt-unix-nossl.3.0.0/opam
@@ -38,6 +38,7 @@ depends: [
   "base-unix"
   "ounit" {with-test}
 ]
+available: false
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/cohttp-lwt-unix-ssl/cohttp-lwt-unix-ssl.3.0.0/opam
+++ b/packages/cohttp-lwt-unix-ssl/cohttp-lwt-unix-ssl.3.0.0/opam
@@ -40,6 +40,7 @@ depends: [
   "base-unix"
   "ounit" {with-test}
 ]
+available: false
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.3.0.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.3.0.0/opam
@@ -40,6 +40,7 @@ depends: [
   "base-unix"
   "ounit" {with-test}
 ]
+available: false
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/cohttp-lwt/cohttp-lwt.3.0.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.3.0.0/opam
@@ -33,6 +33,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.13.0"}
   "logs"
 ]
+available: false
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/cohttp-mirage/cohttp-mirage.3.0.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.3.0.0/opam
@@ -31,6 +31,7 @@ depends: [
   "astring"
   "magic-mime"
 ]
+available: false
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/cohttp-top/cohttp-top.3.0.0/opam
+++ b/packages/cohttp-top/cohttp-top.3.0.0/opam
@@ -25,6 +25,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "cohttp" {=version}
 ]
+available: false
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
otherwise pinning is messing up the versions.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>