### PR TITLE
[new release] pratter (1.2)

### DIFF
--- a/packages/pratter/pratter.1.2/opam
+++ b/packages/pratter/pratter.1.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "An extended Pratt parser"
+description: """
+Pratter is a library that provides a parser that transforms
+streams of terms to applied terms.  Terms may contain infix or prefix operators
+and native applications.  The parser is based on the Pratt parsing
+algorithm and extended to handle term application and non associative
+operators."""
+maintainer: ["leirbag@sdfeu.org"]
+authors: ["Gabriel Hondet"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/gabrielhdt/pratter"
+bug-reports: "https://github.com/gabrielhdt/pratter/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "2.7"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/gabrielhdt/pratter.git"
+x-commit-hash: "b35e769cbf21030afcee7eaa2d45cafc99a6a977"
+url {
+  src:
+    "https://github.com/gabrielhdt/pratter/releases/download/1.2/pratter-1.2.tbz"
+  checksum: [
+    "sha256=9767478a4c9b1fc4e596a79d97032ba412aa1702449478fc52ef8508e9aaa897"
+    "sha512=a18cee025293ab0556a2e4c69689a63f1c97b8d980594c8e13bcf7b26a848066ef80863a3f3e3ab2899d98a0180d2e28e5780d481fa94a167b829636a2e8959d"
+  ]
+}


### PR DESCRIPTION
An extended Pratt parser

- Project page: <a href="https://github.com/gabrielhdt/pratter">https://github.com/gabrielhdt/pratter</a>

##### CHANGES:

This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## [Unreleased]

## [1.2] -- 2021-05-05
### Added
- Walkthrough in README.md.
### Fixed
- Parsing a binary operator without left context fails.
- Binding power can be negative.

## [1.1] -- 2021-01-23
### Added
- Non associative operators
- Error handling on partially applied operators (which raises a
  `Stream.Failure`)
### Changed
- One function `get` for operators in API
- `make_appl` does not use the table of operators

## [1.0.1] -- 2021-01-16
### Fixed
- Correct OCaml dependency
- Tests comply with OCaml 4.02
### Added
- Gitlab continuous integration

## [1.0] -- 2021-01-14
### Changed
- API: parser uses a data structure passed as argument
- renamed CHANGELOG to CHANGELOG.md

## [0.1.1] -- 2021-01-06
### Added
- Initial version
