### PR TITLE
[new release] git, git-cohttp, git-cohttp-unix, git-mirage, git-paf and git-unix (3.4.0)

### DIFF
--- a/packages/git-cohttp-unix/git-cohttp-unix.3.4.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "git-cohttp" {= version}
+  "cohttp-lwt-unix"
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "5eb3ef686b101102b40967ef45e76f44cd55e149"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.4.0/git-3.4.0.tbz"
+  checksum: [
+    "sha256=6eef1240c7c85a8e495b82ef863c509ad41d75e0c45cf73c34ed1bdafd03413f"
+    "sha512=5fc02e4ea5fccf2386ddfcf5a15f1c11f49c982ffce0296bd5c00ba3f6510de3515e1ac80add7fe20cc8e3dc6516bbf233156ab9dd70eab7a12f7097ae49da27"
+  ]
+}

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.4.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.4.0/opam
@@ -29,7 +29,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-git.git"
 x-commit-hash: "5eb3ef686b101102b40967ef45e76f44cd55e149"

--- a/packages/git-cohttp/git-cohttp.3.4.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.4.0/opam
@@ -27,7 +27,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-git.git"
 x-commit-hash: "5eb3ef686b101102b40967ef45e76f44cd55e149"

--- a/packages/git-cohttp/git-cohttp.3.4.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "cohttp"
+  "cohttp-lwt"
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "5eb3ef686b101102b40967ef45e76f44cd55e149"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.4.0/git-3.4.0.tbz"
+  checksum: [
+    "sha256=6eef1240c7c85a8e495b82ef863c509ad41d75e0c45cf73c34ed1bdafd03413f"
+    "sha512=5fc02e4ea5fccf2386ddfcf5a15f1c11f49c982ffce0296bd5c00ba3f6510de3515e1ac80add7fe20cc8e3dc6516bbf233156ab9dd70eab7a12f7097ae49da27"
+  ]
+}

--- a/packages/git-mirage/git-mirage.3.4.0/opam
+++ b/packages/git-mirage/git-mirage.3.4.0/opam
@@ -35,7 +35,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-git.git"
 x-commit-hash: "5eb3ef686b101102b40967ef45e76f44cd55e149"

--- a/packages/git-mirage/git-mirage.3.4.0/opam
+++ b/packages/git-mirage/git-mirage.3.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A package to use ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "mimic"
+  "mirage-stack"
+  "git" {= version}
+  "awa"
+  "awa-mirage"
+  "dns-client" {>= "5.0.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "5.0.1"}
+  "lwt" {>= "5.3.0"}
+  "mirage-clock" {>= "3.1.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "mirage-protocols" {>= "5.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.1"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "5eb3ef686b101102b40967ef45e76f44cd55e149"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.4.0/git-3.4.0.tbz"
+  checksum: [
+    "sha256=6eef1240c7c85a8e495b82ef863c509ad41d75e0c45cf73c34ed1bdafd03413f"
+    "sha512=5fc02e4ea5fccf2386ddfcf5a15f1c11f49c982ffce0296bd5c00ba3f6510de3515e1ac80add7fe20cc8e3dc6516bbf233156ab9dd70eab7a12f7097ae49da27"
+  ]
+}

--- a/packages/git-paf/git-paf.3.4.0/opam
+++ b/packages/git-paf/git-paf.3.4.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
-  "git"
+  "git" {= version}
   "mimic" {>= "0.0.3"}
   "paf" {>= "0.0.2"}
   "ca-certs-nss"

--- a/packages/git-paf/git-paf.3.4.0/opam
+++ b/packages/git-paf/git-paf.3.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git"
+  "mimic" {>= "0.0.3"}
+  "paf" {>= "0.0.2"}
+  "ca-certs-nss"
+  "cohttp"
+  "cohttp-lwt"
+  "fmt"
+  "ipaddr"
+  "logs"
+  "lwt"
+  "mirage-clock"
+  "mirage-stack"
+  "mirage-time"
+  "result"
+  "rresult"
+  "tls" {>= "0.13.0"}
+  "uri"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "5eb3ef686b101102b40967ef45e76f44cd55e149"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.4.0/git-3.4.0.tbz"
+  checksum: [
+    "sha256=6eef1240c7c85a8e495b82ef863c509ad41d75e0c45cf73c34ed1bdafd03413f"
+    "sha512=5fc02e4ea5fccf2386ddfcf5a15f1c11f49c982ffce0296bd5c00ba3f6510de3515e1ac80add7fe20cc8e3dc6516bbf233156ab9dd70eab7a12f7097ae49da27"
+  ]
+}

