### PR TITLE
Package conformist.0.6.0

### DIFF
--- a/packages/conformist/conformist.0.6.0/opam
+++ b/packages/conformist/conformist.0.6.0/opam
@@ -22,7 +22,7 @@ depends: [
   "sexplib" {>= "v0.13.0" & with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/conformist/conformist.0.6.0/opam
+++ b/packages/conformist/conformist.0.6.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Conformist allows you to define schemas to decode, validate and sanitize input data declaratively"
+description: """
+
+Conformist allows you to define schemas to decode, validate and sanitize input data declaratively.
+It comes with runtime types for primitive OCaml types such as `int`, `string`, `bool` and `float` but also `Ptime.t`, `option` and custom types.
+Re-use business rules in validators and run it on the client side with js_of_ocaml.
+Arbitrary meta data can be stored in schemas which is useful to build functionality on top of conformist.
+"""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/conformist"
+doc: "https://oxidizing.github.io/conformist/"
+bug-reports: "https://github.com/oxidizing/conformist/issues"
+depends: [
+  "dune" {>= "2.4"}
+  "ocaml" {>= "4.08.0"}
+  "ptime" {>= "0.8.5"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "sexplib" {>= "v0.13.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/conformist.git"
+url {
+  src: "https://github.com/oxidizing/conformist/archive/0.6.0.tar.gz"
+  checksum: [
+    "md5=462215fd0a1615b1f3686da1c80d2351"
+    "sha512=ad1cbe53293e4269d9be47edc5f3e1303b5707dd59715e29d0928b348661aab2d75977e88b4ec4841f2ec5931cd018d40b781911e503dcb5d3a5e3b0d3994aeb"
+  ]
+}

--- a/packages/sihl/sihl.0.4.0/opam
+++ b/packages/sihl/sihl.0.4.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "conformist" {= "0.3.0"}
+  "conformist" {>= "0.4.0" & < "0.6.0"}
   "tsort" {>= "2.0.0"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}

--- a/packages/sihl/sihl.0.4.0/opam
+++ b/packages/sihl/sihl.0.4.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "conformist" {>= "0.3.0"}
+  "conformist" {= "0.3.0"}
   "tsort" {>= "2.0.0"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}

--- a/packages/sihl/sihl.0.4.1/opam
+++ b/packages/sihl/sihl.0.4.1/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "conformist" {>= "0.4.0" & <= "0.5.0"}
+  "conformist" {>= "0.4.0" & < "0.6.0"}
   "tsort" {>= "2.0.0"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}

--- a/packages/sihl/sihl.0.4.1/opam
+++ b/packages/sihl/sihl.0.4.1/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "conformist" {>= "0.4.0"}
+  "conformist" {>= "0.4.0" & <= "0.5.0"}
   "tsort" {>= "2.0.0"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}

--- a/packages/sihl/sihl.0.5.0/opam
+++ b/packages/sihl/sihl.0.5.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "conformist" {>= "0.4.0" & <= "0.5.0"}
+  "conformist" {>= "0.4.0" & < "0.6.0"}
   "tsort" {>= "2.0.0"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}

--- a/packages/sihl/sihl.0.5.0/opam
+++ b/packages/sihl/sihl.0.5.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/oxidizing/sihl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "conformist" {>= "0.4.0"}
+  "conformist" {>= "0.4.0" & <= "0.5.0"}
   "tsort" {>= "2.0.0"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}


### PR DESCRIPTION
### `conformist.0.6.0`
Conformist allows you to define schemas to decode, validate and sanitize input data declaratively
Conformist allows you to define schemas to decode, validate and sanitize input data declaratively.
It comes with runtime types for primitive OCaml types such as `int`, `string`, `bool` and `float` but also `Ptime.t`, `option` and custom types.
Re-use business rules in validators and run it on the client side with js_of_ocaml.
Arbitrary meta data can be stored in schemas which is useful to build functionality on top of conformist.



---
* Homepage: https://github.com/oxidizing/conformist
* Source repo: git+https://github.com/oxidizing/conformist.git
* Bug tracker: https://github.com/oxidizing/conformist/issues

---
:camel: Pull-request generated by opam-publish v2.0.3