### PR TITLE
[new release] elpi (1.13.1)

### DIFF
--- a/packages/elpi/elpi.1.13.1/opam
+++ b/packages/elpi/elpi.1.13.1/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/LPCIC/elpi.git"
 bug-reports: "https://github.com/LPCIC/elpi/issues"
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [make "build" "DUNE_OPTS=-p %{name}% -j %{jobs}%"]
   [make "tests" "DUNE_OPTS=-p %{name}%" "TIMEOUT=120"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"}
 ]

--- a/packages/elpi/elpi.1.13.1/opam
+++ b/packages/elpi/elpi.1.13.1/opam
@@ -1,0 +1,85 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Claudio Sacerdoti Coen" "Enrico Tassi" ]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+build: [
+  ["dune" "subst"] {pinned}
+  [make "build" "DUNE_OPTS=-p %{name}% -j %{jobs}%"]
+  [make "tests" "DUNE_OPTS=-p %{name}%" "TIMEOUT=120"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"}
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "camlp5" {< "7.99"}
+  "ppxlib" {>= "0.12.0" & < "0.15.0"}
+  "ocaml-migrate-parsetree" {>= "1.6.0"}
+  "ppx_deriving"
+  "re" {>= "1.7.2"}
+  "ANSITerminal" {with-test}
+  "cmdliner" {with-test}
+  "dune" {>= "2.2.0"}
+  "conf-time" {with-test}
+]
+synopsis: "ELPI - Embeddable λProlog Interpreter"
+description: """
+ELPI implements a variant of λProlog enriched with Constraint Handling Rules,
+a programming language well suited to manipulate syntax trees with binders.
+
+ELPI is designed to be embedded into larger applications written in OCaml as
+an extension language. It comes with an API to drive the interpreter and 
+with an FFI for defining built-in predicates and data types, as well as
+quotations and similar goodies that are handy to adapt the language to the host
+application.
+
+This package provides both a command line interpreter (elpi) and a library to
+be linked in other applications (eg by passing -package elpi to ocamlfind).
+
+The ELPI programming language has the following features:
+
+- Native support for variable binding and substitution, via an Higher Order
+  Abstract Syntax (HOAS) embedding of the object language. The programmer needs
+  not to care about De Bruijn indexes.
+
+- Native support for hypothetical context. When moving under a binder one can
+  attach to the bound variable extra information that is collected when the
+  variable gets out of scope. For example when writing a type-checker the
+  programmer needs not to care about managing the typing context.
+
+- Native support for higher order unification variables, again via HOAS.
+  Unification variables of the meta-language (λProlog) can be reused to
+  represent the unification variables of the object language. The programmer
+  does not need to care about the unification-variable assignment map and
+  cannot assign to a unification variable a term containing variables out of
+  scope, or build a circular assignment.
+
+- Native support for syntactic constraints and their meta-level handling rules.
+  The generative semantics of Prolog can be disabled by turning a goal into a
+  syntactic constraint (suspended goal). A syntactic constraint is resumed as
+  soon as relevant variables gets assigned. Syntactic constraints can be
+  manipulated by constraint handling rules (CHR).
+
+- Native support for backtracking. To ease implementation of search.
+
+- The constraint store is extensible.  The host application can declare
+  non-syntactic constraints and use custom constraint solvers to check their
+  consistency.
+
+- Clauses are graftable. The user is free to extend an existing program by
+  inserting/removing clauses, both at runtime (using implication) and at
+  "compilation" time by accumulating files.
+
+ELPI is free software released under the terms of LGPL 2.1 or above."""
+x-commit-hash: "ba3ccbf2ded5b7669ead3ff1b6eb469105f29cbe"
+url {
+  src:
+    "https://github.com/LPCIC/elpi/releases/download/v1.13.1/elpi-v1.13.1.tbz"
+  checksum: [
+    "sha256=5a92188168c71ee324e65b70a4d0568513613bc30d275d6d6ee94484d2d30fdc"
+    "sha512=e03334802341fbf1712c1da36187322158630681b45e79cba095baab1537c58d9d33c8f8c6e71ccd88b28906d3af5d7a03f9b74ea660e521a022bf8b1d3eec6f"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- API:
  - New `gc.get` and `gc.set` for reading and writing GC settings
  - New `gc.minor`
  - New `gc.major`
  - New `gc.full`
  - New `gc.compact`
  - New `gc.stat`
  - New `gc.quick-stat`
  - New `min` and `max` operators for the `is` builtin, they work on
    `int` and `float`
  - Rename `rex_match` -> `rex.match`
  - Rename `rex_replace` -> `rex.replace`
  - Rename `rex_split` -> `rex.split`
  - Rename `counter` -> `trace.counter`
- FFI:
  - New `Builtin.unspec` type to express optional input