### PR TITLE
Package ppx_deriving_encoding.0.2.3

### DIFF
--- a/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2.3/opam
+++ b/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for json-encoding"
+maintainer: ["contact@origin-labs.com"]
+authors: ["Maxime Levillain <maxime.levillain@origin-labs.com"]
+license: "LGPL-2.1-or-later"
+homepage: "https://gitlab.com/o-labs/ppx_deriving_encoding"
+bug-reports: "https://gitlab.com/o-labs/ppx_deriving_encoding/-/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "json-data-encoding" {>= "0.9"}
+  "ppxlib"
+  "ocamlfind" {build}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://gitlab.com/o-labs/ppx_deriving_encoding"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/22769538/repository/archive?sha=9ffa2ee0d920be3ebce9abb37bbd670701b84e09"
+  checksum: [
+    "md5=984d109bc66ff6f6ac6358eb22718a73"
+    "sha512=ed2b0d0ad6a472b454a18c791da51de29b96c93d4d98f36b9317d2e8b52bd76843396be534ec502f49709eeec25cdba6d650d2bc250d6df6942cac0f04149946"
+  ]
+}


### PR DESCRIPTION
### `ppx_deriving_encoding.0.2.3`
Ppx deriver for json-encoding



---
* Homepage: https://gitlab.com/o-labs/ppx_deriving_encoding
* Source repo: git://gitlab.com/o-labs/ppx_deriving_encoding
* Bug tracker: https://gitlab.com/o-labs/ppx_deriving_encoding/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3