### PR TITLE
Package httph.0.1

### DIFF
--- a/packages/httph/httph.0.1/opam
+++ b/packages/httph/httph.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Minimal OCaml to the httpserver.h http server toolkit"
+description: """
+A very simple OCaml http toolkit intended to be a very straightforward set of bindings to the underlying
+httpserver.h C library.
+"""
+maintainer: "Travis Brady <travis.brady@gmail.com>"
+authors: "Travis Brady <travis.brady@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/travisbrady/ocaml-httph"
+bug-reports: "https://github.com/travisbrady/ocaml-httph/issues"
+dev-repo: "git://git@github.com:travisbrady/ocaml-httph.git"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.12.0"}
+  "yojson" {>= "1.7.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install"]
+]
+url {
+  src: "https://github.com/travisbrady/ocaml-httph/archive/0.1.4.tar.gz"
+  checksum: [
+    "md5=7ef4bb45af5fde6600cbeece8da87805"
+    "sha512=0a7dbcbe5a34bbbd3f1a542357f64a1f1aa852dfd4becf798a10474d6126e31179a0d1be5f118768e764ec177f5e5a82f3f4a442dad38c3fffe72d5e866cbcc0"
+  ]
+}


### PR DESCRIPTION
### `httph.0.1`
Minimal OCaml to the httpserver.h http server toolkit
A very simple OCaml http toolkit intended to be a very straightforward set of bindings to the underlying
httpserver.h C library.



---
* Homepage: https://github.com/travisbrady/ocaml-httph
* Source repo: git+ssh://git@github.com/travisbrady/ocaml-httph.git
* Bug tracker: https://github.com/travisbrady/ocaml-httph/issues

---
:camel: Pull-request generated by opam-publish v2.0.3