### PR TITLE
geoip: Fix compilation on mac os

### DIFF
--- a/packages/conf-libgeoip/conf-libgeoip.1/files/store_config.sh
+++ b/packages/conf-libgeoip/conf-libgeoip.1/files/store_config.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -ex
+
+cflags=$(pkg-config --cflags geoip)
+echo "cflags: \"$cflags\"" > geoip.config

--- a/packages/conf-libgeoip/conf-libgeoip.1/files/store_config.sh
+++ b/packages/conf-libgeoip/conf-libgeoip.1/files/store_config.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -ex
 
 cflags=$(pkg-config --cflags geoip)
-echo "cflags: \"$cflags\"" > geoip.config
+echo "cflags: \"$cflags\"" > conf-libgeoip.config

--- a/packages/conf-libgeoip/conf-libgeoip.1/opam
+++ b/packages/conf-libgeoip/conf-libgeoip.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://github.com/maxmind/geoip-api-c"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "geoip dev team"
+license: "LGPL-2.1-or-later"
+build: [
+  ["pkg-config" "--print-errors" "--exists" "geoip"]
+  ["sh" "-ex" "./store_config.sh"]
+]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["libgeoip-dev"] {os-family = "debian"}
+  ["libgeoip-dev"] {os-family = "ubuntu"}
+  ["GeoIP-devel"] {os-distribution = "fedora"}
+  ["GeoIP-devel"] {os-distribution = "rhel"}
+  ["GeoIP-devel"] {os-distribution = "centos"}
+  ["libGeoIP-devel"] {os-family = "suse"}
+  ["geoip-dev"] {os-family = "alpine"}
+  ["geoip"] {os-family = "arch"}
+  ["geoip"] {os = "macos" & os-distribution = "homebrew"}
+  ["libgeoip"] {os = "macos" & os-distribution = "macports"}
+]
+extra-files: [
+  ["store_config.sh" "md5=0daa00365d081d99de397d577a7cc6a4"]
+]
+synopsis: "Virtual package relying on geoip"
+description:
+  "This package can only install if the geoip library is installed on the system."
+flags: conf

--- a/packages/conf-libgeoip/conf-libgeoip.1/opam
+++ b/packages/conf-libgeoip/conf-libgeoip.1/opam
@@ -24,7 +24,7 @@ depexts: [
   ["libgeoip"] {os = "macos" & os-distribution = "macports"}
 ]
 extra-files: [
-  ["store_config.sh" "md5=0daa00365d081d99de397d577a7cc6a4"]
+  ["store_config.sh" "md5=4792c510b9493d60d4de75feab2b54e7"]
 ]
 synopsis: "Virtual package relying on geoip"
 description:

