### PR TITLE
[new release] logs-ppx (0.2.0)

### DIFF
--- a/packages/logs-ppx/logs-ppx.0.2.0/opam
+++ b/packages/logs-ppx/logs-ppx.0.2.0/opam
@@ -31,7 +31,7 @@ dev-repo: "git+https://github.com/ulrikstrid/logs-ppx.git"
 x-commit-hash: "4138638011c0c75752394e3a58b5685aabe96130"
 url {
   src:
-    "https://github.com/ulrikstrid/logs-ppx/releases/download/0.2.0/logs-ppx-0.2.0.tbz"
+    "https://github.com/ulrikstrid/logs-ppx/releases/download/v0.2.0/logs-ppx-0.2.0.tbz"
   checksum: [
     "sha256=053f043ef959d6dc079503eab482e91ac1509685d393c4b51f6991c210c0bfb1"
     "sha512=15f5d2f88305bf26c653500f2c883e4774039b2b34a8f7cda3c4e6ae3dcc21939981a23d787e9a89a869c0bd76d0299cdcce2db548df108296f754e8c1584cd3"

--- a/packages/logs-ppx/logs-ppx.0.2.0/opam
+++ b/packages/logs-ppx/logs-ppx.0.2.0/opam
@@ -4,7 +4,7 @@ description:
   "PPX to remove the closure when logging with Logs. The PPX will still generate the closure which keeps the nice properties of the Logs library."
 maintainer: ["ulrik.strid@outlook.com"]
 authors: ["Ulrik Strid"]
-license: "BSD-3"
+license: "BSD-3-Clause"
 homepage: "https://github.com/ulrikstrid/logs-ppx"
 bug-reports: "https://github.com/ulrikstrid/logs-ppx/issues"
 depends: [
@@ -14,7 +14,7 @@ depends: [
   "logs" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/logs-ppx/logs-ppx.0.2.0/opam
+++ b/packages/logs-ppx/logs-ppx.0.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "PPX to cut down on boilerplate when using Logs"
+description:
+  "PPX to remove the closure when logging with Logs. The PPX will still generate the closure which keeps the nice properties of the Logs library."
+maintainer: ["ulrik.strid@outlook.com"]
+authors: ["Ulrik Strid"]
+license: "BSD-3"
+homepage: "https://github.com/ulrikstrid/logs-ppx"
+bug-reports: "https://github.com/ulrikstrid/logs-ppx/issues"
+depends: [
+  "ocaml" {>= "4.8.0"}
+  "dune" {>= "2.6"}
+  "ppxlib"
+  "logs" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/logs-ppx.git"
+x-commit-hash: "4138638011c0c75752394e3a58b5685aabe96130"
+url {
+  src:
+    "https://github.com/ulrikstrid/logs-ppx/releases/download/0.2.0/logs-ppx-0.2.0.tbz"
+  checksum: [
+    "sha256=053f043ef959d6dc079503eab482e91ac1509685d393c4b51f6991c210c0bfb1"
+    "sha512=15f5d2f88305bf26c653500f2c883e4774039b2b34a8f7cda3c4e6ae3dcc21939981a23d787e9a89a869c0bd76d0299cdcce2db548df108296f754e8c1584cd3"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- More hygenic output of logging function `m` -> `logger-function`
- Breaking: Emit `Log` instead of `Logs` since that is the recommendation