### PR TITLE
[new release] csexp (1.5.1)

### DIFF
--- a/packages/csexp/csexp.1.5.1/opam
+++ b/packages/csexp/csexp.1.5.1/opam
@@ -30,6 +30,8 @@ bug-reports: "https://github.com/ocaml-dune/csexp/issues"
 depends: [
   "dune" {>= "1.11"}
   "ocaml" {>= "4.03.0"}
+  "ppx_expect" {with-test & >= "v0.14"}
+  "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml-dune/csexp.git"
 build: [
@@ -42,7 +44,7 @@ build: [
     "-j"
     jobs
     "@install"
-#   "@runtest" {with-test & ocaml:version >= "4.04"}
+    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/csexp/csexp.1.5.1/opam
+++ b/packages/csexp/csexp.1.5.1/opam
@@ -30,7 +30,7 @@ bug-reports: "https://github.com/ocaml-dune/csexp/issues"
 depends: [
   "dune" {>= "1.11"}
   "ocaml" {>= "4.03.0"}
-  "ppx_expect" {with-test & >= "v0.14"}
+#  "ppx_expect" {with-test & >= "v0.14"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml-dune/csexp.git"
@@ -44,7 +44,8 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+# Tests disabled because of a cyclic dependency with csexp, dune-configurator and ppx_expect
+#    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/csexp/csexp.1.5.1/opam
+++ b/packages/csexp/csexp.1.5.1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Parsing and printing of S-expressions in Canonical form"
+description: """
+
+This library provides minimal support for Canonical S-expressions
+[1]. Canonical S-expressions are a binary encoding of S-expressions
+that is super simple and well suited for communication between
+programs.
+
+This library only provides a few helpers for simple applications. If
+you need more advanced support, such as parsing from more fancy input
+sources, you should consider copying the code of this library given
+how simple parsing S-expressions in canonical form is.
+
+To avoid a dependency on a particular S-expression library, the only
+module of this library is parameterised by the type of S-expressions.
+
+[1] https://en.wikipedia.org/wiki/Canonical_S-expressions
+"""
+maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
+authors: [
+  "Quentin Hocquet <mefyl@gruntech.org>"
+  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jeremie Dimino <jeremie@dimino.org>"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-dune/csexp"
+doc: "https://ocaml-dune.github.io/csexp/"
+bug-reports: "https://github.com/ocaml-dune/csexp/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.03.0"}
+]
+dev-repo: "git+https://github.com/ocaml-dune/csexp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+#   "@runtest" {with-test & ocaml:version >= "4.04"}
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "7eeb86206819d2b1782d6cde1be9d6cf8b5fc851"
+url {
+  src:
+    "https://github.com/ocaml-dune/csexp/releases/download/1.5.1/csexp-1.5.1.tbz"
+  checksum: [
+    "sha256=d605e4065fa90a58800440ef2f33a2d931398bf2c22061a8acb7df845c0aac02"
+    "sha512=d785bbabaff9f6bf601399149ef0a42e5e99647b54e27f97ef1625907793dda22a45bf83e0e8a1eba2c63634c5484b54739ff0904ef556f5fc592efa38af7505"
+  ]
+}


### PR DESCRIPTION
Parsing and printing of S-expressions in Canonical form

- Project page: <a href="https://github.com/ocaml-dune/csexp">https://github.com/ocaml-dune/csexp</a>
- Documentation: <a href="https://ocaml-dune.github.io/csexp/">https://ocaml-dune.github.io/csexp/</a>

##### CHANGES:

- Drop dependency on result and compatibility with OCaml 4.02 (ocaml-dune/csexp#17,
  @rgrinberg)
