### PR TITLE
[new release] alcotest, alcotest-async, alcotest-mirage and alcotest-lwt (1.4.0)

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.4.0/opam
+++ b/packages/alcotest-async/alcotest-async.1.4.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Async-based helpers for Alcotest"
+description: "Async-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.2"}
+  "re" {with-test}
+  "fmt" {with-test}
+  "cmdliner" {with-test}
+  "core"
+  "base"
+  "async_kernel"
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "async_unix" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "fc6bdde24632677eb1bc25b7bfe6d89bf3ae072d"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.4.0/alcotest-mirage-1.4.0.tbz"
+  checksum: [
+    "sha256=438b73dca0011661ee6576e6a603bcd2eb4d810bbddcfe79160aa3609881d37a"
+    "sha512=44335d9116cde857db03b4f5c883c6de07d991c54c23c06eb97b52b31b069ca2456ccf180b6c27d348118a31c9f5ce86441d0c7e263bd30efd39bfa2bc7ad5d8"
+  ]
+}

--- a/packages/alcotest-lwt/alcotest-lwt.1.4.0/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Lwt-based helpers for Alcotest"
+description: "Lwt-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.2"}
+  "re" {with-test}
+  "cmdliner" {with-test}
+  "fmt"
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "lwt"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "fc6bdde24632677eb1bc25b7bfe6d89bf3ae072d"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.4.0/alcotest-mirage-1.4.0.tbz"
+  checksum: [
+    "sha256=438b73dca0011661ee6576e6a603bcd2eb4d810bbddcfe79160aa3609881d37a"
+    "sha512=44335d9116cde857db03b4f5c883c6de07d991c54c23c06eb97b52b31b069ca2456ccf180b6c27d348118a31c9f5ce86441d0c7e263bd30efd39bfa2bc7ad5d8"
+  ]
+}

--- a/packages/alcotest-mirage/alcotest-mirage.1.4.0/opam
+++ b/packages/alcotest-mirage/alcotest-mirage.1.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Mirage implementation for Alcotest"
+description: "Mirage implementation for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.2"}
+  "re" {with-test}
+  "cmdliner" {with-test}
+  "fmt"
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
+  "mirage-clock" {>= "2.0.0"}
+  "duration"
+  "lwt"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "fc6bdde24632677eb1bc25b7bfe6d89bf3ae072d"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.4.0/alcotest-mirage-1.4.0.tbz"
+  checksum: [
+    "sha256=438b73dca0011661ee6576e6a603bcd2eb4d810bbddcfe79160aa3609881d37a"
+    "sha512=44335d9116cde857db03b4f5c883c6de07d991c54c23c06eb97b52b31b069ca2456ccf180b6c27d348118a31c9f5ce86441d0c7e263bd30efd39bfa2bc7ad5d8"
+  ]
+}

--- a/packages/alcotest/alcotest.1.4.0/opam
+++ b/packages/alcotest/alcotest.1.4.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Alcotest is a lightweight and colourful test framework"
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.2"}
+  "ocaml" {>= "4.03.0"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "cmdliner"
+  "uuidm"
+  "re"
+  "stdlib-shims"
+  "uutf"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-commit-hash: "fc6bdde24632677eb1bc25b7bfe6d89bf3ae072d"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.4.0/alcotest-mirage-1.4.0.tbz"
+  checksum: [
+    "sha256=438b73dca0011661ee6576e6a603bcd2eb4d810bbddcfe79160aa3609881d37a"
+    "sha512=44335d9116cde857db03b4f5c883c6de07d991c54c23c06eb97b52b31b069ca2456ccf180b6c27d348118a31c9f5ce86441d0c7e263bd30efd39bfa2bc7ad5d8"
+  ]
+}


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework

- Project page: <a href="https://github.com/mirage/alcotest">https://github.com/mirage/alcotest</a>
- Documentation: <a href="https://mirage.github.io/alcotest">https://mirage.github.io/alcotest</a>

##### CHANGES:

- Add `?here` and `?pos` arguments to the test assertion functions. These can be
  used to pass information about the location of the call-site, which is
  displayed in failing test output. (mirage/alcotest#291, @CraigFe)
