### PR TITLE
[new release] cohttp-lwt-jsoo, cohttp, cohttp-lwt, cohttp-lwt-unix, cohttp-top, cohttp-async and cohttp-mirage (4.0.0)

### DIFF
--- a/packages/cohttp-async/cohttp-async.4.0.0/opam
+++ b/packages/cohttp-async/cohttp-async.4.0.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for the Async concurrency library"
+description: """
+An implementation of an HTTP client and server using the Async
+concurrency library. See the `Cohttp_async` module for information
+on how to use this.  The package also installs `cohttp-curl-async`
+and a `cohttp-server-async` binaries for quick uses of a HTTP(S)
+client and server respectively.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "async_kernel" {>= "v0.14.0"}
+  "async_unix" {>= "v0.14.0"}
+  "async" {>= "v0.14.0"}
+  "base" {>= "v0.11.0"}
+  "core" {with-test}
+  "cohttp" {=version}
+  "conduit-async" {>="1.2.0" & <"3.0.0"}
+  "magic-mime"
+  "mirage-crypto" {with-test}
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "ounit" {with-test}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "ipaddr"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "9144f05bf9ef91e31a81fb65de1421df1fa155b1"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.0.0/cohttp-v4.0.0.tbz"
+  checksum: [
+    "sha256=bd7aa4cd2c82744990ed7c49e3ee7a40324c64cb3d8509804809155e2bacd1d2"
+    "sha512=f56014c80ec77f79cc9a3a55afaa5fb8e37d9d69a4115f1b25fa96623c8e6875844bfdc97dd6fe41f83ac4b251a397b905a3eb31df90dae95d5a96101d265e03"
+  ]
+}

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.4.0.0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.4.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for the Js_of_ocaml JavaScript compiler"
+description: """
+An implementation of an HTTP client for JavaScript, but using the
+CoHTTP types.  This lets you build HTTP clients that can compile
+natively (using one of the other Cohttp backends such as `cohttp-lwt-unix`)
+and also to native JavaScript via js_of_ocaml.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "cohttp" {=version}
+  "cohttp-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "js_of_ocaml" {>= "3.3.0"}
+  "js_of_ocaml-ppx" {>= "3.3.0"}
+  "js_of_ocaml-lwt" {>= "3.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "9144f05bf9ef91e31a81fb65de1421df1fa155b1"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.0.0/cohttp-v4.0.0.tbz"
+  checksum: [
+    "sha256=bd7aa4cd2c82744990ed7c49e3ee7a40324c64cb3d8509804809155e2bacd1d2"
+    "sha512=f56014c80ec77f79cc9a3a55afaa5fb8e37d9d69a4115f1b25fa96623c8e6875844bfdc97dd6fe41f83ac4b251a397b905a3eb31df90dae95d5a96101d265e03"
+  ]
+}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.4.0.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.4.0.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for Unix and Windows using Lwt"
+description: """
+An implementation of an HTTP client and server using the Lwt
+concurrency library. See the `Cohttp_lwt_unix` module for information
+on how to use this.  The package also installs `cohttp-curl-lwt`
+and a `cohttp-server-lwt` binaries for quick uses of a HTTP(S)
+client and server respectively.
+
+Although the name implies that this only works under Unix, it
+should also be fine under Windows too."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "conduit-lwt" {>= "1.0.3" & < "3.0.0"}
+  "conduit-lwt-unix" {>= "1.0.3" & < "3.0.0"}
+  "cmdliner"
+  "magic-mime"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "cohttp-lwt" {=version}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "lwt" {>= "3.0.0"}
+  "base-unix"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "9144f05bf9ef91e31a81fb65de1421df1fa155b1"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.0.0/cohttp-v4.0.0.tbz"
+  checksum: [
+    "sha256=bd7aa4cd2c82744990ed7c49e3ee7a40324c64cb3d8509804809155e2bacd1d2"
+    "sha512=f56014c80ec77f79cc9a3a55afaa5fb8e37d9d69a4115f1b25fa96623c8e6875844bfdc97dd6fe41f83ac4b251a397b905a3eb31df90dae95d5a96101d265e03"
+  ]
+}

--- a/packages/cohttp-lwt/cohttp-lwt.4.0.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.4.0.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation using the Lwt concurrency library"
+description: """
+This is a portable implementation of HTTP that uses the Lwt
+concurrency library to multiplex IO.  It implements as much of the
+logic in an OS-independent way as possible, so that more specialised
+modules can be tailored for different targets.  For example, you
+can install `cohttp-lwt-unix` or `cohttp-lwt-jsoo` for a Unix or
+JavaScript backend, or `cohttp-mirage` for the MirageOS unikernel
+version of the library. All of these implementations share the same
+IO logic from this module."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "cohttp" {=version}
+  "lwt" {>= "2.5.0"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "logs"
+  "uri" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "9144f05bf9ef91e31a81fb65de1421df1fa155b1"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.0.0/cohttp-v4.0.0.tbz"
+  checksum: [
+    "sha256=bd7aa4cd2c82744990ed7c49e3ee7a40324c64cb3d8509804809155e2bacd1d2"
+    "sha512=f56014c80ec77f79cc9a3a55afaa5fb8e37d9d69a4115f1b25fa96623c8e6875844bfdc97dd6fe41f83ac4b251a397b905a3eb31df90dae95d5a96101d265e03"
+  ]
+}

