### PR TITLE
[new release] doi2bib (0.4.0)

### DIFF
--- a/packages/doi2bib/doi2bib.0.4.0/opam
+++ b/packages/doi2bib/doi2bib.0.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "Small CLI to get a bibtex entry from a DOI, an arXiv ID or a PubMed ID"
+maintainer: ["marcello.seri@gmail.com"]
+authors: ["Marcello Seri"]
+license: "MIT"
+homepage: "https://github.com/mseri/doi2bib"
+bug-reports: "https://github.com/mseri/doi2bib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "astring" {>= "0.8.0"}
+  "cohttp-lwt-unix" {>= "2.5.0"}
+  "cmdliner" {>= "1.0.0"}
+  "decompress" {>= "1.3.0"}
+  "ezxmlm" {>= "1.1.0"}
+  "tls" {>= "0.12.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mseri/doi2bib.git"
+x-commit-hash: "31191edebc0128d0500ce0f08e2990d997a14057"
+url {
+  src:
+    "https://github.com/mseri/doi2bib/releases/download/0.4.0/doi2bib-0.4.0.tbz"
+  checksum: [
+    "sha256=7554267255c77b2e7fd14dff54f0b21b1e8bf8cde95a4e20177b7a2be36d6d97"
+    "sha512=b5073b8ee009ddc429e81bcd6f92ab3765e253a48b0b5963d56be8d2e908967e28800f86354855be711607754fb12efa099078e6e5a743b43a21dea80f6dca80"
+  ]
+}


### PR DESCRIPTION
Small CLI to get a bibtex entry from a DOI, an arXiv ID or a PubMed ID

- Project page: <a href="https://github.com/mseri/doi2bib">https://github.com/mseri/doi2bib</a>

##### Release 0.4.0 with gzip support via decompress