### PR TITLE
Package lilv.0.1.0

### DIFF
--- a/packages/conf-lilv/conf-lilv.1/opam
+++ b/packages/conf-lilv/conf-lilv.1/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "http://drobilla.net/software/kilv"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "lilv dev team"
+license: "ISC"
+depexts: [
+  ["lilv-dev"] {os-family = "alpine"}
+  ["lilv-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse"}
+  ["liblilv-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["lilv"] {os-family = "arch" | os-distribution = "nixos" | os = "freebsd" | os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on lilv"
+description:
+  "This package installs system-specific external dependencies to build lilv plugins, when they exist."
+flags: conf

--- a/packages/lilv/lilv.0.1.0/opam
+++ b/packages/lilv/lilv.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Bindings to lilv library for using LV2 audio plugins"
+description:
+  "Bindings to the lilv library for simple use of LV2 plugins in applications. LV2 is an open extensible standard for audio plugins. Many types of plugins can be built with LV2, including audio effects, synthesizers, and control processors for modulation and automation."
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["Romain Beauxis <toots@rastageeks.org>"]
+license: "LGPL-2.1"
+homepage: "https://github.com/savonet/ocaml-lilv"
+bug-reports: "https://github.com/savonet/ocaml-lilv/issues"
+depends: [
+  "conf-pkg-config"
+  "conf-lilv"
+  "dune" {>= "2.8"}
+  "dune-configurator"
+  "ctypes"
+  "ctypes-foreign"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-lilv.git"
+url {
+  src: "https://github.com/savonet/ocaml-lilv/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=c165d258c71a50f46f426825b8e688e0"
+    "sha512=e522c4aad328844b5d9b70a5ea1588bc2de16055916ecb87ae6b74139bb576ef337ba5663a2a7caa57951a7f517c11988b3f04cbcc1b6ece828d79ce80ed65ac"
+  ]
+}

--- a/packages/liquidsoap/liquidsoap.1.4.0/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.0/opam
@@ -68,6 +68,7 @@ depopts: [
   "ladspa"
   "lame"
   "lastfm"
+  "lilv"
   "lo"
   "mad"
   "magic"

--- a/packages/liquidsoap/liquidsoap.1.4.1-1/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1-1/opam
@@ -79,6 +79,7 @@ depopts: [
   "ladspa"
   "lame"
   "lastfm"
+  "lilv"
   "lo"
   "mad"
   "magic"

--- a/packages/liquidsoap/liquidsoap.1.4.1-2/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1-2/opam
@@ -82,6 +82,7 @@ depopts: [
   "ladspa"
   "lame"
   "lastfm"
+  "lilv"
   "lo"
   "mad"
   "magic"

--- a/packages/liquidsoap/liquidsoap.1.4.1/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1/opam
@@ -68,6 +68,7 @@ depopts: [
   "ladspa"
   "lame"
   "lastfm"
+  "lilv"
   "lo"
   "mad"
   "magic"

--- a/packages/liquidsoap/liquidsoap.1.4.2/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.2/opam
@@ -79,6 +79,7 @@ depopts: [
   "ladspa"
   "lame"
   "lastfm"
+  "lilv"
   "lo"
   "mad"
   "magic"

--- a/packages/liquidsoap/liquidsoap.1.4.3/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.3/opam
@@ -79,6 +79,7 @@ depopts: [
   "ladspa"
   "lame"
   "lastfm"
+  "lilv"
   "lo"
   "mad"
   "magic"

--- a/packages/liquidsoap/liquidsoap.1.4.4/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.4/opam
@@ -81,6 +81,7 @@ depopts: [
   "ladspa"
   "lame"
   "lastfm"
+  "lilv"
   "lo"
   "mad"
   "magic"


### PR DESCRIPTION
### `lilv.0.1.0`
Bindings to lilv library for using LV2 audio plugins
Bindings to the lilv library for simple use of LV2 plugins in applications. LV2 is an open extensible standard for audio plugins. Many types of plugins can be built with LV2, including audio effects, synthesizers, and control processors for modulation and automation.



---
* Homepage: https://github.com/savonet/ocaml-lilv
* Source repo: git+https://github.com/savonet/ocaml-lilv.git
* Bug tracker: https://github.com/savonet/ocaml-lilv/issues

---
:camel: Pull-request generated by opam-publish v2.0.3