### PR TITLE
Liquidsoap prometheus optional dependency.

### DIFF
--- a/packages/liquidsoap/liquidsoap.1.4.0/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.0/opam
@@ -76,6 +76,7 @@ depopts: [
   "opus"
   "osx-secure-transport"
   "portaudio"
+  "prometheus-liquidsoap"
   "pulseaudio"
   "samplerate"
   "shine"

--- a/packages/liquidsoap/liquidsoap.1.4.1-1/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1-1/opam
@@ -87,6 +87,7 @@ depopts: [
   "opus"
   "osx-secure-transport"
   "portaudio"
+  "prometheus-liquidsoap"
   "pulseaudio"
   "samplerate"
   "shine"

--- a/packages/liquidsoap/liquidsoap.1.4.1-2/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1-2/opam
@@ -90,6 +90,7 @@ depopts: [
   "opus"
   "osx-secure-transport"
   "portaudio"
+  "prometheus-liquidsoap"
   "pulseaudio"
   "samplerate"
   "shine"

--- a/packages/liquidsoap/liquidsoap.1.4.1/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1/opam
@@ -76,6 +76,7 @@ depopts: [
   "opus"
   "osx-secure-transport"
   "portaudio"
+  "prometheus-liquidsoap"
   "pulseaudio"
   "samplerate"
   "shine"

--- a/packages/liquidsoap/liquidsoap.1.4.2/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.2/opam
@@ -87,6 +87,7 @@ depopts: [
   "opus"
   "osx-secure-transport"
   "portaudio"
+  "prometheus-liquidsoap"
   "pulseaudio"
   "samplerate"
   "shine"

--- a/packages/liquidsoap/liquidsoap.1.4.3/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.3/opam
@@ -87,6 +87,7 @@ depopts: [
   "opus"
   "osx-secure-transport"
   "portaudio"
+  "prometheus-liquidsoap"
   "pulseaudio"
   "samplerate"
   "shine"

--- a/packages/liquidsoap/liquidsoap.1.4.4/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.4/opam
@@ -89,6 +89,7 @@ depopts: [
   "opus"
   "osx-secure-transport"
   "portaudio"
+  "prometheus-liquidsoap"
   "pulseaudio"
   "samplerate"
   "shine"

--- a/packages/prometheus-liquidsoap/prometheus-liquidsoap.1/opam
+++ b/packages/prometheus-liquidsoap/prometheus-liquidsoap.1/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+maintainer: "romain.beauxis@gmail.com"
+homepage: "https://github.com/savonet/liquidsoap"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+synopsis: "Virtual package installing liquidsoap's prometheus dependencies"
+description:
+  "This package installs prometheus dependencies for liquidsoap."
+depends: ["cohttp-lwt-unix" "prometheus-app"]
+bug-reports: "https://github.com/savonet/liquidsoap/issues"


### PR DESCRIPTION
This PR ads a missing optional dependency on prometheus for liquidsoap. Since the dependency actually requires two packages, we introduce a virtual package that installs both of them.