### PR TITLE
[new release] vhd-format-lwt and vhd-format (0.12.1)

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.4.1.5/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.1.5/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml" {>= "4.02.1" & < "4.08.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.6.0"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "cppo_ocamlbuild" {build}
   "ppx_tools" {>= "4.02.3"}
   "result"

--- a/packages/ppx_deriving/ppx_deriving.4.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.1/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml" {>= "4.02.1" & < "4.05"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.6.0"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "cppo_ocamlbuild" {build}
   "ppx_tools" {>= "4.02.3"}
   "result"

--- a/packages/ppx_deriving/ppx_deriving.4.2.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.2.1/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml" {> "4.03.0" & < "4.08.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.6.0"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "cppo_ocamlbuild" {build}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"

--- a/packages/ppx_deriving/ppx_deriving.4.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.2/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml" {> "4.03.0" & < "4.06.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.6.0"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "cppo_ocamlbuild" {build}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"

--- a/packages/ppx_deriving/ppx_deriving.4.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.3/opam
@@ -8,14 +8,14 @@ bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
 tags: [ "syntax" ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version >= "4.03"}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
   "dune"     {>= "1.6.3"}
-  "cppo"     {build}
+  "cppo"     {build & >= "1.1.0"}
   "ppxfind"  {build}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"

--- a/packages/ppx_deriving/ppx_deriving.4.4.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.4.1/opam
@@ -8,14 +8,14 @@ bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
 tags: [ "syntax" ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version >= "4.03"}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
   "dune"     {>= "1.6.3"}
-  "cppo"     {build}
+  "cppo"     {build & >= "1.1.0"}
   "ppxfind"  {build}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"

--- a/packages/ppx_deriving/ppx_deriving.4.4/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.4/opam
@@ -8,14 +8,14 @@ bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
 tags: [ "syntax" ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version >= "4.03"}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
   "dune"     {>= "1.6.3"}
-  "cppo"     {build}
+  "cppo"     {build & >= "1.1.0"}
   "ppxfind"  {build}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"

--- a/packages/ppx_deriving/ppx_deriving.4.5/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.5/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "dune"     {>= "1.6.3"}
-  "cppo"     {build}
+  "cppo"     {build & >= "1.1.0"}
   "ppxfind"  {build}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"

