### PR TITLE
[new release] bitwuzla and bitwuzla-bin (0.0.0)

### DIFF
--- a/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
+++ b/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
@@ -19,9 +19,6 @@ depends: [
   "conf-g++" {build}
   "conf-gmp" {build}
 ]
-depexts: [
-  ["libstdc++-static" "libc-static" "gcc-static"] {os-family = "fedora"}
-]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -44,4 +41,4 @@ url {
     "sha512=a94a466ef8b299c18cde51dd82e1be61f357de0e5efe617320ee7a888aeb8f7cd53d278f1e70e80b24c43003afe9595b8ad97c91c07a866616003e39642b35e8"
   ]
 }
-available: [ os-family = "debian" | os-family = "alpine" | os-family = "fedora" ]
+available: [ os-family = "debian" | os-family = "alpine" ]

--- a/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
+++ b/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Bitwuzla SMT solver executable"
+description: """
+
+Standalone installer for the SMT solver Bitwuzla.
+
+Bitwuzla is a Satisfiability Modulo Theories (SMT) solver for the theories of fixed-size bit-vectors, arrays and uninterpreted functions and their combinations. Its name is derived from an Austrian dialect expression that can be translated as “someone who tinkers with bits”."""
+maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]
+authors: ["Frédéric Recoules"]
+license: "MIT"
+tags: ["SMT solver" "SMT-COMP 2020" "QF_AUFBVFP"]
+homepage: "https://bitwuzla.github.io"
+bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "conf-git" {build}
+  "conf-cmake" {build}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "conf-gmp" {build}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
+x-commit-hash: "e1f77a4a4b12c9a8b624c6d9f11b0409f9b092fa"
+url {
+  src:
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/0.0.0/bitwuzla-bin-0.0.0.tbz"
+  checksum: [
+    "sha256=d4226ee5d1972caae12ea7bfde7ffd20a04fa81abb7a85a7432fb71be34b6207"
+    "sha512=a94a466ef8b299c18cde51dd82e1be61f357de0e5efe617320ee7a888aeb8f7cd53d278f1e70e80b24c43003afe9595b8ad97c91c07a866616003e39642b35e8"
+  ]
+}

--- a/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
+++ b/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
@@ -19,6 +19,9 @@ depends: [
   "conf-g++" {build}
   "conf-gmp" {build}
 ]
+depexts: [
+  ["libstdc++-static" "libc-static" "gcc-static"] {os = "fedora"}
+]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -41,4 +44,4 @@ url {
     "sha512=a94a466ef8b299c18cde51dd82e1be61f357de0e5efe617320ee7a888aeb8f7cd53d278f1e70e80b24c43003afe9595b8ad97c91c07a866616003e39642b35e8"
   ]
 }
-available: [ os-family = "debian" | os-distribution = "alpine" ]
+available: [ os-family = "debian" | os-family = "alpine" | os-family = "fedora" ]

--- a/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
+++ b/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "conf-gmp" {build}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -29,8 +29,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
-    "@doc" {with-doc}
   ]
 ]
 dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
@@ -43,3 +41,4 @@ url {
     "sha512=a94a466ef8b299c18cde51dd82e1be61f357de0e5efe617320ee7a888aeb8f7cd53d278f1e70e80b24c43003afe9595b8ad97c91c07a866616003e39642b35e8"
   ]
 }
+available: [ os-family = "debian" | os-distribution = "alpine" ]

--- a/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
+++ b/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "conf-gmp" {build}
 ]
 depexts: [
-  ["libstdc++-static" "libc-static" "gcc-static"] {os = "fedora"}
+  ["libstdc++-static" "libc-static" "gcc-static"] {os-family = "fedora"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/bitwuzla/bitwuzla.0.0.0/opam
+++ b/packages/bitwuzla/bitwuzla.0.0.0/opam
@@ -21,10 +21,11 @@ depends: [
   "conf-g++" {build}
   "conf-gmp"
   "ppx_expect" {with-test}
+  "odoc" {with-doc}
 ]
 depopts: ["zarith"]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -47,3 +48,4 @@ url {
     "sha512=a94a466ef8b299c18cde51dd82e1be61f357de0e5efe617320ee7a888aeb8f7cd53d278f1e70e80b24c43003afe9595b8ad97c91c07a866616003e39642b35e8"
   ]
 }
+available: [ os-family = "debian" | os-distribution = "alpine" ]

--- a/packages/bitwuzla/bitwuzla.0.0.0/opam
+++ b/packages/bitwuzla/bitwuzla.0.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "SMT solver for QF_AUFBVFP"
+description: """
+
+OCaml binding for the SMT solver Bitwuzla.
+
+Bitwuzla is a Satisfiability Modulo Theories (SMT) solver for the theories of fixed-size bit-vectors, arrays and uninterpreted functions and their combinations. Its name is derived from an Austrian dialect expression that can be translated as “someone who tinkers with bits”."""
+maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]
+authors: ["Frédéric Recoules"]
+license: "MIT"
+tags: ["SMT solver" "SMT-COMP 2020" "QF_AUFBVFP"]
+homepage: "https://bitwuzla.github.io"
+doc: "https://bitwuzla.github.io/docs/ocaml/"
+bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "ocaml" {>= "4.08"}
+  "conf-git" {build}
+  "conf-cmake" {build}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "conf-gmp"
+  "ppx_expect" {with-test}
+]
+depopts: ["zarith"]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
+x-commit-hash: "e1f77a4a4b12c9a8b624c6d9f11b0409f9b092fa"
+url {
+  src:
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/0.0.0/bitwuzla-bin-0.0.0.tbz"
+  checksum: [
+    "sha256=d4226ee5d1972caae12ea7bfde7ffd20a04fa81abb7a85a7432fb71be34b6207"
+    "sha512=a94a466ef8b299c18cde51dd82e1be61f357de0e5efe617320ee7a888aeb8f7cd53d278f1e70e80b24c43003afe9595b8ad97c91c07a866616003e39642b35e8"
+  ]
+}

