### PR TITLE
Package batsat.0.6

### DIFF
--- a/packages/batsat/batsat.0.6/opam
+++ b/packages/batsat/batsat.0.6/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for batsat, a SAT solver in rust"
+maintainer: "simon.cruanes.2007@m4x.org"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+# TODO: add dependency on cargo?
+depends: [
+  "ocaml" { >= "4.06.0" }
+  "dune" {>= "1.3.0" }
+  "odoc" {with-doc}
+  "conf-rust-2018" {build}
+]
+tags: [ "minisat" "solver" "SAT" ]
+homepage: "https://github.com/c-cube/batsat-ocaml/"
+dev-repo: "git+https://github.com/c-cube/batsat-ocaml.git"
+bug-reports: "https://github.com/c-cube/batsat-ocaml/issues"
+authors: "simon.cruanes.2007@m4x.org"
+url {
+  src: "https://github.com/c-cube/batsat-ocaml/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=4f0c3d560103914306496f51edf263a2"
+    "sha512=a184d4649b5a8a72495413a483c7bd8509da42f11b099f22ebc76da58f523e7bb4903679a5a0c3686633d9fe57a6801d923e88c68de6e4f316ab2cb2626a9cc6"
+  ]
+}

--- a/packages/batsat/batsat.0.6/opam
+++ b/packages/batsat/batsat.0.6/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 synopsis: "OCaml bindings for batsat, a SAT solver in rust"
 maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
@@ -8,8 +9,8 @@ build: [
 ]
 # TODO: add dependency on cargo?
 depends: [
-  "ocaml" { >= "4.06.0" }
-  "dune" {>= "1.3.0" }
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.3.0"}
   "odoc" {with-doc}
   "conf-rust-2018" {build}
 ]


### PR DESCRIPTION
### `batsat.0.6`
OCaml bindings for batsat, a SAT solver in rust



---
* Homepage: https://github.com/c-cube/batsat-ocaml/
* Source repo: git+https://github.com/c-cube/batsat-ocaml.git
* Bug tracker: https://github.com/c-cube/batsat-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.0