### PR TITLE
[new release] dolmen_type, dolmen_bin, dolmen_loop, dolmen_lsp and dolmen (0.6)

### DIFF
--- a/packages/dolmen/dolmen.0.6/opam
+++ b/packages/dolmen/dolmen.0.6/opam
@@ -3,12 +3,13 @@ maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
 authors: "Guillaume Bury <guillaume.bury@gmail.com>"
 license: "BSD-2-Clause"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "ocaml" {>= "4.08"}
-  "menhir" {>= "20180703" & ( ! with-test | >= "20201201") }
+  "menhir" {>= "20180703"}
+  "menhir" {with-test & >= "20201201"}
   "dune" { >= "2.7" }
   "fmt" { >= "0.8.7" }
   "seq"

--- a/packages/dolmen/dolmen.0.6/opam
+++ b/packages/dolmen/dolmen.0.6/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
+authors: "Guillaume Bury <guillaume.bury@gmail.com>"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "menhir" {>= "20180703" & ( ! with-test | >= "20201201") }
+  "dune" { >= "2.7" }
+  "fmt" { >= "0.8.7" }
+  "seq"
+  "odoc" { with-doc }
+]
+
+tags: [ "parser" "logic" "tptp" "smtlib" "dimacs" ]
+homepage: "https://github.com/Gbury/dolmen"
+dev-repo: "git+https://github.com/Gbury/dolmen.git"
+bug-reports: "https://github.com/Gbury/dolmen/issues"
+
+doc: "http://gbury.github.io/dolmen"
+synopsis: "A parser library"
+description:
+"Dolmen is a parser library. It currently targets languages used in automated theorem provers,
+but may be extended ot other domains.
+
+Dolmen provides functors that takes as arguments a representation of terms and statements,
+and returns a module that can parse files (or streams of tokens) into the provided representation
+of terms or statements. This is meant so that Dolmen can be used as a drop-in replacement of existing
+parser, in order to factorize parsers among projects.
+
+Additionally, Dolmen also provides a standard implementation of terms and statements that cna be
+used ot instantiate its parsers."
+x-commit-hash: "b24807c44c0325c938e9d5b81ea82fe6cf5b461d"
+url {
+  src:
+    "https://github.com/Gbury/dolmen/releases/download/v0.6/dolmen-v0.6.tbz"
+  checksum: [
+    "sha256=81b034da2de84da19fb6368aaa39135f6259ee2773ff08c8f03da9ceeb10748c"
+    "sha512=98786ff1cc5b0c8bc4cb2dfe756ae15556c3876a206546b04374826be7d0a422dd5526d93f09cb0ea0d4985b71c408c182a951d4df908399c7e04b17c91a7d70"
+  ]
+}

--- a/packages/dolmen_bin/dolmen_bin.0.6/opam
+++ b/packages/dolmen_bin/dolmen_bin.0.6/opam
@@ -3,7 +3,7 @@ maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
 authors: "Guillaume Bury <guillaume.bury@gmail.com>"
 license: "BSD-2-Clause"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/dolmen_bin/dolmen_bin.0.6/opam
+++ b/packages/dolmen_bin/dolmen_bin.0.6/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
+authors: "Guillaume Bury <guillaume.bury@gmail.com>"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dolmen" {= version }
+  "dolmen_type" {= version }
+  "dolmen_loop" {= version }
+  "dune" { >= "2.7" }
+  "fmt"
+  "cmdliner"
+  "odoc" { with-doc }
+]
+tags: [ "logic" "computation" "automated theorem prover" "logic" "smtlib" "tptp"]
+homepage: "https://github.com/Gbury/dolmen"
+dev-repo: "git+https://github.com/Gbury/dolmen.git"
+bug-reports: "https://github.com/Gbury/dolmen/issues"
+
+doc: "http://gbury.github.io/dolmen"
+synopsis: "A linter for logic languages"
+description:
+"The dolmen binary is an instantiation of the Dolmen library
+to provide a binary to easily parse and type files used in
+automated deduction. "
+x-commit-hash: "b24807c44c0325c938e9d5b81ea82fe6cf5b461d"
+url {
+  src:
+    "https://github.com/Gbury/dolmen/releases/download/v0.6/dolmen-v0.6.tbz"
+  checksum: [
+    "sha256=81b034da2de84da19fb6368aaa39135f6259ee2773ff08c8f03da9ceeb10748c"
+    "sha512=98786ff1cc5b0c8bc4cb2dfe756ae15556c3876a206546b04374826be7d0a422dd5526d93f09cb0ea0d4985b71c408c182a951d4df908399c7e04b17c91a7d70"
+  ]
+}

--- a/packages/dolmen_loop/dolmen_loop.0.6/opam
+++ b/packages/dolmen_loop/dolmen_loop.0.6/opam
@@ -3,7 +3,7 @@ maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
 authors: "Guillaume Bury <guillaume.bury@gmail.com>"
 license: "BSD-2-Clause"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/dolmen_loop/dolmen_loop.0.6/opam
