### PR TITLE
Package binaryen.0.10.0

### DIFF
--- a/packages/binaryen/binaryen.0.10.0/opam
+++ b/packages/binaryen/binaryen.0.10.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.09"}
+  "dune" {>= "2.7.1"}
+  "dune-configurator" {>= "2.7.1"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+]
+available: arch = "x86_64" & (os = "linux" | os = "macos" | os = "win32")
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.10.0/binaryen-archive-v0.10.0.tar.gz"
+  checksum: [
+    "md5=a72ff934127c2f06588bdc0620f61276"
+    "sha512=eccab52a334cc353dea3bf8b799bf64ca1a89ac1d8e0903c6107599d0ce512a6cb96d0fc47f5b8c0877eb857f137114313c4efb51b90d821fbebce9c8f226b87"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.10.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---


### ⚠ BREAKING CHANGES

* Move expressions into namespaces
* Move element segment into own module
* Move `Features` into `Module.Feature`
* Create Settings modules & move global functions
* Convert some Settings from ints to bools
* Remove SIMD methods that Binaryen replaced
* Upgrade Binaryen to v101 (#99)

### Features

* Add `Module.get_features` ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Add `Type.expandType` ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Add operations on element segments ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Add operations on exports ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Add operations on expressions ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Add operations on functions ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Add operations on globals ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Add operations on imports ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Add support for reference types ([#101](https://www.github.com/grain-lang/binaryen.ml/issues/101)) ([5058492](https://www.github.com/grain-lang/binaryen.ml/commit/50584929466b7aae5f7c9b48b8b9bab5676ed53e))
* Build vendored Binaryen with GCC 7 instead of 9 ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Convert some Settings from ints to bools ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Create Settings modules & move global functions ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Move `Features` into `Module.Feature` ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Move element segment into own module ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Move expressions into namespaces ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))
* Upgrade Binaryen to v101 ([#99](https://www.github.com/grain-lang/binaryen.ml/issues/99)) ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))


### Miscellaneous Chores

* Remove SIMD methods that Binaryen replaced ([3de1b28](https://www.github.com/grain-lang/binaryen.ml/commit/3de1b289ed4673f701801f3087e48ac9746d89d1))


---
:camel: Pull-request generated by opam-publish v2.0.3