### PR TITLE
Release merlin (4.2-411/412 and 3.5.0) and dot-merlin-reader (3.5.0)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.3.5.0/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.3.5.0/opam
@@ -6,12 +6,12 @@ homepage:     "https://github.com/ocaml/merlin"
 bug-reports:  "https://github.com/ocaml/merlin/issues"
 dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "ocaml" {>= "4.02.1" & < "4.12"}
-  "dune" {>= "1.8.0"}
+  "dune" {>= "2.7.0"}
   "yojson" {>= "1.6.0"}
   "ocamlfind" {>= "1.6.0"}
   "csexp" {>= "1.2.3"}

--- a/packages/dot-merlin-reader/dot-merlin-reader.3.5.0/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.3.5.0/opam
@@ -5,6 +5,7 @@ synopsis:     "Reads config files for merlin"
 homepage:     "https://github.com/ocaml/merlin"
 bug-reports:  "https://github.com/ocaml/merlin/issues"
 dev-repo: "git+https://github.com/ocaml/merlin.git"
+license: "MIT"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/dot-merlin-reader/dot-merlin-reader.3.5.0/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.3.5.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.1" & < "4.12"}
+  "dune" {>= "1.8.0"}
+  "yojson" {>= "1.6.0"}
+  "ocamlfind" {>= "1.6.0"}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "menhirLib" { dev }
+]
+x-commit-hash: "353bcb82443b37cc1924039578d2b22cdb6951a9"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v3.5.0/merlin-v3.5.0.tbz"
+  checksum: [
+    "sha256=cdf5426a0f2702a862d8a0290f6175daee53e044659899060597134ad2485328"
+    "sha512=77b89009ac57a7c4e524d1a091211dd75451fd7d342bccc37012ce0a7a488bf269631fede6cb75d345f521be7ad488416ec0282090d377225dba7e8b385bc1e2"
+  ]
+}

--- a/packages/merlin/merlin.3.5.0/opam
+++ b/packages/merlin/merlin.3.5.0/opam
@@ -4,6 +4,7 @@ authors:      "The Merlin team"
 homepage:     "https://github.com/ocaml/merlin"
 bug-reports:  "https://github.com/ocaml/merlin/issues"
 dev-repo: "git+https://github.com/ocaml/merlin.git"
+license: "MIT"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/merlin/merlin.3.5.0/opam
+++ b/packages/merlin/merlin.3.5.0/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test & ocaml:version >= "4.03"}
+]
+depends: [
+  "ocaml" {>= "4.02.3" & < "4.12"}
+  "dune" {>= "1.8.0"}
+  "dot-merlin-reader" {>= "3.4.2"}
+  "yojson" {>= "1.6.0"}
+  "mdx" {with-test & >= "1.3.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+x-commit-hash: "353bcb82443b37cc1924039578d2b22cdb6951a9"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v3.5.0/merlin-v3.5.0.tbz"
+  checksum: [
+    "sha256=cdf5426a0f2702a862d8a0290f6175daee53e044659899060597134ad2485328"
+    "sha512=77b89009ac57a7c4e524d1a091211dd75451fd7d342bccc37012ce0a7a488bf269631fede6cb75d345f521be7ad488416ec0282090d377225dba7e8b385bc1e2"
+  ]
+}

--- a/packages/merlin/merlin.3.5.0/opam
+++ b/packages/merlin/merlin.3.5.0/opam
@@ -5,7 +5,7 @@ homepage:     "https://github.com/ocaml/merlin"
 bug-reports:  "https://github.com/ocaml/merlin/issues"
 dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test & ocaml:version >= "4.03"}
 ]

--- a/packages/merlin/merlin.4.2-411/opam
+++ b/packages/merlin/merlin.4.2-411/opam
@@ -5,7 +5,7 @@ homepage:     "https://github.com/ocaml/merlin"
 bug-reports:  "https://github.com/ocaml/merlin/issues"
 dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
 ]

--- a/packages/merlin/merlin.4.2-411/opam
+++ b/packages/merlin/merlin.4.2-411/opam
@@ -4,6 +4,7 @@ authors:      "The Merlin team"
 homepage:     "https://github.com/ocaml/merlin"
 bug-reports:  "https://github.com/ocaml/merlin/issues"
 dev-repo: "git+https://github.com/ocaml/merlin.git"
+license: "MIT"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/merlin/merlin.4.2-411/opam
+++ b/packages/merlin/merlin.4.2-411/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.11.0" & < "4.12"}
+  "dune" {>= "2.7.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "1.6.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+x-commit-hash: "3160ccc7a272920c5fd43ccf867ff4c5d393d5d0"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.2-411/merlin-v4.2-411.tbz"
+  checksum: [
+    "sha256=445a60b55c9defe6725e32ed21228e7c372454ff3e6647657198c3dd498fe5ad"
+    "sha512=4d456415e90f5e4ca0a228864fc9441c7428385d3d96f8c346d169f77640528f8444382c00fbc1c53a8beb0c97411261a9574048c885af60c51a934f1b2ba405"
+  ]
+}

