### PR TITLE
Package prbnmcn-mcts.0.0.1

### DIFF
--- a/packages/prbnmcn-mcts/prbnmcn-mcts.0.0.1/opam
+++ b/packages/prbnmcn-mcts/prbnmcn-mcts.0.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Monte-Carlo tree search based on UCB1 bandits"
+description: "Monte-Carlo tree search based on UCB1 bandits"
+maintainer: ["igarnier@protonmail.com"]
+authors: ["Ilias Garnier"]
+license: "MIT"
+homepage: "http://github.com/igarnier/prbnmcn-mcts"
+bug-reports: "http://github.com/igarnier/prbnmcn-mcts"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "prbnmcn-ucb1" {= "0.0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/igarnier/prbnmcn-mcts"
+url {
+  src: "https://github.com/igarnier/prbnmcn-mcts/archive/0.0.1.tar.gz"
+  checksum: [
+    "md5=9a15d7c68bf48bf9d110627d81442f85"
+    "sha512=2492e2d420c1d68921f77275db1a1864d99b2dcea6a5b6fb88a91b9a6b90670ef83bc5b11316efeadef5f0c1164f3d854bb6c760e2ccab331e270eea29279313"
+  ]
+}


### PR DESCRIPTION
### `prbnmcn-mcts.0.0.1`
Monte-Carlo tree search based on UCB1 bandits
Monte-Carlo tree search based on UCB1 bandits



---
* Homepage: http://github.com/igarnier/prbnmcn-mcts
* Source repo: git+https://gitlab.com/igarnier/monorepo.git
* Bug tracker: http://github.com/igarnier/prbnmcn-mcts

---
:camel: Pull-request generated by opam-publish v2.0.3