### PR TITLE
5 packages from gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.4.3/ocaml-bls12-381-0.4.3.tar.bz2

### DIFF
--- a/packages/bls12-381-gen/bls12-381-gen.0.4.3/opam
+++ b/packages/bls12-381-gen/bls12-381-gen.0.4.3/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Functors to generate BLS12-381 primitives based on stubs"
+description: "Functors to generate BLS12-381 primitives based on stubs"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.4.3/ocaml-bls12-381-0.4.3.tar.bz2"
+  checksum: [
+    "md5=f81a4562579a69cc0312d6c948678d35"
+    "sha512=b9997e85babe1e160bd5ed1d1986584f375a544e120258a18b1f27bf01b86c9a243181e09120ed69fbd611d5ca4721c89a9e3a18e1cf89f7419a430d5b9b2aef"
+  ]
+}

--- a/packages/bls12-381-js-gen/bls12-381-js-gen.0.4.3/opam
+++ b/packages/bls12-381-js-gen/bls12-381-js-gen.0.4.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis:
+  "Functors to generate BLS12-381 JavaScript primitives based on stubs"
+description:
+  "Functors to generate BLS12-381 JavaScript primitives based on stubs"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "dune-configurator" {build}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "1.12"}
+  "zarith_stubs_js"
+  "js_of_ocaml" {>= "3.7.1"}
+  "js_of_ocaml-compiler" {>= "3.7.1"}
+  "js_of_ocaml-ppx" {>= "3.7.1"}
+  "bls12-381-gen" {= version}
+  "bls12-381" {= version}
+  "alcotest" {with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.4.3/ocaml-bls12-381-0.4.3.tar.bz2"
+  checksum: [
+    "md5=f81a4562579a69cc0312d6c948678d35"
+    "sha512=b9997e85babe1e160bd5ed1d1986584f375a544e120258a18b1f27bf01b86c9a243181e09120ed69fbd611d5ca4721c89a9e3a18e1cf89f7419a430d5b9b2aef"
+  ]
+}

--- a/packages/bls12-381-js/bls12-381-js.0.4.3/opam
+++ b/packages/bls12-381-js/bls12-381-js.0.4.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: """\
+JavaScript version of BLS12-381 primitives implementing the virtual
+package bls12-381"""
+description: """\
+JavaScript version of BLS12-381 primitives implementing the virtual
+package bls12-381"""
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "bls12-381-gen" {= version}
+  "bls12-381" {= version}
+  "bls12-381-js-gen" {= version}
+  "js_of_ocaml" {>= "3.7.1"}
+  "js_of_ocaml-compiler" {>= "3.7.1"}
+  "js_of_ocaml-ppx" {>= "3.7.1"}
+  "alcotest" {with-test}
+  "zarith" {>= "1.10" & < "1.12" & with-test}
+  "zarith_stubs_js" {with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.4.3/ocaml-bls12-381-0.4.3.tar.bz2"
+  checksum: [
+    "md5=f81a4562579a69cc0312d6c948678d35"
+    "sha512=b9997e85babe1e160bd5ed1d1986584f375a544e120258a18b1f27bf01b86c9a243181e09120ed69fbd611d5ca4721c89a9e3a18e1cf89f7419a430d5b9b2aef"
+  ]
+}

--- a/packages/bls12-381-unix/bls12-381-unix.0.4.3/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.0.4.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: """\
+UNIX version of BLS12-381 primitives implementing the virtual package
+bls12-381"""
+description: """\
+UNIX version of BLS12-381 primitives implementing the virtual package
+bls12-381"""
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "conf-rust" {build}
+  "dune" {>= "2.8.4"}
+  "dune-configurator" {build}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "ctypes" {>= "0.18.0" & < "0.19.0"}
+  "ctypes-foreign"
+  "bls12-381-gen" {= version}
+  "bls12-381" {= version}
+  "tezos-rust-libs" {= "1.1"}
+  "alcotest" {with-test}
+  "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.4.3/ocaml-bls12-381-0.4.3.tar.bz2"
+  checksum: [
+    "md5=f81a4562579a69cc0312d6c948678d35"
+    "sha512=b9997e85babe1e160bd5ed1d1986584f375a544e120258a18b1f27bf01b86c9a243181e09120ed69fbd611d5ca4721c89a9e3a18e1cf89f7419a430d5b9b2aef"
+  ]
+}

--- a/packages/bls12-381/bls12-381.0.4.3/opam
+++ b/packages/bls12-381/bls12-381.0.4.3/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Virtual package for BLS12-381 primitives"
+description: "Virtual package for BLS12-381 primitives"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "bls12-381-gen" {= version}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.4.3/ocaml-bls12-381-0.4.3.tar.bz2"
+  checksum: [
+    "md5=f81a4562579a69cc0312d6c948678d35"
+    "sha512=b9997e85babe1e160bd5ed1d1986584f375a544e120258a18b1f27bf01b86c9a243181e09120ed69fbd611d5ca4721c89a9e3a18e1cf89f7419a430d5b9b2aef"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`bls12-381.0.4.3`: Virtual package for BLS12-381 primitives
-`bls12-381-gen.0.4.3`: Functors to generate BLS12-381 primitives based on stubs
-`bls12-381-js.0.4.3`: JavaScript version of BLS12-381 primitives implementing the virtual
 package bls12-381
-`bls12-381-js-gen.0.4.3`: Functors to generate BLS12-381 JavaScript primitives based on stubs
-`bls12-381-unix.0.4.3`: UNIX version of BLS12-381 primitives implementing the virtual package
 bls12-381



---
* Homepage: https://gitlab.com/dannywillems/ocaml-bls12-381
* Source repo: git+https://gitlab.com/dannywillems/ocaml-bls12-381.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-bls12-381/issues

---
:camel: Pull-request generated by opam-publish v2.0.3