### PR TITLE
z3: fixes the installation of dynamic libraries

### DIFF
--- a/packages/z3/z3.4.8.9-1/opam
+++ b/packages/z3/z3.4.8.9-1/opam
@@ -9,9 +9,12 @@ build: [
   [ "python2.7" "scripts/mk_make.py" "--ml" "--staticlib" ]
   [ make "-C" "build" "-j" jobs ]
 ]
+
 install: [
-  [ "sh" "-c" "ocamlfind install z3 build/api/ml/META -nodll build/libz3* build/api/ml/*" ]
+  [ "sh" "-c" "ocamlfind install z3 build/api/ml/* build/libz3-static.a"]
+  [ "cp" "build/z3" "%{bin}%/z3"]
 ]
+
 depends: [
   "ocaml"
   "ocamlfind" {build}
@@ -19,7 +22,6 @@ depends: [
   "conf-gmp"
   "conf-python-2-7" {build}
 ]
-available: [false]
 synopsis: "Z3 solver"
 url {
   src:

--- a/packages/z3/z3.4.8.9/opam
+++ b/packages/z3/z3.4.8.9/opam
@@ -9,9 +9,12 @@ build: [
   [ "python2.7" "scripts/mk_make.py" "--ml" "--staticlib" ]
   [ make "-C" "build" "-j" jobs ]
 ]
+
 install: [
-  [ "sh" "-c" "ocamlfind install z3 build/api/ml/META -nodll build/libz3* build/api/ml/*" ]
+  [ "sh" "-c" "ocamlfind install z3 build/api/ml/* build/libz3-static.a"]
+  [ "cp" "build/z3" "%{bin}%/z3"]
 ]
+
 depends: [
   "ocaml"
   "ocamlfind" {build}


### PR DESCRIPTION
@c-cube accidentaly reverted (in #17558) the installation command back to what was used in 4.8.8 instead of using one from 4.8.8-1, so the dll files are again not installed, which prevents us from packing z3 into a plugin (cmxs) or loading it in a toplevel (ocaml or utop).

It also restored the installation of the z3 binary, which is also extremely useful.