### PR TITLE
[new release] reparse and reparse-unix (2.1.0)

### DIFF
--- a/packages/reparse-unix/reparse-unix.2.1.0/opam
+++ b/packages/reparse-unix/reparse-unix.2.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Provides support for parsing files as source of input for reparse library "
+description:
+  "Provides support for parsing files as source of input for reparse library "
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "reparse" {= "2.0.0"}
+  "base-unix"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+x-commit-hash: "9137639ce41a03a4d55d774cd727493248341471"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v2.1.0/reparse-unix-v2.1.0.tbz"
+  checksum: [
+    "sha256=49849c0a1b71d7c4e17258171decd1862937e9c1fe69bc2324e361446c0abb74"
+    "sha512=88817cf42d8e42b62e24cc645931995fce175370842056051f309eeb497f59ae5b82197282fdbd898b5d9327d1ec6ec793d1a28cbebf2df85eab631361438c57"
+  ]
+}

--- a/packages/reparse/reparse.2.1.0/opam
+++ b/packages/reparse/reparse.2.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Recursive descent parsing library for ocaml"
+description:
+  "Monadic, recursive descent based, parser construction library for ocaml. Comprehensively documented and tested."
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+x-commit-hash: "9137639ce41a03a4d55d774cd727493248341471"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v2.1.0/reparse-unix-v2.1.0.tbz"
+  checksum: [
+    "sha256=49849c0a1b71d7c4e17258171decd1862937e9c1fe69bc2324e361446c0abb74"
+    "sha512=88817cf42d8e42b62e24cc645931995fce175370842056051f309eeb497f59ae5b82197282fdbd898b5d9327d1ec6ec793d1a28cbebf2df85eab631361438c57"
+  ]
+}


### PR DESCRIPTION
Recursive descent parsing library for ocaml

- Project page: <a href="https://github.com/lemaetech/reparse">https://github.com/lemaetech/reparse</a>

##### CHANGES:

This release has backwards incompatible changes.

- Infix functions are now available in `Parser` module itself.
- Add support for let operators - `let+`, `let*` ,`and+` and `and*`.
- `bind` and `map` function are now labelled following `base` library
  dependency convention.
- Items in `all_unit` are now `unit t` rather than `_ t` following monad
  combinator convention in `base` library dependency.
- `pure` is now deprecated. Use `return` instead. This is to stay consistent
  with monad conventions in `base` library dependency.
- `>|=` is deprecated. Use `>>|` instead. This is to stay consistent with monad
  conventions in `base` library dependency.
- Removed `map4` function.
- Add support for `ppx_let`.
- Deprecate `Parser` module. Use `Reparse` instead.
