### PR TITLE
Package bogue.20210508

### DIFF
--- a/packages/bogue/bogue.20210508/opam
+++ b/packages/bogue/bogue.20210508/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "GUI library for ocaml, with animations, based on SDL2"
+description: """
+bogue is a GUI library for ocaml, with animations, based on SDL2.
+
+This library can be used for games or for adding GUI elements to any
+ocaml program.
+
+It uses the SDL2 renderer library, which makes it quite fast.
+
+It is themable, and does not try to look like your desktop. Instead,
+it will look the same on every platform.
+
+Graphics output is scalable, and hence easily adapts to Hi-DPI
+displays.
+
+Programming with bogue is easy if you're used to GUIs with widgets,
+layouts, callbacks, and of course it has a functional flavor. It uses
+Threads when non-blocking reactions are needed."""
+maintainer: ["Vu Ngoc San <san.vu-ngoc@laposte.net>"]
+authors: ["Vu Ngoc San <san.vu-ngoc@laposte.net>"]
+license: "IST"
+homepage: "https://github.com/sanette/bogue"
+doc: "http://sanette.github.io/bogue/Bogue.html"
+bug-reports: "https://github.com/sanette/bogue/issues"
+depends: [
+  "stdlib-shims" {>= "0.1.0"}
+  "tsdl-image" {= "0.1.2"}
+  "tsdl-ttf" {>= "0.2"}
+  "ocaml" {>= "4.08.0"}
+  "tsdl" {>= "0.9.0"}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sanette/bogue.git"
+
+               
+               
+url {
+  src: "https://github.com/sanette/bogue/archive/refs/tags/20210508.tar.gz"
+  checksum: [
+    "md5=445c9466ac111a83c9837599bb6a42b4"
+    "sha512=2af8af2ed84e32d2c63e69304ceec61a8d13b5bed786591d135177e8240dcfd2a4b3b71149940c822bbcf0a7382a9757dc1d215d6a5cece48da9016e24727a5f"
+  ]
+}


### PR DESCRIPTION
### `bogue.20210508`
GUI library for ocaml, with animations, based on SDL2
bogue is a GUI library for ocaml, with animations, based on SDL2.

This library can be used for games or for adding GUI elements to any
ocaml program.

It uses the SDL2 renderer library, which makes it quite fast.

It is themable, and does not try to look like your desktop. Instead,
it will look the same on every platform.

Graphics output is scalable, and hence easily adapts to Hi-DPI
displays.

Programming with bogue is easy if you're used to GUIs with widgets,
layouts, callbacks, and of course it has a functional flavor. It uses
Threads when non-blocking reactions are needed.



---
* Homepage: https://github.com/sanette/bogue
* Source repo: git+https://github.com/sanette/bogue.git
* Bug tracker: https://github.com/sanette/bogue/issues

---
:camel: Pull-request generated by opam-publish v2.0.3