### PR TITLE
releases FrontC 4.0.0

### DIFF
--- a/packages/FrontC/FrontC.4.0.0/opam
+++ b/packages/FrontC/FrontC.4.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+version: "4.0.0"
+synopsis: "Parses C programs to an abstract syntax tree"
+description:
+  "FrontC provides a C parser and an OCaml definition of an abstract syntax treee for the C language. It also includes AST pretty-printers in plain and XML formats."
+maintainer: ["Ivan Gotovchits <ivg@ieee.org>"]
+authors: ["Hugues Cassé <casse@irit.fr> et al"]
+license: "LGPL-2.0-only"
+tags: ["FrontC" "C" "parser" "XML"]
+homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
+depends: [
+  "dune" {>= "2.7" & >= "2.7" & build}
+  "menhir"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC.git"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v4.0.0.tar.gz"
+  checksum: "md5=2e8875a947b12ae3de2e89b1d9b3c7fe"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/v4.0.0.tar.gz"
+}

--- a/packages/FrontC/FrontC.4.0.0/opam
+++ b/packages/FrontC/FrontC.4.0.0/opam
@@ -10,6 +10,7 @@ tags: ["FrontC" "C" "parser" "XML"]
 homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 depends: [
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7" & >= "2.7" & build}
   "menhir"
   "odoc" {with-doc}

--- a/packages/FrontC/FrontC.4.0.0/opam
+++ b/packages/FrontC/FrontC.4.0.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "4.0.0"
 synopsis: "Parses C programs to an abstract syntax tree"
 description:
   "FrontC provides a C parser and an OCaml definition of an abstract syntax treee for the C language. It also includes AST pretty-printers in plain and XML formats."
@@ -11,7 +10,7 @@ homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.7" & >= "2.7" & build}
+  "dune" {>= "2.7"}
   "menhir"
   "odoc" {with-doc}
 ]

--- a/packages/calipso/calipso.4.0.0/opam
+++ b/packages/calipso/calipso.4.0.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "4.0.0"
 synopsis: "Rewrites C programs to remove non-structured control-flow"
 description:
   "Calipso analyzes programs in order to replace all nonstructured instructions (i.e., break, return, switch...) by branches and, then, remove all branches. See https://dblp.org/rec/journals/tsi/CasseFRS02 for more details"

--- a/packages/calipso/calipso.4.0.0/opam
+++ b/packages/calipso/calipso.4.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+version: "4.0.0"
+synopsis: "Rewrites C programs to remove non-structured control-flow"
+description:
+  "Calipso analyzes programs in order to replace all nonstructured instructions (i.e., break, return, switch...) by branches and, then, remove all branches. See https://dblp.org/rec/journals/tsi/CasseFRS02 for more details"
+maintainer: ["Ivan Gotovchits <ivg@ieee.org>"]
+authors: ["Hugues Cassé <casse@irit.fr> et al"]
+license: "LGPL-2.0-only"
+tags: ["FrontC" "C" "analysis"]
+homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "FrontC" {>= "4.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC.git"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v4.0.0.tar.gz"
+  checksum: "md5=2e8875a947b12ae3de2e89b1d9b3c7fe"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/v4.0.0.tar.gz"
+}

--- a/packages/calipso/calipso.4.0.0/opam
+++ b/packages/calipso/calipso.4.0.0/opam
@@ -10,6 +10,7 @@ tags: ["FrontC" "C" "analysis"]
 homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 depends: [
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
   "FrontC" {>= "4.0.0"}
   "odoc" {with-doc}

--- a/packages/ctoxml/ctoxml.4.0.0/opam
+++ b/packages/ctoxml/ctoxml.4.0.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "4.0.0"
 synopsis: "Parses a C program into Cabs AST and dumps as an XML document"
 maintainer: ["Ivan Gotovchits <ivg@ieee.org>"]
 authors: ["Hugues Cassé <casse@irit.fr> et al"]

--- a/packages/ctoxml/ctoxml.4.0.0/opam
+++ b/packages/ctoxml/ctoxml.4.0.0/opam
@@ -8,6 +8,7 @@ tags: ["FrontC" "C" "parser" "XML"]
 homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 depends: [
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
   "FrontC" {>= "4.0.0"}
   "odoc" {with-doc}

--- a/packages/ctoxml/ctoxml.4.0.0/opam
+++ b/packages/ctoxml/ctoxml.4.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+version: "4.0.0"
+synopsis: "Parses a C program into Cabs AST and dumps as an XML document"
+maintainer: ["Ivan Gotovchits <ivg@ieee.org>"]
+authors: ["Hugues Cassé <casse@irit.fr> et al"]
+license: "LGPL-2.0-only"
+tags: ["FrontC" "C" "parser" "XML"]
+homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "FrontC" {>= "4.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC.git"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v4.0.0.tar.gz"
+  checksum: "md5=2e8875a947b12ae3de2e89b1d9b3c7fe"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/v4.0.0.tar.gz"
+}


### PR DESCRIPTION
This release doesn't really introduce any new features but it switches
FrontC to menhir and dune. The switch to menir was required because
the parser has a circular dependency on the lexer and only menhir is
capable of refactoring tokens from the parser. The circular
dependency, on its own, prevented us from upgrading FrontC to dune,
which in turn prevented us from using FrontC in duniverse.

Switching to menhir required some number of tweaks to the grammar,
which might change the behavior of the parser, hence the new
version. We will still support the old version of FrontC (aka stable)
and release bug fixes, but only the 4.x version will receive new
feautures, such as support for the more modern C syntax.

We also added tests and split the package into three subpackages.
The FrontC package is the library with the same contents as
before. And there are also two packages with executables:

- calipso - a program analysis tool that reduces non-structural
  control flow in C programs;

- ctoxml - a program that will dump the parser C AST in XML.

The `printc` executable is no longer installed as its main purpose is
testing and doesn't provide any useful features for the end users, it
just works as `cat`.