### PR TITLE
[new release] dns, dns-stub, dns-certify, dns-mirage, dns-resolver, dns-client, dns-server, dns-tsig and dns-cli (5.0.1)

### DIFF
--- a/packages/dns-certify/dns-certify.5.0.1/opam
+++ b/packages/dns-certify/dns-certify.5.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "0.13.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "logs"
+  "mirage-crypto-ec"
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+x-commit-hash: "9d5676fc62381c3c6b5e6fcadda2b645e2bc38be"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.1/dns-v5.0.1.tbz"
+  checksum: [
+    "sha256=72c0a1a91c8e409bd448c8e0ea28d16d13177c326aea403ee1c30ddcb5969adc"
+    "sha512=f5067d4ef6aca863bd06e6721a63a03da80052ab8e361440e72fae07ca45773763e0321236c6810afe80bd679d68763dc63fb57aec2e953173cc9a944785c93c"
+  ]
+}

--- a/packages/dns-cli/dns-cli.5.0.1/opam
+++ b/packages/dns-cli/dns-cli.5.0.1/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-client" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "rresult" {>= "0.6.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "0.13.0"}
+  "mirage-crypto" {>= "0.8.0"}
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "hex" {>= "1.4.0"}
+  "ptime" {>= "0.8.5"}
+  "mtime" {>= "1.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.0.0"}
+  "randomconv"
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+x-commit-hash: "9d5676fc62381c3c6b5e6fcadda2b645e2bc38be"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.1/dns-v5.0.1.tbz"
+  checksum: [
+    "sha256=72c0a1a91c8e409bd448c8e0ea28d16d13177c326aea403ee1c30ddcb5969adc"
+    "sha512=f5067d4ef6aca863bd06e6721a63a03da80052ab8e361440e72fae07ca45773763e0321236c6810afe80bd679d68763dc63fb57aec2e953173cc9a944785c93c"
+  ]
+}

--- a/packages/dns-client/dns-client.5.0.1/opam
+++ b/packages/dns-client/dns-client.5.0.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt" {>= "0.8.8"}
+  "logs" {>= "0.6.3"}
+  "dns" {= version}
+  "rresult" {>= "0.6.0"}
+  "randomconv" {>= "0.1.2"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "alcotest" {with-test}
+]
+synopsis: "Pure DNS resolver API"
+description: """
+A pure resolver implementation using uDNS.
+"""
+x-commit-hash: "9d5676fc62381c3c6b5e6fcadda2b645e2bc38be"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.1/dns-v5.0.1.tbz"
+  checksum: [
+    "sha256=72c0a1a91c8e409bd448c8e0ea28d16d13177c326aea403ee1c30ddcb5969adc"
+    "sha512=f5067d4ef6aca863bd06e6721a63a03da80052ab8e361440e72fae07ca45773763e0321236c6810afe80bd679d68763dc63fb57aec2e953173cc9a944785c93c"
+  ]
+}

--- a/packages/dns-mirage/dns-mirage.5.0.1/opam
+++ b/packages/dns-mirage/dns-mirage.5.0.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-stack" {>= "2.2.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+x-commit-hash: "9d5676fc62381c3c6b5e6fcadda2b645e2bc38be"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.1/dns-v5.0.1.tbz"
+  checksum: [
+    "sha256=72c0a1a91c8e409bd448c8e0ea28d16d13177c326aea403ee1c30ddcb5969adc"
+    "sha512=f5067d4ef6aca863bd06e6721a63a03da80052ab8e361440e72fae07ca45773763e0321236c6810afe80bd679d68763dc63fb57aec2e953173cc9a944785c93c"
+  ]
+}

--- a/packages/dns-resolver/dns-resolver.5.0.1/opam
+++ b/packages/dns-resolver/dns-resolver.5.0.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+x-commit-hash: "9d5676fc62381c3c6b5e6fcadda2b645e2bc38be"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.1/dns-v5.0.1.tbz"
+  checksum: [
+    "sha256=72c0a1a91c8e409bd448c8e0ea28d16d13177c326aea403ee1c30ddcb5969adc"
+    "sha512=f5067d4ef6aca863bd06e6721a63a03da80052ab8e361440e72fae07ca45773763e0321236c6810afe80bd679d68763dc63fb57aec2e953173cc9a944785c93c"
+  ]
+}

