### PR TITLE
2 packages from LexiFi/gen_js_api at 1.0.8

### DIFF
--- a/packages/gen_js_api/gen_js_api.1.0.8/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.8/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Easy OCaml bindings for JavaScript libraries"
+description: """
+
+gen_js_api aims at simplifying the creation of OCaml bindings for
+JavaScript libraries.  Authors of bindings write OCaml signatures for
+JavaScript libraries and the tool generates the actual binding code
+with a combination of implicit conventions and explicit annotations.
+
+gen_js_api is to be used with the js_of_ocaml compiler.
+ """
+maintainer: ["Alain Frisch <alain.frisch@lexifi.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Sebastien Briais <sebastien.briais@lexifi.com>"
+]
+license: "MIT"
+homepage: "https://github.com/LexiFi/gen_js_api"
+bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.22"}
+  "js_of_ocaml-compiler" {with-test}
+  "conf-npm" {with-test}
+  "ojs"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "js_of_ocaml-compiler" {< "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/LexiFi/gen_js_api.git"
+url {
+  src: "https://github.com/LexiFi/gen_js_api/archive/v1.0.8.tar.gz"
+  checksum: [
+    "md5=4e796cdd06f3c7440e9342ff034c14d5"
+    "sha512=df3dad1ce2359b8fbaee5fcc08b07fc34ba57016baac4e153f2d3cd061eba21596d5ec0088ca697420227e153a37a56b64e301a8524bc853fe8c12e215cb0689"
+  ]
+}

--- a/packages/gen_js_api/gen_js_api.1.0.8/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.8/opam
@@ -43,6 +43,9 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+x-ci-accept-failures: [
+  "ubuntu-16.04"
+]
 dev-repo: "git+https://github.com/LexiFi/gen_js_api.git"
 url {
   src: "https://github.com/LexiFi/gen_js_api/archive/v1.0.8.tar.gz"

--- a/packages/ojs/ojs.1.0.8/opam
+++ b/packages/ojs/ojs.1.0.8/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Runtime Library for gen_js_api generated libraries"
+description: "To be used in conjunction with gen_js_api"
+maintainer: ["Alain Frisch <alain.frisch@lexifi.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Sebastien Briais <sebastien.briais@lexifi.com>"
+]
+license: "MIT"
+homepage: "https://github.com/LexiFi/gen_js_api"
+bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "js_of_ocaml-compiler" {< "3.0.0"}
+]
+dev-repo: "git+https://github.com/LexiFi/gen_js_api.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+url {
+  src: "https://github.com/LexiFi/gen_js_api/archive/v1.0.8.tar.gz"
+  checksum: [
+    "md5=4e796cdd06f3c7440e9342ff034c14d5"
+    "sha512=df3dad1ce2359b8fbaee5fcc08b07fc34ba57016baac4e153f2d3cd061eba21596d5ec0088ca697420227e153a37a56b64e301a8524bc853fe8c12e215cb0689"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`gen_js_api.1.0.8`: Easy OCaml bindings for JavaScript libraries
-`ojs.1.0.8`: Runtime Library for gen_js_api generated libraries



---
* Homepage: https://github.com/LexiFi/gen_js_api
* Source repo: git+https://github.com/LexiFi/gen_js_api.git
* Bug tracker: https://github.com/LexiFi/gen_js_api/issues

---
:camel: Pull-request generated by opam-publish v2.0.3