### PR TITLE
3 packages from ocaml/ocaml-lsp at 1.5.0

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.5.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.5.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: "Rudi Grinberg <me@rgrinerg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "yojson"
+  "stdlib-shims"
+  "ocaml-syntax-shims"
+  "ppx_yojson_conv_lib"
+  "result" {>= "1.5"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.06"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.5.0/jsonrpc-1.5.0.tbz"
+  checksum: [
+    "md5=2c19731536a4f62923554c1947c39211"
+    "sha512=9bc252e2564fe6c9017b5ee1b2c4ddebf73c4be4b2a3d48f1d61b6ec1910a2cb9f4fa4952a7a6d89482c28ddbad8e0d9c34c206a1b2fe42bb2c3a7156aa953e9"
+  ]
+}

--- a/packages/lsp/lsp.1.5.0/opam
+++ b/packages/lsp/lsp.1.5.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """\
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO."""
+maintainer: "Rudi Grinberg <me@rgrinerg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "stdlib-shims"
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib"
+  "ocaml-syntax-shims"
+  "cppo"
+  "uutf"
+  "csexp"
+  "odoc" {with-doc}
+  "menhir" {with-test}
+  "cinaps" {with-test}
+  "ppx_expect" {with-test & >= "v0.14.0"}
+  "ocaml" {>= "4.06"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.5.0/jsonrpc-1.5.0.tbz"
+  checksum: [
+    "md5=2c19731536a4f62923554c1947c39211"
+    "sha512=9bc252e2564fe6c9017b5ee1b2c4ddebf73c4be4b2a3d48f1d61b6ec1910a2cb9f4fa4952a7a6d89482c28ddbad8e0d9c34c206a1b2fe42bb2c3a7156aa953e9"
+  ]
+}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.5.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinerg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "yojson"
+  "stdlib-shims"
+  "ppx_yojson_conv_lib"
+  "dune-build-info"
+  "dot-merlin-reader"
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "ocamlformat" {with-test}
+  "ocamlfind" {>= "1.5.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12" & < "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-j" jobs "ocaml-lsp-server.install" "--release"]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.5.0/jsonrpc-1.5.0.tbz"
+  checksum: [
+    "md5=2c19731536a4f62923554c1947c39211"
+    "sha512=9bc252e2564fe6c9017b5ee1b2c4ddebf73c4be4b2a3d48f1d61b6ec1910a2cb9f4fa4952a7a6d89482c28ddbad8e0d9c34c206a1b2fe42bb2c3a7156aa953e9"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`jsonrpc.1.5.0`: Jsonrpc protocol implemenation
-`lsp.1.5.0`: LSP protocol implementation in OCaml
-`ocaml-lsp-server.1.5.0`: LSP Server for OCaml



---
* Homepage: https://github.com/ocaml/ocaml-lsp
* Source repo: git+https://github.com/ocaml/ocaml-lsp.git
* Bug tracker: https://github.com/ocaml/ocaml-lsp/issues

---
:camel: Pull-request generated by opam-publish v2.0.2