### PR TITLE
Package binaryen.0.9.0

### DIFF
--- a/packages/binaryen/binaryen.0.9.0/opam
+++ b/packages/binaryen/binaryen.0.9.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.09"}
+  "dune" {>= "2.7.1"}
+  "dune-configurator" {>= "2.7.1"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+]
+available: arch = "x86_64" & (os = "linux" | os = "macos" | os = "win32")
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.9.0/binaryen-archive-v0.9.0.tar.gz"
+  checksum: [
+    "md5=226d40416b984bf35bb70d170e48fa82"
+    "sha512=46fe924f1399eecfb4a585edfdb5155dfeb1dd9d2c6747d15bc9078d9bd052d68c01940da2bfd044d260b3dc8bf5b86b2e4478d799fca79a998470a38246d986"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.9.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---


### Features

* add Function_table.unlimited constant ([#87](https://www.github.com/grain-lang/binaryen.ml/issues/87)) ([0d2fcde](https://www.github.com/grain-lang/binaryen.ml/commit/0d2fcde007b77e6edd5c66975fd7a611ae9a8ef8))
* write bindings for add_table ([6dc0fa8](https://www.github.com/grain-lang/binaryen.ml/commit/6dc0fa83d5873630cf7a0a6f2895600c68ad4f30))


### Bug Fixes

* **js:** cast the call_indirect string arguments to JS strings ([7b4136a](https://www.github.com/grain-lang/binaryen.ml/commit/7b4136a2e2fdae3efd85351dc40aad2ad4c3ed3e))
* **js:** utilize JSOO externals to convert between uint8array & bytes ([#85](https://www.github.com/grain-lang/binaryen.ml/issues/85)) ([61d28c5](https://www.github.com/grain-lang/binaryen.ml/commit/61d28c5e7e6ca6217759a75e2c96e7cb5c1b3d45))
* return JS null value from Expression.null ([#83](https://www.github.com/grain-lang/binaryen.ml/issues/83)) ([61861e2](https://www.github.com/grain-lang/binaryen.ml/commit/61861e2590816bccc5c6c17a2a5b77f3a3db3779))


### Miscellaneous Chores

* fix formatter & format the code ([#80](https://www.github.com/grain-lang/binaryen.ml/issues/80)) ([b9c485a](https://www.github.com/grain-lang/binaryen.ml/commit/b9c485a69cfb6ffbcc8a7a7611c2ea09386486e2))
* set dune language to the version of dune we use ([e9eb5c9](https://www.github.com/grain-lang/binaryen.ml/commit/e9eb5c927dbee84f9ab783a2bfb7f2e16c94e7f6))
* use test file directly in one rule so ocaml-lsp works ([34b7a13](https://www.github.com/grain-lang/binaryen.ml/commit/34b7a13864f81d5d2b8781f1b172d72f28354209))


### Documentation

* cleanup Binaryen submodule & building language (closes [#65](https://www.github.com/grain-lang/binaryen.ml/issues/65)) ([3bdb23d](https://www.github.com/grain-lang/binaryen.ml/commit/3bdb23dbca2734d58ee0802b796593016ac80c6e))


---
:camel: Pull-request generated by opam-publish v2.0.3