### PR TITLE
[new release] tcpip (6.1.0)

### DIFF
--- a/packages/tcpip/tcpip.6.1.0/opam
+++ b/packages/tcpip/tcpip.6.1.0/opam
@@ -15,7 +15,7 @@ tags: ["org:mirage"]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" "1"] {with-test}
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}

--- a/packages/tcpip/tcpip.6.1.0/opam
+++ b/packages/tcpip/tcpip.6.1.0/opam
@@ -1,0 +1,82 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+depends: [
+  "conf-pkg-config" {build}
+  "dune" {>= "2.7.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ocaml" {>= "4.06.0"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {>= "3.2.0"}
+  "cstruct-lwt"
+  "ppx_cstruct"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-protocols" {>= "5.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv"
+  "ethernet" {>= "2.0.0"}
+  "mirage-flow" {with-test & >= "2.0.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "alcotest" {with-test & >="0.7.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "arp" {with-test & >= "2.3.0"}
+  "ipaddr-cstruct" {with-test}
+  "lru" {>= "0.3.0"}
+]
+depopts: [
+  "ocaml-freestanding"
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+x-commit-hash: "4bbd84996e6bd5b1ce202930874722c708b69d78"
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v6.1.0/tcpip-v6.1.0.tbz"
+  checksum: [
+    "sha256=f07bac8f633934bbba028a851093370b6fad3d8daa13a0c368ba6bb82fb0a720"
+    "sha512=6ca283ce38f03ed1743025251f769c61f771f59fcb5d100738a98175642ba4006647b568b51d92330cfc5bc4c3eb9469a3506c7c7327e0ea8f7365c6f4e2b5af"
+  ]
+}


### PR DESCRIPTION
OCaml TCP/IP networking stack, used in MirageOS

- Project page: <a href="https://github.com/mirage/mirage-tcpip">https://github.com/mirage/mirage-tcpip</a>
- Documentation: <a href="https://mirage.github.io/mirage-tcpip/">https://mirage.github.io/mirage-tcpip/</a>

##### CHANGES:

* Ensure that listen really binds the given socket before
  creating a task on `tcpip.stack-socket` (@dinosaure, @hannesm, mirage/mirage-tcpip#439)
* Add `ppx_cstruct` as a dependency (@hannesm, @dinosaure, mirage/mirage-tcpip#439)
* Upgrade to ocamlformat.0.17.0 (@dinosaure, mirage/mirage-tcpip#442)
* Drop the support of OCaml 4.08.0 (@dinosaure, mirage/mirage-tcpip#442)
* Use the usual layout to compile freestanding C stubs and link them to
  a Solo5 unikernel (@dinosaure, @hannesm, mirage/mirage-tcpip#441)
  **breaking changes**
  C stubs are prepended by `mirage_`. Symbols such as checksum's
  symbols are `caml_mirage_tcpip_*` instead of `caml_tcpip_*`
  `tcpip.unix` is a fake sub-package and user does not it anymore, he can
  safely remove it from its project.
* Conflict with `< ocaml-freestanding.0.4.1` (@hannesm, mirage/mirage-tcpip#441)
