### PR TITLE
[new release] ocamlformat, ocamlformat-rpc and ocamlformat-rpc-lib (0.18.0)

### DIFF
--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.18.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.18.0/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml" {>= "4.08" & < "4.13"}
   "csexp"
   "sexplib0"
-  "ocamlformat" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.18.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.18.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.13"}
+  "csexp"
+  "sexplib0"
+  "ocamlformat" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+x-commit-hash: "3697f0f92854a681fd1156fe4f6fb97d060da1d8"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.18.0/ocamlformat-0.18.0.tbz"
+  checksum: [
+    "sha256=981a44296485da6ca29ab2cd8c711270398e5e1d1624408ec403c0b0ea9fe114"
+    "sha512=d1cbd63e4b82ff2e9ec0c96a9305704d3eea3e978c703ef9d1244853d8aaea912ad9f934379eeddfc1a0468b1cb1c2dc39ecf452189f2a35fa1ae53aec10b277"
+  ]
+}

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.18.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.18.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.13"}
+  "ocaml-version"
+  "ocamlformat-rpc-lib"
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune-build-info"
+  "fix"
+  "fpath"
+  "menhir" {>= "20180528"}
+  "menhirLib" {>= "20200624"}
+  "menhirSdk" {>= "20200624"}
+  "ocp-indent" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}
+  "odoc" {>= "1.4.2"}
+  "ppxlib" {>= "0.22.0"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+x-commit-hash: "3697f0f92854a681fd1156fe4f6fb97d060da1d8"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.18.0/ocamlformat-0.18.0.tbz"
+  checksum: [
+    "sha256=981a44296485da6ca29ab2cd8c711270398e5e1d1624408ec403c0b0ea9fe114"
+    "sha512=d1cbd63e4b82ff2e9ec0c96a9305704d3eea3e978c703ef9d1244853d8aaea912ad9f934379eeddfc1a0468b1cb1c2dc39ecf452189f2a35fa1ae53aec10b277"
+  ]
+}

--- a/packages/ocamlformat/ocamlformat.0.18.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.18.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.13"}
+  "ocaml-version"
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune-build-info"
+  "fix"
+  "fpath"
+  "menhir" {>= "20180528"}
+  "menhirLib" {>= "20200624"}
+  "menhirSdk" {>= "20200624"}
+  "ocp-indent" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}
+  "odoc" {>= "1.4.2"}
+  "ppxlib" {>= "0.22.0"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+x-commit-hash: "3697f0f92854a681fd1156fe4f6fb97d060da1d8"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.18.0/ocamlformat-0.18.0.tbz"
+  checksum: [
+    "sha256=981a44296485da6ca29ab2cd8c711270398e5e1d1624408ec403c0b0ea9fe114"
+    "sha512=d1cbd63e4b82ff2e9ec0c96a9305704d3eea3e978c703ef9d1244853d8aaea912ad9f934379eeddfc1a0468b1cb1c2dc39ecf452189f2a35fa1ae53aec10b277"
+  ]
+}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### Bug fixes

  + Fix extraneous parenthesis after `let open` with `closing-on-separate-line` (#1612, @Julow)

  + Add missing break between polytype quantification and arrow-type body (#1615, @gpetiot)

#### Changes

  + Use dune instrumentation backend for `bisect_ppx` (#1550, @tmattio)

  + Format objects and classes consistently with structure and signature items (#1569, @bikallem)

#### New features

  + Expose a RPC interface through a new binary `ocamlformat-rpc` and a new library `ocamlformat-rpc-lib` (#1586, @gpetiot, @voodoos)