### PR TITLE
[new release] earlybird (1.1.0)

### DIFF
--- a/packages/earlybird/earlybird.1.1.0/opam
+++ b/packages/earlybird/earlybird.1.1.0/opam
@@ -1,13 +1,12 @@
 opam-version: "2.0"
 synopsis: "Debug adapter for OCaml 4.11"
-description: "Debug adapter for OCaml 4.11."
 maintainer: ["hackwaly@qq.com"]
 authors: ["hackwaly@qq.com"]
 homepage: "https://github.com/hackwaly/ocamlearlybird"
 bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.11.0" & <= "4.12.0"}
+  "ocaml" {>= "4.11.0" & < "4.13"}
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.6.1"}
   "menhir" {>= "20201216" & build}

--- a/packages/earlybird/earlybird.1.1.0/opam
+++ b/packages/earlybird/earlybird.1.1.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Debug adapter for OCaml 4.11"
+description: "Debug adapter for OCaml 4.11."
+maintainer: ["hackwaly@qq.com"]
+authors: ["hackwaly@qq.com"]
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0" & <= "4.12.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "menhir" {>= "20201216" & build}
+  "menhirLib" {>= "20201216"}
+  "ocaml-compiler-libs" {>= "0.12.3"}
+  "iter" {>= "1.2.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react" {>= "1.1.3"}
+  "cmdliner" {>= "1.0.4"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "path_glob" {>= "0.2"}
+  "sexplib" {>= "0.14.0"}
+  "csexp" {>= "1.3.2"}
+  "lru" {>= "0.3.0"}
+  "dap" {>= "1.0.6"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hackwaly/ocamlearlybird.git"
+x-commit-hash: "5f39f4d2f96aafb896ccd0ce494150f38f929b38"
+url {
+  src:
+    "https://github.com/hackwaly/ocamlearlybird/releases/download/1.1.0/earlybird-1.1.0.tbz"
+  checksum: [
+    "sha256=aae7257fa73a502ea808eb5c3f3bf9fa0218cedf43342289ca44f03b32839fdf"
+    "sha512=c1b3e24a52c8c6a4e757b9aae6b2d39131d65df401d35f7a35e175fc12d3ea964e92b7a28d24df6e5d026fd194460f994ba8cecf81fd41e8134f09a5e31973b1"
+  ]
+}


### PR DESCRIPTION
Debug adapter for OCaml 4.11+

- Project page: <a href="https://github.com/hackwaly/ocamlearlybird">https://github.com/hackwaly/ocamlearlybird</a>

##### CHANGES:

### Added

* Added OCaml 4.12.0 Support.
Note: Ocamlearlybird built under ocamlc 4.12 can not debug bytecode produced by ocamlc 4.11, and vice versa.
