### PR TITLE
[new release] textmate-language (0.2.1)

### DIFF
--- a/packages/textmate-language/textmate-language.0.2.1/opam
+++ b/packages/textmate-language/textmate-language.0.2.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Tokenizing source code with TextMate grammars"
+description: """
+
+Tokenizing source code with TextMate grammars."""
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "MIT"
+homepage: "https://github.com/alan-j-hu/ocaml-textmate-language"
+doc: "https://alan-j-hu.github.io/ocaml-textmate-language/"
+bug-reports: "https://github.com/alan-j-hu/ocaml-textmate-language/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "oniguruma" {< "0.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/ocaml-textmate-language.git"
+x-commit-hash: "096fca63f54f5213acb7e5d327d54945265f2a38"
+url {
+  src:
+    "https://github.com/alan-j-hu/ocaml-textmate-language/releases/download/0.2.1/textmate-language-0.2.1.tbz"
+  checksum: [
+    "sha256=eccf792650ed3156d8aa2e221f002098614168f5c9cd70220904865924ee56e0"
+    "sha512=7e9c618eef3fdcf4ee702e57079460e321390a9eb9ea062fec1bacde3cc982596bdcaf77acf59b4f615a4fa17fa9b3897f82d4dd5f79b7d071c0c581729c4c5e"
+  ]
+}


### PR DESCRIPTION
Tokenizing source code with TextMate grammars

- Project page: <a href="https://github.com/alan-j-hu/ocaml-textmate-language">https://github.com/alan-j-hu/ocaml-textmate-language</a>
- Documentation: <a href="https://alan-j-hu.github.io/ocaml-textmate-language/">https://alan-j-hu.github.io/ocaml-textmate-language/</a>

##### CHANGES:

- Check capture index bounds and ignore out-of-bounds captures indices in
  rules. Previously the underlying Oniguruma library would throw an
  `Invalid_argument` exception.
