### PR TITLE
Add upper bound to http-multipart-formdata

### DIFF
--- a/packages/http-multipart-formdata/http-multipart-formdata.1.0.0/opam
+++ b/packages/http-multipart-formdata/http-multipart-formdata.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.10.0"}
   "fmt" {>= "0.8.9"}
-  "reparse"
+  "reparse" {<= "2.0.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/http-multipart-formdata/http-multipart-formdata.1.0.1/opam
+++ b/packages/http-multipart-formdata/http-multipart-formdata.1.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.10.0"}
   "fmt" {>= "0.8.9"}
-  "reparse"
+  "reparse" {<= "2.0.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Both version 1.0.0 and 1.0.1. This is needed for https://github.com/ocaml/opam-repository/pull/18459 to pass CI checks successfully.