### PR TITLE
[new release] csexp (1.5.0)

### DIFF
--- a/packages/csexp/csexp.1.5.0/opam
+++ b/packages/csexp/csexp.1.5.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Parsing and printing of S-expressions in Canonical form"
+description: """
+
+This library provides minimal support for Canonical S-expressions
+[1]. Canonical S-expressions are a binary encoding of S-expressions
+that is super simple and well suited for communication between
+programs.
+
+This library only provides a few helpers for simple applications. If
+you need more advanced support, such as parsing from more fancy input
+sources, you should consider copying the code of this library given
+how simple parsing S-expressions in canonical form is.
+
+To avoid a dependency on a particular S-expression library, the only
+module of this library is parameterised by the type of S-expressions.
+
+[1] https://en.wikipedia.org/wiki/Canonical_S-expressions
+"""
+maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
+authors: [
+  "Quentin Hocquet <mefyl@gruntech.org>"
+  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jeremie Dimino <jeremie@dimino.org>"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-dune/csexp"
+doc: "https://ocaml-dune.github.io/csexp/"
+bug-reports: "https://github.com/ocaml-dune/csexp/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/ocaml-dune/csexp.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+#   "@runtest" {with-test & ocaml:version >= "4.04"}
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "4e4cadd5baee1c22d82b5c4eab9a15b0d1408e1b"
+url {
+  src:
+    "https://github.com/ocaml-dune/csexp/releases/download/1.5.0/csexp-1.5.0.tbz"
+  checksum: [
+    "sha256=85fffe6e95ba2b21c692d64b28959d92fdb81a5bc67e3f3e59613aee2660a455"
+    "sha512=f198770e29435934e1ba1124657d46997027b5d0c38f992304d7889861b77d1d106838b5b41cadebd84c20a903a1ba9c51488e05514c9515390caabdec14dfdf"
+  ]
+}


### PR DESCRIPTION
Parsing and printing of S-expressions in Canonical form

- Project page: <a href="https://github.com/ocaml-dune/csexp">https://github.com/ocaml-dune/csexp</a>
- Documentation: <a href="https://ocaml-dune.github.io/csexp/">https://ocaml-dune.github.io/csexp/</a>

##### CHANGES:

- Drop dependency on result and compatibility with OCaml 4.02 (ocaml-dune/csexp#17,
  @rgrinberg)
