### PR TITLE
tls 0.11* 0.12*: require x509 < 0.12.0

### DIFF
--- a/packages/capnp-rpc-net/capnp-rpc-net.1.0/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ptime"
   "prometheus" {>= "0.5"}
   "asn1-combinators" {>= "0.2.0"}
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "tls-mirage"
   "dune" {>= "2.0"}
   "mirage-crypto"

--- a/packages/tls/tls.0.11.1/opam
+++ b/packages/tls/tls.0.11.1/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/tls/tls.0.12.0/opam
+++ b/packages/tls/tls.0.12.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/tls/tls.0.12.1/opam
+++ b/packages/tls/tls.0.12.1/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/tls/tls.0.12.2/opam
+++ b/packages/tls/tls.0.12.2/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng" {>= "0.8.0"}
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/tls/tls.0.12.3/opam
+++ b/packages/tls/tls.0.12.3/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng" {>= "0.8.0"}
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/tls/tls.0.12.4/opam
+++ b/packages/tls/tls.0.12.4/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng" {>= "0.8.0"}
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/tls/tls.0.12.5/opam
+++ b/packages/tls/tls.0.12.5/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng" {>= "0.8.0"}
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}


### PR DESCRIPTION
further bounds from #18444 -- these tls versions did not show up in revdeps in the CI run since revdeps are executed with a new compiler (that fails to compile the tls versions in this PR). sorry for the inconvenience.