### PR TITLE
releases FrontC 4.1.0

### DIFF
--- a/packages/FrontC/FrontC.4.1.0/opam
+++ b/packages/FrontC/FrontC.4.1.0/opam
@@ -24,7 +24,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/FrontC/FrontC.4.1.0/opam
+++ b/packages/FrontC/FrontC.4.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Parses C programs to an abstract syntax tree"
+description:
+  "FrontC provides a C parser and an OCaml definition of an abstract syntax treee for the C language. It also includes AST pretty-printers in plain and XML formats."
+maintainer: ["Ivan Gotovchits <ivg@ieee.org>"]
+authors: ["Hugues Cassé <casse@irit.fr> et al"]
+license: "LGPL-2.0-only"
+tags: ["FrontC" "C" "parser" "XML"]
+homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "menhir"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC.git"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v4.0.0.tar.gz"
+  checksum: "md5=08e58fa6c9eb311b03c0b85d74d2e256"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/v4.1.0.tar.gz"
+}

--- a/packages/FrontC/FrontC.4.1.0/opam
+++ b/packages/FrontC/FrontC.4.1.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
-  "menhir"
+  "menhir" {>= "20180523"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/FrontC/FrontC.4.1.0/opam
+++ b/packages/FrontC/FrontC.4.1.0/opam
@@ -31,7 +31,7 @@ build: [
 dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC.git"
 
 url {
-  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v4.0.0.tar.gz"
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v4.1.0.tar.gz"
   checksum: "md5=08e58fa6c9eb311b03c0b85d74d2e256"
   mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/v4.1.0.tar.gz"
 }

--- a/packages/calipso/calipso.4.1.0/opam
+++ b/packages/calipso/calipso.4.1.0/opam
@@ -24,7 +24,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/calipso/calipso.4.1.0/opam
+++ b/packages/calipso/calipso.4.1.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
-  "FrontC" {>= "4.0.0"}
+  "FrontC" {= "4.1.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/calipso/calipso.4.1.0/opam
+++ b/packages/calipso/calipso.4.1.0/opam
@@ -31,7 +31,7 @@ build: [
 dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC.git"
 
 url {
-  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v4.0.0.tar.gz"
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v4.1.0.tar.gz"
   checksum: "md5=08e58fa6c9eb311b03c0b85d74d2e256"
   mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/v4.1.0.tar.gz"
 }

--- a/packages/calipso/calipso.4.1.0/opam
+++ b/packages/calipso/calipso.4.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Rewrites C programs to remove non-structured control-flow"
+description:
+  "Calipso analyzes programs in order to replace all nonstructured instructions (i.e., break, return, switch...) by branches and, then, remove all branches. See https://dblp.org/rec/journals/tsi/CasseFRS02 for more details"
+maintainer: ["Ivan Gotovchits <ivg@ieee.org>"]
+authors: ["Hugues Cassé <casse@irit.fr> et al"]
+license: "LGPL-2.0-only"
+tags: ["FrontC" "C" "analysis"]
+homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "FrontC" {>= "4.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC.git"
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v4.0.0.tar.gz"
+  checksum: "md5=08e58fa6c9eb311b03c0b85d74d2e256"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/v4.1.0.tar.gz"
+}

--- a/packages/calipso/calipso.4.1.0/opam
+++ b/packages/calipso/calipso.4.1.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
-  "FrontC" {= "4.1.0"}
+  "FrontC" {= version}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ctoxml/ctoxml.4.1.0/opam
+++ b/packages/ctoxml/ctoxml.4.1.0/opam
@@ -22,7 +22,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ctoxml/ctoxml.4.1.0/opam
+++ b/packages/ctoxml/ctoxml.4.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Parses a C program into Cabs AST and dumps as an XML document"
+maintainer: ["Ivan Gotovchits <ivg@ieee.org>"]
+authors: ["Hugues Cassé <casse@irit.fr> et al"]
+license: "LGPL-2.0-only"
+tags: ["FrontC" "C" "parser" "XML"]
+homepage: "https://github.com/BinaryAnalysisPlatform/FrontC"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "FrontC" {= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC.git"
+
+
+url {
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v4.0.0.tar.gz"
+  checksum: "md5=08e58fa6c9eb311b03c0b85d74d2e256"
+  mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/v4.1.0.tar.gz"
+}

--- a/packages/ctoxml/ctoxml.4.1.0/opam
+++ b/packages/ctoxml/ctoxml.4.1.0/opam
@@ -30,7 +30,7 @@ dev-repo: "git+https://github.com/BinaryAnalysisPlatform/FrontC.git"
 
 
 url {
-  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v4.0.0.tar.gz"
+  src: "https://github.com/BinaryAnalysisPlatform/FrontC/archive/refs/tags/v4.1.0.tar.gz"
   checksum: "md5=08e58fa6c9eb311b03c0b85d74d2e256"
   mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/FrontC/v4.1.0.tar.gz"
 }

--- a/packages/ctoxml/ctoxml.4.1.0/opam
+++ b/packages/ctoxml/ctoxml.4.1.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/FrontC/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
-  "FrontC" {= "4.1.0"}
+  "FrontC" {= version}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Important: do not merge before #18735

Since the 4.0.0 release we striving to turn FrontC into a robust
parser capable of reading modern C programs. Our immediate goal,
that is mostly achieved is to be able to parse standard C and POSIX
header files available on modern linux systems so that we can parsea
simple C89 programs.

This update received many features from c99 to c11 and a few GNU
extensions but it is still mostly c89 (but we can understand a few
modern features that are used in headers). Otherwise, FrontC is a
pretty robust parser that could be used with real-world C programs.

The full least of features:

* tweaks the grammar to handle empty files (BinaryAnalysisPlatform/FrontC#18)
* enables type redefinitions (BinaryAnalysisPlatform/FrontC#19)
* supports attributes after asm in function declaration (BinaryAnalysisPlatform/FrontC#22)
* allows a typedefed named to immediately follow its typedef (BinaryAnalysisPlatform/FrontC#26)
* removes all grammar conflicts (BinaryAnalysisPlatform/FrontC#27)
* allows const volatile type modifiers (BinaryAnalysisPlatform/FrontC#28)
* enables GNU attributes in record fields and types inside attributes (BinaryAnalysisPlatform/FrontC#30)
* supports GNU extension in union declarations (BinaryAnalysisPlatform/FrontC#31)
* supports designated initialization style (BinaryAnalysisPlatform/FrontC#35)
* implements complex types (BinaryAnalysisPlatform/FrontC#36)
* enables type qualifiers between brackets in the array parameters (BinaryAnalysisPlatform/FrontC#38)
* adds the C99 _Bool type (BinaryAnalysisPlatform/FrontC#39)
* adds GCC-specific builtin floating types (BinaryAnalysisPlatform/FrontC#40)
* adds support for unnamed bit fields (BinaryAnalysisPlatform/FrontC#41)