### PR TITLE
Package binaryen.0.9.1

### DIFF
--- a/packages/binaryen/binaryen.0.9.1/opam
+++ b/packages/binaryen/binaryen.0.9.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.09"}
+  "dune" {>= "2.7.1"}
+  "dune-configurator" {>= "2.7.1"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+]
+available: arch = "x86_64" & (os = "linux" | os = "macos" | os = "win32")
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.9.1/binaryen-archive-v0.9.1.tar.gz"
+  checksum: [
+    "md5=ec73e0a05ec01966380e6333fe49363a"
+    "sha512=8ab2f8c46c0532dddd4b695f22f48ab540a0e668bc893e7769f2725ed060a675d6d2f17f959994cda899c5d9b7a9a3c3653563f69f2214708db6480ae817a00e"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.9.1`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---


### Bug Fixes

* Correct JS conversion of i64 & float64_bits literals ([#96](https://www.github.com/grain-lang/binaryen.ml/issues/96)) ([00b7093](https://www.github.com/grain-lang/binaryen.ml/commit/00b7093ad57c7698ff7f6e69f59fd426ee341fbf))


---
:camel: Pull-request generated by opam-publish v2.0.3