--- a/packages/geoip/geoip.0.0.2/opam
+++ b/packages/geoip/geoip.0.0.2/opam
@@ -5,13 +5,13 @@ homepage: "https://ygrek.org/p/ocaml-geoip/"
 doc: ["https://ygrek.org/p/ocaml-geoip/api/index.html"]
 bug-reports: "https://github.com/ygrek/ocaml-geoip/issues"
 dev-repo: "git://github.com/ygrek/ocaml-geoip.git"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 tags: ["org:ygrek"]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build" "-cflags" conf-libgeoip:cflags]
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]
-remove: [["ocamlfind" "remove" "geoip"]]
 depends: [
   "ocaml" {< "4.06.0"}
   "ocamlfind" {build}
@@ -19,10 +19,9 @@ depends: [
   "conf-libgeoip" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
-synopsis: "Bindings to GeoIP database library."
+synopsis: "Bindings to GeoIP database library"
 description:
   "GeoIP lets you discover information about a specific IP address."
-flags: light-uninstall
 url {
   src: "https://ygrek.org/p/release/ocaml-geoip/ocaml-geoip-0.0.2.tar.gz"
   checksum: "md5=baae04937a9d0fd02cc531b600a080b2"

--- a/packages/geoip/geoip.0.0.2/opam
+++ b/packages/geoip/geoip.0.0.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git://github.com/ygrek/ocaml-geoip.git"
 tags: ["org:ygrek"]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
-  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-build" "-cflags" conf-libgeoip:cflags]
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]
 remove: [["ocamlfind" "remove" "geoip"]]
@@ -16,12 +16,7 @@ depends: [
   "ocaml" {< "4.06.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-]
-depexts: [
-  ["libgeoip-dev"] {os-family = "debian"}
-  ["geoip"] {os = "macos" & os-distribution = "homebrew"}
-  ["geoip-dev"] {os-distribution = "alpine"}
-  ["GeoIP-devel"] {os-distribution = "centos"}
+  "conf-libgeoip" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Bindings to GeoIP database library."

--- a/packages/geoip/geoip.0.0.3/opam
+++ b/packages/geoip/geoip.0.0.3/opam
@@ -26,9 +26,10 @@ depexts: [
   ["GeoIP-devel"] {os-distribution = "centos"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
-synopsis: "Bindings to GeoIP database library."
+synopsis: "Bindings to GeoIP database library"
 description:
   "GeoIP lets you discover information about a specific IP address."
+license: "LGPL-2.1 with OCaml linking exception"
 flags: light-uninstall
 url {
   src: "https://ygrek.org/p/release/ocaml-geoip/ocaml-geoip-0.0.3.tar.gz"

--- a/packages/geoip/geoip.0.0.3/opam
+++ b/packages/geoip/geoip.0.0.3/opam
@@ -8,7 +8,8 @@ dev-repo: "git://github.com/ygrek/ocaml-geoip.git"
 tags: ["org:ygrek"]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
-  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-build"] { os != macos }
+  ["ocaml" "setup.ml" "-build" "-cflags" "-I/opt/local/include -I/opt/homebrew/include -I/usr/local/include" "-lflags" "-L/opt/local/lib -L/opt/homebrew/lib -L/usr/local/lib"] { os = macos }
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]
 remove: [["ocamlfind" "remove" "geoip"]]
@@ -20,6 +21,7 @@ depends: [
 depexts: [
   ["libgeoip-dev"] {os-family = "debian"}
   ["geoip"] {os = "macos" & os-distribution = "homebrew"}
+  ["libgeoip"] {os = "macos" & os-distribution = "macports"}
   ["geoip-dev"] {os-distribution = "alpine"}
   ["GeoIP-devel"] {os-distribution = "centos"}
 ]

--- a/packages/geoip/geoip.0.0.3/opam
+++ b/packages/geoip/geoip.0.0.3/opam
@@ -8,8 +8,7 @@ dev-repo: "git://github.com/ygrek/ocaml-geoip.git"
 tags: ["org:ygrek"]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
-  ["ocaml" "setup.ml" "-build"] { os != macos }
-  ["ocaml" "setup.ml" "-build" "-cflags" "-I/opt/local/include -I/opt/homebrew/include -I/usr/local/include" "-lflags" "-L/opt/local/lib -L/opt/homebrew/lib -L/usr/local/lib"] { os = macos }
+  ["ocaml" "setup.ml" "-build" "-cflags" conf-libgeoip:cflags]
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]
 remove: [["ocamlfind" "remove" "geoip"]]
@@ -17,13 +16,7 @@ depends: [
   "ocaml"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-]
-depexts: [
-  ["libgeoip-dev"] {os-family = "debian"}
-  ["geoip"] {os = "macos" & os-distribution = "homebrew"}
-  ["libgeoip"] {os = "macos" & os-distribution = "macports"}
-  ["geoip-dev"] {os-distribution = "alpine"}
-  ["GeoIP-devel"] {os-distribution = "centos"}
+  "conf-libgeoip" {build}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Bindings to GeoIP database library"

--- a/packages/geoip/geoip.0.0.3/opam
+++ b/packages/geoip/geoip.0.0.3/opam
@@ -5,13 +5,13 @@ homepage: "https://ygrek.org/p/ocaml-geoip/"
 doc: ["https://ygrek.org/p/ocaml-geoip/api/index.html"]
 bug-reports: "https://github.com/ygrek/ocaml-geoip/issues"
 dev-repo: "git://github.com/ygrek/ocaml-geoip.git"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 tags: ["org:ygrek"]
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build" "-cflags" conf-libgeoip:cflags]
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]
-remove: [["ocamlfind" "remove" "geoip"]]
 depends: [
   "ocaml"
   "ocamlfind" {build}
@@ -22,8 +22,6 @@ install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Bindings to GeoIP database library"
 description:
   "GeoIP lets you discover information about a specific IP address."
-license: "LGPL-2.1 with OCaml linking exception"
-flags: light-uninstall
 url {
   src: "https://ygrek.org/p/release/ocaml-geoip/ocaml-geoip-0.0.3.tar.gz"
   checksum: "md5=470df2ff7952d36fe58cf23082cdfcae"


### PR DESCRIPTION
Add include paths and library paths where lib is installed with either macports or homebrew.
(Not tested with homebrew but should be ok.)