### PR TITLE
Package ocsigen-start.4.1.0

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.4.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+authors: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"
+description: "Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom). It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users. Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management. This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users. The goal is to enable the programmer to concentrate on the core of the app, and not on user management."
+homepage: "https://ocsigen.org/ocsigen-start/"
+bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "pgocaml" {>= "4.0"}
+  "pgocaml_ppx" {>= "4.0"}
+  "safepass" {>= "3.0"}
+  "ocsigen-i18n" {>= "3.7.0"}
+  "eliom" {>= "7.0.0"}
+  "ocsigen-toolkit" {>= "2.7.0"}
+  "ocsigen-i18n" {>= "3.7.0"}
+  "yojson" {>= "1.4.1"}
+  "resource-pooling" {>= "1.0" & < "2.0"}
+  "cohttp-lwt-unix"
+  "conf-npm" {>= "1"}
+  "ocamlnet"
+]
+depexts: [
+	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}
+  ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-start/archive/4.1.0.tar.gz"
+  checksum: [
+    "md5=1193f86c4144084801869df157c588c2"
+    "sha512=ca4a98417bda21a359d61d4eac44bc82a30c8b80dc2d40e77b2f458f8cd62a3b204a22961b8414a87b62cbfd8012a3b080dbc15fdde6951714f8bb4529fe81c8"
+  ]
+}

--- a/packages/ocsigen-start/ocsigen-start.4.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.1.0/opam
@@ -6,7 +6,7 @@ description: "Ocsigen Start is a set of higher-level libraries for building clie
 homepage: "https://ocsigen.org/ocsigen-start/"
 bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
 dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
 depends: [
@@ -25,7 +25,7 @@ depends: [
   "ocamlnet"
 ]
 depexts: [
-	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}
+  ["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
 ]
 url {


### PR DESCRIPTION
### `ocsigen-start.4.1.0`
An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc
Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom). It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users. Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management. This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users. The goal is to enable the programmer to concentrate on the core of the app, and not on user management.



---
* Homepage: https://ocsigen.org/ocsigen-start/
* Source repo: git+https://github.com/ocsigen/ocsigen-start.git
* Bug tracker: https://github.com/ocsigen/ocsigen-start/issues

---
:camel: Pull-request generated by opam-publish v2.0.3