### PR TITLE
[new release] wayland (0.2)

### DIFF
--- a/packages/wayland/wayland.0.2/opam
+++ b/packages/wayland/wayland.0.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml Wayland protocol library"
+description:
+  "Wayland is a communications protocol intended for use between processes on a single computer. It is mainly used by graphical applications (clients) to talk to display servers, but nothing about the protocol is specific to graphics and it could be used for other things. This library can be used to write Wayland clients, servers and proxies."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0 (excluding schema files)"
+homepage: "https://github.com/talex5/ocaml-wayland"
+doc: "https://talex5.github.io/ocaml-wayland/"
+bug-reports: "https://github.com/talex5/ocaml-wayland/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "ocaml" {>= "4.08.0"}
+  "xmlm" {>= "1.3.0"}
+  "lwt" {>= "5.4.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cstruct" {>= "6.0.0"}
+  "cmdliner" {>= "1.0.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/talex5/ocaml-wayland.git"
+x-commit-hash: "1f46a3b3d13260c674c3846f42ee8e636cd86516"
+url {
+  src:
+    "https://github.com/talex5/ocaml-wayland/releases/download/v0.2/wayland-v0.2.tbz"
+  checksum: [
+    "sha256=4eb323e42a8c64e9e49b15a588342bfcc1e99640305cb261d128c75612d9458c"
+    "sha512=1478b79022c5e12199b9c724e49a9832166cd4979da9c4bf38d9f06970dafb8c51a11324b772dc982f56e58307c8bc17962948987fb30fec1fdb104f6e63b15b"
+  ]
+}


### PR DESCRIPTION
Pure OCaml Wayland protocol library

- Project page: <a href="https://github.com/talex5/ocaml-wayland">https://github.com/talex5/ocaml-wayland</a>
- Documentation: <a href="https://talex5.github.io/ocaml-wayland/">https://talex5.github.io/ocaml-wayland/</a>

##### CHANGES:

- Bugfix: handle `SIGPIPE` properly (talex5/ocaml-wayland#15).
- Add license field to opam metadata.
