### PR TITLE
bls12-381-unix can use 0.18.0

### DIFF
--- a/packages/bls12-381-unix/bls12-381-unix.0.4.1/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.0.4.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dune-configurator" {build}
   "ff-sig" {>= "0.6.1" & < "0.7.0"}
   "zarith" {>= "1.10" & < "2.0"}
-  "ctypes" {>= "0.17.1" & < "0.18.0"}
+  "ctypes" {>= "0.17.1" & < "0.19.0"}
   "ctypes-foreign"
   "bls12-381-gen" {= version}
   "bls12-381" {= version}


### PR DESCRIPTION
Some warnings appear with ctypes 0.17.1 (see https://github.com/ocamllabs/ocaml-ctypes/pull/646 and https://github.com/ocamllabs/ocaml-ctypes/pull/638). There is a fix upstream in master for future releases (https://gitlab.com/dannywillems/ocaml-bls12-381/-/commit/50c2416b4e1ea12e7ab01c2529cf5d8d8a424998). 0.17.1 is still allowed in this version in case of already some users require 0.17.1. However, tezos uses ctypes 0.18.0 and require this version.