### PR TITLE
5 packages from smimram/ocaml-pandoc at 0.1.0

### DIFF
--- a/packages/pandoc-abbreviations/pandoc-abbreviations.0.1.0/opam
+++ b/packages/pandoc-abbreviations/pandoc-abbreviations.0.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Pandoc filter to add non-breaking spaces after abbreviations"
+description:
+  "This pandoc filter adds non-breaking spaces after the abbreviations listed in the `abbreviations` file"
+maintainer: ["Samuel Mimram <smimram@gmail.com>"]
+authors: ["Samuel Mimram <smimram@gmail.com>"]
+license: "LGPL-2.1"
+homepage: "https://github.com/smimram/ocaml-pandoc"
+bug-reports: "https://github.com/smimram/ocaml-pandoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "pandoc" {>= "0.1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/smimram/ocaml-pandoc.git"
+url {
+  src: "https://github.com/smimram/ocaml-pandoc/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=51e94d022cc795157404c0e4cde60896"
+    "sha512=2df5ab08ff1bd4dbe11dcbd572ae97ff762a0ca9ee8d4332ade4491c22a0111c3323a0982c9cb8e3158b3f1ab89dcd9d92551bf4cd4e29b8a5015e68c816edd0"
+  ]
+}

--- a/packages/pandoc-abbreviations/pandoc-abbreviations.0.1.0/opam
+++ b/packages/pandoc-abbreviations/pandoc-abbreviations.0.1.0/opam
@@ -10,6 +10,7 @@ bug-reports: "https://github.com/smimram/ocaml-pandoc/issues"
 depends: [
   "dune" {>= "2.0"}
   "pandoc" {>= "0.1.0"}
+  "ocaml" {>="4.04.0"} # due to String.split_on_char
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/pandoc-crossref/pandoc-crossref.0.1.0/opam
+++ b/packages/pandoc-crossref/pandoc-crossref.0.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Pandoc filter to have LaTeX cross-references"
+description:
+  "This pandoc filter replaces #chap: and #sec: references to cref invokations"
+maintainer: ["Samuel Mimram <smimram@gmail.com>"]
+authors: ["Samuel Mimram <smimram@gmail.com>"]
+license: "LGPL-2.1"
+homepage: "https://github.com/smimram/ocaml-pandoc"
+bug-reports: "https://github.com/smimram/ocaml-pandoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "pandoc" {>= "0.1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/smimram/ocaml-pandoc.git"
+url {
+  src: "https://github.com/smimram/ocaml-pandoc/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=51e94d022cc795157404c0e4cde60896"
+    "sha512=2df5ab08ff1bd4dbe11dcbd572ae97ff762a0ca9ee8d4332ade4491c22a0111c3323a0982c9cb8e3158b3f1ab89dcd9d92551bf4cd4e29b8a5015e68c816edd0"
+  ]
+}

--- a/packages/pandoc-include/pandoc-include.0.1.0/opam
+++ b/packages/pandoc-include/pandoc-include.0.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Pandoc filter to include other files"
+description:
+  "This pandoc filter allows the inclusion of other markdown files into markdown"
+maintainer: ["Samuel Mimram <smimram@gmail.com>"]
+authors: ["Samuel Mimram <smimram@gmail.com>"]
+license: "LGPL-2.1"
+homepage: "https://github.com/smimram/ocaml-pandoc"
+bug-reports: "https://github.com/smimram/ocaml-pandoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "pandoc" {>= "0.1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/smimram/ocaml-pandoc.git"
+url {
+  src: "https://github.com/smimram/ocaml-pandoc/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=51e94d022cc795157404c0e4cde60896"
+    "sha512=2df5ab08ff1bd4dbe11dcbd572ae97ff762a0ca9ee8d4332ade4491c22a0111c3323a0982c9cb8e3158b3f1ab89dcd9d92551bf4cd4e29b8a5015e68c816edd0"
+  ]
+}

--- a/packages/pandoc-inspect/pandoc-inspect.0.1.0/opam
+++ b/packages/pandoc-inspect/pandoc-inspect.0.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Pandoc filter to inspect pandoc's JSON"
+description:
+  "This pandoc filter prints pandoc's internal JSON on the standard error"
+maintainer: ["Samuel Mimram <smimram@gmail.com>"]
+authors: ["Samuel Mimram <smimram@gmail.com>"]
+license: "LGPL-2.1"
+homepage: "https://github.com/smimram/ocaml-pandoc"
+bug-reports: "https://github.com/smimram/ocaml-pandoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "pandoc" {>= "0.1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/smimram/ocaml-pandoc.git"
+url {
+  src: "https://github.com/smimram/ocaml-pandoc/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=51e94d022cc795157404c0e4cde60896"
+    "sha512=2df5ab08ff1bd4dbe11dcbd572ae97ff762a0ca9ee8d4332ade4491c22a0111c3323a0982c9cb8e3158b3f1ab89dcd9d92551bf4cd4e29b8a5015e68c816edd0"
+  ]
+}

--- a/packages/pandoc/pandoc.0.1.0/opam
+++ b/packages/pandoc/pandoc.0.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Library to write pandoc filters"
+description:
+  "This library helps writing filters for pandoc, which is a tool to convert between textual formats notably, markdown and LaTeX"
+maintainer: ["Samuel Mimram <smimram@gmail.com>"]
+authors: ["Samuel Mimram <smimram@gmail.com>"]
+license: "LGPL-2.1"
+homepage: "https://github.com/smimram/ocaml-pandoc"
+bug-reports: "https://github.com/smimram/ocaml-pandoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "yojson" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/smimram/ocaml-pandoc.git"
+url {
+  src: "https://github.com/smimram/ocaml-pandoc/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=51e94d022cc795157404c0e4cde60896"
+    "sha512=2df5ab08ff1bd4dbe11dcbd572ae97ff762a0ca9ee8d4332ade4491c22a0111c3323a0982c9cb8e3158b3f1ab89dcd9d92551bf4cd4e29b8a5015e68c816edd0"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`pandoc.0.1.0`: Library to write pandoc filters
-`pandoc-abbreviations.0.1.0`: Pandoc filter to add non-breaking spaces after abbreviations
-`pandoc-crossref.0.1.0`: Pandoc filter to have LaTeX cross-references
-`pandoc-include.0.1.0`: Pandoc filter to include other files
-`pandoc-inspect.0.1.0`: Pandoc filter to inspect pandoc's JSON



---
* Homepage: https://github.com/smimram/ocaml-pandoc
* Source repo: git+https://github.com/smimram/ocaml-pandoc.git
* Bug tracker: https://github.com/smimram/ocaml-pandoc/issues

---
:camel: Pull-request generated by opam-publish v2.0.3