### PR TITLE
[new release] cf-lwt and cf (0.3)

### DIFF
--- a/packages/cf-lwt/cf-lwt.0.3/opam
+++ b/packages/cf-lwt/cf-lwt.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Lwt interface to macOS CoreFoundation"
+description: """
+An Lwt interface to the macOS CoreFoundation library, using the
+`cf` library for the low-level bindings."""
+maintainer: ["Thomas Gazagnaire"]
+authors: ["David Sheets" "Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cf"
+doc: "https://mirage.github.io/ocaml-cf/"
+bug-reports: "https://github.com/mirage/ocaml-cf/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "cf" {= version}
+  "alcotest" {with-test}
+  "lwt" {>= "3.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cf.git"
+x-commit-hash: "8fc3906cc751bbfc10594d34b467ce5983b6bede"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cf/releases/download/0.3/cf-lwt-0.3.tbz"
+  checksum: [
+    "sha256=afc551a2bf4390969900f9babb8ad9cce7436fa0f426ff12308744693de50e5a"
+    "sha512=4c42daf15829490f274c85b64658fadbf96fa8784491978d6e7f51bc29e6a72a1a7a2ed6e033cd6478bdcf710c8768cdd0baa306ce99713a2a6da4572a250e8e"
+  ]
+}

--- a/packages/cf/cf.0.3/opam
+++ b/packages/cf/cf.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings to macOS CoreFoundation"
+description: """
+These bindings use [ctypes](https://github.com/ocamllabs/ocaml-ctypes)
+for type-safe stub generation."""
+maintainer: ["Thomas Gazagnaire"]
+authors: ["David Sheets" "Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cf"
+doc: "https://mirage.github.io/ocaml-cf/"
+bug-reports: "https://github.com/mirage/ocaml-cf/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "base-bytes"
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cf.git"
+x-commit-hash: "8fc3906cc751bbfc10594d34b467ce5983b6bede"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cf/releases/download/0.3/cf-lwt-0.3.tbz"
+  checksum: [
+    "sha256=afc551a2bf4390969900f9babb8ad9cce7436fa0f426ff12308744693de50e5a"
+    "sha512=4c42daf15829490f274c85b64658fadbf96fa8784491978d6e7f51bc29e6a72a1a7a2ed6e033cd6478bdcf710c8768cdd0baa306ce99713a2a6da4572a250e8e"
+  ]
+}


### PR DESCRIPTION
Lwt interface to macOS CoreFoundation

- Project page: <a href="https://github.com/mirage/ocaml-cf">https://github.com/mirage/ocaml-cf</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cf/">https://mirage.github.io/ocaml-cf/</a>

##### CHANGES:

* Bump dune version and use opam file autogeneration (@avsm).
* Install library on non-macOS platforms as an empty archive,
  so that it works better in a monorepo (@avsm).
* Update to ocamlformat 0.18.0 (@avsm)
