### PR TITLE
[new release] ca-certs-nss (3.63.1)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.63.1/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.63.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "X.509 trust anchors extracted from Mozilla's NSS"
+description: """
+Trust anchors extracted from Mozilla's NSS certdata.txt package,
+to be used in MirageOS unikernels.
+"""
+maintainer: ["Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs-nss"
+doc: "https://mirage.github.io/ca-certs-nss/doc"
+bug-reports: "https://github.com/mirage/ca-certs-nss/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "rresult"
+  "mirage-crypto"
+  "mirage-clock"
+  "x509" {>= "0.11.0"}
+  "ocaml" {>= "4.07.0"}
+  "logs" {build}
+  "fmt" {build}
+  "hex" {build}
+  "bos" {build}
+  "astring" {build}
+  "cmdliner" {build}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ca-certs-nss.git"
+tags: ["org:mirage"]
+x-commit-hash: "caa191fead69c9ab40d6c7e2802b921789d825f8"
+url {
+  src:
+    "https://github.com/mirage/ca-certs-nss/releases/download/v3.63.1/ca-certs-nss-v3.63.1.tbz"
+  checksum: [
+    "sha256=5fc13b5a9960c8f077f2f88878c73cb9828f4ee7a9ea31bc57517faa1b28f078"
+    "sha512=4bb593762b8073a06c482aca5a34c750be4e1952b1deef712f8683b77fa5abe4550939c2117e0b3f83cacd87644b69560afc858083beefbfafc895ab130ed65a"
+  ]
+}


### PR DESCRIPTION
X.509 trust anchors extracted from Mozilla's NSS

- Project page: <a href="https://github.com/mirage/ca-certs-nss">https://github.com/mirage/ca-certs-nss</a>
- Documentation: <a href="https://mirage.github.io/ca-certs-nss/doc">https://mirage.github.io/ca-certs-nss/doc</a>

##### CHANGES:

* Update to NSS 3.63.1 (Apr 9th 2021)
