### PR TITLE
Package ppx_make.0.2.0

### DIFF
--- a/packages/ppx_make/ppx_make.0.2.0/opam
+++ b/packages/ppx_make/ppx_make.0.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Ppxlib based make deriver"
+maintainer: ["Boning <erebuxy@gmail.com>"]
+authors: ["Boning <erebuxy@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/erebuxy/ppx_make"
+doc: "https://github.com/erebuxy/ppx_make"
+bug-reports: "https://github.com/erebuxy/ppx_make/issues"
+depends: [
+  "dune" {>= "2.0.0"}
+  "ppxlib" {>= "0.10.0"}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/erebuxy/ppx_make.git"
+url {
+  src: "https://github.com/erebuxy/ppx_make/archive/v0.2.0.tar.gz"
+  checksum: [
+    "md5=c963be11d29621dd8c4bbbec4f765795"
+    "sha512=bcd6b8e9b7874e61aeb113e867f0309f05a415c9df1a4bff9f3af03bbf06d49f2834b4d319289312220114e5bb5e618ddec2ab7eb7b3cb8479d148cefc129cfb"
+  ]
+}

--- a/packages/ppx_make/ppx_make.0.2.0/opam
+++ b/packages/ppx_make/ppx_make.0.2.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ounit2" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
### `ppx_make.0.2.0`
Ppxlib based make deriver



---
* Homepage: https://github.com/erebuxy/ppx_make
* Source repo: git+https://github.com/erebuxy/ppx_make.git
* Bug tracker: https://github.com/erebuxy/ppx_make/issues

---
:camel: Pull-request generated by opam-publish v2.0.3