### PR TITLE
[new release] bimage-unix, bimage, bimage-io, bimage-display and bimage-lwt (0.4.0)

### DIFF
--- a/packages/bimage-display/bimage-display.0.4.0/opam
+++ b/packages/bimage-display/bimage-display.0.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "glfw-ocaml"
+    "conf-glew"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Window system for Bimage
+"""
+
+description: """
+Allows for Bimage Images to be displayed using OpenGL
+"""
+x-commit-hash: "5ba10c5fc34630e5b0e55ad4db3faca313e7ef3f"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.4.0/bimage-v0.4.0.tbz"
+  checksum: [
+    "sha256=726857dcd495a35ec7be2e0fdc25473b3e39ba5f211142b4a5bc3b66ee9221ef"
+    "sha512=91a48e63499303ca08ed01d745fd40639e8aaaecc1e72deb11f3c29120dc36fab8b0e1f5329bf971df8bf5e1fd35e3a983d9cccb9513615e5f916cc315792947"
+  ]
+}

--- a/packages/bimage-io/bimage-io.0.4.0/opam
+++ b/packages/bimage-io/bimage-io.0.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "conf-openimageio"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Input/output for Bimage using OpenImageIO
+"""
+
+description: """
+Input/output for Bimage using OpenImageIO
+"""
+x-commit-hash: "5ba10c5fc34630e5b0e55ad4db3faca313e7ef3f"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.4.0/bimage-v0.4.0.tbz"
+  checksum: [
+    "sha256=726857dcd495a35ec7be2e0fdc25473b3e39ba5f211142b4a5bc3b66ee9221ef"
+    "sha512=91a48e63499303ca08ed01d745fd40639e8aaaecc1e72deb11f3c29120dc36fab8b0e1f5329bf971df8bf5e1fd35e3a983d9cccb9513615e5f916cc315792947"
+  ]
+}

--- a/packages/bimage-lwt/bimage-lwt.0.4.0/opam
+++ b/packages/bimage-lwt/bimage-lwt.0.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "lwt"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library (LWT bindings)
+"""
+
+description: """
+LWT bindings for Bimage, an image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+x-commit-hash: "5ba10c5fc34630e5b0e55ad4db3faca313e7ef3f"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.4.0/bimage-v0.4.0.tbz"
+  checksum: [
+    "sha256=726857dcd495a35ec7be2e0fdc25473b3e39ba5f211142b4a5bc3b66ee9221ef"
+    "sha512=91a48e63499303ca08ed01d745fd40639e8aaaecc1e72deb11f3c29120dc36fab8b0e1f5329bf971df8bf5e1fd35e3a983d9cccb9513615e5f916cc315792947"
+  ]
+}

--- a/packages/bimage-unix/bimage-unix.0.4.0/opam
+++ b/packages/bimage-unix/bimage-unix.0.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "ctypes" {>= "0.14"}
+    "ctypes-foreign" {>= "0.4"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/stb_image
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+x-commit-hash: "5ba10c5fc34630e5b0e55ad4db3faca313e7ef3f"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.4.0/bimage-v0.4.0.tbz"
+  checksum: [
+    "sha256=726857dcd495a35ec7be2e0fdc25473b3e39ba5f211142b4a5bc3b66ee9221ef"
+    "sha512=91a48e63499303ca08ed01d745fd40639e8aaaecc1e72deb11f3c29120dc36fab8b0e1f5329bf971df8bf5e1fd35e3a983d9cccb9513615e5f916cc315792947"
+  ]
+}

--- a/packages/bimage/bimage.0.4.0/opam
+++ b/packages/bimage/bimage.0.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+x-commit-hash: "5ba10c5fc34630e5b0e55ad4db3faca313e7ef3f"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.4.0/bimage-v0.4.0.tbz"
+  checksum: [
+    "sha256=726857dcd495a35ec7be2e0fdc25473b3e39ba5f211142b4a5bc3b66ee9221ef"
+    "sha512=91a48e63499303ca08ed01d745fd40639e8aaaecc1e72deb11f3c29120dc36fab8b0e1f5329bf971df8bf5e1fd35e3a983d9cccb9513615e5f916cc315792947"
+  ]
+}

--- a/packages/conf-glfw3/conf-glfw3.2/opam
+++ b/packages/conf-glfw3/conf-glfw3.2/opam
@@ -21,7 +21,7 @@ depexts: [
   ["libglfw-devel" "mesagl-devel"] {os-distribution = "mageia"}
   ["libglfw-devel" "Mesa-libGL-devel"] {os-family = "suse"}
   ["glfw-dev"] {os-family = "alpine"}
-  ["glfw"] {os-family = "arch"}
+  ["glfw-x11"] {os-family = "arch"}
   ["glfw"] {os = "macos" & os-distribution = "homebrew"}
 ]
 x-ci-accept-failures: [

--- a/packages/conf-openimageio/conf-openimageio.1/opam
+++ b/packages/conf-openimageio/conf-openimageio.1/opam
@@ -17,6 +17,7 @@ depexts: [
   ["OpenImageIO-devel"] {os-distribution = "fedora"}
   ["OpenImageIO-devel" "epel-release"] {os-distribution = "centos"}
   ["OpenImageIO-devel"] {os-family = "suse"}
+  ["openimageio-dev@testing" "boost1.76-filesystem@edge" "boost1.76-thread@edge"] {os-family = "alpine"}
   ["openimageio"] {os-family = "arch"}
   ["openimageio"] {os = "macos" & os-distribution = "homebrew"}
   ["openimageio"] {os = "macos" & os-distribution = "macports"}
@@ -25,7 +26,6 @@ depexts: [
   ["openimageio"] {os = "netbsd"}
 ]
 x-ci-accept-failures: [
-  "alpine-3.12" # openimageio-dev@testing has missing dependencies (unable to install)
   "centos-7" # too old
   "opensuse-15.2" # too old
   "ubuntu-16.04" # too old


### PR DESCRIPTION
Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/stb_image

- Project page: <a href="https://github.com/zshipko/ocaml-bimage">https://github.com/zshipko/ocaml-bimage</a>
- Documentation: <a href="https://zshipko.github.io/ocaml-bimage/doc">https://zshipko.github.io/ocaml-bimage/doc</a>

##### CHANGES:

- Added `let*` and `let+` operators
- Added `Window.window`
- Fix type in `Bimage_display`

Sorry about the duplicate, I had accidentally set up 0.4.1 for release without releasing v0.4.0 first.
