### PR TITLE
Package eliom.7.0.0

### DIFF
--- a/packages/eliom/eliom.7.0.0/opam
+++ b/packages/eliom/eliom.7.0.0/opam
@@ -5,7 +5,7 @@ synopsis: "Client/server Web framework"
 description: "Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
 homepage: "http://ocsigen.org/eliom/"
 bug-reports: "https://github.com/ocsigen/eliom/issues/"
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [

--- a/packages/eliom/eliom.7.0.0/opam
+++ b/packages/eliom/eliom.7.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: "Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppx_tools" {>= "0.99.3"}
+  "js_of_ocaml-compiler" {>= "3.5.1"}
+  "js_of_ocaml" {>= "3.5.1"}
+  "js_of_ocaml-lwt" {>= "3.5.1"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx" {>= "3.5.1"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1"}
+  "js_of_ocaml-tyxml" {>= "3.5.1"}
+  "lwt_log"
+  "lwt_ppx"
+  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "ocsigenserver" {>= "2.18.0"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+  "ppx_tools_versioned"
+]
+url {
+  src: "https://github.com/ocsigen/eliom/archive/7.0.0.tar.gz"
+  checksum: [
+    "md5=cca0958f7ac3a069dc9d55091bc6a751"
+    "sha512=5fb8cd9f62e9f6c58971402083942161df123567252e765f6409e40b9fcde74f43a6151f762a487d244c0c1f3b6edd4d161dad9ff686e7143aa70f1150bf4194"
+  ]
+}

--- a/packages/ocsigen-start/ocsigen-start.2.11.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.11.0/opam
@@ -16,7 +16,7 @@ depends: [
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.4.0"}
+  "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.12.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.12.0/opam
@@ -16,7 +16,7 @@ depends: [
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.4.0"}
+  "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.13.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.13.0/opam
@@ -16,7 +16,7 @@ depends: [
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.4.0"}
+  "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.4.0"}
+  "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.1/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.10.1"}
+  "eliom" {>= "6.10.1" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.2/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.4.0"}
+  "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.16.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.16.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.10.1"}
+  "eliom" {>= "6.10.1" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.16.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.16.1/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.10.1"}
+  "eliom" {>= "6.10.1" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.18.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.18.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.10.1"}
+  "eliom" {>= "6.10.1" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.19.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.19.2/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.12.4"}
+  "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.19.3/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.19.3/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.12.4"}
+  "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "yojson" {>= "1.4.1"}
   "resource-pooling" {>= "1.0" & < "2.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.21.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.21.1/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.12.4"}
+  "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}
   "yojson" {>= "1.4.1"}

--- a/packages/ocsigen-start/ocsigen-start.2.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.3.0/opam
@@ -15,7 +15,7 @@ depends: [
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.4.0"}
+  "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.4.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.4.0/opam
@@ -15,7 +15,7 @@ depends: [
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.4.0"}
+  "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.7.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.7.0/opam
@@ -15,7 +15,7 @@ depends: [
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.4.0"}
+  "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.9.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.9.1/opam
@@ -16,7 +16,7 @@ depends: [
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.4.0"}
+  "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.9.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.9.2/opam
@@ -16,7 +16,7 @@ depends: [
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.4.0"}
+  "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}

--- a/packages/ocsigen-start/ocsigen-start.4.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.1.0"}
-  "eliom" {>= "6.12.4"}
+  "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}
   "yojson" {>= "1.4.1"}

--- a/packages/ocsigen-start/ocsigen-start.4.0.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.7.0"}
-  "eliom" {>= "6.12.4"}
+  "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}
   "yojson" {>= "1.4.1"}


### PR DESCRIPTION
### `eliom.7.0.0`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.0.3