### PR TITLE
Package ezjs_min.0.2.3

### DIFF
--- a/packages/ezjs_min/ezjs_min.0.2.3/opam
+++ b/packages/ezjs_min/ezjs_min.0.2.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A bunch of js_of_ocaml shortcuts"
+description: "A bunch of js_of_ocaml shortcuts"
+maintainer: "OCamlPro <contact@ocamlpro.com>"
+authors: "OCamlPro <contact@ocamlpro.com>"
+license: "LGPL-2.1"
+homepage: "https://github.com/ocamlpro/ezjs_min"
+bug-reports: "https://github.com/ocamlpro/ezjs_min/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.05"}
+  "js_of_ocaml-ppx"
+  "stdlib-shims" {>= "0.1"}
+  "odoc" {with-doc}
+]
+depopts: ["lwt"]
+conflicts: [
+  "lwt" {< "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamlpro/ezjs_min.git"
+url {
+  src: "https://github.com/ocamlpro/ezjs_min/archive/0.2.3.tar.gz"
+  checksum: [
+    "md5=0e6cc68eb0ede22ee2888ec290f45ea3"
+    "sha512=984baf5c76a0edca969a404eda68bc6be8268cca10bca3b9745486f4226945ae1a80b937417491db9c09d9dc9dc1aa21c1c80381bba490b8b35094fa67e1509d"
+  ]
+}


### PR DESCRIPTION
### `ezjs_min.0.2.3`
A bunch of js_of_ocaml shortcuts
A bunch of js_of_ocaml shortcuts



---
* Homepage: https://github.com/ocamlpro/ezjs_min
* Source repo: git+https://github.com/ocamlpro/ezjs_min.git
* Bug tracker: https://github.com/ocamlpro/ezjs_min/issues

---
:camel: Pull-request generated by opam-publish v2.0.3