### PR TITLE
BLS12-381 packages depend on dune >= 2.8.4 since 0.4.1

### DIFF
--- a/packages/bls12-381-gen/bls12-381-gen.0.4.1/opam
+++ b/packages/bls12-381-gen/bls12-381-gen.0.4.1/opam
@@ -8,7 +8,7 @@ homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
 bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "2.7"}
+  "dune" {>= "2.8.4"}
   "ff-sig" {>= "0.6.1" & < "0.7.0"}
   "zarith" {>= "1.10" & < "2.0"}
   "bisect_ppx" {with-test & >= "2.5"}

--- a/packages/bls12-381-js-gen/bls12-381-js-gen.0.4.1/opam
+++ b/packages/bls12-381-js-gen/bls12-381-js-gen.0.4.1/opam
@@ -10,7 +10,7 @@ homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
 bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "2.7"}
+  "dune" {>= "2.8.4"}
   "dune-configurator" {build}
   "ff-sig" {>= "0.6.1" & < "0.7.0"}
   "zarith" {>= "1.10" & < "2.0"}

--- a/packages/bls12-381-js/bls12-381-js.0.4.1/opam
+++ b/packages/bls12-381-js/bls12-381-js.0.4.1/opam
@@ -12,7 +12,7 @@ homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
 bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "2.7"}
+  "dune" {>= "2.8.4"}
   "bls12-381-gen" {= version}
   "bls12-381" {= version}
   "bls12-381-js-gen" {= version}

--- a/packages/bls12-381-unix/bls12-381-unix.0.4.1/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.0.4.1/opam
@@ -13,7 +13,7 @@ bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "conf-rust" {build}
-  "dune" {>= "2.7"}
+  "dune" {>= "2.8.4"}
   "dune-configurator" {build}
   "ff-sig" {>= "0.6.1" & < "0.7.0"}
   "zarith" {>= "1.10" & < "2.0"}

--- a/packages/bls12-381/bls12-381.0.4.1/opam
+++ b/packages/bls12-381/bls12-381.0.4.1/opam
@@ -8,7 +8,7 @@ homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
 bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "2.7"}
+  "dune" {>= "2.8.4"}
   "ff-sig" {>= "0.6.1" & < "0.7.0"}
   "zarith" {>= "1.10" & < "2.0"}
   "bls12-381-gen" {= version}


### PR DESCRIPTION
Related to issues when installing implementation of virtual packages in a sandoxed opam environment, see https://github.com/ocaml/dune/pull/4233

It is fixed upstream for future versions