### PR TITLE
[new release] ocamlnet (4.1.9)

### DIFF
--- a/packages/ocamlnet/ocamlnet.3.2.1/opam
+++ b/packages/ocamlnet/ocamlnet.3.2.1/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [

--- a/packages/ocamlnet/ocamlnet.3.2.1/opam
+++ b/packages/ocamlnet/ocamlnet.3.2.1/opam
@@ -10,25 +10,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgssapi"]
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-]
 depends: [
   "ocaml" {>= "3.11" < "4.00.0"}
   "ocamlfind"
@@ -49,7 +30,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
 url {
   src: "http://download.camlcity.org/download/ocamlnet-3.2.1.tar.gz"

--- a/packages/ocamlnet/ocamlnet.3.2.1/opam
+++ b/packages/ocamlnet/ocamlnet.3.2.1/opam
@@ -3,8 +3,8 @@ authors: "Gerd Stolpmann"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   ["./configure" "-bindir" bin]
   [make "all"]

--- a/packages/ocamlnet/ocamlnet.3.5.1/opam
+++ b/packages/ocamlnet/ocamlnet.3.5.1/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
 build: [

--- a/packages/ocamlnet/ocamlnet.3.5.1/opam
+++ b/packages/ocamlnet/ocamlnet.3.5.1/opam
@@ -19,32 +19,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "equeue-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgssapi"]
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "nethttpd-for-netcgi2"]
-  ["ocamlfind" "remove" "netmech-scram"] {"%{cryptokit:installed}%"}
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "rpc-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-]
 depends: [
   "ocaml" {>= "3.12" & < "4.00.0"}
   "ocamlfind"
@@ -67,7 +41,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
 url {
   src: "http://download.camlcity.org/download/ocamlnet-3.5.1.tar.gz"

--- a/packages/ocamlnet/ocamlnet.3.5.1/opam
+++ b/packages/ocamlnet/ocamlnet.3.5.1/opam
@@ -3,8 +3,8 @@ authors: "Gerd Stolpmann"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.3.6.0/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.0/opam
@@ -4,8 +4,8 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.6.0/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.3.6.0/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.0/opam
@@ -21,33 +21,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "equeue-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgssapi"]
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "nethttpd-for-netcgi2"]
-  ["ocamlfind" "remove" "netmech-scram"] {"%{cryptokit:installed}%"}
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "rpc-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-]
 depends: [
   "ocaml" {>= "3.12" & < "4.01.0"}
   "ocamlfind"
@@ -75,7 +48,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: [
   ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
   ["ocamlnet-ocaml4.diff" "md5=a681fe195de5024b2847b8f95f157a8c"]

--- a/packages/ocamlnet/ocamlnet.3.6.0/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.0/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.6.0/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.3.6.3/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.3/opam
@@ -21,33 +21,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "equeue-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgssapi"]
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "nethttpd-for-netcgi2"]
-  ["ocamlfind" "remove" "netmech-scram"] {"%{cryptokit:installed}%"}
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "rpc-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-]
 depends: [
   "ocaml" {>= "3.12" & < "4.01.0"}
   "ocamlfind"
@@ -74,7 +47,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
 url {
   src: "http://download.camlcity.org/download/ocamlnet-3.6.3.tar.gz"

--- a/packages/ocamlnet/ocamlnet.3.6.3/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.3/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.6.3/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.3.6.3/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.3/opam
@@ -4,8 +4,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.6.3/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.3.6.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.5/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.6.5/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.3.6.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.5/opam
@@ -4,8 +4,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.6.5/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.3.6.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.6.5/opam
@@ -21,33 +21,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "equeue-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgssapi"]
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "nethttpd-for-netcgi2"]
-  ["ocamlfind" "remove" "netmech-scram"] {"%{cryptokit:installed}%"}
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "rpc-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-]
 depends: [
   "ocaml" {>= "3.12" & < "4.02.0"}
   "ocamlfind"
@@ -80,7 +53,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: [
   ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
   ["netpop.patch" "md5=4fec3114768d6157a5a86c35d86968f7"]

--- a/packages/ocamlnet/ocamlnet.3.7.3/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.3/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.3/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.3.7.3/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.3/opam
@@ -4,8 +4,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.3/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.3.7.3/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.3/opam
@@ -21,33 +21,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "equeue-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgssapi"]
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "nethttpd-for-netcgi2"]
-  ["ocamlfind" "remove" "netmech-scram"] {"%{cryptokit:installed}%"}
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "rpc-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-]
 depends: [
   "ocaml" {>= "4.00" & < "4.02.0"}
   "ocamlfind"
@@ -75,7 +48,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: [
   ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
   ["fix-ocaml-4.02.patch" "md5=5f017d099ce253c0973ab24c9fea5e0c"]

--- a/packages/ocamlnet/ocamlnet.3.7.4-1/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.4-1/opam
@@ -4,8 +4,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.4/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.3.7.4-1/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.4-1/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.4/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.3.7.4-1/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.4-1/opam
@@ -21,33 +21,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "equeue-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgssapi"]
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "nethttpd-for-netcgi2"]
-  ["ocamlfind" "remove" "netmech-scram"] {"%{cryptokit:installed}%"}
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "rpc-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-]
 depends: [
   "ocaml" {>= "4.00" & < "4.02.0"}
   "ocamlfind"
@@ -75,7 +48,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: [
   ["robust-host.patch" "md5=990dd1931da1a4f906df60f4925ebe8c"]
   ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]

--- a/packages/ocamlnet/ocamlnet.3.7.4/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.4/opam
@@ -4,8 +4,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.4/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.3.7.4/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.4/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.4/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.3.7.4/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.4/opam
@@ -21,33 +21,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "equeue-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgssapi"]
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "nethttpd-for-netcgi2"]
-  ["ocamlfind" "remove" "netmech-scram"] {"%{cryptokit:installed}%"}
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "rpc-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-]
 depends: [
   "ocaml" {>= "4.00" & < "4.02.0"}
   "ocamlfind"
@@ -74,7 +47,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
 url {
   src: "http://download.camlcity.org/download/ocamlnet-3.7.4.tar.gz"

--- a/packages/ocamlnet/ocamlnet.3.7.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.5/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.5/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.3.7.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.5/opam
@@ -4,8 +4,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.5/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.3.7.5/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.5/opam
@@ -21,33 +21,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "equeue-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgssapi"]
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "nethttpd-for-netcgi2"]
-  ["ocamlfind" "remove" "netmech-scram"] {"%{cryptokit:installed}%"}
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "rpc-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-]
 depends: [
   "ocaml" {>= "3.12" & < "4.03.0"}
   "ocamlfind"
@@ -76,7 +49,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: [
   ["robust-host.patch" "md5=990dd1931da1a4f906df60f4925ebe8c"]
   ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]

--- a/packages/ocamlnet/ocamlnet.3.7.6/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.6/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.6/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.3.7.6/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.6/opam
@@ -4,8 +4,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.6/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.3.7.6/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.6/opam
@@ -21,33 +21,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "equeue-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgssapi"]
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "nethttpd-for-netcgi2"]
-  ["ocamlfind" "remove" "netmech-scram"] {"%{cryptokit:installed}%"}
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "rpc-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-]
 depends: [
   "ocaml" {>= "3.12" & < "4.03.0"}
   "ocamlfind"
@@ -75,7 +48,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: [
   ["robust-host.patch" "md5=990dd1931da1a4f906df60f4925ebe8c"]
   ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]

--- a/packages/ocamlnet/ocamlnet.3.7.7/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.7/opam
@@ -21,33 +21,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "equeue-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgssapi"]
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "nethttpd-for-netcgi2"]
-  ["ocamlfind" "remove" "netmech-scram"] {"%{cryptokit:installed}%"}
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "rpc-ssl"] {"%{ssl:installed}%"}
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-]
 depends: [
   "ocaml" {>= "3.12" & < "4.03.0"}
   "ocamlfind"
@@ -75,7 +48,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: [
   ["robust-host.patch" "md5=990dd1931da1a4f906df60f4925ebe8c"]
   ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]

--- a/packages/ocamlnet/ocamlnet.3.7.7/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.7/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.7/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.3.7.7/opam
+++ b/packages/ocamlnet/ocamlnet.3.7.7/opam
@@ -4,8 +4,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-3.7.7/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.0.1/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.1/opam
@@ -21,32 +21,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgss-system"] {"%{conf-gssapi:installed}%"}
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "nettls-gnutls"] {"%{conf-gnutls:installed}%"}
-  ["ocamlfind" "remove" "netunidata"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-
-]
 depends: [
   "ocaml" {< "4.03.0" & >= "4.00.0"}
   "ocamlfind"
@@ -73,7 +47,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
 url {
   src: "http://download.camlcity.org/download/ocamlnet-4.0.1.tar.gz"

--- a/packages/ocamlnet/ocamlnet.4.0.1/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.1/opam
@@ -4,8 +4,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.0.1/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.0.1/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.1/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.0.1/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.4.0.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.2/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.0.2/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.4.0.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.2/opam
@@ -4,8 +4,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.0.2/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.0.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.2/opam
@@ -21,32 +21,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgss-system"] {"%{conf-gssapi:installed}%"}
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "nettls-gnutls"] {"%{conf-gnutls:installed}%"}
-  ["ocamlfind" "remove" "netunidata"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-
-]
 depends: [
   "ocaml" {< "4.03.0" & >= "4.00.0"}
   "ocamlfind"
@@ -73,7 +47,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
 url {
   src: "http://download.camlcity.org/download/ocamlnet-4.0.2.tar.gz"

--- a/packages/ocamlnet/ocamlnet.4.0.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.4/opam
@@ -21,32 +21,6 @@ build: [
   [make "opt"]
 ]
 authors: ["Gerd Stolpmann"]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgss-system"] {"%{conf-gssapi:installed}%"}
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "nettls-gnutls"] {"%{conf-gnutls:installed}%"}
-  ["ocamlfind" "remove" "netunidata"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-
-]
 depends: [
   "ocaml" {< "4.03.0" & >= "4.00.0"}
   "ocamlfind"
@@ -73,7 +47,6 @@ management of multiple worker processes, and the interaction with
 other programs running on the same machine. You can also view Ocamlnet
 as an extension of the system interface as provided by the Unix module
 of the standard library."""
-flags: light-uninstall
 extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
 url {
   src: "http://download.camlcity.org/download/ocamlnet-4.0.4.tar.gz"

--- a/packages/ocamlnet/ocamlnet.4.0.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.4/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.0.4/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.4.0.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.0.4/opam
@@ -3,8 +3,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.0.4/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.1.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.2/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.1.2/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.4.1.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.2/opam
@@ -3,8 +3,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.1.2/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.1.2/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.2/opam
@@ -21,32 +21,6 @@ build: [
   [make "opt"]
 ]
 authors: ["Gerd Stolpmann"]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgss-system"] {"%{conf-gssapi:installed}%"}
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "nettls-gnutls"] {"%{conf-gnutls:installed}%"}
-  ["ocamlfind" "remove" "netunidata"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-
-]
 depends: [
   "ocaml" {>= "4.00.0" & < "4.05.0"}
   "ocamlfind"
@@ -77,7 +51,6 @@ conflicts: [
   "ocaml-variants" {= "4.04.0+flambda" | = "4.04.2+flambda"}
   "shell"
 ]
-flags: light-uninstall
 extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
 url {
   src: "http://download.camlcity.org/download/ocamlnet-4.1.2.tar.gz"

--- a/packages/ocamlnet/ocamlnet.4.1.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.4/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.1.4/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.4.1.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.4/opam
@@ -3,8 +3,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.1.4/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.1.4/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.4/opam
@@ -21,32 +21,6 @@ build: [
   [make "opt"]
 ]
 authors: ["Gerd Stolpmann"]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgss-system"] {"%{conf-gssapi:installed}%"}
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "nettls-gnutls"] {"%{conf-gnutls:installed}%"}
-  ["ocamlfind" "remove" "netunidata"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-
-]
 depends: [
   "ocaml" {>= "4.00.0" & < "4.07.0"}
   "ocamlfind"
@@ -78,7 +52,6 @@ conflicts: [
     {= "4.04.0+flambda" | = "4.04.1+flambda" | = "4.04.2+flambda"}
   "shell"
 ]
-flags: light-uninstall
 extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
 url {
   src: "http://download.camlcity.org/download/ocamlnet-4.1.4.tar.gz"

--- a/packages/ocamlnet/ocamlnet.4.1.5/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.5/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.1.5/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.4.1.5/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.5/opam
@@ -3,8 +3,8 @@ maintainer: "vb@luminar.eu.org"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.1.5/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.1.5/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.5/opam
@@ -21,32 +21,6 @@ build: [
   [make "opt"]
 ]
 authors: ["Gerd Stolpmann"]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgss-system"] {"%{conf-gssapi:installed}%"}
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "nettls-gnutls"] {"%{conf-gnutls:installed}%"}
-  ["ocamlfind" "remove" "netunidata"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-
-]
 depends: [
   "ocaml" {>= "4.00.0" & < "4.07.0"}
   "ocamlfind"
@@ -79,7 +53,6 @@ conflicts: [
     {= "4.04.0+flambda" | = "4.04.1+flambda" | = "4.04.2+flambda"}
   "shell"
 ]
-flags: light-uninstall
 extra-files: [
   ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
   ["netgzip.patch" "md5=cf4770c05902d19b2aa715008346e6e4"]

--- a/packages/ocamlnet/ocamlnet.4.1.6/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.6/opam
@@ -21,32 +21,6 @@ build: [
   [make "opt"]
 ]
 authors: ["Gerd Stolpmann"]
-remove: [
-  ["ocamlfind" "remove" "equeue"]
-  ["ocamlfind" "remove" "equeue-gtk2"] {"%{lablgtk:installed}%"}
-  ["ocamlfind" "remove" "netcamlbox"]
-  ["ocamlfind" "remove" "netcgi2"]
-  ["ocamlfind" "remove" "netcgi2-plex"]
-  ["ocamlfind" "remove" "netclient"]
-  ["ocamlfind" "remove" "netgss-system"] {"%{conf-gssapi:installed}%"}
-  ["ocamlfind" "remove" "nethttpd"]
-  ["ocamlfind" "remove" "netmulticore"]
-  ["ocamlfind" "remove" "netplex"]
-  ["ocamlfind" "remove" "netshm"]
-  ["ocamlfind" "remove" "netstring"]
-  ["ocamlfind" "remove" "netstring-pcre"] {"%{pcre:installed}%"}
-  ["ocamlfind" "remove" "netsys"]
-  ["ocamlfind" "remove" "nettls-gnutls"] {"%{conf-gnutls:installed}%"}
-  ["ocamlfind" "remove" "netunidata"]
-  ["ocamlfind" "remove" "netzip"] {"%{camlzip:installed}%"}
-  ["ocamlfind" "remove" "pop"]
-  ["ocamlfind" "remove" "rpc"]
-  ["ocamlfind" "remove" "rpc-auth-local"]
-  ["ocamlfind" "remove" "rpc-generator"]
-  ["ocamlfind" "remove" "shell"]
-  ["ocamlfind" "remove" "smtp"]
-
-]
 depends: [
   "ocaml" {>= "4.00.0" & < "4.10"}
   "ocamlfind"
@@ -78,7 +52,6 @@ conflicts: [
     {= "4.04.0+flambda" | = "4.04.1+flambda" | = "4.04.2+flambda"}
   "shell"
 ]
-flags: light-uninstall
 extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
 url {
   src: "http://download.camlcity.org/download/ocamlnet-4.1.6.tar.gz"

--- a/packages/ocamlnet/ocamlnet.4.1.6/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.6/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "gerd@gerd-stolpmann.de"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.1.6/doc/html-main/index.html"]
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.4.1.6/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.6/opam
@@ -3,8 +3,8 @@ maintainer: "gerd@gerd-stolpmann.de"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: ["http://projects.camlcity.org/projects/dl/ocamlnet-4.1.6/doc/html-main/index.html"]
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.1.7/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.7/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "gerd@gerd-stolpmann.de"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: "http://projects.camlcity.org/projects/dl/ocamlnet-4.1.7/doc/html-main/index.html"
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.4.1.7/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.7/opam
@@ -4,8 +4,8 @@ maintainer: "gerd@gerd-stolpmann.de"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: "http://projects.camlcity.org/projects/dl/ocamlnet-4.1.7/doc/html-main/index.html"
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.1.8/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.8/opam
@@ -23,6 +23,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02"}
+  "ocaml" {< "4.12" & os = "macos"}
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/ocamlnet/ocamlnet.4.1.8/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.8/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 authors: "Gerd Stolpmann"
 maintainer: "gerd@gerd-stolpmann.de"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: "http://projects.camlcity.org/projects/dl/ocamlnet-4.1.8/doc/html-main/index.html"
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
 dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"

--- a/packages/ocamlnet/ocamlnet.4.1.8/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.8/opam
@@ -4,8 +4,8 @@ maintainer: "gerd@gerd-stolpmann.de"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: "http://projects.camlcity.org/projects/dl/ocamlnet-4.1.8/doc/html-main/index.html"
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.1.9/files/ocamlnet.install
+++ b/packages/ocamlnet/ocamlnet.4.1.9/files/ocamlnet.install
@@ -1,0 +1,4 @@
+bin: [
+  "src/rpc-generator/ocamlrpcgen"
+  "src/netplex/netplex-admin"
+]

--- a/packages/ocamlnet/ocamlnet.4.1.9/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.9/opam
@@ -4,8 +4,8 @@ maintainer: "gerd@gerd-stolpmann.de"
 homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
 license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: "http://projects.camlcity.org/projects/dl/ocamlnet-4.1.9/doc/html-main/index.html"
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
+dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
     "./configure"

--- a/packages/ocamlnet/ocamlnet.4.1.9/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.9/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+authors: "Gerd Stolpmann"
+maintainer: "gerd@gerd-stolpmann.de"
+homepage: "http://projects.camlcity.org/projects/ocamlnet.html"
+license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
+doc: "http://projects.camlcity.org/projects/dl/ocamlnet-4.1.9/doc/html-main/index.html"
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-ocamlnet3.git"
+build: [
+  [
+    "./configure"
+    "-bindir" bin
+    "-%{conf-gssapi:enable}%-gssapi"
+    "-%{conf-gnutls:enable}%-gnutls"
+    "-%{pcre:enable}%-pcre"
+    "-%{lablgtk:enable}%-gtk2"
+    "-%{camlzip:enable}%-zip"
+    "-with-nethttpd"
+  ]
+  [make "all"]
+  [make "opt"]
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "ocamlfind"
+  "ocamlbuild" {build}
+  "base-bytes"
+]
+depopts: [
+  "conf-gnutls"
+  "conf-gssapi"
+  "lablgtk"
+  "pcre"
+  "camlzip"
+]
+install: [make "install"]
+synopsis:
+  "Internet protocols (HTTP, CGI, e-mail etc.) and helper data structures"
+description: """
+(mail messages, character sets, etc.)
+
+Ocamlnet is an enhanced system platform library for Ocaml. As the name
+suggests, large parts of it have to do with network programming, but
+it is actually not restricted to this. Other parts deal with the
+management of multiple worker processes, and the interaction with
+other programs running on the same machine. You can also view Ocamlnet
+as an extension of the system interface as provided by the Unix module
+of the standard library."""
+conflicts: [
+  "ocaml-variants"
+    {= "4.04.0+flambda" | = "4.04.1+flambda" | = "4.04.2+flambda"}
+  "shell"
+]
+extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
+url {
+  src: "http://download.camlcity.org/download/ocamlnet-4.1.9.tar.gz"
+  checksum: "sha256=f98ed19979848f1949b1b001e30ac132b254d0f4a705150c6dcf9094bbec9cee"
+  mirrors: "http://download2.camlcity.org/download/ocamlnet-4.1.9.tar.gz"
+}

--- a/packages/ocamlnet/ocamlnet.4.1.9/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.9/opam
@@ -8,6 +8,7 @@ bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
 dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
 build: [
   [
+    "env" "MAKE=%{make}%"
     "./configure"
     "-bindir" bin
     "-%{conf-gssapi:enable}%-gssapi"


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam-repository/issues/18306
Other minor changes has been made to the previous versions in their separate commits:
* missing license: see LICENSE files in https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/tree/master/code
* The `remove` field is not necessary since opam 2.0

### Changelog

	* Add support for OCaml 4.12 on macOS (thanks to kate)
	* Disable TLS-1.3 because it created connection problems
	* Supporess E_GNUTLS_PREMATURE_TERMINATION errors
	* Fixing build of cmxs archives (Jerome Voillon)
	* Some fixes for netcgi2-apache (Eike Ritter)
	* Searching gmake on BSD systems (madroach)