### PR TITLE
7 packages from oxidizing/sihl at 0.6.0~rc1

### DIFF
--- a/packages/sihl-cache/sihl-cache.0.6.0~rc1/opam
+++ b/packages/sihl-cache/sihl-cache.0.6.0~rc1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Cache service implementations for Sihl"
+description: "A key-value store with support for PostgreSQL and MariaDB."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "alcotest-lwt" {>= "1.3.0" & with-test}
+  "caqti-driver-postgresql" {>= "1.2.0" & with-test}
+  "caqti-driver-mariadb" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.6.0-rc1.tar.gz"
+  checksum: [
+    "md5=c6997c4e703d4a6fbd1ed4e3439608cf"
+    "sha512=dba9373c7d611a5589bc141aac5b2d4701316f9179b1313a1811dcc5436f4344634346a70c535794209ba41660c770386e0047bd138a6fd07a5659fb09dd7ecc"
+  ]
+}

--- a/packages/sihl-email/sihl-email.0.6.0~rc1/opam
+++ b/packages/sihl-email/sihl-email.0.6.0~rc1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Email service implementations for Sihl"
+description: "Modules for sending emails using Lwt and SMTP or Sendgrid."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "letters" {>= "0.2.1"}
+  "sihl" {= version}
+  "cohttp-lwt-unix" {>= "2.5.4"}
+  "alcotest-lwt" {>= "1.3.0" & with-test}
+  "caqti-driver-postgresql" {>= "1.2.0" & with-test}
+  "caqti-driver-mariadb" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.6.0-rc1.tar.gz"
+  checksum: [
+    "md5=c6997c4e703d4a6fbd1ed4e3439608cf"
+    "sha512=dba9373c7d611a5589bc141aac5b2d4701316f9179b1313a1811dcc5436f4344634346a70c535794209ba41660c770386e0047bd138a6fd07a5659fb09dd7ecc"
+  ]
+}

--- a/packages/sihl-queue/sihl-queue.0.6.0~rc1/opam
+++ b/packages/sihl-queue/sihl-queue.0.6.0~rc1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Queue service implementations for Sihl"
+description:
+  "Modules for running tasks in the background on a persistent queue."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "tyxml-ppx" {>= "4.4.0"}
+  "alcotest-lwt" {>= "1.3.0" & with-test}
+  "caqti-driver-postgresql" {>= "1.2.0" & with-test}
+  "caqti-driver-mariadb" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.6.0-rc1.tar.gz"
+  checksum: [
+    "md5=c6997c4e703d4a6fbd1ed4e3439608cf"
+    "sha512=dba9373c7d611a5589bc141aac5b2d4701316f9179b1313a1811dcc5436f4344634346a70c535794209ba41660c770386e0047bd138a6fd07a5659fb09dd7ecc"
+  ]
+}

--- a/packages/sihl-storage/sihl-storage.0.6.0~rc1/opam
+++ b/packages/sihl-storage/sihl-storage.0.6.0~rc1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Storage service implementations for Sihl"
+description:
+  "Modules for storing large binary blobs using either PostgreSQL or MariaDB."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "alcotest-lwt" {>= "1.3.0" & with-test}
+  "caqti-driver-postgresql" {>= "1.2.0" & with-test}
+  "caqti-driver-mariadb" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.6.0-rc1.tar.gz"
+  checksum: [
+    "md5=c6997c4e703d4a6fbd1ed4e3439608cf"
+    "sha512=dba9373c7d611a5589bc141aac5b2d4701316f9179b1313a1811dcc5436f4344634346a70c535794209ba41660c770386e0047bd138a6fd07a5659fb09dd7ecc"
+  ]
+}

--- a/packages/sihl-token/sihl-token.0.6.0~rc1/opam
+++ b/packages/sihl-token/sihl-token.0.6.0~rc1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Token service implementations for Sihl"
+description:
+  "Modules for token handling with support for JWT blacklisting and server-side stored tokens using PostgreSQL and MariaDB."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "alcotest-lwt" {>= "1.3.0" & with-test}
+  "caqti-driver-postgresql" {>= "1.2.0" & with-test}
+  "caqti-driver-mariadb" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.6.0-rc1.tar.gz"
+  checksum: [
+    "md5=c6997c4e703d4a6fbd1ed4e3439608cf"
+    "sha512=dba9373c7d611a5589bc141aac5b2d4701316f9179b1313a1811dcc5436f4344634346a70c535794209ba41660c770386e0047bd138a6fd07a5659fb09dd7ecc"
+  ]
+}

