### PR TITLE
Package stog-writing.0.19.0

### DIFF
--- a/packages/stog-writing/stog-writing.0.19.0/opam
+++ b/packages/stog-writing/stog-writing.0.19.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis:
+  "Stog plugin adding new rewrite rules to use footnotes and bibliographies in documents"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+tags: ["publication" "web" "blog" "bibliography"]
+homepage: "https://www.good-eris.net/stog/plugins/writing.html"
+doc: "https://www.good-eris.net/stog/plugins/writing.html"
+bug-reports: "https://framagit.org/zoggy/stog-writing/-/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "stog" {>= "0.19.0"}
+  "menhir" {>= "20120123"}
+]
+build: [make "all"]
+install: [make "install"]
+dev-repo: "git+https://framagit.org/zoggy/stog-writing.git"
+url {
+  src:
+    "https://framagit.org/zoggy/stog-writing/-/archive/0.19.0/stog-writing-0.19.0.tar.bz2"
+  checksum: [
+    "md5=fc35d719c79b4da00b70e55513271dea"
+    "sha512=815fb26e7c05d83fa2050ef81153d49f7d18984ea30bf2e78b49ff11828933903cc4bd6e51695c25d30088d8ee245094b0ecb3e5e2418635ef2aaf4df4d6a104"
+  ]
+}


### PR DESCRIPTION
### `stog-writing.0.19.0`
Stog plugin adding new rewrite rules to use footnotes and bibliographies in documents



---
* Homepage: https://www.good-eris.net/stog/plugins/writing.html
* Source repo: git+https://framagit.org/zoggy/stog-writing.git
* Bug tracker: https://framagit.org/zoggy/stog-writing/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3