### PR TITLE
Package reanalyze.2.16.0

### DIFF
--- a/packages/reanalyze/reanalyze.2.16.0/opam
+++ b/packages/reanalyze/reanalyze.2.16.0/opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/rescript-association/reanalyze/issues"
 depends: [
   "dune" {>= "1.7"}
   "ocaml" {>= "4.06.1" & < "4.13"}
+  "cppo" {build}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/reanalyze/reanalyze.2.16.0/opam
+++ b/packages/reanalyze/reanalyze.2.16.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Dead values/types, exception, and termination analysis for OCaml/ReScript"
+description:
+  "Experimental analyses for ReScript/OCaml/Reason: for globally dead values/types, exception analysis, and termination analysis."
+maintainer: "Cristiano Calcagno"
+authors: "Cristiano Calcagno"
+license: "MIT"
+homepage: "https://github.com/rescript-association/reanalyze"
+bug-reports: "https://github.com/rescript-association/reanalyze/issues"
+depends: [
+  "dune" {>= "1.7"}
+  "ocaml" {>= "4.06.1" & < "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rescript-association/reanalyze.git"
+url {
+  src:
+    "https://github.com/rescript-association/reanalyze/archive/refs/tags/v2.16.0.tar.gz"
+  checksum: [
+    "md5=342df1d4cd1f482636c3e9f96f87323f"
+    "sha512=aaf54a871b53a271b5208f3540dfe972b418d6cb575958c7b28eeaaa3b424960cf51974d116d1113d7ef4310de14c93c50b6b2d962f464c28710290c462d528c"
+  ]
+}


### PR DESCRIPTION
### `reanalyze.2.16.0`
Dead values/types, exception, and termination analysis for OCaml/ReScript
Experimental analyses for ReScript/OCaml/Reason: for globally dead values/types, exception analysis, and termination analysis.



---
* Homepage: https://github.com/rescript-association/reanalyze
* Source repo: git+https://github.com/rescript-association/reanalyze.git
* Bug tracker: https://github.com/rescript-association/reanalyze/issues

---
:camel: Pull-request generated by opam-publish v2.0.2