### PR TITLE
[new release] arp (2.3.2)

### DIFF
--- a/packages/arp/arp.2.3.2/opam
+++ b/packages/arp/arp.2.3.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/arp"
+doc: "https://mirage.github.io/arp/"
+dev-repo: "git+https://github.com/mirage/arp.git"
+bug-reports: "https://github.com/mirage/arp/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "2.2.0"}
+  "ipaddr" {>= "4.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "logs"
+  "mirage-time" {>= "2.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "lwt"
+  "duration"
+  "mirage-profile" {>= "0.9"}
+  "mirage-random" {with-test & >= "2.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "alcotest" {with-test}
+  "ethernet" {with-test & >= "2.0.0"}
+  "fmt" {with-test}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-random" {with-test & >= "2.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-flow" {with-test & >= "2.0.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Address Resolution Protocol purely in OCaml"
+description: """
+ARP is an implementation of the address resolution protocol (RFC826) purely in
+OCaml.  It handles IPv4 protocol addresses and Ethernet hardware addresses only.
+"""
+x-commit-hash: "b043dbb6b6b6c6d27858e300e1a39ce8002b413d"
+url {
+  src:
+    "https://github.com/mirage/arp/releases/download/v2.3.2/arp-v2.3.2.tbz"
+  checksum: [
+    "sha256=ffe5072675b79cf709eb4553ad4e92cc455987ad9d9b642713f79a9de48a09e8"
+    "sha512=70ef9d77053a8bcac669b4cd4b1f3b46d0c327dfe795bc4d72865bfc4b4cbaf96740f2561aff3ae5772c9275bd81b2c83f952d45bb1820d745dc33b641eca25b"
+  ]
+}


### PR DESCRIPTION
Address Resolution Protocol purely in OCaml

- Project page: <a href="https://github.com/mirage/arp">https://github.com/mirage/arp</a>
- Documentation: <a href="https://mirage.github.io/arp/">https://mirage.github.io/arp/</a>

##### CHANGES:

* Compatibility with alcotest 1.4.0 (mirage/arp#22 @CraigFE)
* Minor updates for CI (mirage/arp#23 @hannesm)