+++ b/packages/dolmen_loop/dolmen_loop.0.6/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
+authors: "Guillaume Bury <guillaume.bury@gmail.com>"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dolmen" {= version }
+  "dolmen_type" {= version }
+  "dune" { >= "2.7" }
+  "gen"
+  "odoc" { with-doc }
+]
+tags: [ "logic" "computation" "automated theorem prover" ]
+homepage: "https://github.com/Gbury/dolmen"
+dev-repo: "git+https://github.com/Gbury/dolmen.git"
+bug-reports: "https://github.com/Gbury/dolmen/issues"
+
+doc: "http://gbury.github.io/dolmen"
+synopsis: "A tool library for automated deduction tools"
+description:
+"Dolmen Loop is a library of useful helpers to parse
+and loop over statements found in automated deduction files."
+x-commit-hash: "b24807c44c0325c938e9d5b81ea82fe6cf5b461d"
+url {
+  src:
+    "https://github.com/Gbury/dolmen/releases/download/v0.6/dolmen-v0.6.tbz"
+  checksum: [
+    "sha256=81b034da2de84da19fb6368aaa39135f6259ee2773ff08c8f03da9ceeb10748c"
+    "sha512=98786ff1cc5b0c8bc4cb2dfe756ae15556c3876a206546b04374826be7d0a422dd5526d93f09cb0ea0d4985b71c408c182a951d4df908399c7e04b17c91a7d70"
+  ]
+}

--- a/packages/dolmen_lsp/dolmen_lsp.0.6/opam
+++ b/packages/dolmen_lsp/dolmen_lsp.0.6/opam
@@ -3,7 +3,7 @@ maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
 authors: "Guillaume Bury <guillaume.bury@gmail.com>"
 license: "BSD-2-Clause"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/dolmen_lsp/dolmen_lsp.0.6/opam
+++ b/packages/dolmen_lsp/dolmen_lsp.0.6/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
+authors: "Guillaume Bury <guillaume.bury@gmail.com>"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dolmen" {= version }
+  "dolmen_type" {= version }
+  "dolmen_loop" { = version }
+  "dune" { >= "2.7" }
+  "ocaml-syntax-shims"
+  "odoc" { with-doc }
+  "logs"
+  "lsp"
+  "linol" { >= "0.2" & < "0.3" }
+  "linol-lwt" { >= "0.2" & < "0.3" }
+]
+tags: [ "logic" "computation" "automated theorem prover" "lsp" "language server protocol"]
+homepage: "https://github.com/Gbury/dolmen"
+dev-repo: "git+https://github.com/Gbury/dolmen.git"
+bug-reports: "https://github.com/Gbury/dolmen/issues"
+
+doc: "http://gbury.github.io/dolmen"
+synopsis: "A LSP server for automated deduction languages"
+x-commit-hash: "b24807c44c0325c938e9d5b81ea82fe6cf5b461d"
+url {
+  src:
+    "https://github.com/Gbury/dolmen/releases/download/v0.6/dolmen-v0.6.tbz"
+  checksum: [
+    "sha256=81b034da2de84da19fb6368aaa39135f6259ee2773ff08c8f03da9ceeb10748c"
+    "sha512=98786ff1cc5b0c8bc4cb2dfe756ae15556c3876a206546b04374826be7d0a422dd5526d93f09cb0ea0d4985b71c408c182a951d4df908399c7e04b17c91a7d70"
+  ]
+}

--- a/packages/dolmen_type/dolmen_type.0.6/opam
+++ b/packages/dolmen_type/dolmen_type.0.6/opam
@@ -3,7 +3,7 @@ maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
 authors: "Guillaume Bury <guillaume.bury@gmail.com>"
 license: "BSD-2-Clause"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/dolmen_type/dolmen_type.0.6/opam
+++ b/packages/dolmen_type/dolmen_type.0.6/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
+authors: "Guillaume Bury <guillaume.bury@gmail.com>"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dolmen" {= version }
+  "dune" { >= "2.7" }
+  "spelll"
+  "uutf"
+  "odoc" { with-doc }
+]
+tags: [ "logic" "type" "typechecking" "first order" "polymorphism" ]
+homepage: "https://github.com/Gbury/dolmen"
+dev-repo: "git+https://github.com/Gbury/dolmen.git"
+bug-reports: "https://github.com/Gbury/dolmen/issues"
+
+doc: "http://gbury.github.io/dolmen"
+synopsis: "A typechecker for automated deduction languages"
+x-commit-hash: "b24807c44c0325c938e9d5b81ea82fe6cf5b461d"
+url {
+  src:
+    "https://github.com/Gbury/dolmen/releases/download/v0.6/dolmen-v0.6.tbz"
+  checksum: [
+    "sha256=81b034da2de84da19fb6368aaa39135f6259ee2773ff08c8f03da9ceeb10748c"
+    "sha512=98786ff1cc5b0c8bc4cb2dfe756ae15556c3876a206546b04374826be7d0a422dd5526d93f09cb0ea0d4985b71c408c182a951d4df908399c7e04b17c91a7d70"
+  ]
+}


### PR DESCRIPTION
A typechecker for automated deduction languages

- Project page: <a href="https://github.com/Gbury/dolmen">https://github.com/Gbury/dolmen</a>
- Documentation: <a href="http://gbury.github.io/dolmen">http://gbury.github.io/dolmen</a>

##### CHANGES:

### Release

- The official github release now provides access to
  already built binaries for `dolmen` and `dolmenls`,
  for linux (ubuntu) and macos
- The LSP server has been updated to depend on
  `linol~0.2`

### Bugfixes

- Smtlib2 let-bindings were treated as sequential, but are
  now treated as parrallel as specified by the spec;
  i.e. the following is now correctly rejected:
  `(let (x 0) (y x) (...))`

### Features

- Added support for higher order, including tptp's THF and Zf
- Optimized some corner cases of the typechecker to avoid
  exponential blowups

### API

- The interface of the `Expr` module has changed to support
  higher-order
- Additionally, there is now proper support for type aliases
  (which are expanded on demand as necessary), in `Expr`
- There is now a new typechecker module exposed as Thf for
  typing higher order expressions
