### PR TITLE
[new release] caldav (0.1.0)

### DIFF
--- a/packages/caldav/caldav.0.1.0/opam
+++ b/packages/caldav/caldav.0.1.0/opam
@@ -22,7 +22,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune" {build}
+  "dune" {>= "1.3"}
   "alcotest" {with-test & >= "0.8.5"}
   "ounit" {with-test & >= "2.0.0"}
   "mirage-random-test" {with-test}

--- a/packages/caldav/caldav.0.1.0/opam
+++ b/packages/caldav/caldav.0.1.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/roburio/caldav"
+bug-reports: "https://github.com/roburio/caldav/issues"
+dev-repo: "git+https://github.com/roburio/caldav.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://roburio.github.io/caldav/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {build}
+  "alcotest" {with-test & >= "0.8.5"}
+  "ounit" {with-test & >= "2.0.0"}
+  "mirage-random-test" {with-test}
+  "tcpip" {with-test & >= "3.7.0"}
+  "mirage-clock-unix" {with-test & >= "2.0.0"}
+  "mirage-kv-mem" {with-test & >= "2.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "ppx_deriving" {>= "4.3"}
+  "lwt" {>= "4.0"}
+  "ptime" {>= "0.8.5"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt" {>= "2.0.0"}
+  "cohttp-lwt-unix" {with-test & >= "2.0.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng"
+  "base64" {>= "3.0.0"}
+  "xmlm" {>= "1.3.0"}
+  "tyxml" {>= "4.3.0"}
+  "icalendar" {>= "0.1.2"}
+  "rresult" {>= "0.6.0"}
+  "sexplib" {>= "v0.12.0"}
+  "ppx_sexp_conv" {>= "v0.12.0"}
+  "logs" {>= "0.6.3"}
+  "hex" {>= "1.4.0"}
+  "metrics"
+  #from webmachine
+  "dispatch" {>= "0.5.0"}
+  "re" {>= "1.7.2"}
+  "uri" {>= "4.0.0"}
+]
+synopsis: "A CalDAV server"
+description: """
+A CalDAV server (RFC 4791). Supports everything from the roburio/icalendar
+library. Also includes a partial WebDAV implementation.
+"""
+x-commit-hash: "768937e67d337cd91ad85354134a38f4314ccf3a"
+url {
+  src:
+    "https://github.com/roburio/caldav/releases/download/v0.1.0/caldav-v0.1.0.tbz"
+  checksum: [
+    "sha256=d931305bd46acf7e4f72dca2bb2d1c17da064889e79aad004581d7ce136ed834"
+    "sha512=13adab15a5da923b22abad4cf31f974511dbb83f6c34e9c1aa032e678cc00db212218ca8b58b884caea04d0035027da007480895b3660709e9f3a7043e520fd9"
+  ]
+}


### PR DESCRIPTION
A CalDAV server

- Project page: <a href="https://github.com/roburio/caldav">https://github.com/roburio/caldav</a>
- Documentation: <a href="https://roburio.github.io/caldav/">https://roburio.github.io/caldav/</a>

##### CHANGES:

* Initial release, with webmachine vendored, and provided as a sublibrary.
