### PR TITLE
adds FrontC.3.4.3

### DIFF
--- a/packages/FrontC/FrontC.3.4.3/files/FrontC.install
+++ b/packages/FrontC/FrontC.3.4.3/files/FrontC.install
@@ -1,0 +1,6 @@
+bin: [
+  "calipso/calipso"
+  "calipso/calipso_stat"
+  "ctoxml/ctoxml"
+  "printc/printc"
+]

--- a/packages/FrontC/FrontC.3.4.3/opam
+++ b/packages/FrontC/FrontC.3.4.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: "Hugues Cassé <casse@irit.fr>"
+homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+depends: [
+  "ocaml"
+]
+install: [
+  [make "install" "PREFIX=%{lib}%" "OCAML_SITE=%{lib}%"]
+  ["cp" "META" "%{lib}%/FrontC"]
+]
+synopsis: "Library providing a C parser and lexer"
+description: """
+FrontC is an OCAML library providing a C parser and lexer. The result
+is a syntactic tree easy to process with usual OCAML tree management.
+
+It provides support for ANSI C syntax, old-C K&R style syntax and the
+standard GNU CC attributes.
+
+It provides also a C pretty printer as an example of use."""
+extra-files: [
+  ["FrontC.install" "md5=c56e698d092d18179f9458f311c56412"]
+]
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v3.4.3.tar.gz"
+  checksum: "md5=399f66735541ecf8e06220618eef5c98"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/v3.4.3.tar.gz"
+}

--- a/packages/FrontC/FrontC.3.4.3/opam
+++ b/packages/FrontC/FrontC.3.4.3/opam
@@ -8,6 +8,11 @@ license: "LGPL-2.1-only"
 depends: [
   "ocaml"
 ]
+
+build: [
+  [make "PREFIX=%{lib}%" "OCAML_SITE=%{lib}%"]
+]
+
 install: [
   [make "install" "PREFIX=%{lib}%" "OCAML_SITE=%{lib}%"]
   ["cp" "META" "%{lib}%/FrontC"]

--- a/packages/FrontC/FrontC.3.4.3/opam
+++ b/packages/FrontC/FrontC.3.4.3/opam
@@ -4,6 +4,7 @@ homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC"
 maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+license: "LGPL-2.1-only"
 depends: [
   "ocaml"
 ]


### PR DESCRIPTION
This is a small update that adds support for pure-asm bodies and provies better diagnostic messages in case of parsing errors. It also cleans a bit the installation procedure (moves META to the upstream repository and applies the opam.patch). It also builds and installs the cmxs file (and updates, correpsondingly, the META file). 


Changelog:

* BinaryAnalysisPlatform/FrontC#7 raises parse errors rather than asserting false
* BinaryAnalysisPlatform/FrontC#11 supports functions with pure-asm bodies
* BinaryAnalysisPlatform/FrontC#13 builds and installs cmxs