### PR TITLE
3 packages from c-cube/ocaml-containers at 3.3

### DIFF
--- a/packages/containers-data/containers-data.3.0.1/opam
+++ b/packages/containers-data/containers-data.3.0.1/opam
@@ -4,7 +4,7 @@ synopsis: "A set of advanced datatypes for containers"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-data/containers-data.3.1/opam
+++ b/packages/containers-data/containers-data.3.1/opam
@@ -4,7 +4,7 @@ synopsis: "A set of advanced datatypes for containers"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-data/containers-data.3.2/opam
+++ b/packages/containers-data/containers-data.3.2/opam
@@ -4,7 +4,7 @@ synopsis: "A set of advanced datatypes for containers"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-data/containers-data.3.3/opam
+++ b/packages/containers-data/containers-data.3.3/opam
@@ -3,8 +3,8 @@ maintainer: "simon.cruanes.2007@m4x.org"
 synopsis: "A set of advanced datatypes for containers"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-data/containers-data.3.3/opam
+++ b/packages/containers-data/containers-data.3.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A set of advanced datatypes for containers"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "containers" { = version }
+  "seq"
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  #"mdx" { with-test & >= "1.5.0" & < "2.0.0" }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "RAL" "functional" "vector" "okasaki" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.3.tar.gz"
+  checksum: [
+    "md5=aa946f452a156b7cd0b932b5a849b44e"
+    "sha512=fbb6e519ea918afd3895de4cb74bb93a1d7d8899aa1d9def0ee0576a4f648413e3a7d9639040a1117516efb74c66c3432e6da79e6284d2315327175e22766717"
+  ]
+}

--- a/packages/containers-data/containers-data.3.3/opam
+++ b/packages/containers-data/containers-data.3.3/opam
@@ -4,7 +4,7 @@ synopsis: "A set of advanced datatypes for containers"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32"}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-thread/containers-thread.3.0.1/opam
+++ b/packages/containers-thread/containers-thread.3.0.1/opam
@@ -4,7 +4,7 @@ synopsis: "An extension of containers for threading"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-thread/containers-thread.3.1/opam
+++ b/packages/containers-thread/containers-thread.3.1/opam
@@ -4,7 +4,7 @@ synopsis: "An extension of containers for threading"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-thread/containers-thread.3.2/opam
+++ b/packages/containers-thread/containers-thread.3.2/opam
@@ -4,7 +4,7 @@ synopsis: "An extension of containers for threading"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-thread/containers-thread.3.3/opam
+++ b/packages/containers-thread/containers-thread.3.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "An extension of containers for threading"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "base-threads"
+  "dune-configurator"
+  "containers" { = version }
+  "iter" { with-test }
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "thread" "semaphore" "blocking queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.3.tar.gz"
+  checksum: [
+    "md5=aa946f452a156b7cd0b932b5a849b44e"
+    "sha512=fbb6e519ea918afd3895de4cb74bb93a1d7d8899aa1d9def0ee0576a4f648413e3a7d9639040a1117516efb74c66c3432e6da79e6284d2315327175e22766717"
+  ]
+}

--- a/packages/containers-thread/containers-thread.3.3/opam
+++ b/packages/containers-thread/containers-thread.3.3/opam
@@ -3,8 +3,8 @@ maintainer: "simon.cruanes.2007@m4x.org"
 synopsis: "An extension of containers for threading"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers/containers.2.7/opam
