### PR TITLE
[new release] ppx_deriving_cmdliner (0.6.0)

### DIFF
--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.6.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Seb Mondet <seb@mondet.org>"
+authors: [
+  "Isaac Hodes <isaachodes@gmail.com>"
+  "B. Arman Aksoy <arman@aksoy.org>"
+  "Seb Mondet <seb@mondet.org>"
+  "Nick Zalutskiy <nick@const.fun>"
+  "Armaël Guéneau <armael.gueneau@ens-lyon.fr>"
+  "Tom Repetti <trepetti@cs.columbia.edu>"
+  "Marcello Seri <m.seri@rug.nl>"
+]
+homepage: "https://github.com/hammerlab/ppx_deriving_cmdliner"
+bug-reports: "https://github.com/hammerlab/ppx_deriving_cmdliner/issues"
+dev-repo: "git+https://github.com/hammerlab/ppx_deriving_cmdliner.git"
+doc: "http://hammerlab.github.io/ppx_deriving_cmdliner"
+license: "MIT"
+version: "0.6.0"
+tags: ["syntax" "cli"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"        {>= "4.05"}
+  "cmdliner"     {>= "1.0.0"}
+  "result"
+  "ppx_deriving" {>= "5.0"}
+  "dune"
+  "ppxlib"       {>= "0.14.0"}
+  "alcotest"     {with-test}
+]
+synopsis: "Cmdliner.Term.t generator"
+description: """
+ppx_deriving_cmdliner is a ppx_deriving plugin that generates
+a Cmdliner Term.t for a record type."""
+url {
+  src:
+    "https://github.com/hammerlab/ppx_deriving_cmdliner/archive/refs/tags/v0.6.0.tar.gz"
+  checksum: "md5=5a1050704c477f0ee46001cc2f4fe697"
+}

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.6.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.6.0/opam
@@ -14,7 +14,6 @@ bug-reports: "https://github.com/hammerlab/ppx_deriving_cmdliner/issues"
 dev-repo: "git+https://github.com/hammerlab/ppx_deriving_cmdliner.git"
 doc: "http://hammerlab.github.io/ppx_deriving_cmdliner"
 license: "MIT"
-version: "0.6.0"
 tags: ["syntax" "cli"]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
**CHANGES:**

From release notes:

- Migrate to ppxlib thanks to the contributions of @mseri to hopefully avoid most future breakage with new OCaml releases. This also necessitated dropping OCaml 4.04 support.
- Switch from Travis to GitHub Actions CI to keep up to date with OCaml images and leverage @avsm's [setup-ocaml](https://github.com/avsm/setup-ocaml).
