### PR TITLE
Package batsat.0.5

### DIFF
--- a/packages/batsat/batsat.0.5/opam
+++ b/packages/batsat/batsat.0.5/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for batsat, a SAT solver in rust"
+maintainer: "simon.cruanes.2007@m4x.org"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+# TODO: add dependency on cargo?
+depends: [
+  "ocaml" { >= "4.06.0" }
+  "dune" {>= "1.3.0" }
+  "odoc" {with-doc}
+  "conf-rust-2018" {build}
+]
+tags: [ "minisat" "solver" "SAT" ]
+homepage: "https://github.com/c-cube/batsat-ocaml/"
+dev-repo: "git+https://github.com/c-cube/batsat-ocaml.git"
+bug-reports: "https://github.com/c-cube/batsat-ocaml/issues"
+authors: "simon.cruanes.2007@m4x.org"
+url {
+  src: "https://github.com/c-cube/batsat-ocaml/archive/0.5.tar.gz"
+  checksum: [
+    "md5=3a2a576ef335ff73ca4004f507271049"
+    "sha512=5be97404493b1decc1ca5be6a56d162dd58cb908a9c74c8828f8a74007c12156526d5c9da67b78707da846a95b65c0914ede0cc5e7a52b1ed5d3dfa14860e3e9"
+  ]
+}


### PR DESCRIPTION
### `batsat.0.5`
OCaml bindings for batsat, a SAT solver in rust



---
* Homepage: https://github.com/c-cube/batsat-ocaml/
* Source repo: git+https://github.com/c-cube/batsat-ocaml.git
* Bug tracker: https://github.com/c-cube/batsat-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0