### PR TITLE
Package ocamldot.1.1

### DIFF
--- a/packages/ocamldot/ocamldot.1.1/opam
+++ b/packages/ocamldot/ocamldot.1.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Parsing and printing graphviz files in OCaml"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocamldot/"
+doc: "https://zoggy.frama.io/ocamldot/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ocamldot/-/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind" {build}
+]
+depopts: ["lablgtk3"]
+conflicts: [
+  "lablgtk3" {< "3.1.1"}
+]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://framagit.org/zoggy/ocamldot.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocamldot/-/archive/1.1/ocamldot-1.1.tar.bz2"
+  checksum: [
+    "md5=c636d8e00fe1e364e825ee2d14ad1519"
+    "sha512=3722a9c520fcfdb477165219df956142a3e5b6a499fc94fc3df12af84b1220a8bd11c1e3450dc096a6e77777cb880bc169f8195f1230a83d5777a29045eed1b0"
+  ]
+}


### PR DESCRIPTION
### `ocamldot.1.1`
Parsing and printing graphviz files in OCaml



---
* Homepage: https://zoggy.frama.io/ocamldot/
* Source repo: git+https://framagit.org/zoggy/ocamldot.git
* Bug tracker: https://framagit.org/zoggy/ocamldot/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3