### PR TITLE
conf-capnproto: switch to edgecommunity on alpine

### DIFF
--- a/packages/conf-capnproto/conf-capnproto.1/opam
+++ b/packages/conf-capnproto/conf-capnproto.1/opam
@@ -13,7 +13,7 @@ build: [
   ["capnp" "--version"]
 ]
 depexts: [
-  ["capnproto-dev@testing"] {os-distribution = "alpine"}
+  ["capnproto-dev@edgecommunity"] {os-distribution = "alpine"}
   ["capnproto"] {os-distribution = "arch"}
   ["capnproto" "epel-release"] {os-distribution = "centos"}
   ["capnproto" "libcapnp-dev"] {os-family = "debian"}


### PR DESCRIPTION
Since https://github.com/ocurrent/docker-base-images/pull/109
and https://github.com/avsm/ocaml-dockerfile/pull/48, we can
use the edgecommunity repository, which is where the depext for
capnproto now lives