### PR TITLE
Package http-multipart-formdata.1.1.0

### DIFF
--- a/packages/http-multipart-formdata/http-multipart-formdata.1.1.0/opam
+++ b/packages/http-multipart-formdata/http-multipart-formdata.1.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.10.0"}
   "fmt" {>= "0.8.9"}
-  "reparse" {= "2.1.0"}
+  "reparse" {>= "2.1.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/http-multipart-formdata/http-multipart-formdata.1.1.0/opam
+++ b/packages/http-multipart-formdata/http-multipart-formdata.1.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Http multipart/formdata parser"
+description:
+  "OCaml implementation of RFC 7578 (Returning Values from Forms: multipart/form-data)- https://tools.ietf.org/html/rfc7578"
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem, <gbikal@gmail.com>"]
+license: "MPL-2.0"
+tags: ["http" "multipart" "formadata" "form" "web"]
+homepage: "https://github.com/lemaetech/http-mutlipart-formdata"
+bug-reports: "https://github.com/lemaetech/http-mutlipart-formdata/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "fmt" {>= "0.8.9"}
+  "reparse" {= "2.1.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/http-mutlipart-formdata.git"
+url {
+  src:
+    "https://github.com/lemaetech/http-mutlipart-formdata/archive/v1.1.0.tar.gz"
+  checksum: [
+    "md5=bc7caa989b76b1202fbe0a2271acd10a"
+    "sha512=d05c9bfc0dd3f65fd890e581c88a9a3729ab2c88e2c8d424581f0411fc52525af445b79a1f8a1f9760a012629e22fc323e467a58e7ab2dfd4769dea45df74efd"
+  ]
+}


### PR DESCRIPTION
### `http-multipart-formdata.1.1.0`
Http multipart/formdata parser
OCaml implementation of RFC 7578 (Returning Values from Forms: multipart/form-data)- https://tools.ietf.org/html/rfc7578



---
* Homepage: https://github.com/lemaetech/http-mutlipart-formdata
* Source repo: git+https://github.com/lemaetech/http-mutlipart-formdata.git
* Bug tracker: https://github.com/lemaetech/http-mutlipart-formdata/issues

---
:camel: Pull-request generated by opam-publish v2.0.3