### PR TITLE
FrontC: fixes building cmxs files and installs cmx files

### DIFF
--- a/packages/FrontC/FrontC.3.4.3-1/files/FrontC.install
+++ b/packages/FrontC/FrontC.3.4.3-1/files/FrontC.install
@@ -1,0 +1,6 @@
+bin: [
+  "calipso/calipso"
+  "calipso/calipso_stat"
+  "ctoxml/ctoxml"
+  "printc/printc"
+]

--- a/packages/FrontC/FrontC.3.4.3-1/files/fix-cmxs-cmx.patch
+++ b/packages/FrontC/FrontC.3.4.3-1/files/fix-cmxs-cmx.patch
@@ -1,0 +1,31 @@
+diff --git a/Makefile.head b/Makefile.head
+index 88e5b65..5f9969f 100644
+--- a/Makefile.head
++++ b/Makefile.head
+@@ -100,8 +100,9 @@ $(1)_CMIX = $$(patsubst %.cmx,%.cmi,$$($(1)_CMX))
+ _DEPS += $$(patsubst %.cmx,$(DEP_DIR)/%.d,$$($(1)_CMX)) \
+ 	 $$(patsubst %.mly,$(DEP_DIR)/%.mli.d,$$($(1)_MLYX))
+ _PRE_DEPS += $$($(1)_MLX)
+-_DIST_CLEAN += $(1).cmxa $(1).a $$($(1)_CMIX)
++_DIST_CLEAN += $(1).cmxa $(1).cmxs $(1).a $$($(1)_CMIX)
+ _CLEAN += $$($(1)_CMX) \
++	$(1).cmxa $(1).cmxs \
+ 	$$(patsubst %.cmx,%.o,$$($(1)_CMX)) \
+ 	$$(patsubst %.mll,%.ml,$$($(1)_MLLX)) \
+ 	$$(patsubst %.mly,%.ml,$$($(1)_MLYX)) \
+@@ -113,12 +114,12 @@ _INSTALL += _install_$(1)_CMXA _install_$(1)_CMXS
+ $(1).cmxa: $$($(1)_CMX)
+ 	$$(OCAMLOPT) -a $$($(1)_LDFLAGS) $$(OCAMLOPT_LDFLAGS) -o $$@ $$($(1)_CMX) $$(OCAMLOPT_LIBS)
+ 
+-$(1).cmxs: $$($(1).cmxa)
+-	$$(OCAMLOPT) -shared -linkall $$($(1).cmxa) -o $$@
++$(1).cmxs: $(1).cmxa $(1).a
++	$$(OCAMLOPT) -shared -linkall $(1).cmxa -o $$@
+ 
+ _install_$(1)_CMXA:
+ 	install -d $(OCAML_SITE)/FrontC
+-	install $(1).cmxa $(1).a $$($(1)_CMIX) $(OCAML_SITE)/FrontC
++	install $(1).cmxa $(1).a $$($(1)_CMX) $$($(1)_CMIX) $(OCAML_SITE)/FrontC
+ 
+ _install_$(1)_CMXS:
+ 	install -d $(OCAML_SITE)/FrontC

--- a/packages/FrontC/FrontC.3.4.3-1/opam
+++ b/packages/FrontC/FrontC.3.4.3-1/opam
@@ -9,6 +9,8 @@ depends: [
   "ocaml"
 ]
 
+patches: ["fix-cmxs-cmx.patch"]
+
 build: [
   [make "PREFIX=%{lib}%" "OCAML_SITE=%{lib}%"]
 ]
@@ -27,6 +29,7 @@ standard GNU CC attributes.
 
 It provides also a C pretty printer as an example of use."""
 extra-files: [
+  ["fix-cmxs-cmx.patch" "md5=c1adc4cd6bcfe4939c3290683eaea33b"]
   ["FrontC.install" "md5=c56e698d092d18179f9458f311c56412"]
 ]
 
@@ -35,5 +38,3 @@ url {
   checksum: "md5=399f66735541ecf8e06220618eef5c98"
   mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/v3.4.3.tar.gz"
 }
-
-available: false


### PR DESCRIPTION
This PR disables the recently released FrontC 3.4.3 (#18559), as it
was installing incorrectly linked cmxs files that were missing code.
In addition it enables the installation of cmx files.

Since no code was changed but Makefiles only, I decided to pack this
is a patch rather then making a new release. The corresponding patch
is merged into FrontC so in the next release there would not be a need
for such patch.