### PR TITLE
Release Caqti 1.5.0.

### DIFF
--- a/packages/caqti-async/caqti-async.1.3.0/opam
+++ b/packages/caqti-async/caqti-async.1.3.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "async_kernel" {>= "v0.11.0"}
   "async_unix" {>= "v0.11.0"}
-  "caqti" {>= "1.3.0" & < "1.5.0~"}
+  "caqti" {>= "1.3.0" & < "1.6.0~"}
   "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
   "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
   "core_kernel"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.5.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.5.0/opam
@@ -7,25 +7,22 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml"
-  "caqti" {>= "1.3.0" & < "1.6.0~"}
-  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
-  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti" {>= "1.5.0" & < "1.6.0~"}
   "dune" {>= "1.11"}
-  "logs"
-  "lwt" {>= "3.2.0"}
+  "mariadb" {>= "1.1.1"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
-synopsis: "Lwt support for Caqti"
-x-commit-hash: "60bd0293d8deffe72e8f909775bfdd2ed4a8ec0d"
+synopsis: "MariaDB driver for Caqti using C bindings"
+x-commit-hash: "bccdbe39e813e76e87b910ca875392703f8e4caa"
 url {
   src:
-    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.3.0/caqti-v1.3.0.tbz"
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.5.0/caqti-v1.5.0.tbz"
   checksum: [
-    "sha256=a15d71b6428997703273dc6d55a99045fb62c3243c751de5ae8c3fc25421f16a"
-    "sha512=386502d9ea2f1769081b81e6888bf4c2a27248498eabc0d4eb4adfde04c74f48f2aa587c0ce3a34604c73d157ed6533052b4d0b9a0fb3f352929ef847f3aa9fa"
+    "sha256=9524c75c87677eb75e68fbbf421d84b7b610bf2f344bfa227e23465644e62e26"
+    "sha512=8c1f289d269d0017bf8b489e64c1153448c62f79a991349662722f4de74c0cbbd75dcdca266b7276af55200346d38dce8135da247e5fbc235a3660785a03b01f"
   ]
 }

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.5.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.5.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.5.0" & < "1.6.0~"}
+  "dune" {>= "1.11"}
+  "postgresql" {>= "5.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+x-commit-hash: "bccdbe39e813e76e87b910ca875392703f8e4caa"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.5.0/caqti-v1.5.0.tbz"
+  checksum: [
+    "sha256=9524c75c87677eb75e68fbbf421d84b7b610bf2f344bfa227e23465644e62e26"
+    "sha512=8c1f289d269d0017bf8b489e64c1153448c62f79a991349662722f4de74c0cbbd75dcdca266b7276af55200346d38dce8135da247e5fbc235a3660785a03b01f"
+  ]
+}

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.5.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.5.0/opam
@@ -7,25 +7,22 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml"
-  "caqti" {>= "1.3.0" & < "1.6.0~"}
-  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
-  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti" {>= "1.5.0" & < "1.6.0~"}
   "dune" {>= "1.11"}
-  "logs"
-  "lwt" {>= "3.2.0"}
+  "sqlite3"
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
-synopsis: "Lwt support for Caqti"
-x-commit-hash: "60bd0293d8deffe72e8f909775bfdd2ed4a8ec0d"
+synopsis: "Sqlite3 driver for Caqti using C bindings"
+x-commit-hash: "bccdbe39e813e76e87b910ca875392703f8e4caa"
 url {
   src:
-    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.3.0/caqti-v1.3.0.tbz"
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.5.0/caqti-v1.5.0.tbz"
   checksum: [
-    "sha256=a15d71b6428997703273dc6d55a99045fb62c3243c751de5ae8c3fc25421f16a"
-    "sha512=386502d9ea2f1769081b81e6888bf4c2a27248498eabc0d4eb4adfde04c74f48f2aa587c0ce3a34604c73d157ed6533052b4d0b9a0fb3f352929ef847f3aa9fa"
+    "sha256=9524c75c87677eb75e68fbbf421d84b7b610bf2f344bfa227e23465644e62e26"
+    "sha512=8c1f289d269d0017bf8b489e64c1153448c62f79a991349662722f4de74c0cbbd75dcdca266b7276af55200346d38dce8135da247e5fbc235a3660785a03b01f"
   ]
 }

--- a/packages/caqti-dynload/caqti-dynload.1.3.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.1.3.0/opam
@@ -7,7 +7,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "caqti" {>= "1.3.0" & < "1.5.0~"}
+  "caqti" {>= "1.3.0" & < "1.6.0~"}
   "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
   "dune" {>= "1.11"}
   "ocamlfind"

--- a/packages/caqti/caqti.1.5.0/opam
+++ b/packages/caqti/caqti.1.5.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "Nathan Rebours <nathan@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "cppo" {build}
+  "dune" {>= "1.11"}
+  "logs"
+  "ocaml" {>= "4.04.0"}
+  "ptime"
+  "uri" {>= "1.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Unified interface to relational database libraries"
+description: """
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators."""
+x-commit-hash: "bccdbe39e813e76e87b910ca875392703f8e4caa"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.5.0/caqti-v1.5.0.tbz"
+  checksum: [
+    "sha256=9524c75c87677eb75e68fbbf421d84b7b610bf2f344bfa227e23465644e62e26"
+    "sha512=8c1f289d269d0017bf8b489e64c1153448c62f79a991349662722f4de74c0cbbd75dcdca266b7276af55200346d38dce8135da247e5fbc235a3660785a03b01f"
+  ]
+}


### PR DESCRIPTION
There is only two changes since the last release,

- Request the full UTF-8 character for the MariaDB connection.
- Support int16 and enum types for parameters and rows.

but some people hit some limitations due to the increased DB type safety introduced by 1.4.0, which is addressed by the second point.
