### PR TITLE
2 packages from jobjo/popper at 0.1.1

### DIFF
--- a/packages/popper/popper.0.1.1/opam
+++ b/packages/popper/popper.0.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Property-based testing at ease"
+description:
+  "Popper (after Karl) is an OCaml library for writing regular unit tests as well as property-based tests. The design is inspired by the Python library Hypothesis and supports built-in shrinking for counter-examples."
+maintainer: ["Joel Bjornson <joel.bjornson@gmail.com>"]
+authors: ["Joel Bjornson <joel.bjornson@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/jobjo/popper"
+doc: "https://jobjo.github.io/popper/"
+bug-reports: "https://github.com/jobjo/popper/issues"
+depends: [
+  "pringo"
+  "ocaml" {>= "4.09.1"}
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jobjo/popper.git"
+url {
+  src: "https://github.com/jobjo/popper/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=ec6fab68323d279721178237a6f8f68c"
+    "sha512=f93e207f285dbc9e0fb946d8dc2a16453119078e10029f23663f6733992a664ed01e4b3d18d9ebf82d0571a9db0235086f468c0e79f4ecf4a109ce1aa0964372"
+  ]
+}

--- a/packages/ppx_deriving_popper/ppx_deriving_popper.0.1.1/opam
+++ b/packages/ppx_deriving_popper/ppx_deriving_popper.0.1.1/opam
@@ -10,7 +10,7 @@ doc: "https://jobjo.github.io/popper/"
 bug-reports: "https://github.com/jobjo/popper/issues"
 depends: [
   "ppx_deriving"
-  "ppxlib"
+  "ppxlib" {>= "0.9.0"}
   "popper" {= version}
   "ocaml" {>= "4.09.1" }
   "dune" {>= "2.8"}

--- a/packages/ppx_deriving_popper/ppx_deriving_popper.0.1.1/opam
+++ b/packages/ppx_deriving_popper/ppx_deriving_popper.0.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A ppx deriving sample-functions for Popper"
+description:
+  "This ppx derives popper samplers and comparators for custom data-types."
+maintainer: ["Joel Bjornson <joel.bjornson@gmail.com>"]
+authors: ["Joel Bjornson <joel.bjornson@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/jobjo/popper"
+doc: "https://jobjo.github.io/popper/"
+bug-reports: "https://github.com/jobjo/popper/issues"
+depends: [
+  "ppx_deriving"
+  "ppxlib"
+  "popper" {= version}
+  "ocaml" {>= "4.09.1" }
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jobjo/popper.git"
+url {
+  src: "https://github.com/jobjo/popper/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=ec6fab68323d279721178237a6f8f68c"
+    "sha512=f93e207f285dbc9e0fb946d8dc2a16453119078e10029f23663f6733992a664ed01e4b3d18d9ebf82d0571a9db0235086f468c0e79f4ecf4a109ce1aa0964372"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`popper.0.1.1`: Property-based testing at ease
-`ppx_deriving_popper.0.1.1`: A ppx deriving sample-functions for Popper



---
* Homepage: https://github.com/jobjo/popper
* Source repo: git+https://github.com/jobjo/popper.git
* Bug tracker: https://github.com/jobjo/popper/issues

---
:camel: Pull-request generated by opam-publish v2.0.3