### PR TITLE
Package goblint-cil.1.8.0

### DIFF
--- a/packages/goblint-cil/goblint-cil.1.8.0/opam
+++ b/packages/goblint-cil/goblint-cil.1.8.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis:
+  "A front-end for the C programming language that facilitates program analysis and transformation"
+description: """
+This is a fork of the 'cil' package needed to build 'goblint'.
+Changes:
+- Proper support for C99, (#9) and VLAs in particular (#5, #7)
+- It uses Zarith instead of the deprecated Num
+- Support for more recent OCaml versions (≥ 4.06)
+- Large integer constants that do not fit in an OCaml int are represented as a string instead of getting truncated
+- Syntactic search extension (#21)
+- Some warnings were made optional
+- Unmaintained extensions (#30) were removed
+- Many bug fixes"""
+maintainer: [
+  "Michael Schwarz <michael.schwarz93@gmail.com>"
+  "Ralf Vogler <ralf.vogler@gmail.com>"
+]
+authors: ["gabriel@kerneis.info"]
+license: "BSD-3-Clause"
+homepage: "https://cil-project.github.io/cil/"
+bug-reports: "https://github.com/goblint/cil/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "ocamlfind"
+  "zarith"
+  "hevea" {with-doc}
+  "dune" {>= "2.7"}
+  "odoc" {with-doc}
+  "stdlib-shims"
+  "ppx_deriving_yojson" {>= "3.2"}
+  "yojson"
+  "batteries" {>= "3.2.0"}
+  "conf-perl"
+]
+conflicts: ["cil"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/goblint/cil.git"
+depexts: [
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
+  ["perl-FindBin"] {os-distribution = "fedora"}
+  ["build-base"] {os-distribution = "alpine"}
+]
+available: arch != "ppc32" & arch != "ppc64"
+url {
+  src: "https://github.com/goblint/cil/archive/1.8.0.tar.gz"
+  checksum: [
+    "md5=796ad26120b5c6b939a57e8623088aef"
+    "sha512=01a58ac6d928afead21c8a97af5865715114cd0562234d1d4aef9e4ac5d91415d040a15927c52cb896dbb39a53e915627f498ebe2d026a548c3ff597682041b2"
+  ]
+}


### PR DESCRIPTION
### `goblint-cil.1.8.0`
A front-end for the C programming language that facilitates program analysis and transformation
This is a fork of the 'cil' package needed to build 'goblint'.
Changes:
- Proper support for C99, (#9) and VLAs in particular (#5, #7)
- It uses Zarith instead of the deprecated Num
- Support for more recent OCaml versions (≥ 4.06)
- Large integer constants that do not fit in an OCaml int are represented as a string instead of getting truncated
- Syntactic search extension (#21)
- Some warnings were made optional
- Unmaintained extensions (#30) were removed
- Many bug fixes



---
* Homepage: https://cil-project.github.io/cil/
* Source repo: git+https://github.com/goblint/cil.git
* Bug tracker: https://github.com/goblint/cil/issues

---
:camel: Pull-request generated by opam-publish v2.0.3