--- a/packages/ppx_deriving/ppx_deriving.5.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0" & < "4.12"}
   "dune" {>= "1.6.3"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "ocamlfind"
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"

--- a/packages/ppx_deriving/ppx_deriving.5.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.1/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0" & < "4.12"}
   "dune" {>= "1.6.3"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "ocamlfind"
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"

--- a/packages/ppx_deriving/ppx_deriving.5.2.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.2.1/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.6.3"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "ocamlfind"
   "ppx_derivers"
   "ppxlib" {>= "0.20.0"}

--- a/packages/ppx_deriving/ppx_deriving.5.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.2/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.6.3"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "ocamlfind"
   "ppx_derivers"
   "ppxlib" {>= "0.20.0"}

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.12.0/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.12.0/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "dave@recoil.org"
 authors: ["Dave Scott" "Jon Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.12.1/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.12.1/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "dave@recoil.org"
 authors: ["Dave Scott" "Jon Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.12.1/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.12.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Jon Ludlam"]
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-vhd"
+doc: "https://mirage.github.io/ocaml-vhd/"
+bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "cstruct"
+  "lwt" {>= "3.2.0"}
+  "mirage-block" {>= "2.0.1"}
+  "ounit" {with-test}
+  "vhd-format"
+  "io-page-unix" {with-test}
+  "dune" {>= "1.0"}
+  "io-page" {with-test & >= "2.4.0"}
+]
+available: os = "linux" | os = "macos"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+dev-repo: "git+https://github.com/mirage/ocaml-vhd.git"
+synopsis: "Lwt interface to read/write VHD format data"
+description: """
+A pure OCaml library to read and write
+[vhd](http://en.wikipedia.org/wiki/VHD_(file_format)) format data, plus a
+simple command-line tool which allows vhd files to be interrogated,
+manipulated, format-converted and streamed to and from files and remote
+servers.
+
+This package provides an Lwt compatible interface to the library.
+"""
+x-commit-hash: "592a1ed0bc09a971012558e6017d4ba67d2a4907"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vhd/releases/download/v0.12.1/vhd-format-v0.12.1.tbz"
+  checksum: [
+    "sha256=d32a295ddabfe4e21424264fd1afd840d11f7eaa7b7fbed55ea625ee8bc04d78"
+    "sha512=67928482f2c402d668b5a69010a6e8fa54a76defa04ed7213d9d6544ad47229b4660e20b503ef26d78372b37fcaf0c686425552eb8d0c7f202c2c8901270caa7"
+  ]
+}

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.9.1/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.9.1/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dave@recoil.org"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.9.2/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.9.2/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dave@recoil.org"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/vhd-format/vhd-format.0.0.2/opam
+++ b/packages/vhd-format/vhd-format.0.0.2/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dave.scott@eu.citrix.com"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/vhd-format/vhd-format.0.12.0/opam
+++ b/packages/vhd-format/vhd-format.0.12.0/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "dave@recoil.org"
 authors: ["Dave Scott" "Jon Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"

--- a/packages/vhd-format/vhd-format.0.12.0/opam
+++ b/packages/vhd-format/vhd-format.0.12.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "cstruct" {>= "1.9"}
   "io-page"
-  "rresult"
+  "rresult" {>= "0.2.0"}
   "uuidm"
   "dune" {>= "1.0"}
   "ppx_cstruct" {build}

--- a/packages/vhd-format/vhd-format.0.12.1/opam
+++ b/packages/vhd-format/vhd-format.0.12.1/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "dave@recoil.org"
 authors: ["Dave Scott" "Jon Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"

--- a/packages/vhd-format/vhd-format.0.12.1/opam
+++ b/packages/vhd-format/vhd-format.0.12.1/opam
@@ -6,13 +6,13 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.03.0"}
   "cstruct" {>= "1.9"}
   "io-page"
   "rresult"
   "uuidm"
   "dune" {>= "1.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct" {build & >= "3.0.0"}
 ]
 available: os = "linux" | os = "macos"
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/vhd-format/vhd-format.0.12.1/opam
+++ b/packages/vhd-format/vhd-format.0.12.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Jon Ludlam"]
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-vhd"
+doc: "https://mirage.github.io/ocaml-vhd/"
+bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "cstruct" {>= "1.9"}
+  "io-page"
+  "rresult"
+  "uuidm"
+  "dune" {>= "1.0"}
+  "ppx_cstruct" {build}
+]
+available: os = "linux" | os = "macos"
+build: ["dune" "build" "-p" name "-j" jobs]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+dev-repo: "git+https://github.com/mirage/ocaml-vhd.git"
+synopsis: "Pure OCaml library to read/write VHD format data"
+description: """
+A pure OCaml library to read and write
+[vhd](http://en.wikipedia.org/wiki/VHD_(file_format)) format data, plus a
+simple command-line tool which allows vhd files to be interrogated,
+manipulated, format-converted and streamed to and from files and remote
+servers.
+"""
+x-commit-hash: "592a1ed0bc09a971012558e6017d4ba67d2a4907"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vhd/releases/download/v0.12.1/vhd-format-v0.12.1.tbz"
+  checksum: [
+    "sha256=d32a295ddabfe4e21424264fd1afd840d11f7eaa7b7fbed55ea625ee8bc04d78"
+    "sha512=67928482f2c402d668b5a69010a6e8fa54a76defa04ed7213d9d6544ad47229b4660e20b503ef26d78372b37fcaf0c686425552eb8d0c7f202c2c8901270caa7"
+  ]
+}

--- a/packages/vhd-format/vhd-format.0.12.1/opam
+++ b/packages/vhd-format/vhd-format.0.12.1/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "cstruct" {>= "1.9"}
   "io-page"
-  "rresult"
+  "rresult" {>= "0.2.0"}
   "uuidm"
   "dune" {>= "1.0"}
   "ppx_cstruct" {build & >= "3.0.0"}

--- a/packages/vhd-format/vhd-format.0.6.0/opam
+++ b/packages/vhd-format/vhd-format.0.6.0/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dave.scott@eu.citrix.com"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/vhd-format/vhd-format.0.6.4/opam
+++ b/packages/vhd-format/vhd-format.0.6.4/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dave.scott@eu.citrix.com"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/vhd-format/vhd-format.0.7.0/opam
+++ b/packages/vhd-format/vhd-format.0.7.0/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dave.scott@eu.citrix.com"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: ["org:mirage" "org:xapi-project"]
 build: make
 remove: [

--- a/packages/vhd-format/vhd-format.0.7.1/opam
+++ b/packages/vhd-format/vhd-format.0.7.1/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dave.scott@eu.citrix.com"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: ["org:mirage" "org:xapi-project"]
 build: make
 remove: [

--- a/packages/vhd-format/vhd-format.0.8.0/opam
+++ b/packages/vhd-format/vhd-format.0.8.0/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dave@recoil.org"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: ["org:mirage" "org:xapi-project"]
 authors: ["Dave Scott" "Jon Ludlam"]
 homepage: "https://github.com/mirage/ocaml-vhd"

--- a/packages/vhd-format/vhd-format.0.9.1/opam
+++ b/packages/vhd-format/vhd-format.0.9.1/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dave@recoil.org"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/vhd-format/vhd-format.0.9.1/opam
+++ b/packages/vhd-format/vhd-format.0.9.1/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder"
   "cstruct" {>= "1.9" & < "3.4.0"}
   "io-page"
-  "rresult"
+  "rresult" {>= "0.2.0"}
   "uuidm"
   "ppx_cstruct"
 ]

--- a/packages/vhd-format/vhd-format.0.9.2/opam
+++ b/packages/vhd-format/vhd-format.0.9.2/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "dave@recoil.org"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/vhd-format/vhd-format.0.9.2/opam
+++ b/packages/vhd-format/vhd-format.0.9.2/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder"
   "cstruct" {>= "1.9" & <"3.4.0"}
   "io-page"
-  "rresult"
+  "rresult" {>= "0.2.0"}
   "uuidm"
   "ppx_cstruct"
 ]


### PR DESCRIPTION
Lwt interface to read/write VHD format data

- Project page: <a href="https://github.com/mirage/ocaml-vhd">https://github.com/mirage/ocaml-vhd</a>
- Documentation: <a href="https://mirage.github.io/ocaml-vhd/">https://mirage.github.io/ocaml-vhd/</a>

##### CHANGES:

* Upgrade to `cstruct.6.0.0` (@psafont, mirage/ocaml-vhd#67)
* Move `patterns_lwt` out of `vhd_format_lwt` (@psafont, mirage/ocaml-vhd#67)
* Upgrade the code base with `mirage-block` (`mirage-types-lwt` is deprecated)
  (@dinosaure, mirage/ocaml-vhd#70)
