### PR TITLE
Package catala.0.3.0

### DIFF
--- a/packages/catala/catala.0.3.0/opam
+++ b/packages/catala/catala.0.3.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Low-level language for tax code specification"
+description: """
+The Catala language is designed to be a low-level target for
+higher-level specification languages for fiscal legislation.
+"""
+maintainer: ["contact@catala-lang.org"]
+authors: ["Denis Merigoux"]
+license: "Apache-2.0"
+homepage: "https://github.com/CatalaLang/catala"
+bug-reports: "https://github.com/CatalaLang/catala/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ANSITerminal" {>= "0.8.2"}
+  "sedlex" {>= "2.1"}
+  "menhir" {>= "20200211"}
+  "menhirLib" {>= "20200211"}
+  "unionFind" {>= "20200320"}
+  "bindlib" {>= "5.0.1"}
+  "cmdliner" {>= "1.0.4"}
+  "re" {>= "1.9.0"}
+  "zarith" {>= "1.10"}
+  "zarith_stubs_js" {>= "0.14.0"}
+  "dune" {>= "2.2"}
+  "ocamlgraph" {>= "1.8.8"}
+  "calendar" {>= "2.04"}
+  "visitors" {>= "20200210"}
+  "benchmark" {>= "1.6"}
+  "js_of_ocaml-ppx" {>= "3.8.0"}
+  "camomile" {>= "1.0.2"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CatalaLang/catala.git"
+url {
+  src: "https://github.com/CatalaLang/catala/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=4a2c5495f30d8fc2e3bf977df6e602f9"
+    "sha512=8dcc404b6068b9dbd76982ade60d8fba1950fdd0a8a626db17429120483367dce1f51997e96d7b8ee5308f305c3bcbb897ef85336f25e9ef3681f4cb9237f56a"
+  ]
+}


### PR DESCRIPTION
### `catala.0.3.0`
Low-level language for tax code specification
The Catala language is designed to be a low-level target for
higher-level specification languages for fiscal legislation.



---
* Homepage: https://github.com/CatalaLang/catala
* Source repo: git+https://github.com/CatalaLang/catala.git
* Bug tracker: https://github.com/CatalaLang/catala/issues

---
:camel: Pull-request generated by opam-publish v2.0.3