### PR TITLE
Package embedded_ocaml_templates.0.6

### DIFF
--- a/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.6/opam
+++ b/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.6/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "EML is a simple templating language that lets you generate text with plain OCaml"
+description: """
+Inspired by EJS templates, it does currently implements all of its functionnality.
+I plan to implement everything eventually, especially if someone actually want to use this.
+Please contact me if you find this interesting but there is a missing feature that you need !
+"""
+maintainer: "Emile Trotignon emile.trotignon@gmail.com"
+authors: "Emile Trotignon emile.trotignon@gmail.com"
+license: "MIT"
+homepage: "https://github.com/EmileTrotignon/embedded_ocaml_templates"
+bug-reports: "https://github.com/EmileTrotignon/embedded_ocaml_templates/issues"
+dev-repo: "git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git"
+depends: [
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.5.0"}
+    "sedlex" { >= "2.0" }
+    "uutf"
+    "menhir"
+    "pprint"
+    "ppxlib"
+    "containers"
+    "ppx_inline_test"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/EmileTrotignon/embedded_ocaml_templates/archive/0.6.tar.gz"
+  checksum: [
+    "md5=2b99e2c811ced830da77bb7ae1aa2527"
+    "sha512=9c1bf7def98f43bda97b19e0120ac675e527abdb1cb5dc72c15c372127be2e3e60562acdf811cacf6eac2489a52c0369dfe5e20e8fe417fc278488aa5f1eca41"
+  ]
+}


### PR DESCRIPTION
### `embedded_ocaml_templates.0.6`
EML is a simple templating language that lets you generate text with plain OCaml
Inspired by EJS templates, it does currently implements all of its functionnality.
I plan to implement everything eventually, especially if someone actually want to use this.
Please contact me if you find this interesting but there is a missing feature that you need !



---
* Homepage: https://github.com/EmileTrotignon/embedded_ocaml_templates
* Source repo: git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git
* Bug tracker: https://github.com/EmileTrotignon/embedded_ocaml_templates/issues

---
:camel: Pull-request generated by opam-publish v2.0.2