### PR TITLE
Package ocamlfind.1.9.1

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.0/opam
@@ -40,6 +40,7 @@ install: [
 extra-files: [
   ["fix-bsd.patch" "md5=00e4db61fceee51af794c3a36e4cef0e"]
 ]
+available: false
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
 url {
   src: "https://github.com/ocaml/ocamlfind/archive/findlib-1.9.tar.gz"

--- a/packages/ocamlfind/ocamlfind.1.9.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.1/opam
@@ -1,15 +1,17 @@
 opam-version: "2.0"
 synopsis: "A library manager for OCaml"
-description: """\
+description: """
 Findlib is a library manager for OCaml. It provides a convention how
 to store libraries, and a file format ("META") to describe the
 properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
-in programs and scripts."""
+in programs and scripts.
+"""
+license: "MIT"
 maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 homepage: "http://projects.camlcity.org/projects/findlib.html"
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+bug-reports: "https://github.com/ocaml/ocamlfind/issues"
 depends: [
   "ocaml" {>= "4.00.0"}
 ]
@@ -17,14 +19,10 @@ depopts: ["graphics"]
 build: [
   [
     "./configure"
-    "-bindir"
-    bin
-    "-sitelib"
-    lib
-    "-mandir"
-    man
-    "-config"
-    "%{lib}%/findlib.conf"
+    "-bindir" bin
+    "-sitelib" lib
+    "-mandir" man
+    "-config" "%{lib}%/findlib.conf"
     "-no-custom"
     "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
@@ -36,7 +34,7 @@ install: [
   [make "install"]
   ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
 ]
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+dev-repo: "git+https://github.com/ocaml/ocamlfind.git"
 url {
   src: "http://download.camlcity.org/download/findlib-1.9.1.tar.gz"
   checksum: [

--- a/packages/ocamlfind/ocamlfind.1.9.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A library manager for OCaml"
+description: """\
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts."""
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage: "http://projects.camlcity.org/projects/findlib.html"
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+depends: [
+  "ocaml" {>= "4.00.0"}
+]
+depopts: ["graphics"]
+build: [
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-sitelib"
+    lib
+    "-mandir"
+    man
+    "-config"
+    "%{lib}%/findlib.conf"
+    "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "all"]
+  [make "opt"] {ocaml:native}
+]
+install: [
+  [make "install"]
+  ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
+]
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+url {
+  src: "http://download.camlcity.org/download/findlib-1.9.1.tar.gz"
+  checksum: [
+    "md5=65e6dc9b305ccbed1267275fe180f538"
+    "sha512=83a05f3e310fa7cabb0475c5525f7a87c1b6bc2dc5e39f094cabfb5d944a826a5581844ba00ec1a48dd96184eb9de3c4d1055cdddee2b83c700a2de5a6dc6f84"
+  ]
+}


### PR DESCRIPTION
### `ocamlfind.1.9.1`
A library manager for OCaml
Findlib is a library manager for OCaml. It provides a convention how
to store libraries, and a file format ("META") to describe the
properties of libraries. There is also a tool (ocamlfind) for
interpreting the META files, so that it is very easy to use libraries
in programs and scripts.



---
* Homepage: http://projects.camlcity.org/projects/findlib.html
* Source repo: git+https://gitlab.camlcity.org/gerd/lib-findlib.git
* Bug tracker: https://gitlab.camlcity.org/gerd/lib-findlib/issues

---
:camel: Pull-request generated by opam-publish v2.0.2