### PR TITLE
[new release] encore (0.8)

### DIFF
--- a/packages/encore/encore.0.8/opam
+++ b/packages/encore/encore.0.8/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/encore"
+bug-reports:  "https://github.com/mirage/encore/issues"
+dev-repo:     "git+https://github.com/mirage/encore.git"
+doc:          "https://mirage.github.io/encore/"
+license:      "MIT"
+synopsis:     "Library to generate encoder/decoder which ensure isomorphism"
+description: """
+Encore is a little library to provide an interface to generate an angstrom decoder and
+an internal encoder from a shared description. The goal is to ensure a dual isomorphism
+between them.
+"""
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"  {>= "2.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "fmt"
+  "bigstringaf" {>= "0.5.0"}
+  "alcotest" {with-test}
+]
+x-commit-hash: "3d904011d6bb3ee168b8621cea8f8a023177c2c3"
+url {
+  src:
+    "https://github.com/mirage/encore/releases/download/v0.8/encore-v0.8.tbz"
+  checksum: [
+    "sha256=a406bc9863b04bb424692045939d6c170a2bb65a98521ae5608d25b0559344f6"
+    "sha512=0e9f71254bba875407dd5f57540a836d1c732b29b3f184c8901d6dba47689084596b065e80738f6ab7cad89122d904e03e2820828efc5c3c16365de7c7c5c89c"
+  ]
+}


### PR DESCRIPTION
Library to generate encoder/decoder which ensure isomorphism

- Project page: <a href="https://github.com/mirage/encore">https://github.com/mirage/encore</a>
- Documentation: <a href="https://mirage.github.io/encore/">https://mirage.github.io/encore/</a>

##### CHANGES:

- Upgrade to ocamlformat.0.17.0 (@dinosaure, mirage/encore#31)
- Fix stack-overflow on large objects (@dinosaure, @zshipko, mirage/encore#31)
- Remove conflict with `git.2.1.3` (@dinosaure, @kit-ty-kate, fd0ef8c)
