### PR TITLE
[new release] fsevents and fsevents-lwt (0.3.0)

### DIFF
--- a/packages/fsevents-lwt/fsevents-lwt.0.3.0/opam
+++ b/packages/fsevents-lwt/fsevents-lwt.0.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Lwt interface to macOS FSEvents"
+description: """
+An Lwt interface to the macOS FSEvents framework, using the
+`cf-lwt` library for the low-level bindings."""
+maintainer: ["Thomas Gazagnaire"]
+authors: ["David Sheets" "Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-fsevents"
+bug-reports: "https://github.com/mirage/ocaml-fsevents/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "fsevents" {= version}
+  "cf-lwt"
+  "cmdliner"
+  "alcotest" {with-test}
+  "lwt" {>= "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-fsevents.git"
+x-commit-hash: "fe4d6f180fafa18a60e9f7834b1254495e68dbc8"
+url {
+  src:
+    "https://github.com/mirage/ocaml-fsevents/releases/download/0.3.0/fsevents-lwt-0.3.0.tbz"
+  checksum: [
+    "sha256=0bbfea93c14e99c1dbb2bf9de2ef8c93e4f1043490df73c00f9c0a969f472b7a"
+    "sha512=f76eff7de44d1d878c88bed490d8b5d45f92774908ce7c687d828c3696dbf97cc1d40b804691c85041e6f7800d48b6a91d07a17638a68058329185235549b03a"
+  ]
+}

--- a/packages/fsevents/fsevents.0.3.0/opam
+++ b/packages/fsevents/fsevents.0.3.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mirage/ocaml-fsevents/issues"
 depends: [
   "dune" {>= "2.8"}
   "base-bytes"
-  "cf" {>= "0.4.0"}
+  "cf" {>= "0.4"}
   "ctypes" {>= "0.4.0"}
   "odoc" {with-doc}
 ]

--- a/packages/fsevents/fsevents.0.3.0/opam
+++ b/packages/fsevents/fsevents.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings to macOS FSEvents"
+description: """
+These bindings use [ctypes](https://github.com/ocamllabs/ocaml-ctypes)
+for type-safe stub generation."""
+maintainer: ["Thomas Gazagnaire"]
+authors: ["David Sheets" "Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-fsevents"
+bug-reports: "https://github.com/mirage/ocaml-fsevents/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "base-bytes"
+  "cf" {>= "0.4.0"}
+  "ctypes" {>= "0.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-fsevents.git"
+x-commit-hash: "fe4d6f180fafa18a60e9f7834b1254495e68dbc8"
+url {
+  src:
+    "https://github.com/mirage/ocaml-fsevents/releases/download/0.3.0/fsevents-lwt-0.3.0.tbz"
+  checksum: [
+    "sha256=0bbfea93c14e99c1dbb2bf9de2ef8c93e4f1043490df73c00f9c0a969f472b7a"
+    "sha512=f76eff7de44d1d878c88bed490d8b5d45f92774908ce7c687d828c3696dbf97cc1d40b804691c85041e6f7800d48b6a91d07a17638a68058329185235549b03a"
+  ]
+}


### PR DESCRIPTION
OCaml bindings to macOS FSEvents

- Project page: <a href="https://github.com/mirage/ocaml-fsevents">https://github.com/mirage/ocaml-fsevents</a>

##### CHANGES:

* library renamed to `fsevents` from `osx-fsevents`
  with a new upstream at https://github.com/mirage (@avsm @samoht)
* switch to dune (@samoht)
* use dune-project opam file generation (@avsm).
* support building on non-macOS by just installing a
  stub library (@avsm)
* switch from Travis CI to GitHub Actions and ocaml-ci (@avsm)
