### PR TITLE
[new release] lwt-dllist (1.0.1)

### DIFF
--- a/packages/lwt-dllist/lwt-dllist.1.0.1/opam
+++ b/packages/lwt-dllist/lwt-dllist.1.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: [ "Anil Madhavapeddy <anil@recoil.org>" ]
+authors: ["Jérôme Vouillon" "Jérémie Dimino"]
+license: "MIT"
+homepage: "https://github.com/mirage/lwt-dllist"
+doc: "https://mirage.github.io/lwt-dllist/"
+bug-reports: "https://github.com/mirage/lwt-dllist/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "lwt" {with-test}
+  "dune"
+]
+build: [
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/lwt-dllist.git"
+synopsis: "Mutable doubly-linked list with Lwt iterators"
+description: """
+A sequence is an object holding a list of elements which support
+the following operations:
+
+- adding an element to the left or the right in time and space O(1)
+- taking an element from the left or the right in time and space O(1)
+- removing a previously added element from a sequence in time and space O(1)
+- removing an element while the sequence is being transversed.
+"""
+x-commit-hash: "66a569e31cdb65e9eaab4e684e5d549ea4bc7517"
+url {
+  src:
+    "https://github.com/mirage/lwt-dllist/releases/download/v1.0.1/lwt-dllist-v1.0.1.tbz"
+  checksum: [
+    "sha256=e86ce75e40f00d51514cf8b2e71e5184c4cb5dae96136be24613406cfc0dba6e"
+    "sha512=1df7e8e12e01a5d32e1db746f922e05f23a67c0d20e72a5b9126fead1e04decdb062081574b1c410c822305ef4eac990b7dd69f36673db8f50b9db2152abad80"
+  ]
+}


### PR DESCRIPTION
Mutable doubly-linked list with Lwt iterators

- Project page: <a href="https://github.com/mirage/lwt-dllist">https://github.com/mirage/lwt-dllist</a>
- Documentation: <a href="https://mirage.github.io/lwt-dllist/">https://mirage.github.io/lwt-dllist/</a>

##### CHANGES:

- Remove `lwt` dependency; it's only really needed for the tests (@aantron mirage/lwt-dllist#1).
- Fix deprecation warnings with OCaml 4.08 (@aantron mirage/lwt-dllist#1).
- Add support for OCaml 4.02 (@aantron mirage/lwt-dllist#1).
