### PR TITLE
[new release] pgx_lwt_mirage, pgx_value_core, pgx_async, pgx_unix, pgx_lwt_unix, pgx_lwt and pgx (2.0)

### DIFF
--- a/packages/pgx/pgx.2.0/opam
+++ b/packages/pgx/pgx.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Pure-OCaml PostgreSQL client library"
+description:
+  "PGX is a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations."
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "alcotest" {with-test & >= "1.0.0"}
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "dune" {>= "1.11"}
+  "hex"
+  "ipaddr"
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+  "ppx_compare" {>= "v0.13.0"}
+  "ppx_custom_printf" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "re"
+  "sexplib0" {>= "v0.13.0"}
+  "uuidm"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "cdef3ff4eba56ea9b2a74c2b3bbfe652b4864a39"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}

--- a/packages/pgx_async/pgx_async.2.0/opam
+++ b/packages/pgx_async/pgx_async.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Pgx using Async for IO"
+description: "Pgx using Async for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest-async" {with-test & >= "1.0.0"}
+  "async_kernel" {>= "v0.13.0"}
+  "async_unix" {>= "v0.13.0"}
+  "async_ssl"
+  "base64" {with-test & >= "3.0.0"}
+  "conduit-async"
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+  "pgx_value_core" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "cdef3ff4eba56ea9b2a74c2b3bbfe652b4864a39"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}

--- a/packages/pgx_lwt/pgx_lwt.2.0/opam
+++ b/packages/pgx_lwt/pgx_lwt.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pgx using Lwt for IO"
+description: "Pgx using Lwt for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "lwt"
+  "logs"
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "cdef3ff4eba56ea9b2a74c2b3bbfe652b4864a39"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}

--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.0/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Pgx using Lwt on Mirage for IO"
+description: "Pgx using Lwt on Mirage for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "lwt"
+  "ocaml" {>= "4.08"}
+  "logs"
+  "mirage-channel"
+  "conduit-mirage" {>= "2.2.0" & < "2.3.0"}
+  "dns-client"
+  "mirage-random"
+  "mirage-time"
+  "mirage-clock"
+  "mirage-stack"
+  "pgx" {= version}
+  "pgx_lwt" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "cdef3ff4eba56ea9b2a74c2b3bbfe652b4864a39"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}

--- a/packages/pgx_lwt_unix/pgx_lwt_unix.2.0/opam
+++ b/packages/pgx_lwt_unix/pgx_lwt_unix.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Pgx using Lwt and Unix libraries for IO"
+description: "Pgx using Lwt and Unix libraries for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest-lwt" {with-test & >= "1.0.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+  "pgx_lwt" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "cdef3ff4eba56ea9b2a74c2b3bbfe652b4864a39"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}

--- a/packages/pgx_unix/pgx_unix.2.0/opam
+++ b/packages/pgx_unix/pgx_unix.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "PGX using the standard library's Unix module for IO (synchronous)"
+description:
+  "PGX using the standard library's Unix module for IO (synchronous)"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest" {with-test & >= "1.0.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "cdef3ff4eba56ea9b2a74c2b3bbfe652b4864a39"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}

--- a/packages/pgx_value_core/pgx_value_core.2.0/opam
+++ b/packages/pgx_value_core/pgx_value_core.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pgx_value converters for Core types like Date and Time"
+description: "Pgx_value converters for Core types like Date and Time"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest" {with-test & >= "1.0.0"}
+  "core_kernel" {>= "v0.13.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "cdef3ff4eba56ea9b2a74c2b3bbfe652b4864a39"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}


### PR DESCRIPTION
Pgx using Lwt on Mirage for IO

- Project page: <a href="https://github.com/arenadotio/pgx">https://github.com/arenadotio/pgx</a>
- Documentation: <a href="https://arenadotio.github.io/pgx">https://arenadotio.github.io/pgx</a>

##### CHANGES:

### Breaking changes

* Pgx_value.t is an opaque type now. Use `Pgx_value.of/to` converters. Note that these converters are _not_ equivalent
  to the OCaml functions like `bool_of_string` or `float_of_string`, and that for bytea data, you need to use
  `Pgx_value.of/to_binary`, not `Pgx_value.of/to_string`.
* Pgx_lwt has been renamed Pgx_lwt_unix.
* `Pgx.execute` now uses the unnamed prepare statement. In most cases this should not affect anything, but if you were
  relying on Pgx not internally using the unnamed prepared statement, you will need to fix your code. If you run into
  this, the fix is to use `Pgx.with_prepared` and name your prepared statement.
* `Pgx_value.of_inet`/`to_inet` now use `Ipaddr.t` from the `ipaddr` library instead of `Unix.inet_addr`.

### Added

* `Pgx_value.of_binary` and `Pgx_value.to_binary` added for bytea data.
* Add `execute_map` helper to Pgx
* Add `execute_pipe` helper to Pgx_async
* Add `execute_unit` helper to Pgx
* Break out `Pgx_value_core` library, which will allow users of Pgx_unix and Pgx_lwt to use the `Core_kernel.Tim` and
  `Date` types. This is still included by default in Pgx_async.
* Added Pgx_lwt_mirage
* Pgx_value types now all implement `compare` and `sexp_of`

### Fixed

* Pgx no longer assumes all strings are binary data. Strings must be valid varchar data in the database's encoding.
  Use `Pgx_value.of/to_binary` with bytea columns if you want binary.
* Use a tail-recursive `List.map` implementation
* Use `Unix.getuid` + `Lwt_unix.getpwuid` instead of `Lwt.getlogin` for the default username, since `getlogin` fails
  in some cases.
* Use int64 to keep track of prepared statements just in case someone prepares several million statements in one program

### Changed

* Re-raise exceptions with backtraces if possible.
* Pgx_async uses Async.Log for logging instead of printing directly to stderr
* Use Sexplib0 instead of Sexplib
* Use the Query protocol for parameterless `execute` instead of Prepare + Bind
* Use the unnamed prepared statement for `execute`
* Use `ipaddr` library instead of `Unix.inet_addr`
* Split Pgx_lwt into Pgx_lwt_unix and Pgx_lwt_mirage
