### PR TITLE
Package advi.2.0.0

### DIFF
--- a/packages/advi/advi.2.0.0/opam
+++ b/packages/advi/advi.2.0.0/opam
@@ -34,7 +34,7 @@ depends: [
   "conf-which"
 ]
 build: [
-    ["dune" "subst"] {pinned}
+    ["dune" "subst"] {dev}
     [ make ]
     ]
 install:

--- a/packages/advi/advi.2.0.0/opam
+++ b/packages/advi/advi.2.0.0/opam
@@ -1,7 +1,6 @@
 opam-version: "2.0"
 synopsis: "Active DVI Dune package!"
 description: """
-
 Active-DVI is a DVI previewer and presenter written in OCaml with some eye
 candy effects for presentation, support for interactive demonstrations, and
 embedding of arbitrary applications within the presentation.
@@ -22,25 +21,24 @@ authors: [
 ]
 license: "LGPL-2.1-or-later"
 homepage: "http://advi.inria.fr"
-dev-repo: "git+https://github.com:diremy/advi.git"
+dev-repo: "git+https://github.com/diremy/advi.git"
 doc: "http://advi.inria.fr"
 bug-reports: "Didier.Remy@inria.fr"
 depends: [
-  "ocaml-base-compiler" {>= "4.11.1"}
+  "ocaml" {>= "4.11.1"}
   "dune" {>= "2.5"}
   "graphics" {>= "5.1.1"}
   "camlimages" {>= "5.0.4"}
-  "conf-texlive"
-  "conf-which"
+  "conf-texlive" {build}
+  "conf-ghostscript" {build}
+  "conf-which" {build}
 ]
 build: [
-    ["dune" "subst"] {dev}
-    [ make ]
-    ]
-install:
-    [ make "install" ]
-post-messages:
-    [
+  ["dune" "subst"] {dev}
+  [ make ]
+]
+install: [ make "install" ]
+post-messages: [
 "This only installed the 'advi' command.  To benefit from advanced features
 of advi you also need to install additional latex source files.  To see how
 to do so, run the command 'advi-latex-files --install help'.  "

--- a/packages/advi/advi.2.0.0/opam
+++ b/packages/advi/advi.2.0.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Active DVI Dune package!"
+description: """
+
+Active-DVI is a DVI previewer and presenter written in OCaml with some eye
+candy effects for presentation, support for interactive demonstrations, and
+embedding of arbitrary applications within the presentation.
+
+Active-DVI is well suited for use in combination with WhizzyTeX
+(http://cristal.inria.fr/whizzytex/)
+"""
+maintainer: ["Didier Rémy <Didier.Remy@inria.fr>"]
+authors: [
+  "Alexandre Miquel"
+  "Jun Furuse"
+  "Didier Rémy"
+  "Pierre Weis"
+  "Xavier Leroy"
+  "Roberto Di Cosmo"
+  "Didier Le Botlan"
+  "Alan Schmitt"
+]
+license: "LGPL-2.1-or-later"
+homepage: "http://advi.inria.fr"
+dev-repo: "git+https://github.com:diremy/advi.git"
+doc: "http://advi.inria.fr"
+bug-reports: "Didier.Remy@inria.fr"
+depends: [
+  "ocaml-base-compiler" {>= "4.11.1"}
+  "dune" {>= "2.5"}
+  "graphics" {>= "5.1.1"}
+  "camlimages" {>= "5.0.4"}
+  "conf-texlive"
+  "conf-which"
+]
+build: [
+    ["dune" "subst"] {pinned}
+    [ make ]
+    ]
+install:
+    [ make "install" ]
+post-messages:
+    [
+"This only installed the 'advi' command.  To benefit from advanced features
+of advi you also need to install additional latex source files.  To see how
+to do so, run the command 'advi-latex-files --install help'.  "
+]
+url {
+  src: "https://github.com/diremy/advi/archive/advi-2.0.0.tar.gz"
+  checksum: [
+    "md5=c18e0a393befc87ba449adadaefa87a8"
+    "sha512=a88d24e864f8f69f6b2bb0f0f494aadb8e16b32543e532f23d44a0baae3df25bbb7bfe96148089e8b7a871b647b2186a71238c278ea49bf08151afeb9142940b"
+  ]
+}

--- a/packages/conf-ghostscript/conf-ghostscript.1/opam
+++ b/packages/conf-ghostscript/conf-ghostscript.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://www.ghostscript.com/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "Artifex Software, Inc"
+license: "AGPL-3.0-only"
+build: ["gs" "--version"]
+depexts: [
+  ["ghostscript"] {os-family = "debian"}
+  ["ghostscript"] {os-family = "ubuntu"}
+  ["ghostscript"] {os-distribution = "fedora"}
+  ["ghostscript"] {os-distribution = "rhel"}
+  ["ghostscript"] {os-distribution = "ol"}
+  ["ghostscript"] {os-distribution = "centos"}
+  ["ghostscript"] {os-family = "alpine"}
+  ["ghostscript"] {os-family = "suse"}
+  ["ghostscript"] {os-family = "arch"}
+  ["ghostscript"] {os = "freebsd"}
+  ["ghostscript"] {os-distribution = "homebrew" & os = "macos"}
+  ["ghostscript"] {os-distribution = "macports" & os = "macos"}
+]
+synopsis: "Virtual package relying on ghostscript"
+description:
+  "This package can only install if the gs binary is installed on the system."
+flags: conf

--- a/packages/conf-texlive/conf-texlive.1/opam
+++ b/packages/conf-texlive/conf-texlive.1/opam
@@ -10,7 +10,9 @@ depexts: [
   ["texlive-latex"] {os-distribution = "fedora"}
   ["texlive-latex"] {os-distribution = "rhel"}
   ["texlive-latex"] {os-distribution = "ol"}
+  ["texlive-latex-bin-bin"] {os-distribution = "ol" & os-version < "8"}
   ["texlive-latex"] {os-distribution = "centos"}
+  ["texlive-latex-bin-bin"] {os-distribution = "centos" & os-version < "8"}
   ["texlive"] {os-distribution = "alpine"}
   ["texlive-latex-bin-bin"] {os-family = "suse"}
   ["texlive-bin"] {os-distribution = "arch"}

--- a/packages/conf-texlive/conf-texlive.1/opam
+++ b/packages/conf-texlive/conf-texlive.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["texlive-latex-bin-bin"] {os-distribution = "centos" & os-version < "8"}
   ["texlive"] {os-family = "alpine"}
   ["texlive-latex-bin-bin"] {os-family = "suse"}
-  ["texlive-bin"] {os-family = "arch"}
+  ["texlive-core"] {os-family = "arch"}
   ["tex-formats"] {os = "freebsd"}
   ["basictex"] {os-distribution = "homebrew" & os = "macos"}
 ]

--- a/packages/conf-texlive/conf-texlive.1/opam
+++ b/packages/conf-texlive/conf-texlive.1/opam
@@ -7,16 +7,17 @@ license: "LaTeX Project Public License and GPL-2"
 build: ["pdflatex" "-version"]
 depexts: [
   ["texlive-latex-base"] {os-family = "debian"}
+  ["texlive-latex-base"] {os-family = "ubuntu"}
   ["texlive-latex"] {os-distribution = "fedora"}
   ["texlive-latex"] {os-distribution = "rhel"}
   ["texlive-latex"] {os-distribution = "ol"}
   ["texlive-latex-bin-bin"] {os-distribution = "ol" & os-version < "8"}
   ["texlive-latex"] {os-distribution = "centos"}
   ["texlive-latex-bin-bin"] {os-distribution = "centos" & os-version < "8"}
-  ["texlive"] {os-distribution = "alpine"}
+  ["texlive"] {os-family = "alpine"}
   ["texlive-latex-bin-bin"] {os-family = "suse"}
-  ["texlive-bin"] {os-distribution = "arch"}
-  ["tex-formats"] {os-distribution = "freebsd"}
+  ["texlive-bin"] {os-family = "arch"}
+  ["tex-formats"] {os = "freebsd"}
   ["basictex"] {os-distribution = "homebrew" & os = "macos"}
 ]
 synopsis: "Virtual package relying on texlive / pdflatex"


### PR DESCRIPTION
### `advi.2.0.0`
Active DVI Dune package!
Active-DVI is a DVI previewer and presenter written in OCaml with some eye
candy effects for presentation, support for interactive demonstrations, and
embedding of arbitrary applications within the presentation.

Active-DVI is well suited for use in combination with WhizzyTeX
(http://cristal.inria.fr/whizzytex/)



---
* Homepage: http://advi.inria.fr
* Source repo: git+https://github.com:diremy/advi.git
* Bug tracker: Didier.Remy@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.3