### PR TITLE
[new release] mirage-crypto-pk, mirage-crypto-ec, mirage-crypto, mirage-crypto-rng, mirage-crypto-rng-mirage and mirage-crypto-rng-async (0.9.1)

### DIFF
--- a/packages/mirage-crypto-ec/mirage-crypto-ec.0.9.0/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.0.9.0/opam
@@ -47,7 +47,7 @@ conflicts: [
   "ocaml-freestanding" {< "0.4.1"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/packages/mirage-crypto-ec/mirage-crypto-ec.0.9.1/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.0.9.1/opam
@@ -53,13 +53,12 @@ build: [
 ]
 dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
 tags: ["org:mirage"]
-x-commit-hash: "3013c5286f563743e2f5c13da068a6bdf90cd805"
+x-commit-hash: "85a2c340be0480c23ec724838ac0b0b66e118882"
 url {
   src:
-    "https://github.com/mirage/mirage-crypto/releases/download/v0.9.0/mirage-crypto-v0.9.0.tbz"
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.9.1/mirage-crypto-v0.9.1.tbz"
   checksum: [
-    "sha256=716684f8a70031f16115e3c84d42141c75fb1e688b7a699bbd09166176ed5217"
-    "sha512=7eb56f28583567824b32bf33635b15c39dd684a047455b2cc6a5f768c52ccbe6d8eac80308fac80d78c8f678b0132059fdbc219a252de6ecfd53c26c717a9a3a"
+    "sha256=53e0ae90f19651ab7f09156557ea5ec07bce7a52468ec6687471e0333f3e2133"
+    "sha512=8d93266ad71fabed7abeb825f427f6fc76baae48f2142f6b00f8908b7b494faf0efc60362624a27ac7c6ad90c771e4f17b5b33bd8e309bcbfeda8b9a65eb2747"
   ]
 }
-available: false

--- a/packages/mirage-crypto-ec/mirage-crypto-ec.0.9.1/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.0.9.1/opam
@@ -47,7 +47,7 @@ conflicts: [
   "ocaml-freestanding" {< "0.4.1"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.9.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.9.1/opam
@@ -8,7 +8,7 @@ maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
 license:      "ISC"
 synopsis:     "Simple public-key cryptography for the modern age"
 
-build: [ ["dune" "subst"] {pinned}
+build: [ ["dune" "subst"] {dev}
          ["dune" "build" "-p" name "-j" jobs ]
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.9.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.9.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.7"}
+  "rresult" {>= "0.6.0"}
+  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding")
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+x-commit-hash: "85a2c340be0480c23ec724838ac0b0b66e118882"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.9.1/mirage-crypto-v0.9.1.tbz"
+  checksum: [
+    "sha256=53e0ae90f19651ab7f09156557ea5ec07bce7a52468ec6687471e0333f3e2133"
+    "sha512=8d93266ad71fabed7abeb825f427f6fc76baae48f2142f6b00f8908b7b494faf0efc60362624a27ac7c6ad90c771e4f17b5b33bd8e309bcbfeda8b9a65eb2747"
+  ]
+}

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.9.1/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.9.1/opam
@@ -8,7 +8,7 @@ maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
 license:      "ISC"
 synopsis:     "Feed the entropy source in an Async-friendly way"
 
-build: [ ["dune" "subst"] {pinned}
+build: [ ["dune" "subst"] {dev}
          ["dune" "build" "-p" name "-j" jobs ]
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.9.1/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.9.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an Async-friendly way"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "async"
+  "logs"
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+]
+available: os != "win32"
+description: """
+
+Mirage-crypto-rng-async feeds the entropy source for Mirage_crypto_rng-based
+random number genreator implementations, in an Async-friendly way.
+"""
+x-commit-hash: "85a2c340be0480c23ec724838ac0b0b66e118882"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.9.1/mirage-crypto-v0.9.1.tbz"
+  checksum: [
+    "sha256=53e0ae90f19651ab7f09156557ea5ec07bce7a52468ec6687471e0333f3e2133"
+    "sha512=8d93266ad71fabed7abeb825f427f6fc76baae48f2142f6b00f8908b7b494faf0efc60362624a27ac7c6ad90c771e4f17b5b33bd8e309bcbfeda8b9a65eb2747"
+  ]
+}

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.9.1/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.9.1/opam
@@ -8,7 +8,7 @@ maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
 license:      "BSD-2-Clause"
 synopsis:     "Entropy collection for a cryptographically secure PRNG"
 
-build: [ ["dune" "subst"] {pinned}
+build: [ ["dune" "subst"] {dev}
          ["dune" "build" "-p" name "-j" jobs ]
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.9.1/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.9.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "BSD-2-Clause"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "lwt" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+x-commit-hash: "85a2c340be0480c23ec724838ac0b0b66e118882"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.9.1/mirage-crypto-v0.9.1.tbz"
+  checksum: [
+    "sha256=53e0ae90f19651ab7f09156557ea5ec07bce7a52468ec6687471e0333f3e2133"
+    "sha512=8d93266ad71fabed7abeb825f427f6fc76baae48f2142f6b00f8908b7b494faf0efc60362624a27ac7c6ad90c771e4f17b5b33bd8e309bcbfeda8b9a65eb2747"
+  ]
+}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.9.1/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.9.1/opam
@@ -8,7 +8,7 @@ maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
 license:      "ISC"
 synopsis:     "A cryptographically secure PRNG"
 
-build: [ ["dune" "subst"] {pinned}
+build: [ ["dune" "subst"] {dev}
          ["dune" "build" "-p" name "-j" jobs ]
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.9.1/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.9.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "mirage-crypto" {=version}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+# lwt sublibrary
+  "mtime"
+  "lwt" {>= "4.0.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+x-commit-hash: "85a2c340be0480c23ec724838ac0b0b66e118882"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.9.1/mirage-crypto-v0.9.1.tbz"
+  checksum: [
+    "sha256=53e0ae90f19651ab7f09156557ea5ec07bce7a52468ec6687471e0333f3e2133"
+    "sha512=8d93266ad71fabed7abeb825f427f6fc76baae48f2142f6b00f8908b7b494faf0efc60362624a27ac7c6ad90c771e4f17b5b33bd8e309bcbfeda8b9a65eb2747"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.9.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.9.1/opam
@@ -8,7 +8,7 @@ maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
 license:      "ISC"
 synopsis:     "Simple symmetric cryptography for the modern age"
 
-build: [ ["dune" "subst"] {pinned}
+build: [ ["dune" "subst"] {dev}
          ["dune" "build" "-p" name "-j" jobs ]
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 

--- a/packages/mirage-crypto/mirage-crypto.0.9.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.9.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "eqaf" {>= "0.7"}
+]
+depopts: [
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
+hashes (MD5, SHA-1, SHA-2).
+"""
+x-commit-hash: "85a2c340be0480c23ec724838ac0b0b66e118882"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.9.1/mirage-crypto-v0.9.1.tbz"
+  checksum: [
+    "sha256=53e0ae90f19651ab7f09156557ea5ec07bce7a52468ec6687471e0333f3e2133"
+    "sha512=8d93266ad71fabed7abeb825f427f6fc76baae48f2142f6b00f8908b7b494faf0efc60362624a27ac7c6ad90c771e4f17b5b33bd8e309bcbfeda8b9a65eb2747"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- mirage-crypto-ec: fix ECDSA verify if r or s are shorter than the modulus
  (mirage/mirage-crypto#117 by @hannesm)
- Fixed esy cross-compile CI (mirage/mirage-crypto#116 by @EduardoRFS)

(mark mirage-crypto-ec 0.9.0 as unavailable due to the bug fixed)