### PR TITLE
Dream 1.0.0~alpha2: tidy Web framework

### DIFF
--- a/packages/dream/dream.1.0.0~alpha1/opam
+++ b/packages/dream/dream.1.0.0~alpha1/opam
@@ -68,7 +68,7 @@ depends: [
   "multipart-form-data" {>= "0.3.0"}
   "ocaml" {>= "4.08.0"}
   "opam-installer" {build}
-  "uri"
+  "uri" {>= "4.0.0"}
   "yojson"  # ...
 
   # Currently vendored.

--- a/packages/dream/dream.1.0.0~alpha1/opam
+++ b/packages/dream/dream.1.0.0~alpha1/opam
@@ -50,6 +50,7 @@ depends: [
   "base64" {>= "3.1.0"}  # Base64.encode_string.
   "bigarray-compat"
   "caqti-lwt"
+  "caqti" {>= "1.4.0"}
   "conf-libev"
   "cstruct"
   "dune" {>= "2.7.0"}  # --instrument-with.

--- a/packages/dream/dream.1.0.0~alpha1/opam
+++ b/packages/dream/dream.1.0.0~alpha1/opam
@@ -82,7 +82,7 @@ depends: [
 
   # Dependencies of vendored packages.
   "angstrom" {>= "0.14.0"}
-  "bigstringaf" {>= "0.4.0"}
+  "bigstringaf" {>= "0.5.0"}
   "digestif" {>= "0.7"}  # websocket/af, sha1.
   "faraday" {>= "0.6.1"}
   "faraday-lwt-unix"

--- a/packages/dream/dream.1.0.0~alpha1/opam
+++ b/packages/dream/dream.1.0.0~alpha1/opam
@@ -58,8 +58,9 @@ depends: [
   "graphql-lwt"
   "hmap"
   "lwt"
-  "lwt_ppx"
+  "lwt_ppx" {>= "1.2.2"}
   "lwt_ssl"
+  "ssl" {>= "0.5.8"}
   "logs" {>= "0.5.0"}
   "magic-mime"
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.

--- a/packages/dream/dream.1.0.0~alpha2/opam
+++ b/packages/dream/dream.1.0.0~alpha2/opam
@@ -60,8 +60,9 @@ depends: [
   "graphql-lwt"
   "hmap"
   "lwt"
-  "lwt_ppx"
+  "lwt_ppx" {>= "1.2.2"}
   "lwt_ssl"
+  "ssl" {>= "0.5.8"}
   "logs" {>= "0.5.0"}
   "magic-mime"
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.

--- a/packages/dream/dream.1.0.0~alpha2/opam
+++ b/packages/dream/dream.1.0.0~alpha2/opam
@@ -1,0 +1,119 @@
+opam-version: "2.0"
+
+synopsis: "Tidy, feature-complete Web framework"
+tags: ["http" "web" "framework" "websocket" "graphql" "server" "http2" "tls"]
+
+description: """
+Dream is a feature-complete Web framework with a simple programming
+model and no boilerplate. It provides only two data types, request and
+response.
+
+Almost everything else is either a built-in OCaml type, or an
+abbreviation for a bare function. For example, a Web app, known in
+Dream as a handler, is just an ordinary function from requests to
+responses. And a middleware is then just a function from handlers to
+handlers.
+
+Within this model, Dream adds:
+
+- Session management with pluggable back ends.
+- A fully composable router.
+- Support for HTTP/1.1, HTTP/2, and HTTPS.
+- WebSockets.
+- GraphQL, including subscriptions and a built-in GraphiQL editor.
+- SQL connection pool helpers.
+- Server-side HTML templates.
+- Automatic secure handling of cookies and forms.
+- Unified, internationalization-friendly error handling.
+- A neat log, and OCaml runtime configuration.
+- Helpers for Web formats, such as Base64url, and a modern cipher.
+
+Because of the simple programming model, everything is optional and
+composable. It is trivailly possible to strip Dream down to just a
+bare driver of the various HTTP protocols.
+
+Dream is presented as a single module, whose API is documented on one
+page. In addition, Dream comes with a large number of examples.
+Security topics are introduced throughout, wherever they are
+applicable."""
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "base-unix"
+  "base64" {>= "3.1.0"}  # Base64.encode_string.
+  "bigarray-compat"
+  "caqti" {>= "1.4.0"}  # ~post_connect.
+  "caqti-lwt"
+  "conf-libev" {os != "win32"}
+  "cstruct" {>= "6.0.0"}
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "fmt" {>= "0.8.7"}  # `Italic.
+  "graphql_parser"
+  "graphql-lwt"
+  "hmap"
+  "lwt"
+  "lwt_ppx"
+  "lwt_ssl"
+  "logs" {>= "0.5.0"}
+  "magic-mime"
+  "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
+  "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
+  "multipart_form" {>= "0.3.0"}
+  "ocaml" {>= "4.08.0"}
+  "uri" {>= "4.2.0"}
+  "yojson"  # ...
+
+  # Currently vendored.
+  # "gluten"
+  # "gluten-lwt-unix"
+  # "httpaf"
+  # "httpaf-lwt-unix"
+  # "h2"
+  # "h2-lwt-unix"
+  # "hpack"
+  # "websocketaf"
+
+  # Dependencies of vendored packages.
+  "angstrom" {>= "0.14.0"}
+  "bigstringaf" {>= "0.4.0"}
+  "digestif" {>= "0.7"}  # websocket/af, sha1.
+  "faraday" {>= "0.6.1"}
+  "faraday-lwt-unix"
+  "psq"  # h2.
+  "result"  # http/af, websocket/af.
+
+  # https://github.com/ocaml-ppx/ppxlib/issues/221.
+  # esy appears to ignore conflicts.
+  "ppxlib" {< "0.21.0" | > "0.22.0"}
+
+  # Testing, development.
+  "alcotest" {with-test}
+  # Commented out because of https://github.com/ocaml-ppx/ppxlib/issues/221.
+  # "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.
+  "caqti-driver-sqlite3" {with-test}
+  "crunch" {with-test}
+  "lambdasoup" {with-test}
+  "ppx_expect" {with-test}
+  "ppx_yojson_conv" {with-test}
+  "reason" {with-test}
+  "tyxml" {with-test & >= "4.5.0"}
+  "tyxml-jsx" {with-test & >= "4.5.0"}
+  "tyxml-ppx" {with-test & >= "4.5.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha2/dream-1.0.0-alpha2.tar.gz"
+  checksum: "md5=1220f17530522e488653eb91115867e3"
+}

--- a/packages/dream/dream.1.0.0~alpha2/opam
+++ b/packages/dream/dream.1.0.0~alpha2/opam
@@ -84,7 +84,7 @@ depends: [
 
   # Dependencies of vendored packages.
   "angstrom" {>= "0.14.0"}
-  "bigstringaf" {>= "0.4.0"}
+  "bigstringaf" {>= "0.5.0"}
   "digestif" {>= "0.7"}  # websocket/af, sha1.
   "faraday" {>= "0.6.1"}
   "faraday-lwt-unix"


### PR DESCRIPTION
- [Project page](https://github.com/aantron/dream)
- [API](https://aantron.github.io/dream)

[Changelog](https://github.com/aantron/dream/releases/tag/1.0.0-alpha2):

> Changes
>
> - Rename `Dream.from_target` to [`Dream.split_target`](https://aantron.github.io/dream/#val-split_target) (aantron/dream@a3c1508).
> - Rename `Dream.from_target_path` to [`Dream.from_path`](https://aantron.github.io/dream/#val-from_path) (aantron/dream@a3c1508).
> - [`Dream.redirect`](https://aantron.github.io/dream/#val-redirect) now needs a `request` as argument (aantron/dream@90bba6e).
> - Reorder arguments of [`Dream.write`](https://aantron.github.io/dream/#val-write), [`Dream.write_bigstring`](https://aantron.github.io/dream/#val-write_buffer), [`Dream.verify_csrf_token`](https://aantron.github.io/dream/#val-verify_csrf_token), [`Dream.send`](https://aantron.github.io/dream/#val-send), [`Dream.sql`](https://aantron.github.io/dream/#val-sql) (aantron/dream@c1ba95a).
> - Improve how dependencies are vendored (aantron/dream@343e912, suggested by Antonio Nuno Monteiro).
> - Rename `Dream.identity` to [`Dream.no_middleware`](https://aantron.github.io/dream/#val-no_middleware) (aantron/dream@42625d1).
> - Use library [`multipart_form`](https://github.com/dinosaure/multipart_form) instead of `multipart-form-data` (aantron/dream#45, Calascibetta Romain).
> - Rename `Dream.bigstring` to [`Dream.buffer`](https://aantron.github.io/dream/#type-buffer) (aantron/dream@1386bf3).
>
> Additions
>
> - Example [**`r-graphql`**](https://github.com/aantron/dream/tree/a0dcaf5b4729b24a37c89001bd23343e47190979/example/r-graphql#files) (aantron/dream#51, Tom Ekander).
> - Example [**`w-live-reload`**](https://github.com/aantron/dream/tree/a0dcaf5b4729b24a37c89001bd23343e47190979/example/w-live-reload#files) (aantron/dream#52, Thibaut Mattio).
> - Better error template (aantron/dream#53, Thibaut Mattio).
> - Multi-stage Docker deployment build and opam instructions (aantron/dream#57, Thibaut Mattio).
> - [`Dream.to_path`](https://aantron.github.io/dream/#val-to_path) (aantron/dream@a3c1508).
> - Expose [`Dream.from_filesystem`](https://aantron.github.io/dream/#val-from_filesystem) (aantron/dream#14).
> - [`Dream.mime_lookup`](https://aantron.github.io/dream/#val-mime_lookup) (aantron/dream#14).
> - [`Dream.no_route`](https://aantron.github.io/dream/#val-no_route) (aantron/dream@37a27c4).
> - [Playground](http://dream.as).
> - [Deployment instructions](https://github.com/aantron/dream/tree/a0dcaf5b4729b24a37c89001bd23343e47190979/example#deploying).
>
> Fixes
>
> - Work around paurkedal/ocaml-caqti#68 (aantron/dream@385fa45, reported by Konstantin Olkhovskiy).
> - Require Cstruct 6.0.0 (aantron/dream#60, reported by Edwin Török).
