### PR TITLE
[new release] grenier (0.12)

### DIFF
--- a/packages/grenier/grenier.0.12/opam
+++ b/packages/grenier/grenier.0.12/opam
@@ -9,7 +9,7 @@ doc: "https://let-def.github.io/grenier/doc"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm64"}
 ]
 depends: [
   "ocaml" {>= "4.08"}

--- a/packages/grenier/grenier.0.12/opam
+++ b/packages/grenier/grenier.0.12/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/grenier"
+bug-reports: "https://github.com/let-def/grenier"
+license: "ISC"
+dev-repo: "git+https://github.com/let-def/grenier.git"
+doc: "https://let-def.github.io/grenier/doc"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.2.0"}
+]
+synopsis: "A collection of various algorithms in OCaml"
+description: """
+This library implements various datastructures and algorithms:
+- automata minimization and transformation to regular expression
+- balanced trees
+- binpacking
+- cardinality estimation (hyperloglog)
+- immutable sequences
+- jump consistent hashing
+- solutions to the order maintenance problem
+- ...
+"""
+x-commit-hash: "a63568fc9b7807d973cae2aa53d847c872ec00dd"
+url {
+  src:
+    "https://github.com/let-def/grenier/releases/download/v0.12/grenier-v0.12.tbz"
+  checksum: [
+    "sha256=b08e4c774ef72fc53c4fcee477e739d1beac9702079300daddf51ced9fa9cd26"
+    "sha512=984d92c51dac7b3f169cad595969a4fdbeb2be7b420ed1a85618d6adbb64af855cf2618d9bd0834e84d6734b99196944cab04435e1aeacad8cdfbc9a7f73d6d4"
+  ]
+}


### PR DESCRIPTION
A collection of various algorithms in OCaml

- Project page: <a href="https://github.com/let-def/grenier">https://github.com/let-def/grenier</a>
- Documentation: <a href="https://let-def.github.io/grenier/doc">https://let-def.github.io/grenier/doc</a>

##### CHANGES:

Balmap: alternative to Stdlib Maps and Sets based on baltree.
Dbseq: fast sequence datastructure for DeBruijn-indexed environments.
State elimination: convert e-NFA to regular expressions.

Fixed many bugs in and increased expressiveness of Valmari implementation.
