### PR TITLE
redirect ocaml/ocaml issues to ocaml/opam-repository

### DIFF
--- a/packages/graphics/graphics.3.07+1/opam
+++ b/packages/graphics/graphics.3.07+1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.07+2/opam
+++ b/packages/graphics/graphics.3.07+2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.07/opam
+++ b/packages/graphics/graphics.3.07/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.08.0/opam
+++ b/packages/graphics/graphics.3.08.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.08.1/opam
+++ b/packages/graphics/graphics.3.08.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.08.2/opam
+++ b/packages/graphics/graphics.3.08.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.08.3/opam
+++ b/packages/graphics/graphics.3.08.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.08.4/opam
+++ b/packages/graphics/graphics.3.08.4/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.09.0/opam
+++ b/packages/graphics/graphics.3.09.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.09.1/opam
+++ b/packages/graphics/graphics.3.09.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.09.2/opam
+++ b/packages/graphics/graphics.3.09.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.09.3/opam
+++ b/packages/graphics/graphics.3.09.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.10.0/opam
+++ b/packages/graphics/graphics.3.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.10.1/opam
+++ b/packages/graphics/graphics.3.10.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.10.2/opam
+++ b/packages/graphics/graphics.3.10.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.11.0/opam
+++ b/packages/graphics/graphics.3.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.11.1/opam
+++ b/packages/graphics/graphics.3.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.11.2/opam
+++ b/packages/graphics/graphics.3.11.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.12.0/opam
+++ b/packages/graphics/graphics.3.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.3.12.1/opam
+++ b/packages/graphics/graphics.3.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.00.0/opam
+++ b/packages/graphics/graphics.4.00.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.00.1/opam
+++ b/packages/graphics/graphics.4.00.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.01.0/opam
+++ b/packages/graphics/graphics.4.01.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.02.0/opam
+++ b/packages/graphics/graphics.4.02.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.02.1/opam
+++ b/packages/graphics/graphics.4.02.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.02.2/opam
+++ b/packages/graphics/graphics.4.02.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.02.3/opam
+++ b/packages/graphics/graphics.4.02.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.03.0/opam
+++ b/packages/graphics/graphics.4.03.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.04.0/opam
+++ b/packages/graphics/graphics.4.04.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.04.1/opam
+++ b/packages/graphics/graphics.4.04.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.04.2/opam
+++ b/packages/graphics/graphics.4.04.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.05.0/opam
+++ b/packages/graphics/graphics.4.05.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.06.0/opam
+++ b/packages/graphics/graphics.4.06.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.06.1/opam
+++ b/packages/graphics/graphics.4.06.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.07.0/opam
+++ b/packages/graphics/graphics.4.07.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.07.1/opam
+++ b/packages/graphics/graphics.4.07.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.08.0/opam
+++ b/packages/graphics/graphics.4.08.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/graphics/graphics.4.08.1/opam
+++ b/packages/graphics/graphics.4.08.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david.allsopp@metastack.com>"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
 authors: [ "Xavier Leroy"
            "Jun Furuse"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+1/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.07+1 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.07"
 depends: [
   "ocaml" {= "3.07+1" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07+2/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.07+2 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.07"
 depends: [
   "ocaml" {= "3.07+2" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.07/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.07 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.07"
 depends: [
   "ocaml" {= "3.07" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.08.0 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.08"
 depends: [
   "ocaml" {= "3.08.0" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.1/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.08.1 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.08"
 depends: [
   "ocaml" {= "3.08.1" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.2/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.08.2 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.08"
 depends: [
   "ocaml" {= "3.08.2" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.3/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.08.3 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.08"
 depends: [
   "ocaml" {= "3.08.3" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.08.4/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.08.4 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.08"
 depends: [
   "ocaml" {= "3.08.4" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.09.0 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.09"
 depends: [
   "ocaml" {= "3.09.0" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.1/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.09.1 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.09"
 depends: [
   "ocaml" {= "3.09.1" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.2/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.09.2 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.09"
 depends: [
   "ocaml" {= "3.09.2" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.09.3/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.09.3 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.09"
 depends: [
   "ocaml" {= "3.09.3" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.10.0 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.10"
 depends: [
   "ocaml" {= "3.10.0" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.1/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.10.1 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.10"
 depends: [
   "ocaml" {= "3.10.1" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.10.2/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.10.2 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.10"
 depends: [
   "ocaml" {= "3.10.2" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.11.0 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.11"
 depends: [
   "ocaml" {= "3.11.0" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.1/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.11.1 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.11"
 depends: [
   "ocaml" {= "3.11.1" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.11.2/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.11.2 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.11"
 depends: [
   "ocaml" {= "3.11.2" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.12.0 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.12"
 depends: [
   "ocaml" {= "3.12.0" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
@@ -3,7 +3,7 @@ synopsis: "Official 3.12.1 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#3.12"
 depends: [
   "ocaml" {= "3.12.1" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official 4.00.0 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.00"
 depends: [
   "ocaml" {= "4.00.0" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
@@ -3,7 +3,7 @@ synopsis: "Official 4.00.1 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.00"
 depends: [
   "ocaml" {= "4.00.1" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official 4.01.0 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.01"
 depends: [
   "ocaml" {= "4.01.0" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official 4.02.0 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 depends: [
   "ocaml" {= "4.02.0" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
@@ -3,7 +3,7 @@ synopsis: "Official 4.02.1 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 depends: [
   "ocaml" {= "4.02.1" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
@@ -3,7 +3,7 @@ synopsis: "Official 4.02.2 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 depends: [
   "ocaml" {= "4.02.2" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
@@ -3,7 +3,7 @@ synopsis: "Official 4.02.3 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 depends: [
   "ocaml" {= "4.02.3" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official 4.03.0 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.03"
 depends: [
   "ocaml" {= "4.03.0" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official 4.04.0 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 depends: [
   "ocaml" {= "4.04.0" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
@@ -3,7 +3,7 @@ synopsis: "Official 4.04.1 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 depends: [
   "ocaml" {= "4.04.1" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
@@ -3,7 +3,7 @@ synopsis: "Official 4.04.2 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 depends: [
   "ocaml" {= "4.04.2" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official 4.05.0 release"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 depends: [
   "ocaml" {= "4.05.0" & post}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.08.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -33,7 +33,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.08.1"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -33,7 +33,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -38,7 +38,7 @@ extra-files: [
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.1/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.1"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -34,7 +34,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -34,7 +34,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.1/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.1"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -34,7 +34,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.2"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -34,7 +34,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -34,7 +34,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.1/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.1"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -34,7 +34,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.2/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.2"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -34,7 +34,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -34,7 +34,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha1/opam
@@ -3,7 +3,7 @@ synopsis: "First alpha release of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -35,7 +35,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
@@ -3,7 +3,7 @@ synopsis: "Second alpha release of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -35,7 +35,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/opam
@@ -3,7 +3,7 @@ synopsis: "Third alpha release of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -35,7 +35,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/opam
@@ -3,7 +3,7 @@ synopsis: "First beta release of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -35,7 +35,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta release of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -35,7 +35,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~rc1/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -35,7 +35,7 @@ extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb45
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-beta/ocaml-beta.disabled/opam
+++ b/packages/ocaml-beta/ocaml-beta.disabled/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "platform@lists.ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml-manual/ocaml-manual.4.08.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.08.0/opam
@@ -10,7 +10,7 @@ homepage: "http://ocaml.org/"
 doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
 license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 install:
 [
  [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}

--- a/packages/ocaml-manual/ocaml-manual.4.09.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.09.0/opam
@@ -10,7 +10,7 @@ homepage: "http://ocaml.org/"
 doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
 license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 install:
 [
  [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}

--- a/packages/ocaml-manual/ocaml-manual.4.10.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.10.0/opam
@@ -10,7 +10,7 @@ homepage: "http://ocaml.org/"
 doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
 license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 install:
 [
  [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}

--- a/packages/ocaml-manual/ocaml-manual.4.11.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.11.0/opam
@@ -10,7 +10,7 @@ homepage: "http://ocaml.org/"
 doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
 license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 install:
 [
  [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}

--- a/packages/ocaml-manual/ocaml-manual.4.12.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.12.0/opam
@@ -10,7 +10,7 @@ homepage: "http://ocaml.org/"
 doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
 license: "(c) Institut National de Recherche en Informatique et en Automatique (INRIA)"
 dev-repo: "git+https://github.com/ocaml/ocaml.git"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 install:
 [
  [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/opam
@@ -3,7 +3,7 @@ synopsis: "OCaml 4.08.1 Secondary Switch Compiler"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: "ocaml" {< "4.08.0" | >= "4.09~"}
 build: [
@@ -40,7 +40,7 @@ patches: [
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
@@ -3,7 +3,7 @@ synopsis: "OCaml 4.08.1 Secondary Switch Compiler"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: "ocaml" {< "4.08.0"}
 build: [
@@ -37,7 +37,7 @@ patches: [
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-system/ocaml-system.4.09.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.09.1/opam
@@ -3,7 +3,7 @@ synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {post}

--- a/packages/ocaml-system/ocaml-system.4.10.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.10.0/opam
@@ -3,7 +3,7 @@ synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {post}

--- a/packages/ocaml-system/ocaml-system.4.10.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.10.1/opam
@@ -3,7 +3,7 @@ synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {post}

--- a/packages/ocaml-system/ocaml-system.4.10.2/opam
+++ b/packages/ocaml-system/ocaml-system.4.10.2/opam
@@ -3,7 +3,7 @@ synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {post}

--- a/packages/ocaml-system/ocaml-system.4.11.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.11.0/opam
@@ -3,7 +3,7 @@ synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {post}

--- a/packages/ocaml-system/ocaml-system.4.11.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.11.1/opam
@@ -3,7 +3,7 @@ synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {post}

--- a/packages/ocaml-system/ocaml-system.4.11.2/opam
+++ b/packages/ocaml-system/ocaml-system.4.11.2/opam
@@ -3,7 +3,7 @@ synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {post}

--- a/packages/ocaml-system/ocaml-system.4.12.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.12.0/opam
@@ -3,7 +3,7 @@ synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {post}

--- a/packages/ocaml-variants/ocaml-variants.4.02.4+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.4+trunk/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.02 trunk snapshot"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 depends: [
   "ocaml" {= "4.02.4" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.03.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.1+trunk/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.03 snapshot"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.03"
 depends: [
   "ocaml" {= "4.03.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.04.3+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.3+trunk/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.04 snapshot"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 depends: [
   "ocaml" {= "4.04.3" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.05 snapshot with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 depends: [
   "ocaml" {= "4.05.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.05 snapshot with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 depends: [
   "ocaml" {= "4.05.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.05 snapshot with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 depends: [
   "ocaml" {= "4.05.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.05 snapshot with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 depends: [
   "ocaml" {= "4.05.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+safe-string/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.05 snapshot with -safe-string enabled"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 depends: [
   "ocaml" {= "4.05.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.05 snapshot"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 depends: [
   "ocaml" {= "4.05.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+afl/opam
@@ -3,7 +3,7 @@ synopsis: "4.06 release branch with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 depends: [
   "ocaml" {= "4.06.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "4.06 release branch with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 depends: [
   "ocaml" {= "4.06.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+force-safe-string/opam
@@ -3,7 +3,7 @@ synopsis: "4.06 release branch with -safe-string enabled"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 depends: [
   "ocaml" {= "4.06.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "4.06 release branch with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 depends: [
   "ocaml" {= "4.06.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+fp/opam
@@ -3,7 +3,7 @@ synopsis: "4.06 release branch with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 depends: [
   "ocaml" {= "4.06.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk/opam
@@ -3,7 +3,7 @@ synopsis: "4.06 release branch snapshot"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 depends: [
   "ocaml" {= "4.06.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
@@ -60,7 +60,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
@@ -49,7 +49,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
@@ -50,7 +50,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
@@ -49,7 +49,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
@@ -48,7 +48,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
@@ -48,7 +48,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
@@ -43,7 +43,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
@@ -50,7 +50,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
@@ -48,7 +48,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
@@ -43,7 +43,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
@@ -50,7 +50,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
@@ -60,7 +60,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
@@ -48,7 +48,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
@@ -50,7 +50,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
@@ -43,7 +43,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
@@ -50,7 +50,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
@@ -56,7 +56,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
@@ -48,7 +48,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
@@ -60,7 +60,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
@@ -48,7 +48,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
@@ -50,7 +50,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
@@ -43,7 +43,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
@@ -50,7 +50,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.07 development with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 depends: [
   "ocaml" {= "4.07.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+default-unsafe-string/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.07 development without safe strings by default"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 depends: [
   "ocaml" {= "4.07.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.07 development with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 depends: [
   "ocaml" {= "4.07.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.07 development with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 depends: [
   "ocaml" {= "4.07.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.07 development with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 depends: [
   "ocaml" {= "4.07.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.07 development snapshot"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 depends: [
   "ocaml" {= "4.07.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+32bit/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -44,7 +44,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.08.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
@@ -33,7 +33,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
@@ -32,7 +32,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
@@ -31,7 +31,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
@@ -33,7 +33,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
@@ -32,7 +32,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
@@ -31,7 +31,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
@@ -32,7 +32,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
@@ -32,7 +32,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
@@ -31,7 +31,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+bytecode-only/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.08.0, without the native-code compiler"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+flambda+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.08.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+force-safe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+fp+flambda/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.08.0, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -46,7 +46,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+afl/opam
@@ -33,7 +33,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+default-unsafe-string/opam
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+flambda/opam
@@ -32,7 +32,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp+flambda/opam
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp/opam
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1/opam
@@ -31,7 +31,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.08.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+default-unsafe-string/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.08.0, without safe strings by default"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.08.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.08.0, with frame-pointers and flambda 
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.08.0, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.08.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+spacetime/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.08.0, with spacetime activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+32bit/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.08.1, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+bytecode-only/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.08.1, without the native-code compiler"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+flambda+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.08.1, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+force-safe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+fp+flambda/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.08.1, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -43,7 +43,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -46,7 +46,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+afl/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.08.1, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.08.1, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+force-safe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.08.1, with frame-pointers and flambda a
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+fp/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.08.1, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.08.1"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.08.1, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.08.1, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+force-safe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.08.1, with frame-pointers and flambda 
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.08.1, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.08.1"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Third release candidate for 4.08.1, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Third release candidate for 4.08.1, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+force-safe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Third release candidate for 4.08.1, with frame-pointers and flambda a
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Third release candidate for 4.08.1, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3/opam
@@ -3,7 +3,7 @@ synopsis: "Third release candidate for 4.08.1"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+spacetime/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.08.1, with spacetime activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.08.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.08 development, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.08"
 depends: [
   "ocaml" {= "4.08.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.08"
 depends: [
   "ocaml" {= "4.08.2" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.08 development, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.08"
 depends: [
   "ocaml" {= "4.08.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+force-safe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.08"
 depends: [
   "ocaml" {= "4.08.2" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.08.2 development, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.08"
 depends: [
   "ocaml" {= "4.08.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.08 development, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.08"
 depends: [
   "ocaml" {= "4.08.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.08 development"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.08"
 depends: [
   "ocaml" {= "4.08.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+32bit/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+afl/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.09.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+default-unsafe-string/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.09.0, without safe strings by default"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.09.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.09.0, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.09.0, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.09.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.09.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+default-unsafe-string/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.09.0, without safe strings by default"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.09.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.09.0, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.09.0, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.09.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+bytecode-only/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.0, without the native-code compiler"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+flambda+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+force-safe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+fp+flambda/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.0, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -45,7 +45,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+spacetime/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.0, with spacetime activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+32bit/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+afl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+afl+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.1, with afl-fuzz instrumentation and flambda ac
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.1, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+bytecode-only/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.1, without the native-code compiler"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+flambda+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.1, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+force-safe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+fp+flambda/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.1, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+musl+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+musl+static+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -45,7 +45,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+spacetime/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.09.1, with spacetime activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.09.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.09 development, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.09"
 depends: [
   "ocaml" {= "4.09.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+default-unsafe-string/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.09 development, without safe strings by default"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.09"
 depends: [
   "ocaml" {= "4.09.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.09 development, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.09"
 depends: [
   "ocaml" {= "4.09.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.09 development, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.09"
 depends: [
   "ocaml" {= "4.09.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.09 development, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.09"
 depends: [
   "ocaml" {= "4.09.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.09.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.2+trunk/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.09 development"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.09"
 depends: [
   "ocaml" {= "4.09.2" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+32bit/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+afl/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.10.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.10.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.10.0, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+fp/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.10.0, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.10.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.10.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.10.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.10.0, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.10.0, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.10.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+bytecode-only/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.0, without the native-code compiler"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+flambda+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+fp+flambda/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.0, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+musl+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+musl+static+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -45,7 +45,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+nnpcheck/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+nnpcheck/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.0, with a dynamic check for naked pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+afl/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.10.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.10.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.10.0, with frame-pointers and flambda a
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+fp/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.10.0, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.10.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.10.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.10.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.10.0, with frame-pointers and flambda 
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.10.0, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.10.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+spacetime/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.0, with spacetime activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+32bit/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.1, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+bytecode-only/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.1, without the native-code compiler"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+flambda+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.1, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+fp+flambda/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.1, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+musl+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+musl+static+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -45,7 +45,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+afl/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.10.1, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.10.1, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.10.1, with frame-pointers and flambda a
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+fp/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.10.1, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.10.1"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -33,7 +33,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+spacetime/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.1, with spacetime activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+32bit/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.2, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+bytecode-only/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.2, without the native-code compiler"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+flambda+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.2, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+fp+flambda/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.2, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+musl+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+musl+static+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -45,7 +45,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+spacetime/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.10.2, with spacetime activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.10.2" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.10.3+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.3+trunk+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.10 development, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.10"
 depends: [
   "ocaml" {= "4.10.3" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.10.3+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.3+trunk+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.10 development, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.10"
 depends: [
   "ocaml" {= "4.10.3" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.10.3+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.3+trunk+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.10 development, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.10"
 depends: [
   "ocaml" {= "4.10.3" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.10.3+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.3+trunk/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.09 development"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.10"
 depends: [
   "ocaml" {= "4.10.3" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+32bit/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+afl/opam
@@ -3,7 +3,7 @@ synopsis: "First alpha for 4.11.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First alpha for 4.11.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First alpha for 4.11.0, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp/opam
@@ -3,7 +3,7 @@ synopsis: "First alpha for 4.11.0, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1/opam
@@ -3,7 +3,7 @@ synopsis: "First alpha for 4.11.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Second alpha for 4.11.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second alpha for 4.11.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second alpha for 4.11.0, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Second alpha for 4.11.0, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2/opam
@@ -3,7 +3,7 @@ synopsis: "Second alpha for 4.11.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Third alpha for 4.11.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Third alpha for 4.11.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Third alpha for 4.11.0, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Third alpha for 4.11.0, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3/opam
@@ -3,7 +3,7 @@ synopsis: "Third alpha for 4.11.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+afl/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.11.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.11.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.11.0, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.11.0, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1/opam
@@ -3,7 +3,7 @@ synopsis: "First beta for 4.11.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.11.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -37,7 +37,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.11.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.11.0, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.11.0, with frame pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -39,7 +39,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta for 4.11.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Third beta for 4.11.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Third beta for 4.11.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Third beta for 4.11.0, with frame-pointers and flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Third beta for 4.11.0, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3/opam
@@ -3,7 +3,7 @@ synopsis: "Third beta for 4.11.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -33,7 +33,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+bytecode-only/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.0, without the native-code compiler"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+flambda+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+fp+flambda/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.0, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+musl+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+musl+static+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -45,7 +45,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+afl/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.11.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.11.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.11.0, with frame-pointers and flambda a
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+fp/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.11.0, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate for 4.11.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -33,7 +33,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.11.0, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.11.0, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+fp+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.11.0, with frame-pointers and flambda 
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.11.0, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2/opam
@@ -3,7 +3,7 @@ synopsis: "Second release candidate for 4.11.0"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -33,7 +33,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+spacetime/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.0, with spacetime activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.0" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+32bit/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+BER/opam
@@ -30,7 +30,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.1, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+bytecode-only/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.1, without the native-code compiler"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+flambda+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.1, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+fp+flambda/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.1, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+musl+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+musl+static+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -45,7 +45,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+spacetime/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.1, with spacetime activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.1" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+32bit/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -47,7 +47,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.2, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+bytecode-only/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.2, without the native-code compiler"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -34,7 +34,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+default-unsafe-string/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -41,7 +41,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+flambda+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.2, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+fp+flambda/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -38,7 +38,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.2, with frame-pointers"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+musl+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -42,7 +42,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+musl+static+flambda/opam
@@ -6,7 +6,7 @@ description:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -45,7 +45,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+no-flat-float-array/opam
@@ -4,7 +4,7 @@ synopsis:
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -36,7 +36,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+spacetime/opam
@@ -3,7 +3,7 @@ synopsis: "Official release 4.11.2, with spacetime activated"
 maintainer: "platform@lists.ocaml.org"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git://github.com/ocaml/ocaml"
 depends: [
   "ocaml" {= "4.11.2" & post}
@@ -35,7 +35,7 @@ url {
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.11.3+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.3+trunk+afl/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.11 development, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.11"
 depends: [
   "ocaml" {= "4.11.3" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.11.3+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.3+trunk+flambda/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.11 development, with flambda activated"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.11"
 depends: [
   "ocaml" {= "4.11.3" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.11.3+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.3+trunk+fp/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.11 development, with afl-fuzz instrumentation"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.11"
 depends: [
   "ocaml" {= "4.11.3" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.11.3+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.3+trunk/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.11 development"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.11"
 depends: [
   "ocaml" {= "4.11.3" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+options/opam
@@ -3,7 +3,7 @@ synopsis: "Official release of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -56,7 +56,7 @@ extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
@@ -3,7 +3,7 @@ synopsis: "First alpha release of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -56,7 +56,7 @@ extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
@@ -3,7 +3,7 @@ synopsis: "Second alpha release of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -56,7 +56,7 @@ extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
@@ -3,7 +3,7 @@ synopsis: "Third alpha release of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -56,7 +56,7 @@ extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
@@ -3,7 +3,7 @@ synopsis: "First beta release of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -57,7 +57,7 @@ extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
@@ -3,7 +3,7 @@ synopsis: "Second beta release of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -57,7 +57,7 @@ extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~rc1+options/opam
@@ -3,7 +3,7 @@ synopsis: "First release candidate of OCaml 4.12.0"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.12"
 depends: [
   "ocaml" {= "4.12.0" & post}
@@ -57,7 +57,7 @@ extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
-   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
   {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."

--- a/packages/ocaml-variants/ocaml-variants.4.12.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.1+trunk/opam
@@ -3,7 +3,7 @@ synopsis: "Latest 4.12 development"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.12"
 depends: [
   "ocaml" {= "4.12.1" & post}

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+trunk/opam
@@ -3,7 +3,7 @@ synopsis: "Current trunk"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
 depends: [
   "ocaml" {= "4.13.0" & post}

--- a/packages/ocaml/ocaml.4.08.0/opam
+++ b/packages/ocaml/ocaml.4.08.0/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.08.1/opam
+++ b/packages/ocaml/ocaml.4.08.1/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.08.2/opam
+++ b/packages/ocaml/ocaml.4.08.2/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.09.0/opam
+++ b/packages/ocaml/ocaml.4.09.0/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.09.1/opam
+++ b/packages/ocaml/ocaml.4.09.1/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.09.2/opam
+++ b/packages/ocaml/ocaml.4.09.2/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.10.0/opam
+++ b/packages/ocaml/ocaml.4.10.0/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.10.1/opam
+++ b/packages/ocaml/ocaml.4.10.1/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.10.2/opam
+++ b/packages/ocaml/ocaml.4.10.2/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.10.3/opam
+++ b/packages/ocaml/ocaml.4.10.3/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.11.0/opam
+++ b/packages/ocaml/ocaml.4.11.0/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.11.1/opam
+++ b/packages/ocaml/ocaml.4.11.1/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.11.2/opam
+++ b/packages/ocaml/ocaml.4.11.2/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.11.3/opam
+++ b/packages/ocaml/ocaml.4.11.3/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.12.0/opam
+++ b/packages/ocaml/ocaml.4.12.0/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.12.1/opam
+++ b/packages/ocaml/ocaml.4.12.1/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.4.13.0/opam
+++ b/packages/ocaml/ocaml.4.13.0/opam
@@ -18,7 +18,7 @@ setenv: [
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/ocaml/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"


### PR DESCRIPTION
Most issues with OCaml compilation these days stem from some packaging problem (such as disaggregation from the compiler). This PR changes the default location for bug reports to the opam-repository issue tracker.  The opam-repo team can triage these and transfer relevant issues to ocaml/ocaml.

Fixes #18479