### PR TITLE
Package visitors.20210316

### DIFF
--- a/packages/visitors/visitors.20210316/opam
+++ b/packages/visitors/visitors.20210316/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/visitors"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/visitors.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ppxlib" {>= "0.22.0"}
+  "ppx_deriving" {>= "5.0"}
+  "result"
+  "dune" {>= "2.0"}
+]
+synopsis: "An OCaml syntax extension for generating visitor classes"
+description: """
+Annotating an algebraic data type definition with [@@deriving visitors { ... }]
+causes visitor classes to be automatically generated. A visitor is an object
+that knows how to traverse and transform a data structure."""
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/visitors/repository/20210316/archive.tar.gz"
+  checksum: [
+    "md5=090496ab5efb67528eb6f202cd1d1f06"
+    "sha512=9d0c3b3be64ca162a9d01531713c3b0d42514533a2e9a4ef8e8b73703e4fb853a3f10147c8454976587af570fc8fd513250354b3e1dfcb50640ca5cc542f19e1"
+  ]
+}


### PR DESCRIPTION
### `visitors.20210316`
An OCaml syntax extension for generating visitor classes
Annotating an algebraic data type definition with [@@deriving visitors { ... }]
causes visitor classes to be automatically generated. A visitor is an object
that knows how to traverse and transform a data structure.



---
* Homepage: https://gitlab.inria.fr/fpottier/visitors
* Source repo: git+https://gitlab.inria.fr/fpottier/visitors.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.3