### PR TITLE
Package iri.0.5.0

### DIFF
--- a/packages/iri/iri.0.5.0/opam
+++ b/packages/iri/iri.0.5.0/opam
@@ -8,14 +8,13 @@ homepage: "https://framagit.org/zoggy/ocaml-iri"
 bug-reports: "https://framagit.org/zoggy/ocaml-iri/-/issues"
 depends: [
   "ocaml" {>= "4.12.0"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "sedlex" {>= "2.3"}
   "uutf" {>= "1.0.0"}
   "uunf" {>= "2.0.0"}
 ]
 build: [make "all"]
 install: [make "install"]
-remove: ["ocamlfind" "remove" "iri"]
 dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
 url {
   src:

--- a/packages/iri/iri.0.5.0/opam
+++ b/packages/iri/iri.0.5.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Implementation of Internationalized Resource Identifiers (IRIs)"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["web" "iri" "rfc3987"]
+homepage: "https://framagit.org/zoggy/ocaml-iri"
+bug-reports: "https://framagit.org/zoggy/ocaml-iri/-/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind"
+  "sedlex" {>= "2.3"}
+  "uutf" {>= "1.0.0"}
+  "uunf" {>= "2.0.0"}
+]
+build: [make "all"]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "iri"]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-iri/-/archive/0.5.0/ocaml-iri-0.5.0.tar.bz2"
+  checksum: [
+    "md5=1d9dd75f5bba095b94ed18d6a8987528"
+    "sha512=c370787665baac178342f3b06d023bca3004c1e909bdb59fd58441000f617288a8e0a5a83f00472ecd43925703ba10265c92fdd9f9b9ce2e53b46ac132f82776"
+  ]
+}


### PR DESCRIPTION
### `iri.0.5.0`
Implementation of Internationalized Resource Identifiers (IRIs)



---
* Homepage: https://framagit.org/zoggy/ocaml-iri
* Source repo: git+https://framagit.org/zoggy/ocaml-iri.git
* Bug tracker: https://framagit.org/zoggy/ocaml-iri/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3