### PR TITLE
[new release] rpclib-html, rpclib-async, rpclib, rpc, rpclib-lwt, ppx_deriving_rpc and rpclib-js (8.1.0)

### DIFF
--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for ocaml-rpc, a library to deal with RPCs in OCaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/ppx_deriving_rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "2.0.0"}
+  "rpclib" {= version}
+  "rresult"
+  "ppxlib" {>= "0.18.0"}
+  "lwt" {with-test & >= "3.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+x-commit-hash: "3c282c6ca62fe64d5f8c875ec1b3a35b931dd481"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.0/rpclib-v8.1.0.tbz"
+  checksum: [
+    "sha256=aaa93cc249d95a119f834d7d2cdc47ea820af242065bb7f7841222ccd1936a39"
+    "sha512=0aa4a87535dde610b48c553e6de90f0d31233adf6a53424c34b5282b1ba1e1e223fd37f3e8d23efc4f165dfd2a4ed609c2692672ae04f9cadb35b04411e53e85"
+  ]
+}

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/ppx_deriving_rpc"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.0.0"}
   "rpclib" {= version}
   "rresult"

--- a/packages/rpc/rpc.8.1.0/opam
+++ b/packages/rpc/rpc.8.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - meta-package"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project" "deprecated"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune"
+  "rpclib" {=version}
+  "rpclib-lwt" {=version}
+  "ppx_deriving_rpc" {=version}
+  "alcotest" {with-test}
+  # "md2mld" {(with-doc | with-test) & >= "0.3.0"}
+  "conf-which" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc"] {with-doc}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+
+This is a dummy package installing the main library components.
+"""
+post-messages: ["DEPRECATED. This package is a virtual package and is outdated, you should consider using directly rpclib, rpclib-lwt, rpclib-async and ppx_deriving_rpc instead"]
+x-commit-hash: "3c282c6ca62fe64d5f8c875ec1b3a35b931dd481"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.0/rpclib-v8.1.0.tbz"
+  checksum: [
+    "sha256=aaa93cc249d95a119f834d7d2cdc47ea820af242065bb7f7841222ccd1936a39"
+    "sha512=0aa4a87535dde610b48c553e6de90f0d31233adf6a53424c34b5282b1ba1e1e223fd37f3e8d23efc4f165dfd2a4ed609c2692672ae04f9cadb35b04411e53e85"
+  ]
+}

--- a/packages/rpclib-async/rpclib-async.8.1.0/opam
+++ b/packages/rpclib-async/rpclib-async.8.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Async interface"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-async"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune"
+  "rpclib" {=version}
+  "async" {>= "v0.9.0"}
+  "ppx_deriving_rpc" {with-test & =version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+x-commit-hash: "3c282c6ca62fe64d5f8c875ec1b3a35b931dd481"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.0/rpclib-v8.1.0.tbz"
+  checksum: [
+    "sha256=aaa93cc249d95a119f834d7d2cdc47ea820af242065bb7f7841222ccd1936a39"
+    "sha512=0aa4a87535dde610b48c553e6de90f0d31233adf6a53424c34b5282b1ba1e1e223fd37f3e8d23efc4f165dfd2a4ed609c2692672ae04f9cadb35b04411e53e85"
+  ]
+}

--- a/packages/rpclib-html/rpclib-html.8.1.0/opam
+++ b/packages/rpclib-html/rpclib-html.8.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis:
+  "A library to deal with RPCs in OCaml - html documentation generator"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-html"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "dune"
+  "rpclib" {=version}
+  "cow"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+x-commit-hash: "3c282c6ca62fe64d5f8c875ec1b3a35b931dd481"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.0/rpclib-v8.1.0.tbz"
+  checksum: [
+    "sha256=aaa93cc249d95a119f834d7d2cdc47ea820af242065bb7f7841222ccd1936a39"
+    "sha512=0aa4a87535dde610b48c553e6de90f0d31233adf6a53424c34b5282b1ba1e1e223fd37f3e8d23efc4f165dfd2a4ed609c2692672ae04f9cadb35b04411e53e85"
+  ]
+}

--- a/packages/rpclib-js/rpclib-js.8.1.0/opam
+++ b/packages/rpclib-js/rpclib-js.8.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Bindings for js_of_ocaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-js"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "dune"
+  "rpclib" {=version}
+  "js_of_ocaml" {>= "3.5.0"}
+  "js_of_ocaml-ppx" {>= "3.5.0"}
+  "lwt"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+x-commit-hash: "3c282c6ca62fe64d5f8c875ec1b3a35b931dd481"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.0/rpclib-v8.1.0.tbz"
+  checksum: [
+    "sha256=aaa93cc249d95a119f834d7d2cdc47ea820af242065bb7f7841222ccd1936a39"
+    "sha512=0aa4a87535dde610b48c553e6de90f0d31233adf6a53424c34b5282b1ba1e1e223fd37f3e8d23efc4f165dfd2a4ed609c2692672ae04f9cadb35b04411e53e85"
+  ]
+}

--- a/packages/rpclib-lwt/rpclib-lwt.8.1.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.8.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Lwt interface"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-lwt"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune"
+  "rpclib" {=version}
+  "lwt" {>= "3.0.0"}
+  "alcotest-lwt" {with-test}
+  "ppx_deriving_rpc" {with-test & =version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+x-commit-hash: "3c282c6ca62fe64d5f8c875ec1b3a35b931dd481"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.0/rpclib-v8.1.0.tbz"
+  checksum: [
+    "sha256=aaa93cc249d95a119f834d7d2cdc47ea820af242065bb7f7841222ccd1936a39"
+    "sha512=0aa4a87535dde610b48c553e6de90f0d31233adf6a53424c34b5282b1ba1e1e223fd37f3e8d23efc4f165dfd2a4ed609c2692672ae04f9cadb35b04411e53e85"
+  ]
+}

--- a/packages/rpclib/rpclib.8.1.0/opam
+++ b/packages/rpclib/rpclib.8.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "alcotest" {with-test}
+  "dune" {>= "2.0.0"}
+  "base64" {>= "3.4.0"}
+  "cmdliner"
+  "rresult"
+  "xmlm"
+  "yojson" {>= "1.7.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+x-commit-hash: "3c282c6ca62fe64d5f8c875ec1b3a35b931dd481"
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.0/rpclib-v8.1.0.tbz"
+  checksum: [
+    "sha256=aaa93cc249d95a119f834d7d2cdc47ea820af242065bb7f7841222ccd1936a39"
+    "sha512=0aa4a87535dde610b48c553e6de90f0d31233adf6a53424c34b5282b1ba1e1e223fd37f3e8d23efc4f165dfd2a4ed609c2692672ae04f9cadb35b04411e53e85"
+  ]
+}


### PR DESCRIPTION
A library to deal with RPCs in OCaml - html documentation generator

- Project page: <a href="https://github.com/mirage/ocaml-rpc">https://github.com/mirage/ocaml-rpc</a>
- Documentation: <a href="https://mirage.github.io/ocaml-rpc/rpclib-html">https://mirage.github.io/ocaml-rpc/rpclib-html</a>

##### CHANGES:

* github: test with 4.12 (@psafont)
* ppx_deriving_rpc: make compatible with ppxlib.0.18.0 (@NathanReb)
