### PR TITLE
[new release] ocaml-lsp-server, lsp and jsonrpc (1.6.0)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.6.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.6.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "6fc037f1700400c04c25f5acd1b33d54fcd19d0c"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.6.0/jsonrpc-1.6.0.tbz"
+  checksum: [
+    "sha256=35e8c7341f8eb1fa39fb0f0e0701a7ed90b9a0bb89ccf84b7ed997cd258cbec3"
+    "sha512=c96a7a3ca845ec193e9edc4a74804a22d6e37efc852b54575011879bd2105e0df021408632219f542ca3ad85b36b5c8b72f2b417204d154d5f0dd0839535afa5"
+  ]
+}

--- a/packages/lsp/lsp.1.6.0/opam
+++ b/packages/lsp/lsp.1.6.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib"
+  "csexp"
+  "uutf"
+  "odoc" {with-doc}
+  "menhir" {with-test}
+  "cinaps" {with-test}
+  "ppx_expect" {with-test & >= "v0.14.0"}
+  "ocaml" {>= "4.08"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "6fc037f1700400c04c25f5acd1b33d54fcd19d0c"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.6.0/jsonrpc-1.6.0.tbz"
+  checksum: [
+    "sha256=35e8c7341f8eb1fa39fb0f0e0701a7ed90b9a0bb89ccf84b7ed997cd258cbec3"
+    "sha512=c96a7a3ca845ec193e9edc4a74804a22d6e37efc852b54575011879bd2105e0df021408632219f542ca3ad85b36b5c8b72f2b417204d154d5f0dd0839535afa5"
+  ]
+}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.6.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.6.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "yojson"
+  "ppx_yojson_conv_lib"
+  "dune-build-info"
+  "dot-merlin-reader"
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "ocamlformat" {with-test}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12" & < "4.13"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "ocaml-lsp-server.install"
+    "--release"
+  ]
+]
+x-commit-hash: "6fc037f1700400c04c25f5acd1b33d54fcd19d0c"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.6.0/jsonrpc-1.6.0.tbz"
+  checksum: [
+    "sha256=35e8c7341f8eb1fa39fb0f0e0701a7ed90b9a0bb89ccf84b7ed997cd258cbec3"
+    "sha512=c96a7a3ca845ec193e9edc4a74804a22d6e37efc852b54575011879bd2105e0df021408632219f542ca3ad85b36b5c8b72f2b417204d154d5f0dd0839535afa5"
+  ]
+}


### PR DESCRIPTION
LSP Server for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Features

- Code action to annotate a value with its type (ocaml/ocaml-lsp#397)

## Fixes

- Fix interface/implementation switching on Windows (ocaml/ocaml-lsp#427)

- Correctly parse project paths with spaces and other special characters that
  must be escaped.

- Print types with `-short-paths` even if the project wasn't built yet
