### PR TITLE
3 packages from c-cube/ocaml-containers at 3.4

### DIFF
--- a/packages/containers-data/containers-data.3.4/opam
+++ b/packages/containers-data/containers-data.3.4/opam
@@ -5,7 +5,7 @@ license: "BSD-2-Clause"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-data/containers-data.3.4/opam
+++ b/packages/containers-data/containers-data.3.4/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A set of advanced datatypes for containers"
+license: "BSD-2"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "containers" { = version }
+  "seq"
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  #"mdx" { with-test & >= "1.5.0" & < "2.0.0" }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "RAL" "functional" "vector" "okasaki" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.4.tar.gz"
+  checksum: [
+    "md5=8cd9d8ddf89a60d8f2b005163707ea0e"
+    "sha512=eaeaf87c20ef124b923e461ce108e97d368d5228dd737c83d78c53741e15a8d9bc2af97150efd266cb99c4af63a7a87de47a1c2f3c51725cf62fe4d53b46daa5"
+  ]
+}

--- a/packages/containers-data/containers-data.3.4/opam
+++ b/packages/containers-data/containers-data.3.4/opam
@@ -5,7 +5,7 @@ license: "BSD-2-Clause"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-data/containers-data.3.4/opam
+++ b/packages/containers-data/containers-data.3.4/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
 synopsis: "A set of advanced datatypes for containers"
-license: "BSD-2"
+license: "BSD-2-Clause"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}

--- a/packages/containers-thread/containers-thread.3.4/opam
+++ b/packages/containers-thread/containers-thread.3.4/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2"
+synopsis: "An extension of containers for threading"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "base-threads"
+  "dune-configurator"
+  "containers" { = version }
+  "iter" { with-test }
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "thread" "semaphore" "blocking queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.4.tar.gz"
+  checksum: [
+    "md5=8cd9d8ddf89a60d8f2b005163707ea0e"
+    "sha512=eaeaf87c20ef124b923e461ce108e97d368d5228dd737c83d78c53741e15a8d9bc2af97150efd266cb99c4af63a7a87de47a1c2f3c51725cf62fe4d53b46daa5"
+  ]
+}

--- a/packages/containers-thread/containers-thread.3.4/opam
+++ b/packages/containers-thread/containers-thread.3.4/opam
@@ -5,7 +5,7 @@ synopsis: "An extension of containers for threading"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers-thread/containers-thread.3.4/opam
+++ b/packages/containers-thread/containers-thread.3.4/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
-license: "BSD-2"
+license: "BSD-2-Clause"
 synopsis: "An extension of containers for threading"
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/containers/containers.3.4/opam
+++ b/packages/containers/containers.3.4/opam
@@ -5,7 +5,7 @@ synopsis: "A modular, clean and powerful extension of the OCaml standard library
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/containers/containers.3.4/opam
+++ b/packages/containers/containers.3.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2"
+synopsis: "A modular, clean and powerful extension of the OCaml standard library"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "dune-configurator"
+  "seq"
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+depopts: [
+  "base-unix"
+  "base-threads"
+]
+tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.4.tar.gz"
+  checksum: [
+    "md5=8cd9d8ddf89a60d8f2b005163707ea0e"
+    "sha512=eaeaf87c20ef124b923e461ce108e97d368d5228dd737c83d78c53741e15a8d9bc2af97150efd266cb99c4af63a7a87de47a1c2f3c51725cf62fe4d53b46daa5"
+  ]
+}

--- a/packages/containers/containers.3.4/opam
+++ b/packages/containers/containers.3.4/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
-license: "BSD-2"
+license: "BSD-2-Clause"
 synopsis: "A modular, clean and powerful extension of the OCaml standard library"
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/containers/containers.3.4/opam
+++ b/packages/containers/containers.3.4/opam
@@ -5,7 +5,7 @@ synopsis: "A modular, clean and powerful extension of the OCaml standard library
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }


### PR DESCRIPTION
This pull-request concerns:
-`containers.3.4`: A modular, clean and powerful extension of the OCaml standard library
-`containers-data.3.4`: A set of advanced datatypes for containers
-`containers-thread.3.4`: An extension of containers for threading



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: git+https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0