### PR TITLE
[new release] tls-mirage and tls (0.13.1)

### DIFF
--- a/packages/paf/paf.0.0.2/opam
+++ b/packages/paf/paf.0.0.2/opam
@@ -37,6 +37,7 @@ depends: [
   "faraday" {>= "0.7.2"}
   "ipaddr" {>= "5.0.1"}
   "tls" {>= "0.13.0"}
+  "x509" {< "0.13.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]

--- a/packages/tls-mirage/tls-mirage.0.13.1/opam
+++ b/packages/tls-mirage/tls-mirage.0.13.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "tls" {= version}
+  "x509" {>= "0.13.0"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"
+description: """
+Tls-mirage provides an effectful FLOW module to be used in the MirageOS
+ecosystem.
+"""
+x-commit-hash: "a1fc37efaedbcbec89874ca746cde69b2950f0f6"
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.13.1/tls-v0.13.1.tbz"
+  checksum: [
+    "sha256=ca95fa59a82f7d38b0b495fc0cd1ff54e7728492a292895d0067c1ba9de81b7b"
+    "sha512=f5ec06a9401c5bba7b9ba011fbec14136685b673f4ec87d0eefedb9cb53f93d02142bb9a75955b8c2c5832cdcebec8751c63ce092d2b6e361a19fe1a8a1e36b1"
+  ]
+}

--- a/packages/tls/tls.0.13.1/opam
+++ b/packages/tls/tls.0.13.1/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_cstruct" {>= "3.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "cstruct-sexp"
+  "sexplib"
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "x509" {>= "0.13.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt"
+  "rresult"
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "ounit2" {with-test & >= "2.2.0"}
+  "lwt" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "hkdf"
+  "logs"
+  "alcotest" {with-test}
+]
+
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+x-commit-hash: "a1fc37efaedbcbec89874ca746cde69b2950f0f6"
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.13.1/tls-v0.13.1.tbz"
+  checksum: [
+    "sha256=ca95fa59a82f7d38b0b495fc0cd1ff54e7728492a292895d0067c1ba9de81b7b"
+    "sha512=f5ec06a9401c5bba7b9ba011fbec14136685b673f4ec87d0eefedb9cb53f93d02142bb9a75955b8c2c5832cdcebec8751c63ce092d2b6e361a19fe1a8a1e36b1"
+  ]
+}


### PR DESCRIPTION
Transport Layer Security purely in OCaml, MirageOS layer

- Project page: <a href="https://github.com/mirleft/ocaml-tls">https://github.com/mirleft/ocaml-tls</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-tls/doc">https://mirleft.github.io/ocaml-tls/doc</a>

##### CHANGES:

* Breaking: use deriving sexp_of instead of sexp. Constructing a state from
  a sexp has not been supported (lead to exception), and is now removed
  (mirleft/ocaml-tls#430 by @torinnd, continued in mirleft/ocaml-tls#431 by @hannesm)
* Bugfix: TLS 1.3 client authentication with certificate, client side. This
  used to work accidentally before 0.13.0 changed the signature algorithms
  handling, now the right signature algorithm (as requested by server) is used.
  (mirleft/ocaml-tls#431 @hannesm, @talex5 reported https://github.com/mirage/capnp-rpc/pull/228)
* adapt to x509 0.13.0 and mirage-crypto-ec 0.10.0 changes (mirleft/ocaml-tls#431 @hannesm)
