### PR TITLE
Package conformist.0.5.0

### DIFF
--- a/packages/conformist/conformist.0.5.0/opam
+++ b/packages/conformist/conformist.0.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "sexplib" {>= "v0.13.0" & with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/conformist/conformist.0.5.0/opam
+++ b/packages/conformist/conformist.0.5.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Conformist allows you to define schemas to decode, validate and sanitize input data declaratively"
+description: """
+
+Conformist allows you to define schemas to decode, validate and sanitize input data declaratively.
+It comes with runtime types for primitive OCaml types such as `int`, `string`, `bool` and `float` but also `Ptime.date`, optional and custom types.
+Re-use business rules in validators and run it on the client side with js_of_ocaml.
+Arbitrary meta data can be stored in schemas which is useful to build functionality on top of conformist.
+"""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/conformist"
+doc: "https://oxidizing.github.io/conformist/"
+bug-reports: "https://github.com/oxidizing/conformist/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.08.0"}
+  "ptime" {>= "0.8.5"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "sexplib" {>= "v0.13.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/conformist.git"
+url {
+  src: "https://github.com/oxidizing/conformist/archive/0.5.0.tar.gz"
+  checksum: [
+    "md5=4a9eed391f23b44c3b24ea0891efd8b3"
+    "sha512=1a2fa6d4c36b7cd74807a686297ee4fc3361b6c6a8e42732206a12a448ace93d91d59c56fe758a4a9bd6a1d330f91b0f7910541d671544ea6cf7630b3b26c473"
+  ]
+}


### PR DESCRIPTION
### `conformist.0.5.0`
Conformist allows you to define schemas to decode, validate and sanitize input data declaratively
Conformist allows you to define schemas to decode, validate and sanitize input data declaratively.
It comes with runtime types for primitive OCaml types such as `int`, `string`, `bool` and `float` but also `Ptime.date`, optional and custom types.
Re-use business rules in validators and run it on the client side with js_of_ocaml.
Arbitrary meta data can be stored in schemas which is useful to build functionality on top of conformist.



---
* Homepage: https://github.com/oxidizing/conformist
* Source repo: git+https://github.com/oxidizing/conformist.git
* Bug tracker: https://github.com/oxidizing/conformist/issues

---
:camel: Pull-request generated by opam-publish v2.0.3