### PR TITLE
[new release] decompress and rfc1951 (1.4.0)

### DIFF
--- a/packages/decompress/decompress.1.4.0/opam
+++ b/packages/decompress/decompress.1.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "base-bytes"
+  "bigarray-compat"
+  "cmdliner"
+  "optint"      {>= "0.0.4"}
+  "checkseum"   {>= "0.2.0"}
+  "bigstringaf" {with-test}
+  "alcotest"    {with-test}
+  "ctypes"      {with-test & >= "0.18.0"}
+  "fmt"         {with-test}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+]
+x-commit-hash: "6637d0fb0e0d4f9ad562924d6b04a813c6bcdd64"
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.4.0/decompress-v1.4.0.tbz"
+  checksum: [
+    "sha256=d1669e07446d73dd5e16f020d4a1682abcbb1b7a1e3bf19b805429636c26a19b"
+    "sha512=808e278640ab84b8ead7c5b7d22b70e3809255e37cc80a595cc58dd4974e5240f70307f048041ab1d8678826ce041da4f186179aa7ebbba5e7cfacaaf054f3e6"
+  ]
+}

--- a/packages/rfc1951/rfc1951.1.4.0/opam
+++ b/packages/rfc1951/rfc1951.1.4.0/opam
@@ -17,7 +17,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"      {>= "4.07.0"}
-  "dune"       {>= "1.0"}
+  "dune"       {>= "2.8"}
   "decompress" {= version}
   "bigarray-compat"
   "checkseum"

--- a/packages/rfc1951/rfc1951.1.4.0/opam
+++ b/packages/rfc1951/rfc1951.1.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "dune"       {>= "1.0"}
+  "decompress" {= version}
+  "bigarray-compat"
+  "checkseum"
+  "optint"
+  "ctypes"     {with-test & >= "0.18.0"}
+]
+x-commit-hash: "6637d0fb0e0d4f9ad562924d6b04a813c6bcdd64"
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.4.0/decompress-v1.4.0.tbz"
+  checksum: [
+    "sha256=d1669e07446d73dd5e16f020d4a1682abcbb1b7a1e3bf19b805429636c26a19b"
+    "sha512=808e278640ab84b8ead7c5b7d22b70e3809255e37cc80a595cc58dd4974e5240f70307f048041ab1d8678826ce041da4f186179aa7ebbba5e7cfacaaf054f3e6"
+  ]
+}


### PR DESCRIPTION
Implementation of Zlib and GZip in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- Add a well-know limitation about the encoding on the documentation, the
  output buffer must be upper than 2 bytes in any cases.
  (@dinosaure, mirage/decompress#114)
- Improve the documentation
  (@dinosaure, @brendanlong, mirage/decompress#115)
- **breaking changes**, the type of the window used to deflate according
  RFC 1951 was updated to `De.Lz77.window`
  (@dinosaure, mirage/decompress#116 & mirage/decompress#115)
- Fix a bug when we want to add the EOB _op-code_ into the queue. The deflation
  takes care about that. Note that the queue must be larger than 2.
  (@dinosaure, @kluvin, mirage/decompress#117)
- Improve the documentation a bit
  (@mseri, @dinosaure, mirage/decompress#119)
- Fix the use of `optint` and how we handle large files with `Gz`. Fix an error
  when we encode the `isize` into the deflated stream.
  (@dinosaure, @igarnier, mirage/decompress#121 & mirage/decompress#120)
- Add a _non-stream_ implementation (@clecat, @dinosaure, mirage/decompress#102 & mirage/decompress#92)

  The non-blocking stream API has a cost to maintain a _state_ across _syscall_
  such as `read` and `write`. It's useful when we want to plug `decompress`
  behind something like a `socket` and care about memory-consumption but it has
  a big cost when we want to compress/decompress an object saved into one and
  unique buffer.

  The _non-stream_ API gives an opportunity to inflate/deflate one and unique
  buffer without the usual plumbing required by the non-blocking stream API.
  However, we are limited to compute only objects which can fit into a
  `bigarray`.

  About performance, the non-stream API is better than the non-blocking stream
  API. See the PR for more details about performances. On the
  `book2` (from the Calgary corpus) file:
  - `decompress` (stream):
     15 Mb/s (deflation), 76 Mb/s (inflation), ratio: 42.46 %
  - `decompress` (non-stream):
     17 Mb/s (deflation), 105 Mb/s (inflation), ratio: 34.66 %

  Even if we checked the implementation with our tests (we ran `ocaml-git` and
  `irmin` with this path), the implementation is young and we probably miss
  some details/bugs. So we advise the user to compare, at least, the non-stream
  implementation with the non-blocking stream implementation if something is
  wrong.