--- a/packages/cohttp-mirage/cohttp-mirage.4.0.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.4.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+synopsis: "CoHTTP implementation for the MirageOS unikernel"
+description: """
+This HTTP implementation uses the Cohttp portable implementaiton
+along with the Lwt threading library in order to provide a
+`Cohttp_mirage` functor that can be used in MirageOS unikernels
+to build very small and efficient HTTP clients and servers
+without having a hard dependency on an underlying operating
+system.
+
+Please see <https://mirage.io> for a self-hosted explanation
+and instructions on how to use this library."""
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+  "conduit" {>= "2.0.2" & <"3.0.0"}
+  "conduit-mirage" {>= "2.0.2" & <"3.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp" {=version}
+  "cohttp-lwt" {=version}
+  "astring"
+  "magic-mime"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "9144f05bf9ef91e31a81fb65de1421df1fa155b1"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.0.0/cohttp-v4.0.0.tbz"
+  checksum: [
+    "sha256=bd7aa4cd2c82744990ed7c49e3ee7a40324c64cb3d8509804809155e2bacd1d2"
+    "sha512=f56014c80ec77f79cc9a3a55afaa5fb8e37d9d69a4115f1b25fa96623c8e6875844bfdc97dd6fe41f83ac4b251a397b905a3eb31df90dae95d5a96101d265e03"
+  ]
+}

--- a/packages/cohttp-mirage/cohttp-mirage.4.0.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.4.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
   "conduit" {>= "2.0.2" & <"3.0.0"}
