### PR TITLE
[new release] ca-certs-nss (3.64)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.64/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.64/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "X.509 trust anchors extracted from Mozilla's NSS"
+description: """
+Trust anchors extracted from Mozilla's NSS certdata.txt package,
+to be used in MirageOS unikernels.
+"""
+maintainer: ["Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs-nss"
+doc: "https://mirage.github.io/ca-certs-nss/doc"
+bug-reports: "https://github.com/mirage/ca-certs-nss/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "rresult"
+  "mirage-crypto"
+  "mirage-clock"
+  "x509" {>= "0.11.0"}
+  "ocaml" {>= "4.07.0"}
+  "logs" {build}
+  "fmt" {build}
+  "hex" {build}
+  "bos" {build}
+  "astring" {build}
+  "cmdliner" {build}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ca-certs-nss.git"
+tags: ["org:mirage"]
+x-commit-hash: "8a843ce619d1da51c7ffc17b3152eac59acfcbb9"
+url {
+  src:
+    "https://github.com/mirage/ca-certs-nss/releases/download/v3.64/ca-certs-nss-v3.64.tbz"
+  checksum: [
+    "sha256=bb2a74d717320759eef4d245dc6fb678c841ae16f32ebbc11b35876961ff073a"
+    "sha512=90e7faae0908b73a6ed6e0da9f24155e80db39cafb7534f553e636b77a6100477c4afd3a3b5c21bcc0a3ac2d6d7b8e81e7057948aaece57d93ab68a3ab5bfefa"
+  ]
+}


### PR DESCRIPTION
X.509 trust anchors extracted from Mozilla's NSS

- Project page: <a href="https://github.com/mirage/ca-certs-nss">https://github.com/mirage/ca-certs-nss</a>
- Documentation: <a href="https://mirage.github.io/ca-certs-nss/doc">https://mirage.github.io/ca-certs-nss/doc</a>

##### CHANGES:

* Update to NSS 3.64 (Apr 15th 2021)
