### PR TITLE
[new release] mirage-unix (4.0.1)

### DIFF
--- a/packages/mirage-unix/mirage-unix.4.0.1/opam
+++ b/packages/mirage-unix/mirage-unix.4.0.1/opam
@@ -8,14 +8,14 @@ doc:          "https://mirage.github.io/mirage-unix/doc"
 license:      "ISC"
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune"
+  "dune" {>= "1.11"}
   "lwt" {>= "2.4.3"}
   "duration"
   "mirage-runtime" {>= "3.7.0"}

--- a/packages/mirage-unix/mirage-unix.4.0.1/opam
+++ b/packages/mirage-unix/mirage-unix.4.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-unix"
+bug-reports:  "https://github.com/mirage/mirage-unix/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-unix.git"
+doc:          "https://mirage.github.io/mirage-unix/doc"
+license:      "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "lwt" {>= "2.4.3"}
+  "duration"
+  "mirage-runtime" {>= "3.7.0"}
+  "io-page" {>= "2.4.0"}
+]
+tags: "org:mirage"
+synopsis: "Unix core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Unix targets, which handles the main loop and timers.
+"""
+x-commit-hash: "56b6adee18053ae3ae6aca376920f6bb96f225fb"
+url {
+  src:
+    "https://github.com/mirage/mirage-unix/releases/download/v4.0.1/mirage-unix-v4.0.1.tbz"
+  checksum: [
+    "sha256=f7299505bddd9216fe30df7bfec5defe8437e82571d24aee8f7b1dd7d2e2159e"
+    "sha512=b2f7757419292ee5587297d5b68cf251b082fb8ebb360efa63b21d03c10b8f9227a00ab68c68ec80ce17b76266fcef180bbc05b88b3ca78e3842131a95c1799a"
+  ]
+}


### PR DESCRIPTION
Unix core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-unix">https://github.com/mirage/mirage-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-unix/doc">https://mirage.github.io/mirage-unix/doc</a>

##### CHANGES:

* Delete `io-page-unix` and use `io-page.2.4.0` instead
  (@samoht , @dinosaure, mirage/mirage-unix#16)
