### PR TITLE
Fix tezos-client-* packages which use an implicit dependency on base (pulled by cohttp 2.x)

### DIFF
--- a/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.7.0/opam
+++ b/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.7.0/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-stdlib-unix" { = version }
-  "cohttp-lwt-unix" { >= "1.0.0" }
+  "cohttp-lwt-unix" { >= "1.0.0" & < "3.0.0" }
   "tezos-rpc-http-client" { = version }
 ]
 build: [

--- a/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.7.1/opam
+++ b/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.7.1/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-stdlib-unix" { = version }
-  "cohttp-lwt-unix" { >= "1.0.0" }
+  "cohttp-lwt-unix" { >= "1.0.0" & < "3.0.0" }
   "tezos-rpc-http-client" { = version }
 ]
 build: [

--- a/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.7.2/opam
+++ b/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.7.2/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-stdlib-unix" { = version }
-  "cohttp-lwt-unix" { >= "1.0.0" }
+  "cohttp-lwt-unix" { >= "1.0.0" & < "3.0.0" }
   "tezos-rpc-http-client" { = version }
 ]
 build: [

--- a/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.7.3/opam
+++ b/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.7.3/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-stdlib-unix" { = version }
-  "cohttp-lwt-unix" { >= "1.0.0" }
+  "cohttp-lwt-unix" { >= "1.0.0" & < "3.0.0" }
   "tezos-rpc-http-client" { = version }
 ]
 build: [

--- a/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.7.4/opam
+++ b/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.7.4/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "tezos-stdlib-unix" { = version }
-  "cohttp-lwt-unix" { >= "1.0.0" }
+  "cohttp-lwt-unix" { >= "1.0.0" & < "3.0.0" }
   "tezos-rpc-http-client" { = version }
 ]
 build: [

--- a/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.8.0/opam
+++ b/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.8.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.0" }
-  "cohttp-lwt-unix" { >= "1.0.0" }
+  "cohttp-lwt-unix" { >= "1.0.0" & < "3.0.0" }
   "tezos-rpc-http-client" { = version }
 ]
 build: [

--- a/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.8.1/opam
+++ b/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.8.1/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.0" }
-  "cohttp-lwt-unix" { >= "1.0.0" }
+  "cohttp-lwt-unix" { >= "1.0.0" & < "3.0.0" }
   "tezos-rpc-http-client" { = version }
 ]
 build: [

--- a/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.8.2/opam
+++ b/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.8.2/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.0" }
-  "cohttp-lwt-unix" { >= "1.0.0" }
+  "cohttp-lwt-unix" { >= "1.0.0" & < "3.0.0" }
   "tezos-rpc-http-client" { = version }
 ]
 build: [


### PR DESCRIPTION
cc @pirbo 