### PR TITLE
[new release] irmin-watcher (0.5.0)

### DIFF
--- a/packages/irmin-watcher/irmin-watcher.0.5.0/opam
+++ b/packages/irmin-watcher/irmin-watcher.0.5.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Portable Irmin watch backends using FSevents or Inotify"
+description: """
+irmin-watcher implements [Irmin's watch hooks][watch] for various OS,
+using FSevents in macOS and Inotify on Linux.
+
+irmin-watcher is distributed under the ISC license.
+
+[watch]: http://mirage.github.io/irmin/irmin/Irmin/Private/Watch/index.html#type-hook
+"""
+maintainer: ["Thomas Gazagnaire"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/irmin-watcher"
+doc: "https://mirage.github.io/irmin-watcher/"
+bug-reports: "https://github.com/mirage/irmin-watcher/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.02.0"}
+  "alcotest" {with-test}
+  "mtime" {with-test & >= "1.0.0"}
+  "inotify" {os = "linux"}
+  "cf-lwt" {>= "0.4"}
+  "lwt"
+  "logs"
+  "fmt"
+  "astring"
+  "fsevents-lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/irmin-watcher.git"
+x-commit-hash: "7f6bef9a480d945732ffc5b1b2d7ca07291deba9"
+url {
+  src:
+    "https://github.com/mirage/irmin-watcher/releases/download/0.5.0/irmin-watcher-0.5.0.tbz"
+  checksum: [
+    "sha256=beae24c1acf84141bdc747c611b40c02e0c68e54f7ffa966f318974d4a899993"
+    "sha512=f91a80fc483e5dbb47e64869857e84cfaadb44c6ea625e909738370fdfd24fc2f56303f3d60eeda832baac2a57cd093c8c40e20044d90c5a870f28f7e6c95451"
+  ]
+}


### PR DESCRIPTION
Portable Irmin watch backends using FSevents or Inotify

- Project page: <a href="https://github.com/mirage/irmin-watcher">https://github.com/mirage/irmin-watcher</a>
- Documentation: <a href="https://mirage.github.io/irmin-watcher/">https://mirage.github.io/irmin-watcher/</a>

##### CHANGES:

- Switch to GitHub Actions from Travis (mirage/irmin-watcher#31, @avsm)
- Initialise backends only when needed via a
  lazy watcher interface (mirage/irmin-watcher#31, @samoht @avsm)
- Use fsevents and cf-lwt packages (mirage/irmin-watcher#31, @avsm)
- Use ocamlformat.0.18.0 (mirage/irmin-watcher#31, @avsm)