--- a/packages/merlin/merlin.4.2-412/opam
+++ b/packages/merlin/merlin.4.2-412/opam
@@ -5,7 +5,7 @@ homepage:     "https://github.com/ocaml/merlin"
 bug-reports:  "https://github.com/ocaml/merlin/issues"
 dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
 ]

--- a/packages/merlin/merlin.4.2-412/opam
+++ b/packages/merlin/merlin.4.2-412/opam
@@ -4,6 +4,7 @@ authors:      "The Merlin team"
 homepage:     "https://github.com/ocaml/merlin"
 bug-reports:  "https://github.com/ocaml/merlin/issues"
 dev-repo: "git+https://github.com/ocaml/merlin.git"
+license: "MIT"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/merlin/merlin.4.2-412/opam
+++ b/packages/merlin/merlin.4.2-412/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.12" & < "4.13"}
+  "dune" {>= "2.7.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "1.6.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+x-commit-hash: "fe7380bb13ff91f8ed5cfbfea6a6ca01ee1ef88c"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.2-412/merlin-v4.2-412.tbz"
+  checksum: [
+    "sha256=86c30769277d3e2c09a8be6c68a98cd342bc0bdbde07c7225bfe2e6d0da2d394"
+    "sha512=27fbfb2ac50d7cd86807bd8cb02ff1e4661ee46abf071b9bec505e1df6d41f366c9c287988e66096fb7a14b67fd806df39c56b9f70c53ec40612192ba2a0e530"
+  ]
+}


### PR DESCRIPTION
Project page: https://github.com/ocaml/merlin

## CHANGES

### v4.2-41X:
  + merlin binary
    - external configuration reading:
      + use relative paths to communicate with Dune when possible. This solves
        issues related to symlinks on Unix and improve Windows support (#1271,
        fixes ocaml/merlin#1288)
      + make the `workdir` configuration value when using the
        `dune ocaml-merlin` configuration provider the same as when using
        `dot-merlin-reader` so that ppxes behaves in the same way as before
        (#1284, fixes ocaml/dune#4479, discussion in #1292)
    - destruct:
      + improve prefixing of generated constructors in Destruct by filtering
        opened modules (#1277)
      + make the destruct command more resilient to ill-typed expressions and
        when called without nodes (#1304, fixes ocaml/merlin#1300)
    - reintroduce some record recovery and improve completion (#1276)
    - introduce a new AST node for holes (`_`), allow correct typing of these
      holes and add a new `holes` command that returns the locations of all
      holes in the current file along with their types (#1242, #1289)
    - Mppx: don't restore cookies after invocation. Ppx are invoked only once
      so there is no need to manage cookies. This small change should increase
      performance and should not change any other behavior (#1309)
    - Windows: system command variant: do not open a window console when
      launching a ppx (#1270, fixes ocaml/merlin#714)
    - fix same file documentation bug (#1265 by @ulugbekna, fixes ocaml/merlin#1261)
  + editor modes
    - vim: Add `MerlinNextHole` and `MerlinPreviousHole` commands to navigate
      between holes. Jump to the first hole after destruct (#1287, #1303)
    - emacs: Add `merlin-next-hole` and `merlin-previous-hole` commands to
      navigate holes. Jump to the first hole after calling destruct. (#1291)
    - emacs: modernization of the elisp code and conformance with coding
      guidelines (#1247, #1310 by Steve Purcell )
    - vim & emacs : new client-side "merlin use package" commands, restoring
      previous behavior (#1272, fixes ocaml/merlin#1191)
  + test suite
    - cover constructor disambiguation and record fields (#1276)
    - cover the new `holes` command and AST node (#1242, #1289)
    - cover the document fix (#1265, #1315)

### v3.5.0:
Tue Apr 12 11:44:22 AM CET 2021

  + merlin binary
    - external configuration reading:
      + use relative paths to communicate with Dune when possible. This solves
        issues related to symlinks on Unix and improve Windows support (#1271,
        fixes #1288)
      + make the `workdir` configuration value when using the
        `dune ocaml-merlin` configuration provider the same as when using
        `dot-merlin-reader` so that ppxes behaves in the same way as before
        (#1284, fixes ocaml/dune#4479, discussion in #1292)
    - destruct:  make the destruct command more resilient to ill-typed
      expressions and when called without nodes (#1304, fixes #1300)
    - Mppx: don't restore cookies after invocation. Ppx are invoked only once
      so there is no need to manage cookies. This small change should increase
      performance and should not change any other behavior (#1309)
    - windows:
      + system command variant: do not open a window console when
        launching a ppx (#1270, fixes #714)
      + fix Emacs hanging when starting Merlin (#1263)
      + fix path canonicalization (#1254)
    - fix same file documentation bug (#1265 by @ulugbekna, fixes #1261)
  + editor modes
    - emacs:
      + modernization of the elisp code and conformance with coding
        guidelines (#1247, #1310 by Steve Purcell )
      + use opam var where applicable (#1310)
      + fix "wrong number of argument" (#1250 by @atharvashukla, fixes #1234)
      + fix for Neovim's CursorMoved semantics (#1213 by @ddickstein)
    - vim & emacs : new client-side "merlin use package" commands, restoring
      previous behavior (#1272, fixes #1191)
  + test suite
    - cover the document fix (#1265, #1315)
