### PR TITLE
[new release] reparse-unix and reparse (2.1.0)

### DIFF
--- a/packages/capnp-rpc-net/capnp-rpc-net.1.0/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ptime"
   "prometheus" {>= "0.5"}
   "asn1-combinators" {>= "0.2.0"}
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "tls-mirage"
   "dune" {>= "2.0"}
   "mirage-crypto"

--- a/packages/http-multipart-formdata/http-multipart-formdata.1.0.0/opam
+++ b/packages/http-multipart-formdata/http-multipart-formdata.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.10.0"}
   "fmt" {>= "0.8.9"}
-  "reparse"
+  "reparse" {<= "2.0.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/http-multipart-formdata/http-multipart-formdata.1.0.1/opam
+++ b/packages/http-multipart-formdata/http-multipart-formdata.1.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.10.0"}
   "fmt" {>= "0.8.9"}
-  "reparse"
+  "reparse" {<= "2.0.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/reparse-unix/reparse-unix.2.1.0/opam
+++ b/packages/reparse-unix/reparse-unix.2.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Provides support for parsing files as source of input for reparse library "
+description:
+  "Provides support for parsing files as source of input for reparse library "
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "reparse" {= "2.1.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+x-commit-hash: "89ca9788a0a580459f6941a0db9d1a4f2815f052"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v2.1.0/reparse-unix-v2.1.0.tbz"
+  checksum: [
+    "sha256=51f7bb7087679e7e8dabf237a2e080094391bc626476c4c614515a14a3da6919"
+    "sha512=b886a2261131b7ccf5d38def08a57724a8eb1a8b95d299f452659b874f7d186aa1e25e77aebfa921b269804f1d9895c0e124c31bbd5d204af9c5dd9b1c720ebf"
+  ]
+}

--- a/packages/reparse/reparse.2.1.0/opam
+++ b/packages/reparse/reparse.2.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Recursive descent parsing library for ocaml"
+description:
+  "Monadic, recursive descent based, parser construction library for ocaml. Comprehensively documented and tested."
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "base"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+x-commit-hash: "89ca9788a0a580459f6941a0db9d1a4f2815f052"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v2.1.0/reparse-unix-v2.1.0.tbz"
+  checksum: [
+    "sha256=51f7bb7087679e7e8dabf237a2e080094391bc626476c4c614515a14a3da6919"
+    "sha512=b886a2261131b7ccf5d38def08a57724a8eb1a8b95d299f452659b874f7d186aa1e25e77aebfa921b269804f1d9895c0e124c31bbd5d204af9c5dd9b1c720ebf"
+  ]
+}

--- a/packages/tls/tls.0.11.1/opam
+++ b/packages/tls/tls.0.11.1/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/tls/tls.0.12.0/opam
+++ b/packages/tls/tls.0.12.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/tls/tls.0.12.1/opam
+++ b/packages/tls/tls.0.12.1/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/tls/tls.0.12.2/opam
+++ b/packages/tls/tls.0.12.2/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng" {>= "0.8.0"}
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/tls/tls.0.12.3/opam
+++ b/packages/tls/tls.0.12.3/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng" {>= "0.8.0"}
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/tls/tls.0.12.4/opam
+++ b/packages/tls/tls.0.12.4/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng" {>= "0.8.0"}
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/tls/tls.0.12.5/opam
+++ b/packages/tls/tls.0.12.5/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-pk"
   "mirage-crypto-rng" {>= "0.8.0"}
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}


### PR DESCRIPTION
Provides support for parsing files as source of input for reparse library

- Project page: <a href="https://github.com/lemaetech/reparse">https://github.com/lemaetech/reparse</a>

##### CHANGES:

This release has backwards incompatible changes.

- Infix functions are now available in `Parser` module itself.
- Add support for let operators - `let+`, `let*` ,`and+` and `and*`.
- `bind` and `map` function are now labelled following `base` library
  dependency convention.
- Items in `all_unit` are now `unit t` rather than `_ t` following monad
  combinator convention in `base` library dependency.
- `pure` is now deprecated. Use `return` instead. This is to stay consistent
  with monad conventions in `base` library dependency.
- `>|=` is deprecated. Use `>>|` instead. This is to stay consistent with monad
  conventions in `base` library dependency.
- Removed `map4` function.
- Add support for `ppx_let`.
- Deprecate `Parser` module. Use `Reparse` instead.