-  "conduit-mirage" {>= "2.0.2" & <"3.0.0"}
+  "conduit-mirage" {>= "2.3.0" & <"3.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {=version}

--- a/packages/cohttp-top/cohttp-top.4.0.0/opam
+++ b/packages/cohttp-top/cohttp-top.4.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP toplevel pretty printers for HTTP types"
+description: """
+This library installs toplevel prettyprinters for CoHTTP
+types such as the `Request`, `Response` and `Types` modules.
+Once this library has been loaded, you can directly see the
+values of those types in toplevels such as `utop` or `ocaml`."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.1.0"}
+  "cohttp" {=version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "9144f05bf9ef91e31a81fb65de1421df1fa155b1"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.0.0/cohttp-v4.0.0.tbz"
+  checksum: [
+    "sha256=bd7aa4cd2c82744990ed7c49e3ee7a40324c64cb3d8509804809155e2bacd1d2"
+    "sha512=f56014c80ec77f79cc9a3a55afaa5fb8e37d9d69a4115f1b25fa96623c8e6875844bfdc97dd6fe41f83ac4b251a397b905a3eb31df90dae95d5a96101d265e03"
+  ]
+}

--- a/packages/cohttp/cohttp.4.0.0/opam
+++ b/packages/cohttp/cohttp.4.0.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries.
+
+See the cohttp-async, cohttp-lwt, cohttp-lwt-unix, cohttp-lwt-jsoo and
+cohttp-mirage libraries for concrete implementations for particular
+targets.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0.0"}
+  "re" {>= "1.9.0"}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "stringext"
+  "base64" {>= "3.1.0"}
+  "fmt" {with-test}
+  "jsonm" {build}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+x-commit-hash: "9144f05bf9ef91e31a81fb65de1421df1fa155b1"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.0.0/cohttp-v4.0.0.tbz"
+  checksum: [
+    "sha256=bd7aa4cd2c82744990ed7c49e3ee7a40324c64cb3d8509804809155e2bacd1d2"
+    "sha512=f56014c80ec77f79cc9a3a55afaa5fb8e37d9d69a4115f1b25fa96623c8e6875844bfdc97dd6fe41f83ac4b251a397b905a3eb31df90dae95d5a96101d265e03"
+  ]
+}

--- a/packages/comby/comby.1.2.2/opam
+++ b/packages/comby/comby.1.2.2/opam
@@ -14,7 +14,7 @@ build: [
       "-j"
       jobs
       "@install"
-      "@runtest" {with-test}
+      "@runtest" {with-test & cohttp-lwt-unix:version < "3.0.0"}
     ]
 ]
 depends: [

--- a/packages/doi2bib/doi2bib.0.3.0/opam
+++ b/packages/doi2bib/doi2bib.0.3.0/opam
@@ -26,7 +26,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & cohttp-lwt-unix:version < "3.0.0" }
     "@doc" {with-doc}
   ]
 ]

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.2.0/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.6.0"}
   "git" {= version}
   "mimic"
-  "cohttp-mirage"
+  "cohttp-mirage" {< "3.0.0"}
   "cohttp" {>= "2.5.4"}
   "cohttp-lwt" {>= "2.5.4"}
   "fmt" {>= "0.8.9"}

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.0/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.6.0"}
   "git" {= version}
   "mimic"
-  "cohttp-mirage"
+  "cohttp-mirage" {< "3.0.0"}
   "cohttp" {>= "2.5.4"}
   "cohttp-lwt" {>= "2.5.4"}
   "fmt" {>= "0.8.9"}

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.1/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic"
-  "cohttp-mirage"
+  "cohttp-mirage" {< "3.0.0"}
   "cohttp" {>= "2.5.4"}
   "cohttp-lwt" {>= "2.5.4"}
   "fmt" {>= "0.8.9"}

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.2/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.2/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic"
-  "cohttp-mirage"
+  "cohttp-mirage" {< "3.0.0"}
   "cohttp" {>= "2.5.4"}
   "cohttp-lwt" {>= "2.5.4"}
   "fmt" {>= "0.8.9"}

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.3/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.3/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic"
-  "cohttp-mirage"
+  "cohttp-mirage" {< "3.0.0"}
   "cohttp" {>= "2.5.4"}
   "cohttp-lwt" {>= "2.5.4"}
   "fmt" {>= "0.8.9"}

--- a/packages/git-http/git-http.2.0.0/opam
+++ b/packages/git-http/git-http.2.0.0/opam
@@ -18,8 +18,8 @@ depends: [
   "ocaml"        {>= "4.03.0"}
   "dune"
   "git"          {= version}
-  "cohttp"       {>= "1.0.0"}
-  "cohttp-lwt"   {>= "1.0.0"}
+  "cohttp"       {>= "1.0.0" & < "3.0.0"}
+  "cohttp-lwt"   {>= "1.0.0" & < "3.0.0"}
   "sexplib"      {< "v0.15"}
 ]
 url {

--- a/packages/git-http/git-http.2.1.0/opam
+++ b/packages/git-http/git-http.2.1.0/opam
@@ -18,8 +18,8 @@ depends: [
   "ocaml"        {>= "4.03.0"}
   "dune"
   "git"          {= version}
-  "cohttp"       {>= "1.0.0"}
-  "cohttp-lwt"   {>= "1.0.0"}
+  "cohttp"       {>= "1.0.0" & < "3.0.0"}
+  "cohttp-lwt"   {>= "1.0.0" & < "3.0.0"}
 ]
 url {
   src:

--- a/packages/git-http/git-http.2.1.1/opam
+++ b/packages/git-http/git-http.2.1.1/opam
@@ -18,8 +18,8 @@ depends: [
   "ocaml"        {>= "4.03.0"}
   "dune"         {>= "1.1"}
   "git"          {= version}
-  "cohttp"       {>= "1.0.0"}
-  "cohttp-lwt"   {>= "1.0.0"}
+  "cohttp"       {>= "1.0.0" & < "3.0.0"}
+  "cohttp-lwt"   {>= "1.0.0" & < "3.0.0"}
 ]
 url {
   src:

--- a/packages/git-http/git-http.2.1.2/opam
+++ b/packages/git-http/git-http.2.1.2/opam
@@ -18,8 +18,8 @@ depends: [
   "ocaml"        {>= "4.03.0"}
   "dune"         {>= "1.1"}
   "git"          {= version}
-  "cohttp"       {>= "1.0.0"}
-  "cohttp-lwt"   {>= "1.0.0"}
+  "cohttp"       {>= "1.0.0" & < "3.0.0"}
+  "cohttp-lwt"   {>= "1.0.0" & < "3.0.0"}
 ]
 url {
   src:

--- a/packages/git-http/git-http.2.1.3/opam
+++ b/packages/git-http/git-http.2.1.3/opam
@@ -18,8 +18,8 @@ depends: [
   "ocaml"        {>= "4.07.0"}
   "dune"
   "git"          {= version}
-  "cohttp"       {>= "1.0.0"}
-  "cohttp-lwt"   {>= "1.0.0"}
+  "cohttp"       {>= "1.0.0" & < "3.0.0"}
+  "cohttp-lwt"   {>= "1.0.0" & < "3.0.0"}
 ]
 url {
   src:


### PR DESCRIPTION
# ocaml-cohttp -- an OCaml library for HTTP clients and servers

Cohttp is an OCaml library for creating HTTP daemons. It has a portable HTTP parser, and implementations using various asynchronous programming libraries:

- Cohttp_lwt_unix uses the Lwt library, and specifically the UNIX bindings. It uses ocaml-tls as the TLS implementation to handle HTTPS connections.
- Cohttp_async uses the Async library and async_ssl to handle HTTPS connections.
- Cohttp_lwt exposes an OS-independent Lwt interface, which is used by the Mirage interface to generate standalone microkernels (use the cohttp-mirage subpackage).
- Cohttp_lwt_jsoo compiles to a JavaScript module that maps the Cohttp calls to XMLHTTPRequests. This is used to compile OCaml libraries like the GitHub bindings to JavaScript and still run efficiently.

You can implement other targets using the parser very easily. Look at the IO signature in lib/s.mli and implement that in the desired backend.

- Project page: <a href="https://github.com/mirage/ocaml-cohttp">https://github.com/mirage/ocaml-cohttp</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cohttp/">https://mirage.github.io/ocaml-cohttp/</a>

##### CHANGES:

- cohttp.response: fix malformed status header for custom status codes (@mseri @aalekseyev mirage/ocaml-cohttp#752)
- Remove dependency to base (@samoht mirage/ocaml-cohttp#745)
- fix opam files and dependencies
- add GitHub Actions workflow (@smorimoto mirage/ocaml-cohttp#739)
- lwt_jsoo: Forward exceptions to caller when response is null (@mefyl mirage/ocaml-cohttp#738)
- Remove wrapped false (@rgrinberg mirage/ocaml-cohttp#734)
- Use implicit executable dependency for generate.exe (@TheLortex mirage/ocaml-cohttp#735)
- cohttp: update HTTP codes (@emillon mirage/ocaml-cohttp#711)
- cohttp: add Uti.t to uri scheme (@brendanlong mirage/ocaml-cohttp#707)
- cohttp: fix chunked encoding of empty body (@mefyl mirage/ocaml-cohttp#715)
- cohttp-async: fix body not being uploaded with unchunked Async.Pipe (@mefyl mirage/ocaml-cohttp#706)
- cohttp-{async, lwt}: fix suprising behaviours of Body.is_empty (@anuragsoni mirage/ocaml-cohttp#714 mirage/ocaml-cohttp#712 mirage/ocaml-cohttp#713)
- cohttp-lwt-jsoo: rename Cohttp_lwt_xhr to Cohttp_lwt_jsoo for consistency (@mseri mirage/ocaml-cohttp#717)
- refactoring of tests (@mseri mirage/ocaml-cohttp#709, @dinosaure mirage/ocaml-cohttp#692)
- update documentation (@dinosaure mirage/ocaml-cohttp#716, @mseri mirage/ocaml-cohttp#720)
- cohttp: fix transfer-encoding ordering in headers (@mseri mirage/ocaml-cohttp#721)
- lower-level support for long-running cohttp-async connections (@brendanlong mirage/ocaml-cohttp#704)
- fix deadlock in logging (@dinosaure mirage/ocaml-cohttp#722)
- add of_form and to_form functions to body (@seliopou mirage/ocaml-cohttp#440, @mseri mirage/ocaml-cohttp#723)
- cohttp-lwt: partly inline read_response, fix body stream leak (@madroach @dinosaure mirage/ocaml-cohttp#696)
- improve media type parsing (@seliopou mirage/ocaml-cohttp#542, @dinosaure mirage/ocaml-cohttp#725)
- add comparison functions for Request.t and Response.t via ppx_compare (@msaffer-js @dinosaure mirage/ocaml-cohttp#686)
- [reverted] breaking changes to client and server API to use conduit
  3.0.0 (@dinosaure mirage/ocaml-cohttp#692). However, as the design discussion did not reach
  consensus, these changes were reverted to preserve better compatibility with
  existing cohttp users. (mirage/ocaml-cohttp#741,  @samoht)
