### PR TITLE
No spacetime in 4.12

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.12.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+options/opam
@@ -26,7 +26,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -62,6 +61,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+conflicts: [
+  "ocaml-option-spacetime"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
@@ -72,7 +74,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]


### PR DESCRIPTION
Slightly academic, but the spacetime option remained in the package. The `ocaml-option-spacetime` package won't install with 4.12, so this is a belt-and-braces "remove an option which shouldn't be there".

cf. https://github.com/ocaml/ocaml/pull/10310. It's probably best to hold this off until either the pinning updates (when I finish those) or 4.12.1, given that the change in the opam file will trigger rebuilds.