### PR TITLE
5 packages from gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2f6c97bbd86ce05428e9f06ffdf3239982bd9083/ocaml-bls12-381-2f6c97bbd86ce05428e9f06ffdf3239982bd9083.tar.bz2

### DIFF
--- a/packages/bls12-381-gen/bls12-381-gen.0.4.2/opam
+++ b/packages/bls12-381-gen/bls12-381-gen.0.4.2/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Functors to generate BLS12-381 primitives based on stubs"
+description: "Functors to generate BLS12-381 primitives based on stubs"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2f6c97bbd86ce05428e9f06ffdf3239982bd9083/ocaml-bls12-381-2f6c97bbd86ce05428e9f06ffdf3239982bd9083.tar.bz2"
+  checksum: [
+    "md5=3b88994951c586751fb615af236d2285"
+    "sha512=90f97d5229a2b000452b9903fc30d938538698aebdf542b799ada56d8f635c38effce93365c1994a9667f88769f696335a0d627baa68fef6cd41573f0aa7299c"
+  ]
+}

--- a/packages/bls12-381-js-gen/bls12-381-js-gen.0.4.2/opam
+++ b/packages/bls12-381-js-gen/bls12-381-js-gen.0.4.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis:
+  "Functors to generate BLS12-381 JavaScript primitives based on stubs"
+description:
+  "Functors to generate BLS12-381 JavaScript primitives based on stubs"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "dune-configurator" {build}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "1.12"}
+  "zarith_stubs_js"
+  "js_of_ocaml" {>= "3.7.1"}
+  "js_of_ocaml-compiler" {>= "3.7.1"}
+  "js_of_ocaml-ppx" {>= "3.7.1"}
+  "bls12-381-gen" {= version}
+  "bls12-381" {= version}
+  "alcotest" {with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2f6c97bbd86ce05428e9f06ffdf3239982bd9083/ocaml-bls12-381-2f6c97bbd86ce05428e9f06ffdf3239982bd9083.tar.bz2"
+  checksum: [
+    "md5=3b88994951c586751fb615af236d2285"
+    "sha512=90f97d5229a2b000452b9903fc30d938538698aebdf542b799ada56d8f635c38effce93365c1994a9667f88769f696335a0d627baa68fef6cd41573f0aa7299c"
+  ]
+}

--- a/packages/bls12-381-js/bls12-381-js.0.4.2/opam
+++ b/packages/bls12-381-js/bls12-381-js.0.4.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: """\
+JavaScript version of BLS12-381 primitives implementing the virtual
+package bls12-381"""
+description: """\
+JavaScript version of BLS12-381 primitives implementing the virtual
+package bls12-381"""
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "bls12-381-gen" {= version}
+  "bls12-381" {= version}
+  "bls12-381-js-gen" {= version}
+  "js_of_ocaml" {>= "3.7.1"}
+  "js_of_ocaml-compiler" {>= "3.7.1"}
+  "js_of_ocaml-ppx" {>= "3.7.1"}
+  "alcotest" {with-test}
+  "zarith" {>= "1.10" & < "1.12" & with-test}
+  "zarith_stubs_js" {with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2f6c97bbd86ce05428e9f06ffdf3239982bd9083/ocaml-bls12-381-2f6c97bbd86ce05428e9f06ffdf3239982bd9083.tar.bz2"
+  checksum: [
+    "md5=3b88994951c586751fb615af236d2285"
+    "sha512=90f97d5229a2b000452b9903fc30d938538698aebdf542b799ada56d8f635c38effce93365c1994a9667f88769f696335a0d627baa68fef6cd41573f0aa7299c"
+  ]
+}

--- a/packages/bls12-381-unix/bls12-381-unix.0.4.2/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.0.4.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: """\
+UNIX version of BLS12-381 primitives implementing the virtual package
+bls12-381"""
+description: """\
+UNIX version of BLS12-381 primitives implementing the virtual package
+bls12-381"""
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "conf-rust" {build}
+  "dune" {>= "2.8.4"}
+  "dune-configurator" {build}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "ctypes" {>= "0.18.0" & < "0.19.0"}
+  "ctypes-foreign"
+  "bls12-381-gen" {= version}
+  "bls12-381" {= version}
+  "tezos-rust-libs" {= "1.1"}
+  "alcotest" {with-test}
+  "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2f6c97bbd86ce05428e9f06ffdf3239982bd9083/ocaml-bls12-381-2f6c97bbd86ce05428e9f06ffdf3239982bd9083.tar.bz2"
+  checksum: [
+    "md5=3b88994951c586751fb615af236d2285"
+    "sha512=90f97d5229a2b000452b9903fc30d938538698aebdf542b799ada56d8f635c38effce93365c1994a9667f88769f696335a0d627baa68fef6cd41573f0aa7299c"
+  ]
+}

--- a/packages/bls12-381/bls12-381.0.4.2/opam
+++ b/packages/bls12-381/bls12-381.0.4.2/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Virtual package for BLS12-381 primitives"
+description: "Virtual package for BLS12-381 primitives"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "bls12-381-gen" {= version}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2f6c97bbd86ce05428e9f06ffdf3239982bd9083/ocaml-bls12-381-2f6c97bbd86ce05428e9f06ffdf3239982bd9083.tar.bz2"
+  checksum: [
+    "md5=3b88994951c586751fb615af236d2285"
+    "sha512=90f97d5229a2b000452b9903fc30d938538698aebdf542b799ada56d8f635c38effce93365c1994a9667f88769f696335a0d627baa68fef6cd41573f0aa7299c"
+  ]
+}


### PR DESCRIPTION
Releasing a new version of bls12-381 because 0.4.1 is affected by the bug https://github.com/ocaml/dune/issues/4372. A fix has been provided in https://gitlab.com/dannywillems/ocaml-bls12-381/-/commit/718eab6a754862998ef6a7b36d12ea669de381ce. MISC changes on the deps, like ctypes and zarith.

0.4.1 should be removed from OPAM.

This pull-request concerns:
-`bls12-381.0.4.2`: Virtual package for BLS12-381 primitives
-`bls12-381-gen.0.4.2`: Functors to generate BLS12-381 primitives based on stubs
-`bls12-381-js.0.4.2`: JavaScript version of BLS12-381 primitives implementing the virtual
 package bls12-381
-`bls12-381-js-gen.0.4.2`: Functors to generate BLS12-381 JavaScript primitives based on stubs
-`bls12-381-unix.0.4.2`: UNIX version of BLS12-381 primitives implementing the virtual package
 bls12-381



---
* Homepage: https://gitlab.com/dannywillems/ocaml-bls12-381
* Source repo: git+https://gitlab.com/dannywillems/ocaml-bls12-381.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-bls12-381/issues

---
:camel: Pull-request generated by opam-publish v2.0.3