--- a/packages/sihl-user/sihl-user.0.6.0~rc1/opam
+++ b/packages/sihl-user/sihl-user.0.6.0~rc1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "User service implementations for Sihl"
+description:
+  "Modules for user management and password reset workflows with support for PostgreSQL and MariaDB."
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "sihl" {= version}
+  "sihl-token" {= version & with-test}
+  "alcotest-lwt" {>= "1.3.0" & with-test}
+  "caqti-driver-postgresql" {>= "1.2.0" & with-test}
+  "caqti-driver-mariadb" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.6.0-rc1.tar.gz"
+  checksum: [
+    "md5=c6997c4e703d4a6fbd1ed4e3439608cf"
+    "sha512=dba9373c7d611a5589bc141aac5b2d4701316f9179b1313a1811dcc5436f4344634346a70c535794209ba41660c770386e0047bd138a6fd07a5659fb09dd7ecc"
+  ]
+}

--- a/packages/sihl/sihl.0.6.0~rc1/opam
+++ b/packages/sihl/sihl.0.6.0~rc1/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "The Sihl web framework"
+description: """
+
+Sihl is a batteries-included web framework. Thanks to the modular architecture, included batteries can be swapped out easily. Statically typed functional programming with OCaml makes web development fun, fast and safe. Sihl supports PostgreSQL and MariaDB.
+"""
+maintainer: ["josef@oxidizing.io"]
+authors: ["Josef Erben" "Aron Erben" "Miko Nieminen"]
+license: "MIT"
+homepage: "https://github.com/oxidizing/sihl"
+doc: "https://oxidizing.github.io/sihl/"
+bug-reports: "https://github.com/oxidizing/sihl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "conformist" {= "0.5.0"}
+  "dune-build-info" {>= "2.8.4"}
+  "tsort" {>= "2.0.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.8"}
+  "sexplib" {>= "v0.13.0"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.5.2"}
+  "tls" {>= "0.11.1"}
+  "ssl" {>= "0.5.9"}
+  "uuidm" {>= "0.9.7"}
+  "lwt_ssl" {>= "1.1.3"}
+  "lwt_ppx" {>= "2.0.1"}
+  "caqti" {>= "1.2.1"}
+  "safepass" {>= "3.0"}
+  "jwto" {>= "0.3.0"}
+  "uuidm" {>= "0.9.7"}
+  "ppx_fields_conv" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "opium" {>= "0.20.0"}
+  "caqti" {>= "1.2.1"}
+  "caqti-lwt" {>= "1.2.0"}
+  "cohttp-lwt-unix" {>= "2.5.4" & with-test}
+  "alcotest-lwt" {>= "1.3.0" & with-test}
+  "caqti-driver-postgresql" {>= "1.2.0" & with-test}
+  "caqti-driver-mariadb" {>= "1.2.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/oxidizing/sihl.git"
+url {
+  src: "https://github.com/oxidizing/sihl/archive/0.6.0-rc1.tar.gz"
+  checksum: [
+    "md5=c6997c4e703d4a6fbd1ed4e3439608cf"
+    "sha512=dba9373c7d611a5589bc141aac5b2d4701316f9179b1313a1811dcc5436f4344634346a70c535794209ba41660c770386e0047bd138a6fd07a5659fb09dd7ecc"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`sihl.0.6.0~rc1`: The Sihl web framework
-`sihl-cache.0.6.0~rc1`: Cache service implementations for Sihl
-`sihl-email.0.6.0~rc1`: Email service implementations for Sihl
-`sihl-queue.0.6.0~rc1`: Queue service implementations for Sihl
-`sihl-storage.0.6.0~rc1`: Storage service implementations for Sihl
-`sihl-token.0.6.0~rc1`: Token service implementations for Sihl
-`sihl-user.0.6.0~rc1`: User service implementations for Sihl



---
* Homepage: https://github.com/oxidizing/sihl
* Source repo: git+https://github.com/oxidizing/sihl.git
* Bug tracker: https://github.com/oxidizing/sihl/issues

---
:camel: Pull-request generated by opam-publish v2.0.3