### PR TITLE
Package xmldiff.0.6.0

### DIFF
--- a/packages/crowbar/crowbar.0.1/opam
+++ b/packages/crowbar/crowbar.0.1/opam
@@ -43,7 +43,7 @@ depends: [
   "uunf" {with-test}
   "uutf" {with-test}
 ]
-synopsis: "write tests, let a fuzzer find failing cases"
+synopsis: "Write tests, let a fuzzer find failing cases"
 description: """
 Crowbar is a library for testing code, combining QuickCheck-style
 property-based testing and the magical bug-finding powers of

--- a/packages/crowbar/crowbar.0.1/opam
+++ b/packages/crowbar/crowbar.0.1/opam
@@ -33,11 +33,11 @@ depends: [
   "ocaml" {>= "4.03"}
   "jbuilder"
   "ocplib-endian"
-  "cmdliner"
+  "cmdliner" {>= "1.0.0"}
   "afl-persistent" {>= "1.1"}
   "calendar" {with-test & >= "2.00"}
   "xmldiff" {with-test}
-  "pprint" {with-test}
+  "pprint" {with-test & < "20180523"}
   "fpath" {with-test}
   "uucp" {with-test}
   "uunf" {with-test}

--- a/packages/crowbar/crowbar.0.1/opam
+++ b/packages/crowbar/crowbar.0.1/opam
@@ -31,7 +31,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta6"}
   "ocplib-endian"
   "cmdliner" {>= "1.0.0"}
   "afl-persistent" {>= "1.1"}

--- a/packages/crowbar/crowbar.0.1/opam
+++ b/packages/crowbar/crowbar.0.1/opam
@@ -37,6 +37,7 @@ depends: [
   "afl-persistent" {>= "1.1"}
   "calendar" {with-test & >= "2.00"}
   "xmldiff" {with-test}
+  "pprint" {with-test}
   "fpath" {with-test}
   "uucp" {with-test}
   "uunf" {with-test}

--- a/packages/xmldiff/xmldiff.0.6.0/opam
+++ b/packages/xmldiff/xmldiff.0.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Computing and applying diffs on XML trees"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/xmldiff/"
+doc: "https://zoggy.frama.io/xmldiff/refdoc/"
+bug-reports: "https://framagit.org/zoggy/xmldiff/-/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind" {build}
+  "xmlm" {>= "1.3.0"}
+]
+depopts: [
+  "js_of_ocaml" {>= "3.9.0"}
+]
+conflicts: [
+  "js_of_ocaml" {< "2.4.0"}
+]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://framagit.org/zoggy/xmldiff.git"
+url {
+  src:
+    "https://framagit.org/zoggy/xmldiff/-/archive/0.6.0/xtmpl-0.6.0.tar.bz2"
+  checksum: [
+    "md5=e32cbc56cf235e9f0a1e64eb35f338ec"
+    "sha512=27eb24bccc9b00b0cd215beefee3b38863efc1f2e8050ecb284dd4798f0fdffac39b27fe5ef48eaae21c8172e62290fe2dfb5a73471b97e6cc92ba6309745251"
+  ]
+}

--- a/packages/xmldiff/xmldiff.0.6.0/opam
+++ b/packages/xmldiff/xmldiff.0.6.0/opam
@@ -12,10 +12,12 @@ depends: [
   "xmlm" {>= "1.3.0"}
 ]
 depopts: [
-  "js_of_ocaml" {>= "3.9.0"}
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
 ]
 conflicts: [
-  "js_of_ocaml" {< "2.4.0"}
+  "js_of_ocaml" {< "3.9.0"}
+  "js_of_ocaml-ppx" {< "3.9.0"}
 ]
 build: [
   ["./configure" "--prefix" prefix]


### PR DESCRIPTION
### `xmldiff.0.6.0`
Computing and applying diffs on XML trees



---
* Homepage: https://zoggy.frama.io/xmldiff/
* Source repo: git+https://framagit.org/zoggy/xmldiff.git
* Bug tracker: https://framagit.org/zoggy/xmldiff/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3