### PR TITLE
irmin: fix older builds

### DIFF
--- a/packages/irmin/irmin.1.0.0/opam
+++ b/packages/irmin/irmin.1.0.0/opam
@@ -41,16 +41,18 @@ depends: [
   "ocamlgraph"
   "lwt" {>= "2.4.7"}
   "logs" {>= "0.5.0"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "3.3.0"}
   "jsonm" {>= "1.0.0"}
   "uri" {>= "1.3.12"}
   "astring"
   "hex"
+  "re"
   "alcotest" {with-test}
   "git-unix" {with-test & >= "1.10.0"}
   "mtime" {with-test & < "1.0.0"}
   "irmin-watcher" {with-test & >= "0.2.0"}
 ]
+conflicts: [ "result" { >= "1.5" } ]
 synopsis:
   "Irmin, a distributed database that follows the same design principles as Git"
 description: """

--- a/packages/irmin/irmin.1.0.0/opam
+++ b/packages/irmin/irmin.1.0.0/opam
@@ -47,7 +47,7 @@ depends: [
   "astring"
   "hex"
   "re"
-  "alcotest" {with-test}
+  "alcotest" {with-test & < "1.0.0" }
   "git-unix" {with-test & >= "1.10.0"}
   "mtime" {with-test & < "1.0.0"}
   "irmin-watcher" {with-test & >= "0.2.0"}

--- a/packages/irmin/irmin.1.0.1/opam
+++ b/packages/irmin/irmin.1.0.1/opam
@@ -41,16 +41,18 @@ depends: [
   "ocamlgraph"
   "lwt" {>= "2.4.7"}
   "logs" {>= "0.5.0"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & <"3.3.0"}
   "jsonm" {>= "1.0.0"}
   "uri" {>= "1.3.12"}
   "astring"
   "hex"
+  "re"
   "alcotest" {with-test}
   "git-unix" {with-test & >= "1.10.0"}
   "mtime" {with-test & < "1.0.0"}
   "irmin-watcher" {with-test & >= "0.2.0"}
 ]
+conflicts: [ "result" { >= "1.5" } ]
 synopsis:
   "Irmin, a distributed database that follows the same design principles as Git"
 description: """

--- a/packages/irmin/irmin.1.0.1/opam
+++ b/packages/irmin/irmin.1.0.1/opam
@@ -47,7 +47,7 @@ depends: [
   "astring"
   "hex"
   "re"
-  "alcotest" {with-test}
+  "alcotest" {with-test  & < "1.0.0" }
   "git-unix" {with-test & >= "1.10.0"}
   "mtime" {with-test & < "1.0.0"}
   "irmin-watcher" {with-test & >= "0.2.0"}

--- a/packages/irmin/irmin.1.0.2/opam
+++ b/packages/irmin/irmin.1.0.2/opam
@@ -41,16 +41,18 @@ depends: [
   "ocamlgraph"
   "lwt" {>= "2.4.7"}
   "logs" {>= "0.5.0"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & <"3.3.0"}
   "jsonm" {>= "1.0.0"}
   "uri" {>= "1.3.12"}
   "astring"
+  "re"
   "hex" {>= "0.2.0"}
   "alcotest" {with-test}
   "git-unix" {with-test & >= "1.10.0"}
   "mtime" {with-test & < "1.0.0"}
   "irmin-watcher" {with-test & >= "0.2.0"}
 ]
+conflicts: [ "result" { >= "1.5" } ]
 synopsis:
   "Irmin, a distributed database that follows the same design principles as Git"
 description: """

--- a/packages/irmin/irmin.1.0.2/opam
+++ b/packages/irmin/irmin.1.0.2/opam
@@ -47,7 +47,7 @@ depends: [
   "astring"
   "re"
   "hex" {>= "0.2.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test  & < "1.0.0" }
   "git-unix" {with-test & >= "1.10.0"}
   "mtime" {with-test & < "1.0.0"}
   "irmin-watcher" {with-test & >= "0.2.0"}

--- a/packages/irmin/irmin.1.1.0/opam
+++ b/packages/irmin/irmin.1.1.0/opam
@@ -45,12 +45,14 @@ depends: [
   "jsonm" {>= "1.0.0"}
   "uri" {>= "1.3.12"}
   "astring"
+  "re"
   "hex" {>= "0.2.0"}
   "alcotest" {with-test}
   "git-unix" {with-test & >= "1.10.0"}
   "mtime" {with-test & < "1.0.0"}
   "irmin-watcher" {with-test & >= "0.2.0"}
 ]
+conflicts: [ "result" { >= "1.5" } ]
 synopsis:
   "Irmin, a distributed database that follows the same design principles as Git"
 description: """

--- a/packages/irmin/irmin.1.1.0/opam
+++ b/packages/irmin/irmin.1.1.0/opam
@@ -47,7 +47,7 @@ depends: [
   "astring"
   "re"
   "hex" {>= "0.2.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test  & < "1.0.0" }
   "git-unix" {with-test & >= "1.10.0"}
   "mtime" {with-test & < "1.0.0"}
   "irmin-watcher" {with-test & >= "0.2.0"}

--- a/packages/irmin/irmin.1.2.0/opam
+++ b/packages/irmin/irmin.1.2.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "jbuilder"
-  "result"
+  "result" {< "1.5"}
   "fmt" {>= "0.8.0"}
   "uri" {>= "1.3.12"}
   "cstruct" {>= "1.6.0"}

--- a/packages/irmin/irmin.1.3.0/opam
+++ b/packages/irmin/irmin.1.3.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "jbuilder" {>= "1.0+beta10"}
-  "result"
+  "result" {< "1.5"}
   "fmt" {>= "0.8.0"}
   "uri" {>= "1.3.12"}
   "cstruct" {>= "1.6.0"}


### PR DESCRIPTION
irmin 1.2/1.3 cannot use the latest Result due to the switch
to module aliases (causing a Result.t = t type collision)

Older ones also required a `re` dependency