### PR TITLE
[new release] multipart_form (0.2.0)

### DIFF
--- a/packages/multipart_form/multipart_form.0.2.0/opam
+++ b/packages/multipart_form/multipart_form.0.2.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Multipart-form: RFC2183, RFC2388 & RFC7578"
+description: """\
+Implementation of RFC7578 in OCaml
+
+Returning values from forms: multipart/form-data"""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "base64"
+  "unstrctrd" {>= "0.2"}
+  "rresult"
+  "uutf"
+  "stdlib-shims"
+  "pecu" {>= "0.4"}
+  "lwt"
+  "mrmime"
+  "fmt"
+  "logs"
+  "ke" {>= "0.4"}
+  "alcotest" {with-test}
+  "bigarray-compat" {>= "1.0.0"}
+  "bigstringaf" {>= "0.7.0"}
+  "result" {>= "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"
+x-commit-hash: "b4d2a0534d34a772210a17c6f1e698f18996ea8a"
+url {
+  src:
+    "https://github.com/dinosaure/multipart_form/releases/download/v0.2.0/multipart_form-v0.2.0.tbz"
+  checksum: [
+    "sha256=cff5758d3ea1bd759d65b628611527deec9719dc10e89779a0306cfcf36bf6a0"
+    "sha512=e59a6cd6893825452672e8ee1fa3ae8d8d72449948ca1b8500a81670b416cd1715e2a8f7bb72794565c422064e0fe7950038b5cba600aa04647eaedeee6b1ac0"
+  ]
+}


### PR DESCRIPTION
Multipart-form: RFC2183, RFC2388 & RFC7578

- Project page: <a href="https://github.com/dinosaure/multipart_form">https://github.com/dinosaure/multipart_form</a>
- Documentation: <a href="https://dinosaure.github.io/multipart_form/">https://dinosaure.github.io/multipart_form/</a>

##### CHANGES:

- Add an encoder of `multipart/form-data` (@dinosaure, dinosaure/multipart_form#9)
- Provide `multipart_form.lwt` which is a specialization
  of `multipart_form` with `lwt` and _streams_
  (@Armael, @dinosaure, dinosaure/multipart_form#10)
- Add convenience functions such as `map` or `flatten`
  (@Armael, dinosaure/multipart_form#10)
- Add `Multipart_form.parse` (@Armael, dinosaure/multipart_form#10)
- Add documentation to help user (@Armael, @dinosaure, dinosaure/multipart_form#10, dinosaure/multipart_form#11, dinosaure/multipart_form#13)
- Update the README.md (@dinosaure, dinosaure/multipart_form#12)
