### PR TITLE
Package bio_io.0.1.1

### DIFF
--- a/packages/bio_io/bio_io.0.1.1/opam
+++ b/packages/bio_io/bio_io.0.1.1/opam
@@ -9,9 +9,11 @@ doc: "https://mooreryan.github.io/bio_io/"
 bug-reports: "https://github.com/mooreryan/bio_io/issues"
 depends: [
   "dune" {>= "2.8"}
-  "bisect_ppx" {with-test}
-  "core_kernel"
-  "ocaml" {>= "4.08.0"}
+  "bisect_ppx" {dev}
+  "core_kernel" {>= "v0.12"}
+  "ppx_sexp_conv" {>= "v0.12"}
+  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0" & with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/bio_io/bio_io.0.1.1/opam
+++ b/packages/bio_io/bio_io.0.1.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "A library for reading and writing common file formats used in bioinformatics like FASTA files"
+maintainer: ["Ryan Moore"]
+authors: ["Ryan Moore"]
+license: "MIT"
+homepage: "https://github.com/mooreryan/bio_io"
+doc: "https://mooreryan.github.io/bio_io/"
+bug-reports: "https://github.com/mooreryan/bio_io/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "bisect_ppx" {with-test}
+  "core_kernel"
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mooreryan/bio_io.git"
+url {
+  src: "https://github.com/mooreryan/bio_io/archive/v0.1.1.tar.gz"
+  checksum: [
+    "md5=c23adc905dfb7eb2157a4418a20553f5"
+    "sha512=19de9e409154dbace9b428e71953b65f0060081c4fcd07d1ed7fff7e96c8c1274a09fdd8c6e96049da891748055689bb591d957ba3a4717da58e520f0d14d8bd"
+  ]
+}


### PR DESCRIPTION
### `bio_io.0.1.1`
A library for reading and writing common file formats used in bioinformatics like FASTA files



---
* Homepage: https://github.com/mooreryan/bio_io
* Source repo: git+https://github.com/mooreryan/bio_io.git
* Bug tracker: https://github.com/mooreryan/bio_io/issues

---
:camel: Pull-request generated by opam-publish v2.0.3