### PR TITLE
[new release] jose (0.6.0)

### DIFF
--- a/packages/jose/jose.0.6.0/opam
+++ b/packages/jose/jose.0.6.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ulrikstrid/reason-jose/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "base64" {>= "3.0.0"}
-  "dune" {>= "2.8" & >= "1.11"}
+  "dune" {>= "2.8"}
   "eqaf" {>= "0.7"}
   "mirage-crypto" {>= "0.10.0"}
   "x509" {>= "0.13.0"}

--- a/packages/jose/jose.0.6.0/opam
+++ b/packages/jose/jose.0.6.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "JOSE implementation for OCaml and ReasonML"
+description:
+  "JavaScript Object Signing and Encryption built ontop of pure OCaml libs"
+maintainer: ["ulrik.strid@outlook.com"]
+authors: ["Ulrik Strid"]
+license: "MIT"
+homepage: "https://ulrikstrid.github.io/reason-jose"
+doc: "https://ulrikstrid.github.io/reason-jose"
+bug-reports: "https://github.com/ulrikstrid/reason-jose/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base64" {>= "3.0.0"}
+  "dune" {>= "2.8" & >= "1.11"}
+  "eqaf" {>= "0.7"}
+  "mirage-crypto" {>= "0.10.0"}
+  "x509" {>= "0.13.0"}
+  "cstruct" {>= "4.0.0"}
+  "astring"
+  "yojson"
+  "result"
+  "zarith"
+  "containers" {with-test}
+  "bisect_ppx" {with-test}
+  "alcotest" {with-test}
+  "junit" {with-test}
+  "junit_alcotest" {with-test}
+  "lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
+x-commit-hash: "30215c30b0b14907f54a951e7db8d2062cd29774"
+url {
+  src:
+    "https://github.com/ulrikstrid/reason-jose/releases/download/0.6.0/jose-0.6.0.tbz"
+  checksum: [
+    "sha256=508fade0ca615aaf92b2d9ce25980162c1713173b091adc4e0a16c5e89a2f7cc"
+    "sha512=8a569aee92987681cadfbf862aacfeeb5f1e48d5b3d5741a913801d1ac369bce7a8b97a89521e7f151ba342488d276928d9d7aa0a2da8bf21c696706ae202acc"
+  ]
+}

--- a/packages/jose/jose.0.6.0/opam
+++ b/packages/jose/jose.0.6.0/opam
@@ -46,7 +46,7 @@ dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
 x-commit-hash: "30215c30b0b14907f54a951e7db8d2062cd29774"
 url {
   src:
-    "https://github.com/ulrikstrid/reason-jose/releases/download/0.6.0/jose-0.6.0.tbz"
+    "https://github.com/ulrikstrid/reason-jose/releases/download/v0.6.0/jose-0.6.0.tbz"
   checksum: [
     "sha256=508fade0ca615aaf92b2d9ce25980162c1713173b091adc4e0a16c5e89a2f7cc"
     "sha512=8a569aee92987681cadfbf862aacfeeb5f1e48d5b3d5741a913801d1ac369bce7a8b97a89521e7f151ba342488d276928d9d7aa0a2da8bf21c696706ae202acc"


### PR DESCRIPTION
CHANGES:

- JWT/JWS/JWK: Add support for ES256 and ES512 signing via the updated mirage-crypto and x509 (by @ulrikstrid)
- JWT: [BREAKING] JWT will not validate `exp` by default anymore (by @ulrikstrid)