### PR TITLE
[new release] pgx_lwt_mirage, pgx_value_core, pgx_async, pgx_unix, pgx_lwt_unix, pgx_lwt and pgx (2.0)

### DIFF
--- a/packages/pgx/pgx.0.1/opam
+++ b/packages/pgx/pgx.0.1/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 authors: ["Arena Developers <silver-snakes@arena.io>"]
 maintainer: "silver-snakes@arena.io"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 dev-repo: "git+https://github.com/arenadotio/pgx.git"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx/pgx.1.0/opam
+++ b/packages/pgx/pgx.1.0/opam
@@ -24,7 +24,7 @@ depends: [
   "uuidm"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx/pgx.1.0/opam
+++ b/packages/pgx/pgx.1.0/opam
@@ -4,7 +4,7 @@ description:
   "PGX is a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations."
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx/pgx.1.0/opam
+++ b/packages/pgx/pgx.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_compare" {>= "v0.13.0" & < "v0.15"}
   "ppx_custom_printf" {>= "v0.13.0" & < "v0.15"}
   "ppx_sexp_conv" {>= "v0.13.0" & < "v0.15"}
-  "re"
+  "re" {>= "1.5.0"}
   "sexplib0" {>= "v0.13.0" & < "v0.15"}
   "uuidm"
 ]

--- a/packages/pgx/pgx.2.0/opam
+++ b/packages/pgx/pgx.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "uuidm"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx/pgx.2.0/opam
+++ b/packages/pgx/pgx.2.0/opam
@@ -4,7 +4,7 @@ description:
   "PGX is a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations."
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx/pgx.2.0/opam
+++ b/packages/pgx/pgx.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Pure-OCaml PostgreSQL client library"
+description:
+  "PGX is a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations."
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "alcotest" {with-test & >= "1.0.0"}
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "dune" {>= "1.11"}
+  "hex"
+  "ipaddr"
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+  "ppx_compare" {>= "v0.13.0"}
+  "ppx_custom_printf" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "re"
+  "sexplib0" {>= "v0.13.0"}
+  "uuidm"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "b73b09d8e376f0ba10219f9b860e33ea94281461"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}

--- a/packages/pgx/pgx.2.0/opam
+++ b/packages/pgx/pgx.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_compare" {>= "v0.13.0"}
   "ppx_custom_printf" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
-  "re"
+  "re" {>= "1.5.0"}
   "sexplib0" {>= "v0.13.0"}
   "uuidm"
 ]

--- a/packages/pgx_async/pgx_async.0.1/opam
+++ b/packages/pgx_async/pgx_async.0.1/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 authors: ["Arena Developers <silver-snakes@arena.io>"]
 maintainer: "silver-snakes@arena.io"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 dev-repo: "git+https://github.com/arenadotio/pgx.git"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_async/pgx_async.1.0/opam
+++ b/packages/pgx_async/pgx_async.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "pgx_value_core" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_async/pgx_async.1.0/opam
+++ b/packages/pgx_async/pgx_async.1.0/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx using Async for IO"
 description: "Pgx using Async for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_async/pgx_async.2.0/opam
+++ b/packages/pgx_async/pgx_async.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "pgx_value_core" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_async/pgx_async.2.0/opam
+++ b/packages/pgx_async/pgx_async.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Pgx using Async for IO"
+description: "Pgx using Async for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest-async" {with-test & >= "1.0.0"}
+  "async_kernel" {>= "v0.13.0"}
+  "async_unix" {>= "v0.13.0"}
+  "async_ssl"
+  "base64" {with-test & >= "3.0.0"}
+  "conduit-async"
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+  "pgx_value_core" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "b73b09d8e376f0ba10219f9b860e33ea94281461"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}

--- a/packages/pgx_async/pgx_async.2.0/opam
+++ b/packages/pgx_async/pgx_async.2.0/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx using Async for IO"
 description: "Pgx using Async for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_async/pgx_async.2.0/opam
+++ b/packages/pgx_async/pgx_async.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "async_unix" {>= "v0.13.0"}
   "async_ssl"
   "base64" {with-test & >= "3.0.0"}
