### PR TITLE
Add xorgproto depext to conf-libX11 for macOS

### DIFF
--- a/packages/conf-libX11/conf-libX11.1/opam
+++ b/packages/conf-libX11/conf-libX11.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["libx11-dev"] {os-distribution = "alpine"}
   ["libx11"] {os-distribution = "arch"}
   ["libX11-dev"] {os-distribution = "cygwin"}
-  ["xquartz"] {os = "macos" & os-distribution = "homebrew"}
+  ["xquartz" "xorgproto"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on an Xlib system installation"
 description:


### PR DESCRIPTION
To avoid this error:

```
 #=== ERROR while compiling conf-libX11.1 ======================================#
# context     2.0.8 | macos/x86_64 | ocaml-base-compiler.4.12.0 | git+https://github.com/ocaml/opam-repository.git
# path        ~/work/js_of_ocaml/js_of_ocaml/_opam/.opam-switch/build/conf-libX11.1
# command     ~/.opam/opam-init/hooks/sandbox.sh build sh -exc PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig" pkg-config --libs x11
# exit-code   1
# env-file    ~/.opam/log/conf-libX11-2719-84e04e.env
# output-file ~/.opam/log/conf-libX11-2719-84e04e.out
### output ###
# + PKG_CONFIG_PATH=/Users/runner/work/js_of_ocaml/js_of_ocaml/_opam/lib/pkgconfig:/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig
# + pkg-config --libs x11
# Package xproto was not found in the pkg-config search path.
# Perhaps you should add the directory containing `xproto.pc'
# to the PKG_CONFIG_PATH environment variable
# Package 'xproto', required by 'x11', not found
```

https://formulae.brew.sh/formula/xorgproto