### PR TITLE
Add Luv 0.5.8: binding to libuv, the asynchronous I/O library

### DIFF
--- a/packages/luv/luv.0.5.8/opam
+++ b/packages/luv/luv.0.5.8/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+
+synopsis: "Binding to libuv: cross-platform asynchronous I/O"
+
+license: "MIT"
+homepage: "https://github.com/aantron/luv"
+doc: "https://aantron.github.io/luv"
+bug-reports: "https://github.com/aantron/luv/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/luv.git"
+
+depends: [
+  "base-unix" {build}
+  "ctypes" {>= "0.13.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.02.0"}
+  "result"
+
+  "alcotest" {with-test & >= "0.8.1"}
+  "base-unix" {with-test}
+  "odoc" {with-doc & = "1.5.2"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Luv is a binding to libuv, the cross-platform C library that does
+asynchronous I/O in Node.js and runs its main loop.
+
+Besides asynchronous I/O, libuv also supports multiprocessing and
+multithreading. Multiple event loops can be run in different threads. libuv also
+exposes a lot of other functionality, amounting to a full OS API, and an
+alternative to the standard module Unix."
+
+url {
+  src: "https://github.com/aantron/luv/releases/download/0.5.8/luv-0.5.8.tar.gz"
+  checksum: "md5=9d0e3498b9f59993b0d42f80793d8fad"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/luv/releases/tag/0.5.8):

> Bugs fixed
>
> - Socket addresses: `sa_family_t` has different size on different platforms (aantron/luv#111, aantron/luv#112, diagnosed by David Scott).
> - Don't install vendored libuv headers when building against system libuv (follow-on to aantron/luv#94, suggested by Andy Li and @code-ghalib).
> - Tests: relax `uname` checks (aantron/luv#101, reported by @RiderALT).
> - Tests: time values should not be converted to OCaml `int`s before comparison; affects 32-bit systems (aantron/luv#102, reported by @RiderALT).
> - Tests: provide at least one buffer to `writev`-style TCP writing interface (aantron/luv#106, reported by Olaf Hering).

cc @djs55