### PR TITLE
[new release] awa-mirage, awa-lwt and awa (0.0.2)

### DIFF
--- a/packages/awa-lwt/awa-lwt.0.0.2/opam
+++ b/packages/awa-lwt/awa-lwt.0.0.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "awa" {= version}
+  "cstruct" {>= "3.2.0"}
+  "mtime"
+  "lwt"
+  "cstruct-unix"
+  "mirage-crypto-rng"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-commit-hash: "a29cca7141580660ab4b2150f575c747ca182516"
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.0.2/awa-v0.0.2.tbz"
+  checksum: [
+    "sha256=288c6599312882b00724049d103ac4f395149ddcc5ea2ca644698b4616ef4468"
+    "sha512=779aa5061b05eb0d8f46df54814509e924c175690faf9805e18c5be1556928e983e84afaf029be33025e37d2f5efbe882cf39dfda380c79a2eda7debc2c94440"
+  ]
+}

--- a/packages/awa-mirage/awa-mirage.0.0.2/opam
+++ b/packages/awa-mirage/awa-mirage.0.0.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "awa" {= version}
+  "cstruct" {>= "3.2.0"}
+  "mtime"
+  "lwt"
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-commit-hash: "a29cca7141580660ab4b2150f575c747ca182516"
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.0.2/awa-v0.0.2.tbz"
+  checksum: [
+    "sha256=288c6599312882b00724049d103ac4f395149ddcc5ea2ca644698b4616ef4468"
+    "sha512=779aa5061b05eb0d8f46df54814509e924c175690faf9805e18c5be1556928e983e84afaf029be33025e37d2f5efbe882cf39dfda380c79a2eda7debc2c94440"
+  ]
+}

--- a/packages/awa/awa.0.0.2/opam
+++ b/packages/awa/awa.0.0.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-rng"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec"
+  "x509" {>= "0.12.0"}
+  "cstruct" {>= "3.2.0"}
+  "cstruct-unix"
+  "cstruct-sexp"
+  "sexplib"
+  "rresult"
+  "mtime"
+  "logs"
+  "fmt"
+  "cmdliner"
+  "base64" {>= "3.0.0"}
+  "zarith"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-commit-hash: "a29cca7141580660ab4b2150f575c747ca182516"
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.0.2/awa-v0.0.2.tbz"
+  checksum: [
+    "sha256=288c6599312882b00724049d103ac4f395149ddcc5ea2ca644698b4616ef4468"
+    "sha512=779aa5061b05eb0d8f46df54814509e924c175690faf9805e18c5be1556928e983e84afaf029be33025e37d2f5efbe882cf39dfda380c79a2eda7debc2c94440"
+  ]
+}


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* Use mirage-crypto-ec instead of hack_x25519 (mirage/awa-ssh#24 @hannesm)
* Support X.509 >= 0.12.0 (mirage/awa-ssh#24 @hannesm)
