### PR TITLE
Package xtmpl.0.18.0

### DIFF
--- a/packages/xtmpl/xtmpl.0.18.0/opam
+++ b/packages/xtmpl/xtmpl.0.18.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Xml templating library"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["xml" "template" "javascript"]
+homepage: "https://www.good-eris.net/xtmpl/"
+doc: "https://www.good-eris.net/xtmpl/doc.html"
+bug-reports: "https://framagit.org/zoggy/xtmpl/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind" {build}
+  "sedlex" {>= "2.3"}
+  "uutf" {>= "1.0.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "ppx_tools" {>= "6.3"}
+  "re" {>= "1.7.3"}
+  "iri" {>= "0.5.0"}
+]
+build: [make "all"]
+install: [make "install"]
+dev-repo: "git+https://framagit.org/zoggy/xtmpl.git"
+url {
+  src:
+    "https://framagit.org/zoggy/xtmpl/-/archive/0.18.0/xtmpl-0.18.0.tar.gz"
+  checksum: [
+    "md5=9141a2582ec9a685a86197a905749c10"
+    "sha512=d8d39b7b32678c911d3b630d5aadb4310d05fdecc77ecd55a0880625e3316ceeec1b9968f71c163a5dc1f6e72348c31f8e4dd67927aa7caea16ec1db60e6a541"
+  ]
+}


### PR DESCRIPTION
### `xtmpl.0.18.0`
Xml templating library



---
* Homepage: https://www.good-eris.net/xtmpl/
* Source repo: git+https://framagit.org/zoggy/xtmpl.git
* Bug tracker: https://framagit.org/zoggy/xtmpl/issues

---
:camel: Pull-request generated by opam-publish v2.0.3