### PR TITLE
Precise the dune version for coq-of-ocaml

### DIFF
--- a/packages/coq-of-ocaml/coq-of-ocaml.2.5.0/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.5.0/opam
@@ -14,7 +14,7 @@ install: [
   [make "-C" "proofs" "install"] {coq:installed}
 ]
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.8"}
   "csexp"
   "ocaml" {>= "4.12" & < "4.13"}
   "ocamlfind" {>= "1.5.2"}


### PR DESCRIPTION
Precise the version of dune due to the change of the dune <-> Merlin protocol.