### PR TITLE
[new release] repr-bench, ppx_repr, repr and repr-fuzz (0.3.0)

### DIFF
--- a/packages/ppx_repr/ppx_repr.0.3.0/opam
+++ b/packages/ppx_repr/ppx_repr.0.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "PPX deriver for type representations"
+description: "PPX deriver for type representations"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "ppxlib" {>= "0.12.0"}
+  "ppx_deriving"
+  "hex" {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {= "1.7.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.3.0/repr-fuzz-0.3.0.tbz"
+  checksum: [
+    "sha256=d9bd2fe51c2eb6fca27731034c46f9a77dc8bc9fb7b76216f8a571603d6e7d74"
+    "sha512=7b4ad2cbcd92f6647a1abe1d82557f02e4955c5f37f02089388c752e23b865af0f55fdd6bc63a1d2a00962baf96ccd99ccd9b8ecd8898dcc2a0cd17302f067c3"
+  ]
+}
+x-commit-hash: "d410d610bc45ee42ac95f17b931be414dc007f7c"

--- a/packages/repr-bench/repr-bench.0.3.0/opam
+++ b/packages/repr-bench/repr-bench.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Benchmarks for the `repr` package"
+description: "Benchmarks for the `repr` package"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "ppx_repr" {= version}
+  "bechamel"
+  "yojson"
+  "fpath"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.3.0/repr-fuzz-0.3.0.tbz"
+  checksum: [
+    "sha256=d9bd2fe51c2eb6fca27731034c46f9a77dc8bc9fb7b76216f8a571603d6e7d74"
+    "sha512=7b4ad2cbcd92f6647a1abe1d82557f02e4955c5f37f02089388c752e23b865af0f55fdd6bc63a1d2a00962baf96ccd99ccd9b8ecd8898dcc2a0cd17302f067c3"
+  ]
+}
+x-commit-hash: "d410d610bc45ee42ac95f17b931be414dc007f7c"

--- a/packages/repr-fuzz/repr-fuzz.0.3.0/opam
+++ b/packages/repr-fuzz/repr-fuzz.0.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Fuzz tests for the `repr` package"
+description: "Fuzz tests for the `repr` package"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "crowbar" {= "0.2"}
+  "ppxlib" {>= "0.12.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.3.0/repr-fuzz-0.3.0.tbz"
+  checksum: [
+    "sha256=d9bd2fe51c2eb6fca27731034c46f9a77dc8bc9fb7b76216f8a571603d6e7d74"
+    "sha512=7b4ad2cbcd92f6647a1abe1d82557f02e4955c5f37f02089388c752e23b865af0f55fdd6bc63a1d2a00962baf96ccd99ccd9b8ecd8898dcc2a0cd17302f067c3"
+  ]
+}
+x-commit-hash: "d410d610bc45ee42ac95f17b931be414dc007f7c"

--- a/packages/repr/repr.0.3.0/opam
+++ b/packages/repr/repr.0.3.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Dynamic type representations. Provides no stability guarantee"
+description: """
+This package defines a library of combinators for building dynamic type
+representations and a set of generic operations over representable types, used
+in the implementation of Irmin and related packages.
+
+It is not yet intended for public consumption and provides no stability
+guarantee.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.7"}
+  "uutf"
+  "either"
+  "jsonm" {>= "1.0.0"}
+  "base64" {>= "3.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.3.0/repr-fuzz-0.3.0.tbz"
+  checksum: [
+    "sha256=d9bd2fe51c2eb6fca27731034c46f9a77dc8bc9fb7b76216f8a571603d6e7d74"
+    "sha512=7b4ad2cbcd92f6647a1abe1d82557f02e4955c5f37f02089388c752e23b865af0f55fdd6bc63a1d2a00962baf96ccd99ccd9b8ecd8898dcc2a0cd17302f067c3"
+  ]
+}
+x-commit-hash: "d410d610bc45ee42ac95f17b931be414dc007f7c"


### PR DESCRIPTION
Benchmarks for the `repr` package

- Project page: <a href="https://github.com/mirage/repr">https://github.com/mirage/repr</a>

##### CHANGES:

- `Repr.v` is now called `Repr.abstract`. (mirage/repr#52, @CraigFe)

- Added `Repr.partially_abstract`, a helper combinator for constructing type
  representations with overridden operations. (mirage/repr#52, @CraigFe)

- Add combinators for standard library container types: `ref`, `Lazy.t`,
  `Seq.t`, `Queue.t`, `Stack.t`, `Hashtbl.t`, `Set.t` and `Map.t`.
  (mirage/repr#43, @CraigFe)

- Improve PPX `Repr.t` generation for types in the standard library. References
  to e.g. `Bool.t` or `Stdlib.Int32.t` will be resolved to the corresponding
  combinators. (mirage/repr#43, @CraigFe)

- Add support for deriving mutually-recursive pairs of type representations
  with `ppx_repr`. (mirage/repr#42, @CraigFe)

- Add a JSON object combinator: `Json.assoc` (mirage/repr#53, @Ngoguey42)

- Drop the payload of NaN floating point values during JSON encoding. `-nan`
  strings are not emitted any more. (mirage/repr#55, @Ngoguey42)
