### PR TITLE
Package tezos-sapling-parameters.1.0.0

### DIFF
--- a/packages/tezos-sapling-parameters/tezos-sapling-parameters.1.0.0/opam
+++ b/packages/tezos-sapling-parameters/tezos-sapling-parameters.1.0.0/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+synopsis: "Sapling parameters used in Tezos"
+maintainer: "Nomadic Labs <contact@nomadic-labs.com>"
+authors: "Nomadic Labs <contact@nomadic-labs.com>"
+license: "MIT"
+homepage: "https://gitlab.com/tezos/tezos"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+url {
+  src:
+    "https://gitlab.com/tezos/tezos-sapling-parameters/-/archive/1.0.0/tezos-sapling-parameters-1.0.0.tar.bz2"
+  checksum: [
+    "md5=d77be0c425dfd4c4feb78b79e1a4d631"
+    "sha512=53b71b7f9313598a00ab8fa41965fe045dec88a01fff4e2ab23d3c9fbb0a01bcb259b1b32c1755c08f904e20cd5f604813d9c3aec94382c329421a6e6162e9dd"
+  ]
+}


### PR DESCRIPTION
### `tezos-sapling-parameters.1.0.0`
Sapling parameters used in Tezos.
The repository simply installs the files containing the parameters using a file `.install`, see [tezos-sapling-parameters.install](https://gitlab.com/tezos/tezos-sapling-parameters/-/blob/master/tezos-sapling-parameters.install)
Context: https://gitlab.com/tezos/tezos/-/merge_requests/2565.

> Sapling requires some parameters for the spend and output circuits. Until now, the code was looking at different places (`/usr/share/`, `share` in the opam swich, etc). Lots of users faced issues with the loading of the parameters. It has been discussed previously to move the parameters into a OPAM package. The packages requiring the parameters can simply use `tezos-sapling-parameters` as a dependency and the parameters are going to be installed in `$OPAM_SWITCH_PREFIX/lib/tezos-sapling-parameters`. It might be also useful for the wallet developers.

Require @pirbo's approval 


---
* Homepage: https://gitlab.com/tezos/tezos
* Source repo: git+https://gitlab.com/tezos/tezos.git
* Bug tracker: https://gitlab.com/tezos/tezos/issues

---
:camel: Pull-request generated by opam-publish v2.0.3