### PR TITLE
[new release] bimage-unix, bimage, bimage-io, bimage-display and bimage-lwt (0.4.1)

### DIFF
--- a/packages/bimage-display/bimage-display.0.4.1/opam
+++ b/packages/bimage-display/bimage-display.0.4.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "glfw-ocaml"
+    "conf-glew"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Window system for Bimage
+"""
+
+description: """
+Allows for Bimage Images to be displayed using OpenGL
+"""
+x-commit-hash: "250422b7a6bc9023253af5315bd5f8f11162e742"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.4.1/bimage-v0.4.1.tbz"
+  checksum: [
+    "sha256=b7c49a31fb5bc6c47e8e0c5fceb1f61e88a03482ff44de2c4ff806ffbeb22766"
+    "sha512=d1a2376261303e952f4711b3e974c8930b0b87c618597e14e516b9a949fb5bf02ce38d0504c53526cad7f2d9270dfaed7cae78f1b5ef0b1149c7d6414a6eefa1"
+  ]
+}

--- a/packages/bimage-io/bimage-io.0.4.1/opam
+++ b/packages/bimage-io/bimage-io.0.4.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "conf-openimageio"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Input/output for Bimage using OpenImageIO
+"""
+
+description: """
+Input/output for Bimage using OpenImageIO
+"""
+x-commit-hash: "250422b7a6bc9023253af5315bd5f8f11162e742"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.4.1/bimage-v0.4.1.tbz"
+  checksum: [
+    "sha256=b7c49a31fb5bc6c47e8e0c5fceb1f61e88a03482ff44de2c4ff806ffbeb22766"
+    "sha512=d1a2376261303e952f4711b3e974c8930b0b87c618597e14e516b9a949fb5bf02ce38d0504c53526cad7f2d9270dfaed7cae78f1b5ef0b1149c7d6414a6eefa1"
+  ]
+}

--- a/packages/bimage-lwt/bimage-lwt.0.4.1/opam
+++ b/packages/bimage-lwt/bimage-lwt.0.4.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "lwt"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library (LWT bindings)
+"""
+
+description: """
+LWT bindings for Bimage, an image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+x-commit-hash: "250422b7a6bc9023253af5315bd5f8f11162e742"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.4.1/bimage-v0.4.1.tbz"
+  checksum: [
+    "sha256=b7c49a31fb5bc6c47e8e0c5fceb1f61e88a03482ff44de2c4ff806ffbeb22766"
+    "sha512=d1a2376261303e952f4711b3e974c8930b0b87c618597e14e516b9a949fb5bf02ce38d0504c53526cad7f2d9270dfaed7cae78f1b5ef0b1149c7d6414a6eefa1"
+  ]
+}

--- a/packages/bimage-unix/bimage-unix.0.4.1/opam
+++ b/packages/bimage-unix/bimage-unix.0.4.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "ctypes" {>= "0.14"}
+    "ctypes-foreign" {>= "0.4"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/stb_image
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+x-commit-hash: "250422b7a6bc9023253af5315bd5f8f11162e742"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.4.1/bimage-v0.4.1.tbz"
+  checksum: [
+    "sha256=b7c49a31fb5bc6c47e8e0c5fceb1f61e88a03482ff44de2c4ff806ffbeb22766"
+    "sha512=d1a2376261303e952f4711b3e974c8930b0b87c618597e14e516b9a949fb5bf02ce38d0504c53526cad7f2d9270dfaed7cae78f1b5ef0b1149c7d6414a6eefa1"
+  ]
+}

--- a/packages/bimage/bimage.0.4.1/opam
+++ b/packages/bimage/bimage.0.4.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+x-commit-hash: "250422b7a6bc9023253af5315bd5f8f11162e742"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.4.1/bimage-v0.4.1.tbz"
+  checksum: [
+    "sha256=b7c49a31fb5bc6c47e8e0c5fceb1f61e88a03482ff44de2c4ff806ffbeb22766"
+    "sha512=d1a2376261303e952f4711b3e974c8930b0b87c618597e14e516b9a949fb5bf02ce38d0504c53526cad7f2d9270dfaed7cae78f1b5ef0b1149c7d6414a6eefa1"
+  ]
+}


### PR DESCRIPTION
Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/stb_image

- Project page: <a href="https://github.com/zshipko/ocaml-bimage">https://github.com/zshipko/ocaml-bimage</a>
- Documentation: <a href="https://zshipko.github.io/ocaml-bimage/doc">https://zshipko.github.io/ocaml-bimage/doc</a>

##### CHANGES:

- Added `Window.window`
- Fix type in `Bimage_display`
