### PR TITLE
2 packages from uzh/ask at 0.2.0

### DIFF
--- a/packages/ask-integrator/ask-integrator.0.2.0/opam
+++ b/packages/ask-integrator/ask-integrator.0.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Link questionnaires to an uuid of 'a type"
+description: "Generate a link between questionnaires and types"
+maintainer: ["marc.biedermann@econ.uzh.ch"]
+authors: ["Marc Biedermann"]
+license: "MIT"
+homepage: "https://github.com/uzh/ask"
+doc: "https://github.com/uzh/ask"
+bug-reports: "https://github.com/uzh/ask/-/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.11"}
+  "ask" {= version}
+  "sihl" {= "0.4.0"}
+  "sihl-storage" {= "0.4.0"}
+  "conformist" {= "0.4.0"}
+  "lwt_ssl" {>= "1.1.3"}
+  "ppx_fields_conv" {>= "0.13.0"}
+  "alcotest-lwt" {>= "1.3.0" & with-test}
+  "caqti-driver-mariadb" {>= "1.2.1" & with-test}
+  "ocamlformat" {dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/uzh/ask.git"
+url {
+  src: "https://github.com/uzh/ask/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=05a93836d4cb56962eb57c56387dc1aa"
+    "sha512=91fae426d7ef0745262e62e201204e9bfda3d9165d165f110661bc917648fec60e6041d800a9d9fa5258f6a457487a17726c304c837305f8df950822ffaad990"
+  ]
+}

--- a/packages/ask/ask.0.2.0/opam
+++ b/packages/ask/ask.0.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Create/Answer questionnaires"
+description: "Generating and answering questions should be easy"
+maintainer: ["marc.biedermann@econ.uzh.ch"]
+authors: ["Marc Biedermann"]
+license: "MIT"
+homepage: "https://github.com/uzh/ask"
+doc: "https://github.com/uzh/ask"
+bug-reports: "https://github.com/uzh/ask/-/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.11"}
+  "sihl" {= "0.4.0"}
+  "sihl-storage" {= "0.4.0"}
+  "conformist" {= "0.4.0"}
+  "lwt_ssl" {>= "1.1.3"}
+  "ppx_fields_conv" {>= "0.13.0"}
+  "alcotest-lwt" {>= "1.3.0" & with-test}
+  "caqti-driver-mariadb" {>= "1.2.1" & with-test}
+  "ocamlformat" {dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/uzh/ask.git"
+url {
+  src: "https://github.com/uzh/ask/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=05a93836d4cb56962eb57c56387dc1aa"
+    "sha512=91fae426d7ef0745262e62e201204e9bfda3d9165d165f110661bc917648fec60e6041d800a9d9fa5258f6a457487a17726c304c837305f8df950822ffaad990"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ask.0.2.0`: Create/Answer questionnaires
-`ask-integrator.0.2.0`: Link questionnaires to an uuid of 'a type



---
* Homepage: https://github.com/uzh/ask
* Source repo: git+https://github.com/uzh/ask.git
* Bug tracker: https://github.com/uzh/ask/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3