### PR TITLE
Add Polly 0.2.2 bindings for the Linux epoll system call

### DIFF
--- a/packages/polly/polly.0.2.2/opam
+++ b/packages/polly/polly.0.2.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "polly"
+synopsis: "Bindings for the Linux epoll system call"
+description: """
+Bindings for the Linux epoll system call. The binding avoids
+  most allocation in the event loop by iterating over all file
+  descriptios that are reported as ready ."""
+maintainer: "Christian Lindig <christian.lindig@citrix.com>"
+authors: "Christian Lindig <christian.lindig@citrix.com>"
+license: "MIT"
+homepage: "https://github.com/lindig/polly"
+doc: "https://github.com/lindig/polly"
+bug-reports: "https://github.com/lindig/polly/issues"
+depends: [
+  "dune" {build}
+  "ocaml"
+  "cmdliner"
+  "base-unix"
+  "conf-linux-libc-dev"
+]
+build: ["dune" "build" "-p" name "-j" jobs "@install"]
+dev-repo: "git://github.com/lindig/polly.git"
+
+url {
+  src: "https://github.com/lindig/polly/archive/0.2.2/polly-0.2.2.tar.gz"
+  checksum: "md5=a25291f7adb6b1d7bdd7513f2c22d9de"
+}

--- a/packages/polly/polly.0.2.2/opam
+++ b/packages/polly/polly.0.2.2/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "polly"
 synopsis: "Bindings for the Linux epoll system call"
 description: """
 Bindings for the Linux epoll system call. The binding avoids

--- a/packages/polly/polly.0.2.2/opam
+++ b/packages/polly/polly.0.2.2/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/lindig/polly"
 doc: "https://github.com/lindig/polly"
 bug-reports: "https://github.com/lindig/polly/issues"
 depends: [
-  "dune" {build}
+  "dune" {>= "2.0"}
   "ocaml"
   "cmdliner"
   "base-unix"

--- a/packages/polly/polly.0.2.2/opam
+++ b/packages/polly/polly.0.2.2/opam
@@ -3,7 +3,7 @@ synopsis: "Bindings for the Linux epoll system call"
 description: """
 Bindings for the Linux epoll system call. The binding avoids
   most allocation in the event loop by iterating over all file
-  descriptios that are reported as ready ."""
+  descriptors that are reported as ready."""
 maintainer: "Christian Lindig <christian.lindig@citrix.com>"
 authors: "Christian Lindig <christian.lindig@citrix.com>"
 license: "MIT"


### PR DESCRIPTION
```
opam-version: "2.0"
name: "polly"
synopsis: "Bindings for the Linux epoll system call"
description: """
Bindings for the Linux epoll system call. The binding avoids
  most allocation in the event loop by iterating over all file
  descriptios that are reported as ready ."""
maintainer: "Christian Lindig <christian.lindig@citrix.com>"
authors: "Christian Lindig <christian.lindig@citrix.com>"
license: "MIT"
homepage: "https://github.com/lindig/polly"
doc: "https://github.com/lindig/polly"
bug-reports: "https://github.com/lindig/polly/issues"
depends: [
  "dune" {build}
  "ocaml"
  "cmdliner"
  "base-unix"
  "conf-linux-libc-dev"
]
build: ["dune" "build" "-p" name "-j" jobs "@install"]
dev-repo: "git://github.com/lindig/polly.git"

url {
  src: "https://github.com/lindig/polly/archive/0.2.2/polly-0.2.2.tar.gz"
  checksum: "md5=a25291f7adb6b1d7bdd7513f2c22d9de"
}
```