### PR TITLE
[new release] mrmime (0.4.0)

### DIFF
--- a/packages/mrmime/mrmime.0.4.0/opam
+++ b/packages/mrmime/mrmime.0.4.0/opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml"            {>= "4.08.0"}
-  "dune"             {>= "1.2"}
+  "dune"             {>= "2.7"}
   "rresult"
   "fmt"
   "ke"               {>= "0.4"}

--- a/packages/mrmime/mrmime.0.4.0/opam
+++ b/packages/mrmime/mrmime.0.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/mrmime"
+bug-reports:  "https://github.com/mirage/mrmime/issues"
+dev-repo:     "git+https://github.com/mirage/mrmime.git"
+doc:          "https://mirage.github.io/mrmime/"
+license:      "MIT"
+synopsis:     "Mr. MIME"
+description:  """Parser and generator of mail in OCaml"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"            {>= "4.08.0"}
+  "dune"             {>= "1.2"}
+  "rresult"
+  "fmt"
+  "ke"               {>= "0.4"}
+  "unstrctrd"        {>= "0.2"}
+  "ptime"
+  "uutf"
+  "rosetta"          {>= "0.3.0"}
+  "ipaddr"
+  "emile"            {>= "1.0"}
+  "base64"           {>= "3.1.0"}
+  "pecu"             {>= "0.5"}
+  "prettym"
+  "bigstringaf"
+  "bigarray-compat"
+  "bigarray-overlap" {>= "0.2.0"}
+  "angstrom"         {>= "0.14.0"}
+  "hxd"              {with-test}
+  "alcotest"         {with-test}
+  "jsonm"            {with-test}
+]
+x-commit-hash: "5c492eae4a5c65229fa91629e10e5ed77915cb6b"
+url {
+  src:
+    "https://github.com/mirage/mrmime/releases/download/v0.4.0/mrmime-v0.4.0.tbz"
+  checksum: [
+    "sha256=38d96d96b4d00a8003954c1e1726d87ccd80592bee7034451c2a73b6e2ef40f4"
+    "sha512=eab7d073a074fb7964f7bb9d0f75f9a475f70901d71087c8340459513efb19454527efffdb2fc8f817c5d8239b105c98912a89cb21fc2e4c280b6ae05dabafb4"
+  ]
+}

--- a/packages/multipart_form/multipart_form.0.2.0/opam
+++ b/packages/multipart_form/multipart_form.0.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "stdlib-shims"
   "pecu" {>= "0.4"}
   "lwt"
-  "mrmime"
+  "mrmime" {< "0.4.0"}
   "fmt"
   "logs"
   "ke" {>= "0.4"}

--- a/packages/piaf/piaf.0.1.0/opam
+++ b/packages/piaf/piaf.0.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "conf-libssl"
   "ssl" {>= "0.5.10"}
   "lwt_ssl"
-  "mrmime" {>= "0.3.2"}
+  "mrmime" {>= "0.3.2" & < "0.4.0"}
   "pecu"
   "psq"
   "uri"

--- a/packages/received/received.0.2.0/opam
+++ b/packages/received/received.0.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml"    {>= "4.03.0"}
   "dune"     {>= "1.8.0"}
   "colombe"  {= version}
-  "mrmime"   {>= "0.2.0"}
+  "mrmime"   {>= "0.2.0" & < "0.4.0"}
   "emile"    {>= "0.8" & < "1.0"}
   "angstrom" {>= "0.11.0"}
 ]

--- a/packages/received/received.0.3.0/opam
+++ b/packages/received/received.0.3.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml"    {>= "4.03.0"}
   "dune"     {>= "1.8.0"}
   "colombe"  {= version}
-  "mrmime"   {>= "0.2.0"}
+  "mrmime"   {>= "0.2.0" & < "0.4.0"}
   "emile"    {>= "0.8" & < "1.0"}
   "angstrom" {>= "0.14.0"}
 ]

--- a/packages/received/received.0.4.0/opam
+++ b/packages/received/received.0.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml"    {>= "4.03.0"}
   "dune"     {>= "1.8.0"}
   "colombe"  {= version}
-  "mrmime"   {>= "0.2.0"}
+  "mrmime"   {>= "0.2.0" & < "0.4.0"}
   "emile"    {>= "0.8"}
   "angstrom" {>= "0.14.0"}
 ]


### PR DESCRIPTION
Mr. MIME

- Project page: <a href="https://github.com/mirage/mrmime">https://github.com/mirage/mrmime</a>
- Documentation: <a href="https://mirage.github.io/mrmime/">https://mirage.github.io/mrmime/</a>

##### CHANGES:

- Return the zone of the date (mirage/mrmime#41, @dinosaure)
- Add `Content_type.to_string` (mirage/mrmime#43, @dinosaure)
- Be resilient on date (accept nano-seconds) (mirage/mrmime#44, @dinosaure)
- Add a simple example to craft an email with an attachment (mirage/mrmime#47, @dinosaure)
- Drop the support of OCaml 4.08.0 (mirage/mrmime#47, @dinosaure)