--- a/packages/bitwuzla/bitwuzla.0.0.1/opam
+++ b/packages/bitwuzla/bitwuzla.0.0.1/opam
@@ -47,3 +47,4 @@ url {
     "sha512=7cd047a5d64444077381222d8c3190689b6b6160ed2fa2520eafc3e1ed267cfb9b2aa4580ae5b6b3d1294aa55fa08a76c2098adff51098beb4535a37c6175dc4"
   ]
 }
+available: [ os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) ]

--- a/packages/bitwuzla/bitwuzla.0.0.1/opam
+++ b/packages/bitwuzla/bitwuzla.0.0.1/opam
@@ -38,14 +38,12 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
-x-commit-hash: "0c7368a5f47fba40f66caf6fe2138ccf7536633d"
+x-commit-hash: "e070b27a7d44df3e74b4f3447122afe5f016e344"
 url {
   src:
     "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/0.0.1/bitwuzla-0.0.1.tbz"
   checksum: [
-    "sha256=c727ca57fbb7e0a4b860dd0b2010fdc1d848b2ce6bb381ffd70307959a03d0d7"
-    "sha512=ebcf66150d0d0f26b246723452bcec23cad37d6cb81d4d5b6301723c3a6d91ce170eda69a25bc1c6c4b05a4d6c89830805e41a1fdcde5853c8273a58262a2938"
+    "sha256=2c486dbb38240297ddf18b118c5df552acf748630e0d63f6e12ce96f6ad42645"
+    "sha512=7cd047a5d64444077381222d8c3190689b6b6160ed2fa2520eafc3e1ed267cfb9b2aa4580ae5b6b3d1294aa55fa08a76c2098adff51098beb4535a37c6175dc4"
   ]
 }
-
-available: [ os = "linux" ]

--- a/packages/bitwuzla/bitwuzla.0.0.1/opam
+++ b/packages/bitwuzla/bitwuzla.0.0.1/opam
@@ -13,10 +13,9 @@ homepage: "https://bitwuzla.github.io"
 doc: "https://bitwuzla.github.io/docs/ocaml/"
 bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
 depends: [
-  "dune" {>= "2.6"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "conf-git" {build}
-  "conf-cmake" {build}
   "conf-gcc" {build}
   "conf-g++" {build}
   "conf-gmp"
@@ -39,13 +38,14 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
-x-commit-hash: "e1f77a4a4b12c9a8b624c6d9f11b0409f9b092fa"
+x-commit-hash: "0c7368a5f47fba40f66caf6fe2138ccf7536633d"
 url {
   src:
-    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/0.0.0/bitwuzla-bin-0.0.0.tbz"
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/0.0.1/bitwuzla-0.0.1.tbz"
   checksum: [
-    "sha256=d4226ee5d1972caae12ea7bfde7ffd20a04fa81abb7a85a7432fb71be34b6207"
-    "sha512=a94a466ef8b299c18cde51dd82e1be61f357de0e5efe617320ee7a888aeb8f7cd53d278f1e70e80b24c43003afe9595b8ad97c91c07a866616003e39642b35e8"
+    "sha256=c727ca57fbb7e0a4b860dd0b2010fdc1d848b2ce6bb381ffd70307959a03d0d7"
+    "sha512=ebcf66150d0d0f26b246723452bcec23cad37d6cb81d4d5b6301723c3a6d91ce170eda69a25bc1c6c4b05a4d6c89830805e41a1fdcde5853c8273a58262a2938"
   ]
 }
-available: [ os-family = "debian" | os-distribution = "alpine" ]
+
+available: [ os = "linux" ]


### PR DESCRIPTION
SMT solver for QF_AUFBVFP

- Project page: <a href="https://bitwuzla.github.io">https://bitwuzla.github.io</a>
- Documentation: <a href="https://bitwuzla.github.io/docs/ocaml/">https://bitwuzla.github.io/docs/ocaml/</a>

##### CHANGES:

Initial release.

OCaml binding for the SMT solver [Bitwuzla](https://bitwuzla.github.io/).

- `Bitwuzla_c` library exposes low level functions from the
  [C API](https://bitwuzla.github.io/docs/c/interface.html);
- `Bitwuzla_z` library converts bitvector value to
  [Zarith](https://github.com/ocaml/Zarith) integer;
- `bitwuzla-bin` package installs Bitwuzla executable.

Vendor submodules:
- [Cadical](https://github.com/arminbiere/cadical) tag:sc2021
- [SymFPU](https://github.com/martin-cs/symfpu) commit:8fbe139
- [Btor2Tools](https://github.com/Boolector/btor2tools) commit:1df768d
- [Bitwuzla](https://github.com/bitwuzla/bitwuzla) commit:2f4dad6