+++ b/packages/containers/containers.2.7/opam
@@ -19,6 +19,7 @@ depends: [
   "uutf" { with-test }
   "odoc" { with-doc }
   "ocaml" { >= "4.02.0" }
+  "ocaml" { with-test & < "4.11" }
 ]
 depopts: [
   "base-unix"

--- a/packages/containers/containers.2.7/opam
+++ b/packages/containers/containers.2.7/opam
@@ -4,7 +4,7 @@ synopsis: "A modular, clean and powerful extension of the OCaml standard library
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "dune"

--- a/packages/containers/containers.2.8.1/opam
+++ b/packages/containers/containers.2.8.1/opam
@@ -4,7 +4,7 @@ synopsis: "A modular, clean and powerful extension of the OCaml standard library
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers/containers.2.8.1/opam
+++ b/packages/containers/containers.2.8.1/opam
@@ -8,6 +8,7 @@ build: [
 ]
 depends: [
   "ocaml" { >= "4.03.0" }
+  "ocaml" { with-test & < "4.11" }
   "dune" { >= "1.1" }
   "dune-configurator"
   "seq"

--- a/packages/containers/containers.2.8/opam
+++ b/packages/containers/containers.2.8/opam
@@ -4,7 +4,7 @@ synopsis: "A modular, clean and powerful extension of the OCaml standard library
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers/containers.2.8/opam
+++ b/packages/containers/containers.2.8/opam
@@ -8,6 +8,7 @@ build: [
 ]
 depends: [
   "ocaml" { >= "4.03.0" }
+  "ocaml" { with-test & < "4.11" }
   "dune" { >= "1.1" }
   "dune-configurator"
   "seq"

--- a/packages/containers/containers.3.0.1/opam
+++ b/packages/containers/containers.3.0.1/opam
@@ -4,7 +4,7 @@ synopsis: "A modular, clean and powerful extension of the OCaml standard library
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers/containers.3.1/opam
+++ b/packages/containers/containers.3.1/opam
@@ -4,7 +4,7 @@ synopsis: "A modular, clean and powerful extension of the OCaml standard library
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers/containers.3.2/opam
+++ b/packages/containers/containers.3.2/opam
@@ -4,7 +4,7 @@ synopsis: "A modular, clean and powerful extension of the OCaml standard library
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers/containers.3.3/opam
+++ b/packages/containers/containers.3.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A modular, clean and powerful extension of the OCaml standard library"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "dune-configurator"
+  "seq"
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+depopts: [
+  "base-unix"
+  "base-threads"
+]
+tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.3.tar.gz"
+  checksum: [
+    "md5=aa946f452a156b7cd0b932b5a849b44e"
+    "sha512=fbb6e519ea918afd3895de4cb74bb93a1d7d8899aa1d9def0ee0576a4f648413e3a7d9639040a1117516efb74c66c3432e6da79e6284d2315327175e22766717"
+  ]
+}

--- a/packages/containers/containers.3.3/opam
+++ b/packages/containers/containers.3.3/opam
@@ -3,8 +3,8 @@ maintainer: "simon.cruanes.2007@m4x.org"
 synopsis: "A modular, clean and powerful extension of the OCaml standard library"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/sihl/sihl.0.0.56/opam
+++ b/packages/sihl/sihl.0.0.56/opam
@@ -35,6 +35,7 @@ depends: [
   "ppx_fields_conv" {>= "0.13.0"}
   "ppx_sexp_conv" {>= "0.13.0"}
   "alcotest" {>= "1.2.0"}
+  "containers" {>= "2.8"}
   "utop" {dev}
   "merlin" {dev}
   "ocamlformat" {dev}

--- a/packages/sihl/sihl.0.1.0/opam
+++ b/packages/sihl/sihl.0.1.0/opam
@@ -35,6 +35,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
   "alcotest" {>= "1.2.0"}
+  "containers" {>= "2.8"}
   "alcotest-lwt" {>= "1.2.0" & with-test}
   "cohttp-lwt-unix" {>= "2.5.1" & with-test}
 ]

--- a/packages/sihl/sihl.0.1.1/opam
+++ b/packages/sihl/sihl.0.1.1/opam
@@ -35,6 +35,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
   "alcotest" {>= "1.2.0"}
+  "containers" {>= "2.8"}
   "alcotest-lwt" {>= "1.2.0" & with-test}
   "cohttp-lwt-unix" {>= "2.5.1" & with-test}
 ]

--- a/packages/sihl/sihl.0.1.10/opam
+++ b/packages/sihl/sihl.0.1.10/opam
@@ -32,6 +32,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
   "alcotest" {>= "1.2.0"}
+  "containers" {>= "2.8"}
   "alcotest-lwt" {>= "1.2.0" & < "3.0.0" & with-test}
   "cohttp-lwt-unix" {>= "2.5.1"& with-test}
   "odoc" {with-doc}

--- a/packages/sihl/sihl.0.1.2/opam
+++ b/packages/sihl/sihl.0.1.2/opam
@@ -35,6 +35,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
   "alcotest" {>= "1.2.0"}
+  "containers" {>= "2.8"}
   "alcotest-lwt" {>= "1.2.0" & with-test}
   "cohttp-lwt-unix" {>= "2.5.1" & with-test}
 ]

