### PR TITLE
conf-sqlite3: use the Homebrew package name, not the alias

### DIFF
--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -23,7 +23,7 @@ depexts: [
   ["sqlite-dev"] {os-distribution = "alpine"}
   ["sqlite3-devel"] {os-family = "suse"}
   ["sqlite"] {os-distribution = "nixos"}
-  ["sqlite3"] {os = "macos" & os-distribution = "homebrew"}
+  ["sqlite"] {os = "macos" & os-distribution = "homebrew"}
   ["sqlite3"] {os = "macos" & os-distribution = "macports"}
 ]
 synopsis: "Virtual package relying on an SQLite3 system installation"


### PR DESCRIPTION
The Homebrew package for sqlite is called "sqlite", not "sqlite3".
This affects opam 2.1's builtin depext detection, which doesnt
like aliases.

https://github.com/Homebrew/homebrew-core/blob/master/Formula/sqlite.rb