### PR TITLE
Package 1801bd8447d430ef3e9287f8c2e59218-ocaml-iri-0.5.0.tar.bz2

### DIFF
--- a/packages/1801bd8447d430ef3e9287f8c2e59218-ocaml-iri-0/1801bd8447d430ef3e9287f8c2e59218-ocaml-iri-0.5.0.tar.bz2/opam
+++ b/packages/1801bd8447d430ef3e9287f8c2e59218-ocaml-iri-0/1801bd8447d430ef3e9287f8c2e59218-ocaml-iri-0.5.0.tar.bz2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Implementation of Internationalized Resource Identifiers (IRIs)"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GNU Lesser General Public License version 3"
+tags: ["web" "iri" "rfc3987"]
+homepage: "https://framagit.org/zoggy/ocaml-iri"
+bug-reports: "https://framagit.org/zoggy/ocaml-iri/-/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind"
+  "sedlex" {>= "2.3"}
+  "uutf" {>= "1.0.0"}
+  "uunf" {>= "2.0.0"}
+]
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "iri"]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-iri/-/archive/0.5.0/ocaml-iri-0.5.0.tar.bz2"
+  checksum: [
+    "md5=a72ef0e6b281c0fb9957fc219a6e495c"
+    "sha512=5f0e3f01387aea693a0a50a56adaf20f14fa46673a7e30dc85494fae751243a7809434b7363a94b847d30bb873a5f9a0196e15b530b4faa1eb294479308ad9f3"
+  ]
+}


### PR DESCRIPTION
### `1801bd8447d430ef3e9287f8c2e59218-ocaml-iri-0.5.0.tar.bz2`
Implementation of Internationalized Resource Identifiers (IRIs)



---
* Homepage: https://framagit.org/zoggy/ocaml-iri
* Source repo: git+https://framagit.org/zoggy/ocaml-iri.git
* Bug tracker: https://framagit.org/zoggy/ocaml-iri/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3