### PR TITLE
Enable WebAssembly for LLVM 8, 9, 10, and 11

### DIFF
--- a/packages/llvm/llvm.10.0.0/files/install.sh
+++ b/packages/llvm/llvm.10.0.0/files/install.sh
@@ -6,7 +6,7 @@ cmake="$3"
 make="$4"
 
 function filter_experimental_targets {
-    sed 's/AVR//g' | sed 's/Nios2//g' | sed 's/WebAssembly//g' | xargs
+    sed 's/AVR//g' | sed 's/Nios2//g' | xargs
 }
 
 function llvm_install {

--- a/packages/llvm/llvm.10.0.0/opam
+++ b/packages/llvm/llvm.10.0.0/opam
@@ -28,7 +28,7 @@ synopsis: "The OCaml bindings distributed with LLVM"
 description: "Note: LLVM should be installed first."
 extra-files: [
   ["link-META.patch" "md5=ef4ebb8706be2ed402f31fc351d7dc75"]
-  ["install.sh" "md5=c8122f1f3c974594ba6c8767b187cdab"]
+  ["install.sh" "md5=76fb00c644110c73d04b15a2afb1aaf3"]
   ["fix-shared.patch" "md5=dce86b1db352332968ceb6d042b408a8"]
   ["META.patch" "md5=1d0af08bab7a0f831f68849b6556e414"]
 ]

--- a/packages/llvm/llvm.11.0.0/files/install.sh
+++ b/packages/llvm/llvm.11.0.0/files/install.sh
@@ -6,7 +6,7 @@ cmake="$3"
 make="$4"
 
 function filter_experimental_targets {
-    sed 's/AVR//g' | sed 's/Nios2//g' | sed 's/WebAssembly//g' | xargs
+    sed 's/AVR//g' | sed 's/Nios2//g' | xargs
 }
 
 function llvm_install {

--- a/packages/llvm/llvm.11.0.0/opam
+++ b/packages/llvm/llvm.11.0.0/opam
@@ -28,7 +28,7 @@ synopsis: "The OCaml bindings distributed with LLVM"
 description: "Note: LLVM should be installed first."
 extra-files: [
   ["link-META.patch" "md5=ef4ebb8706be2ed402f31fc351d7dc75"]
-  ["install.sh" "md5=c8122f1f3c974594ba6c8767b187cdab"]
+  ["install.sh" "md5=76fb00c644110c73d04b15a2afb1aaf3"]
   ["fix-shared.patch" "md5=dce86b1db352332968ceb6d042b408a8"]
   ["META.patch" "md5=1d0af08bab7a0f831f68849b6556e414"]
 ]

--- a/packages/llvm/llvm.8.0.0/files/install.sh
+++ b/packages/llvm/llvm.8.0.0/files/install.sh
@@ -6,7 +6,7 @@ cmake="$3"
 make="$4"
 
 function filter_experimental_targets {
-    sed 's/AVR//g' | sed 's/Nios2//g' | sed 's/WebAssembly//g' | xargs
+    sed 's/AVR//g' | sed 's/Nios2//g' | xargs
 }
 
 function llvm_install {

--- a/packages/llvm/llvm.8.0.0/opam
+++ b/packages/llvm/llvm.8.0.0/opam
@@ -28,7 +28,7 @@ synopsis: "The OCaml bindings distributed with LLVM"
 description: "Note: LLVM should be installed first."
 extra-files: [
   ["link-META.patch" "md5=ef4ebb8706be2ed402f31fc351d7dc75"]
-  ["install.sh" "md5=c8122f1f3c974594ba6c8767b187cdab"]
+  ["install.sh" "md5=76fb00c644110c73d04b15a2afb1aaf3"]
   ["fix-shared.patch" "md5=826e4bf2e63e510bc6cc1e6a321d1b22"]
   ["META.patch" "md5=1d0af08bab7a0f831f68849b6556e414"]
 ]

--- a/packages/llvm/llvm.9.0.0/files/install.sh
+++ b/packages/llvm/llvm.9.0.0/files/install.sh
@@ -6,7 +6,7 @@ cmake="$3"
 make="$4"
 
 function filter_experimental_targets {
-    sed 's/AVR//g' | sed 's/Nios2//g' | sed 's/WebAssembly//g' | xargs
+    sed 's/AVR//g' | sed 's/Nios2//g' | xargs
 }
 
 function llvm_install {

--- a/packages/llvm/llvm.9.0.0/opam
+++ b/packages/llvm/llvm.9.0.0/opam
@@ -28,7 +28,7 @@ synopsis: "The OCaml bindings distributed with LLVM"
 description: "Note: LLVM should be installed first."
 extra-files: [
   ["link-META.patch" "md5=ef4ebb8706be2ed402f31fc351d7dc75"]
-  ["install.sh" "md5=c8122f1f3c974594ba6c8767b187cdab"]
+  ["install.sh" "md5=76fb00c644110c73d04b15a2afb1aaf3"]
   ["fix-shared.patch" "md5=826e4bf2e63e510bc6cc1e6a321d1b22"]
   ["META.patch" "md5=1d0af08bab7a0f831f68849b6556e414"]
 ]


### PR DESCRIPTION
Hi all,

I want to use LLVM to emit WebAssembly, but when I install the OCaml package, I find that the WebAssembly backend module isn't installed. [LLVM moved WebAssembly from experimental to being a default backend in version 8](https://releases.llvm.org/8.0.0/docs/ReleaseNotes.html#changes-to-the-webassembly-target), so it shouldn't be filtered out in versions 8+. Could you please enable WebAssembly? Thanks.