### PR TITLE
Package monolith.20210525

### DIFF
--- a/packages/monolith/monolith.20210525/opam
+++ b/packages/monolith/monolith.20210525/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/monolith"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/monolith.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "2.0" }
+  "afl-persistent" { >= "1.3" }
+  "pprint" { >= "20200410" }
+  "seq"
+]
+synopsis: "A framework for testing a library using afl-fuzz"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/monolith/-/archive/20210525/archive.tar.gz"
+  checksum: [
+    "md5=f23de1844eb4e2de4cab0071325a5e22"
+    "sha512=1fd19b5f188bd333f5ae9966da71993bcadbe94b2d150e7e6064caaf0a7a1e6cd822926e0a75d42f7037757a075f2b3f44dd6f1fdfd004c17933d73ea81a7cb2"
+  ]
+}


### PR DESCRIPTION
### `monolith.20210525`
A framework for testing a library using afl-fuzz



---
* Homepage: https://gitlab.inria.fr/fpottier/monolith
* Source repo: git+https://gitlab.inria.fr/fpottier/monolith.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.3