### PR TITLE
Constrain older opam-format to older opam-file-format

### DIFF
--- a/packages/opam-format/opam-format.2.0.0/opam
+++ b/packages/opam-format/opam-format.2.0.0/opam
@@ -22,7 +22,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= "2.0.0"}
-  "opam-file-format" {>= "2.0.0~rc2"}
+  "opam-file-format" {>= "2.0.0~rc2" & < "2.1.1"}
   "jbuilder" {>= "1.0+beta18"}
 ]
 synopsis: "opam 2.0 development libraries"

--- a/packages/opam-format/opam-format.2.0.0~beta/opam
+++ b/packages/opam-format/opam-format.2.0.0~beta/opam
@@ -21,7 +21,7 @@ build: [
 depends: [
   "ocaml" {>= "4.01.0"}
   "opam-core" {= "2.0.0~beta"}
-  "opam-file-format" {>= "2.0~alpha5"}
+  "opam-file-format" {>= "2.0~alpha5" & < "2.1.1"}
 ]
 synopsis: "opam 2.0 development libraries"
 description: "Definition of opam datastructures and its file interface."

--- a/packages/opam-format/opam-format.2.0.0~beta3.1/opam
+++ b/packages/opam-format/opam-format.2.0.0~beta3.1/opam
@@ -21,7 +21,7 @@ build: [
 depends: [
   "ocaml" {>= "4.01.0"}
   "opam-core" {= "2.0.0~beta3.1"}
-  "opam-file-format" {>= "2.0.0~beta3"}
+  "opam-file-format" {>= "2.0.0~beta3" & < "2.1.1"}
 ]
 synopsis: "opam 2.0 development libraries"
 description: "Definition of opam datastructures and its file interface."

--- a/packages/opam-format/opam-format.2.0.0~beta3/opam
+++ b/packages/opam-format/opam-format.2.0.0~beta3/opam
@@ -21,7 +21,7 @@ build: [
 depends: [
   "ocaml" {>= "4.01.0"}
   "opam-core" {= "2.0.0~beta3"}
-  "opam-file-format" {>= "2.0.0~beta3"}
+  "opam-file-format" {>= "2.0.0~beta3" & < "2.1.1"}
 ]
 synopsis: "opam 2.0 development libraries"
 description: "Definition of opam datastructures and its file interface."

--- a/packages/opam-format/opam-format.2.0.0~beta5/opam
+++ b/packages/opam-format/opam-format.2.0.0~beta5/opam
@@ -20,7 +20,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= "2.0.0~beta5"}
-  "opam-file-format" {>= "2.0.0~beta5"}
+  "opam-file-format" {>= "2.0.0~beta5" & < "2.1.1"}
   "jbuilder" {>= "1.0+beta12"}
 ]
 synopsis: "opam 2.0 development libraries"

--- a/packages/opam-format/opam-format.2.0.0~rc/opam
+++ b/packages/opam-format/opam-format.2.0.0~rc/opam
@@ -20,7 +20,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= "2.0.0~rc"}
-  "opam-file-format" {>= "2.0.0~beta5"}
+  "opam-file-format" {>= "2.0.0~beta5" & < "2.1.1"}
   "jbuilder" {>= "1.0+beta12"}
 ]
 conflicts: [

--- a/packages/opam-format/opam-format.2.0.0~rc2/opam
+++ b/packages/opam-format/opam-format.2.0.0~rc2/opam
@@ -22,7 +22,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= "2.0.0~rc2"}
-  "opam-file-format" {>= "2.0.0~rc2"}
+  "opam-file-format" {>= "2.0.0~rc2" & < "2.1.1"}
   "jbuilder" {>= "1.0+beta18"}
 ]
 synopsis: "opam 2.0 development libraries"

