### PR TITLE
conf-libx11: brew now installs in /opt

### DIFF
--- a/packages/conf-libX11/conf-libX11.1/opam
+++ b/packages/conf-libX11/conf-libX11.1/opam
@@ -8,7 +8,7 @@ build: [
   ["pkg-config" "x11"] {os != "macos"}
   [
     "sh" "-exc"
-    """PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig" pkg-config --libs x11"""
+    """PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig:/opt/X11/share/pkgconfig" pkg-config --libs x11"""
   ] {os = "macos"}
 ]
 depends: ["conf-pkg-config" {build}]
@@ -18,7 +18,8 @@ depexts: [
   ["libx11-dev"] {os-distribution = "alpine"}
   ["libx11"] {os-distribution = "arch"}
   ["libX11-dev"] {os-distribution = "cygwin"}
-  ["xquartz" "xorgproto"] {os = "macos" & os-distribution = "homebrew"}
+  ["xquartz"] {os = "macos" & os-distribution = "homebrew"}
+  ["xorg-libX11"] {os = "macos" & os-distribution = "macports"}
 ]
 synopsis: "Virtual package relying on an Xlib system installation"
 description:


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/issues/18475

Should we add a post-install (failure?) message mentioning to be careful with the path? An alternative could be to update this as we did in `conf-libssl.3`

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>