### PR TITLE
[new release] mirage-crypto-pk, mirage-crypto-ec, mirage-crypto, mirage-crypto-rng, mirage-crypto-rng-mirage and mirage-crypto-rng-async (0.10.1)

### DIFF
--- a/packages/mirage-crypto-ec/mirage-crypto-ec.0.10.1/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.0.10.1/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "Elliptic Curve Cryptography with primitives taken from Fiat"
+description: """
+An implementation of key exchange (ECDH) and digital signature (ECDSA/EdDSA)
+algorithms using code from Fiat (<https://github.com/mit-plv/fiat-crypto>).
+
+The curves P224 (SECP224R1), P256 (SECP256R1), P384 (SECP384R1),
+P521 (SECP521R1), and 25519 (X25519, Ed25519) are implemented by this package.
+"""
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Nathan Rebours <nathan.p.rebours@gmail.com>"
+  "Clément Pascutto <clement@tarides.com>"
+  "Etienne Millon <me@emillon.org>"
+# and from the fiat-crypto AUTHORS file
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+  "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mirage/mirage-crypto"
+doc: "https://mirage.github.io/mirage-crypto/doc"
+bug-reports: "https://github.com/mirage/mirage-crypto/issues"
+depends: [
+  "conf-pkg-config" {build}
+  "dune" {>= "2.6"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "3.5.0"}
+  "dune-configurator"
+  "eqaf" {>= "0.7"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "mirage-crypto-pk" {with-test & =version}
+  "hex" {with-test}
+  "alcotest" {with-test}
+  "asn1-combinators" {with-test & >= "0.2.5"}
+  "ppx_deriving_yojson" {with-test}
+  "ppx_deriving" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+]
+depopts: ["ocaml-freestanding"]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
+tags: ["org:mirage"]
+x-commit-hash: "42563a78f0ee9e106e045f4bda3284dd58935ca4"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.10.1/mirage-crypto-v0.10.1.tbz"
+  checksum: [
+    "sha256=028e2fc1f0a3e9b06603c6a253ecd043100099bc1c12c0567d8bc46d3781499c"
+    "sha512=08ba60ae7cc0e0c77b4d71fa05241bfd2e47bfb907cf7e1a4f6bd8bf62854ee82becd2f4e65eade1a01b58d91fb33829f4f69b39e8910df9cfeaa87c933a336d"
+  ]
+}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.7"}
+  "rresult" {>= "0.6.0"}
+  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding")
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+x-commit-hash: "42563a78f0ee9e106e045f4bda3284dd58935ca4"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.10.1/mirage-crypto-v0.10.1.tbz"
+  checksum: [
+    "sha256=028e2fc1f0a3e9b06603c6a253ecd043100099bc1c12c0567d8bc46d3781499c"
+    "sha512=08ba60ae7cc0e0c77b4d71fa05241bfd2e47bfb907cf7e1a4f6bd8bf62854ee82becd2f4e65eade1a01b58d91fb33829f4f69b39e8910df9cfeaa87c933a336d"
+  ]
+}

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.10.1/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.10.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an Async-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "async"
+  "logs"
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+]
+available: os != "win32"
+description: """
+
+Mirage-crypto-rng-async feeds the entropy source for Mirage_crypto_rng-based
+random number genreator implementations, in an Async-friendly way.
+"""
+x-commit-hash: "42563a78f0ee9e106e045f4bda3284dd58935ca4"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.10.1/mirage-crypto-v0.10.1.tbz"
+  checksum: [
+    "sha256=028e2fc1f0a3e9b06603c6a253ecd043100099bc1c12c0567d8bc46d3781499c"
+    "sha512=08ba60ae7cc0e0c77b4d71fa05241bfd2e47bfb907cf7e1a4f6bd8bf62854ee82becd2f4e65eade1a01b58d91fb33829f4f69b39e8910df9cfeaa87c933a336d"
+  ]
+}

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.1/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "BSD-2-Clause"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "lwt" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+x-commit-hash: "42563a78f0ee9e106e045f4bda3284dd58935ca4"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.10.1/mirage-crypto-v0.10.1.tbz"
+  checksum: [
+    "sha256=028e2fc1f0a3e9b06603c6a253ecd043100099bc1c12c0567d8bc46d3781499c"
+    "sha512=08ba60ae7cc0e0c77b4d71fa05241bfd2e47bfb907cf7e1a4f6bd8bf62854ee82becd2f4e65eade1a01b58d91fb33829f4f69b39e8910df9cfeaa87c933a336d"
+  ]
+}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.1/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "mirage-crypto" {=version}
+  "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+# lwt sublibrary
+  "mtime"
+  "lwt" {>= "4.0.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+x-commit-hash: "42563a78f0ee9e106e045f4bda3284dd58935ca4"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.10.1/mirage-crypto-v0.10.1.tbz"
+  checksum: [
+    "sha256=028e2fc1f0a3e9b06603c6a253ecd043100099bc1c12c0567d8bc46d3781499c"
+    "sha512=08ba60ae7cc0e0c77b4d71fa05241bfd2e47bfb907cf7e1a4f6bd8bf62854ee82becd2f4e65eade1a01b58d91fb33829f4f69b39e8910df9cfeaa87c933a336d"
+  ]
+}

--- a/packages/mirage-crypto/mirage-crypto.0.10.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.10.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit" {with-test}
+  "cstruct" {>="3.2.0"}
+  "eqaf" {>= "0.7"}
+  "bigarray-compat" # required to get eqaf.cstruct
+]
+depopts: [
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.6.0"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
+hashes (MD5, SHA-1, SHA-2).
+"""
+x-commit-hash: "42563a78f0ee9e106e045f4bda3284dd58935ca4"
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.10.1/mirage-crypto-v0.10.1.tbz"
+  checksum: [
+    "sha256=028e2fc1f0a3e9b06603c6a253ecd043100099bc1c12c0567d8bc46d3781499c"
+    "sha512=08ba60ae7cc0e0c77b4d71fa05241bfd2e47bfb907cf7e1a4f6bd8bf62854ee82becd2f4e65eade1a01b58d91fb33829f4f69b39e8910df9cfeaa87c933a336d"
+  ]
+}


### PR DESCRIPTION
Simple public-key cryptography for the modern age

- Project page: <a href="https://github.com/mirage/mirage-crypto">https://github.com/mirage/mirage-crypto</a>
- Documentation: <a href="https://mirage.github.io/mirage-crypto/doc">https://mirage.github.io/mirage-crypto/doc</a>

##### CHANGES:

- mirage-crypto-ec: make inversion run in constant time (mirage/mirage-crypto#121 by @dfaranha)
