### PR TITLE
Update conf-capnproto for Alpine changes

### DIFF
--- a/packages/conf-capnproto/conf-capnproto.1/opam
+++ b/packages/conf-capnproto/conf-capnproto.1/opam
@@ -13,7 +13,7 @@ build: [
   ["capnp" "--version"]
 ]
 depexts: [
-  ["capnproto-dev@testing"] {os-distribution = "alpine"}
+  ["capnproto-dev@edgecommunity"] {os-distribution = "alpine"}
   ["capnproto"] {os-distribution = "arch"}
   ["capnproto" "epel-release"] {os-distribution = "centos"}
   ["capnproto" "libcapnp-dev"] {os-family = "debian"}


### PR DESCRIPTION
Alpine has moved the capnproto package from `testing` to `community`.
Attempting to install it now fails with:

    $ docker run --rm -it ocaml/opam:alpine-3.13-ocaml-4.12
    bash-5.1$ opam depext conf-capnproto
    capnproto-dev@testing
    The following command needs to be run through "sudo":
        apk add capnproto-dev@testing
    ERROR: unable to select packages:
      capnproto-0.8.0-r1:
        masked in: @edgecommunity