### PR TITLE
doi2bib: no need to test

### DIFF
--- a/packages/doi2bib/doi2bib.0.3.0/opam
+++ b/packages/doi2bib/doi2bib.0.3.0/opam
@@ -26,7 +26,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test & cohttp-lwt-unix:version < "3.0.0" }
     "@doc" {with-doc}
   ]
 ]

--- a/packages/doi2bib/doi2bib.0.3.1/opam
+++ b/packages/doi2bib/doi2bib.0.3.1/opam
@@ -26,7 +26,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/doi2bib/doi2bib.0.4.0/opam
+++ b/packages/doi2bib/doi2bib.0.4.0/opam
@@ -27,7 +27,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
This will remove spurious errors when the test touch upon external rate limits or when the DNS is slow. These have appeared in multiple revdeps recently, due to the sandboxing.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>