### PR TITLE
[new release] paf (0.0.2)

### DIFF
--- a/packages/paf/paf.0.0.2/opam
+++ b/packages/paf/paf.0.0.2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "mirage-stack"
+  "mirage-time"
+  "httpaf"
+  "tls-mirage"
+  "mimic"
+  "cohttp-lwt"
+  "letsencrypt"
+  "emile"
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "tcpip" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "domain-name" {>= "0.3.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.7.0"}
+  "duration" {>= "0.1.3"}
+  "faraday" {>= "0.7.2"}
+  "ipaddr" {>= "5.0.1"}
+  "tls" {>= "0.13.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+x-commit-hash: "a9be660fe15d963bcf9a1de69369e840bd8f2c3c"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.2/paf-0.0.2.tbz"
+  checksum: [
+    "sha256=b46a9ba08b178712e6f8f508618ef89ac749c8abae0d5a99271d9043229eeac7"
+    "sha512=9719a52e501d1afbbf9e32850e1558926439074dd9891c8e3f2bf6625741a91c4957e66e7d0343f982108c85bbf058de8f89deaca80d4c5f8b74034180c47420"
+  ]
+}


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Add simple unikernel as an example of `paf` (@dinosaure, dinosaure/paf-le-chien#17)
- Unfunctorize the client part of HTTP/AF (@dinosaure, dinosaure/paf-le-chien#18)
- Ensure to pass queries to the server handler (@dinosaure, dinosaure/paf-le-chien#19)
- Add the support of `h2` and ALPN (@dinosaure, dinosaure/paf-le-chien#20)
- Support `tls.0.13.0` (@dinosaure, @hannesm, dinosaure/paf-le-chien#21)
- Add tests about ALPN dispatcher (@dinosaure, dinosaure/paf-le-chien#22)
