### PR TITLE
Package ezjs_min.0.2.2

### DIFF
--- a/packages/ezjs_min/ezjs_min.0.2.2/opam
+++ b/packages/ezjs_min/ezjs_min.0.2.2/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/ocamlpro/ezjs_min"
 bug-reports: "https://github.com/ocamlpro/ezjs_min/issues"
 depends: [
   "ocaml" {>= "4.05"}
-  "dune" {>= "2.8" & >= "2.8"}
+  "dune" {>= "2.8"}
   "js_of_ocaml-ppx"
   "stdlib-shims" {>= "0.1"}
   "odoc" {with-doc}

--- a/packages/ezjs_min/ezjs_min.0.2.2/opam
+++ b/packages/ezjs_min/ezjs_min.0.2.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A bunch of js_of_ocaml shortcuts"
+description: "A bunch of js_of_ocaml shortcuts"
+maintainer: "OCamlPro <contact@ocamlpro.com>"
+authors: "OCamlPro <contact@ocamlpro.com>"
+license: "LGPL-2.1"
+homepage: "https://github.com/ocamlpro/ezjs_min"
+bug-reports: "https://github.com/ocamlpro/ezjs_min/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "2.8" & >= "2.8"}
+  "js_of_ocaml-ppx"
+  "stdlib-shims" {>= "0.1"}
+  "odoc" {with-doc}
+]
+depopts: ["lwt"]
+conflicts: [
+  "lwt" {< "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamlpro/ezjs_min.git"
+url {
+  src: "https://github.com/ocamlpro/ezjs_min/archive/0.2.2.tar.gz"
+  checksum: [
+    "md5=4590d360b986bfba2bd117a7161ede98"
+    "sha512=b0b94f5bdd8dadf7bacf6cbb6fcd78885f9762bc9a3e8b1d5b866a1251e00b0f893dbff5d84987203cfdf9ac1fd43f542f328e8b9f9d8333949c1aaf0d5681ea"
+  ]
+}


### PR DESCRIPTION
### `ezjs_min.0.2.2`
A bunch of js_of_ocaml shortcuts
A bunch of js_of_ocaml shortcuts



---
* Homepage: https://github.com/ocamlpro/ezjs_min
* Source repo: git+https://github.com/ocamlpro/ezjs_min.git
* Bug tracker: https://github.com/ocamlpro/ezjs_min/issues

---
:camel: Pull-request generated by opam-publish v2.0.3