### PR TITLE
2 packages from c-cube/linol at 0.2

### DIFF
--- a/packages/linol-lwt/linol-lwt.0.2/opam
+++ b/packages/linol-lwt/linol-lwt.0.2/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
 homepage: "https://github.com/c-cube/linol"
 synopsis: "LSP server library (with Lwt for concurrency)"
+license: "MIT"
 build: [
   ["dune" "build" "@install" "-p" name "-j" jobs]
   ["dune" "build" "@runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/linol-lwt/linol-lwt.0.2/opam
+++ b/packages/linol-lwt/linol-lwt.0.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/linol"
+synopsis: "LSP server library (with Lwt for concurrency)"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "linol" { = version }
+  "lsp" { >= "1.4" & < "1.5" }
+  "jsonrpc" { >= "1.4" & < "1.5" }
+  "containers" { >= "3.0" & < "4.0" }
+  "lwt" { >= "5.1" & < "6.0" }
+  "base-unix"
+  "yojson" { >= "1.6" }
+  "ocaml" { >= "4.08" }
+  "odoc" { with-doc }
+]
+tags: [ "lsp" "server" "lwt" "linol" ]
+bug-reports: "https://github.com/c-cube/linol/issues"
+dev-repo: "git+https://github.com/c-cube/linol.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/linol/archive/v0.2.tar.gz"
+  checksum: [
+    "md5=2f6137dfbf81e89697213583b7f6d3ab"
+    "sha512=b5d736c62f92b175c5a62d7f6fe91f0c43d6941997d734cd8fda5a6c7e3675839683ccda92d4df90820047847c9d93b54d8a86e1b3cfc91d5ab19ba4b6174d32"
+  ]
+}

--- a/packages/linol/linol.0.2/opam
+++ b/packages/linol/linol.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/linol"
+synopsis: "LSP server library"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "containers" { >= "3.0" & < "4.0" }
+  "yojson" { >= "1.6" }
+  "lsp" { >= "1.4" & < "1.5" }
+  "ocaml" { >= "4.08" }
+  "odoc" { with-doc }
+]
+tags: [ "lsp" "server" "lwt" ]
+bug-reports: "https://github.com/c-cube/linol/issues"
+dev-repo: "git+https://github.com/c-cube/linol.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/linol/archive/v0.2.tar.gz"
+  checksum: [
+    "md5=2f6137dfbf81e89697213583b7f6d3ab"
+    "sha512=b5d736c62f92b175c5a62d7f6fe91f0c43d6941997d734cd8fda5a6c7e3675839683ccda92d4df90820047847c9d93b54d8a86e1b3cfc91d5ab19ba4b6174d32"
+  ]
+}

--- a/packages/linol/linol.0.2/opam
+++ b/packages/linol/linol.0.2/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
 homepage: "https://github.com/c-cube/linol"
 synopsis: "LSP server library"
+license: "MIT"
 build: [
   ["dune" "build" "@install" "-p" name "-j" jobs]
   ["dune" "build" "@runtest" "-p" name "-j" jobs] {with-test}


### PR DESCRIPTION
This pull-request concerns:
-`linol.0.2`: LSP server library
-`linol-lwt.0.2`: LSP server library (with Lwt for concurrency)



---
* Homepage: https://github.com/c-cube/linol
* Source repo: git+https://github.com/c-cube/linol.git
* Bug tracker: https://github.com/c-cube/linol/issues

---
:camel: Pull-request generated by opam-publish v2.0.0