### PR TITLE
Package catala.0.3.0

### DIFF
--- a/packages/catala/catala.0.3.0/opam
+++ b/packages/catala/catala.0.3.0/opam
@@ -26,6 +26,8 @@ depends: [
   "calendar" {>= "2.04"}
   "visitors" {>= "20200210"}
   "benchmark" {>= "1.6"}
+  "js_of_ocaml-ppx" {>= "3.8.0"}
+  "camomile" {>= "1.0.2"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/catala/catala.0.3.0/opam
+++ b/packages/catala/catala.0.3.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Low-level language for tax code specification"
+description: """
+The Catala language is designed to be a low-level target for
+higher-level specification languages for fiscal legislation.
+"""
+maintainer: ["contact@catala-lang.org"]
+authors: ["Denis Merigoux"]
+license: "Apache-2.0"
+homepage: "https://github.com/CatalaLang/catala"
+bug-reports: "https://github.com/CatalaLang/catala/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ANSITerminal" {>= "0.8.2"}
+  "sedlex" {>= "2.1"}
+  "menhir" {>= "20200211"}
+  "menhirLib" {>= "20200211"}
+  "unionFind" {>= "20200320"}
+  "bindlib" {>= "5.0.1"}
+  "cmdliner" {>= "1.0.4"}
+  "re" {>= "1.9.0"}
+  "zarith" {>= "1.10"}
+  "zarith_stubs_js" {>= "0.14.0"}
+  "dune" {>= "2.2"}
+  "ocamlgraph" {>= "1.8.8"}
+  "calendar" {>= "2.04"}
+  "visitors" {>= "20200210"}
+  "benchmark" {>= "1.6"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CatalaLang/catala.git"
+url {
+  src: "https://github.com/CatalaLang/catala/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=7ecbb617c23e73fa9d2b9873540890b0"
+    "sha512=109e8a034e6af9292238db8d50cfb06ee0eecc60293f5cca766049bf182c6cd01f2ad10008e4f0d2dfb1f7c6d3d9bbee10a5c833ce12e9c9ce8582d94c687e80"
+  ]
+}


### PR DESCRIPTION
### `catala.0.3.0`
Low-level language for tax code specification
The Catala language is designed to be a low-level target for
higher-level specification languages for fiscal legislation.



---
* Homepage: https://github.com/CatalaLang/catala
* Source repo: git+https://github.com/CatalaLang/catala.git
* Bug tracker: https://github.com/CatalaLang/catala/issues

---
:camel: Pull-request generated by opam-publish v2.0.3