### PR TITLE
malfunction 0.3 is not compatible with omd 2.0

### DIFF
--- a/packages/malfunction/malfunction.0.3/opam
+++ b/packages/malfunction/malfunction.0.3/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind"
   "dune"
   "cppo" {build}
-  "omd" {with-test & < "2.0.0"}
+  "omd" {with-test & < "2.0.0~"}
   "craml" {with-test}
   "zarith"
 ]

--- a/packages/malfunction/malfunction.0.3/opam
+++ b/packages/malfunction/malfunction.0.3/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind"
   "dune"
   "cppo" {build}
-  "omd" {with-test}
+  "omd" {with-test & < "2.0.0"}
   "craml" {with-test}
   "zarith"
 ]

--- a/packages/malfunction/malfunction.0.3/opam
+++ b/packages/malfunction/malfunction.0.3/opam
@@ -18,7 +18,7 @@ depends: [
   "craml" {with-test}
   "zarith"
 ]
-synopsis: "Compiler back-end for functional languages, based on OCaml."
+synopsis: "Compiler back-end for functional languages, based on OCaml"
 description: """
 Malfunction is a high-performance, low-level untyped program
 representation, designed as a target for compilers of functional


### PR DESCRIPTION
I see the following compilation error with omd 2.0.0~alpha1
```
File "test/test.ml", line 160, characters 11-29:
160 |   let open Omd_representation in
                 ^^^^^^^^^^^^^^^^^^
Error: Unbound module Omd_representation
```