### PR TITLE
[new release] index (1.3.1)

### DIFF
--- a/packages/index-bench/index-bench.1.3.1/opam
+++ b/packages/index-bench/index-bench.1.3.1/opam
@@ -7,7 +7,7 @@ bug-reports:  "https://github.com/mirage/index/issues"
 dev-repo:     "git+https://github.com/mirage/index.git"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
  ["dune" "runtest" "-p" name] {with-test}
 ]

--- a/packages/index-bench/index-bench.1.3.1/opam
+++ b/packages/index-bench/index-bench.1.3.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.03.0"}
+  "cmdliner"
+  "dune"    {>= "2.7.0"}
+  "fmt"
+  "index"
+  "metrics"
+  "metrics-unix"
+  "ppx_deriving_yojson"
+  "re"
+  "stdlib-shims"
+  "yojson"
+  "ppx_repr"
+]
+
+synopsis: "Index benchmarking suite"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.3.1/index-1.3.1.tbz"
+  checksum: [
+    "sha256=c9c662fd314ba06465a12a6362a1f91421d63f77b28930880cb112127e629ee2"
+    "sha512=db22d6f986f9ea92c2b6c677c956cdbb8cab4cec57e2828f13560ebe6167a08d1f33332cf8a1a2cdc72cea77a3786d43365181d3fc0a90572fce6212f242836a"
+  ]
+}
+x-commit-hash: "f528c18f806380df14cf0f306d2879792c7174d6"

--- a/packages/index/index.1.3.1/opam
+++ b/packages/index/index.1.3.1/opam
@@ -13,7 +13,7 @@ dev-repo:     "git+https://github.com/mirage/index.git"
 doc:          "https://mirage.github.io/index/"
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
  ["dune" "runtest" "-p" name] {with-test}
 ]

--- a/packages/index/index.1.3.1/opam
+++ b/packages/index/index.1.3.1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      [
+   "Craig Ferguson <craig@tarides.com>"
+   "Thomas Gazagnaire <thomas@tarides.com>"
+   "Ioana Cristescu <ioana@tarides.com>"
+   "Clément Pascutto <clement@tarides.com>"
+]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+doc:          "https://mirage.github.io/index/"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "repr"    {>= "0.2.0"}
+  "ppx_repr"
+  "fmt"
+  "logs"
+  "mtime"   {>= "1.0.0"}
+  "cmdliner"
+  "progress"
+  "semaphore-compat"
+  "jsonm"
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "crowbar"  {with-test & >= "0.2"}
+  "re"       {with-test}
+]
+synopsis: "A platform-agnostic multi-level index for OCaml"
+description:"""
+Index is a scalable implementation of persistent indices in OCaml.
+
+It takes an arbitrary IO implementation and user-supplied content
+types and supplies a standard key-value interface for persistent
+storage. Index provides instance sharing: each OCaml
+run-time can share a common singleton instance.
+
+Index supports multiple-reader/single-writer access. Concurrent access
+is safely managed using lock files."""
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.3.1/index-1.3.1.tbz"
+  checksum: [
+    "sha256=c9c662fd314ba06465a12a6362a1f91421d63f77b28930880cb112127e629ee2"
+    "sha512=db22d6f986f9ea92c2b6c677c956cdbb8cab4cec57e2828f13560ebe6167a08d1f33332cf8a1a2cdc72cea77a3786d43365181d3fc0a90572fce6212f242836a"
+  ]
+}
+x-commit-hash: "f528c18f806380df14cf0f306d2879792c7174d6"


### PR DESCRIPTION
A platform-agnostic multi-level index for OCaml

- Project page: <a href="https://github.com/mirage/index">https://github.com/mirage/index</a>
- Documentation: <a href="https://mirage.github.io/index/">https://mirage.github.io/index/</a>

##### CHANGES:

## Fixed

- Reduce allocations during merge (mirage/index#274, mirage/index#277)

- Protect concurrent syncs with a lock (mirage/index#309)

- Fixed a performance issue for `Index.sync` when there is a blocking merge in
  progress: the `log_async` file was not cached properly and fully reloaded
  from disk every time. (mirage/index#310)

- Release the merge lock if a merge raises an exception (mirage/index#312)

- Added fsync after `Index.clear` to signal more quickly to read-only instances
  than something has changed in the file (mirage/index#308)

## Changed

- Specialise `IO.v` to create read-only or read-write instances. (mirage/index#291)

- `clear` removes the files on disks and opens new ones containing only the
  header. (mirage/index#288, mirage/index#307, mirage/index#317)