--- a/packages/opam-format/opam-format.2.0.0~rc3/opam
+++ b/packages/opam-format/opam-format.2.0.0~rc3/opam
@@ -22,7 +22,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= "2.0.0~rc3"}
-  "opam-file-format" {>= "2.0.0~rc2"}
+  "opam-file-format" {>= "2.0.0~rc2" & < "2.1.1"}
   "jbuilder" {>= "1.0+beta18"}
 ]
 synopsis: "opam 2.0 development libraries"

--- a/packages/opam-format/opam-format.2.0.1/opam
+++ b/packages/opam-format/opam-format.2.0.1/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= "2.0.1"}
-  "opam-file-format" {>= "2.0.0~rc2"}
+  "opam-file-format" {>= "2.0.0~rc2" & < "2.1.1"}
   "jbuilder" {>= "1.0+beta18"}
 ]
 build: [

--- a/packages/opam-format/opam-format.2.0.2/opam
+++ b/packages/opam-format/opam-format.2.0.2/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= "2.0.2"}
-  "opam-file-format" {>= "2.0.0~rc2"}
+  "opam-file-format" {>= "2.0.0~rc2" & < "2.1.1"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-format/opam-format.2.0.3/opam
+++ b/packages/opam-format/opam-format.2.0.3/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= "2.0.3"}
-  "opam-file-format" {>= "2.0.0~rc2"}
+  "opam-file-format" {>= "2.0.0~rc2" & < "2.1.1"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-format/opam-format.2.0.4/opam
+++ b/packages/opam-format/opam-format.2.0.4/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= "2.0.4"}
-  "opam-file-format" {>= "2.0.0~rc2"}
+  "opam-file-format" {>= "2.0.0~rc2" & < "2.1.1"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-format/opam-format.2.0.5/opam
+++ b/packages/opam-format/opam-format.2.0.5/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= "2.0.5"}
-  "opam-file-format" {>= "2.0.0~rc2"}
+  "opam-file-format" {>= "2.0.0~rc2" & < "2.1.1"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-format/opam-format.2.0.6/opam
+++ b/packages/opam-format/opam-format.2.0.6/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= "2.0.6"}
-  "opam-file-format" {>= "2.0.0~rc2"}
+  "opam-file-format" {>= "2.0.0~rc2" & < "2.1.1"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-format/opam-format.2.0.7/opam
+++ b/packages/opam-format/opam-format.2.0.7/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= version}
-  "opam-file-format" {>= "2.0.0~rc2"}
+  "opam-file-format" {>= "2.0.0~rc2" & < "2.1.1"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-format/opam-format.2.0~alpha5/opam
+++ b/packages/opam-format/opam-format.2.0~alpha5/opam
@@ -21,7 +21,7 @@ build: [
 depends: [
   "ocaml" {>= "4.01.0"}
   "opam-core" {= "2.0~alpha5"}
-  "opam-file-format" {>= "2.0~alpha5"}
+  "opam-file-format" {>= "2.0~alpha5" & < "2.1.1"}
 ]
 synopsis: "opam 2.0 development libraries"
 description: "Definition of opam datastructures and its file interface."

--- a/packages/opam-format/opam-format.2.1.0~beta2/opam
+++ b/packages/opam-format/opam-format.2.1.0~beta2/opam
@@ -26,7 +26,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= version}
-  "opam-file-format" {>= "2.0.0~rc2"}
+  "opam-file-format" {>= "2.0.0~rc2" & < "2.1.1"}
   "dune" {>= "1.5.0"}
 ]
 url {


### PR DESCRIPTION
#18119 introduced a constraint on opam-file-format for opam-format.2.0.8 - this should either be present on the earlier versions too or not present at all. The same constraint applies to opam-format.2.1.0~beta2 (failure seen in [revdeps for #18270](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/9528af89646f39e2f463821ce0e167d89decf024/variant/opam-2.1,compilers,4.12,opam-file-format.2.1.3,revdeps,opam-devel.2.1.0~beta2).

The caveat for this is that it's seeking to avoid deprecation warnings, so it's not _completely_ clear to me if these constraints should be present at all.