### PR TITLE
Package smtlib-utils.0.3

### DIFF
--- a/packages/smtlib-utils/smtlib-utils.0.3/opam
+++ b/packages/smtlib-utils/smtlib-utils.0.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Parser for SMTLIB2"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-bytes"
+  "result"
+  "menhir" {build}
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "SMTLIB" "smt2" "parse" "logic" ]
+homepage: "https://github.com/c-cube/smtlib-utils/"
+bug-reports: "https://github.com/c-cube/smtlib-utils/issues"
+dev-repo: "git+https://github.com/c-cube/smtlib-utils.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/smtlib-utils/archive/v0.3.tar.gz"
+  checksum: [
+    "md5=c3ab27ea094abd7ce9ffa9cc6110fca5"
+    "sha512=aea21801afcce3519e85de22df15c50f11812aa556cf1f2b4b24bcd35f61d88e60ecf982339cd792abfa21976f5051d17ad555f8e501a71ee806b1fbc15ddf89"
+  ]
+}


### PR DESCRIPTION
### `smtlib-utils.0.3`
Parser for SMTLIB2



---
* Homepage: https://github.com/c-cube/smtlib-utils/
* Source repo: git+https://github.com/c-cube/smtlib-utils.git
* Bug tracker: https://github.com/c-cube/smtlib-utils/issues

---
:camel: Pull-request generated by opam-publish v2.0.0