### PR TITLE
Package ocsigen-toolkit.2.10.1

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.10.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.10.1/opam
@@ -6,10 +6,9 @@ authors: "dev@ocsigen.org"
 homepage: "http://www.ocsigen.org"
 bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
 dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
-remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.12.1"}

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.10.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.10.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1 with OCaml linking exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ make "uninstall" ]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "eliom" {>= "6.12.1"}
+  "calendar"
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.10.1.tar.gz"
+  checksum: [
+    "md5=b7e16fe663f41b21f08132aeb3a1a8e6"
+    "sha512=50df12110211f5ca17335df328e24356e6ae6aebb7f432b23064014a1955b96517b3c2314c747058bb544c2fcb1abbd7db2597bb557666663b1f863d251a0aa0"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.10.1`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.0.3