### PR TITLE
[new release] dkim-mirage and dkim (0.2.0)

### DIFF
--- a/packages/dkim-mirage/dkim-mirage.0.2.0/opam
+++ b/packages/dkim-mirage/dkim-mirage.0.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/ocaml-dkim"
+bug-reports:  "https://github.com/dinosaure/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/dinosaure/ocaml-dkim.git"
+doc:          "https://dinosaure.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml for MirageOS"
+description: """A light layer of the dkim library for MirageOS"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0.0"}
+  "dkim"       {= version}
+  "dns-client" {>= "5.0.0"}
+  "mirage-time"
+  "mirage-random"
+  "mirage-clock"
+  "mirage-stack"
+  "lwt"
+  "alcotest"   {with-test}
+  "digestif"   {with-test}
+  "fmt"        {with-test}
+  "logs"       {with-test}
+  "mirage-crypto-rng" {with-test}
+]
+x-commit-hash: "10b5680751d2d470af16078545e1ccfb41c9f6ed"
+url {
+  src:
+    "https://github.com/dinosaure/ocaml-dkim/releases/download/v0.2.0/dkim-v0.2.0.tbz"
+  checksum: [
+    "sha256=6764cf63de6becdcb4979e81e246369db1dd0b2009fb114f187a65e6e4dfeae6"
+    "sha512=19855ff8a878f7c00ecca9c969a7cd8fad6ecee444f6645cec19d0969773873b5c61956c2e1a65da3290241f90b5379bcf18258647d16305b73ad1667a18fc04"
+  ]
+}

--- a/packages/dkim-mirage/dkim-mirage.0.2.0/opam
+++ b/packages/dkim-mirage/dkim-mirage.0.2.0/opam
@@ -10,7 +10,7 @@ synopsis:     "Implementation of DKIM in OCaml for MirageOS"
 description: """A light layer of the dkim library for MirageOS"""
 
 build: [
-  [ "dune" "subst" ] {pinned}
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]

--- a/packages/dkim/dkim.0.2.0/opam
+++ b/packages/dkim/dkim.0.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/ocaml-dkim"
+bug-reports:  "https://github.com/dinosaure/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/dinosaure/ocaml-dkim.git"
+doc:          "https://dinosaure.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml"
+description: """A library and a binary to verify and sign an email
+with the DKIM mechanism described by the RFC 6376"""
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0.0"}
+  "mrmime"     {>= "0.3.1"}
+  "digestif"   {>= "0.9.0"}
+  "ipaddr"
+  "base-unix"
+  "hmap"
+  "domain-name"
+  "dns-client" {>= "5.0.0"}
+  "cmdliner"
+  "logs"
+  "fmt"
+  "fpath"
+  "base64"     {>= "3.0.0"}
+  "mirage-crypto" {>= "0.9.2"}
+  "mirage-crypto-pk" {>= "0.9.2"}
+  "x509" {>= "0.6.3"}
+  "mirage-crypto-rng" {with-test}
+  "alcotest"   {with-test}
+]
+x-commit-hash: "10b5680751d2d470af16078545e1ccfb41c9f6ed"
+url {
+  src:
+    "https://github.com/dinosaure/ocaml-dkim/releases/download/v0.2.0/dkim-v0.2.0.tbz"
+  checksum: [
+    "sha256=6764cf63de6becdcb4979e81e246369db1dd0b2009fb114f187a65e6e4dfeae6"
+    "sha512=19855ff8a878f7c00ecca9c969a7cd8fad6ecee444f6645cec19d0969773873b5c61956c2e1a65da3290241f90b5379bcf18258647d16305b73ad1667a18fc04"
+  ]
+}

--- a/packages/dkim/dkim.0.2.0/opam
+++ b/packages/dkim/dkim.0.2.0/opam
@@ -11,7 +11,7 @@ description: """A library and a binary to verify and sign an email
 with the DKIM mechanism described by the RFC 6376"""
 
 build: [
-  [ "dune" "subst" ] {pinned}
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]


### PR DESCRIPTION
Implementation of DKIM in OCaml for MirageOS

- Project page: <a href="https://github.com/dinosaure/ocaml-dkim">https://github.com/dinosaure/ocaml-dkim</a>
- Documentation: <a href="https://dinosaure.github.io/ocaml-dkim/">https://dinosaure.github.io/ocaml-dkim/</a>

##### CHANGES:

- Upgrade to `tls.0.13.0` and `dns.5.0.0` (@dinosaure, dinosaure/ocaml-dkim#9)
- Support of Ed25519 key (@dinosaure, dinosaure/ocaml-dkim#9)
- `dkim-mirage` requires a `Stack.V4V6` TCP/IP stack (@dinosaure, dinosaure/ocaml-dkim#9)
- Lint opam files (@dinosaure, dinosaure/ocaml-dkim#11)
