### PR TITLE
Package ppx_make.0.2.1

### DIFF
--- a/packages/ppx_make/ppx_make.0.2.1/opam
+++ b/packages/ppx_make/ppx_make.0.2.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/erebuxy/ppx_make"
 doc: "https://github.com/erebuxy/ppx_make"
 bug-reports: "https://github.com/erebuxy/ppx_make/issues"
 depends: [
-  "dune" {>= "2.7" & >= "2.7.0"}
+  "dune" {>= "2.7"}
   "ppxlib" {>= "0.10.0"}
   "ounit2" {with-test}
   "odoc" {with-doc}

--- a/packages/ppx_make/ppx_make.0.2.1/opam
+++ b/packages/ppx_make/ppx_make.0.2.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Ppxlib based make deriver"
+maintainer: ["Boning <erebuxy@gmail.com>"]
+authors: ["Boning <erebuxy@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/erebuxy/ppx_make"
+doc: "https://github.com/erebuxy/ppx_make"
+bug-reports: "https://github.com/erebuxy/ppx_make/issues"
+depends: [
+  "dune" {>= "2.7" & >= "2.7.0"}
+  "ppxlib" {>= "0.10.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/erebuxy/ppx_make.git"
+url {
+  src: "https://github.com/erebuxy/ppx_make/archive/v0.2.1.tar.gz"
+  checksum: [
+    "md5=f4069baed3a43fa5f02e7d6714f8c987"
+    "sha512=4063bc038d255b6542f4e2e3e39da9295c1e8c71ac4fe5f3e00db771c4f1a315918248308773fef96ba904aca7adc52d30fb4add58e0a13986a44c97aea239d3"
+  ]
+}


### PR DESCRIPTION
### `ppx_make.0.2.1`
Ppxlib based make deriver



---
* Homepage: https://github.com/erebuxy/ppx_make
* Source repo: git+https://github.com/erebuxy/ppx_make.git
* Bug tracker: https://github.com/erebuxy/ppx_make/issues

---
:camel: Pull-request generated by opam-publish v2.0.3