### PR TITLE
[new release] rfc1951 and decompress (1.4.1)

### DIFF
--- a/packages/decompress/decompress.1.4.1/opam
+++ b/packages/decompress/decompress.1.4.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "base-bytes"
+  "bigarray-compat"
+  "cmdliner"
+  "optint"      {>= "0.1.0"}
+  "checkseum"   {>= "0.2.0"}
+  "bigstringaf" {with-test}
+  "alcotest"    {with-test}
+  "ctypes"      {with-test & >= "0.18.0"}
+  "fmt"         {with-test}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+  "crowbar"     {with-test & >= "0.2"}
+  "rresult"     {with-test}
+]
+x-commit-hash: "fcbc448e253fcb70b65fb58b5a692468f17a243e"
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.4.1/decompress-v1.4.1.tbz"
+  checksum: [
+    "sha256=0130ea6acb61b0a25393fa23148e116d7a17c77558196f7abddaee9e05a1d7a8"
+    "sha512=1668df538fba7c96574146a18fcbeef5200ea0e36110ec94c9b9924e368f465447702029fdb00d2749ca55081169b0e7c74e2f0887e4367ec580633e1e2a1c6c"
+  ]
+}

--- a/packages/decompress/decompress.1.4.1/opam
+++ b/packages/decompress/decompress.1.4.1/opam
@@ -20,7 +20,7 @@ depends: [
   "dune"        {>= "2.8.0"}
   "base-bytes"
   "bigarray-compat"
-  "cmdliner"
+  "cmdliner"    {>= "1.0.0"}
   "optint"      {>= "0.1.0"}
   "checkseum"   {>= "0.2.0"}
   "bigstringaf" {with-test}

--- a/packages/rfc1951/rfc1951.1.4.1/opam
+++ b/packages/rfc1951/rfc1951.1.4.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "dune"       {>= "2.8"}
+  "decompress" {= version}
+  "bigarray-compat"
+  "checkseum"
+  "optint"
+  "ctypes"     {with-test & >= "0.18.0"}
+]
+x-commit-hash: "fcbc448e253fcb70b65fb58b5a692468f17a243e"
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.4.1/decompress-v1.4.1.tbz"
+  checksum: [
+    "sha256=0130ea6acb61b0a25393fa23148e116d7a17c77558196f7abddaee9e05a1d7a8"
+    "sha512=1668df538fba7c96574146a18fcbeef5200ea0e36110ec94c9b9924e368f465447702029fdb00d2749ca55081169b0e7c74e2f0887e4367ec580633e1e2a1c6c"
+  ]
+}


### PR DESCRIPTION
Implementation of RFC1951 in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- Fix and of file and end of block _op-code_ (@dinosaure, mirage/decompress#123)
  **breaking changes**
  Semantically, the module `De` has another behavior about the inflation.
  Previously, the _stream_ inflation was smart enough to recognize the end
  of the stream and the user did not need to really emit:
  `De.Inf.src decoder empty 0 0` to say the end of the stream. Now, such
  call is required to notice to `De.Inf` the end of the stream. By this
  way, we are able to terminate the inflation correctly and we still
  continue to raise an error for unterminated stream
  (see `tests/invalid_distance_code`).

  For `Zl`/`Gz` users, this update does not imply anything when these
  implementations take care about such detail. Only `De` users should update
  their code to really emit the end of the stream with
  `De.Inf.src decoder empty 0 0`. In the PR, the diff show how to upgrade such
  code.
- Upgrade `decompress` to `optint.0.1.0` (@samoht, @dinosaure, mirage/decompress#124)
- Fix compilation of benchmarks (@dinosaure, mirage/decompress#128)
- Fix out of bounds errors on the _non-stream_ implementation (@clecat,
  @ewanmellor, @dinosaure, mirage/decompress#126, mirage/decompress#127)
- Optimize `memcpy` used on the _non-stream_ implementation (@clecat,
  @dinosaure, mirage/decompress#129)
