### PR TITLE
[new release] awa-mirage, awa-lwt and awa (0.0.3)

### DIFF
--- a/packages/awa-lwt/awa-lwt.0.0.3/opam
+++ b/packages/awa-lwt/awa-lwt.0.0.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "awa" {= version}
+  "cstruct" {>= "3.2.0"}
+  "mtime"
+  "lwt"
+  "cstruct-unix"
+  "mirage-crypto-rng"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-commit-hash: "200091e42500f79f4ccb399ac685987638be64af"
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.0.3/awa-v0.0.3.tbz"
+  checksum: [
+    "sha256=5a7927363ffe672cccf12d5425386e84f6f553a17ffec2b01ae5dc28180c831a"
+    "sha512=3b4165339ae17a89a6744bfb8a879c77614a8ed0e40bc755bd52a5512e80af1d7d2f9f019eeeb29f40e28d122e5d9a0e450ce26bcf91bc9ee89e32485bbcdeda"
+  ]
+}

--- a/packages/awa-mirage/awa-mirage.0.0.3/opam
+++ b/packages/awa-mirage/awa-mirage.0.0.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "awa" {= version}
+  "cstruct" {>= "3.2.0"}
+  "mtime"
+  "lwt"
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-commit-hash: "200091e42500f79f4ccb399ac685987638be64af"
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.0.3/awa-v0.0.3.tbz"
+  checksum: [
+    "sha256=5a7927363ffe672cccf12d5425386e84f6f553a17ffec2b01ae5dc28180c831a"
+    "sha512=3b4165339ae17a89a6744bfb8a879c77614a8ed0e40bc755bd52a5512e80af1d7d2f9f019eeeb29f40e28d122e5d9a0e450ce26bcf91bc9ee89e32485bbcdeda"
+  ]
+}

--- a/packages/awa/awa.0.0.3/opam
+++ b/packages/awa/awa.0.0.3/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-rng"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "x509" {>= "0.12.0"}
+  "cstruct" {>= "3.2.0"}
+  "cstruct-unix"
+  "cstruct-sexp"
+  "sexplib"
+  "rresult"
+  "mtime"
+  "logs"
+  "fmt"
+  "cmdliner"
+  "base64" {>= "3.0.0"}
+  "zarith"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-commit-hash: "200091e42500f79f4ccb399ac685987638be64af"
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.0.3/awa-v0.0.3.tbz"
+  checksum: [
+    "sha256=5a7927363ffe672cccf12d5425386e84f6f553a17ffec2b01ae5dc28180c831a"
+    "sha512=3b4165339ae17a89a6744bfb8a879c77614a8ed0e40bc755bd52a5512e80af1d7d2f9f019eeeb29f40e28d122e5d9a0e450ce26bcf91bc9ee89e32485bbcdeda"
+  ]
+}


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* Adapt to mirage-crypto-ec 0.10.0 API changes (mirage/awa-ssh#26 @hannesm)
