### PR TITLE
[new release] cohttp-lwt-jsoo, cohttp, cohttp-lwt, cohttp-lwt-unix, cohttp-top, cohttp-async and cohttp-mirage (2.5.5)

### DIFF
--- a/packages/cohttp-async/cohttp-async.2.5.5/opam
+++ b/packages/cohttp-async/cohttp-async.2.5.5/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for the Async concurrency library"
+description: """
+An implementation of an HTTP client and server using the Async
+concurrency library. See the `Cohttp_async` module for information
+on how to use this.  The package also installs `cohttp-curl-async`
+and a `cohttp-server-async` binaries for quick uses of a HTTP(S)
+client and server respectively.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.1.0"}
+  "async_kernel" {>= "v0.14.0"}
+  "async_unix" {>= "v0.14.0"}
+  "async" {>= "v0.14.0"}
+  "base" {>= "v0.11.0"}
+  "core" {with-test}
+  "cohttp" {=version}
+  "conduit-async" {>="1.2.0" & < "3.0.0"}
+  "magic-mime"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "sexplib0"
+  "stdlib-shims"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "ounit" {with-test}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "a9bb82a16cad32725be56e06267871bebb0d972b"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.5/cohttp-v2.5.5.tbz"
+  checksum: [
+    "sha256=352a8ef1288572ad0b00f5c63be62ed6daa6bf5c3d1203da13fa9a4b09c5957b"
+    "sha512=9c32228e6284e372d70d236cba35dc0aa822180779ca457caaa1f3a048cb3d5f4c6473046ac4c92e2f608b15e44d03ff431163776bd46a093c9f1ed8fbcc821d"
+  ]
+}

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.5.5/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.5.5/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for the Js_of_ocaml JavaScript compiler"
+description: """
+An implementation of an HTTP client for JavaScript, but using the
+CoHTTP types.  This lets you build HTTP clients that can compile
+natively (using one of the other Cohttp backends such as `cohttp-lwt-unix`)
+and also to native JavaScript via js_of_ocaml.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.1.0"}
+  "cohttp" {=version}
+  "cohttp-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "js_of_ocaml" {>= "3.3.0"}
+  "js_of_ocaml-ppx" {>= "3.3.0"}
+  "js_of_ocaml-lwt" {>= "3.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "a9bb82a16cad32725be56e06267871bebb0d972b"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.5/cohttp-v2.5.5.tbz"
+  checksum: [
+    "sha256=352a8ef1288572ad0b00f5c63be62ed6daa6bf5c3d1203da13fa9a4b09c5957b"
+    "sha512=9c32228e6284e372d70d236cba35dc0aa822180779ca457caaa1f3a048cb3d5f4c6473046ac4c92e2f608b15e44d03ff431163776bd46a093c9f1ed8fbcc821d"
+  ]
+}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.5.5/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.5.5/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for Unix and Windows using Lwt"
+description: """
+An implementation of an HTTP client and server using the Lwt
+concurrency library. See the `Cohttp_lwt_unix` module for information
+on how to use this.  The package also installs `cohttp-curl-lwt`
+and a `cohttp-server-lwt` binaries for quick uses of a HTTP(S)
+client and server respectively.
+
+Although the name implies that this only works under Unix, it
+should also be fine under Windows too."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.1.0"}
+  "conduit-lwt-unix" {>= "1.0.3" & < "3.0.0"}
+  "cmdliner"
+  "magic-mime"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "cohttp-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "base-unix"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "a9bb82a16cad32725be56e06267871bebb0d972b"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.5/cohttp-v2.5.5.tbz"
+  checksum: [
+    "sha256=352a8ef1288572ad0b00f5c63be62ed6daa6bf5c3d1203da13fa9a4b09c5957b"
+    "sha512=9c32228e6284e372d70d236cba35dc0aa822180779ca457caaa1f3a048cb3d5f4c6473046ac4c92e2f608b15e44d03ff431163776bd46a093c9f1ed8fbcc821d"
+  ]
+}

--- a/packages/cohttp-lwt/cohttp-lwt.2.5.5/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.2.5.5/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation using the Lwt concurrency library"
+description: """
+This is a portable implementation of HTTP that uses the Lwt
+concurrency library to multiplex IO.  It implements as much of the
+logic in an OS-independent way as possible, so that more specialised
+modules can be tailored for different targets.  For example, you
+can install `cohttp-lwt-unix` or `cohttp-lwt-jsoo` for a Unix or
+JavaScript backend, or `cohttp-mirage` for the MirageOS unikernel
+version of the library. All of these implementations share the same
+IO logic from this module."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.1.0"}
+  "cohttp" {=version}
+  "lwt" {>= "2.5.0"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "a9bb82a16cad32725be56e06267871bebb0d972b"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.5/cohttp-v2.5.5.tbz"
+  checksum: [
+    "sha256=352a8ef1288572ad0b00f5c63be62ed6daa6bf5c3d1203da13fa9a4b09c5957b"
+    "sha512=9c32228e6284e372d70d236cba35dc0aa822180779ca457caaa1f3a048cb3d5f4c6473046ac4c92e2f608b15e44d03ff431163776bd46a093c9f1ed8fbcc821d"
+  ]
+}

