### PR TITLE
Add conf-capnproto.2.

### DIFF
--- a/packages/conf-capnproto/conf-capnproto.2/opam
+++ b/packages/conf-capnproto/conf-capnproto.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: [
+  "Sandstorm Development Group, Inc."
+  "Cloudflare, Inc."
+  "other contributors"
+]
+homepage: "https://capnproto.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/capnproto/capnproto.git"
+license: "MIT"
+build: [
+  ["capnp" "--version"]
+]
+depexts: [
+  ["capnproto-dev@edgecommunity"] {os-distribution = "alpine"}
+  ["capnproto"] {os-distribution = "arch"}
+  ["capnproto" "epel-release"] {os-distribution = "centos"}
+  ["capnproto" "libcapnp-dev"] {os-family = "debian"}
+  ["capnproto"] {os-distribution = "fedora"}
+  ["capnproto"] {os-distribution = "gentoo"}
+  ["capnp"] {os-distribution = "homebrew" & os = "macos"}
+  ["capnproto"] {os-distribution = "macports" & os = "macos"}
+  ["capnproto"] {os-family = "suse"}
+  ["capnproto"] {os = "freebsd"}
+]
+synopsis: "Virtual package relying on captnproto installation"
+flags: conf


### PR DESCRIPTION
This is the same as conf-capnproto.1, except the Alpine package has
moved from @testing to @edgecommunity.

This will require a line in /etc/apk/repositories like:
@edgecommunity https://dl-cdn.alpinelinux.org/alpine/edge/community

Note that we are preserving conf-capnproto.1 (even though it no longer
builds with the current Alpine package repos) so that users with an old
mirror can continue to use that.

Signed-off-by: Ewan Mellor <ewan@tarides.com>