### PR TITLE
[new release] conformist (0.3.0)

### DIFF
--- a/packages/conformist/conformist.0.3.0/opam
+++ b/packages/conformist/conformist.0.3.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Conformist allows you to define schemas to decode, validate and sanitize input data declaratively"
+description: """
+
+Conformist allows you to define schemas to decode, validate and sanitize input data declaratively.
+It comes with runtime types for primitive OCaml types such as `int`, `string`, `bool` and `float` but also `Ptime.date`, optional and custom types.
+Re-use business rules in validators and run it on the client side with js_of_ocaml.
+Arbitrary meta data can be stored in schemas which is useful to build functionality on top of conformist.
+"""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/conformist"
+doc: "https://oxidizing.github.io/conformist/"
+bug-reports: "https://github.com/oxidizing/conformist/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "sexplib" {>= "v0.13.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/conformist.git"
+x-commit-hash: "b721e42ebf320f1c65fb01360e7efd94afdffc21"
+url {
+  src:
+    "https://github.com/oxidizing/conformist/releases/download/0.3.0/conformist-0.3.0.tbz"
+  checksum: [
+    "sha256=ebc3e3ae1119e4e19e11df940510bf32ab04568d4bdc6ba5f71072a45092b74a"
+    "sha512=42d91900faf8849c078b1a7652057fe3b3560223b2b333cf61ceebee6e7bb8f73bdcdee5b9b5ead4c130cdf8c575a085b4e04dbccde202479f7ac0b40bd6b233"
+  ]
+}

--- a/packages/sihl-core/sihl-core.0.2.0/opam
+++ b/packages/sihl-core/sihl-core.0.2.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "conformist" {>= "0.1.0"}
+  "conformist" {>= "0.1.0" & < "0.3.0"}
   "tsort" {>= "2.0.0"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}

--- a/packages/sihl-core/sihl-core.0.2.1/opam
+++ b/packages/sihl-core/sihl-core.0.2.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "conformist" {>= "0.1.0"}
+  "conformist" {>= "0.1.0" & < "0.3.0"}
   "tsort" {>= "2.0.0"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}

--- a/packages/sihl-core/sihl-core.0.2.2/opam
+++ b/packages/sihl-core/sihl-core.0.2.2/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "conformist" {>= "0.1.0"}
+  "conformist" {>= "0.1.0" & < "0.3.0"}
   "tsort" {>= "2.0.0"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}

--- a/packages/sihl-core/sihl-core.0.3.0~rc1/opam
+++ b/packages/sihl-core/sihl-core.0.3.0~rc1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "conformist" {>= "0.1.0"}
+  "conformist" {>= "0.1.0" & < "0.3.0"}
   "tsort" {>= "2.0.0"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}

--- a/packages/sihl/sihl.0.1.10/opam
+++ b/packages/sihl/sihl.0.1.10/opam
@@ -15,7 +15,7 @@ depends: [
   "multipart-form-data" {>= "0.3.0"}
   "yojson" {>= "1.7.0"}
   "ppx_deriving_yojson" {>= "3.5.2"}
-  "conformist" {>= "0.1.0"}
+  "conformist" {>= "0.1.0" & < "0.3.0"}
   "tsort" {>= "2.0.0"}
   "tls" {>= "0.11.1"}
   "ssl" {>= "0.5.9"}

--- a/packages/sihl/sihl.0.1.5/opam
+++ b/packages/sihl/sihl.0.1.5/opam
@@ -14,7 +14,7 @@ depends: [
   "opium" {>= "0.17.1" & < "0.19.0"}
   "yojson" {>= "1.7.0"}
   "ppx_deriving_yojson" {>= "3.5.2"}
-  "conformist" {>= "0.1.0"}
+  "conformist" {>= "0.1.0" & < "0.3.0"}
   "tsort" {>= "2.0.0"}
   "tls" {>= "0.11.1"}
   "ssl" {>= "0.5.9"}

--- a/packages/sihl/sihl.0.1.6/opam
+++ b/packages/sihl/sihl.0.1.6/opam
@@ -15,7 +15,7 @@ depends: [
   "multipart-form-data" {>= "0.3.0"}
   "yojson" {>= "1.7.0"}
   "ppx_deriving_yojson" {>= "3.5.2"}
-  "conformist" {>= "0.1.0"}
+  "conformist" {>= "0.1.0" & < "0.3.0"}
   "tsort" {>= "2.0.0"}
   "tls" {>= "0.11.1"}
   "ssl" {>= "0.5.9"}

--- a/packages/sihl/sihl.0.1.7/opam
+++ b/packages/sihl/sihl.0.1.7/opam
@@ -15,7 +15,7 @@ depends: [
   "multipart-form-data" {>= "0.3.0"}
   "yojson" {>= "1.7.0"}
   "ppx_deriving_yojson" {>= "3.5.2"}
-  "conformist" {>= "0.1.0"}
+  "conformist" {>= "0.1.0" & < "0.3.0"}
   "tsort" {>= "2.0.0"}
   "tls" {>= "0.11.1"}
   "ssl" {>= "0.5.9"}

--- a/packages/sihl/sihl.0.1.8/opam
+++ b/packages/sihl/sihl.0.1.8/opam
@@ -15,7 +15,7 @@ depends: [
   "multipart-form-data" {>= "0.3.0"}
   "yojson" {>= "1.7.0"}
   "ppx_deriving_yojson" {>= "3.5.2"}
-  "conformist" {>= "0.1.0"}
+  "conformist" {>= "0.1.0" & < "0.3.0"}
   "tsort" {>= "2.0.0"}
   "tls" {>= "0.11.1"}
   "ssl" {>= "0.5.9"}

--- a/packages/sihl/sihl.0.1.9/opam
+++ b/packages/sihl/sihl.0.1.9/opam
@@ -15,7 +15,7 @@ depends: [
   "multipart-form-data" {>= "0.3.0"}
   "yojson" {>= "1.7.0"}
   "ppx_deriving_yojson" {>= "3.5.2"}
-  "conformist" {>= "0.1.0"}
+  "conformist" {>= "0.1.0" & < "0.3.0"}
   "tsort" {>= "2.0.0"}
   "tls" {>= "0.11.1"}
   "ssl" {>= "0.5.9"}

--- a/packages/sihl/sihl.0.3.0/opam
+++ b/packages/sihl/sihl.0.3.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "conformist" {>= "0.1.0"}
+  "conformist" {>= "0.1.0" & < "0.3.0"}
   "tsort" {>= "2.0.0"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}

--- a/packages/sihl/sihl.0.3.0~rc2/opam
+++ b/packages/sihl/sihl.0.3.0~rc2/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "conformist" {>= "0.1.0"}
+  "conformist" {>= "0.1.0" & < "0.3.0"}
   "tsort" {>= "2.0.0"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}


### PR DESCRIPTION
Conformist allows you to define schemas to decode, validate and sanitize input data declaratively

- Project page: <a href="https://github.com/oxidizing/conformist">https://github.com/oxidizing/conformist</a>
- Documentation: <a href="https://oxidizing.github.io/conformist/">https://oxidizing.github.io/conformist/</a>

##### CHANGES:

### Changed
- `decode` returns a triple containing `(field_name, input, error_msg)` instead of a concatenated string. This makes it easier to extract information.

### Added
- `decode_and_validate` combines `decode` and `validate` where the returned value is either the decoded value or a list of errors. When using `decode_and_validate`, one can forget about the difference between `decode` and `validate` and simply forward the list of errors. This covers a common use case.
