### PR TITLE
[new release] paf (0.0.3)

### DIFF
--- a/packages/paf/paf.0.0.3/opam
+++ b/packages/paf/paf.0.0.3/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "mirage-stack"
+  "mirage-time"
+  "httpaf"
+  "tls-mirage" {>= "0.13.0"}
+  "mimic"
+  "cohttp-lwt"
+  "letsencrypt"
+  "emile"
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "tcpip" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "domain-name" {>= "0.3.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.7.0"}
+  "duration" {>= "0.1.3"}
+  "faraday" {>= "0.7.2"}
+  "ipaddr" {>= "5.0.1"}
+  "tls" {>= "0.13.0"}
+  "x509" {>= "0.13.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+x-commit-hash: "e9ed3f013c47099894749c7ed767e0cd12b97879"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.3/paf-0.0.3.tbz"
+  checksum: [
+    "sha256=a0bbb84b19e1f0255337fc4d7017f3ea3611b241746e391b11c1d8b1f5f30a2b"
+    "sha512=4510cea2cfc5cfdeb9a615b0cb4733b0d845a522fc51d7c2c0daa9985142a7529d27e7ef620522cf5dbe2f98af26274e7dd4f742f110165a8a52e3617de78d7b"
+  ]
+}


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Update to X509.0.13.0 (@hannesm, dinosaure/paf-le-chien#26)
