### PR TITLE
[new release] x509 (0.13.0)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.57/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.57/opam
@@ -15,7 +15,7 @@ depends: [
   "rresult"
   "mirage-crypto"
   "mirage-clock"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.13.0"}
   "ocaml" {>= "4.07.0"}
   "logs" {build}
   "fmt" {build}

--- a/packages/ca-certs-nss/ca-certs-nss.3.59/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.59/opam
@@ -15,7 +15,7 @@ depends: [
   "rresult"
   "mirage-crypto"
   "mirage-clock"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.13.0"}
   "ocaml" {>= "4.07.0"}
   "logs" {build}
   "fmt" {build}

--- a/packages/ca-certs-nss/ca-certs-nss.3.60/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.60/opam
@@ -15,7 +15,7 @@ depends: [
   "rresult"
   "mirage-crypto"
   "mirage-clock"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.13.0"}
   "ocaml" {>= "4.07.0"}
   "logs" {build}
   "fmt" {build}

--- a/packages/ca-certs-nss/ca-certs-nss.3.63.1/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.63.1/opam
@@ -15,7 +15,7 @@ depends: [
   "rresult"
   "mirage-crypto"
   "mirage-clock"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.13.0"}
   "ocaml" {>= "4.07.0"}
   "logs" {build}
   "fmt" {build}

--- a/packages/ca-certs-nss/ca-certs-nss.3.63/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.63/opam
@@ -16,7 +16,7 @@ depends: [
   "rresult"
   "mirage-crypto"
   "mirage-clock"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.13.0"}
   "ocaml" {>= "4.07.0"}
   "logs" {build}
   "fmt" {build}

--- a/packages/ca-certs-nss/ca-certs-nss.3.64/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.64/opam
@@ -15,7 +15,7 @@ depends: [
   "rresult"
   "mirage-crypto"
   "mirage-clock"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.13.0"}
   "ocaml" {>= "4.07.0"}
   "logs" {build}
   "fmt" {build}

--- a/packages/ca-certs/ca-certs.0.1.2/opam
+++ b/packages/ca-certs/ca-certs.0.1.2/opam
@@ -18,7 +18,7 @@ depends: [
   "rresult"
   "ptime"
   "mirage-crypto"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.13.0"}
   "ocaml" {>= "4.07.0"}
   "alcotest" {with-test}
 ]

--- a/packages/ca-certs/ca-certs.0.1.3/opam
+++ b/packages/ca-certs/ca-certs.0.1.3/opam
@@ -22,7 +22,7 @@ depends: [
   "ptime"
   "logs"
   "mirage-crypto"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.13.0"}
   "ocaml" {>= "4.07.0"}
   "alcotest" {with-test}
 ]

--- a/packages/ca-certs/ca-certs.0.2.0/opam
+++ b/packages/ca-certs/ca-certs.0.2.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ptime"
   "logs"
   "mirage-crypto"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.13.0"}
   "ocaml" {>= "4.07.0"}
   "alcotest" {with-test}
 ]

--- a/packages/conex-mirage-crypto/conex-mirage-crypto.0.11.1/opam
+++ b/packages/conex-mirage-crypto/conex-mirage-crypto.0.11.1/opam
@@ -15,7 +15,7 @@ depends: [
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-rng"
-  "x509" {>= "0.7.0"}
+  "x509" {>= "0.7.0" & < "0.13.0"}
   "logs"
   "fmt"
   "rresult"

--- a/packages/letsencrypt/letsencrypt.0.2.4/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.4/opam
@@ -26,7 +26,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & >= "0.8.9"}
   "mirage-crypto-rng"
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.13.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}
   "dns"

--- a/packages/x509/x509.0.13.0/opam
+++ b/packages/x509/x509.0.13.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2"}
+  "cstruct" {>= "4.0.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "ptime"
+  "base64" {>= "3.0.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "mirage-crypto-rng"
+  "rresult"
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+  "pbkdf"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 5, PKCS 7, PKCS 8, PKCS 9, PKCS 10, and PKCS 12.
+"""
+x-commit-hash: "530fd30fec2f25ef5eef35971ce444054c74f06f"
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v0.13.0/x509-v0.13.0.tbz"
+  checksum: [
+    "sha256=4577c2a616bda45cc777869fc44e272397d63a029135a993df8937bcfd6f6c49"
+    "sha512=ab6d4df7e6b6796b962d4ec3d949723c2a039fc9d534a196d8ebd71499dce310716aba3be7bd9600428b534f5eadf7b8b106f77633a63f46c16eceb447e946cc"
+  ]
+}


### PR DESCRIPTION
Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-x509">https://github.com/mirleft/ocaml-x509</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-x509/doc">https://mirleft.github.io/ocaml-x509/doc</a>

##### CHANGES:

* FEATURE support for RFC 5915 "BEGIN EC PRIVATE KEY" pem encoded private keys
  (mirleft/ocaml-x509#147 @hannesm, requested by @ulrikstrid)
* BREAKING remove EC_pub _ from Public_key.t and EC _ from Certificate.key_type
  (mirleft/ocaml-x509#147 by @hannesm)
* BREAKING move Certificate.key_type to Key_type.t (mirleft/ocaml-x509#147 @hannesm)
* FEATURE some private key utilities (of_cstruct, generate, sign), and
  Public_key.verify (#report mirleft/ocaml-x509#146, fix mirleft/ocaml-x509#147 @hannesm)
* BREAKING rename hash_whitelist to allowed_hashes (mirleft/ocaml-x509#147 @hannesm)
* BREAKING provide Key_type.signature_scheme and use across the API
  (mirleft/ocaml-x509#147 @hannesm)
