### PR TITLE
[new release] optint (0.1.0)

### DIFF
--- a/packages/optint/optint.0.1.0/opam
+++ b/packages/optint/optint.0.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   [ "romain.calascibetta@gmail.com" ]
+authors:      "Romain Calascibetta"
+license:      "ISC"
+homepage:     "https://github.com/mirage/optint"
+bug-reports:  "https://github.com/mirage/optint/issues"
+dev-repo:     "git+https://github.com/mirage/optint.git"
+doc:          "https://mirage.github.io/optint/"
+synopsis:     "Efficient integer types on 64-bit architectures"
+description: """
+This library provides two new integer types, `Optint.t` and `Int63.t`, which
+guarantee efficient representation on 64-bit architectures and provide a
+best-effort boxed representation on 32-bit architectures.
+
+Implementation depends on target architecture.
+"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "crowbar" {with-test & >= "0.2"}
+  "monolith" {with-test}
+  "fmt" {with-test}
+]
+x-commit-hash: "34f6f88360df1b71870d471088e1dbb581578f20"
+url {
+  src:
+    "https://github.com/mirage/optint/releases/download/v0.1.0/optint-v0.1.0.tbz"
+  checksum: [
+    "sha256=27847660223c16cc7eaf8fcd9d5589a0b802114330a2529578f8007d3b01185d"
+    "sha512=6ec2f6977b2cb148b0b9c2664e8a8525b0d0b987652f5a4c9754d200d8026de8bfab664d31807e68b5f1dffa8bbe5b51167435e6e66faf5baefb509c667e0c77"
+  ]
+}


### PR DESCRIPTION
Efficient integer types on 64-bit architectures

- Project page: <a href="https://github.com/mirage/optint">https://github.com/mirage/optint</a>
- Documentation: <a href="https://mirage.github.io/optint/">https://mirage.github.io/optint/</a>

##### CHANGES:

- Annotate integer types with `[@@immediate64]` (@CraigFe, mirage/optint#13)
- Move unwrapped module `Int63` to `Optint.Int63` (@CraigFe, mirage/optint#13)