--- a/packages/cohttp-mirage/cohttp-mirage.2.5.5/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.5.5/opam
@@ -26,8 +26,8 @@ depends: [
   "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
-  "cohttp"
-  "cohttp-lwt"
+  "cohttp" {=version}
+  "cohttp-lwt" {=version}
   "astring"
   "magic-mime"
 ]

--- a/packages/cohttp-mirage/cohttp-mirage.2.5.5/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.5.5/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
   "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
+  "conduit-mirage" {>= "2.0.2" & < "2.3.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {=version}

--- a/packages/cohttp-mirage/cohttp-mirage.2.5.5/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.5.5/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+synopsis: "CoHTTP implementation for the MirageOS unikernel"
+description: """
+This HTTP implementation uses the Cohttp portable implementaiton
+along with the Lwt threading library in order to provide a
+`Cohttp_mirage` functor that can be used in MirageOS unikernels
+to build very small and efficient HTTP clients and servers
+without having a hard dependency on an underlying operating
+system.
+
+Please see <https://mirage.io> for a self-hosted explanation
+and instructions on how to use this library."""
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+  "conduit" {>= "2.0.2"}
+  "conduit-mirage" {>= "2.0.2" & < "3.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp"
+  "cohttp-lwt"
+  "astring"
+  "magic-mime"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "a9bb82a16cad32725be56e06267871bebb0d972b"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.5/cohttp-v2.5.5.tbz"
+  checksum: [
+    "sha256=352a8ef1288572ad0b00f5c63be62ed6daa6bf5c3d1203da13fa9a4b09c5957b"
+    "sha512=9c32228e6284e372d70d236cba35dc0aa822180779ca457caaa1f3a048cb3d5f4c6473046ac4c92e2f608b15e44d03ff431163776bd46a093c9f1ed8fbcc821d"
+  ]
+}

--- a/packages/cohttp-top/cohttp-top.2.5.5/opam
+++ b/packages/cohttp-top/cohttp-top.2.5.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP toplevel pretty printers for HTTP types"
+description: """
+This library installs toplevel prettyprinters for CoHTTP
+types such as the `Request`, `Response` and `Types` modules.
+Once this library has been loaded, you can directly see the
+values of those types in toplevels such as `utop` or `ocaml`."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.1.0"}
+  "cohttp" {=version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "a9bb82a16cad32725be56e06267871bebb0d972b"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.5/cohttp-v2.5.5.tbz"
+  checksum: [
+    "sha256=352a8ef1288572ad0b00f5c63be62ed6daa6bf5c3d1203da13fa9a4b09c5957b"
+    "sha512=9c32228e6284e372d70d236cba35dc0aa822180779ca457caaa1f3a048cb3d5f4c6473046ac4c92e2f608b15e44d03ff431163776bd46a093c9f1ed8fbcc821d"
+  ]
+}

--- a/packages/cohttp/cohttp.2.5.5/opam
+++ b/packages/cohttp/cohttp.2.5.5/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries.
+
+See the cohttp-async, cohttp-lwt, cohttp-lwt-unix, cohttp-lwt-jsoo and
+cohttp-mirage libraries for concrete implementations for particular
+targets.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.1.0"}
+  "re" {>= "1.9.0"}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "fieldslib"
+  "sexplib0"
+  "ppx_fields_conv" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "stringext"
+  "base64" {>= "3.1.0"}
+  "stdlib-shims"
+  "fmt" {with-test}
+  "jsonm" {build}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "a9bb82a16cad32725be56e06267871bebb0d972b"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.5/cohttp-v2.5.5.tbz"
+  checksum: [
+    "sha256=352a8ef1288572ad0b00f5c63be62ed6daa6bf5c3d1203da13fa9a4b09c5957b"
+    "sha512=9c32228e6284e372d70d236cba35dc0aa822180779ca457caaa1f3a048cb3d5f4c6473046ac4c92e2f608b15e44d03ff431163776bd46a093c9f1ed8fbcc821d"
+  ]
+}


### PR DESCRIPTION
CoHTTP implementation for the Js_of_ocaml JavaScript compiler

- Project page: <a href="https://github.com/mirage/ocaml-cohttp">https://github.com/mirage/ocaml-cohttp</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cohttp/">https://mirage.github.io/ocaml-cohttp/</a>

##### CHANGES:

- `Cohttp_async.resolve_local_file`, `Cohttp_lwt.resolve_local_file` and `Cohttp_lwt_unix.resolve_file`
  are now the same code under the hood (`Cohttp.Path.resolve_local_file`). The old names
  have been preserved for compatibility, but will be marked as deprecated in the next release. This
  changes the behavior of `Cohttp_lwt_unix.resolve_file`: it now percent-decodes the paths and blocks
  escaping from the docroot correctly. This also fixes and tests the corner cases in these methods
  when the docroot is empty. (@ewanmellor mirage/ocaml-cohttp#755)