--- a/packages/dns-server/dns-server.5.0.1/opam
+++ b/packages/dns-server/dns-server.5.0.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-crypto-rng" {with-test}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "base64" {with-test & >= "3.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+x-commit-hash: "9d5676fc62381c3c6b5e6fcadda2b645e2bc38be"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.1/dns-v5.0.1.tbz"
+  checksum: [
+    "sha256=72c0a1a91c8e409bd448c8e0ea28d16d13177c326aea403ee1c30ddcb5969adc"
+    "sha512=f5067d4ef6aca863bd06e6721a63a03da80052ab8e361440e72fae07ca45773763e0321236c6810afe80bd679d68763dc63fb57aec2e953173cc9a944785c93c"
+  ]
+}

--- a/packages/dns-stub/dns-stub.5.0.1/opam
+++ b/packages/dns-stub/dns-stub.5.0.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "dns-client" {= version}
+  "dns-mirage" {= version}
+  "dns-resolver" {= version}
+  "dns-tsig" {= version}
+  "dns-server" {= version}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS stub resolver"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+x-commit-hash: "9d5676fc62381c3c6b5e6fcadda2b645e2bc38be"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.1/dns-v5.0.1.tbz"
+  checksum: [
+    "sha256=72c0a1a91c8e409bd448c8e0ea28d16d13177c326aea403ee1c30ddcb5969adc"
+    "sha512=f5067d4ef6aca863bd06e6721a63a03da80052ab8e361440e72fae07ca45773763e0321236c6810afe80bd679d68763dc63fb57aec2e953173cc9a944785c93c"
+  ]
+}

--- a/packages/dns-tsig/dns-tsig.5.0.1/opam
+++ b/packages/dns-tsig/dns-tsig.5.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "dns" {= version}
+  "mirage-crypto"
+  "base64" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+x-commit-hash: "9d5676fc62381c3c6b5e6fcadda2b645e2bc38be"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.1/dns-v5.0.1.tbz"
+  checksum: [
+    "sha256=72c0a1a91c8e409bd448c8e0ea28d16d13177c326aea403ee1c30ddcb5969adc"
+    "sha512=f5067d4ef6aca863bd06e6721a63a03da80052ab8e361440e72fae07ca45773763e0321236c6810afe80bd679d68763dc63fb57aec2e953173cc9a944785c93c"
+  ]
+}

--- a/packages/dns/dns.5.0.1/opam
+++ b/packages/dns/dns.5.0.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.07.0"}
+  "rresult" "astring" "fmt" "logs" "ptime"
+  "domain-name" {>= "0.3.0"}
+  "gmap" {>= "0.3.0"}
+  "cstruct" {>= "3.2.0"}
+  "ipaddr" {>= "3.0.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "metrics"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+x-commit-hash: "9d5676fc62381c3c6b5e6fcadda2b645e2bc38be"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v5.0.1/dns-v5.0.1.tbz"
+  checksum: [
+    "sha256=72c0a1a91c8e409bd448c8e0ea28d16d13177c326aea403ee1c30ddcb5969adc"
+    "sha512=f5067d4ef6aca863bd06e6721a63a03da80052ab8e361440e72fae07ca45773763e0321236c6810afe80bd679d68763dc63fb57aec2e953173cc9a944785c93c"
+  ]
+}


### PR DESCRIPTION
An opinionated Domain Name System (DNS) library

- Project page: <a href="https://github.com/mirage/ocaml-dns">https://github.com/mirage/ocaml-dns</a>
- Documentation: <a href="https://mirage.github.io/ocaml-dns/">https://mirage.github.io/ocaml-dns/</a>

##### CHANGES:

* dns-certify: adapt to X.509 0.13.0 API changes (mirage/ocaml-dns#254 @hannesm)
