### PR TITLE
Release Caqti 1.5.1 driver bug fixes.

### DIFF
--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.5.1/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.5.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.5.0" & < "1.6.0~"}
+  "dune" {>= "1.11"}
+  "mariadb" {>= "1.1.1"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MariaDB driver for Caqti using C bindings"
+x-commit-hash: "06242515a50e2e413b7958ae09acf3aa1381de68"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.5.1/caqti-v1.5.1.tbz"
+  checksum: [
+    "sha256=4baa3d95e2e72ef6946bd1f46d6957f76e077b2b47cfb62096167389cdcc2e49"
+    "sha512=b7a6d60e98e70e3f1cf6f43ee5a4bae90c942605615c132ad1401d1efbd669cf72d5334880f64881a501128b6ca52f23b34526a7873b9c0b7cf83f53d30a5196"
+  ]
+}

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.5.1/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.5.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.5.0" & < "1.6.0~"}
+  "dune" {>= "1.11"}
+  "postgresql" {>= "5.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+x-commit-hash: "06242515a50e2e413b7958ae09acf3aa1381de68"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.5.1/caqti-v1.5.1.tbz"
+  checksum: [
+    "sha256=4baa3d95e2e72ef6946bd1f46d6957f76e077b2b47cfb62096167389cdcc2e49"
+    "sha512=b7a6d60e98e70e3f1cf6f43ee5a4bae90c942605615c132ad1401d1efbd669cf72d5334880f64881a501128b6ca52f23b34526a7873b9c0b7cf83f53d30a5196"
+  ]
+}


### PR DESCRIPTION
This fixes a similar bugs in the PostgreSQL and MariaDB, thanks to @mefyl who found the first one and raised my suspicion about the presence of the other.  Change log:

  - Fix option recognition in PostgreSQL driver (GPR#67 mefyl).
  - Fix option recognition in MariaDB driver and add test (Petter A. Urkedal).
