### PR TITLE
[new release] jekyll-format (0.2.0)

### DIFF
--- a/packages/jekyll-format/jekyll-format.0.2.0/opam
+++ b/packages/jekyll-format/jekyll-format.0.2.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Jekyll post parsing library"
+description: """
+This library provides an OCaml interface to parsing
+posts in the Jekyll format."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: ["Anil Madhavapeddy" "Patrick Ferris"]
+license: "MIT"
+homepage: "https://github.com/avsm/jekyll-format"
+bug-reports: "https://github.com/avsm/jekyll-format/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.05.0"}
+  "result"
+  "astring"
+  "omd"
+  "fmt"
+  "rresult"
+  "ptime"
+  "fpath"
+  "yaml"
+  "ezjsonm"
+  "alcotest" {with-test}
+  "bos" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/avsm/jekyll-format.git"
+x-commit-hash: "b4d576a96a516f1d1ec08a5416cb5fb7f783409b"
+url {
+  src:
+    "https://github.com/avsm/jekyll-format/releases/download/v0.2.0/jekyll-format-v0.2.0.tbz"
+  checksum: [
+    "sha256=8d5b438e235d712827a130906473951ed532522473262730043aa4783a60031a"
+    "sha512=ddd73dbf82ad5e8a613fe6600729b217658c478a445e2fd42c5da5f4cb66aad335a87ef239c37f97c53394e2d5d452034874fe424fd45e4503df3e71da7dff64"
+  ]
+}


### PR DESCRIPTION
Jekyll post parsing library

- Project page: <a href="https://github.com/avsm/jekyll-format">https://github.com/avsm/jekyll-format</a>

##### CHANGES:

- Add a `fields_to_yaml` function to convert the internal field data
  representation to a `Yaml.value` (avsm/jekyll-format#2 @patricoferris)
- `find` now returns a `Yaml.value option` rather than a `string option`
  (avsm/jekyll-format#1 @patricoferris)
- port to dune (@avsm)
- use Yaml library to parse front matter instead of a homebrew parser. (@avsm)
- use ocamlformat 0.18.0 (@avsm)
- minimum OCaml version supported is now 4.05+ (@avsm)
