### PR TITLE
[new release] letsencrypt (0.2.4)

### DIFF
--- a/packages/letsencrypt/letsencrypt.0.2.4/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.4/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2.0"}
+  "astring"
+  "rresult"
+  "base64" {>= "3.1.0"}
+  "cmdliner"
+  "cohttp"
+  "cohttp-lwt" {>= "2.5.1"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "zarith"
+  "logs"
+  "fmt"
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-pk" {with-test & >= "0.8.9"}
+  "mirage-crypto-rng"
+  "x509" {>= "0.11.0"}
+  "yojson" {>= "1.6.0"}
+  "ounit" {with-test}
+  "dns"
+  "dns-tsig"
+  "ptime"
+  "bos"
+  "fpath"
+  "randomconv"
+  "domain-name" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+x-commit-hash: "8a91a33d3c4a1916649320651b53a59c1c9227bc"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.2.4/letsencrypt-v0.2.4.tbz"
+  checksum: [
+    "sha256=91c79828a50243804da29c17563c54d2d528a79207e5b874dce6a3e7fedf7567"
+    "sha512=5dad924844e4420266179d386f8516ac57b4a37d70d8a7f3da88b164b8faeea030312531876420a9fb368993b0df5b32e96f04bc5cd065f4e91f8d80d3f006aa"
+  ]
+}


### PR DESCRIPTION
ACME implementation in OCaml

- Project page: <a href="https://github.com/mmaker/ocaml-letsencrypt">https://github.com/mmaker/ocaml-letsencrypt</a>
- Documentation: <a href="https://mmaker.github.io/ocaml-letsencrypt">https://mmaker.github.io/ocaml-letsencrypt</a>

##### CHANGES:

* adapt to X.509 0.12.0 (mmaker/ocaml-letsencrypt#23 @dinosaure) by completing the pattern match in
  oacmel (still, only RSA account keys are supported)
