### PR TITLE
2 packages from Gbury/mSAT at 0.9.1

### DIFF
--- a/packages/msat-bin/msat-bin.0.9.1/opam
+++ b/packages/msat-bin/msat-bin.0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "SAT solver binary based on the msat library"
-license: "Apache"
+license: "Apache-2.0"
 maintainer: ["guillaume.bury@gmail.com" "simon.cruanes.2007@m4x.org"]
 build: [
   ["dune" "build" "@install" "-p" name "-j" jobs]

--- a/packages/msat-bin/msat-bin.0.9.1/opam
+++ b/packages/msat-bin/msat-bin.0.9.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "SAT solver binary based on the msat library"
+license: "Apache"
+maintainer: ["guillaume.bury@gmail.com" "simon.cruanes.2007@m4x.org"]
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  #["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.1" }
+  "msat" { = version }
+  "containers" { >= "2.8.1" & < "4.0" }
+  "camlzip"
+]
+tags: [ "sat" ]
+homepage: "https://github.com/Gbury/mSAT"
+dev-repo: "git+https://github.com/Gbury/mSAT.git"
+bug-reports: "https://github.com/Gbury/mSAT/issues/"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+url {
+  src: "https://github.com/Gbury/mSAT/archive/v0.9.1.tar.gz"
+  checksum: [
+    "md5=ba623630b0b8e0edc016079dd214c80b"
+    "sha512=51c133cefe8550125e7b1db18549e893bac15663fdd7a9fac87235c07de755f39eab9fc3cfdf6571612fd79b3d5b22f49f459581b480c7349bacddf2618c8a99"
+  ]
+}

--- a/packages/msat/msat.0.9.1/opam
+++ b/packages/msat/msat.0.9.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Library containing a SAT solver that can be parametrized by a theory"
+license: "Apache"
+maintainer: ["guillaume.bury@gmail.com" "simon.cruanes.2007@m4x.org"]
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.1" }
+  "iter" { >= "1.2" }
+  "containers" {with-test & >= "2.8.1" & < "4.0" }
+  "mdx" {with-test}
+]
+tags: [ "sat" "smt" "cdcl" "functor" ]
+homepage: "https://github.com/Gbury/mSAT"
+dev-repo: "git+https://github.com/Gbury/mSAT.git"
+bug-reports: "https://github.com/Gbury/mSAT/issues/"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+url {
+  src: "https://github.com/Gbury/mSAT/archive/v0.9.1.tar.gz"
+  checksum: [
+    "md5=ba623630b0b8e0edc016079dd214c80b"
+    "sha512=51c133cefe8550125e7b1db18549e893bac15663fdd7a9fac87235c07de755f39eab9fc3cfdf6571612fd79b3d5b22f49f459581b480c7349bacddf2618c8a99"
+  ]
+}

--- a/packages/msat/msat.0.9.1/opam
+++ b/packages/msat/msat.0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Library containing a SAT solver that can be parametrized by a theory"
-license: "Apache"
+license: "Apache-2.0"
 maintainer: ["guillaume.bury@gmail.com" "simon.cruanes.2007@m4x.org"]
 build: [
   ["dune" "build" "@install" "-p" name "-j" jobs]


### PR DESCRIPTION
This pull-request concerns:
-`msat.0.9.1`: Library containing a SAT solver that can be parametrized by a theory
-`msat-bin.0.9.1`: SAT solver binary based on the msat library



---
* Homepage: https://github.com/Gbury/mSAT
* Source repo: git+https://github.com/Gbury/mSAT.git
* Bug tracker: https://github.com/Gbury/mSAT/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0