### PR TITLE
[new release] dns, dns-stub, dns-certify, dns-mirage, dns-resolver, dns-client, dns-server, dns-tsig and dns-cli (5.0.0)

### DIFF
--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.7.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.7.0/opam
@@ -16,7 +16,7 @@ depends: [
   "astring"
   "fmt"
   "logs"
-  "dns-client" {>= "4.5.0"}
+  "dns-client" {>= "4.5.0" & < "5.0.0"}
   "tls-mirage"
   "mirage-stack" {>="2.0.0"}
   "arp-mirage" {with-test}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.8.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.8.0/opam
@@ -16,7 +16,7 @@ depends: [
   "astring"
   "fmt"
   "logs"
-  "dns-client" {>= "4.5.0"}
+  "dns-client" {>= "4.5.0" & < "5.0.0"}
   "tls-mirage"
   "mirage-stack" {>="2.0.0"}
   "arp-mirage" {with-test}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.9.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.0.9.0/opam
@@ -16,7 +16,7 @@ depends: [
   "astring" {with-test}
   "fmt"
   "logs"
-  "dns-client" {>= "4.5.0"}
+  "dns-client" {>= "4.5.0" & < "5.0.0"}
   "tls-mirage"
   "mirage-stack" {>= "2.0.0"}
   "arp-mirage" {with-test}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.0/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "astring" {with-test}
   "fmt"
   "logs"
-  "dns-client" {>= "4.5.0"}
+  "dns-client" {>= "4.5.0" & < "5.0.0"}
   "tls-mirage"
   "mirage-stack" {>= "2.0.0"}
   "arp-mirage" {with-test}

--- a/packages/conduit-mirage/conduit-mirage.2.2.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.2.1/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
-  "dns-client" {>= "4.5.0"}
+  "dns-client" {>= "4.5.0" & < "5.0.0"}
   "conduit-lwt" {< "3.0.0"}
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/packages/conduit-mirage/conduit-mirage.2.3.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
-  "dns-client" {>= "4.5.0"}
+  "dns-client" {>= "4.5.0" & < "5.0.0"}
   "conduit-lwt" {=version}
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/packages/conduit-mirage/conduit-mirage.3.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.3.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "tcpip"
   "mirage-flow"
   "mirage-time"
-  "dns-client"  {>= "4.6.0"}
+  "dns-client"  {>= "4.6.0" & < "5.0.0"}
   "ke"
   "bigstringaf"
 ]

--- a/packages/dkim/dkim.0.1.0/opam
+++ b/packages/dkim/dkim.0.1.0/opam
@@ -24,7 +24,7 @@ depends: [
   "base-unix"
   "hmap"
   "domain-name"
-  "dns-client"
+  "dns-client" {< "5.0.0"}
   "cmdliner"
   "logs"
   "fmt"

--- a/packages/dns-certify/dns-certify.5.0.0/opam
+++ b/packages/dns-certify/dns-certify.5.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "0.12.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "logs"
+  "mirage-crypto-ec"
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+x-commit-hash: "29168a8c464796fda77b50d721176f122ee724ae"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.0/dns-v5.0.0.tbz"
+  checksum: [
+    "sha256=ef93435407955a46e51e3be857a1b00a6765ec3b673d4a859a9536c7e3365111"
+    "sha512=083da787d0a0e08eefe1f7cee290fa9c0e3faab6bf8162b9241c6280a3f98b91f63dc3f9c22fccb4f9dc5d51e29e03830cc146bc12e308260e2fdf1de41e3416"
+  ]
+}

--- a/packages/dns-cli/dns-cli.5.0.0/opam
+++ b/packages/dns-cli/dns-cli.5.0.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-client" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "rresult" {>= "0.6.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "0.10.0"}
+  "mirage-crypto" {>= "0.8.0"}
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "hex" {>= "1.4.0"}
+  "ptime" {>= "0.8.5"}
+  "mtime" {>= "1.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.0.0"}
+  "randomconv"
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+x-commit-hash: "29168a8c464796fda77b50d721176f122ee724ae"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.0/dns-v5.0.0.tbz"
+  checksum: [
+    "sha256=ef93435407955a46e51e3be857a1b00a6765ec3b673d4a859a9536c7e3365111"
+    "sha512=083da787d0a0e08eefe1f7cee290fa9c0e3faab6bf8162b9241c6280a3f98b91f63dc3f9c22fccb4f9dc5d51e29e03830cc146bc12e308260e2fdf1de41e3416"
+  ]
+}

