### PR TITLE
[new release] git, git-cohttp, git-cohttp-mirage, git-cohttp-unix, git-mirage and git-unix (3.3.3)

### DIFF
--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.3/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "mimic"
+  "cohttp-mirage"
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "219cd19a1f49b6f8b9d858bf277e374f18f2392a"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.3/git-3.3.3.tbz"
+  checksum: [
+    "sha256=a3ab287daa3f1163be610f9fb7d327e9ab00cf43f5a38cb5ccd02d7278e21749"
+    "sha512=f627ca0aaad112c08831280d44edcaf7324e9e6d48a7fe13cb0d54bb2385b038bbd5d8d334a93b7a56087618debea289d6f99010e1ed09b88c95ac38c8d3d641"
+  ]
+}

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.3.3/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.3.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "git-cohttp" {= version}
+  "cohttp-lwt-unix"
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "219cd19a1f49b6f8b9d858bf277e374f18f2392a"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.3/git-3.3.3.tbz"
+  checksum: [
+    "sha256=a3ab287daa3f1163be610f9fb7d327e9ab00cf43f5a38cb5ccd02d7278e21749"
+    "sha512=f627ca0aaad112c08831280d44edcaf7324e9e6d48a7fe13cb0d54bb2385b038bbd5d8d334a93b7a56087618debea289d6f99010e1ed09b88c95ac38c8d3d641"
+  ]
+}

--- a/packages/git-cohttp/git-cohttp.3.3.3/opam
+++ b/packages/git-cohttp/git-cohttp.3.3.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "cohttp"
+  "cohttp-lwt"
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "219cd19a1f49b6f8b9d858bf277e374f18f2392a"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.3/git-3.3.3.tbz"
+  checksum: [
+    "sha256=a3ab287daa3f1163be610f9fb7d327e9ab00cf43f5a38cb5ccd02d7278e21749"
+    "sha512=f627ca0aaad112c08831280d44edcaf7324e9e6d48a7fe13cb0d54bb2385b038bbd5d8d334a93b7a56087618debea289d6f99010e1ed09b88c95ac38c8d3d641"
+  ]
+}

--- a/packages/git-mirage/git-mirage.3.3.3/opam
+++ b/packages/git-mirage/git-mirage.3.3.3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A package to use ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "mimic"
+  "mirage-stack"
+  "git" {= version}
+  "awa"
+  "awa-mirage"
+  "dns-client" {>= "4.6.2"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "5.0.1"}
+  "lwt" {>= "5.3.0"}
+  "mirage-clock" {>= "3.1.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "mirage-protocols" {>= "5.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.1"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "219cd19a1f49b6f8b9d858bf277e374f18f2392a"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.3/git-3.3.3.tbz"
+  checksum: [
+    "sha256=a3ab287daa3f1163be610f9fb7d327e9ab00cf43f5a38cb5ccd02d7278e21749"
+    "sha512=f627ca0aaad112c08831280d44edcaf7324e9e6d48a7fe13cb0d54bb2385b038bbd5d8d334a93b7a56087618debea289d6f99010e1ed09b88c95ac38c8d3d641"
+  ]
+}

--- a/packages/git-unix/git-unix.3.3.3/opam
+++ b/packages/git-unix/git-unix.3.3.3/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install and configure ocaml-git's Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "mmap" {>= "1.1.0"}
+  "git" {= version}
+  "rresult"
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "fmt" {>= "0.8.7"}
+  "bos"
+  "fpath"
+  "uri" {with-test}
+  "digestif" {>= "0.8.1"}
+  "logs"
+  "lwt"
+  "base-unix"
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "git-cohttp-unix" {= version}
+  "mirage-clock"
+  "mirage-clock-unix"
+  "astring" {>= "0.8.5"}
+  "awa"
+  "cmdliner" {>= "1.0.4"}
+  "cohttp-lwt-unix" {>= "2.5.4"}
+  "decompress" {>= "1.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "5.0.1"}
+  "mtime" {>= "1.2.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "tcpip" {>= "6.0.0"}
+  "cstruct" {>= "6.0.0" & with-test}
+  "awa-mirage"
+  "mirage-flow" {>= "2.0.1"}
+  "ke" {>= "0.4" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "ocurl" {>= "0.9.1" & with-test}
+  "ptime" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "219cd19a1f49b6f8b9d858bf277e374f18f2392a"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.3/git-3.3.3.tbz"
+  checksum: [
+    "sha256=a3ab287daa3f1163be610f9fb7d327e9ab00cf43f5a38cb5ccd02d7278e21749"
+    "sha512=f627ca0aaad112c08831280d44edcaf7324e9e6d48a7fe13cb0d54bb2385b038bbd5d8d334a93b7a56087618debea289d6f99010e1ed09b88c95ac38c8d3d641"
+  ]
+}

--- a/packages/git/git.3.3.3/opam
+++ b/packages/git/git.3.3.3/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "Git format and protocol in pure OCaml"
+description: """\
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "digestif" {>= "0.8.1"}
+  "rresult"
+  "base64" {>= "3.0.0"}
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "optint"
+  "decompress" {>= "1.3.0"}
+  "logs"
+  "lwt"
+  "mimic"
+  "cstruct" {>= "5.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "carton" {>= "0.4.0"}
+  "carton-lwt" {>= "0.4.0"}
+  "carton-git" {>= "0.4.0"}
+  "ke" {>= "0.4"}
+  "fmt" {>= "0.8.7"}
+  "checkseum" {>= "0.2.1"}
+  "ocamlgraph" {>= "1.8.8"}
+  "astring"
+  "fpath"
+  "encore" {>= "0.8"}
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng" {with-test & >= "0.8.0"}
+  "cmdliner" {with-test}
+  "base-unix" {with-test}
+  "fpath"
+  "mirage-flow" {>= "2.0.1"}
+  "domain-name" {>= "0.3.0"}
+  "emile" {>= "1.1"}
+  "ipaddr" {>= "5.0.1"}
+  "psq" {>= "0.2.0"}
+  "uri" {>= "4.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "219cd19a1f49b6f8b9d858bf277e374f18f2392a"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.3.3/git-3.3.3.tbz"
+  checksum: [
+    "sha256=a3ab287daa3f1163be610f9fb7d327e9ab00cf43f5a38cb5ccd02d7278e21749"
+    "sha512=f627ca0aaad112c08831280d44edcaf7324e9e6d48a7fe13cb0d54bb2385b038bbd5d8d334a93b7a56087618debea289d6f99010e1ed09b88c95ac38c8d3d641"
+  ]
+}


### PR DESCRIPTION
Git format and protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Fix stack-overflow on tree objects (@zshipko, @dinosaure, mirage/ocaml-git#485)
