### PR TITLE
Package stog.0.19.0

### DIFF
--- a/packages/stog/stog.0.19.0/opam
+++ b/packages/stog/stog.0.19.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis:
+  "Stog is a static web site compiler, able to handle blog posts as well as regular pages or any XML document in general"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+tags: ["publication" "xml" "documentation" "blog" "web" "website"]
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind" {build}
+  "xtmpl" {>= "0.18.0"}
+  "ocf" {>= "0.6.0"}
+  "higlo" {>= "0.6"}
+  "ppx_blob" {>= "0.7.2"}
+  "ptime" {>= "0.8.2"}
+  "uri" {>= "4.2.0"}
+  "omd" {>= "1.9.9"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "uutf" {>= "1.0.0"}
+]
+depopts: [
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
+  "xmldiff"
+  "websocket"
+  "websocket-lwt-unix"
+  "ojs-base"
+  "cryptokit"
+]
+conflicts: [
+  "js_of_ocaml" {< "3.9.0"}
+  "js_of_ocaml-ppx" {< "3.9.0"}
+  "xmldiff" {< "0.6.0"}
+  "websocket" {< "2.14"}
+  "websocket-lwt-unix" {< "2.14"}
+  "ojs-base" {< "0.6.0"}
+]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.19.0/stog-0.19.0.tar.gz"
+  checksum: [
+    "md5=315d5b5c205ec234c69ff4ffab6ecc4a"
+    "sha512=23500f4cfc0c49411cf70adb4972279c3bff4c79947b6e7e256e6528a49d693d48b7ae5232ccf67b70817bafaaaeea038613665c1691306a02d9bb3e479dd15f"
+  ]
+}


### PR DESCRIPTION
### `stog.0.19.0`
Stog is a static web site compiler, able to handle blog posts as well as regular pages or any XML document in general



---
* Homepage: https://www.good-eris.net/stog/
* Source repo: git+https://framagit.org/zoggy/stog.git
* Bug tracker: https://framagit.org/zoggy/stog/issues

---
:camel: Pull-request generated by opam-publish v2.0.3