### PR TITLE
Package ocf.0.6.0

### DIFF
--- a/packages/ocf/ocf.0.6.0/opam
+++ b/packages/ocf/ocf.0.6.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis:
+  "OCaml library to read and write configuration files in JSON syntax"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["configuration" "options" "json"]
+homepage: "https://zoggy.frama.io/ocf/"
+doc: "https://zoggy.frama.io/ocf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocf/-/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind" {build}
+  "yojson" {>= "1.7.0"}
+  "ppx_tools" {>= "6.3"}
+]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://framagit.org/zoggy/ocf.git"
+url {
+  src: "https://framagit.org/zoggy/ocf/-/archive/0.6.0/ocf-0.6.0.tar.bz2"
+  checksum: [
+    "md5=d49bea28c4aaf85dd5c9d5ac8d836256"
+    "sha512=6fb1ed4d0a9c49f25c1b4bbd8b09b7196de7e1b37920c29cbe16a63e25185c02a70938ca23cb823cf4f76cb0167a5d95fabb2dbf93907b500fad89047098a562"
+  ]
+}

--- a/packages/taglog/taglog.0.2.0/opam
+++ b/packages/taglog/taglog.0.2.0/opam
@@ -15,15 +15,13 @@ build: [
 install: [
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "taglog"]]
 depends: [
-  "ocaml" {>= "4.02.1"}
+  "ocaml" {>= "4.02.1" & < "4.12"}
   "ocamlfind"
   "ocf" {>= "0.3.0"}
   "camlp4"
 ]
 synopsis: "Logging library using levels and tags to determine what to log."
-flags: light-uninstall
 url {
   src: "http://zoggy.github.com/ocaml-taglog/taglog-0.2.0.tar.gz"
   checksum: "md5=bedc5976836a956af817c945e80105d2"

--- a/packages/taglog/taglog.0.3.0/opam
+++ b/packages/taglog/taglog.0.3.0/opam
@@ -12,15 +12,13 @@ build: [
   [make "all"]
 ]
 install: [make "install"]
-remove: ["ocamlfind" "remove" "taglog"]
 depends: [
-  "ocaml" {>= "4.02.1"}
+  "ocaml" {>= "4.02.1" & < "4.12"}
   "ocamlfind"
   "ocf" {>= "0.4.0"}
   "camlp4"
 ]
 synopsis: "Logging library using levels and tags to determine what to log."
-flags: light-uninstall
 url {
   src: "https://zoggy.github.io/ocaml-taglog/taglog-0.3.0.tar.gz"
   checksum: "md5=5a92b93659cdb1b0bdd657e1ff9ae2b9"


### PR DESCRIPTION
### `ocf.0.6.0`
OCaml library to read and write configuration files in JSON syntax



---
* Homepage: https://zoggy.frama.io/ocf/
* Source repo: git+https://framagit.org/zoggy/ocf.git
* Bug tracker: https://framagit.org/zoggy/ocf/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3