### PR TITLE
Package bogue.20210514

### DIFF
--- a/packages/bogue/bogue.20210514/opam
+++ b/packages/bogue/bogue.20210514/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "GUI library for ocaml, with animations, based on SDL2"
+description: """\
+bogue is a GUI library for ocaml, with animations, based on SDL2.
+
+This library can be used for games or for adding GUI elements to any
+ocaml program.
+
+It uses the SDL2 renderer library, which makes it quite fast.
+
+It is themable, and does not try to look like your desktop. Instead,
+it will look the same on every platform.
+
+Graphics output is scalable, and hence easily adapts to Hi-DPI
+displays.
+
+Programming with bogue is easy if you're used to GUIs with widgets,
+layouts, callbacks, and of course it has a functional flavor. It uses
+Threads when non-blocking reactions are needed."""
+maintainer: "Vu Ngoc San <san.vu-ngoc@laposte.net>"
+authors: "Vu Ngoc San <san.vu-ngoc@laposte.net>"
+license: "ISC"
+homepage: "https://github.com/sanette/bogue"
+doc: "http://sanette.github.io/bogue/Bogue.html"
+bug-reports: "https://github.com/sanette/bogue/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "tsdl-image" {= "0.1.2"}
+  "tsdl-ttf" {>= "0.2"}
+  "ocaml" {>= "4.08.0"}
+  "tsdl" {>= "0.9.0"}
+]
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@runtest" {with-test}
+  "@doc" {with-doc}
+]
+dev-repo: "git+https://github.com/sanette/bogue.git"
+url {
+  src: "https://github.com/sanette/bogue/archive/refs/tags/20210514.tar.gz"
+  checksum: [
+    "md5=3238e9d8fbe82a3dc0862f132d2ddcb1"
+    "sha512=42af4d52bfda33c8dc600773d39560a546c00d42e3e08873d7aef533fa6cd4d7d818d79f81d96aa8abcd9297e666d117e7c67ba8047d7fe19fec3d3c410ae408"
+  ]
+}


### PR DESCRIPTION
### `bogue.20210514`
GUI library for ocaml, with animations, based on SDL2
bogue is a GUI library for ocaml, with animations, based on SDL2.

This library can be used for games or for adding GUI elements to any
ocaml program.

It uses the SDL2 renderer library, which makes it quite fast.

It is themable, and does not try to look like your desktop. Instead,
it will look the same on every platform.

Graphics output is scalable, and hence easily adapts to Hi-DPI
displays.

Programming with bogue is easy if you're used to GUIs with widgets,
layouts, callbacks, and of course it has a functional flavor. It uses
Threads when non-blocking reactions are needed.



---
* Homepage: https://github.com/sanette/bogue
* Source repo: git+https://github.com/sanette/bogue.git
* Bug tracker: https://github.com/sanette/bogue/issues

---
:camel: Pull-request generated by opam-publish v2.0.3