### PR TITLE
Package ocaml-iri.0.5.0

### DIFF
--- a/packages/ocaml-iri/ocaml-iri.0.5.0/opam
+++ b/packages/ocaml-iri/ocaml-iri.0.5.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Implementation of Internationalized Resource Identifiers (IRIs)"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GNU Lesser General Public License version 3"
+homepage: "https://framagit.org/zoggy/ocaml-iri"
+bug-reports: "https://framagit.org/zoggy/ocaml-iri/-/issues"
+dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind"
+  "sedlex" {>= "2.3"}
+  "uutf" {>= "1.0.0" }
+  "uunf" {>= "2.0.0"}
+]
+build: [
+  [make "all"]
+]
+install: [
+  [make "install"]
+]
+tags: ["web" "iri" "rfc3987"]
+remove: [["ocamlfind" "remove" "iri"]]


### PR DESCRIPTION
### `ocaml-iri.0.5.0`
Implementation of Internationalized Resource Identifiers (IRIs)



---
* Homepage: https://framagit.org/zoggy/ocaml-iri
* Source repo: git+https://framagit.org/zoggy/ocaml-iri.git
* Bug tracker: https://framagit.org/zoggy/ocaml-iri/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3