### PR TITLE
[new release] key-parsers (1.0.1)

### DIFF
--- a/packages/key-parsers/key-parsers.1.0.1/opam
+++ b/packages/key-parsers/key-parsers.1.0.1/opam
@@ -6,7 +6,7 @@ authors: [
 ]
 homepage: "https://github.com/cryptosense/key-parsers"
 bug-reports: "https://github.com/cryptosense/key-parsers/issues"
-license: "BSD-2"
+license: "BSD-2-Clause"
 dev-repo: "git+https://github.com/cryptosense/key-parsers.git"
 doc: "https://cryptosense.github.io/key-parsers/doc"
 build: [

--- a/packages/key-parsers/key-parsers.1.0.1/opam
+++ b/packages/key-parsers/key-parsers.1.0.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: [
+    "Cryptosense <opensource@cryptosense.com>"
+    "Nathan Rebours <nathan.p.rebours@gmail.com>"
+]
+homepage: "https://github.com/cryptosense/key-parsers"
+bug-reports: "https://github.com/cryptosense/key-parsers/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/key-parsers.git"
+doc: "https://cryptosense.github.io/key-parsers/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "asn1-combinators" {>= "0.2.0"}
+  "cstruct" {>= "1.6.0"}
+  "dune" {>= "1.11.0"}
+  "hex" {>= "1.0.0"}
+  "ocaml" {>= "4.04.1"}
+  "ounit" {with-test & >= "2.0.0"}
+  "ppx_deriving" {>= "4.0"}
+  "result" {>= "1.2"}
+  "zarith" {>= "1.4.1"}
+]
+conflicts: [
+  "ppx_driver" {= "v0.9.1"}
+]
+synopsis: "Parsers for multiple key formats"
+description: """
+This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman or
+Elliptic curve public and private keys.
+"""
+x-commit-hash: "5d16f7214e4517abc0a21ae36143cee3c509d992"
+url {
+  src:
+    "https://github.com/cryptosense/key-parsers/releases/download/1.0.1/key-parsers-1.0.1.tbz"
+  checksum: [
+    "sha256=118ec499fc624579fade9c50a1e04b02604602a26239e1f1dcc7c11940668ca6"
+    "sha512=9cd19fba4bc353785cb4da1ae0a4e9025faa2543ca9c2f0ae8533c15367c3cbd2d2cf7d7e0aad6009b347991c1fdedf9e29a9c58a30bdcf400ad0aa91a562f06"
+  ]
+}


### PR DESCRIPTION
Parsers for multiple key formats

- Project page: <a href="https://github.com/cryptosense/key-parsers">https://github.com/cryptosense/key-parsers</a>
- Documentation: <a href="https://cryptosense.github.io/key-parsers/doc">https://cryptosense.github.io/key-parsers/doc</a>

##### CHANGES:

## 1.0.1

*2021-04-28*

### Fixed

- Detect malformed RSA keys and return an error

## 1.0.0

*2020-12-03*

### Changed

- Correct spelling 'alogrithm' -> 'algorithm' in some labels

### Removed

- Remove dependency on ppx_deriving_yojson and ppx_bin_prot, and associated deprecated
  serialization values (`bin_t`, `bin_size_t`, `to_yojson`, etc).
- Remove deprecated uppercase module aliases `RSA`, `DSA`, `EC` and `DH` in `Asn1`, `Cvc`
  and `Ltpa`.

## 0.10.1

*2018-10-31*

### Fixed

- Allow RSA parameters to be absent form the AlgorithmIdentifier Sequence

## 0.10.0

*2018-08-27*

### Added

- Lowercase aliases for uppercase modules `RSA`, `DSA`, `EC` and `DH` in `Asn1`, `Cvc` and `Ltpa`

### Deprecated

- `Yojson` and `Bin_prot` (de)serializers are deprecated ahead of their removal in `1.0.0`.
- Uppercase modules such as `Asn1.RSA` in favor of their lowercase counterparts

### Changed

- Use dune instead of ocamlbuild and topkg
- Rename uppercase private variants and modules to lowercase ones

## 0.9.2

*2017-12-12*

- Switch to `asn1-combinators >= 0.2.0`
- Refactor `Kp_asn1`
- Add documentation and README

## 0.9.1

*2017-08-30*

- remove `@tailcall` annotations to allow `ppx_deriving > 4.2`

## 0.9.0

*2017-06-21*

- encode Cstruct as 0x prefixed hex string (breaks json compatibility)

## 0.8.1

*2017-05-03*

- `ppx_bin_prot` 0.9.0 compatibility

## 0.8.0

*2016-12-27*

- Add an `equal` function for all exposed types
- Add `bin_prot` serializer and deserializer for all exposed types

## 0.7.0

*2016-11-28*

(This release contains breaking changes)

- Fixes CVC EC keys representation (Breaking change)
- Accept a range of rsa and ecdsa oids for CVC keys

## v0.6.1

*2016-11-15*

- Fixes install


## v0.6.0

*2016-11-14*

- Build using `topkg`
- Add `ppx_deriving.runtime` to `META`
- Add support for parsing CVC keys

## v0.5.0

*2016-08-10*

- Explicitly define ocaml version
- Widen dependencies version ranges
- add `ppx_deriving` annotations for `ord` and `yojson` to most of the exposed types in `Asn1` and `Ltpa`

## v0.4.0

*2016-07-25*

- Accept ECDH and ECMQV OIDs for EC keys AlorithmIdentifier
- Add support for encoding/decoding Diffie-Hellman keys
- Use `ppx_deriving_yojson` 3.0

## v0.3.0

*2016-03-10*

- Add converters and compare functions to Asn1.EC
- Split Key_parsers content between Asn1 and Ltpa submodules.
  Breaks compatibility with previous versions.
- Add some tests
- Decode functions now return ('a, string) Result.result.
  Breaks compatibility with previous versions.
- Add LTPA RSA parsers

## v0.2.0

*2016-02-15*

- Add EC keys and parameters parsers
- Compile with `-safe-string`

## v0.1.0

*2015-11-27*

- Initial release
