### PR TITLE
2 packages from jobjo/popper at 0.1.0

### DIFF
--- a/packages/popper/popper.0.1.0/opam
+++ b/packages/popper/popper.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Property-based testing at ease"
+description:
+  "Popper (after Karl) is an OCaml library for writing regular unit tests as well as property-based tests. The design is inspired by the Python library Hypothesis and supports built-in shrinking for counter-examples."
+maintainer: ["Joel Bjornson <joel.bjornson@gmail.com>"]
+authors: ["Joel Bjornson <joel.bjornson@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/jobjo/popper"
+doc: "https://jobjo.github.io/popper/"
+bug-reports: "https://github.com/jobjo/popper/issues"
+depends: [
+  "pringo"
+  "ocaml" {>= "4.09.1"}
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jobjo/popper.git"
+url {
+  src: "https://github.com/jobjo/popper/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=2db1f48037602cec67ffbf2e32bf7c08"
+    "sha512=a3b9a85197d444e575f3605060d11370e92e15e29b22770be9168e1d900cd15fd06e930cbe22032c87027719af32689141c67259502e2e4d33354d9e2b3074a1"
+  ]
+}

--- a/packages/ppx_deriving_popper/ppx_deriving_popper.0.1.0/opam
+++ b/packages/ppx_deriving_popper/ppx_deriving_popper.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A ppx deriving sample-functions for Popper"
+description:
+  "This ppx derives popper samplers and comparators for custom data-types."
+maintainer: ["Joel Bjornson <joel.bjornson@gmail.com>"]
+authors: ["Joel Bjornson <joel.bjornson@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/jobjo/popper"
+doc: "https://jobjo.github.io/popper/"
+bug-reports: "https://github.com/jobjo/popper/issues"
+depends: [
+  "ppx_deriving"
+  "popper"
+  "ocaml" {>= "4.09.1"}
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jobjo/popper.git"
+url {
+  src: "https://github.com/jobjo/popper/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=2db1f48037602cec67ffbf2e32bf7c08"
+    "sha512=a3b9a85197d444e575f3605060d11370e92e15e29b22770be9168e1d900cd15fd06e930cbe22032c87027719af32689141c67259502e2e4d33354d9e2b3074a1"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`popper.0.1.0`: Property-based testing at ease
-`ppx_deriving_popper.0.1.0`: A ppx deriving sample-functions for Popper



---
* Homepage: https://github.com/jobjo/popper
* Source repo: git+https://github.com/jobjo/popper.git
* Bug tracker: https://github.com/jobjo/popper/issues

---
:camel: Pull-request generated by opam-publish v2.0.3