--- a/packages/sihl/sihl.0.1.3/opam
+++ b/packages/sihl/sihl.0.1.3/opam
@@ -35,6 +35,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
   "alcotest" {>= "1.2.0"}
+  "containers" {>= "2.8"}
   "alcotest-lwt" {>= "1.2.0" & with-test}
   "cohttp-lwt-unix" {>= "2.5.1" & with-test}
 ]

--- a/packages/sihl/sihl.0.1.4/opam
+++ b/packages/sihl/sihl.0.1.4/opam
@@ -33,6 +33,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
   "alcotest" {>= "1.2.0"}
+  "containers" {>= "2.8"}
   "alcotest-lwt" {>= "1.2.0" & with-test}
   "cohttp-lwt-unix" {>= "2.5.1" & with-test & < "3.0.0"}
 ]

--- a/packages/sihl/sihl.0.1.5/opam
+++ b/packages/sihl/sihl.0.1.5/opam
@@ -31,6 +31,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
   "alcotest" {>= "1.2.0"}
+  "containers" {>= "2.8"}
   "alcotest-lwt" {>= "1.2.0" & with-test}
   "cohttp-lwt-unix" {>= "2.5.1" & with-test & < "3.0.0"}
   "odoc" {with-doc}

--- a/packages/sihl/sihl.0.1.6/opam
+++ b/packages/sihl/sihl.0.1.6/opam
@@ -32,6 +32,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
   "alcotest" {>= "1.2.0"}
+  "containers" {>= "2.8"}
   "alcotest-lwt" {>= "1.2.0" & with-test}
   "cohttp-lwt-unix" {>= "2.5.1" & with-test & < "3.0.0"}
   "odoc" {with-doc}

--- a/packages/sihl/sihl.0.1.7/opam
+++ b/packages/sihl/sihl.0.1.7/opam
@@ -32,6 +32,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
   "alcotest" {>= "1.2.0"}
+  "containers" {>= "2.8"}
   "alcotest-lwt" {>= "1.2.0" & with-test}
   "cohttp-lwt-unix" {>= "2.5.1" & with-test & < "3.0.0"}
   "odoc" {with-doc}

--- a/packages/sihl/sihl.0.1.8/opam
+++ b/packages/sihl/sihl.0.1.8/opam
@@ -32,6 +32,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
   "alcotest" {>= "1.2.0"}
+  "containers" {>= "2.8"}
   "alcotest-lwt" {>= "1.2.0" & < "3.0.0" & with-test}
   "cohttp-lwt-unix" {>= "2.5.1"& with-test}
   "odoc" {with-doc}

--- a/packages/sihl/sihl.0.1.9/opam
+++ b/packages/sihl/sihl.0.1.9/opam
@@ -32,6 +32,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
   "alcotest" {>= "1.2.0"}
+  "containers" {>= "2.8"}
   "alcotest-lwt" {>= "1.2.0" & < "3.0.0" & with-test}
   "cohttp-lwt-unix" {>= "2.5.1"& with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
This pull-request concerns:
-`containers.3.3`: A modular, clean and powerful extension of the OCaml standard library
-`containers-data.3.3`: A set of advanced datatypes for containers
-`containers-thread.3.3`: An extension of containers for threading



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: git+https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0