### PR TITLE
Forbid ocaml-secondary-compiler on macOS/arm64

### DIFF
--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/opam
@@ -36,7 +36,7 @@ patches: [
   "0001-Fix-failure-to-install-tools-links.patch"
   "fix-gcc10.patch"
 ]
-
+available: !(os = "macos" & arch = "arm64")
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
@@ -33,7 +33,7 @@ patches: [
   "0001-Don-t-build-manpages-for-stdlib-docs.patch"
   "0001-Fix-failure-to-install-tools-links.patch"
 ]
-
+available: !(os = "macos" & arch = "arm64")
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).


### PR DESCRIPTION
Noticed in https://github.com/ocaml/opam-repository/issues/18586