### PR TITLE
[new release] irmin et al. (2.6.0)

### DIFF
--- a/packages/irmin-bench/irmin-bench.2.6.0/opam
+++ b/packages/irmin-bench/irmin-bench.2.6.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"         {>= "2.7.0"}
+  "irmin-pack"   {= version}
+  "irmin-layers" {= version}
+  "irmin-test"   {= version}
+  "cmdliner"
+  "logs"
+  "lwt"
+  "ppx_deriving_yojson"
+  "yojson"
+  "memtrace"
+  "repr"         {>= "0.2.0"}
+  "ppx_repr"
+  "re"           {>= "1.9.0"}
+  "fmt"
+  "bentov"
+  "uuidm"
+  "progress"
+  "mtime"
+]
+
+synopsis: "Irmin benchmarking suite"
+description: """
+`irmin-bench` provides access to the Irmin suite for benchmarking storage backend
+implementations.
+"""
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-chunk/irmin-chunk.2.6.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.2.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Mounir Nasr Allah" "Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "fmt"
+  "logs"
+  "lwt"
+  "irmin-test" {with-test & = version}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Irmin backend which allow to store values into chunks"
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-containers/irmin-containers.2.6.0/opam
+++ b/packages/irmin-containers/irmin-containers.2.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["KC Sivaramakrishnan" "Anirudh Sunder Raj"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "irmin-unix" {= version}
+  "irmin-git"  {= version}
+  "ppx_irmin"  {= version}
+  "lwt"
+  "mtime"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+
+synopsis: "Mergeable Irmin data structures"
+description: """
+A collection of simple, ready-to-use mergeable data structures built using
+Irmin. Each data structure works with an arbitrary Irmin backend and is
+customisable in a variety of ways.
+"""
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-fs/irmin-fs.2.6.0/opam
+++ b/packages/irmin-fs/irmin-fs.2.6.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "astring"
+  "logs"
+  "lwt"
+  "irmin-test" {with-test & = version}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Generic file-system backend for Irmin"
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-git/irmin-git.2.6.0/opam
+++ b/packages/irmin-git/irmin-git.2.6.0/opam
@@ -13,6 +13,8 @@ build: [
  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
+available: arch != "arm32" & arch != "x86_32"
+
 depends: [
   "ocaml"      {>= "4.02.3"}
   "dune"       {>= "2.7.0"}

--- a/packages/irmin-git/irmin-git.2.6.0/opam
+++ b/packages/irmin-git/irmin-git.2.6.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "ppx_irmin"  {= version}
+  "git"        {>= "3.4.0"}
+  "digestif"   {>= "0.9.0"}
+  "cstruct"
+  "fmt"
+  "astring"
+  "fpath"
+  "logs"
+  "lwt"
+  "uri"
+  "git-cohttp-unix" {with-test}
+  "irmin-test" {with-test & = version}
+  "git-unix"   {with-test}
+  "mtime"      {with-test & >= "1.0.0"}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Git backend for Irmin"
+description: """
+`Irmin_git` expose a bi-directional bridge between Git repositories and
+Irmin stores.
+"""
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-graphql/irmin-graphql.2.6.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.6.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors:      "Andreas Garnaes <andreas.garnaes@gmail.com>"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {>= "2.7.0"}
+  "irmin"          {= version}
+  "graphql"        {>= "0.13.0"}
+  "graphql-lwt"    {>= "0.13.0"}
+  "graphql-cohttp" {>= "0.13.0"}
+  "graphql_parser" {>= "0.13.0"}
+  "cohttp-lwt"
+  "cohttp"
+  "fmt"
+  "lwt"
+  "alcotest-lwt"    {with-test & >= "1.1.0"}
+  "yojson"          {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "alcotest"        {with-test & >= "1.2.3"}
+  "logs"            {with-test}
+]
+
+
+synopsis: "GraphQL server for Irmin"
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-http/irmin-http.2.6.0/opam
+++ b/packages/irmin-http/irmin-http.2.6.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.7.0"}
+  "crunch"     {>= "2.2.0"}
+  "webmachine" {>= "0.6.0"}
+  "irmin"      {= version}
+  "ppx_irmin"  {= version}
+  "cohttp-lwt" {>= "1.0.0"}
+  "astring"
+  "cohttp"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt"
+  "uri"
+  "irmin-git"  {with-test & = version}
+  "irmin-test" {with-test & = version}
+  "git-unix"   {with-test & >= "3.4.0"}
+  "digestif"   {with-test & >= "0.9.0"}
+]
+
+synopsis: "HTTP client and server for Irmin"
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-layers/irmin-layers.2.6.0/opam
+++ b/packages/irmin-layers/irmin-layers.2.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.7.0"}
+  "mtime"      {>= "1.0.0"}
+  "irmin"      {= version}
+  "logs"
+  "lwt"
+]
+
+synopsis: "Combine different Irmin stores into a single, layered store"
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.6.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"         {>= "2.7.0"}
+  "irmin-mirage" {= version}
+  "irmin-git"    {= version}
+  "mirage-kv"    {>= "3.0.0"}
+  "cohttp"
+  "conduit-lwt"
+  "conduit-mirage"
+  "git-paf"      {>= "3.4.0"}
+  "fmt"
+  "git"          {>= "3.4.0"}
+  "lwt"
+  "mirage-clock"
+  "uri"
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.6.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"          {>= "2.7.0"}
+  "irmin-mirage"  {= version}
+  "irmin-graphql" {= version}
+  "mirage-clock"
+  "cohttp-lwt"
+  "lwt"
+  "uri"
+  "git"           {>= "3.4.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-mirage/irmin-mirage.2.6.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.2.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "fmt"
+  "ptime"
+  "mirage-clock" {>= "3.0.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-pack/irmin-pack.2.6.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"        {>= "4.08.0"}
+  "dune"         {>= "2.7.0"}
+  "irmin"        {= version}
+  "irmin-layers" {= version}
+  "ppx_irmin"    {= version}
+  "index"        {>= "1.3.0"}
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime"
+  "cmdliner"
+  "irmin-test"   {with-test & = version}
+  "alcotest-lwt" {with-test}
+  "astring"      {with-test}
+  "fpath"        {with-test}
+  "alcotest"     {with-test}
+]
+
+synopsis: "Irmin backend which stores values in a pack file"
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-test/irmin-test.2.6.0/opam
+++ b/packages/irmin-test/irmin-test.2.6.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "irmin"        {= version}
+  "irmin-layers" {= version}
+  "ppx_irmin"    {= version}
+  "ocaml"        {>= "4.02.3"}
+  "dune"         {>= "2.7.0"}
+  "alcotest"     {>= "1.0.1"}
+  "mtime"        {>= "1.0.0"}
+  "astring"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt"
+  "metrics-unix"
+  "ocaml-syntax-shims"
+  "cmdliner"
+  "metrics" {>= "0.2.0"}
+]
+
+synopsis: "Irmin test suite"
+description: """
+`irmin-test` provides access to the Irmin test suite for testing storage backend
+implementations.
+"""
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin-unix/irmin-unix.2.6.0/opam
+++ b/packages/irmin-unix/irmin-unix.2.6.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+available: arch != "arm32" & arch != "x86_32"
+
+depends: [
+  "ocaml"         {>= "4.01.0"}
+  "dune"          {>= "2.7.0"}
+  "irmin"         {= version}
+  "irmin-git"     {= version}
+  "irmin-http"    {= version}
+  "irmin-fs"      {= version}
+  "irmin-pack"    {= version}
+  "irmin-graphql" {= version}
+  "irmin-layers"  {= version}
+  "git-unix"      {>= "3.4.0"}
+  "digestif"      {>= "0.9.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "yaml"          {>= "0.1.0"}
+  "astring"
+  "astring"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit"
+  "conduit-lwt"
+  "conduit-lwt-unix"
+  "logs"
+  "uri"
+  "cmdliner"
+  "cohttp-lwt-unix"
+  "fmt"
+  "git"             {>= "3.4.0"}
+  "git-cohttp-unix" {>= "3.4.0"}
+  "lwt"
+  "irmin-test"    {with-test & = version}
+  "alcotest"      {with-test}
+]
+
+synopsis: "Unix backends for Irmin"
+description: """
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.
+"""
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/irmin/irmin.2.6.0/opam
+++ b/packages/irmin/irmin.2.6.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "repr"    {>= "0.2.0"}
+  "fmt"     {>= "0.8.0"}
+  "uri"     {>= "1.3.12"}
+  "uutf"
+  "jsonm"   {>= "1.0.0"}
+  "lwt"     {>= "2.4.7"}
+  "digestif" {>= "0.9.0"}
+  "ocamlgraph"
+  "logs"    {>= "0.5.0"}
+  "bheap" {>= "2.0.0"}
+  "astring"
+  "ppx_irmin" {= version}
+  "hex"      {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "alcotest-lwt" {with-test}
+]
+synopsis: """
+Irmin, a distributed database that follows the same design principles as Git
+"""
+description: """
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.
+"""
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}

--- a/packages/ppx_irmin/ppx_irmin.2.6.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.2.6.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Craig Ferguson <craig@tarides.com>"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mirage/irmin.git"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {>= "2.7.0"}
+  "ppx_repr" {>= "0.2.0"}
+]
+
+synopsis: "PPX deriver for Irmin type representations"
+x-commit-hash: "302981e6af637f6cd5fd9e1c5e2bc38bca57f4c7"
+authors: "Craig Ferguson <craig@tarides.com>"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.6.0/irmin-2.6.0.tbz"
+  checksum: [
+    "sha256=1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f"
+    "sha512=b334e5b909563787e58790e4665f78a9f21e0f9f976eb7344cb76cbe7db870506bab193cec206e338ba74457896b2176000c936397cf3d44326507300a8193d6"
+  ]
+}


### PR DESCRIPTION
##### CHANGES:

### Fixed

- **irmin**
  - Fix stack overflow exception when working with wide trees (mirage/irmin#1313, @zshipko)

  - `Tree.of_concrete` now prunes empty subdirectories, and raises
    `Invalid_argument` if the input contains duplicate bindings. (mirage/irmin#1385,
    @CraigFe)

- **irmin-chunk**
  - Use the pre_hash function to compute entry keys instead of
    their raw binary representation (mirage/irmin#1308, @samoht)

### Changed

- **irmin-git**
  - Upgrade `irmin-git` with `git.3.4.0`. (mirage/irmin#1392, @dinosaure)
