### PR TITLE
[new release] capnp-rpc-mirage, capnp-rpc-net, capnp-rpc, capnp-rpc-unix and capnp-rpc-lwt (1.1)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.1.1/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "lwt"
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "asetmap"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "4c92232bc89d8b6fa3d28c5fa9c9a0c9ddaa3be0"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.1/capnp-rpc-v1.1.tbz"
+  checksum: [
+    "sha256=d16ded2ddcd7d1aa185f45e7f4f241b69c1b179dc8c76b81e7270f51eae84f47"
+    "sha512=095cc49f541d8a5742bd791c08e89097ebf6879ca3659ff10e364b47302f690bcf317cd4abfa769864a366dc00599a68b358139e681f712e53746e268edc8a93"
+  ]
+}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.1/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp" {>= "3.1.0"}
+  "capnp-rpc-net" {= version}
+  "astring" {with-test}
+  "fmt"
+  "logs"
+  "dns-client" {>= "5.0.0"}
+  "tls-mirage"
+  "mirage-stack" {>= "2.0.0"}
+  "arp" {>= "2.3.0" & with-test}
+  "alcotest" {>= "1.0.1" & with-test}
+  "alcotest-lwt" {>= "1.0.1" & with-test}
+  "io-page-unix" {with-test}
+  "tcpip" {>= "6.0.0" & with-test}
+  "mirage-vnetif" {with-test}
+  "mirage-crypto-rng" {>= "0.7.0" & with-test}
+  "dune" {>= "2.0"}
+  "asetmap" {with-test}
+  "ethernet" {>= "2.2.0" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "4c92232bc89d8b6fa3d28c5fa9c9a0c9ddaa3be0"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.1/capnp-rpc-v1.1.tbz"
+  checksum: [
+    "sha256=d16ded2ddcd7d1aa185f45e7f4f241b69c1b179dc8c76b81e7270f51eae84f47"
+    "sha512=095cc49f541d8a5742bd791c08e89097ebf6879ca3659ff10e364b47302f690bcf317cd4abfa769864a366dc00599a68b358139e681f712e53746e268edc8a93"
+  ]
+}

--- a/packages/capnp-rpc-net/capnp-rpc-net.1.1/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "capnp-rpc-lwt" {= version}
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "mirage-flow" {>="2.0.0"}
+  "tls" {>= "0.13.1"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "0.13.0"}
+  "tls-mirage"
+  "dune" {>= "2.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "4c92232bc89d8b6fa3d28c5fa9c9a0c9ddaa3be0"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.1/capnp-rpc-v1.1.tbz"
+  checksum: [
+    "sha256=d16ded2ddcd7d1aa185f45e7f4f241b69c1b179dc8c76b81e7270f51eae84f47"
+    "sha512=095cc49f541d8a5742bd791c08e89097ebf6879ca3659ff10e364b47302f690bcf317cd4abfa769864a366dc00599a68b358139e681f712e53746e268edc8a93"
+  ]
+}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.1.1/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp-rpc-net" {= version}
+  "cmdliner"
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.4"}
+  "logs"
+  "extunix"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "2.0"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "alcotest-lwt" { >= "1.0.1" & with-test}
+  "mirage-crypto-rng" {>= "0.7.0"}
+  "lwt"
+  "asetmap" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "4c92232bc89d8b6fa3d28c5fa9c9a0c9ddaa3be0"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.1/capnp-rpc-v1.1.tbz"
+  checksum: [
+    "sha256=d16ded2ddcd7d1aa185f45e7f4f241b69c1b179dc8c76b81e7270f51eae84f47"
+    "sha512=095cc49f541d8a5742bd791c08e89097ebf6879ca3659ff10e364b47302f690bcf317cd4abfa769864a366dc00599a68b358139e681f712e53746e268edc8a93"
+  ]
+}

--- a/packages/capnp-rpc/capnp-rpc.1.1/opam
+++ b/packages/capnp-rpc/capnp-rpc.1.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "stdint"
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "dune" {>= "2.0"}
+  "alcotest" {with-test & >= "1.0.1"}
+  "afl-persistent" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "4c92232bc89d8b6fa3d28c5fa9c9a0c9ddaa3be0"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.1/capnp-rpc-v1.1.tbz"
+  checksum: [
+    "sha256=d16ded2ddcd7d1aa185f45e7f4f241b69c1b179dc8c76b81e7270f51eae84f47"
+    "sha512=095cc49f541d8a5742bd791c08e89097ebf6879ca3659ff10e364b47302f690bcf317cd4abfa769864a366dc00599a68b358139e681f712e53746e268edc8a93"
+  ]
+}


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

- Update to latest X509, TCP and TLS APIs (@talex5 @hannesm mirage/capnp-rpc#228).

- Add `Service.fail_lwt` convenience function (@talex5 mirage/capnp-rpc#229).

- Remove confusing debug details from `call_for_value_exn` errors (@talex5 mirage/capnp-rpc#230).
  The hidden information is now logged (at debug level) instead.

- Configure TCP keep-alives for incoming connections, not just outgoing ones (@talex5 mirage/capnp-rpc#227).
  This is needed when the client machine crashes without resetting the connection.

- Include version number in opam license field (@talex5 mirage/capnp-rpc#226).
