### PR TITLE
[new release] ocaml-lsp-server, lsp and jsonrpc (1.6.1)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.6.1/opam
+++ b/packages/jsonrpc/jsonrpc.1.6.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "e97fa4c6862732926190cf2dd0965ae2705f365d"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.6.1/jsonrpc-1.6.1.tbz"
+  checksum: [
+    "sha256=bccc0d7194714a4c40c362766ad9095d3c58505a1d4f1dc4becd9b3d1bda8209"
+    "sha512=199bee8c74aec6822bc83bf9a7c3757206bdaa55a19cd1f5cf480127618a078baa1e917f6a90a6135a5277e4eb87977e685c10e6503f546997e6b985949e190f"
+  ]
+}

--- a/packages/lsp/lsp.1.6.1/opam
+++ b/packages/lsp/lsp.1.6.1/opam
@@ -24,7 +24,7 @@ depends: [
   "yojson"
   "ppx_yojson_conv_lib"
   "pp"
-  "csexp"
+  "csexp" {>= "1.4.0"}
   "uutf"
   "odoc" {with-doc}
   "menhir" {with-test}

--- a/packages/lsp/lsp.1.6.1/opam
+++ b/packages/lsp/lsp.1.6.1/opam
@@ -30,7 +30,7 @@ depends: [
   "menhir" {with-test}
   "cinaps" {with-test}
   "ppx_expect" {with-test & >= "v0.14.0"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.12"}
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [

--- a/packages/lsp/lsp.1.6.1/opam
+++ b/packages/lsp/lsp.1.6.1/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.7"}
   "jsonrpc" {= version}
   "yojson"
-  "ppx_yojson_conv_lib"
+  "ppx_yojson_conv_lib" {>= "v0.14.0"}
   "pp"
   "csexp" {>= "1.4.0"}
   "uutf"

--- a/packages/lsp/lsp.1.6.1/opam
+++ b/packages/lsp/lsp.1.6.1/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib"
+  "pp"
+  "csexp"
+  "uutf"
+  "odoc" {with-doc}
+  "menhir" {with-test}
+  "cinaps" {with-test}
+  "ppx_expect" {with-test & >= "v0.14.0"}
+  "ocaml" {>= "4.08"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+x-commit-hash: "e97fa4c6862732926190cf2dd0965ae2705f365d"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.6.1/jsonrpc-1.6.1.tbz"
+  checksum: [
+    "sha256=bccc0d7194714a4c40c362766ad9095d3c58505a1d4f1dc4becd9b3d1bda8209"
+    "sha512=199bee8c74aec6822bc83bf9a7c3757206bdaa55a19cd1f5cf480127618a078baa1e917f6a90a6135a5277e4eb87977e685c10e6503f546997e6b985949e190f"
+  ]
+}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.6.1/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.6.1/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_yojson_conv_lib" {>= "v0.14.0"}
   "dune-build-info"
   "dot-merlin-reader"
-  "pp"
+  "pp" {>= "1.1.2"}
   "csexp" {>= "1.4.0"}
   "result" {>= "1.5"}
   "ocamlformat" {with-test}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.6.1/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.6.1/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
   "dune" {>= "2.7"}
   "yojson"
-  "ppx_yojson_conv_lib"
+  "ppx_yojson_conv_lib" {>= "v0.14.0"}
   "dune-build-info"
   "dot-merlin-reader"
   "pp"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.6.1/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.6.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "yojson"
+  "ppx_yojson_conv_lib"
+  "dune-build-info"
+  "dot-merlin-reader"
+  "pp"
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "ocamlformat" {with-test}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12" & < "4.13"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "ocaml-lsp-server.install"
+    "--release"
+  ]
+]
+x-commit-hash: "e97fa4c6862732926190cf2dd0965ae2705f365d"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.6.1/jsonrpc-1.6.1.tbz"
+  checksum: [
+    "sha256=bccc0d7194714a4c40c362766ad9095d3c58505a1d4f1dc4becd9b3d1bda8209"
+    "sha512=199bee8c74aec6822bc83bf9a7c3757206bdaa55a19cd1f5cf480127618a078baa1e917f6a90a6135a5277e4eb87977e685c10e6503f546997e6b985949e190f"
+  ]
+}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.6.1/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.6.1/opam
@@ -21,7 +21,7 @@ depends: [
   "dune-build-info"
   "dot-merlin-reader"
   "pp"
-  "csexp" {>= "1.2.3"}
+  "csexp" {>= "1.4.0"}
   "result" {>= "1.5"}
   "ocamlformat" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
LSP Server for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Fixes

- Switch `verbosity` from 1 to 0. This is the same default that merlin uses.
  The old value for verbosity (ocaml/ocaml-lsp#433)

- Get fresh diagnostics (warning and error messages) on a file save (ocaml/ocaml-lsp#438)

  Note: If you want the fresh diagnostics to take into account changes in other
  files, you likely need to rebuild your project. An easy way to get automatic
  rebuilds is to run `dune` in a watching mode, e.g.,[dune build --watch].
