### PR TITLE
[new release] http-cookie (3.0.0)

### DIFF
--- a/packages/http-cookie/http-cookie.3.0.0/opam
+++ b/packages/http-cookie/http-cookie.3.0.0/opam
@@ -26,12 +26,12 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/lemaetech/http-cookie.git"
-x-commit-hash: "8d9e601e994ab43ba610d46856b1ea939671041e"
+x-commit-hash: "063f3160517f3c8bfe848d0f0d80b76450a9034c"
 url {
   src:
     "https://github.com/lemaetech/http-cookie/releases/download/v3.0.0/http-cookie-v3.0.0.tbz"
   checksum: [
-    "sha256=66b131ca6e63bc46ef859fc8924c815377377abfb2c52324c658d9c000130475"
-    "sha512=42d351a522355edca8bdf64b0048e7fb6af0be21bded8ff8fb75bf7ff463360511b2e17de4b22a9ad29887993baf916bc0ee3d1092496a6ca86bb05832abf118"
+    "sha256=e212047a2b4694a8d13bcbc89f193f49eab0d1d302e6401c200cba10aa36c819"
+    "sha512=d84780669435830c5be08514e596f5800ecaf563dc634ee0cc698c78aab228ad1930698a23f180960c41aa476b19117f298a7f2e2c73133b1e18c4268ce13d5f"
   ]
 }


### PR DESCRIPTION
HTTP cookie library for OCaml

- Project page: <a href="https://github.com/lemaetech/http-cookie">https://github.com/lemaetech/http-cookie</a>

##### CHANGES:

- Backwards incompatible change: remove `base-unix` dependency. Uses own `date_time` instead of `Unix.tm`.