--- a/packages/dns-client/dns-client.5.0.0/opam
+++ b/packages/dns-client/dns-client.5.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt" {>= "0.8.8"}
+  "logs" {>= "0.6.3"}
+  "dns" {= version}
+  "rresult" {>= "0.6.0"}
+  "randomconv" {>= "0.1.2"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "alcotest" {with-test}
+]
+synopsis: "Pure DNS resolver API"
+description: """
+A pure resolver implementation using uDNS.
+"""
+x-commit-hash: "29168a8c464796fda77b50d721176f122ee724ae"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.0/dns-v5.0.0.tbz"
+  checksum: [
+    "sha256=ef93435407955a46e51e3be857a1b00a6765ec3b673d4a859a9536c7e3365111"
+    "sha512=083da787d0a0e08eefe1f7cee290fa9c0e3faab6bf8162b9241c6280a3f98b91f63dc3f9c22fccb4f9dc5d51e29e03830cc146bc12e308260e2fdf1de41e3416"
+  ]
+}

--- a/packages/dns-mirage/dns-mirage.5.0.0/opam
+++ b/packages/dns-mirage/dns-mirage.5.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack" {>= "2.2.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+x-commit-hash: "29168a8c464796fda77b50d721176f122ee724ae"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.0/dns-v5.0.0.tbz"
+  checksum: [
+    "sha256=ef93435407955a46e51e3be857a1b00a6765ec3b673d4a859a9536c7e3365111"
+    "sha512=083da787d0a0e08eefe1f7cee290fa9c0e3faab6bf8162b9241c6280a3f98b91f63dc3f9c22fccb4f9dc5d51e29e03830cc146bc12e308260e2fdf1de41e3416"
+  ]
+}

--- a/packages/dns-resolver/dns-resolver.5.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.5.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+x-commit-hash: "29168a8c464796fda77b50d721176f122ee724ae"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.0/dns-v5.0.0.tbz"
+  checksum: [
+    "sha256=ef93435407955a46e51e3be857a1b00a6765ec3b673d4a859a9536c7e3365111"
+    "sha512=083da787d0a0e08eefe1f7cee290fa9c0e3faab6bf8162b9241c6280a3f98b91f63dc3f9c22fccb4f9dc5d51e29e03830cc146bc12e308260e2fdf1de41e3416"
+  ]
+}

--- a/packages/dns-server/dns-server.5.0.0/opam
+++ b/packages/dns-server/dns-server.5.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-crypto-rng" {with-test}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "base64" {with-test & >= "3.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+x-commit-hash: "29168a8c464796fda77b50d721176f122ee724ae"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.0/dns-v5.0.0.tbz"
+  checksum: [
+    "sha256=ef93435407955a46e51e3be857a1b00a6765ec3b673d4a859a9536c7e3365111"
+    "sha512=083da787d0a0e08eefe1f7cee290fa9c0e3faab6bf8162b9241c6280a3f98b91f63dc3f9c22fccb4f9dc5d51e29e03830cc146bc12e308260e2fdf1de41e3416"
+  ]
+}

--- a/packages/dns-stub/dns-stub.5.0.0/opam
+++ b/packages/dns-stub/dns-stub.5.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-client" {= version}
+  "dns-mirage" {= version}
+  "dns-resolver" {= version}
+  "dns-tsig" {= version}
+  "dns-server" {= version}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS stub resolver"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+x-commit-hash: "29168a8c464796fda77b50d721176f122ee724ae"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.0/dns-v5.0.0.tbz"
+  checksum: [
+    "sha256=ef93435407955a46e51e3be857a1b00a6765ec3b673d4a859a9536c7e3365111"
+    "sha512=083da787d0a0e08eefe1f7cee290fa9c0e3faab6bf8162b9241c6280a3f98b91f63dc3f9c22fccb4f9dc5d51e29e03830cc146bc12e308260e2fdf1de41e3416"
+  ]
+}

--- a/packages/dns-tsig/dns-tsig.5.0.0/opam
+++ b/packages/dns-tsig/dns-tsig.5.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "mirage-crypto"
+  "base64" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+x-commit-hash: "29168a8c464796fda77b50d721176f122ee724ae"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.0/dns-v5.0.0.tbz"
+  checksum: [
+    "sha256=ef93435407955a46e51e3be857a1b00a6765ec3b673d4a859a9536c7e3365111"
+    "sha512=083da787d0a0e08eefe1f7cee290fa9c0e3faab6bf8162b9241c6280a3f98b91f63dc3f9c22fccb4f9dc5d51e29e03830cc146bc12e308260e2fdf1de41e3416"
+  ]
+}