--- a/packages/git-paf/git-paf.3.4.0/opam
+++ b/packages/git-paf/git-paf.3.4.0/opam
@@ -29,7 +29,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-git.git"
 x-commit-hash: "5eb3ef686b101102b40967ef45e76f44cd55e149"

--- a/packages/git-unix/git-unix.3.4.0/opam
+++ b/packages/git-unix/git-unix.3.4.0/opam
@@ -50,6 +50,10 @@ depends: [
   "tls-mirage" {>= "0.12.8"}
   "cohttp-lwt-unix" {with-test}
 ]
+x-ci-accept-failures: [
+  "centos-7" # git is too old and fails during tests
+  "oraclelinux-7" # git is too old and fails during tests
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}

--- a/packages/git-unix/git-unix.3.4.0/opam
+++ b/packages/git-unix/git-unix.3.4.0/opam
@@ -56,7 +56,7 @@ x-ci-accept-failures: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-git.git"
 x-commit-hash: "5eb3ef686b101102b40967ef45e76f44cd55e149"

--- a/packages/git-unix/git-unix.3.4.0/opam
+++ b/packages/git-unix/git-unix.3.4.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install and configure ocaml-git's Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "mmap" {>= "1.1.0"}
+  "git" {= version}
+  "rresult"
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "fmt" {>= "0.8.7"}
+  "bos"
+  "fpath"
+  "uri" {with-test}
+  "digestif" {>= "0.8.1"}
+  "logs"
+  "lwt"
+  "base-unix"
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "git-cohttp-unix" {= version}
+  "mirage-clock"
+  "mirage-clock-unix"
+  "astring" {>= "0.8.5"}
+  "awa"
+  "cmdliner" {>= "1.0.4"}
+  "decompress" {>= "1.4.0"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "5.0.1"}
+  "mtime" {>= "1.2.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "tcpip" {>= "6.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "awa-mirage"
+  "mirage-flow" {>= "2.0.1"}
+  "ke" {>= "0.4" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "ptime"
+  "mimic"
+  "ca-certs-nss" {>= "3.60"}
+  "tls" {>= "0.12.8"}
+  "tls-mirage" {>= "0.12.8"}
+  "cohttp-lwt-unix" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "5eb3ef686b101102b40967ef45e76f44cd55e149"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.4.0/git-3.4.0.tbz"
+  checksum: [
+    "sha256=6eef1240c7c85a8e495b82ef863c509ad41d75e0c45cf73c34ed1bdafd03413f"
+    "sha512=5fc02e4ea5fccf2386ddfcf5a15f1c11f49c982ffce0296bd5c00ba3f6510de3515e1ac80add7fe20cc8e3dc6516bbf233156ab9dd70eab7a12f7097ae49da27"
+  ]
+}

--- a/packages/git/git.3.4.0/opam
+++ b/packages/git/git.3.4.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "Git format and protocol in pure OCaml"
+description: """\
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "digestif" {>= "0.8.1"}
+  "rresult"
+  "base64" {>= "3.0.0"}
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "optint"
+  "decompress" {>= "1.4.0"}
+  "logs"
+  "lwt"
+  "mimic"
+  "cstruct" {>= "5.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "carton" {>= "0.4.0"}
+  "carton-lwt" {>= "0.4.0"}
+  "carton-git" {>= "0.4.0"}
+  "ke" {>= "0.4"}
+  "fmt" {>= "0.8.7"}
+  "checkseum" {>= "0.2.1"}
+  "ocamlgraph" {>= "1.8.8"}
+  "astring"
+  "fpath"
+  "encore" {>= "0.8"}
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng" {with-test & >= "0.8.0"}
+  "cmdliner" {with-test}
+  "base-unix" {with-test}
+  "fpath"
+  "hxd" {>= "0.3.1"}
+  "mirage-flow" {>= "2.0.1"}
+  "domain-name" {>= "0.3.0"}
+  "emile" {>= "1.1"}
+  "ipaddr" {>= "5.0.1"}
+  "psq" {>= "0.2.0"}
+  "uri" {>= "4.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "5eb3ef686b101102b40967ef45e76f44cd55e149"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.4.0/git-3.4.0.tbz"
+  checksum: [
+    "sha256=6eef1240c7c85a8e495b82ef863c509ad41d75e0c45cf73c34ed1bdafd03413f"
+    "sha512=5fc02e4ea5fccf2386ddfcf5a15f1c11f49c982ffce0296bd5c00ba3f6510de3515e1ac80add7fe20cc8e3dc6516bbf233156ab9dd70eab7a12f7097ae49da27"
+  ]
+}

--- a/packages/git/git.3.4.0/opam
+++ b/packages/git/git.3.4.0/opam
@@ -57,7 +57,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-git.git"
 x-commit-hash: "5eb3ef686b101102b40967ef45e76f44cd55e149"

--- a/packages/irmin-git/irmin-git.2.5.1/opam
+++ b/packages/irmin-git/irmin-git.2.5.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"       {>= "2.7.0"}
   "irmin"      {= version}
   "ppx_irmin"  {= version}
-  "git"        {>= "3.3.0"}
+  "git"        {>= "3.3.0" & < "3.4.0"}
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"

--- a/packages/irmin-git/irmin-git.2.5.2/opam
+++ b/packages/irmin-git/irmin-git.2.5.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"       {>= "2.7.0"}
   "irmin"      {= version}
   "ppx_irmin"  {= version}
-  "git"        {>= "3.3.0"}
+  "git"        {>= "3.3.0" & < "3.4.0"}
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"

--- a/packages/irmin-git/irmin-git.2.5.3/opam
+++ b/packages/irmin-git/irmin-git.2.5.3/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"       {>= "2.7.0"}
   "irmin"      {= version}
   "ppx_irmin"  {= version}
-  "git"        {>= "3.3.0"}
+  "git"        {>= "3.3.0" & < "3.4.0"}
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"

--- a/packages/irmin-unix/irmin-unix.2.5.1/opam
+++ b/packages/irmin-unix/irmin-unix.2.5.1/opam
@@ -42,7 +42,7 @@ depends: [
   "cmdliner"
   "cohttp-lwt-unix"
   "fmt"
-  "git"             {>= "3.3.0"}
+  "git"             {>= "3.3.0" & < "3.4.0"}
   "git-cohttp-unix" {>= "3.3.0"}
   "lwt"
   "irmin-test"    {with-test & = version}

--- a/packages/irmin-unix/irmin-unix.2.5.2/opam
+++ b/packages/irmin-unix/irmin-unix.2.5.2/opam
@@ -42,7 +42,7 @@ depends: [
   "cmdliner"
   "cohttp-lwt-unix"
   "fmt"
-  "git"             {>= "3.3.0"}
+  "git"             {>= "3.3.0" & < "3.4.0"}
   "git-cohttp-unix" {>= "3.3.0"}
   "lwt"
   "irmin-test"    {with-test & = version}

--- a/packages/irmin-unix/irmin-unix.2.5.3/opam
+++ b/packages/irmin-unix/irmin-unix.2.5.3/opam
@@ -42,7 +42,7 @@ depends: [
   "cmdliner"
   "cohttp-lwt-unix"
   "fmt"
-  "git"             {>= "3.3.0"}
+  "git"             {>= "3.3.0" & < "3.4.0"}
   "git-cohttp-unix" {>= "3.3.0"}
   "lwt"
   "irmin-test"    {with-test & = version}


### PR DESCRIPTION
Git format and protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Fix several issues on `git-unix` (@dinosaure, @sternenseemann, mirage/ocaml-git#488)
- Fix set of references by `git-unix` (@dinosaure, @jnavila, mirage/ocaml-git#490, mirage/ocaml-git#489)
- Remove dependency with `curl` (@dinosaure, mirage/ocaml-git#491)
- Provide `Git_unix.ctx` (@dinosaure, mirage/ocaml-git#493)
- Update the plumbing between `carton.0.4.1` and `git` (@dinosaure, mirage/ocaml-git#493)
- Expose information used by `Git_unix` to start a connection (@dinosaure, mirage/ocaml-git#498)
- Add missing `fmt` and `logs` on several `dune` files (@CraigFe, @dinosaure, mirage/ocaml-git#499)
- Be able to pass threads argument when we fetch (@dinosaure, mirage/ocaml-git#500)
- Fix documentation on `search.ml` (@dinosaure, mirage/ocaml-git#501)
- Be compatible with `alcotest.1.4.0` (@dinosaure, mirage/ocaml-git#504)
- Delete `mimic` from the distribution (now available on https://github.com/dinosaure/mimic)
  (@dinosaure, mirage/ocaml-git#505)
- Fix temporary directories on unix tests (@dinosaure, mirage/ocaml-git#506)
- Use the `non-stream` API of `decompress` for _loose_ objects (@clecat, @dinosaure, mirage/ocaml-git#502)
- Use `git-paf` and `paf.0.0.2` instead of CoHTTP (@dinosaure, mirage/ocaml-git#508)
- Don't try to download tags implicitely (@dinosaure, mirage/ocaml-git#507)
- Fix bug about negotiation over HTTP connection (@dinosaure, mirage/ocaml-git#507)
