### PR TITLE
Fix dependency about git.3.4.0 (it requires at least carton.0.4.1)

### DIFF
--- a/packages/git/git.3.4.0/opam
+++ b/packages/git/git.3.4.0/opam
@@ -30,9 +30,9 @@ depends: [
   "mimic"
   "cstruct" {>= "5.0.0"}
   "angstrom" {>= "0.14.0"}
-  "carton" {>= "0.4.0"}
-  "carton-lwt" {>= "0.4.0"}
-  "carton-git" {>= "0.4.0"}
+  "carton" {>= "0.4.1"}
+  "carton-lwt" {>= "0.4.1"}
+  "carton-git" {>= "0.4.1"}
   "ke" {>= "0.4"}
   "fmt" {>= "0.8.7"}
   "checkseum" {>= "0.2.1"}


### PR DESCRIPTION
A simple fix about `git.3.4.0` and `carton.0.4.1` spotted by @samoht.