### PR TITLE
Package ojs-base.0.6.0

### DIFF
--- a/packages/ojs-base/ojs-base.0.6.0/opam
+++ b/packages/ojs-base/ojs-base.0.6.0/opam
@@ -33,7 +33,7 @@ url {
   src:
     "https://framagit.org/zoggy/ojs-base/-/archive/0.6.0/ojs-base-0.6.0.tar.bz2"
   checksum: [
-    "md5=7b857862bd0b2774acc4f6ecd4cbdc1e"
-    "sha512=43fe04eb478a28ac7186cb029f1b6c5e15a8a29e36ec5f850a0e467cb3672227fdc92c77b7ab478da5883a7ef352e9ba3de40d8ab6101a94c5422d36e32cd8fe"
+    "md5=87a5b66896adda7807aa936625a61410"
+    "sha512=029177f3ad8afab63b162eeab969ba1cbf8db76022f05e977ac1aa0a77dfd3d3a315622f8bdaa44e2d9b31211ad0519df77cdf496bafe21a55134cad2e056c28"
   ]
 }

--- a/packages/ojs-base/ojs-base.0.6.0/opam
+++ b/packages/ojs-base/ojs-base.0.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Base library for developing OCaml web apps based on websockets and js_of_ocaml"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+tags: ["javascript" "web" "components"]
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/-/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind" {build}
+  "js_of_ocaml" {>= "3.9.0"}
+  "websocket" {>= "2.14"}
+  "websocket-lwt-unix" {>= "2.14"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "cohttp" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "xtmpl" {>= "0.18.0"}
+  "magic-mime" {>= "1.0"}
+  "base64" {>= "3.5.0"}
+]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ojs-base/-/archive/0.6.0/ojs-base-0.6.0.tar.bz2"
+  checksum: [
+    "md5=7b857862bd0b2774acc4f6ecd4cbdc1e"
+    "sha512=43fe04eb478a28ac7186cb029f1b6c5e15a8a29e36ec5f850a0e467cb3672227fdc92c77b7ab478da5883a7ef352e9ba3de40d8ab6101a94c5422d36e32cd8fe"
+  ]
+}


### PR DESCRIPTION
### `ojs-base.0.6.0`
Base library for developing OCaml web apps based on websockets and js_of_ocaml



---
* Homepage: http://zoggy.frama.io/ojs-base/
* Source repo: git+https://framagit.org/zoggy/ojs-base.git
* Bug tracker: https://framagit.org/zoggy/ojs-base/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3