### PR TITLE
[new release] received (0.5.0)

### DIFF
--- a/packages/received/received.0.5.0/opam
+++ b/packages/received/received.0.5.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "Received field according RFC5321"
+doc:          "https://mirage.github.io/colombe/"
+description: """A little library to parse or emit a Received field according
+RFC5321. It is able to notify which SMTP server serves the email (and track, by this way,
+on which way - TLS or not - the email was transmitted)."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {>= "1.8.0"}
+  "mrmime"   {>= "0.4.0"}
+  "emile"    {>= "0.8"}
+  "angstrom" {>= "0.14.0"}
+  "colombe"  {>= "0.4.0"}
+]
+x-commit-hash: "ff32ced77d3bd07e45459e947e97ea0eed9c1949"
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/received-v0.5.0/received-received-v0.5.0.tbz"
+  checksum: [
+    "sha256=794534295ba0de26102794d1f96fe7cfa5bf18698d405c69acf4a13f2d2315aa"
+    "sha512=8784074625c63e101fb4ca02bca1cfe4c4f04ef9bd98991df630eef28c9231963d0aa8db7f7a2b73085efbe0afcbc521bc62fb69404c60969da77ac1abe078b6"
+  ]
+}


### PR DESCRIPTION
Received field according RFC5321

- Project page: <a href="https://github.com/mirage/colombe">https://github.com/mirage/colombe</a>
- Documentation: <a href="https://mirage.github.io/colombe/">https://mirage.github.io/colombe/</a>

##### CHANGES:

- Show the good timezone of the given date (mirage/colombe#33, @dinosaure)
- Add several accessors to manipulate `Received:` field (mirage/colombe#33, @dinosaure)
