### PR TITLE
Add a post-message to Merlin regarding completion in Emacs

### DIFF
--- a/packages/merlin/merlin.3.5.0/opam
+++ b/packages/merlin/merlin.3.5.0/opam
@@ -66,6 +66,11 @@ should take care of basic setup.
 See https://github.com/OCamlPro/opam-user-setup
 "
   {success & !user-setup:installed}
+"Since version 3.5.0, Merlin integration with completion packages company
+and auto-complete has moved to separate modules. Make sure to add
+`(require 'merlin-company)` or `(require 'merlin-ac)` to your emacs
+configuration if you were using one of these."
+  {success}
 ]
 x-commit-hash: "353bcb82443b37cc1924039578d2b22cdb6951a9"
 url {

--- a/packages/merlin/merlin.4.2-411/opam
+++ b/packages/merlin/merlin.4.2-411/opam
@@ -65,6 +65,11 @@ should take care of basic setup.
 See https://github.com/OCamlPro/opam-user-setup
 "
   {success & !user-setup:installed}
+"Since version 4.2, Merlin integration with completion packages company
+and auto-complete has moved to separate modules. Make sure to add
+`(require 'merlin-company)` or `(require 'merlin-ac)` to your emacs
+configuration if you were using one of these."
+  {success}
 ]
 x-commit-hash: "3160ccc7a272920c5fd43ccf867ff4c5d393d5d0"
 url {

--- a/packages/merlin/merlin.4.2-412/opam
+++ b/packages/merlin/merlin.4.2-412/opam
@@ -65,6 +65,11 @@ should take care of basic setup.
 See https://github.com/OCamlPro/opam-user-setup
 "
   {success & !user-setup:installed}
+"Since version 4.2, Merlin integration with completion packages company
+and auto-complete has moved to separate modules. Make sure to add
+`(require 'merlin-company)` or `(require 'merlin-ac)` to your emacs
+configuration if you were using one of these."
+  {success}
 ]
 x-commit-hash: "fe7380bb13ff91f8ed5cfbfea6a6ca01ee1ef88c"
 url {


### PR DESCRIPTION
This PR adds the following post-install message to Merlin packages. 
Sadly there is no way to have this message only show when user upgrade from a specific version, so I guess it will be best not to include it in future release assuming that people will have done the update by then.

```
"Since version 4.2, Merlin integration with completion packages company
and auto-complete has moved to separate modules. Make sure to add
`(require 'merlin-company)` or `(require 'merlin-ac)` to your emacs
configuration if you were using one of these."
  {success}
  ```

@trefis, @let-def 