-  "conduit-async"
+  "conduit-async" {>= "1.5.0"}
   "ocaml" {>= "4.08"}
   "pgx" {= version}
   "pgx_value_core" {= version}

--- a/packages/pgx_lwt/pgx_lwt.0.1/opam
+++ b/packages/pgx_lwt/pgx_lwt.0.1/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 authors: ["Arena Developers <silver-snakes@arena.io>"]
 maintainer: "silver-snakes@arena.io"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 dev-repo: "git+https://github.com/arenadotio/pgx.git"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_lwt/pgx_lwt.1.0/opam
+++ b/packages/pgx_lwt/pgx_lwt.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgx" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_lwt/pgx_lwt.1.0/opam
+++ b/packages/pgx_lwt/pgx_lwt.1.0/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx using Lwt for IO"
 description: "Pgx using Lwt for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_lwt/pgx_lwt.2.0/opam
+++ b/packages/pgx_lwt/pgx_lwt.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgx" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_lwt/pgx_lwt.2.0/opam
+++ b/packages/pgx_lwt/pgx_lwt.2.0/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx using Lwt for IO"
 description: "Pgx using Lwt for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_lwt/pgx_lwt.2.0/opam
+++ b/packages/pgx_lwt/pgx_lwt.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pgx using Lwt for IO"
+description: "Pgx using Lwt for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "lwt"
+  "logs"
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "b73b09d8e376f0ba10219f9b860e33ea94281461"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}

--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.1.0/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "pgx_lwt" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.1.0/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.1.0/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx using Lwt on Mirage for IO"
 description: "Pgx using Lwt on Mirage for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.0/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.0/opam
@@ -23,7 +23,7 @@ depends: [
   "pgx_lwt" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.0/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Pgx using Lwt on Mirage for IO"
+description: "Pgx using Lwt on Mirage for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "lwt"
+  "ocaml" {>= "4.08"}
+  "logs"
+  "mirage-channel"
+  "conduit-mirage" {>= "2.2.0" & < "2.3.0"}
+  "dns-client"
+  "mirage-random"
+  "mirage-time"
+  "mirage-clock"
+  "mirage-stack"
+  "pgx" {= version}
+  "pgx_lwt" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "b73b09d8e376f0ba10219f9b860e33ea94281461"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}

--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.0/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.0/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx using Lwt on Mirage for IO"
 description: "Pgx using Lwt on Mirage for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_lwt_unix/pgx_lwt_unix.1.0/opam
+++ b/packages/pgx_lwt_unix/pgx_lwt_unix.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "pgx_lwt" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_lwt_unix/pgx_lwt_unix.1.0/opam
+++ b/packages/pgx_lwt_unix/pgx_lwt_unix.1.0/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx using Lwt and Unix libraries for IO"
 description: "Pgx using Lwt and Unix libraries for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_lwt_unix/pgx_lwt_unix.2.0/opam
+++ b/packages/pgx_lwt_unix/pgx_lwt_unix.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "pgx_lwt" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_lwt_unix/pgx_lwt_unix.2.0/opam
+++ b/packages/pgx_lwt_unix/pgx_lwt_unix.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Pgx using Lwt and Unix libraries for IO"
+description: "Pgx using Lwt and Unix libraries for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest-lwt" {with-test & >= "1.0.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+  "pgx_lwt" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "b73b09d8e376f0ba10219f9b860e33ea94281461"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}

--- a/packages/pgx_lwt_unix/pgx_lwt_unix.2.0/opam
+++ b/packages/pgx_lwt_unix/pgx_lwt_unix.2.0/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx using Lwt and Unix libraries for IO"
 description: "Pgx using Lwt and Unix libraries for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_unix/pgx_unix.0.1/opam
+++ b/packages/pgx_unix/pgx_unix.0.1/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 authors: ["Arena Developers <silver-snakes@arena.io>"]
 maintainer: "silver-snakes@arena.io"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 dev-repo: "git+https://github.com/arenadotio/pgx.git"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_unix/pgx_unix.1.0/opam
+++ b/packages/pgx_unix/pgx_unix.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "pgx" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_unix/pgx_unix.1.0/opam
+++ b/packages/pgx_unix/pgx_unix.1.0/opam
@@ -4,7 +4,7 @@ description:
   "PGX using the standard library's Unix module for IO (synchronous)"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_unix/pgx_unix.2.0/opam
+++ b/packages/pgx_unix/pgx_unix.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "pgx" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_unix/pgx_unix.2.0/opam
+++ b/packages/pgx_unix/pgx_unix.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "PGX using the standard library's Unix module for IO (synchronous)"
+description:
+  "PGX using the standard library's Unix module for IO (synchronous)"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest" {with-test & >= "1.0.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "b73b09d8e376f0ba10219f9b860e33ea94281461"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}

