### PR TITLE
2 packages from c-cube/linol at 0.3

### DIFF
--- a/packages/linol-lwt/linol-lwt.0.3/opam
+++ b/packages/linol-lwt/linol-lwt.0.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+license: "MIT"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/linol"
+synopsis: "LSP server library (with Lwt for concurrency)"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "linol" { = version }
+  "lsp" { >= "1.4" & < "1.6" }
+  "jsonrpc" { >= "1.4" & < "1.6" }
+  "containers" { >= "3.0" & < "4.0" }
+  "lwt" { >= "5.1" & < "6.0" }
+  "base-unix"
+  "yojson" { >= "1.6" }
+  "ocaml" { >= "4.08" }
+  "odoc" { with-doc }
+]
+tags: [ "lsp" "server" "lwt" "linol" ]
+bug-reports: "https://github.com/c-cube/linol/issues"
+dev-repo: "git+https://github.com/c-cube/linol.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/linol/archive/v0.3.tar.gz"
+  checksum: [
+    "md5=15ce89bc735fac1febf4adb758d36f0d"
+    "sha512=d2ddc16d8d0dfd750efbe6fef293aaf2526ccaac0d27fec29d5cc5b7ac3e3f6b8947109dd0a48c02d0ac2cf3439403d81ea31cf01da1ffee7dd5bffe3b2cc22c"
+  ]
+}

--- a/packages/linol/linol.0.3/opam
+++ b/packages/linol/linol.0.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+homepage: "https://github.com/c-cube/linol"
+synopsis: "LSP server library"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "containers" { >= "3.0" & < "4.0" }
+  "yojson" { >= "1.6" }
+  "logs"
+  "lsp" { >= "1.4" & < "1.6" }
+  "ocaml" { >= "4.08" }
+  "odoc" { with-doc }
+]
+tags: [ "lsp" "server" "lwt" ]
+bug-reports: "https://github.com/c-cube/linol/issues"
+dev-repo: "git+https://github.com/c-cube/linol.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/linol/archive/v0.3.tar.gz"
+  checksum: [
+    "md5=15ce89bc735fac1febf4adb758d36f0d"
+    "sha512=d2ddc16d8d0dfd750efbe6fef293aaf2526ccaac0d27fec29d5cc5b7ac3e3f6b8947109dd0a48c02d0ac2cf3439403d81ea31cf01da1ffee7dd5bffe3b2cc22c"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`linol.0.3`: LSP server library
-`linol-lwt.0.3`: LSP server library (with Lwt for concurrency)



---
* Homepage: https://github.com/c-cube/linol
* Source repo: git+https://github.com/c-cube/linol.git
* Bug tracker: https://github.com/c-cube/linol/issues

---
:camel: Pull-request generated by opam-publish v2.0.0