### PR TITLE
[new release] mirage, mirage-runtime, mirage-types-lwt and mirage-types (3.10.2)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.10.2/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.10.2/opam
@@ -11,14 +11,14 @@ tags:         ["org:mirage" "org:xapi-project"]
 doc:          "https://mirage.github.io/mirage/"
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "1.1.0"}
+  "dune" {>= "2.0"}
   "ipaddr"             {>= "5.0.0"}
   "functoria-runtime"  {>= "3.0.2"}
   "fmt"

--- a/packages/mirage-runtime/mirage-runtime.3.10.2/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.10.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "5.0.0"}
+  "functoria-runtime"  {>= "3.0.2"}
+  "fmt"
+  "logs"
+  "lwt" {>= "4.0.0"}
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+x-commit-hash: "08600e95d2f547d86cbbf4596b33d3c6973b14f6"
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.10.2/mirage-v3.10.2.tbz"
+  checksum: [
+    "sha256=bb21b953709f596a5556406c1bde3ac56300526ca5886c1898d83e564b45c7a7"
+    "sha512=f40c89b163b004da1cfb8f2a8e39320f0c2b38ef40be99eb14dc51eb65a9a0276f7de879fb9d2e7b73d0759fd6122a1bd7fd96a72bb4561c936a2aefc885f211"
+  ]
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.10.2/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.10.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends:   [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-types" {= version}
+]
+
+synopsis: "Lwt module type definitions for MirageOS applications"
+description: """
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`
+"""
+post-messages: [
+ "This package will be retired in MirageOS 4.0. Please use individual signatures (mirage-net / mirage-clock / etc.) instead."
+]
+x-commit-hash: "08600e95d2f547d86cbbf4596b33d3c6973b14f6"
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.10.2/mirage-v3.10.2.tbz"
+  checksum: [
+    "sha256=bb21b953709f596a5556406c1bde3ac56300526ca5886c1898d83e564b45c7a7"
+    "sha512=f40c89b163b004da1cfb8f2a8e39320f0c2b38ef40be99eb14dc51eb65a9a0276f7de879fb9d2e7b73d0759fd6122a1bd7fd96a72bb4561c936a2aefc885f211"
+  ]
+}

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.10.2/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.10.2/opam
@@ -9,14 +9,14 @@ tags:         ["org:mirage" "org:xapi-project"]
 
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends:   [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "1.1.0"}
+  "dune" {>= "2.0"}
   "mirage-types" {= version}
 ]
 

--- a/packages/mirage-types/mirage-types.3.10.2/opam
+++ b/packages/mirage-types/mirage-types.3.10.2/opam
@@ -11,14 +11,14 @@ tags:         ["org:mirage" "org:xapi-project"]
 
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "1.1.0"}
+  "dune" {>= "2.0"}
   "mirage-device" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/mirage-types/mirage-types.3.10.2/opam
+++ b/packages/mirage-types/mirage-types.3.10.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-console" {>= "3.0.0"}
+  "mirage-protocols" {>= "5.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "mirage-fs" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+]
+synopsis: "Module type definitions for MirageOS applications"
+description: """
+Module type definitions for MirageOS applications
+"""
+post-messages: [
+  "This package will be retired in MirageOS 4.0. Please use individual signatures (mirage-net / mirage-clock / etc.) instead."
+]
+x-commit-hash: "08600e95d2f547d86cbbf4596b33d3c6973b14f6"
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.10.2/mirage-v3.10.2.tbz"
+  checksum: [
+    "sha256=bb21b953709f596a5556406c1bde3ac56300526ca5886c1898d83e564b45c7a7"
+    "sha512=f40c89b163b004da1cfb8f2a8e39320f0c2b38ef40be99eb14dc51eb65a9a0276f7de879fb9d2e7b73d0759fd6122a1bd7fd96a72bb4561c936a2aefc885f211"
+  ]
+}

--- a/packages/mirage/mirage.3.10.2/opam
+++ b/packages/mirage/mirage.3.10.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.1.0"}
+  "ipaddr"             {>= "5.0.0"}
+  "functoria"          {>= "3.1.0"}
+  "bos"
+  "astring"
+  "logs"
+  "stdlib-shims"
+  "mirage-runtime"     {=version | (>= "3.10.0" & < "3.11.0")}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+x-commit-hash: "08600e95d2f547d86cbbf4596b33d3c6973b14f6"
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.10.2/mirage-v3.10.2.tbz"
+  checksum: [
+    "sha256=bb21b953709f596a5556406c1bde3ac56300526ca5886c1898d83e564b45c7a7"
+    "sha512=f40c89b163b004da1cfb8f2a8e39320f0c2b38ef40be99eb14dc51eb65a9a0276f7de879fb9d2e7b73d0759fd6122a1bd7fd96a72bb4561c936a2aefc885f211"
+  ]
+}

--- a/packages/mirage/mirage.3.10.2/opam
+++ b/packages/mirage/mirage.3.10.2/opam
@@ -11,14 +11,14 @@ tags:         ["org:mirage" "org:xapi-project"]
 doc:          "https://mirage.github.io/mirage/"
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "1.1.0"}
+  "dune" {>= "2.0"}
   "ipaddr"             {>= "5.0.0"}
   "functoria"          {>= "3.1.0"}
   "bos"


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

* Adapt to conduit 2.3 and cohttp 4.0 (@samoht @dinosaure mirage/mirage#1209)
* Allow mirage-crypto-rng-mirage 0.9 (@hannesm mirage/mirage#1218)
* Adapt to tcpip 6.1.0 release (the unix sublibrary is no longer needed)