--- a/packages/pgx_unix/pgx_unix.2.0/opam
+++ b/packages/pgx_unix/pgx_unix.2.0/opam
@@ -4,7 +4,7 @@ description:
   "PGX using the standard library's Unix module for IO (synchronous)"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_value_core/pgx_value_core.1.0/opam
+++ b/packages/pgx_value_core/pgx_value_core.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgx" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_value_core/pgx_value_core.1.0/opam
+++ b/packages/pgx_value_core/pgx_value_core.1.0/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx_value converters for Core types like Date and Time"
 description: "Pgx_value converters for Core types like Date and Time"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_value_core/pgx_value_core.2.0/opam
+++ b/packages/pgx_value_core/pgx_value_core.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgx" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_value_core/pgx_value_core.2.0/opam
+++ b/packages/pgx_value_core/pgx_value_core.2.0/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx_value converters for Core types like Date and Time"
 description: "Pgx_value converters for Core types like Date and Time"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_value_core/pgx_value_core.2.0/opam
+++ b/packages/pgx_value_core/pgx_value_core.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pgx_value converters for Core types like Date and Time"
+description: "Pgx_value converters for Core types like Date and Time"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2 with OCaml linking exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest" {with-test & >= "1.0.0"}
+  "core_kernel" {>= "v0.13.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+x-commit-hash: "b73b09d8e376f0ba10219f9b860e33ea94281461"
+url {
+  src:
+    "https://github.com/arenadotio/pgx/releases/download/2.0/pgx_lwt_mirage-2.0.tbz"
+  checksum: [
+    "sha256=be6bac83e4030b6225f3966fd482b242818ff1147efc273163d4a9cd749b62bd"
+    "sha512=c18e3b7d246f184c5a689d081f613937d569f9b794b95e586c5c16ddb7402581049642dd20852ec95316c4681b70f5e8f494fc9475adecf64d53b13d70257c98"
+  ]
+}


### PR DESCRIPTION
Pgx using Lwt on Mirage for IO

- Project page: <a href="https://github.com/arenadotio/pgx">https://github.com/arenadotio/pgx</a>
- Documentation: <a href="https://arenadotio.github.io/pgx">https://arenadotio.github.io/pgx</a>

##### CHANGES:

### Breaking changes

* The Pgx module is now wrapped, which means `Pgx_aux`, `Types`, `Access`, etc. aren't added to the global scope.
  The main result of this is that `Pgx_value` now needs to be accessed as `Pgx.Value`.
  (https://github.com/arenadotio/pgx/pull/103)
* `Pgx_async.connect` and `with_conn` now have an additional optional `?ssl` argument (see below).

### Added

* Pgx_async now supports TLS connections using Conduit_async. This is enabled by default and can be controlled with the
  new `?ssl` argument to `connect` and `with_conn`.
  (https://github.com/arenadotio/pgx/pull/108)

### Fixed

* Improved message for authentication errors. Previously these raised `Pgx_eof`, and now they raise
  `PostgreSQL_Error("Failed to authenticate with postgres server", additional details ...)`.
  (https://github.com/arenadotio/pgx/pull/105)

### Changed

* Support new Mirage-conduit timeout argument (https://github.com/arenadotio/pgx/pull/95).