--- a/packages/dns/dns.5.0.0/opam
+++ b/packages/dns/dns.5.0.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "rresult" "astring" "fmt" "logs" "ptime"
+  "domain-name" {>= "0.3.0"}
+  "gmap" {>= "0.3.0"}
+  "cstruct" {>= "3.2.0"}
+  "ipaddr" {>= "3.0.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "metrics"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+x-commit-hash: "29168a8c464796fda77b50d721176f122ee724ae"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.0/dns-v5.0.0.tbz"
+  checksum: [
+    "sha256=ef93435407955a46e51e3be857a1b00a6765ec3b673d4a859a9536c7e3365111"
+    "sha512=083da787d0a0e08eefe1f7cee290fa9c0e3faab6bf8162b9241c6280a3f98b91f63dc3f9c22fccb4f9dc5d51e29e03830cc146bc12e308260e2fdf1de41e3416"
+  ]
+}

--- a/packages/git-mirage/git-mirage.3.0.0/opam
+++ b/packages/git-mirage/git-mirage.3.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "git" {= version}
   "awa"
   "awa-mirage"
-  "dns-client" {>= "4.6.2"}
+  "dns-client" {>= "4.6.2" & < "5.0.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}

--- a/packages/git-mirage/git-mirage.3.1.0/opam
+++ b/packages/git-mirage/git-mirage.3.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "git" {= version}
   "awa"
   "awa-mirage"
-  "dns-client" {>= "4.6.2"}
+  "dns-client" {>= "4.6.2" & < "5.0.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}

--- a/packages/git-mirage/git-mirage.3.1.1/opam
+++ b/packages/git-mirage/git-mirage.3.1.1/opam
@@ -14,7 +14,7 @@ depends: [
   "git" {= version}
   "awa"
   "awa-mirage"
-  "dns-client" {>= "4.6.2"}
+  "dns-client" {>= "4.6.2" & < "5.0.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}

--- a/packages/git-mirage/git-mirage.3.2.0/opam
+++ b/packages/git-mirage/git-mirage.3.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "git" {= version}
   "awa"
   "awa-mirage"
-  "dns-client" {>= "4.6.2"}
+  "dns-client" {>= "4.6.2" & < "5.0.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}

--- a/packages/git-mirage/git-mirage.3.3.0/opam
+++ b/packages/git-mirage/git-mirage.3.3.0/opam
@@ -14,7 +14,7 @@ depends: [
   "git" {= version}
   "awa"
   "awa-mirage"
-  "dns-client" {>= "4.6.2"}
+  "dns-client" {>= "4.6.2" & < "5.0.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}

--- a/packages/git-mirage/git-mirage.3.3.1/opam
+++ b/packages/git-mirage/git-mirage.3.3.1/opam
@@ -14,7 +14,7 @@ depends: [
   "git" {= version}
   "awa"
   "awa-mirage"
-  "dns-client" {>= "4.6.2"}
+  "dns-client" {>= "4.6.2" & < "5.0.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}

--- a/packages/git-mirage/git-mirage.3.3.2/opam
+++ b/packages/git-mirage/git-mirage.3.3.2/opam
@@ -14,7 +14,7 @@ depends: [
   "git" {= version}
   "awa"
   "awa-mirage"
-  "dns-client" {>= "4.6.2"}
+  "dns-client" {>= "4.6.2" & < "5.0.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}

--- a/packages/git-mirage/git-mirage.3.3.3/opam
+++ b/packages/git-mirage/git-mirage.3.3.3/opam
@@ -14,7 +14,7 @@ depends: [
   "git" {= version}
   "awa"
   "awa-mirage"
-  "dns-client" {>= "4.6.2"}
+  "dns-client" {>= "4.6.2" & < "5.0.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}

--- a/packages/resp-mirage/resp-mirage.0.10.0/opam
+++ b/packages/resp-mirage/resp-mirage.0.10.0/opam
@@ -12,7 +12,7 @@ depends: [
   "resp-client" {= version}
   "resp-server" {= version}
   "lwt"
-  "conduit-mirage" {>= "2.0.0" & < "3.0.0"}
+  "conduit-mirage" {>= "2.3.0" & < "3.0.0"}
 ]
 build: ["dune" "build" "-p" name]
 dev-repo: "git+https://github.com/zshipko/resp.git"


### PR DESCRIPTION
An opinionated Domain Name System (DNS) library

- Project page: <a href="https://github.com/mirage/ocaml-dns">https://github.com/mirage/ocaml-dns</a>
- Documentation: <a href="https://mirage.github.io/ocaml-dns/">https://mirage.github.io/ocaml-dns/</a>

##### CHANGES:

* IPv6 support for client and server (Mirage, Unix, Lwt) (mirage/ocaml-dns#249 mirage/ocaml-dns#252 @hannesm)
  This results in breaking changes, especially in the Mirage boilerplate,
  since now a Mirage_stack.V4V6 is needed instead of a Mirage_stack.V4.
* dns-certify: support EC private keys, now that X509 0.12.0 supports them
  (mirage/ocaml-dns#252 @hannesm)
