### PR TITLE
Remove opensource@janestreet.com email address

### DIFF
--- a/packages/accessor/accessor.v0.14.0/opam
+++ b/packages/accessor/accessor.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/accessor"
 bug-reports: "https://github.com/janestreet/accessor/issues"
 dev-repo: "git+https://github.com/janestreet/accessor.git"

--- a/packages/accessor/accessor.v0.14.1/opam
+++ b/packages/accessor/accessor.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/accessor"
 bug-reports: "https://github.com/janestreet/accessor/issues"
 dev-repo: "git+https://github.com/janestreet/accessor.git"

--- a/packages/accessor_async/accessor_async.v0.14.0/opam
+++ b/packages/accessor_async/accessor_async.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/accessor_async"
 bug-reports: "https://github.com/janestreet/accessor_async/issues"
 dev-repo: "git+https://github.com/janestreet/accessor_async.git"

--- a/packages/accessor_async/accessor_async.v0.14.1/opam
+++ b/packages/accessor_async/accessor_async.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/accessor_async"
 bug-reports: "https://github.com/janestreet/accessor_async/issues"
 dev-repo: "git+https://github.com/janestreet/accessor_async.git"

--- a/packages/accessor_base/accessor_base.v0.14.0/opam
+++ b/packages/accessor_base/accessor_base.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/accessor_base"
 bug-reports: "https://github.com/janestreet/accessor_base/issues"
 dev-repo: "git+https://github.com/janestreet/accessor_base.git"

--- a/packages/accessor_base/accessor_base.v0.14.1/opam
+++ b/packages/accessor_base/accessor_base.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/accessor_base"
 bug-reports: "https://github.com/janestreet/accessor_base/issues"
 dev-repo: "git+https://github.com/janestreet/accessor_base.git"

--- a/packages/accessor_core/accessor_core.v0.14.0/opam
+++ b/packages/accessor_core/accessor_core.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/accessor_core"
 bug-reports: "https://github.com/janestreet/accessor_core/issues"
 dev-repo: "git+https://github.com/janestreet/accessor_core.git"

--- a/packages/accessor_core/accessor_core.v0.14.1/opam
+++ b/packages/accessor_core/accessor_core.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/accessor_core"
 bug-reports: "https://github.com/janestreet/accessor_core/issues"
 dev-repo: "git+https://github.com/janestreet/accessor_core.git"

--- a/packages/async/async.108.00.01/opam
+++ b/packages/async/async.108.00.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.108.00.02/opam
+++ b/packages/async/async.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.108.07.00/opam
+++ b/packages/async/async.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.108.07.01/opam
+++ b/packages/async/async.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.108.08.00/opam
+++ b/packages/async/async.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.109.07.00/opam
+++ b/packages/async/async.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.109.08.00/opam
+++ b/packages/async/async.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.109.09.00/opam
+++ b/packages/async/async.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.109.10.00/opam
+++ b/packages/async/async.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.109.11.00/opam
+++ b/packages/async/async.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.109.12.00/opam
+++ b/packages/async/async.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.109.13.00/opam
+++ b/packages/async/async.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.109.14.00/opam
+++ b/packages/async/async.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.109.15.00/opam
+++ b/packages/async/async.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.109.17.00/opam
+++ b/packages/async/async.109.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async"]]
 depends: [

--- a/packages/async/async.109.19.00/opam
+++ b/packages/async/async.109.19.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.20.00/opam
+++ b/packages/async/async.109.20.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.21.00/opam
+++ b/packages/async/async.109.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.22.00/opam
+++ b/packages/async/async.109.22.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.24.00/opam
+++ b/packages/async/async.109.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.27.00/opam
+++ b/packages/async/async.109.27.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.30.00/opam
+++ b/packages/async/async.109.30.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.31.00/opam
+++ b/packages/async/async.109.31.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.32.00/opam
+++ b/packages/async/async.109.32.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.33.00/opam
+++ b/packages/async/async.109.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.34.00/opam
+++ b/packages/async/async.109.34.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.35.00/opam
+++ b/packages/async/async.109.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.38.00/opam
+++ b/packages/async/async.109.38.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.42.00/opam
+++ b/packages/async/async.109.42.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.53.00/opam
+++ b/packages/async/async.109.53.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.53.02/opam
+++ b/packages/async/async.109.53.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.58.00/opam
+++ b/packages/async/async.109.58.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.109.60.00/opam
+++ b/packages/async/async.109.60.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.110.01.00/opam
+++ b/packages/async/async.110.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.111.03.00/opam
+++ b/packages/async/async.111.03.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.111.11.00/opam
+++ b/packages/async/async.111.11.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.111.13.00/opam
+++ b/packages/async/async.111.13.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.111.17.00/opam
+++ b/packages/async/async.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.111.25.00/opam
+++ b/packages/async/async.111.25.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.112.01.00/opam
+++ b/packages/async/async.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.112.06.00/opam
+++ b/packages/async/async.112.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.112.17.00/opam
+++ b/packages/async/async.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.112.24.00/opam
+++ b/packages/async/async.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.112.35.00/opam
+++ b/packages/async/async.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.113.00.00/opam
+++ b/packages/async/async.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async"
 license: "Apache-2.0"
 build: [

--- a/packages/async/async.113.24.00/opam
+++ b/packages/async/async.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async"
 bug-reports: "https://github.com/janestreet/async/issues"
 dev-repo: "git+https://github.com/janestreet/async.git"

--- a/packages/async/async.113.33.00/opam
+++ b/packages/async/async.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async"
 bug-reports: "https://github.com/janestreet/async/issues"
 dev-repo: "git+https://github.com/janestreet/async.git"

--- a/packages/async/async.113.33.03/opam
+++ b/packages/async/async.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async"
 bug-reports: "https://github.com/janestreet/async/issues"
 dev-repo: "git+https://github.com/janestreet/async.git"

--- a/packages/async/async.v0.10.0/opam
+++ b/packages/async/async.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async"
 bug-reports: "https://github.com/janestreet/async/issues"
 dev-repo: "git+https://github.com/janestreet/async.git"

--- a/packages/async/async.v0.11.0/opam
+++ b/packages/async/async.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async"
 bug-reports: "https://github.com/janestreet/async/issues"
 dev-repo: "git+https://github.com/janestreet/async.git"

--- a/packages/async/async.v0.12.0/opam
+++ b/packages/async/async.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async"
 bug-reports: "https://github.com/janestreet/async/issues"
 dev-repo: "git+https://github.com/janestreet/async.git"

--- a/packages/async/async.v0.13.0/opam
+++ b/packages/async/async.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async"
 bug-reports: "https://github.com/janestreet/async/issues"
 dev-repo: "git+https://github.com/janestreet/async.git"

--- a/packages/async/async.v0.14.0/opam
+++ b/packages/async/async.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async"
 bug-reports: "https://github.com/janestreet/async/issues"
 dev-repo: "git+https://github.com/janestreet/async.git"

--- a/packages/async/async.v0.9.0/opam
+++ b/packages/async/async.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async"
 bug-reports: "https://github.com/janestreet/async/issues"
 dev-repo: "git+https://github.com/janestreet/async.git"

--- a/packages/async_core/async_core.108.00.01/opam
+++ b/packages/async_core/async_core.108.00.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.108.00.02/opam
+++ b/packages/async_core/async_core.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.108.07.00/opam
+++ b/packages/async_core/async_core.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.108.07.01/opam
+++ b/packages/async_core/async_core.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.108.08.00/opam
+++ b/packages/async_core/async_core.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.109.07.00/opam
+++ b/packages/async_core/async_core.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.109.08.00/opam
+++ b/packages/async_core/async_core.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.109.09.00/opam
+++ b/packages/async_core/async_core.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.109.10.00/opam
+++ b/packages/async_core/async_core.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.109.11.00/opam
+++ b/packages/async_core/async_core.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.109.12.00/opam
+++ b/packages/async_core/async_core.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.109.13.00/opam
+++ b/packages/async_core/async_core.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.109.14.00/opam
+++ b/packages/async_core/async_core.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.109.15.00/opam
+++ b/packages/async_core/async_core.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_core"]]
 depends: [

--- a/packages/async_core/async_core.109.19.00/opam
+++ b/packages/async_core/async_core.109.19.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.20.00/opam
+++ b/packages/async_core/async_core.109.20.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.22.00/opam
+++ b/packages/async_core/async_core.109.22.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.24.00/opam
+++ b/packages/async_core/async_core.109.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.27.00/opam
+++ b/packages/async_core/async_core.109.27.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.28.00/opam
+++ b/packages/async_core/async_core.109.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.30.00/opam
+++ b/packages/async_core/async_core.109.30.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.32.00/opam
+++ b/packages/async_core/async_core.109.32.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.34.00/opam
+++ b/packages/async_core/async_core.109.34.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.35.00/opam
+++ b/packages/async_core/async_core.109.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.36.00/opam
+++ b/packages/async_core/async_core.109.36.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.37.00/opam
+++ b/packages/async_core/async_core.109.37.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.38.00/opam
+++ b/packages/async_core/async_core.109.38.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.40.00/opam
+++ b/packages/async_core/async_core.109.40.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.41.00/opam
+++ b/packages/async_core/async_core.109.41.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.42.00/opam
+++ b/packages/async_core/async_core.109.42.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.45.00/opam
+++ b/packages/async_core/async_core.109.45.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.47.00/opam
+++ b/packages/async_core/async_core.109.47.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.53.00/opam
+++ b/packages/async_core/async_core.109.53.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.55.00/opam
+++ b/packages/async_core/async_core.109.55.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_core/async_core.109.55.02/opam
+++ b/packages/async_core/async_core.109.55.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_core"
 license: "Apache-2.0"
 build: [

--- a/packages/async_durable/async_durable.v0.10.0/opam
+++ b/packages/async_durable/async_durable.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_durable"
 bug-reports: "https://github.com/janestreet/async_durable/issues"
 dev-repo: "git+https://github.com/janestreet/async_durable.git"

--- a/packages/async_durable/async_durable.v0.11.0/opam
+++ b/packages/async_durable/async_durable.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_durable"
 bug-reports: "https://github.com/janestreet/async_durable/issues"
 dev-repo: "git+https://github.com/janestreet/async_durable.git"

--- a/packages/async_durable/async_durable.v0.12.0/opam
+++ b/packages/async_durable/async_durable.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_durable"
 bug-reports: "https://github.com/janestreet/async_durable/issues"
 dev-repo: "git+https://github.com/janestreet/async_durable.git"

--- a/packages/async_durable/async_durable.v0.13.0/opam
+++ b/packages/async_durable/async_durable.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_durable"
 bug-reports: "https://github.com/janestreet/async_durable/issues"
 dev-repo: "git+https://github.com/janestreet/async_durable.git"

--- a/packages/async_durable/async_durable.v0.14.0/opam
+++ b/packages/async_durable/async_durable.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_durable"
 bug-reports: "https://github.com/janestreet/async_durable/issues"
 dev-repo: "git+https://github.com/janestreet/async_durable.git"

--- a/packages/async_extended/async_extended.111.17.00/opam
+++ b/packages/async_extended/async_extended.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extended/async_extended.111.21.00/opam
+++ b/packages/async_extended/async_extended.111.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extended/async_extended.111.28.00/opam
+++ b/packages/async_extended/async_extended.111.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extended/async_extended.112.01.00/opam
+++ b/packages/async_extended/async_extended.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extended/async_extended.112.06.00/opam
+++ b/packages/async_extended/async_extended.112.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extended/async_extended.112.17.00/opam
+++ b/packages/async_extended/async_extended.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extended/async_extended.112.24.00/opam
+++ b/packages/async_extended/async_extended.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extended/async_extended.112.35.00/opam
+++ b/packages/async_extended/async_extended.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extended/async_extended.113.00.00/opam
+++ b/packages/async_extended/async_extended.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extended/async_extended.113.24.00/opam
+++ b/packages/async_extended/async_extended.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extended"
 bug-reports: "https://github.com/janestreet/async_extended/issues"
 dev-repo: "git+https://github.com/janestreet/async_extended.git"

--- a/packages/async_extended/async_extended.113.33.00/opam
+++ b/packages/async_extended/async_extended.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extended"
 bug-reports: "https://github.com/janestreet/async_extended/issues"
 dev-repo: "git+https://github.com/janestreet/async_extended.git"

--- a/packages/async_extended/async_extended.113.33.03/opam
+++ b/packages/async_extended/async_extended.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extended"
 bug-reports: "https://github.com/janestreet/async_extended/issues"
 dev-repo: "git+https://github.com/janestreet/async_extended.git"

--- a/packages/async_extended/async_extended.v0.10.0/opam
+++ b/packages/async_extended/async_extended.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extended"
 bug-reports: "https://github.com/janestreet/async_extended/issues"
 dev-repo: "git+https://github.com/janestreet/async_extended.git"

--- a/packages/async_extended/async_extended.v0.11.0/opam
+++ b/packages/async_extended/async_extended.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extended"
 bug-reports: "https://github.com/janestreet/async_extended/issues"
 dev-repo: "git+https://github.com/janestreet/async_extended.git"

--- a/packages/async_extended/async_extended.v0.9.0/opam
+++ b/packages/async_extended/async_extended.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extended"
 bug-reports: "https://github.com/janestreet/async_extended/issues"
 dev-repo: "git+https://github.com/janestreet/async_extended.git"

--- a/packages/async_extra/async_extra.108.00.01/opam
+++ b/packages/async_extra/async_extra.108.00.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.108.00.02/opam
+++ b/packages/async_extra/async_extra.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.108.07.00/opam
+++ b/packages/async_extra/async_extra.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.108.07.01/opam
+++ b/packages/async_extra/async_extra.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.108.08.00/opam
+++ b/packages/async_extra/async_extra.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.109.07.00/opam
+++ b/packages/async_extra/async_extra.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.109.08.00/opam
+++ b/packages/async_extra/async_extra.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.109.09.00/opam
+++ b/packages/async_extra/async_extra.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.109.10.00/opam
+++ b/packages/async_extra/async_extra.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.109.11.00/opam
+++ b/packages/async_extra/async_extra.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.109.12.00/opam
+++ b/packages/async_extra/async_extra.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.109.13.00/opam
+++ b/packages/async_extra/async_extra.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.109.14.00/opam
+++ b/packages/async_extra/async_extra.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.109.15.00/opam
+++ b/packages/async_extra/async_extra.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.109.17.00/opam
+++ b/packages/async_extra/async_extra.109.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_extra"]]
 depends: [

--- a/packages/async_extra/async_extra.109.19.00/opam
+++ b/packages/async_extra/async_extra.109.19.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.20.00/opam
+++ b/packages/async_extra/async_extra.109.20.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.22.00/opam
+++ b/packages/async_extra/async_extra.109.22.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.24.00/opam
+++ b/packages/async_extra/async_extra.109.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.27.00/opam
+++ b/packages/async_extra/async_extra.109.27.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.28.00/opam
+++ b/packages/async_extra/async_extra.109.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.31.00/opam
+++ b/packages/async_extra/async_extra.109.31.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.32.00/opam
+++ b/packages/async_extra/async_extra.109.32.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.33.00/opam
+++ b/packages/async_extra/async_extra.109.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.34.00/opam
+++ b/packages/async_extra/async_extra.109.34.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.35.00/opam
+++ b/packages/async_extra/async_extra.109.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.38.00/opam
+++ b/packages/async_extra/async_extra.109.38.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.40.00/opam
+++ b/packages/async_extra/async_extra.109.40.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.41.00/opam
+++ b/packages/async_extra/async_extra.109.41.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.42.00/opam
+++ b/packages/async_extra/async_extra.109.42.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.45.00/opam
+++ b/packages/async_extra/async_extra.109.45.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.47.00/opam
+++ b/packages/async_extra/async_extra.109.47.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.53.00/opam
+++ b/packages/async_extra/async_extra.109.53.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.55.00/opam
+++ b/packages/async_extra/async_extra.109.55.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.55.02/opam
+++ b/packages/async_extra/async_extra.109.55.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.58.00/opam
+++ b/packages/async_extra/async_extra.109.58.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.109.60.00/opam
+++ b/packages/async_extra/async_extra.109.60.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.110.01.00/opam
+++ b/packages/async_extra/async_extra.110.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.111.03.00/opam
+++ b/packages/async_extra/async_extra.111.03.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.111.06.00/opam
+++ b/packages/async_extra/async_extra.111.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.111.08.00/opam
+++ b/packages/async_extra/async_extra.111.08.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.111.11.00/opam
+++ b/packages/async_extra/async_extra.111.11.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.111.13.00/opam
+++ b/packages/async_extra/async_extra.111.13.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.111.17.00/opam
+++ b/packages/async_extra/async_extra.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.111.21.00/opam
+++ b/packages/async_extra/async_extra.111.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.111.25.00/opam
+++ b/packages/async_extra/async_extra.111.25.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.111.28.00/opam
+++ b/packages/async_extra/async_extra.111.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.112.01.00/opam
+++ b/packages/async_extra/async_extra.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.112.06.00/opam
+++ b/packages/async_extra/async_extra.112.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.112.17.00/opam
+++ b/packages/async_extra/async_extra.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.112.24.00/opam
+++ b/packages/async_extra/async_extra.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.112.35.00/opam
+++ b/packages/async_extra/async_extra.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.113.00.00/opam
+++ b/packages/async_extra/async_extra.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 license: "Apache-2.0"
 build: [

--- a/packages/async_extra/async_extra.113.24.00/opam
+++ b/packages/async_extra/async_extra.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 bug-reports: "https://github.com/janestreet/async_extra/issues"
 dev-repo: "git+https://github.com/janestreet/async_extra.git"

--- a/packages/async_extra/async_extra.113.33.00+4.03/opam
+++ b/packages/async_extra/async_extra.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 bug-reports: "https://github.com/janestreet/async_extra/issues"
 dev-repo: "git+https://github.com/janestreet/async_extra.git"

--- a/packages/async_extra/async_extra.113.33.00/opam
+++ b/packages/async_extra/async_extra.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 bug-reports: "https://github.com/janestreet/async_extra/issues"
 dev-repo: "git+https://github.com/janestreet/async_extra.git"

--- a/packages/async_extra/async_extra.113.33.03/opam
+++ b/packages/async_extra/async_extra.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 bug-reports: "https://github.com/janestreet/async_extra/issues"
 dev-repo: "git+https://github.com/janestreet/async_extra.git"

--- a/packages/async_extra/async_extra.v0.10.0/opam
+++ b/packages/async_extra/async_extra.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 bug-reports: "https://github.com/janestreet/async_extra/issues"
 dev-repo: "git+https://github.com/janestreet/async_extra.git"

--- a/packages/async_extra/async_extra.v0.11.0/opam
+++ b/packages/async_extra/async_extra.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 bug-reports: "https://github.com/janestreet/async_extra/issues"
 dev-repo: "git+https://github.com/janestreet/async_extra.git"

--- a/packages/async_extra/async_extra.v0.11.1/opam
+++ b/packages/async_extra/async_extra.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 bug-reports: "https://github.com/janestreet/async_extra/issues"
 dev-repo: "git+https://github.com/janestreet/async_extra.git"

--- a/packages/async_extra/async_extra.v0.12.0/opam
+++ b/packages/async_extra/async_extra.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 bug-reports: "https://github.com/janestreet/async_extra/issues"
 dev-repo: "git+https://github.com/janestreet/async_extra.git"

--- a/packages/async_extra/async_extra.v0.13.0/opam
+++ b/packages/async_extra/async_extra.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 bug-reports: "https://github.com/janestreet/async_extra/issues"
 dev-repo: "git+https://github.com/janestreet/async_extra.git"

--- a/packages/async_extra/async_extra.v0.14.0/opam
+++ b/packages/async_extra/async_extra.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 bug-reports: "https://github.com/janestreet/async_extra/issues"
 dev-repo: "git+https://github.com/janestreet/async_extra.git"

--- a/packages/async_extra/async_extra.v0.9.0/opam
+++ b/packages/async_extra/async_extra.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_extra"
 bug-reports: "https://github.com/janestreet/async_extra/issues"
 dev-repo: "git+https://github.com/janestreet/async_extra.git"

--- a/packages/async_find/async_find.109.14.00/opam
+++ b/packages/async_find/async_find.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_find"]]
 depends: [

--- a/packages/async_find/async_find.109.15.00/opam
+++ b/packages/async_find/async_find.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_find"]]
 depends: [

--- a/packages/async_find/async_find.109.15.02/opam
+++ b/packages/async_find/async_find.109.15.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_find"]]
 depends: [

--- a/packages/async_find/async_find.111.28.00/opam
+++ b/packages/async_find/async_find.111.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_find"
 license: "Apache-2.0"
 build: [

--- a/packages/async_find/async_find.113.24.00/opam
+++ b/packages/async_find/async_find.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_find"
 bug-reports: "https://github.com/janestreet/async_find/issues"
 dev-repo: "git+https://github.com/janestreet/async_find.git"

--- a/packages/async_find/async_find.113.33.00/opam
+++ b/packages/async_find/async_find.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_find"
 bug-reports: "https://github.com/janestreet/async_find/issues"
 dev-repo: "git+https://github.com/janestreet/async_find.git"

--- a/packages/async_find/async_find.113.33.03/opam
+++ b/packages/async_find/async_find.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_find"
 bug-reports: "https://github.com/janestreet/async_find/issues"
 dev-repo: "git+https://github.com/janestreet/async_find.git"

--- a/packages/async_find/async_find.v0.10.0/opam
+++ b/packages/async_find/async_find.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_find"
 bug-reports: "https://github.com/janestreet/async_find/issues"
 dev-repo: "git+https://github.com/janestreet/async_find.git"

--- a/packages/async_find/async_find.v0.11.0/opam
+++ b/packages/async_find/async_find.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_find"
 bug-reports: "https://github.com/janestreet/async_find/issues"
 dev-repo: "git+https://github.com/janestreet/async_find.git"

--- a/packages/async_find/async_find.v0.12.0/opam
+++ b/packages/async_find/async_find.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_find"
 bug-reports: "https://github.com/janestreet/async_find/issues"
 dev-repo: "git+https://github.com/janestreet/async_find.git"

--- a/packages/async_find/async_find.v0.13.0/opam
+++ b/packages/async_find/async_find.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_find"
 bug-reports: "https://github.com/janestreet/async_find/issues"
 dev-repo: "git+https://github.com/janestreet/async_find.git"

--- a/packages/async_find/async_find.v0.14.0/opam
+++ b/packages/async_find/async_find.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_find"
 bug-reports: "https://github.com/janestreet/async_find/issues"
 dev-repo: "git+https://github.com/janestreet/async_find.git"

--- a/packages/async_find/async_find.v0.9.0/opam
+++ b/packages/async_find/async_find.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_find"
 bug-reports: "https://github.com/janestreet/async_find/issues"
 dev-repo: "git+https://github.com/janestreet/async_find.git"

--- a/packages/async_inotify/async_inotify.109.14.00/opam
+++ b/packages/async_inotify/async_inotify.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_inotify"]]
 depends: [

--- a/packages/async_inotify/async_inotify.109.15.00/opam
+++ b/packages/async_inotify/async_inotify.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_inotify"]]
 depends: [

--- a/packages/async_inotify/async_inotify.109.34.00/opam
+++ b/packages/async_inotify/async_inotify.109.34.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_inotify"]]
 depends: [

--- a/packages/async_inotify/async_inotify.109.34.02/opam
+++ b/packages/async_inotify/async_inotify.109.34.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_inotify"]]
 depends: [

--- a/packages/async_inotify/async_inotify.109.58.00/opam
+++ b/packages/async_inotify/async_inotify.109.58.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_inotify"]]
 depends: [

--- a/packages/async_inotify/async_inotify.109.58.01/opam
+++ b/packages/async_inotify/async_inotify.109.58.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_inotify"]]
 depends: [

--- a/packages/async_inotify/async_inotify.111.17.00/opam
+++ b/packages/async_inotify/async_inotify.111.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_inotify"]]
 depends: [

--- a/packages/async_inotify/async_inotify.111.28.00/opam
+++ b/packages/async_inotify/async_inotify.111.28.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_inotify"]]
 depends: [

--- a/packages/async_inotify/async_inotify.113.00.00/opam
+++ b/packages/async_inotify/async_inotify.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_inotify"
 license: "Apache-2.0"
 build: [

--- a/packages/async_inotify/async_inotify.113.24.00/opam
+++ b/packages/async_inotify/async_inotify.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_inotify"
 bug-reports: "https://github.com/janestreet/async_inotify/issues"
 dev-repo: "git+https://github.com/janestreet/async_inotify.git"

--- a/packages/async_inotify/async_inotify.113.33.00/opam
+++ b/packages/async_inotify/async_inotify.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_inotify"
 bug-reports: "https://github.com/janestreet/async_inotify/issues"
 dev-repo: "git+https://github.com/janestreet/async_inotify.git"

--- a/packages/async_inotify/async_inotify.113.33.03/opam
+++ b/packages/async_inotify/async_inotify.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_inotify"
 bug-reports: "https://github.com/janestreet/async_inotify/issues"
 dev-repo: "git+https://github.com/janestreet/async_inotify.git"

--- a/packages/async_inotify/async_inotify.v0.10.0/opam
+++ b/packages/async_inotify/async_inotify.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_inotify"
 bug-reports: "https://github.com/janestreet/async_inotify/issues"
 dev-repo: "git+https://github.com/janestreet/async_inotify.git"

--- a/packages/async_inotify/async_inotify.v0.11.0/opam
+++ b/packages/async_inotify/async_inotify.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_inotify"
 bug-reports: "https://github.com/janestreet/async_inotify/issues"
 dev-repo: "git+https://github.com/janestreet/async_inotify.git"

--- a/packages/async_inotify/async_inotify.v0.12.0/opam
+++ b/packages/async_inotify/async_inotify.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_inotify"
 bug-reports: "https://github.com/janestreet/async_inotify/issues"
 dev-repo: "git+https://github.com/janestreet/async_inotify.git"

--- a/packages/async_inotify/async_inotify.v0.13.0/opam
+++ b/packages/async_inotify/async_inotify.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_inotify"
 bug-reports: "https://github.com/janestreet/async_inotify/issues"
 dev-repo: "git+https://github.com/janestreet/async_inotify.git"

--- a/packages/async_inotify/async_inotify.v0.14.0/opam
+++ b/packages/async_inotify/async_inotify.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_inotify"
 bug-reports: "https://github.com/janestreet/async_inotify/issues"
 dev-repo: "git+https://github.com/janestreet/async_inotify.git"

--- a/packages/async_inotify/async_inotify.v0.9.0/opam
+++ b/packages/async_inotify/async_inotify.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_inotify"
 bug-reports: "https://github.com/janestreet/async_inotify/issues"
 dev-repo: "git+https://github.com/janestreet/async_inotify.git"

--- a/packages/async_interactive/async_interactive.v0.10.0/opam
+++ b/packages/async_interactive/async_interactive.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_interactive"
 bug-reports: "https://github.com/janestreet/async_interactive/issues"
 dev-repo: "git+https://github.com/janestreet/async_interactive.git"

--- a/packages/async_interactive/async_interactive.v0.11.0/opam
+++ b/packages/async_interactive/async_interactive.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_interactive"
 bug-reports: "https://github.com/janestreet/async_interactive/issues"
 dev-repo: "git+https://github.com/janestreet/async_interactive.git"

--- a/packages/async_interactive/async_interactive.v0.12.0/opam
+++ b/packages/async_interactive/async_interactive.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_interactive"
 bug-reports: "https://github.com/janestreet/async_interactive/issues"
 dev-repo: "git+https://github.com/janestreet/async_interactive.git"

--- a/packages/async_interactive/async_interactive.v0.13.0/opam
+++ b/packages/async_interactive/async_interactive.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_interactive"
 bug-reports: "https://github.com/janestreet/async_interactive/issues"
 dev-repo: "git+https://github.com/janestreet/async_interactive.git"

--- a/packages/async_interactive/async_interactive.v0.14.0/opam
+++ b/packages/async_interactive/async_interactive.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_interactive"
 bug-reports: "https://github.com/janestreet/async_interactive/issues"
 dev-repo: "git+https://github.com/janestreet/async_interactive.git"

--- a/packages/async_interactive/async_interactive.v0.9.0/opam
+++ b/packages/async_interactive/async_interactive.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_interactive"
 bug-reports: "https://github.com/janestreet/async_interactive/issues"
 dev-repo: "git+https://github.com/janestreet/async_interactive.git"

--- a/packages/async_js/async_js.v0.10.0/opam
+++ b/packages/async_js/async_js.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_js"
 bug-reports: "https://github.com/janestreet/async_js/issues"
 dev-repo: "git+https://github.com/janestreet/async_js.git"

--- a/packages/async_js/async_js.v0.11.0/opam
+++ b/packages/async_js/async_js.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_js"
 bug-reports: "https://github.com/janestreet/async_js/issues"
 dev-repo: "git+https://github.com/janestreet/async_js.git"

--- a/packages/async_js/async_js.v0.12.0/opam
+++ b/packages/async_js/async_js.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_js"
 bug-reports: "https://github.com/janestreet/async_js/issues"
 dev-repo: "git+https://github.com/janestreet/async_js.git"

--- a/packages/async_js/async_js.v0.13.0/opam
+++ b/packages/async_js/async_js.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_js"
 bug-reports: "https://github.com/janestreet/async_js/issues"
 dev-repo: "git+https://github.com/janestreet/async_js.git"

--- a/packages/async_js/async_js.v0.14.0/opam
+++ b/packages/async_js/async_js.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_js"
 bug-reports: "https://github.com/janestreet/async_js/issues"
 dev-repo: "git+https://github.com/janestreet/async_js.git"

--- a/packages/async_js/async_js.v0.9.0/opam
+++ b/packages/async_js/async_js.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_js"
 bug-reports: "https://github.com/janestreet/async_js/issues"
 dev-repo: "git+https://github.com/janestreet/async_js.git"

--- a/packages/async_js/async_js.v0.9.1/opam
+++ b/packages/async_js/async_js.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_js"
 bug-reports: "https://github.com/janestreet/async_js/issues"
 dev-repo: "git+https://github.com/janestreet/async_js.git"

--- a/packages/async_kernel/async_kernel.109.58.00/opam
+++ b/packages/async_kernel/async_kernel.109.58.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.109.60.00/opam
+++ b/packages/async_kernel/async_kernel.109.60.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.110.01.00/opam
+++ b/packages/async_kernel/async_kernel.110.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.111.03.00/opam
+++ b/packages/async_kernel/async_kernel.111.03.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.111.06.00/opam
+++ b/packages/async_kernel/async_kernel.111.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.111.08.00/opam
+++ b/packages/async_kernel/async_kernel.111.08.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.111.11.00/opam
+++ b/packages/async_kernel/async_kernel.111.11.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.111.17.00/opam
+++ b/packages/async_kernel/async_kernel.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.111.25.00/opam
+++ b/packages/async_kernel/async_kernel.111.25.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.111.28.00/opam
+++ b/packages/async_kernel/async_kernel.111.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.112.01.00/opam
+++ b/packages/async_kernel/async_kernel.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.112.06.00/opam
+++ b/packages/async_kernel/async_kernel.112.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.112.17.00/opam
+++ b/packages/async_kernel/async_kernel.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.112.24.00/opam
+++ b/packages/async_kernel/async_kernel.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.112.35.00/opam
+++ b/packages/async_kernel/async_kernel.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.113.00.00/opam
+++ b/packages/async_kernel/async_kernel.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_kernel/async_kernel.113.24.00/opam
+++ b/packages/async_kernel/async_kernel.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 bug-reports: "https://github.com/janestreet/async_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_kernel.git"

--- a/packages/async_kernel/async_kernel.113.33.00/opam
+++ b/packages/async_kernel/async_kernel.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 bug-reports: "https://github.com/janestreet/async_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_kernel.git"

--- a/packages/async_kernel/async_kernel.113.33.03/opam
+++ b/packages/async_kernel/async_kernel.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 bug-reports: "https://github.com/janestreet/async_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_kernel.git"

--- a/packages/async_kernel/async_kernel.v0.10.0/opam
+++ b/packages/async_kernel/async_kernel.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 bug-reports: "https://github.com/janestreet/async_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_kernel.git"

--- a/packages/async_kernel/async_kernel.v0.11.0/opam
+++ b/packages/async_kernel/async_kernel.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 bug-reports: "https://github.com/janestreet/async_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_kernel.git"

--- a/packages/async_kernel/async_kernel.v0.11.1/opam
+++ b/packages/async_kernel/async_kernel.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 bug-reports: "https://github.com/janestreet/async_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_kernel.git"

--- a/packages/async_kernel/async_kernel.v0.12.0/opam
+++ b/packages/async_kernel/async_kernel.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 bug-reports: "https://github.com/janestreet/async_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_kernel.git"

--- a/packages/async_kernel/async_kernel.v0.13.0/opam
+++ b/packages/async_kernel/async_kernel.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 bug-reports: "https://github.com/janestreet/async_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_kernel.git"

--- a/packages/async_kernel/async_kernel.v0.14.0/opam
+++ b/packages/async_kernel/async_kernel.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 bug-reports: "https://github.com/janestreet/async_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_kernel.git"

--- a/packages/async_kernel/async_kernel.v0.9.0/opam
+++ b/packages/async_kernel/async_kernel.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_kernel"
 bug-reports: "https://github.com/janestreet/async_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_kernel.git"

--- a/packages/async_parallel/async_parallel.109.23.00/opam
+++ b/packages/async_parallel/async_parallel.109.23.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.109.27.00/opam
+++ b/packages/async_parallel/async_parallel.109.27.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.109.30.00/opam
+++ b/packages/async_parallel/async_parallel.109.30.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.109.34.00/opam
+++ b/packages/async_parallel/async_parallel.109.34.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.109.35.00/opam
+++ b/packages/async_parallel/async_parallel.109.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.109.40.00/opam
+++ b/packages/async_parallel/async_parallel.109.40.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.109.41.00/opam
+++ b/packages/async_parallel/async_parallel.109.41.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.109.47.00/opam
+++ b/packages/async_parallel/async_parallel.109.47.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.109.53.00/opam
+++ b/packages/async_parallel/async_parallel.109.53.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.109.53.02/opam
+++ b/packages/async_parallel/async_parallel.109.53.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.109.58.00/opam
+++ b/packages/async_parallel/async_parallel.109.58.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.109.58.01/opam
+++ b/packages/async_parallel/async_parallel.109.58.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.111.17.00/opam
+++ b/packages/async_parallel/async_parallel.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.111.25.00/opam
+++ b/packages/async_parallel/async_parallel.111.25.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.111.28.00/opam
+++ b/packages/async_parallel/async_parallel.111.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.112.17.00/opam
+++ b/packages/async_parallel/async_parallel.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.112.35.00/opam
+++ b/packages/async_parallel/async_parallel.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.113.00.00/opam
+++ b/packages/async_parallel/async_parallel.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_parallel/async_parallel.113.24.00/opam
+++ b/packages/async_parallel/async_parallel.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 bug-reports: "https://github.com/janestreet/async_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/async_parallel.git"

--- a/packages/async_parallel/async_parallel.113.33.00/opam
+++ b/packages/async_parallel/async_parallel.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 bug-reports: "https://github.com/janestreet/async_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/async_parallel.git"

--- a/packages/async_parallel/async_parallel.113.33.03/opam
+++ b/packages/async_parallel/async_parallel.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 bug-reports: "https://github.com/janestreet/async_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/async_parallel.git"

--- a/packages/async_parallel/async_parallel.v0.10.0/opam
+++ b/packages/async_parallel/async_parallel.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 bug-reports: "https://github.com/janestreet/async_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/async_parallel.git"

--- a/packages/async_parallel/async_parallel.v0.11.0/opam
+++ b/packages/async_parallel/async_parallel.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 bug-reports: "https://github.com/janestreet/async_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/async_parallel.git"

--- a/packages/async_parallel/async_parallel.v0.9.0/opam
+++ b/packages/async_parallel/async_parallel.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 bug-reports: "https://github.com/janestreet/async_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/async_parallel.git"

--- a/packages/async_parallel/async_parallel.v0.9.1/opam
+++ b/packages/async_parallel/async_parallel.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_parallel"
 bug-reports: "https://github.com/janestreet/async_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/async_parallel.git"

--- a/packages/async_rpc_kernel/async_rpc_kernel.112.35.00/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_rpc_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_rpc_kernel/async_rpc_kernel.113.00.00/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_rpc_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/async_rpc_kernel/async_rpc_kernel.113.24.00/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_rpc_kernel"
 bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_rpc_kernel.git"

--- a/packages/async_rpc_kernel/async_rpc_kernel.113.33.00/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_rpc_kernel"
 bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_rpc_kernel.git"

--- a/packages/async_rpc_kernel/async_rpc_kernel.113.33.03/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_rpc_kernel"
 bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_rpc_kernel.git"

--- a/packages/async_rpc_kernel/async_rpc_kernel.v0.10.0/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_rpc_kernel"
 bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_rpc_kernel.git"

--- a/packages/async_rpc_kernel/async_rpc_kernel.v0.11.0/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_rpc_kernel"
 bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_rpc_kernel.git"

--- a/packages/async_rpc_kernel/async_rpc_kernel.v0.12.0/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_rpc_kernel"
 bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_rpc_kernel.git"

--- a/packages/async_rpc_kernel/async_rpc_kernel.v0.13.0/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_rpc_kernel"
 bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_rpc_kernel.git"

--- a/packages/async_rpc_kernel/async_rpc_kernel.v0.14.0/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_rpc_kernel"
 bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_rpc_kernel.git"

--- a/packages/async_rpc_kernel/async_rpc_kernel.v0.9.0/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_rpc_kernel"
 bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/async_rpc_kernel.git"

--- a/packages/async_sendfile/async_sendfile.v0.10.0/opam
+++ b/packages/async_sendfile/async_sendfile.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_sendfile"
 bug-reports: "https://github.com/janestreet/async_sendfile/issues"
 dev-repo: "git+https://github.com/janestreet/async_sendfile.git"

--- a/packages/async_sendfile/async_sendfile.v0.11.0/opam
+++ b/packages/async_sendfile/async_sendfile.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_sendfile"
 bug-reports: "https://github.com/janestreet/async_sendfile/issues"
 dev-repo: "git+https://github.com/janestreet/async_sendfile.git"

--- a/packages/async_sendfile/async_sendfile.v0.12.0/opam
+++ b/packages/async_sendfile/async_sendfile.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_sendfile"
 bug-reports: "https://github.com/janestreet/async_sendfile/issues"
 dev-repo: "git+https://github.com/janestreet/async_sendfile.git"

--- a/packages/async_sendfile/async_sendfile.v0.13.0/opam
+++ b/packages/async_sendfile/async_sendfile.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_sendfile"
 bug-reports: "https://github.com/janestreet/async_sendfile/issues"
 dev-repo: "git+https://github.com/janestreet/async_sendfile.git"

--- a/packages/async_sendfile/async_sendfile.v0.14.0/opam
+++ b/packages/async_sendfile/async_sendfile.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_sendfile"
 bug-reports: "https://github.com/janestreet/async_sendfile/issues"
 dev-repo: "git+https://github.com/janestreet/async_sendfile.git"

--- a/packages/async_shell/async_shell.109.14.00/opam
+++ b/packages/async_shell/async_shell.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_shell"]]
 depends: [

--- a/packages/async_shell/async_shell.109.15.00/opam
+++ b/packages/async_shell/async_shell.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_shell"]]
 depends: [

--- a/packages/async_shell/async_shell.109.17.00/opam
+++ b/packages/async_shell/async_shell.109.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_shell"]]
 depends: [

--- a/packages/async_shell/async_shell.109.28.00/opam
+++ b/packages/async_shell/async_shell.109.28.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_shell"]]
 depends: [

--- a/packages/async_shell/async_shell.109.28.02/opam
+++ b/packages/async_shell/async_shell.109.28.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_shell"]]
 depends: [

--- a/packages/async_shell/async_shell.109.28.03/opam
+++ b/packages/async_shell/async_shell.109.28.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_shell"
 license: "Apache-2.0"
 build: [

--- a/packages/async_shell/async_shell.113.24.00/opam
+++ b/packages/async_shell/async_shell.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_shell"
 bug-reports: "https://github.com/janestreet/async_shell/issues"
 dev-repo: "git+https://github.com/janestreet/async_shell.git"

--- a/packages/async_shell/async_shell.113.33.00/opam
+++ b/packages/async_shell/async_shell.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_shell"
 bug-reports: "https://github.com/janestreet/async_shell/issues"
 dev-repo: "git+https://github.com/janestreet/async_shell.git"

--- a/packages/async_shell/async_shell.113.33.03/opam
+++ b/packages/async_shell/async_shell.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_shell"
 bug-reports: "https://github.com/janestreet/async_shell/issues"
 dev-repo: "git+https://github.com/janestreet/async_shell.git"

--- a/packages/async_shell/async_shell.v0.10.0/opam
+++ b/packages/async_shell/async_shell.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_shell"
 bug-reports: "https://github.com/janestreet/async_shell/issues"
 dev-repo: "git+https://github.com/janestreet/async_shell.git"

--- a/packages/async_shell/async_shell.v0.11.0/opam
+++ b/packages/async_shell/async_shell.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_shell"
 bug-reports: "https://github.com/janestreet/async_shell/issues"
 dev-repo: "git+https://github.com/janestreet/async_shell.git"

--- a/packages/async_shell/async_shell.v0.12.0/opam
+++ b/packages/async_shell/async_shell.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_shell"
 bug-reports: "https://github.com/janestreet/async_shell/issues"
 dev-repo: "git+https://github.com/janestreet/async_shell.git"

--- a/packages/async_shell/async_shell.v0.13.0/opam
+++ b/packages/async_shell/async_shell.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_shell"
 bug-reports: "https://github.com/janestreet/async_shell/issues"
 dev-repo: "git+https://github.com/janestreet/async_shell.git"

--- a/packages/async_shell/async_shell.v0.14.0/opam
+++ b/packages/async_shell/async_shell.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_shell"
 bug-reports: "https://github.com/janestreet/async_shell/issues"
 dev-repo: "git+https://github.com/janestreet/async_shell.git"

--- a/packages/async_shell/async_shell.v0.9.0/opam
+++ b/packages/async_shell/async_shell.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_shell"
 bug-reports: "https://github.com/janestreet/async_shell/issues"
 dev-repo: "git+https://github.com/janestreet/async_shell.git"

--- a/packages/async_shell/async_shell.v0.9.1/opam
+++ b/packages/async_shell/async_shell.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_shell"
 bug-reports: "https://github.com/janestreet/async_shell/issues"
 dev-repo: "git+https://github.com/janestreet/async_shell.git"

--- a/packages/async_smtp/async_smtp.109.38.alpha1/opam
+++ b/packages/async_smtp/async_smtp.109.38.alpha1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_smtp"]]
 depends: [

--- a/packages/async_smtp/async_smtp.112.17.00/opam
+++ b/packages/async_smtp/async_smtp.112.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_smtp"]]
 depends: [

--- a/packages/async_smtp/async_smtp.112.24.00/opam
+++ b/packages/async_smtp/async_smtp.112.24.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_smtp"]]
 depends: [

--- a/packages/async_smtp/async_smtp.112.35.00/opam
+++ b/packages/async_smtp/async_smtp.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_smtp"
 build: [
   [make]

--- a/packages/async_smtp/async_smtp.113.00.00/opam
+++ b/packages/async_smtp/async_smtp.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_smtp"
 build: [
   [make]

--- a/packages/async_smtp/async_smtp.113.24.00/opam
+++ b/packages/async_smtp/async_smtp.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_smtp"
 bug-reports: "https://github.com/janestreet/async_smtp/issues"
 dev-repo: "git+https://github.com/janestreet/async_smtp.git"

--- a/packages/async_smtp/async_smtp.113.33.00/opam
+++ b/packages/async_smtp/async_smtp.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_smtp"
 bug-reports: "https://github.com/janestreet/async_smtp/issues"
 dev-repo: "git+https://github.com/janestreet/async_smtp.git"

--- a/packages/async_smtp/async_smtp.113.33.03/opam
+++ b/packages/async_smtp/async_smtp.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_smtp"
 bug-reports: "https://github.com/janestreet/async_smtp/issues"
 dev-repo: "git+https://github.com/janestreet/async_smtp.git"

--- a/packages/async_smtp/async_smtp.v0.10.0/opam
+++ b/packages/async_smtp/async_smtp.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_smtp"
 bug-reports: "https://github.com/janestreet/async_smtp/issues"
 dev-repo: "git+https://github.com/janestreet/async_smtp.git"

--- a/packages/async_smtp/async_smtp.v0.11.0/opam
+++ b/packages/async_smtp/async_smtp.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_smtp"
 bug-reports: "https://github.com/janestreet/async_smtp/issues"
 dev-repo: "git+https://github.com/janestreet/async_smtp.git"

--- a/packages/async_smtp/async_smtp.v0.12.0/opam
+++ b/packages/async_smtp/async_smtp.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_smtp"
 bug-reports: "https://github.com/janestreet/async_smtp/issues"
 dev-repo: "git+https://github.com/janestreet/async_smtp.git"

--- a/packages/async_smtp/async_smtp.v0.13.0/opam
+++ b/packages/async_smtp/async_smtp.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_smtp"
 bug-reports: "https://github.com/janestreet/async_smtp/issues"
 dev-repo: "git+https://github.com/janestreet/async_smtp.git"

--- a/packages/async_smtp/async_smtp.v0.14.0/opam
+++ b/packages/async_smtp/async_smtp.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_smtp"
 bug-reports: "https://github.com/janestreet/async_smtp/issues"
 dev-repo: "git+https://github.com/janestreet/async_smtp.git"

--- a/packages/async_smtp/async_smtp.v0.9.0/opam
+++ b/packages/async_smtp/async_smtp.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_smtp"
 bug-reports: "https://github.com/janestreet/async_smtp/issues"
 dev-repo: "git+https://github.com/janestreet/async_smtp.git"

--- a/packages/async_ssl/async_ssl.111.06.00/opam
+++ b/packages/async_ssl/async_ssl.111.06.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_ssl"]]
 depends: [

--- a/packages/async_ssl/async_ssl.111.08.00/opam
+++ b/packages/async_ssl/async_ssl.111.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_ssl"]]
 depends: [

--- a/packages/async_ssl/async_ssl.111.21.00/opam
+++ b/packages/async_ssl/async_ssl.111.21.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_ssl"]]
 depends: [

--- a/packages/async_ssl/async_ssl.112.17.00/opam
+++ b/packages/async_ssl/async_ssl.112.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_ssl"]]
 depends: [

--- a/packages/async_ssl/async_ssl.112.24.02/opam
+++ b/packages/async_ssl/async_ssl.112.24.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_ssl"]]
 depends: [

--- a/packages/async_ssl/async_ssl.112.24.03/opam
+++ b/packages/async_ssl/async_ssl.112.24.03/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_ssl"]]
 depends: [

--- a/packages/async_ssl/async_ssl.112.35.00/opam
+++ b/packages/async_ssl/async_ssl.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 build: [
   [make]

--- a/packages/async_ssl/async_ssl.113.00.00/opam
+++ b/packages/async_ssl/async_ssl.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 build: [
   [make]

--- a/packages/async_ssl/async_ssl.113.00.01/opam
+++ b/packages/async_ssl/async_ssl.113.00.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 build: [
   [make]

--- a/packages/async_ssl/async_ssl.113.24.00/opam
+++ b/packages/async_ssl/async_ssl.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.113.33.00/opam
+++ b/packages/async_ssl/async_ssl.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.113.33.01/opam
+++ b/packages/async_ssl/async_ssl.113.33.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.113.33.03/opam
+++ b/packages/async_ssl/async_ssl.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.113.33.05/opam
+++ b/packages/async_ssl/async_ssl.113.33.05/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.113.33.06/opam
+++ b/packages/async_ssl/async_ssl.113.33.06/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.113.33.07/opam
+++ b/packages/async_ssl/async_ssl.113.33.07/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.v0.10.0/opam
+++ b/packages/async_ssl/async_ssl.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.v0.11.0/opam
+++ b/packages/async_ssl/async_ssl.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.v0.12.0/opam
+++ b/packages/async_ssl/async_ssl.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.v0.13.0/opam
+++ b/packages/async_ssl/async_ssl.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.v0.14.0/opam
+++ b/packages/async_ssl/async_ssl.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.v0.9.0/opam
+++ b/packages/async_ssl/async_ssl.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 dev-repo: "git+https://github.com/janestreet/async_ssl.git"

--- a/packages/async_ssl/async_ssl.v0.9.1/opam
+++ b/packages/async_ssl/async_ssl.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
 homepage: "https://github.com/janestreet/async_ssl"
 bug-reports: "https://github.com/janestreet/async_ssl/issues"
 license: "Apache-2.0"

--- a/packages/async_udp/async_udp.v0.12.0/opam
+++ b/packages/async_udp/async_udp.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_udp"
 bug-reports: "https://github.com/janestreet/async_udp/issues"
 dev-repo: "git+https://github.com/janestreet/async_udp.git"

--- a/packages/async_udp/async_udp.v0.13.0/opam
+++ b/packages/async_udp/async_udp.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_udp"
 bug-reports: "https://github.com/janestreet/async_udp/issues"
 dev-repo: "git+https://github.com/janestreet/async_udp.git"

--- a/packages/async_udp/async_udp.v0.14.0/opam
+++ b/packages/async_udp/async_udp.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_udp"
 bug-reports: "https://github.com/janestreet/async_udp/issues"
 dev-repo: "git+https://github.com/janestreet/async_udp.git"

--- a/packages/async_unix/async_unix.108.00.01/opam
+++ b/packages/async_unix/async_unix.108.00.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.108.00.02/opam
+++ b/packages/async_unix/async_unix.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.108.07.00/opam
+++ b/packages/async_unix/async_unix.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.108.07.01/opam
+++ b/packages/async_unix/async_unix.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.108.08.00/opam
+++ b/packages/async_unix/async_unix.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.109.07.00/opam
+++ b/packages/async_unix/async_unix.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.109.08.00/opam
+++ b/packages/async_unix/async_unix.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.109.09.00/opam
+++ b/packages/async_unix/async_unix.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.109.10.00/opam
+++ b/packages/async_unix/async_unix.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.109.11.00/opam
+++ b/packages/async_unix/async_unix.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.109.12.00/opam
+++ b/packages/async_unix/async_unix.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.109.13.00/opam
+++ b/packages/async_unix/async_unix.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.109.14.00/opam
+++ b/packages/async_unix/async_unix.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.109.15.00/opam
+++ b/packages/async_unix/async_unix.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.109.17.00/opam
+++ b/packages/async_unix/async_unix.109.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.109.18.00/opam
+++ b/packages/async_unix/async_unix.109.18.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "async_unix"]]
 depends: [

--- a/packages/async_unix/async_unix.109.19.00/opam
+++ b/packages/async_unix/async_unix.109.19.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.20.00/opam
+++ b/packages/async_unix/async_unix.109.20.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.21.00/opam
+++ b/packages/async_unix/async_unix.109.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.24.00/opam
+++ b/packages/async_unix/async_unix.109.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.27.00/opam
+++ b/packages/async_unix/async_unix.109.27.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.30.00/opam
+++ b/packages/async_unix/async_unix.109.30.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.31.00/opam
+++ b/packages/async_unix/async_unix.109.31.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.32.00/opam
+++ b/packages/async_unix/async_unix.109.32.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.34.00/opam
+++ b/packages/async_unix/async_unix.109.34.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.35.00/opam
+++ b/packages/async_unix/async_unix.109.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.36.00/opam
+++ b/packages/async_unix/async_unix.109.36.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.38.00/opam
+++ b/packages/async_unix/async_unix.109.38.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.40.00/opam
+++ b/packages/async_unix/async_unix.109.40.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.41.00/opam
+++ b/packages/async_unix/async_unix.109.41.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.42.00/opam
+++ b/packages/async_unix/async_unix.109.42.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.45.00/opam
+++ b/packages/async_unix/async_unix.109.45.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.47.00/opam
+++ b/packages/async_unix/async_unix.109.47.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.53.00/opam
+++ b/packages/async_unix/async_unix.109.53.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.55.00/opam
+++ b/packages/async_unix/async_unix.109.55.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.55.02/opam
+++ b/packages/async_unix/async_unix.109.55.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.58.00/opam
+++ b/packages/async_unix/async_unix.109.58.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.109.60.00/opam
+++ b/packages/async_unix/async_unix.109.60.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.110.01.00/opam
+++ b/packages/async_unix/async_unix.110.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.111.03.00/opam
+++ b/packages/async_unix/async_unix.111.03.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.111.06.00/opam
+++ b/packages/async_unix/async_unix.111.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.111.08.00/opam
+++ b/packages/async_unix/async_unix.111.08.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.111.11.00/opam
+++ b/packages/async_unix/async_unix.111.11.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.111.13.00/opam
+++ b/packages/async_unix/async_unix.111.13.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.111.17.00/opam
+++ b/packages/async_unix/async_unix.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.111.21.00/opam
+++ b/packages/async_unix/async_unix.111.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.111.25.00/opam
+++ b/packages/async_unix/async_unix.111.25.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.111.28.00/opam
+++ b/packages/async_unix/async_unix.111.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.112.01.00/opam
+++ b/packages/async_unix/async_unix.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.112.06.00/opam
+++ b/packages/async_unix/async_unix.112.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.112.17.00/opam
+++ b/packages/async_unix/async_unix.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.112.24.00/opam
+++ b/packages/async_unix/async_unix.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.112.35.00/opam
+++ b/packages/async_unix/async_unix.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.113.00.00/opam
+++ b/packages/async_unix/async_unix.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 license: "Apache-2.0"
 build: [

--- a/packages/async_unix/async_unix.113.24.00/opam
+++ b/packages/async_unix/async_unix.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 bug-reports: "https://github.com/janestreet/async_unix/issues"
 dev-repo: "git+https://github.com/janestreet/async_unix.git"

--- a/packages/async_unix/async_unix.113.33.00+4.03/opam
+++ b/packages/async_unix/async_unix.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 bug-reports: "https://github.com/janestreet/async_unix/issues"
 dev-repo: "git+https://github.com/janestreet/async_unix.git"

--- a/packages/async_unix/async_unix.113.33.00/opam
+++ b/packages/async_unix/async_unix.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 bug-reports: "https://github.com/janestreet/async_unix/issues"
 dev-repo: "git+https://github.com/janestreet/async_unix.git"

--- a/packages/async_unix/async_unix.113.33.03/opam
+++ b/packages/async_unix/async_unix.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 bug-reports: "https://github.com/janestreet/async_unix/issues"
 dev-repo: "git+https://github.com/janestreet/async_unix.git"

--- a/packages/async_unix/async_unix.v0.10.0/opam
+++ b/packages/async_unix/async_unix.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 bug-reports: "https://github.com/janestreet/async_unix/issues"
 dev-repo: "git+https://github.com/janestreet/async_unix.git"

--- a/packages/async_unix/async_unix.v0.11.0/opam
+++ b/packages/async_unix/async_unix.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 bug-reports: "https://github.com/janestreet/async_unix/issues"
 dev-repo: "git+https://github.com/janestreet/async_unix.git"

--- a/packages/async_unix/async_unix.v0.12.0/opam
+++ b/packages/async_unix/async_unix.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 bug-reports: "https://github.com/janestreet/async_unix/issues"
 dev-repo: "git+https://github.com/janestreet/async_unix.git"

--- a/packages/async_unix/async_unix.v0.13.0/opam
+++ b/packages/async_unix/async_unix.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 bug-reports: "https://github.com/janestreet/async_unix/issues"
 dev-repo: "git+https://github.com/janestreet/async_unix.git"

--- a/packages/async_unix/async_unix.v0.13.1/opam
+++ b/packages/async_unix/async_unix.v0.13.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 bug-reports: "https://github.com/janestreet/async_unix/issues"
 dev-repo: "git+https://github.com/janestreet/async_unix.git"

--- a/packages/async_unix/async_unix.v0.14.0/opam
+++ b/packages/async_unix/async_unix.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 bug-reports: "https://github.com/janestreet/async_unix/issues"
 dev-repo: "git+https://github.com/janestreet/async_unix.git"

--- a/packages/async_unix/async_unix.v0.9.0/opam
+++ b/packages/async_unix/async_unix.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 bug-reports: "https://github.com/janestreet/async_unix/issues"
 dev-repo: "git+https://github.com/janestreet/async_unix.git"

--- a/packages/async_unix/async_unix.v0.9.1/opam
+++ b/packages/async_unix/async_unix.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_unix"
 bug-reports: "https://github.com/janestreet/async_unix/issues"
 dev-repo: "git+https://github.com/janestreet/async_unix.git"

--- a/packages/async_websocket/async_websocket.v0.13.0/opam
+++ b/packages/async_websocket/async_websocket.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/websocket"
 bug-reports: "https://github.com/janestreet/websocket/issues"
 dev-repo: "git+https://github.com/janestreet/websocket.git"

--- a/packages/async_websocket/async_websocket.v0.13.1/opam
+++ b/packages/async_websocket/async_websocket.v0.13.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_websocket"
 bug-reports: "https://github.com/janestreet/async_websocket/issues"
 dev-repo: "git+https://github.com/janestreet/async_websocket.git"

--- a/packages/async_websocket/async_websocket.v0.14.0/opam
+++ b/packages/async_websocket/async_websocket.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/async_websocket"
 bug-reports: "https://github.com/janestreet/async_websocket/issues"
 dev-repo: "git+https://github.com/janestreet/async_websocket.git"

--- a/packages/base-native-int63/base-native-int63.0.1/opam
+++ b/packages/base-native-int63/base-native-int63.0.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.10.0/opam
+++ b/packages/base/base.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.11.0/opam
+++ b/packages/base/base.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.11.1/opam
+++ b/packages/base/base.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.12.0/opam
+++ b/packages/base/base.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.12.1/opam
+++ b/packages/base/base.v0.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.12.2/opam
+++ b/packages/base/base.v0.12.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.13.0/opam
+++ b/packages/base/base.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.13.1/opam
+++ b/packages/base/base.v0.13.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.13.2/opam
+++ b/packages/base/base.v0.13.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.14.0/opam
+++ b/packages/base/base.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.14.1/opam
+++ b/packages/base/base.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.9.0/opam
+++ b/packages/base/base.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.9.1/opam
+++ b/packages/base/base.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.9.2/opam
+++ b/packages/base/base.v0.9.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"

--- a/packages/base/base.v0.9.3/opam
+++ b/packages/base/base.v0.9.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 license: "Apache-2.0"

--- a/packages/base/base.v0.9.4/opam
+++ b/packages/base/base.v0.9.4/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
 homepage: "https://github.com/janestreet/base"
 bug-reports: "https://github.com/janestreet/base/issues"
 license: "Apache-2.0"

--- a/packages/base_bigstring/base_bigstring.v0.12.0/opam
+++ b/packages/base_bigstring/base_bigstring.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base_bigstring"
 bug-reports: "https://github.com/janestreet/base_bigstring/issues"
 dev-repo: "git+https://github.com/janestreet/base_bigstring.git"

--- a/packages/base_bigstring/base_bigstring.v0.13.0/opam
+++ b/packages/base_bigstring/base_bigstring.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base_bigstring"
 bug-reports: "https://github.com/janestreet/base_bigstring/issues"
 dev-repo: "git+https://github.com/janestreet/base_bigstring.git"

--- a/packages/base_bigstring/base_bigstring.v0.14.0/opam
+++ b/packages/base_bigstring/base_bigstring.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base_bigstring"
 bug-reports: "https://github.com/janestreet/base_bigstring/issues"
 dev-repo: "git+https://github.com/janestreet/base_bigstring.git"

--- a/packages/base_quickcheck/base_quickcheck.v0.12.0/opam
+++ b/packages/base_quickcheck/base_quickcheck.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base_quickcheck"
 bug-reports: "https://github.com/janestreet/base_quickcheck/issues"
 dev-repo: "git+https://github.com/janestreet/base_quickcheck.git"

--- a/packages/base_quickcheck/base_quickcheck.v0.12.1/opam
+++ b/packages/base_quickcheck/base_quickcheck.v0.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base_quickcheck"
 bug-reports: "https://github.com/janestreet/base_quickcheck/issues"
 dev-repo: "git+https://github.com/janestreet/base_quickcheck.git"

--- a/packages/base_quickcheck/base_quickcheck.v0.13.0/opam
+++ b/packages/base_quickcheck/base_quickcheck.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base_quickcheck"
 bug-reports: "https://github.com/janestreet/base_quickcheck/issues"
 dev-repo: "git+https://github.com/janestreet/base_quickcheck.git"

--- a/packages/base_quickcheck/base_quickcheck.v0.14.0/opam
+++ b/packages/base_quickcheck/base_quickcheck.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base_quickcheck"
 bug-reports: "https://github.com/janestreet/base_quickcheck/issues"
 dev-repo: "git+https://github.com/janestreet/base_quickcheck.git"

--- a/packages/base_quickcheck/base_quickcheck.v0.14.1/opam
+++ b/packages/base_quickcheck/base_quickcheck.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/base_quickcheck"
 bug-reports: "https://github.com/janestreet/base_quickcheck/issues"
 dev-repo: "git+https://github.com/janestreet/base_quickcheck.git"

--- a/packages/bignum/bignum.111.08.00/opam
+++ b/packages/bignum/bignum.111.08.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/bignum/bignum.111.13.00/opam
+++ b/packages/bignum/bignum.111.13.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/bignum/bignum.111.17.00/opam
+++ b/packages/bignum/bignum.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/bignum/bignum.111.28.00/opam
+++ b/packages/bignum/bignum.111.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/bignum/bignum.112.01.00/opam
+++ b/packages/bignum/bignum.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/bignum/bignum.112.06.00/opam
+++ b/packages/bignum/bignum.112.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/bignum/bignum.112.06.02/opam
+++ b/packages/bignum/bignum.112.06.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/bignum/bignum.112.17.00/opam
+++ b/packages/bignum/bignum.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/bignum/bignum.112.24.00/opam
+++ b/packages/bignum/bignum.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/bignum/bignum.112.24.01/opam
+++ b/packages/bignum/bignum.112.24.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/bignum/bignum.112.35.00/opam
+++ b/packages/bignum/bignum.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bignum"
 license: "Apache-2.0"
 build: [

--- a/packages/bignum/bignum.113.00.00/opam
+++ b/packages/bignum/bignum.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bignum"
 license: "Apache-2.0"
 build: [

--- a/packages/bignum/bignum.113.24.00/opam
+++ b/packages/bignum/bignum.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bignum"
 bug-reports: "https://github.com/janestreet/bignum/issues"
 dev-repo: "git+https://github.com/janestreet/bignum.git"

--- a/packages/bignum/bignum.113.33.00/opam
+++ b/packages/bignum/bignum.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bignum"
 bug-reports: "https://github.com/janestreet/bignum/issues"
 dev-repo: "git+https://github.com/janestreet/bignum.git"

--- a/packages/bignum/bignum.113.33.03/opam
+++ b/packages/bignum/bignum.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bignum"
 bug-reports: "https://github.com/janestreet/bignum/issues"
 dev-repo: "git+https://github.com/janestreet/bignum.git"

--- a/packages/bignum/bignum.v0.10.0/opam
+++ b/packages/bignum/bignum.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bignum"
 bug-reports: "https://github.com/janestreet/bignum/issues"
 dev-repo: "git+https://github.com/janestreet/bignum.git"

--- a/packages/bignum/bignum.v0.11.0/opam
+++ b/packages/bignum/bignum.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bignum"
 bug-reports: "https://github.com/janestreet/bignum/issues"
 dev-repo: "git+https://github.com/janestreet/bignum.git"

--- a/packages/bignum/bignum.v0.12.0/opam
+++ b/packages/bignum/bignum.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bignum"
 bug-reports: "https://github.com/janestreet/bignum/issues"
 dev-repo: "git+https://github.com/janestreet/bignum.git"

--- a/packages/bignum/bignum.v0.13.0/opam
+++ b/packages/bignum/bignum.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bignum"
 bug-reports: "https://github.com/janestreet/bignum/issues"
 dev-repo: "git+https://github.com/janestreet/bignum.git"

--- a/packages/bignum/bignum.v0.14.0/opam
+++ b/packages/bignum/bignum.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bignum"
 bug-reports: "https://github.com/janestreet/bignum/issues"
 dev-repo: "git+https://github.com/janestreet/bignum.git"

--- a/packages/bignum/bignum.v0.9.0/opam
+++ b/packages/bignum/bignum.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bignum"
 bug-reports: "https://github.com/janestreet/bignum/issues"
 dev-repo: "git+https://github.com/janestreet/bignum.git"

--- a/packages/bin_prot/bin_prot.108.00.02/opam
+++ b/packages/bin_prot/bin_prot.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [

--- a/packages/bin_prot/bin_prot.108.07.00/opam
+++ b/packages/bin_prot/bin_prot.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [

--- a/packages/bin_prot/bin_prot.108.07.01/opam
+++ b/packages/bin_prot/bin_prot.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [

--- a/packages/bin_prot/bin_prot.108.08.00/opam
+++ b/packages/bin_prot/bin_prot.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [

--- a/packages/bin_prot/bin_prot.109.07.00/opam
+++ b/packages/bin_prot/bin_prot.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [

--- a/packages/bin_prot/bin_prot.109.08.00/opam
+++ b/packages/bin_prot/bin_prot.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [

--- a/packages/bin_prot/bin_prot.109.09.00/opam
+++ b/packages/bin_prot/bin_prot.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [

--- a/packages/bin_prot/bin_prot.109.10.00/opam
+++ b/packages/bin_prot/bin_prot.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [

--- a/packages/bin_prot/bin_prot.109.11.00/opam
+++ b/packages/bin_prot/bin_prot.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [

--- a/packages/bin_prot/bin_prot.109.12.00/opam
+++ b/packages/bin_prot/bin_prot.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [

--- a/packages/bin_prot/bin_prot.109.13.00/opam
+++ b/packages/bin_prot/bin_prot.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [

--- a/packages/bin_prot/bin_prot.109.14.00/opam
+++ b/packages/bin_prot/bin_prot.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "bin_prot"]]
 depends: [

--- a/packages/bin_prot/bin_prot.109.15.00/opam
+++ b/packages/bin_prot/bin_prot.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.109.15.01/opam
+++ b/packages/bin_prot/bin_prot.109.15.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.109.30.00/opam
+++ b/packages/bin_prot/bin_prot.109.30.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.109.41.00/opam
+++ b/packages/bin_prot/bin_prot.109.41.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.109.42.00/opam
+++ b/packages/bin_prot/bin_prot.109.42.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.109.45.00/opam
+++ b/packages/bin_prot/bin_prot.109.45.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.109.47.00/opam
+++ b/packages/bin_prot/bin_prot.109.47.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.109.53.00/opam
+++ b/packages/bin_prot/bin_prot.109.53.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.109.53.02/opam
+++ b/packages/bin_prot/bin_prot.109.53.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -17,7 +17,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.109.53.03/opam
+++ b/packages/bin_prot/bin_prot.109.53.03/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -17,7 +17,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.111.03.00/opam
+++ b/packages/bin_prot/bin_prot.111.03.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.112.01.00/opam
+++ b/packages/bin_prot/bin_prot.112.01.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.112.06.00/opam
+++ b/packages/bin_prot/bin_prot.112.06.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.112.06.01/opam
+++ b/packages/bin_prot/bin_prot.112.06.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.112.17.00/opam
+++ b/packages/bin_prot/bin_prot.112.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.112.24.00/opam
+++ b/packages/bin_prot/bin_prot.112.24.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [
@@ -16,7 +16,7 @@ depends: [
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"
 install: [[make "install"]]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 synopsis: "A binary protocol generator"
 description: """
 Part of Jane Street’s Core library

--- a/packages/bin_prot/bin_prot.112.35.00/opam
+++ b/packages/bin_prot/bin_prot.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [

--- a/packages/bin_prot/bin_prot.113.00.00/opam
+++ b/packages/bin_prot/bin_prot.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 license: "Apache-2.0"
 build: [

--- a/packages/bin_prot/bin_prot.113.24.00/opam
+++ b/packages/bin_prot/bin_prot.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"

--- a/packages/bin_prot/bin_prot.113.33.00+4.03/opam
+++ b/packages/bin_prot/bin_prot.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"

--- a/packages/bin_prot/bin_prot.113.33.00/opam
+++ b/packages/bin_prot/bin_prot.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"

--- a/packages/bin_prot/bin_prot.113.33.03/opam
+++ b/packages/bin_prot/bin_prot.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"

--- a/packages/bin_prot/bin_prot.v0.10.0/opam
+++ b/packages/bin_prot/bin_prot.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"

--- a/packages/bin_prot/bin_prot.v0.11.0/opam
+++ b/packages/bin_prot/bin_prot.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"

--- a/packages/bin_prot/bin_prot.v0.12.0/opam
+++ b/packages/bin_prot/bin_prot.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"

--- a/packages/bin_prot/bin_prot.v0.13.0/opam
+++ b/packages/bin_prot/bin_prot.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"

--- a/packages/bin_prot/bin_prot.v0.14.0/opam
+++ b/packages/bin_prot/bin_prot.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"

--- a/packages/bin_prot/bin_prot.v0.9.0/opam
+++ b/packages/bin_prot/bin_prot.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"

--- a/packages/bin_prot/bin_prot.v0.9.1/opam
+++ b/packages/bin_prot/bin_prot.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"

--- a/packages/bin_prot/bin_prot.v0.9.2/opam
+++ b/packages/bin_prot/bin_prot.v0.9.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bin_prot"
 bug-reports: "https://github.com/janestreet/bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/bin_prot.git"

--- a/packages/bonsai/bonsai.v0.13.0/opam
+++ b/packages/bonsai/bonsai.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bonsai"
 bug-reports: "https://github.com/janestreet/bonsai/issues"
 dev-repo: "git+https://github.com/janestreet/bonsai.git"

--- a/packages/bonsai/bonsai.v0.14.0/opam
+++ b/packages/bonsai/bonsai.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/bonsai"
 bug-reports: "https://github.com/janestreet/bonsai/issues"
 dev-repo: "git+https://github.com/janestreet/bonsai.git"

--- a/packages/cinaps/cinaps.v0.10.0/opam
+++ b/packages/cinaps/cinaps.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/cinaps"
 bug-reports: "https://github.com/janestreet/cinaps/issues"
 dev-repo: "git+https://github.com/janestreet/cinaps.git"

--- a/packages/cinaps/cinaps.v0.11.0/opam
+++ b/packages/cinaps/cinaps.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/cinaps"
 bug-reports: "https://github.com/janestreet/cinaps/issues"
 dev-repo: "git+https://github.com/janestreet/cinaps.git"

--- a/packages/cinaps/cinaps.v0.12.0/opam
+++ b/packages/cinaps/cinaps.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/cinaps"
 bug-reports: "https://github.com/janestreet/cinaps/issues"
 dev-repo: "git+https://github.com/janestreet/cinaps.git"

--- a/packages/cinaps/cinaps.v0.12.1/opam
+++ b/packages/cinaps/cinaps.v0.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/cinaps"
 bug-reports: "https://github.com/janestreet/cinaps/issues"
 dev-repo: "git+https://github.com/janestreet/cinaps.git"

--- a/packages/cinaps/cinaps.v0.13.0/opam
+++ b/packages/cinaps/cinaps.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/cinaps"
 bug-reports: "https://github.com/janestreet/cinaps/issues"
 dev-repo: "git+https://github.com/janestreet/cinaps.git"

--- a/packages/cinaps/cinaps.v0.14.0/opam
+++ b/packages/cinaps/cinaps.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/cinaps"
 bug-reports: "https://github.com/janestreet/cinaps/issues"
 dev-repo: "git+https://github.com/janestreet/cinaps.git"

--- a/packages/cinaps/cinaps.v0.15.0/opam
+++ b/packages/cinaps/cinaps.v0.15.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/cinaps"
 bug-reports: "https://github.com/ocaml-ppx/cinaps/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/cinaps.git"

--- a/packages/cinaps/cinaps.v0.15.1/opam
+++ b/packages/cinaps/cinaps.v0.15.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/cinaps"
 bug-reports: "https://github.com/ocaml-ppx/cinaps/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/cinaps.git"

--- a/packages/cinaps/cinaps.v0.9.0/opam
+++ b/packages/cinaps/cinaps.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/cinaps"
 bug-reports: "https://github.com/janestreet/cinaps/issues"
 dev-repo: "git+https://github.com/janestreet/cinaps.git"

--- a/packages/cinaps/cinaps.v0.9.1/opam
+++ b/packages/cinaps/cinaps.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/cinaps"
 bug-reports: "https://github.com/janestreet/cinaps/issues"
 dev-repo: "git+https://github.com/janestreet/cinaps.git"

--- a/packages/command_rpc/command_rpc.v0.10.0/opam
+++ b/packages/command_rpc/command_rpc.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/command_rpc"
 bug-reports: "https://github.com/janestreet/command_rpc/issues"
 dev-repo: "git+https://github.com/janestreet/command_rpc.git"

--- a/packages/command_rpc/command_rpc.v0.11.0/opam
+++ b/packages/command_rpc/command_rpc.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/command_rpc"
 bug-reports: "https://github.com/janestreet/command_rpc/issues"
 dev-repo: "git+https://github.com/janestreet/command_rpc.git"

--- a/packages/command_rpc/command_rpc.v0.12.0/opam
+++ b/packages/command_rpc/command_rpc.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/command_rpc"
 bug-reports: "https://github.com/janestreet/command_rpc/issues"
 dev-repo: "git+https://github.com/janestreet/command_rpc.git"

--- a/packages/command_rpc/command_rpc.v0.13.0/opam
+++ b/packages/command_rpc/command_rpc.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/command_rpc"
 bug-reports: "https://github.com/janestreet/command_rpc/issues"
 dev-repo: "git+https://github.com/janestreet/command_rpc.git"

--- a/packages/command_rpc/command_rpc.v0.14.0/opam
+++ b/packages/command_rpc/command_rpc.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/command_rpc"
 bug-reports: "https://github.com/janestreet/command_rpc/issues"
 dev-repo: "git+https://github.com/janestreet/command_rpc.git"

--- a/packages/command_rpc/command_rpc.v0.9.0/opam
+++ b/packages/command_rpc/command_rpc.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/command_rpc"
 bug-reports: "https://github.com/janestreet/command_rpc/issues"
 dev-repo: "git+https://github.com/janestreet/command_rpc.git"

--- a/packages/comparelib/comparelib.108.00.02/opam
+++ b/packages/comparelib/comparelib.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.108.07.00/opam
+++ b/packages/comparelib/comparelib.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.108.07.01/opam
+++ b/packages/comparelib/comparelib.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.108.08.00/opam
+++ b/packages/comparelib/comparelib.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.109.07.00/opam
+++ b/packages/comparelib/comparelib.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.109.08.00/opam
+++ b/packages/comparelib/comparelib.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.109.09.00/opam
+++ b/packages/comparelib/comparelib.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.109.10.00/opam
+++ b/packages/comparelib/comparelib.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.109.11.00/opam
+++ b/packages/comparelib/comparelib.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.109.12.00/opam
+++ b/packages/comparelib/comparelib.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.109.13.00/opam
+++ b/packages/comparelib/comparelib.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.109.14.00/opam
+++ b/packages/comparelib/comparelib.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.109.15.00/opam
+++ b/packages/comparelib/comparelib.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.109.27.00/opam
+++ b/packages/comparelib/comparelib.109.27.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.109.27.02/opam
+++ b/packages/comparelib/comparelib.109.27.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.109.60.00/opam
+++ b/packages/comparelib/comparelib.109.60.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "comparelib"]]
 depends: [

--- a/packages/comparelib/comparelib.113.00.00/opam
+++ b/packages/comparelib/comparelib.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/comparelib"
 license: "Apache-2.0"
 build: [

--- a/packages/conf-pam/conf-pam.1/opam
+++ b/packages/conf-pam/conf-pam.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 homepage: "https://github.com/linux-pam/linux-pam"
 author: "https://github.com/linux-pam"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 
 depexts: [

--- a/packages/conf-zstd/conf-zstd.0.1/opam
+++ b/packages/conf-zstd/conf-zstd.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "http://zstd.net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Facebook"]

--- a/packages/conf-zstd/conf-zstd.1.3.8/opam
+++ b/packages/conf-zstd/conf-zstd.1.3.8/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "http://zstd.net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Facebook"]

--- a/packages/configurator/configurator.v0.10.0/opam
+++ b/packages/configurator/configurator.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/configurator"
 bug-reports: "https://github.com/janestreet/configurator/issues"
 dev-repo: "git+https://github.com/janestreet/configurator.git"

--- a/packages/configurator/configurator.v0.11.0/opam
+++ b/packages/configurator/configurator.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/configurator"
 bug-reports: "https://github.com/janestreet/configurator/issues"
 dev-repo: "git+https://github.com/janestreet/configurator.git"

--- a/packages/configurator/configurator.v0.9.0/opam
+++ b/packages/configurator/configurator.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/configurator"
 bug-reports: "https://github.com/janestreet/configurator/issues"
 dev-repo: "git+https://github.com/janestreet/configurator.git"

--- a/packages/configurator/configurator.v0.9.1/opam
+++ b/packages/configurator/configurator.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/configurator"
 bug-reports: "https://github.com/janestreet/configurator/issues"
 dev-repo: "git+https://github.com/janestreet/configurator.git"

--- a/packages/core/core.108.00.02/opam
+++ b/packages/core/core.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.108.07.00/opam
+++ b/packages/core/core.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.108.07.01/opam
+++ b/packages/core/core.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.108.08.00/opam
+++ b/packages/core/core.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.07.00/opam
+++ b/packages/core/core.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.08.00/opam
+++ b/packages/core/core.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.09.00/opam
+++ b/packages/core/core.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.10.00/opam
+++ b/packages/core/core.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.11.00/opam
+++ b/packages/core/core.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.12.00/opam
+++ b/packages/core/core.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.13.00/opam
+++ b/packages/core/core.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.14.00/opam
+++ b/packages/core/core.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.14.01/opam
+++ b/packages/core/core.109.14.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.15.00/opam
+++ b/packages/core/core.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.15.01/opam
+++ b/packages/core/core.109.15.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.17.00/opam
+++ b/packages/core/core.109.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.18.00/opam
+++ b/packages/core/core.109.18.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core"]]
 depends: [

--- a/packages/core/core.109.19.00/opam
+++ b/packages/core/core.109.19.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.20.00/opam
+++ b/packages/core/core.109.20.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.21.00/opam
+++ b/packages/core/core.109.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.22.00/opam
+++ b/packages/core/core.109.22.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.23.00/opam
+++ b/packages/core/core.109.23.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.24.00/opam
+++ b/packages/core/core.109.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.27.00/opam
+++ b/packages/core/core.109.27.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.28.00/opam
+++ b/packages/core/core.109.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.30.00/opam
+++ b/packages/core/core.109.30.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.31.00/opam
+++ b/packages/core/core.109.31.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.32.00/opam
+++ b/packages/core/core.109.32.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.34.00/opam
+++ b/packages/core/core.109.34.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.35.00/opam
+++ b/packages/core/core.109.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.36.00/opam
+++ b/packages/core/core.109.36.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.37.00/opam
+++ b/packages/core/core.109.37.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.38.00/opam
+++ b/packages/core/core.109.38.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.40.00/opam
+++ b/packages/core/core.109.40.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.41.00/opam
+++ b/packages/core/core.109.41.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.42.00/opam
+++ b/packages/core/core.109.42.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.45.00/opam
+++ b/packages/core/core.109.45.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.47.00/opam
+++ b/packages/core/core.109.47.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.53.00/opam
+++ b/packages/core/core.109.53.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.53.01/opam
+++ b/packages/core/core.109.53.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.55.00/opam
+++ b/packages/core/core.109.55.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.55.02/opam
+++ b/packages/core/core.109.55.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.58.00/opam
+++ b/packages/core/core.109.58.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.109.60.00/opam
+++ b/packages/core/core.109.60.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.110.01.00/opam
+++ b/packages/core/core.110.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.111.03.00/opam
+++ b/packages/core/core.111.03.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.111.06.00/opam
+++ b/packages/core/core.111.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.111.08.00/opam
+++ b/packages/core/core.111.08.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.111.11.00/opam
+++ b/packages/core/core.111.11.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.111.11.01/opam
+++ b/packages/core/core.111.11.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.111.13.00/opam
+++ b/packages/core/core.111.13.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.111.17.00/opam
+++ b/packages/core/core.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.111.21.00/opam
+++ b/packages/core/core.111.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.111.25.00/opam
+++ b/packages/core/core.111.25.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.111.28.00/opam
+++ b/packages/core/core.111.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.111.28.01/opam
+++ b/packages/core/core.111.28.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.112.01.00/opam
+++ b/packages/core/core.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.112.01.01/opam
+++ b/packages/core/core.112.01.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.112.06.00/opam
+++ b/packages/core/core.112.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.112.06.01/opam
+++ b/packages/core/core.112.06.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.112.06.02/opam
+++ b/packages/core/core.112.06.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.112.17.00/opam
+++ b/packages/core/core.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.112.24.00/opam
+++ b/packages/core/core.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.112.24.01/opam
+++ b/packages/core/core.112.24.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.112.35.00/opam
+++ b/packages/core/core.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.112.35.01/opam
+++ b/packages/core/core.112.35.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.113.00.00/opam
+++ b/packages/core/core.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 license: "Apache-2.0"
 build: [

--- a/packages/core/core.113.24.00/opam
+++ b/packages/core/core.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.113.24.01/opam
+++ b/packages/core/core.113.24.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.113.24.02/opam
+++ b/packages/core/core.113.24.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.113.33.00+4.03/opam
+++ b/packages/core/core.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.113.33.00/opam
+++ b/packages/core/core.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.113.33.01+4.03/opam
+++ b/packages/core/core.113.33.01+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.113.33.02+4.03/opam
+++ b/packages/core/core.113.33.02+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.113.33.02/opam
+++ b/packages/core/core.113.33.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.113.33.03/opam
+++ b/packages/core/core.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.10.0/opam
+++ b/packages/core/core.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.11.0/opam
+++ b/packages/core/core.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.11.1/opam
+++ b/packages/core/core.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.11.2/opam
+++ b/packages/core/core.v0.11.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.11.3/opam
+++ b/packages/core/core.v0.11.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.12.0/opam
+++ b/packages/core/core.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.12.1/opam
+++ b/packages/core/core.v0.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.12.2/opam
+++ b/packages/core/core.v0.12.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.12.3/opam
+++ b/packages/core/core.v0.12.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.12.4/opam
+++ b/packages/core/core.v0.12.4/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.13.0/opam
+++ b/packages/core/core.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.14.0/opam
+++ b/packages/core/core.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.14.1/opam
+++ b/packages/core/core.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.9.0/opam
+++ b/packages/core/core.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.9.1/opam
+++ b/packages/core/core.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core/core.v0.9.2/opam
+++ b/packages/core/core.v0.9.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "git+https://github.com/janestreet/core.git"

--- a/packages/core_bench/core_bench.109.24.00/opam
+++ b/packages/core_bench/core_bench.109.24.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.27.00/opam
+++ b/packages/core_bench/core_bench.109.27.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.30.00/opam
+++ b/packages/core_bench/core_bench.109.30.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.32.00/opam
+++ b/packages/core_bench/core_bench.109.32.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.34.00/opam
+++ b/packages/core_bench/core_bench.109.34.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.35.00/opam
+++ b/packages/core_bench/core_bench.109.35.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.36.00/opam
+++ b/packages/core_bench/core_bench.109.36.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.40.00/opam
+++ b/packages/core_bench/core_bench.109.40.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.41.00/opam
+++ b/packages/core_bench/core_bench.109.41.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.47.00/opam
+++ b/packages/core_bench/core_bench.109.47.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.53.00/opam
+++ b/packages/core_bench/core_bench.109.53.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.55.00/opam
+++ b/packages/core_bench/core_bench.109.55.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.55.02/opam
+++ b/packages/core_bench/core_bench.109.55.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.58.00/opam
+++ b/packages/core_bench/core_bench.109.58.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.109.58.01/opam
+++ b/packages/core_bench/core_bench.109.58.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.112.01.00/opam
+++ b/packages/core_bench/core_bench.112.01.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.112.06.00/opam
+++ b/packages/core_bench/core_bench.112.06.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.112.17.00/opam
+++ b/packages/core_bench/core_bench.112.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_bench"]]
 depends: [

--- a/packages/core_bench/core_bench.112.35.00/opam
+++ b/packages/core_bench/core_bench.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_bench"
 build: [
   [make]

--- a/packages/core_bench/core_bench.113.24.00/opam
+++ b/packages/core_bench/core_bench.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_bench"
 bug-reports: "https://github.com/janestreet/core_bench/issues"
 dev-repo: "git+https://github.com/janestreet/core_bench.git"

--- a/packages/core_bench/core_bench.113.33.00+4.03/opam
+++ b/packages/core_bench/core_bench.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_bench"
 bug-reports: "https://github.com/janestreet/core_bench/issues"
 dev-repo: "git+https://github.com/janestreet/core_bench.git"

--- a/packages/core_bench/core_bench.113.33.00/opam
+++ b/packages/core_bench/core_bench.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_bench"
 bug-reports: "https://github.com/janestreet/core_bench/issues"
 dev-repo: "git+https://github.com/janestreet/core_bench.git"

--- a/packages/core_bench/core_bench.113.33.03/opam
+++ b/packages/core_bench/core_bench.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_bench"
 bug-reports: "https://github.com/janestreet/core_bench/issues"
 dev-repo: "git+https://github.com/janestreet/core_bench.git"

--- a/packages/core_bench/core_bench.v0.10.0/opam
+++ b/packages/core_bench/core_bench.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_bench"
 bug-reports: "https://github.com/janestreet/core_bench/issues"
 dev-repo: "git+https://github.com/janestreet/core_bench.git"

--- a/packages/core_bench/core_bench.v0.11.0/opam
+++ b/packages/core_bench/core_bench.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_bench"
 bug-reports: "https://github.com/janestreet/core_bench/issues"
 dev-repo: "git+https://github.com/janestreet/core_bench.git"

--- a/packages/core_bench/core_bench.v0.12.0/opam
+++ b/packages/core_bench/core_bench.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_bench"
 bug-reports: "https://github.com/janestreet/core_bench/issues"
 dev-repo: "git+https://github.com/janestreet/core_bench.git"

--- a/packages/core_bench/core_bench.v0.13.0/opam
+++ b/packages/core_bench/core_bench.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_bench"
 bug-reports: "https://github.com/janestreet/core_bench/issues"
 dev-repo: "git+https://github.com/janestreet/core_bench.git"

--- a/packages/core_bench/core_bench.v0.14.0/opam
+++ b/packages/core_bench/core_bench.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_bench"
 bug-reports: "https://github.com/janestreet/core_bench/issues"
 dev-repo: "git+https://github.com/janestreet/core_bench.git"

--- a/packages/core_bench/core_bench.v0.9.0/opam
+++ b/packages/core_bench/core_bench.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_bench"
 bug-reports: "https://github.com/janestreet/core_bench/issues"
 dev-repo: "git+https://github.com/janestreet/core_bench.git"

--- a/packages/core_extended/core_extended.108.00.01/opam
+++ b/packages/core_extended/core_extended.108.00.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.108.00.02/opam
+++ b/packages/core_extended/core_extended.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.108.07.00/opam
+++ b/packages/core_extended/core_extended.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.108.07.01/opam
+++ b/packages/core_extended/core_extended.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.108.08.00/opam
+++ b/packages/core_extended/core_extended.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.109.07.00/opam
+++ b/packages/core_extended/core_extended.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.109.08.00/opam
+++ b/packages/core_extended/core_extended.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.109.09.00/opam
+++ b/packages/core_extended/core_extended.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.109.10.00/opam
+++ b/packages/core_extended/core_extended.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.109.11.00/opam
+++ b/packages/core_extended/core_extended.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.109.12.00/opam
+++ b/packages/core_extended/core_extended.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.109.13.00/opam
+++ b/packages/core_extended/core_extended.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.109.14.00/opam
+++ b/packages/core_extended/core_extended.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.109.15.00/opam
+++ b/packages/core_extended/core_extended.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.109.17.00/opam
+++ b/packages/core_extended/core_extended.109.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "core_extended"]]
 depends: [

--- a/packages/core_extended/core_extended.109.19.00/opam
+++ b/packages/core_extended/core_extended.109.19.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.20.00/opam
+++ b/packages/core_extended/core_extended.109.20.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.21.00/opam
+++ b/packages/core_extended/core_extended.109.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.23.00/opam
+++ b/packages/core_extended/core_extended.109.23.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.24.00/opam
+++ b/packages/core_extended/core_extended.109.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.27.00/opam
+++ b/packages/core_extended/core_extended.109.27.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.28.00/opam
+++ b/packages/core_extended/core_extended.109.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.30.00/opam
+++ b/packages/core_extended/core_extended.109.30.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.31.00/opam
+++ b/packages/core_extended/core_extended.109.31.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.34.00/opam
+++ b/packages/core_extended/core_extended.109.34.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.35.00/opam
+++ b/packages/core_extended/core_extended.109.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.36.00/opam
+++ b/packages/core_extended/core_extended.109.36.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.40.00/opam
+++ b/packages/core_extended/core_extended.109.40.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.41.00/opam
+++ b/packages/core_extended/core_extended.109.41.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.42.00/opam
+++ b/packages/core_extended/core_extended.109.42.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.45.00/opam
+++ b/packages/core_extended/core_extended.109.45.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.47.00/opam
+++ b/packages/core_extended/core_extended.109.47.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.53.00/opam
+++ b/packages/core_extended/core_extended.109.53.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.55.00/opam
+++ b/packages/core_extended/core_extended.109.55.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.55.02/opam
+++ b/packages/core_extended/core_extended.109.55.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.109.58.00/opam
+++ b/packages/core_extended/core_extended.109.58.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.110.01.00/opam
+++ b/packages/core_extended/core_extended.110.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.111.03.00/opam
+++ b/packages/core_extended/core_extended.111.03.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.111.06.00/opam
+++ b/packages/core_extended/core_extended.111.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.111.11.00/opam
+++ b/packages/core_extended/core_extended.111.11.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.111.13.00/opam
+++ b/packages/core_extended/core_extended.111.13.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.111.17.00/opam
+++ b/packages/core_extended/core_extended.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.111.25.00/opam
+++ b/packages/core_extended/core_extended.111.25.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.111.28.00/opam
+++ b/packages/core_extended/core_extended.111.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.112.01.00/opam
+++ b/packages/core_extended/core_extended.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.112.06.00/opam
+++ b/packages/core_extended/core_extended.112.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.112.17.00/opam
+++ b/packages/core_extended/core_extended.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.112.24.00/opam
+++ b/packages/core_extended/core_extended.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.112.35.00/opam
+++ b/packages/core_extended/core_extended.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.113.00.00/opam
+++ b/packages/core_extended/core_extended.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/core_extended/core_extended.113.24.00/opam
+++ b/packages/core_extended/core_extended.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 bug-reports: "https://github.com/janestreet/core_extended/issues"
 dev-repo: "git+https://github.com/janestreet/core_extended.git"

--- a/packages/core_extended/core_extended.113.33.00+4.03/opam
+++ b/packages/core_extended/core_extended.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 bug-reports: "https://github.com/janestreet/core_extended/issues"
 dev-repo: "git+https://github.com/janestreet/core_extended.git"

--- a/packages/core_extended/core_extended.113.33.00/opam
+++ b/packages/core_extended/core_extended.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 bug-reports: "https://github.com/janestreet/core_extended/issues"
 dev-repo: "git+https://github.com/janestreet/core_extended.git"

--- a/packages/core_extended/core_extended.113.33.03/opam
+++ b/packages/core_extended/core_extended.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 bug-reports: "https://github.com/janestreet/core_extended/issues"
 dev-repo: "git+https://github.com/janestreet/core_extended.git"

--- a/packages/core_extended/core_extended.v0.10.0/opam
+++ b/packages/core_extended/core_extended.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 bug-reports: "https://github.com/janestreet/core_extended/issues"
 dev-repo: "git+https://github.com/janestreet/core_extended.git"

--- a/packages/core_extended/core_extended.v0.11.0/opam
+++ b/packages/core_extended/core_extended.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 bug-reports: "https://github.com/janestreet/core_extended/issues"
 dev-repo: "git+https://github.com/janestreet/core_extended.git"

--- a/packages/core_extended/core_extended.v0.12.0/opam
+++ b/packages/core_extended/core_extended.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 bug-reports: "https://github.com/janestreet/core_extended/issues"
 dev-repo: "git+https://github.com/janestreet/core_extended.git"

--- a/packages/core_extended/core_extended.v0.13.0/opam
+++ b/packages/core_extended/core_extended.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 bug-reports: "https://github.com/janestreet/core_extended/issues"
 dev-repo: "git+https://github.com/janestreet/core_extended.git"

--- a/packages/core_extended/core_extended.v0.14.0/opam
+++ b/packages/core_extended/core_extended.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 bug-reports: "https://github.com/janestreet/core_extended/issues"
 dev-repo: "git+https://github.com/janestreet/core_extended.git"

--- a/packages/core_extended/core_extended.v0.9.0/opam
+++ b/packages/core_extended/core_extended.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 bug-reports: "https://github.com/janestreet/core_extended/issues"
 dev-repo: "git+https://github.com/janestreet/core_extended.git"

--- a/packages/core_extended/core_extended.v0.9.1/opam
+++ b/packages/core_extended/core_extended.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_extended"
 bug-reports: "https://github.com/janestreet/core_extended/issues"
 dev-repo: "git+https://github.com/janestreet/core_extended.git"

--- a/packages/core_kernel/core_kernel.109.27.00/opam
+++ b/packages/core_kernel/core_kernel.109.27.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.28.00/opam
+++ b/packages/core_kernel/core_kernel.109.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.30.00/opam
+++ b/packages/core_kernel/core_kernel.109.30.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.31.00/opam
+++ b/packages/core_kernel/core_kernel.109.31.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.32.00/opam
+++ b/packages/core_kernel/core_kernel.109.32.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.33.00/opam
+++ b/packages/core_kernel/core_kernel.109.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.34.00/opam
+++ b/packages/core_kernel/core_kernel.109.34.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.35.00/opam
+++ b/packages/core_kernel/core_kernel.109.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.35.01/opam
+++ b/packages/core_kernel/core_kernel.109.35.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.36.00/opam
+++ b/packages/core_kernel/core_kernel.109.36.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.37.00/opam
+++ b/packages/core_kernel/core_kernel.109.37.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.38.00/opam
+++ b/packages/core_kernel/core_kernel.109.38.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.40.00/opam
+++ b/packages/core_kernel/core_kernel.109.40.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.41.00/opam
+++ b/packages/core_kernel/core_kernel.109.41.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.42.00/opam
+++ b/packages/core_kernel/core_kernel.109.42.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.45.00/opam
+++ b/packages/core_kernel/core_kernel.109.45.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.47.00/opam
+++ b/packages/core_kernel/core_kernel.109.47.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.53.00/opam
+++ b/packages/core_kernel/core_kernel.109.53.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.55.00/opam
+++ b/packages/core_kernel/core_kernel.109.55.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.55.02/opam
+++ b/packages/core_kernel/core_kernel.109.55.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.58.00/opam
+++ b/packages/core_kernel/core_kernel.109.58.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.109.60.00/opam
+++ b/packages/core_kernel/core_kernel.109.60.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.110.01.00/opam
+++ b/packages/core_kernel/core_kernel.110.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.111.03.00/opam
+++ b/packages/core_kernel/core_kernel.111.03.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.111.06.00/opam
+++ b/packages/core_kernel/core_kernel.111.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.111.08.00/opam
+++ b/packages/core_kernel/core_kernel.111.08.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.111.11.00/opam
+++ b/packages/core_kernel/core_kernel.111.11.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.111.13.00/opam
+++ b/packages/core_kernel/core_kernel.111.13.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.111.17.00/opam
+++ b/packages/core_kernel/core_kernel.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.111.21.00/opam
+++ b/packages/core_kernel/core_kernel.111.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.111.25.00/opam
+++ b/packages/core_kernel/core_kernel.111.25.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.111.28.00/opam
+++ b/packages/core_kernel/core_kernel.111.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.112.01.00/opam
+++ b/packages/core_kernel/core_kernel.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.112.06.00/opam
+++ b/packages/core_kernel/core_kernel.112.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.112.06.02/opam
+++ b/packages/core_kernel/core_kernel.112.06.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.112.17.00/opam
+++ b/packages/core_kernel/core_kernel.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.112.24.00/opam
+++ b/packages/core_kernel/core_kernel.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.112.35.00/opam
+++ b/packages/core_kernel/core_kernel.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.113.00.00/opam
+++ b/packages/core_kernel/core_kernel.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 license: "Apache-2.0"
 build: [

--- a/packages/core_kernel/core_kernel.113.24.00/opam
+++ b/packages/core_kernel/core_kernel.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.113.33.00/opam
+++ b/packages/core_kernel/core_kernel.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.113.33.01+4.03/opam
+++ b/packages/core_kernel/core_kernel.113.33.01+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.113.33.01/opam
+++ b/packages/core_kernel/core_kernel.113.33.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.113.33.02+4.03/opam
+++ b/packages/core_kernel/core_kernel.113.33.02+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.113.33.03/opam
+++ b/packages/core_kernel/core_kernel.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.10.0/opam
+++ b/packages/core_kernel/core_kernel.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.11.0/opam
+++ b/packages/core_kernel/core_kernel.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.11.1/opam
+++ b/packages/core_kernel/core_kernel.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.12.0/opam
+++ b/packages/core_kernel/core_kernel.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.12.1/opam
+++ b/packages/core_kernel/core_kernel.v0.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.12.2/opam
+++ b/packages/core_kernel/core_kernel.v0.12.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.12.3/opam
+++ b/packages/core_kernel/core_kernel.v0.12.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.13.0/opam
+++ b/packages/core_kernel/core_kernel.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.13.1/opam
+++ b/packages/core_kernel/core_kernel.v0.13.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.14.0/opam
+++ b/packages/core_kernel/core_kernel.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.14.1/opam
+++ b/packages/core_kernel/core_kernel.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.9.0/opam
+++ b/packages/core_kernel/core_kernel.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_kernel/core_kernel.v0.9.1/opam
+++ b/packages/core_kernel/core_kernel.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_kernel"
 bug-reports: "https://github.com/janestreet/core_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/core_kernel.git"

--- a/packages/core_profiler/core_profiler.112.19.00/opam
+++ b/packages/core_profiler/core_profiler.112.19.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 license: "Apache-2.0"
 build: [

--- a/packages/core_profiler/core_profiler.112.19.01/opam
+++ b/packages/core_profiler/core_profiler.112.19.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 license: "Apache-2.0"
 build: [

--- a/packages/core_profiler/core_profiler.112.35.00/opam
+++ b/packages/core_profiler/core_profiler.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 license: "Apache-2.0"
 build: [

--- a/packages/core_profiler/core_profiler.113.00.00/opam
+++ b/packages/core_profiler/core_profiler.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 license: "Apache-2.0"
 build: [

--- a/packages/core_profiler/core_profiler.113.24.00/opam
+++ b/packages/core_profiler/core_profiler.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 bug-reports: "https://github.com/janestreet/core_profiler/issues"
 dev-repo: "git+https://github.com/janestreet/core_profiler.git"

--- a/packages/core_profiler/core_profiler.113.33.00/opam
+++ b/packages/core_profiler/core_profiler.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 bug-reports: "https://github.com/janestreet/core_profiler/issues"
 dev-repo: "git+https://github.com/janestreet/core_profiler.git"

--- a/packages/core_profiler/core_profiler.113.33.03/opam
+++ b/packages/core_profiler/core_profiler.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 bug-reports: "https://github.com/janestreet/core_profiler/issues"
 dev-repo: "git+https://github.com/janestreet/core_profiler.git"

--- a/packages/core_profiler/core_profiler.v0.10.0/opam
+++ b/packages/core_profiler/core_profiler.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 bug-reports: "https://github.com/janestreet/core_profiler/issues"
 dev-repo: "git+https://github.com/janestreet/core_profiler.git"

--- a/packages/core_profiler/core_profiler.v0.11.0/opam
+++ b/packages/core_profiler/core_profiler.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 bug-reports: "https://github.com/janestreet/core_profiler/issues"
 dev-repo: "git+https://github.com/janestreet/core_profiler.git"

--- a/packages/core_profiler/core_profiler.v0.12.0/opam
+++ b/packages/core_profiler/core_profiler.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 bug-reports: "https://github.com/janestreet/core_profiler/issues"
 dev-repo: "git+https://github.com/janestreet/core_profiler.git"

--- a/packages/core_profiler/core_profiler.v0.13.0/opam
+++ b/packages/core_profiler/core_profiler.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 bug-reports: "https://github.com/janestreet/core_profiler/issues"
 dev-repo: "git+https://github.com/janestreet/core_profiler.git"

--- a/packages/core_profiler/core_profiler.v0.14.0/opam
+++ b/packages/core_profiler/core_profiler.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 bug-reports: "https://github.com/janestreet/core_profiler/issues"
 dev-repo: "git+https://github.com/janestreet/core_profiler.git"

--- a/packages/core_profiler/core_profiler.v0.9.0/opam
+++ b/packages/core_profiler/core_profiler.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_profiler"
 bug-reports: "https://github.com/janestreet/core_profiler/issues"
 dev-repo: "git+https://github.com/janestreet/core_profiler.git"

--- a/packages/csexp/csexp.1.0.0/opam
+++ b/packages/csexp/csexp.1.0.0/opam
@@ -20,7 +20,7 @@ module of this library is parameterised by the type of S-expressions.
 maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
 authors: [
   "Quentin Hocquet <mefyl@gruntech.org>"
-  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jane Street Group, LLC"
   "Jeremie Dimino <jeremie@dimino.org>"
 ]
 license: "MIT"

--- a/packages/csexp/csexp.1.1.0/opam
+++ b/packages/csexp/csexp.1.1.0/opam
@@ -20,7 +20,7 @@ module of this library is parameterised by the type of S-expressions.
 maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
 authors: [
   "Quentin Hocquet <mefyl@gruntech.org>"
-  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jane Street Group, LLC"
   "Jeremie Dimino <jeremie@dimino.org>"
 ]
 license: "MIT"

--- a/packages/csexp/csexp.1.2.0/opam
+++ b/packages/csexp/csexp.1.2.0/opam
@@ -20,7 +20,7 @@ module of this library is parameterised by the type of S-expressions.
 maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
 authors: [
   "Quentin Hocquet <mefyl@gruntech.org>"
-  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jane Street Group, LLC"
   "Jeremie Dimino <jeremie@dimino.org>"
 ]
 license: "MIT"

--- a/packages/csexp/csexp.1.2.2/opam
+++ b/packages/csexp/csexp.1.2.2/opam
@@ -20,7 +20,7 @@ module of this library is parameterised by the type of S-expressions.
 maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
 authors: [
   "Quentin Hocquet <mefyl@gruntech.org>"
-  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jane Street Group, LLC"
   "Jeremie Dimino <jeremie@dimino.org>"
 ]
 license: "MIT"

--- a/packages/csexp/csexp.1.2.3/opam
+++ b/packages/csexp/csexp.1.2.3/opam
@@ -20,7 +20,7 @@ module of this library is parameterised by the type of S-expressions.
 maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
 authors: [
   "Quentin Hocquet <mefyl@gruntech.org>"
-  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jane Street Group, LLC"
   "Jeremie Dimino <jeremie@dimino.org>"
 ]
 license: "MIT"

--- a/packages/csexp/csexp.1.3.1/opam
+++ b/packages/csexp/csexp.1.3.1/opam
@@ -20,7 +20,7 @@ module of this library is parameterised by the type of S-expressions.
 maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
 authors: [
   "Quentin Hocquet <mefyl@gruntech.org>"
-  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jane Street Group, LLC"
   "Jeremie Dimino <jeremie@dimino.org>"
 ]
 license: "MIT"

--- a/packages/csexp/csexp.1.3.2/opam
+++ b/packages/csexp/csexp.1.3.2/opam
@@ -20,7 +20,7 @@ module of this library is parameterised by the type of S-expressions.
 maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
 authors: [
   "Quentin Hocquet <mefyl@gruntech.org>"
-  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jane Street Group, LLC"
   "Jeremie Dimino <jeremie@dimino.org>"
 ]
 license: "MIT"

--- a/packages/csexp/csexp.1.4.0/opam
+++ b/packages/csexp/csexp.1.4.0/opam
@@ -20,7 +20,7 @@ module of this library is parameterised by the type of S-expressions.
 maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
 authors: [
   "Quentin Hocquet <mefyl@gruntech.org>"
-  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jane Street Group, LLC"
   "Jeremie Dimino <jeremie@dimino.org>"
 ]
 license: "MIT"

--- a/packages/csexp/csexp.1.5.1/opam
+++ b/packages/csexp/csexp.1.5.1/opam
@@ -20,7 +20,7 @@ module of this library is parameterised by the type of S-expressions.
 maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
 authors: [
   "Quentin Hocquet <mefyl@gruntech.org>"
-  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jane Street Group, LLC"
   "Jeremie Dimino <jeremie@dimino.org>"
 ]
 license: "MIT"

--- a/packages/csvfields/csvfields.v0.10.0/opam
+++ b/packages/csvfields/csvfields.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/csvfields"
 bug-reports: "https://github.com/janestreet/csvfields/issues"
 dev-repo: "git+https://github.com/janestreet/csvfields.git"

--- a/packages/csvfields/csvfields.v0.11.0/opam
+++ b/packages/csvfields/csvfields.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/csvfields"
 bug-reports: "https://github.com/janestreet/csvfields/issues"
 dev-repo: "git+https://github.com/janestreet/csvfields.git"

--- a/packages/csvfields/csvfields.v0.12.0/opam
+++ b/packages/csvfields/csvfields.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/csvfields"
 bug-reports: "https://github.com/janestreet/csvfields/issues"
 dev-repo: "git+https://github.com/janestreet/csvfields.git"

--- a/packages/csvfields/csvfields.v0.13.0/opam
+++ b/packages/csvfields/csvfields.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/csvfields"
 bug-reports: "https://github.com/janestreet/csvfields/issues"
 dev-repo: "git+https://github.com/janestreet/csvfields.git"

--- a/packages/csvfields/csvfields.v0.14.0/opam
+++ b/packages/csvfields/csvfields.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/csvfields"
 bug-reports: "https://github.com/janestreet/csvfields/issues"
 dev-repo: "git+https://github.com/janestreet/csvfields.git"

--- a/packages/csvfields/csvfields.v0.9.0/opam
+++ b/packages/csvfields/csvfields.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/csvfields"
 bug-reports: "https://github.com/janestreet/csvfields/issues"
 dev-repo: "git+https://github.com/janestreet/csvfields.git"

--- a/packages/csvfields/csvfields.v0.9.1/opam
+++ b/packages/csvfields/csvfields.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/csvfields"
 bug-reports: "https://github.com/janestreet/csvfields/issues"
 dev-repo: "git+https://github.com/janestreet/csvfields.git"

--- a/packages/custom_printf/custom_printf.109.14.00/opam
+++ b/packages/custom_printf/custom_printf.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [

--- a/packages/custom_printf/custom_printf.109.15.00/opam
+++ b/packages/custom_printf/custom_printf.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [

--- a/packages/custom_printf/custom_printf.109.27.00/opam
+++ b/packages/custom_printf/custom_printf.109.27.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [

--- a/packages/custom_printf/custom_printf.109.27.02/opam
+++ b/packages/custom_printf/custom_printf.109.27.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [

--- a/packages/custom_printf/custom_printf.109.60.00/opam
+++ b/packages/custom_printf/custom_printf.109.60.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [

--- a/packages/custom_printf/custom_printf.111.03.00/opam
+++ b/packages/custom_printf/custom_printf.111.03.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [

--- a/packages/custom_printf/custom_printf.111.21.00/opam
+++ b/packages/custom_printf/custom_printf.111.21.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [

--- a/packages/custom_printf/custom_printf.111.25.00/opam
+++ b/packages/custom_printf/custom_printf.111.25.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [

--- a/packages/custom_printf/custom_printf.112.01.00/opam
+++ b/packages/custom_printf/custom_printf.112.01.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [

--- a/packages/custom_printf/custom_printf.112.06.00/opam
+++ b/packages/custom_printf/custom_printf.112.06.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [

--- a/packages/custom_printf/custom_printf.112.17.00/opam
+++ b/packages/custom_printf/custom_printf.112.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [

--- a/packages/custom_printf/custom_printf.112.24.00/opam
+++ b/packages/custom_printf/custom_printf.112.24.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "custom_printf"]]
 depends: [

--- a/packages/custom_printf/custom_printf.113.00.00/opam
+++ b/packages/custom_printf/custom_printf.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/custom_printf"
 license: "Apache-2.0"
 build: [

--- a/packages/delimited_parsing/delimited_parsing.v0.10.0/opam
+++ b/packages/delimited_parsing/delimited_parsing.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/delimited_parsing"
 bug-reports: "https://github.com/janestreet/delimited_parsing/issues"
 dev-repo: "git+https://github.com/janestreet/delimited_parsing.git"

--- a/packages/delimited_parsing/delimited_parsing.v0.11.0/opam
+++ b/packages/delimited_parsing/delimited_parsing.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/delimited_parsing"
 bug-reports: "https://github.com/janestreet/delimited_parsing/issues"
 dev-repo: "git+https://github.com/janestreet/delimited_parsing.git"

--- a/packages/delimited_parsing/delimited_parsing.v0.12.0/opam
+++ b/packages/delimited_parsing/delimited_parsing.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/delimited_parsing"
 bug-reports: "https://github.com/janestreet/delimited_parsing/issues"
 dev-repo: "git+https://github.com/janestreet/delimited_parsing.git"

--- a/packages/delimited_parsing/delimited_parsing.v0.13.0/opam
+++ b/packages/delimited_parsing/delimited_parsing.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/delimited_parsing"
 bug-reports: "https://github.com/janestreet/delimited_parsing/issues"
 dev-repo: "git+https://github.com/janestreet/delimited_parsing.git"

--- a/packages/delimited_parsing/delimited_parsing.v0.14.0/opam
+++ b/packages/delimited_parsing/delimited_parsing.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/delimited_parsing"
 bug-reports: "https://github.com/janestreet/delimited_parsing/issues"
 dev-repo: "git+https://github.com/janestreet/delimited_parsing.git"

--- a/packages/dune-action-plugin/dune-action-plugin.2.0.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.0.0/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.0.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.0.1/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.1.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.1.1/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.1.2/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.1.2/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.1.3/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.1.3/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.2.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.2.0/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.3.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.3.0/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.3.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.3.1/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.4.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.4.0/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.5.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.5.0/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.5.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.5.1/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.6.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.6.0/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.6.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.6.1/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.6.2/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.6.2/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.7.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.7.0/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.7.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.7.1/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.8.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.8.0/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.8.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.8.1/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.8.2/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.8.2/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.8.4/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.8.4/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-action-plugin/dune-action-plugin.2.8.5/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.2.8.5/opam
@@ -9,8 +9,8 @@ Dynamic dune actions do not need to declare their dependencies
 upfront; they are instead discovered automatically during the
 execution of the action.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.1.11.0/opam
+++ b/packages/dune-build-info/dune-build-info.1.11.0/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.1.11.1/opam
+++ b/packages/dune-build-info/dune-build-info.1.11.1/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.1.11.2/opam
+++ b/packages/dune-build-info/dune-build-info.1.11.2/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.1.11.3/opam
+++ b/packages/dune-build-info/dune-build-info.1.11.3/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.1.11.4/opam
+++ b/packages/dune-build-info/dune-build-info.1.11.4/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.0.0/opam
+++ b/packages/dune-build-info/dune-build-info.2.0.0/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.0.1/opam
+++ b/packages/dune-build-info/dune-build-info.2.0.1/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.1.1/opam
+++ b/packages/dune-build-info/dune-build-info.2.1.1/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.1.2/opam
+++ b/packages/dune-build-info/dune-build-info.2.1.2/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.1.3/opam
+++ b/packages/dune-build-info/dune-build-info.2.1.3/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.2.0/opam
+++ b/packages/dune-build-info/dune-build-info.2.2.0/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.3.0/opam
+++ b/packages/dune-build-info/dune-build-info.2.3.0/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.3.1/opam
+++ b/packages/dune-build-info/dune-build-info.2.3.1/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.4.0/opam
+++ b/packages/dune-build-info/dune-build-info.2.4.0/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.5.0/opam
+++ b/packages/dune-build-info/dune-build-info.2.5.0/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.5.1/opam
+++ b/packages/dune-build-info/dune-build-info.2.5.1/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.6.0/opam
+++ b/packages/dune-build-info/dune-build-info.2.6.0/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.6.1/opam
+++ b/packages/dune-build-info/dune-build-info.2.6.1/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.6.2/opam
+++ b/packages/dune-build-info/dune-build-info.2.6.2/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.7.0/opam
+++ b/packages/dune-build-info/dune-build-info.2.7.0/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.7.1/opam
+++ b/packages/dune-build-info/dune-build-info.2.7.1/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.8.0/opam
+++ b/packages/dune-build-info/dune-build-info.2.8.0/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.8.1/opam
+++ b/packages/dune-build-info/dune-build-info.2.8.1/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.8.2/opam
+++ b/packages/dune-build-info/dune-build-info.2.8.2/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.8.4/opam
+++ b/packages/dune-build-info/dune-build-info.2.8.4/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-build-info/dune-build-info.2.8.5/opam
+++ b/packages/dune-build-info/dune-build-info.2.8.5/opam
@@ -8,8 +8,8 @@ versions.  It supports reporting the version from the version control
 system during development to get an precise reference of when the
 executable was built.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.1.11.4/files/0001-dune-configurator-for-Dune-2.0.0-on-OCaml-4.06.patch
+++ b/packages/dune-configurator/dune-configurator.1.11.4/files/0001-dune-configurator-for-Dune-2.0.0-on-OCaml-4.06.patch
@@ -36,8 +36,8 @@ index 00000000..95925e45
 +- import #define from OCaml header files
 +- generate config.h file
 +"""
-+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
++maintainer: ["Jane Street Group, LLC"]
++authors: ["Jane Street Group, LLC"]
 +license: "MIT"
 +homepage: "https://github.com/ocaml/dune"
 +doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.1.11.4/opam
+++ b/packages/dune-configurator/dune-configurator.1.11.4/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.0.0/opam
+++ b/packages/dune-configurator/dune-configurator.2.0.0/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.0.1/opam
+++ b/packages/dune-configurator/dune-configurator.2.0.1/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.1.1/opam
+++ b/packages/dune-configurator/dune-configurator.2.1.1/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.1.2/opam
+++ b/packages/dune-configurator/dune-configurator.2.1.2/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.1.3/opam
+++ b/packages/dune-configurator/dune-configurator.2.1.3/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.2.0/opam
+++ b/packages/dune-configurator/dune-configurator.2.2.0/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.3.0/opam
+++ b/packages/dune-configurator/dune-configurator.2.3.0/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.3.1/opam
+++ b/packages/dune-configurator/dune-configurator.2.3.1/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.4.0/opam
+++ b/packages/dune-configurator/dune-configurator.2.4.0/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.5.0/opam
+++ b/packages/dune-configurator/dune-configurator.2.5.0/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.5.1/opam
+++ b/packages/dune-configurator/dune-configurator.2.5.1/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.6.0/opam
+++ b/packages/dune-configurator/dune-configurator.2.6.0/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.6.1/opam
+++ b/packages/dune-configurator/dune-configurator.2.6.1/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.6.2/opam
+++ b/packages/dune-configurator/dune-configurator.2.6.2/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.7.0/opam
+++ b/packages/dune-configurator/dune-configurator.2.7.0/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.7.1/opam
+++ b/packages/dune-configurator/dune-configurator.2.7.1/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.8.0/opam
+++ b/packages/dune-configurator/dune-configurator.2.8.0/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.8.1/opam
+++ b/packages/dune-configurator/dune-configurator.2.8.1/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.8.2/opam
+++ b/packages/dune-configurator/dune-configurator.2.8.2/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.8.4/opam
+++ b/packages/dune-configurator/dune-configurator.2.8.4/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-configurator/dune-configurator.2.8.5/opam
+++ b/packages/dune-configurator/dune-configurator.2.8.5/opam
@@ -10,8 +10,8 @@ Among other things, dune-configurator allows one to:
 - import #define from OCaml header files
 - generate config.h file
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.0.0/opam
+++ b/packages/dune-glob/dune-glob.2.0.0/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.0.1/opam
+++ b/packages/dune-glob/dune-glob.2.0.1/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.1.1/opam
+++ b/packages/dune-glob/dune-glob.2.1.1/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.1.2/opam
+++ b/packages/dune-glob/dune-glob.2.1.2/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.1.3/opam
+++ b/packages/dune-glob/dune-glob.2.1.3/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.2.0/opam
+++ b/packages/dune-glob/dune-glob.2.2.0/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.3.0/opam
+++ b/packages/dune-glob/dune-glob.2.3.0/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.3.1/opam
+++ b/packages/dune-glob/dune-glob.2.3.1/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.4.0/opam
+++ b/packages/dune-glob/dune-glob.2.4.0/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.5.0/opam
+++ b/packages/dune-glob/dune-glob.2.5.0/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.5.1/opam
+++ b/packages/dune-glob/dune-glob.2.5.1/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.6.0/opam
+++ b/packages/dune-glob/dune-glob.2.6.0/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.6.1/opam
+++ b/packages/dune-glob/dune-glob.2.6.1/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.6.2/opam
+++ b/packages/dune-glob/dune-glob.2.6.2/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.7.0/opam
+++ b/packages/dune-glob/dune-glob.2.7.0/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.7.1/opam
+++ b/packages/dune-glob/dune-glob.2.7.1/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.8.0/opam
+++ b/packages/dune-glob/dune-glob.2.8.0/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.8.1/opam
+++ b/packages/dune-glob/dune-glob.2.8.1/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.8.2/opam
+++ b/packages/dune-glob/dune-glob.2.8.2/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.8.4/opam
+++ b/packages/dune-glob/dune-glob.2.8.4/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-glob/dune-glob.2.8.5/opam
+++ b/packages/dune-glob/dune-glob.2.8.5/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 synopsis: "Glob string matching language supported by dune"
 description:
   "dune-glob provides a parser and interpreter for globs as understood by dune language."
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.0.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.0.0/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.0.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.0.1/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.1.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.1.1/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.1.2/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.1.2/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.1.3/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.1.3/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.2.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.2.0/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.3.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.3.0/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.3.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.3.1/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.4.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.4.0/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.5.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.5.0/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.5.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.5.1/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.6.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.6.0/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.6.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.6.1/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.6.2/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.6.2/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.7.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.7.0/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.7.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.7.1/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.8.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.8.0/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.8.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.8.1/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.8.2/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.8.2/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.8.4/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.8.4/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-private-libs/dune-private-libs.2.8.5/opam
+++ b/packages/dune-private-libs/dune-private-libs.2.8.5/opam
@@ -9,8 +9,8 @@ This package contains code that is shared between various dune-xxx
 packages. However, it is not meant for public consumption and provides
 no stability guarantee.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-site/dune-site.2.8.0/opam
+++ b/packages/dune-site/dune-site.2.8.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Embed locations informations inside executable and libraries"
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-site/dune-site.2.8.1/opam
+++ b/packages/dune-site/dune-site.2.8.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Embed locations informations inside executable and libraries"
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-site/dune-site.2.8.2/opam
+++ b/packages/dune-site/dune-site.2.8.2/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Embed locations informations inside executable and libraries"
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-site/dune-site.2.8.4/opam
+++ b/packages/dune-site/dune-site.2.8.4/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Embed locations informations inside executable and libraries"
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune-site/dune-site.2.8.5/opam
+++ b/packages/dune-site/dune-site.2.8.5/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Embed locations informations inside executable and libraries"
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.1.0.0/opam
+++ b/packages/dune/dune.1.0.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.0.1/opam
+++ b/packages/dune/dune.1.0.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.1.0/opam
+++ b/packages/dune/dune.1.1.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.1.1/opam
+++ b/packages/dune/dune.1.1.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.10.0/opam
+++ b/packages/dune/dune.1.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 bug-reports: "https://github.com/ocaml/dune/issues"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.1.11.0/opam
+++ b/packages/dune/dune.1.11.0/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.1.11.1/opam
+++ b/packages/dune/dune.1.11.1/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.1.11.2/opam
+++ b/packages/dune/dune.1.11.2/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.1.11.3/opam
+++ b/packages/dune/dune.1.11.3/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.1.11.4/opam
+++ b/packages/dune/dune.1.11.4/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.1.2.0/opam
+++ b/packages/dune/dune.1.2.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.2.1/opam
+++ b/packages/dune/dune.1.2.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.3.0/opam
+++ b/packages/dune/dune.1.3.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.4.0/opam
+++ b/packages/dune/dune.1.4.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.5.0/opam
+++ b/packages/dune/dune.1.5.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.5.1/opam
+++ b/packages/dune/dune.1.5.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.6.0/opam
+++ b/packages/dune/dune.1.6.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.6.1/opam
+++ b/packages/dune/dune.1.6.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.6.2/opam
+++ b/packages/dune/dune.1.6.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.6.3/opam
+++ b/packages/dune/dune.1.6.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.7.0/opam
+++ b/packages/dune/dune.1.7.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.7.1/opam
+++ b/packages/dune/dune.1.7.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.7.2/opam
+++ b/packages/dune/dune.1.7.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.7.3/opam
+++ b/packages/dune/dune.1.7.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.8.0/opam
+++ b/packages/dune/dune.1.8.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.8.1/opam
+++ b/packages/dune/dune.1.8.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.8.2/opam
+++ b/packages/dune/dune.1.8.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.9.0/opam
+++ b/packages/dune/dune.1.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.9.1/opam
+++ b/packages/dune/dune.1.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.9.2/opam
+++ b/packages/dune/dune.1.9.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.1.9.3/opam
+++ b/packages/dune/dune.1.9.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune/dune.2.0.0/opam
+++ b/packages/dune/dune.2.0.0/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.0.1/opam
+++ b/packages/dune/dune.2.0.1/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.1.1/opam
+++ b/packages/dune/dune.2.1.1/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.1.2/opam
+++ b/packages/dune/dune.2.1.2/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.1.3/opam
+++ b/packages/dune/dune.2.1.3/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.2.0/opam
+++ b/packages/dune/dune.2.2.0/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.3.0/opam
+++ b/packages/dune/dune.2.3.0/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.3.1/opam
+++ b/packages/dune/dune.2.3.1/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.4.0/opam
+++ b/packages/dune/dune.2.4.0/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.5.0/opam
+++ b/packages/dune/dune.2.5.0/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.5.1/opam
+++ b/packages/dune/dune.2.5.1/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.6.0/opam
+++ b/packages/dune/dune.2.6.0/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.6.1/opam
+++ b/packages/dune/dune.2.6.1/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.6.2/opam
+++ b/packages/dune/dune.2.6.2/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.7.0/opam
+++ b/packages/dune/dune.2.7.0/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.7.1/opam
+++ b/packages/dune/dune.2.7.1/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.8.0/opam
+++ b/packages/dune/dune.2.8.0/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.8.1/opam
+++ b/packages/dune/dune.2.8.1/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.8.2/opam
+++ b/packages/dune/dune.2.8.2/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.8.4/opam
+++ b/packages/dune/dune.2.8.4/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/dune/dune.2.8.5/opam
+++ b/packages/dune/dune.2.8.5/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"

--- a/packages/ecaml/ecaml.v0.10.0/opam
+++ b/packages/ecaml/ecaml.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ecaml"
 bug-reports: "https://github.com/janestreet/ecaml/issues"
 dev-repo: "git+https://github.com/janestreet/ecaml.git"

--- a/packages/ecaml/ecaml.v0.11.0/opam
+++ b/packages/ecaml/ecaml.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ecaml"
 bug-reports: "https://github.com/janestreet/ecaml/issues"
 dev-repo: "git+https://github.com/janestreet/ecaml.git"

--- a/packages/ecaml/ecaml.v0.12.0/opam
+++ b/packages/ecaml/ecaml.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ecaml"
 bug-reports: "https://github.com/janestreet/ecaml/issues"
 dev-repo: "git+https://github.com/janestreet/ecaml.git"

--- a/packages/ecaml/ecaml.v0.13.0/opam
+++ b/packages/ecaml/ecaml.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ecaml"
 bug-reports: "https://github.com/janestreet/ecaml/issues"
 dev-repo: "git+https://github.com/janestreet/ecaml.git"

--- a/packages/ecaml/ecaml.v0.14.0/opam
+++ b/packages/ecaml/ecaml.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ecaml"
 bug-reports: "https://github.com/janestreet/ecaml/issues"
 dev-repo: "git+https://github.com/janestreet/ecaml.git"

--- a/packages/ecaml/ecaml.v0.9.0/opam
+++ b/packages/ecaml/ecaml.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ecaml"
 bug-reports: "https://github.com/janestreet/ecaml/issues"
 dev-repo: "git+https://github.com/janestreet/ecaml.git"

--- a/packages/email_message/email_message.109.38.alpha1/opam
+++ b/packages/email_message/email_message.109.38.alpha1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "email_message"]]
 depends: [

--- a/packages/email_message/email_message.109.42.alpha1/opam
+++ b/packages/email_message/email_message.109.42.alpha1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "email_message"]]
 depends: [

--- a/packages/email_message/email_message.112.17.00/opam
+++ b/packages/email_message/email_message.112.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "email_message"]]
 depends: [

--- a/packages/email_message/email_message.112.35.00/opam
+++ b/packages/email_message/email_message.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 build: [
   [make]

--- a/packages/email_message/email_message.113.00.00/opam
+++ b/packages/email_message/email_message.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 build: [
   [make]

--- a/packages/email_message/email_message.113.24.00/opam
+++ b/packages/email_message/email_message.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 bug-reports: "https://github.com/janestreet/email_message/issues"
 dev-repo: "git+https://github.com/janestreet/email_message.git"

--- a/packages/email_message/email_message.113.33.00+4.03/opam
+++ b/packages/email_message/email_message.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 bug-reports: "https://github.com/janestreet/email_message/issues"
 dev-repo: "git+https://github.com/janestreet/email_message.git"

--- a/packages/email_message/email_message.113.33.00/opam
+++ b/packages/email_message/email_message.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 bug-reports: "https://github.com/janestreet/email_message/issues"
 dev-repo: "git+https://github.com/janestreet/email_message.git"

--- a/packages/email_message/email_message.113.33.03/opam
+++ b/packages/email_message/email_message.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 bug-reports: "https://github.com/janestreet/email_message/issues"
 dev-repo: "git+https://github.com/janestreet/email_message.git"

--- a/packages/email_message/email_message.v0.10.0/opam
+++ b/packages/email_message/email_message.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 bug-reports: "https://github.com/janestreet/email_message/issues"
 dev-repo: "git+https://github.com/janestreet/email_message.git"

--- a/packages/email_message/email_message.v0.11.0/opam
+++ b/packages/email_message/email_message.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 bug-reports: "https://github.com/janestreet/email_message/issues"
 dev-repo: "git+https://github.com/janestreet/email_message.git"

--- a/packages/email_message/email_message.v0.12.0/opam
+++ b/packages/email_message/email_message.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 bug-reports: "https://github.com/janestreet/email_message/issues"
 dev-repo: "git+https://github.com/janestreet/email_message.git"

--- a/packages/email_message/email_message.v0.13.0/opam
+++ b/packages/email_message/email_message.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 bug-reports: "https://github.com/janestreet/email_message/issues"
 dev-repo: "git+https://github.com/janestreet/email_message.git"

--- a/packages/email_message/email_message.v0.14.0/opam
+++ b/packages/email_message/email_message.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 bug-reports: "https://github.com/janestreet/email_message/issues"
 dev-repo: "git+https://github.com/janestreet/email_message.git"

--- a/packages/email_message/email_message.v0.9.0/opam
+++ b/packages/email_message/email_message.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 bug-reports: "https://github.com/janestreet/email_message/issues"
 dev-repo: "git+https://github.com/janestreet/email_message.git"

--- a/packages/email_message/email_message.v0.9.1/opam
+++ b/packages/email_message/email_message.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/email_message"
 bug-reports: "https://github.com/janestreet/email_message/issues"
 dev-repo: "git+https://github.com/janestreet/email_message.git"

--- a/packages/enumerate/enumerate.111.03.00/opam
+++ b/packages/enumerate/enumerate.111.03.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/enumerate/enumerate.111.08.00/opam
+++ b/packages/enumerate/enumerate.111.08.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/enumerate"
 license: "Apache-2.0"
 build: [

--- a/packages/expect_test_helpers/expect_test_helpers.v0.10.0/opam
+++ b/packages/expect_test_helpers/expect_test_helpers.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/expect_test_helpers"
 bug-reports: "https://github.com/janestreet/expect_test_helpers/issues"
 dev-repo: "git+https://github.com/janestreet/expect_test_helpers.git"

--- a/packages/expect_test_helpers/expect_test_helpers.v0.11.0/opam
+++ b/packages/expect_test_helpers/expect_test_helpers.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/expect_test_helpers"
 bug-reports: "https://github.com/janestreet/expect_test_helpers/issues"
 dev-repo: "git+https://github.com/janestreet/expect_test_helpers.git"

--- a/packages/expect_test_helpers/expect_test_helpers.v0.12.0/opam
+++ b/packages/expect_test_helpers/expect_test_helpers.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/expect_test_helpers"
 bug-reports: "https://github.com/janestreet/expect_test_helpers/issues"
 dev-repo: "git+https://github.com/janestreet/expect_test_helpers.git"

--- a/packages/expect_test_helpers/expect_test_helpers.v0.13.0/opam
+++ b/packages/expect_test_helpers/expect_test_helpers.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/expect_test_helpers"
 bug-reports: "https://github.com/janestreet/expect_test_helpers/issues"
 dev-repo: "git+https://github.com/janestreet/expect_test_helpers.git"

--- a/packages/expect_test_helpers/expect_test_helpers.v0.9.0/opam
+++ b/packages/expect_test_helpers/expect_test_helpers.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/expect_test_helpers"
 bug-reports: "https://github.com/janestreet/expect_test_helpers/issues"
 dev-repo: "git+https://github.com/janestreet/expect_test_helpers.git"

--- a/packages/expect_test_helpers_async/expect_test_helpers_async.v0.14.0/opam
+++ b/packages/expect_test_helpers_async/expect_test_helpers_async.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/expect_test_helpers_async"
 bug-reports: "https://github.com/janestreet/expect_test_helpers_async/issues"
 dev-repo: "git+https://github.com/janestreet/expect_test_helpers_async.git"

--- a/packages/expect_test_helpers_core/expect_test_helpers_core.v0.14.0/opam
+++ b/packages/expect_test_helpers_core/expect_test_helpers_core.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/expect_test_helpers_core"
 bug-reports: "https://github.com/janestreet/expect_test_helpers_core/issues"
 dev-repo: "git+https://github.com/janestreet/expect_test_helpers_core.git"

--- a/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.10.0/opam
+++ b/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/expect_test_helpers_kernel"
 bug-reports: "https://github.com/janestreet/expect_test_helpers_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/expect_test_helpers_kernel.git"

--- a/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.11.0/opam
+++ b/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/expect_test_helpers_kernel"
 bug-reports: "https://github.com/janestreet/expect_test_helpers_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/expect_test_helpers_kernel.git"

--- a/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.12.0/opam
+++ b/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/expect_test_helpers_kernel"
 bug-reports: "https://github.com/janestreet/expect_test_helpers_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/expect_test_helpers_kernel.git"

--- a/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.13.0/opam
+++ b/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/expect_test_helpers_kernel"
 bug-reports: "https://github.com/janestreet/expect_test_helpers_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/expect_test_helpers_kernel.git"

--- a/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.9.0/opam
+++ b/packages/expect_test_helpers_kernel/expect_test_helpers_kernel.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/expect_test_helpers_kernel"
 bug-reports: "https://github.com/janestreet/expect_test_helpers_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/expect_test_helpers_kernel.git"

--- a/packages/faillib/faillib.109.35.00/opam
+++ b/packages/faillib/faillib.109.35.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "faillib"]]
 depends: [

--- a/packages/faillib/faillib.109.35.02/opam
+++ b/packages/faillib/faillib.109.35.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "faillib"]]
 depends: [

--- a/packages/faillib/faillib.109.60.00/opam
+++ b/packages/faillib/faillib.109.60.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "faillib"]]
 depends: [

--- a/packages/faillib/faillib.111.17.00/opam
+++ b/packages/faillib/faillib.111.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "faillib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.108.00.02/opam
+++ b/packages/fieldslib/fieldslib.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.108.07.00/opam
+++ b/packages/fieldslib/fieldslib.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.108.07.01/opam
+++ b/packages/fieldslib/fieldslib.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.108.08.00/opam
+++ b/packages/fieldslib/fieldslib.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.109.07.00/opam
+++ b/packages/fieldslib/fieldslib.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.109.08.00/opam
+++ b/packages/fieldslib/fieldslib.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.109.09.00/opam
+++ b/packages/fieldslib/fieldslib.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.109.10.00/opam
+++ b/packages/fieldslib/fieldslib.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.109.11.00/opam
+++ b/packages/fieldslib/fieldslib.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.109.12.00/opam
+++ b/packages/fieldslib/fieldslib.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.109.13.00/opam
+++ b/packages/fieldslib/fieldslib.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.109.14.00/opam
+++ b/packages/fieldslib/fieldslib.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.109.15.00/opam
+++ b/packages/fieldslib/fieldslib.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [

--- a/packages/fieldslib/fieldslib.109.19.00/opam
+++ b/packages/fieldslib/fieldslib.109.19.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 license: "Apache-2.0"
 build: [

--- a/packages/fieldslib/fieldslib.109.20.00/opam
+++ b/packages/fieldslib/fieldslib.109.20.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 license: "Apache-2.0"
 build: [

--- a/packages/fieldslib/fieldslib.109.20.02/opam
+++ b/packages/fieldslib/fieldslib.109.20.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 license: "Apache-2.0"
 build: [

--- a/packages/fieldslib/fieldslib.109.20.03/opam
+++ b/packages/fieldslib/fieldslib.109.20.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 license: "Apache-2.0"
 build: [

--- a/packages/fieldslib/fieldslib.113.00.00/opam
+++ b/packages/fieldslib/fieldslib.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 license: "Apache-2.0"
 build: [

--- a/packages/fieldslib/fieldslib.113.24.00/opam
+++ b/packages/fieldslib/fieldslib.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 bug-reports: "https://github.com/janestreet/fieldslib/issues"
 dev-repo: "git+https://github.com/janestreet/fieldslib.git"

--- a/packages/fieldslib/fieldslib.113.33.03/opam
+++ b/packages/fieldslib/fieldslib.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 bug-reports: "https://github.com/janestreet/fieldslib/issues"
 dev-repo: "git+https://github.com/janestreet/fieldslib.git"

--- a/packages/fieldslib/fieldslib.v0.10.0/opam
+++ b/packages/fieldslib/fieldslib.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 bug-reports: "https://github.com/janestreet/fieldslib/issues"
 dev-repo: "git+https://github.com/janestreet/fieldslib.git"

--- a/packages/fieldslib/fieldslib.v0.11.0/opam
+++ b/packages/fieldslib/fieldslib.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 bug-reports: "https://github.com/janestreet/fieldslib/issues"
 dev-repo: "git+https://github.com/janestreet/fieldslib.git"

--- a/packages/fieldslib/fieldslib.v0.12.0/opam
+++ b/packages/fieldslib/fieldslib.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 bug-reports: "https://github.com/janestreet/fieldslib/issues"
 dev-repo: "git+https://github.com/janestreet/fieldslib.git"

--- a/packages/fieldslib/fieldslib.v0.13.0/opam
+++ b/packages/fieldslib/fieldslib.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 bug-reports: "https://github.com/janestreet/fieldslib/issues"
 dev-repo: "git+https://github.com/janestreet/fieldslib.git"

--- a/packages/fieldslib/fieldslib.v0.14.0/opam
+++ b/packages/fieldslib/fieldslib.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 bug-reports: "https://github.com/janestreet/fieldslib/issues"
 dev-repo: "git+https://github.com/janestreet/fieldslib.git"

--- a/packages/fieldslib/fieldslib.v0.9.0/opam
+++ b/packages/fieldslib/fieldslib.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/fieldslib"
 bug-reports: "https://github.com/janestreet/fieldslib/issues"
 dev-repo: "git+https://github.com/janestreet/fieldslib.git"

--- a/packages/findlib_top/findlib_top.v0.10.0/opam
+++ b/packages/findlib_top/findlib_top.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/findlib_top"
 bug-reports: "https://github.com/janestreet/findlib_top/issues"
 dev-repo: "git+https://github.com/janestreet/findlib_top.git"

--- a/packages/findlib_top/findlib_top.v0.11.0/opam
+++ b/packages/findlib_top/findlib_top.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/findlib_top"
 bug-reports: "https://github.com/janestreet/findlib_top/issues"
 dev-repo: "git+https://github.com/janestreet/findlib_top.git"

--- a/packages/hardcaml/hardcaml.v0.12.0/opam
+++ b/packages/hardcaml/hardcaml.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/hardcaml"
 bug-reports: "https://github.com/janestreet/hardcaml/issues"
 dev-repo: "git+https://github.com/janestreet/hardcaml.git"

--- a/packages/hardcaml/hardcaml.v0.13.0/opam
+++ b/packages/hardcaml/hardcaml.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/hardcaml"
 bug-reports: "https://github.com/janestreet/hardcaml/issues"
 dev-repo: "git+https://github.com/janestreet/hardcaml.git"

--- a/packages/hardcaml/hardcaml.v0.14.0/opam
+++ b/packages/hardcaml/hardcaml.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/hardcaml"
 bug-reports: "https://github.com/janestreet/hardcaml/issues"
 dev-repo: "git+https://github.com/janestreet/hardcaml.git"

--- a/packages/hardcaml/hardcaml.v0.14.1/opam
+++ b/packages/hardcaml/hardcaml.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/hardcaml"
 bug-reports: "https://github.com/janestreet/hardcaml/issues"
 dev-repo: "git+https://github.com/janestreet/hardcaml.git"

--- a/packages/hardcaml/hardcaml.v0.14.2/opam
+++ b/packages/hardcaml/hardcaml.v0.14.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/hardcaml"
 bug-reports: "https://github.com/janestreet/hardcaml/issues"
 dev-repo: "git+https://github.com/janestreet/hardcaml.git"

--- a/packages/hardcaml_waveterm/hardcaml_waveterm.v0.12.0/opam
+++ b/packages/hardcaml_waveterm/hardcaml_waveterm.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/hardcaml_waveterm"
 bug-reports: "https://github.com/janestreet/hardcaml_waveterm/issues"
 dev-repo: "git+https://github.com/janestreet/hardcaml_waveterm.git"

--- a/packages/hardcaml_waveterm/hardcaml_waveterm.v0.13.0/opam
+++ b/packages/hardcaml_waveterm/hardcaml_waveterm.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/hardcaml_waveterm"
 bug-reports: "https://github.com/janestreet/hardcaml_waveterm/issues"
 dev-repo: "git+https://github.com/janestreet/hardcaml_waveterm.git"

--- a/packages/hardcaml_waveterm/hardcaml_waveterm.v0.14.0/opam
+++ b/packages/hardcaml_waveterm/hardcaml_waveterm.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/hardcaml_waveterm"
 bug-reports: "https://github.com/janestreet/hardcaml_waveterm/issues"
 dev-repo: "git+https://github.com/janestreet/hardcaml_waveterm.git"

--- a/packages/herelib/herelib.109.08.00/opam
+++ b/packages/herelib/herelib.109.08.00/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/herelib"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.09.00/opam
+++ b/packages/herelib/herelib.109.09.00/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/herelib"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.10.00/opam
+++ b/packages/herelib/herelib.109.10.00/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/herelib"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.11.00/opam
+++ b/packages/herelib/herelib.109.11.00/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/herelib"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.12.00/opam
+++ b/packages/herelib/herelib.109.12.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/herelib"
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]

--- a/packages/herelib/herelib.109.13.00/opam
+++ b/packages/herelib/herelib.109.13.00/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/herelib"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.14.00/opam
+++ b/packages/herelib/herelib.109.14.00/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/herelib"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.15.00/opam
+++ b/packages/herelib/herelib.109.15.00/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/herelib"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.35.00/opam
+++ b/packages/herelib/herelib.109.35.00/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/herelib"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.109.35.02/opam
+++ b/packages/herelib/herelib.109.35.02/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 homepage: "https://github.com/janestreet/herelib"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC"]
 build: make
 remove: [["ocamlfind" "remove" "herelib"]]
 depends: [

--- a/packages/herelib/herelib.112.35.00/opam
+++ b/packages/herelib/herelib.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/herelib"
 build: [
   [make]

--- a/packages/higher_kinded/higher_kinded.v0.14.0/opam
+++ b/packages/higher_kinded/higher_kinded.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/higher_kinded"
 bug-reports: "https://github.com/janestreet/higher_kinded/issues"
 dev-repo: "git+https://github.com/janestreet/higher_kinded.git"

--- a/packages/higher_kinded/higher_kinded.v0.14.1/opam
+++ b/packages/higher_kinded/higher_kinded.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/higher_kinded"
 bug-reports: "https://github.com/janestreet/higher_kinded/issues"
 dev-repo: "git+https://github.com/janestreet/higher_kinded.git"

--- a/packages/incr_dom/incr_dom.v0.10.0/opam
+++ b/packages/incr_dom/incr_dom.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom"
 bug-reports: "https://github.com/janestreet/incr_dom/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom.git"

--- a/packages/incr_dom/incr_dom.v0.11.0/opam
+++ b/packages/incr_dom/incr_dom.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom"
 bug-reports: "https://github.com/janestreet/incr_dom/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom.git"

--- a/packages/incr_dom/incr_dom.v0.12.0/opam
+++ b/packages/incr_dom/incr_dom.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom"
 bug-reports: "https://github.com/janestreet/incr_dom/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom.git"

--- a/packages/incr_dom/incr_dom.v0.13.0/opam
+++ b/packages/incr_dom/incr_dom.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom"
 bug-reports: "https://github.com/janestreet/incr_dom/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom.git"

--- a/packages/incr_dom/incr_dom.v0.14.0/opam
+++ b/packages/incr_dom/incr_dom.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom"
 bug-reports: "https://github.com/janestreet/incr_dom/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom.git"

--- a/packages/incr_dom/incr_dom.v0.9.0/opam
+++ b/packages/incr_dom/incr_dom.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom"
 bug-reports: "https://github.com/janestreet/incr_dom/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom.git"

--- a/packages/incr_dom_interactive/incr_dom_interactive.v0.14.0/opam
+++ b/packages/incr_dom_interactive/incr_dom_interactive.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom_interactive"
 bug-reports: "https://github.com/janestreet/incr_dom_interactive/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom_interactive.git"

--- a/packages/incr_dom_keyboard/incr_dom_keyboard.v0.12.0/opam
+++ b/packages/incr_dom_keyboard/incr_dom_keyboard.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom_keyboard"
 bug-reports: "https://github.com/janestreet/incr_dom_keyboard/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom_keyboard.git"

--- a/packages/incr_dom_keyboard/incr_dom_keyboard.v0.13.0/opam
+++ b/packages/incr_dom_keyboard/incr_dom_keyboard.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom_keyboard"
 bug-reports: "https://github.com/janestreet/incr_dom_keyboard/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom_keyboard.git"

--- a/packages/incr_dom_keyboard/incr_dom_keyboard.v0.14.0/opam
+++ b/packages/incr_dom_keyboard/incr_dom_keyboard.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom_keyboard"
 bug-reports: "https://github.com/janestreet/incr_dom_keyboard/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom_keyboard.git"

--- a/packages/incr_dom_partial_render/incr_dom_partial_render.v0.12.0/opam
+++ b/packages/incr_dom_partial_render/incr_dom_partial_render.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom_partial_render"
 bug-reports: "https://github.com/janestreet/incr_dom_partial_render/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom_partial_render.git"

--- a/packages/incr_dom_partial_render/incr_dom_partial_render.v0.13.0/opam
+++ b/packages/incr_dom_partial_render/incr_dom_partial_render.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom_partial_render"
 bug-reports: "https://github.com/janestreet/incr_dom_partial_render/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom_partial_render.git"

--- a/packages/incr_dom_partial_render/incr_dom_partial_render.v0.14.0/opam
+++ b/packages/incr_dom_partial_render/incr_dom_partial_render.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom_partial_render"
 bug-reports: "https://github.com/janestreet/incr_dom_partial_render/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom_partial_render.git"

--- a/packages/incr_dom_sexp_form/incr_dom_sexp_form.v0.14.0/opam
+++ b/packages/incr_dom_sexp_form/incr_dom_sexp_form.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom_sexp_form"
 bug-reports: "https://github.com/janestreet/incr_dom_sexp_form/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom_sexp_form.git"

--- a/packages/incr_dom_widgets/incr_dom_widgets.v0.10.0/opam
+++ b/packages/incr_dom_widgets/incr_dom_widgets.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom_widgets"
 bug-reports: "https://github.com/janestreet/incr_dom_widgets/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom_widgets.git"

--- a/packages/incr_dom_widgets/incr_dom_widgets.v0.11.0/opam
+++ b/packages/incr_dom_widgets/incr_dom_widgets.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom_widgets"
 bug-reports: "https://github.com/janestreet/incr_dom_widgets/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom_widgets.git"

--- a/packages/incr_dom_widgets/incr_dom_widgets.v0.12.0/opam
+++ b/packages/incr_dom_widgets/incr_dom_widgets.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom_widgets"
 bug-reports: "https://github.com/janestreet/incr_dom_widgets/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom_widgets.git"

--- a/packages/incr_dom_widgets/incr_dom_widgets.v0.13.0/opam
+++ b/packages/incr_dom_widgets/incr_dom_widgets.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_dom_widgets"
 bug-reports: "https://github.com/janestreet/incr_dom_widgets/issues"
 dev-repo: "git+https://github.com/janestreet/incr_dom_widgets.git"

--- a/packages/incr_map/incr_map.v0.10.0/opam
+++ b/packages/incr_map/incr_map.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_map"
 bug-reports: "https://github.com/janestreet/incr_map/issues"
 dev-repo: "git+https://github.com/janestreet/incr_map.git"

--- a/packages/incr_map/incr_map.v0.11.0/opam
+++ b/packages/incr_map/incr_map.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_map"
 bug-reports: "https://github.com/janestreet/incr_map/issues"
 dev-repo: "git+https://github.com/janestreet/incr_map.git"

--- a/packages/incr_map/incr_map.v0.12.0/opam
+++ b/packages/incr_map/incr_map.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_map"
 bug-reports: "https://github.com/janestreet/incr_map/issues"
 dev-repo: "git+https://github.com/janestreet/incr_map.git"

--- a/packages/incr_map/incr_map.v0.13.0/opam
+++ b/packages/incr_map/incr_map.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_map"
 bug-reports: "https://github.com/janestreet/incr_map/issues"
 dev-repo: "git+https://github.com/janestreet/incr_map.git"

--- a/packages/incr_map/incr_map.v0.14.0/opam
+++ b/packages/incr_map/incr_map.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_map"
 bug-reports: "https://github.com/janestreet/incr_map/issues"
 dev-repo: "git+https://github.com/janestreet/incr_map.git"

--- a/packages/incr_map/incr_map.v0.9.0/opam
+++ b/packages/incr_map/incr_map.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_map"
 bug-reports: "https://github.com/janestreet/incr_map/issues"
 dev-repo: "git+https://github.com/janestreet/incr_map.git"

--- a/packages/incr_select/incr_select.v0.10.0/opam
+++ b/packages/incr_select/incr_select.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_select"
 bug-reports: "https://github.com/janestreet/incr_select/issues"
 dev-repo: "git+https://github.com/janestreet/incr_select.git"

--- a/packages/incr_select/incr_select.v0.11.0/opam
+++ b/packages/incr_select/incr_select.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_select"
 bug-reports: "https://github.com/janestreet/incr_select/issues"
 dev-repo: "git+https://github.com/janestreet/incr_select.git"

--- a/packages/incr_select/incr_select.v0.12.0/opam
+++ b/packages/incr_select/incr_select.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_select"
 bug-reports: "https://github.com/janestreet/incr_select/issues"
 dev-repo: "git+https://github.com/janestreet/incr_select.git"

--- a/packages/incr_select/incr_select.v0.13.0/opam
+++ b/packages/incr_select/incr_select.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_select"
 bug-reports: "https://github.com/janestreet/incr_select/issues"
 dev-repo: "git+https://github.com/janestreet/incr_select.git"

--- a/packages/incr_select/incr_select.v0.14.0/opam
+++ b/packages/incr_select/incr_select.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_select"
 bug-reports: "https://github.com/janestreet/incr_select/issues"
 dev-repo: "git+https://github.com/janestreet/incr_select.git"

--- a/packages/incr_select/incr_select.v0.9.0/opam
+++ b/packages/incr_select/incr_select.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incr_select"
 bug-reports: "https://github.com/janestreet/incr_select/issues"
 dev-repo: "git+https://github.com/janestreet/incr_select.git"

--- a/packages/incremental/incremental.112.35.00/opam
+++ b/packages/incremental/incremental.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental"
 dev-repo: "git+https://github.com/janestreet/incremental.git"
 bug-reports: "https://github.com/janestreet/incremental/issues"

--- a/packages/incremental/incremental.113.00.00/opam
+++ b/packages/incremental/incremental.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental"
 dev-repo: "git+https://github.com/janestreet/incremental.git"
 bug-reports: "https://github.com/janestreet/incremental/issues"

--- a/packages/incremental/incremental.113.24.00/opam
+++ b/packages/incremental/incremental.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental"
 bug-reports: "https://github.com/janestreet/incremental/issues"
 dev-repo: "git+https://github.com/janestreet/incremental.git"

--- a/packages/incremental/incremental.113.33.00/opam
+++ b/packages/incremental/incremental.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental"
 bug-reports: "https://github.com/janestreet/incremental/issues"
 dev-repo: "git+https://github.com/janestreet/incremental.git"

--- a/packages/incremental/incremental.113.33.03/opam
+++ b/packages/incremental/incremental.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental"
 bug-reports: "https://github.com/janestreet/incremental/issues"
 dev-repo: "git+https://github.com/janestreet/incremental.git"

--- a/packages/incremental/incremental.v0.10.0/opam
+++ b/packages/incremental/incremental.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental"
 bug-reports: "https://github.com/janestreet/incremental/issues"
 dev-repo: "git+https://github.com/janestreet/incremental.git"

--- a/packages/incremental/incremental.v0.11.0/opam
+++ b/packages/incremental/incremental.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental"
 bug-reports: "https://github.com/janestreet/incremental/issues"
 dev-repo: "git+https://github.com/janestreet/incremental.git"

--- a/packages/incremental/incremental.v0.12.0/opam
+++ b/packages/incremental/incremental.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental"
 bug-reports: "https://github.com/janestreet/incremental/issues"
 dev-repo: "git+https://github.com/janestreet/incremental.git"

--- a/packages/incremental/incremental.v0.13.0/opam
+++ b/packages/incremental/incremental.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental"
 bug-reports: "https://github.com/janestreet/incremental/issues"
 dev-repo: "git+https://github.com/janestreet/incremental.git"

--- a/packages/incremental/incremental.v0.14.0/opam
+++ b/packages/incremental/incremental.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental"
 bug-reports: "https://github.com/janestreet/incremental/issues"
 dev-repo: "git+https://github.com/janestreet/incremental.git"

--- a/packages/incremental/incremental.v0.9.0/opam
+++ b/packages/incremental/incremental.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental"
 bug-reports: "https://github.com/janestreet/incremental/issues"
 dev-repo: "git+https://github.com/janestreet/incremental.git"

--- a/packages/incremental_kernel/incremental_kernel.113.33.00/opam
+++ b/packages/incremental_kernel/incremental_kernel.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental_kernel"
 bug-reports: "https://github.com/janestreet/incremental_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/incremental_kernel.git"

--- a/packages/incremental_kernel/incremental_kernel.113.33.03/opam
+++ b/packages/incremental_kernel/incremental_kernel.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental_kernel"
 bug-reports: "https://github.com/janestreet/incremental_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/incremental_kernel.git"

--- a/packages/incremental_kernel/incremental_kernel.v0.10.0/opam
+++ b/packages/incremental_kernel/incremental_kernel.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental_kernel"
 bug-reports: "https://github.com/janestreet/incremental_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/incremental_kernel.git"

--- a/packages/incremental_kernel/incremental_kernel.v0.11.0/opam
+++ b/packages/incremental_kernel/incremental_kernel.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental_kernel"
 bug-reports: "https://github.com/janestreet/incremental_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/incremental_kernel.git"

--- a/packages/incremental_kernel/incremental_kernel.v0.11.1/opam
+++ b/packages/incremental_kernel/incremental_kernel.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental_kernel"
 bug-reports: "https://github.com/janestreet/incremental_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/incremental_kernel.git"

--- a/packages/incremental_kernel/incremental_kernel.v0.9.0/opam
+++ b/packages/incremental_kernel/incremental_kernel.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/incremental_kernel"
 bug-reports: "https://github.com/janestreet/incremental_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/incremental_kernel.git"

--- a/packages/jane-street-headers/jane-street-headers.v0.10.0/opam
+++ b/packages/jane-street-headers/jane-street-headers.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jane-street-headers"
 bug-reports: "https://github.com/janestreet/jane-street-headers/issues"
 dev-repo: "git+https://github.com/janestreet/jane-street-headers.git"

--- a/packages/jane-street-headers/jane-street-headers.v0.11.0/opam
+++ b/packages/jane-street-headers/jane-street-headers.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jane-street-headers"
 bug-reports: "https://github.com/janestreet/jane-street-headers/issues"
 dev-repo: "git+https://github.com/janestreet/jane-street-headers.git"

--- a/packages/jane-street-headers/jane-street-headers.v0.12.0/opam
+++ b/packages/jane-street-headers/jane-street-headers.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jane-street-headers"
 bug-reports: "https://github.com/janestreet/jane-street-headers/issues"
 dev-repo: "git+https://github.com/janestreet/jane-street-headers.git"

--- a/packages/jane-street-headers/jane-street-headers.v0.13.0/opam
+++ b/packages/jane-street-headers/jane-street-headers.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jane-street-headers"
 bug-reports: "https://github.com/janestreet/jane-street-headers/issues"
 dev-repo: "git+https://github.com/janestreet/jane-street-headers.git"

--- a/packages/jane-street-headers/jane-street-headers.v0.14.0/opam
+++ b/packages/jane-street-headers/jane-street-headers.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jane-street-headers"
 bug-reports: "https://github.com/janestreet/jane-street-headers/issues"
 dev-repo: "git+https://github.com/janestreet/jane-street-headers.git"

--- a/packages/jane-street-headers/jane-street-headers.v0.9.0/opam
+++ b/packages/jane-street-headers/jane-street-headers.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jane-street-headers"
 bug-reports: "https://github.com/janestreet/jane-street-headers/issues"
 dev-repo: "git+https://github.com/janestreet/jane-street-headers.git"

--- a/packages/jane-street-tests/jane-street-tests.v0.10.0/opam
+++ b/packages/jane-street-tests/jane-street-tests.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jane-street-tests"
 bug-reports: "https://github.com/janestreet/jane-street-tests/issues"
 dev-repo: "git+https://github.com/janestreet/jane-street-tests.git"

--- a/packages/jbuilder/jbuilder.1.0+beta1/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta10/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta10/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta11/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta11/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta12/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta12/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta13/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta13/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta14/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta14/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta15/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta15/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta16/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta16/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta17/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta17/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/jbuilder/jbuilder.1.0+beta18.1/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta18.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/jbuilder/jbuilder.1.0+beta18/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta18/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/jbuilder/jbuilder.1.0+beta19.1/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta19.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/jbuilder/jbuilder.1.0+beta19/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta19/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/jbuilder/jbuilder.1.0+beta2/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta20.1/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta20.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/jbuilder/jbuilder.1.0+beta20.2/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta20.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/jbuilder/jbuilder.1.0+beta20/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta20/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/jbuilder/jbuilder.1.0+beta3/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta4/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta4/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta5/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta5/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta6/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta6/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta7/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta7/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta8/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta8/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.1.0+beta9/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta9/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jbuilder"
 bug-reports: "https://github.com/janestreet/jbuilder/issues"
 dev-repo: "git+https://github.com/janestreet/jbuilder.git"

--- a/packages/jbuilder/jbuilder.transition/opam
+++ b/packages/jbuilder/jbuilder.transition/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml/dune"
 bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/jenga/jenga.109.14.00/opam
+++ b/packages/jenga/jenga.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/jenga/jenga.109.15.00/opam
+++ b/packages/jenga/jenga.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/jenga/jenga.109.17.00/opam
+++ b/packages/jenga/jenga.109.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/jenga/jenga.109.18.00/opam
+++ b/packages/jenga/jenga.109.18.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/jenga/jenga.109.19.00/opam
+++ b/packages/jenga/jenga.109.19.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.20.00/opam
+++ b/packages/jenga/jenga.109.20.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.21.00/opam
+++ b/packages/jenga/jenga.109.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.22.00/opam
+++ b/packages/jenga/jenga.109.22.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.23.00/opam
+++ b/packages/jenga/jenga.109.23.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.24.00/opam
+++ b/packages/jenga/jenga.109.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.27.00/opam
+++ b/packages/jenga/jenga.109.27.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.28.00/opam
+++ b/packages/jenga/jenga.109.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.30.00/opam
+++ b/packages/jenga/jenga.109.30.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.31.00/opam
+++ b/packages/jenga/jenga.109.31.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.32.00/opam
+++ b/packages/jenga/jenga.109.32.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.33.00/opam
+++ b/packages/jenga/jenga.109.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.34.00/opam
+++ b/packages/jenga/jenga.109.34.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.35.00/opam
+++ b/packages/jenga/jenga.109.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.36.00/opam
+++ b/packages/jenga/jenga.109.36.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.37.00/opam
+++ b/packages/jenga/jenga.109.37.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.38.00/opam
+++ b/packages/jenga/jenga.109.38.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.40.00/opam
+++ b/packages/jenga/jenga.109.40.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.41.00/opam
+++ b/packages/jenga/jenga.109.41.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.42.00/opam
+++ b/packages/jenga/jenga.109.42.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.45.00/opam
+++ b/packages/jenga/jenga.109.45.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.47.00/opam
+++ b/packages/jenga/jenga.109.47.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.53.00/opam
+++ b/packages/jenga/jenga.109.53.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.55.00/opam
+++ b/packages/jenga/jenga.109.55.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.55.02/opam
+++ b/packages/jenga/jenga.109.55.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.55.03/opam
+++ b/packages/jenga/jenga.109.55.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.109.58.00/opam
+++ b/packages/jenga/jenga.109.58.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.111.03.00/opam
+++ b/packages/jenga/jenga.111.03.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.111.06.00/opam
+++ b/packages/jenga/jenga.111.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.111.08.00/opam
+++ b/packages/jenga/jenga.111.08.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.111.08.01/opam
+++ b/packages/jenga/jenga.111.08.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.111.17.00/opam
+++ b/packages/jenga/jenga.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.111.21.00/opam
+++ b/packages/jenga/jenga.111.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.111.25.00/opam
+++ b/packages/jenga/jenga.111.25.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.111.28.00/opam
+++ b/packages/jenga/jenga.111.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.112.01.00/opam
+++ b/packages/jenga/jenga.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.112.06.00/opam
+++ b/packages/jenga/jenga.112.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.112.17.00/opam
+++ b/packages/jenga/jenga.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.112.24.00/opam
+++ b/packages/jenga/jenga.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.112.35.00/opam
+++ b/packages/jenga/jenga.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.113.00.00/opam
+++ b/packages/jenga/jenga.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jenga"
 license: "Apache-2.0"
 build: [

--- a/packages/jenga/jenga.113.24.00/opam
+++ b/packages/jenga/jenga.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jenga"
 bug-reports: "https://github.com/janestreet/jenga/issues"
 dev-repo: "git+https://github.com/janestreet/jenga.git"

--- a/packages/jenga/jenga.113.24.02/opam
+++ b/packages/jenga/jenga.113.24.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jenga"
 bug-reports: "https://github.com/janestreet/jenga/issues"
 dev-repo: "git+https://github.com/janestreet/jenga.git"

--- a/packages/jenga/jenga.113.33.00+4.03/opam
+++ b/packages/jenga/jenga.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jenga"
 bug-reports: "https://github.com/janestreet/jenga/issues"
 dev-repo: "git+https://github.com/janestreet/jenga.git"

--- a/packages/jenga/jenga.113.33.00/opam
+++ b/packages/jenga/jenga.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jenga"
 bug-reports: "https://github.com/janestreet/jenga/issues"
 dev-repo: "git+https://github.com/janestreet/jenga.git"

--- a/packages/jenga/jenga.113.33.03/opam
+++ b/packages/jenga/jenga.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jenga"
 bug-reports: "https://github.com/janestreet/jenga/issues"
 dev-repo: "git+https://github.com/janestreet/jenga.git"

--- a/packages/jenga/jenga.v0.10.0/opam
+++ b/packages/jenga/jenga.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jenga"
 bug-reports: "https://github.com/janestreet/jenga/issues"
 dev-repo: "git+https://github.com/janestreet/jenga.git"

--- a/packages/jenga/jenga.v0.11.0/opam
+++ b/packages/jenga/jenga.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jenga"
 bug-reports: "https://github.com/janestreet/jenga/issues"
 dev-repo: "git+https://github.com/janestreet/jenga.git"

--- a/packages/jenga/jenga.v0.9.0/opam
+++ b/packages/jenga/jenga.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jenga"
 bug-reports: "https://github.com/janestreet/jenga/issues"
 dev-repo: "git+https://github.com/janestreet/jenga.git"

--- a/packages/js-build-tools/js-build-tools.113.33.03/opam
+++ b/packages/js-build-tools/js-build-tools.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/js-build-tools"
 bug-reports: "https://github.com/janestreet/js-build-tools/issues"
 dev-repo: "git+https://github.com/janestreet/js-build-tools.git"

--- a/packages/js-build-tools/js-build-tools.113.33.04/opam
+++ b/packages/js-build-tools/js-build-tools.113.33.04/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/js-build-tools"
 bug-reports: "https://github.com/janestreet/js-build-tools/issues"
 dev-repo: "git+https://github.com/janestreet/js-build-tools.git"

--- a/packages/js-lz4/js-lz4.109.38.alpha1/opam
+++ b/packages/js-lz4/js-lz4.109.38.alpha1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "lz4lib"]]
 depends: [

--- a/packages/json-wheel_jane_street_overlay/json-wheel_jane_street_overlay.v0.9.0/opam
+++ b/packages/json-wheel_jane_street_overlay/json-wheel_jane_street_overlay.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/json-wheel_jane_street_overlay"
 bug-reports: "https://github.com/janestreet/json-wheel_jane_street_overlay/issues"
 dev-repo:

--- a/packages/jst-config/jst-config.v0.12.0/opam
+++ b/packages/jst-config/jst-config.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jst-config"
 bug-reports: "https://github.com/janestreet/jst-config/issues"
 dev-repo: "git+https://github.com/janestreet/jst-config.git"

--- a/packages/jst-config/jst-config.v0.13.0/opam
+++ b/packages/jst-config/jst-config.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jst-config"
 bug-reports: "https://github.com/janestreet/jst-config/issues"
 dev-repo: "git+https://github.com/janestreet/jst-config.git"

--- a/packages/jst-config/jst-config.v0.14.0/opam
+++ b/packages/jst-config/jst-config.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/jst-config"
 bug-reports: "https://github.com/janestreet/jst-config/issues"
 dev-repo: "git+https://github.com/janestreet/jst-config.git"

--- a/packages/krb5/krb5.109.38.alpha1/opam
+++ b/packages/krb5/krb5.109.38.alpha1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "krb5"]]
 depends: [

--- a/packages/line-up-words/line-up-words.1.0.0/opam
+++ b/packages/line-up-words/line-up-words.1.0.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/line-up-words"
 bug-reports: "https://github.com/janestreet/line-up-words/issues"
 dev-repo: "git+https://github.com/janestreet/line-up-words.git"

--- a/packages/line-up-words/line-up-words.v0.11.0/opam
+++ b/packages/line-up-words/line-up-words.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/line-up-words"
 bug-reports: "https://github.com/janestreet/line-up-words/issues"
 dev-repo: "git+https://github.com/janestreet/line-up-words.git"

--- a/packages/line-up-words/line-up-words.v0.12.0/opam
+++ b/packages/line-up-words/line-up-words.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/line-up-words"
 bug-reports: "https://github.com/janestreet/line-up-words/issues"
 dev-repo: "git+https://github.com/janestreet/line-up-words.git"

--- a/packages/line-up-words/line-up-words.v0.13.0/opam
+++ b/packages/line-up-words/line-up-words.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/line-up-words"
 bug-reports: "https://github.com/janestreet/line-up-words/issues"
 dev-repo: "git+https://github.com/janestreet/line-up-words.git"

--- a/packages/line-up-words/line-up-words.v0.14.0/opam
+++ b/packages/line-up-words/line-up-words.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/line-up-words"
 bug-reports: "https://github.com/janestreet/line-up-words/issues"
 dev-repo: "git+https://github.com/janestreet/line-up-words.git"

--- a/packages/memtrace/memtrace.0.1.1/opam
+++ b/packages/memtrace/memtrace.0.1.1/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 synopsis: "Streaming client for Memprof"
 description: "Generates compact traces of a program's memory use."
-maintainer: ["opensource@janestreet.com"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street developers"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/janestreet/memtrace"
 bug-reports: "https://github.com/janestreet/memtrace/issues"

--- a/packages/memtrace/memtrace.0.1.2/opam
+++ b/packages/memtrace/memtrace.0.1.2/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 synopsis: "Streaming client for Memprof"
 description: "Generates compact traces of a program's memory use."
-maintainer: ["opensource@janestreet.com"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street developers"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/janestreet/memtrace"
 bug-reports: "https://github.com/janestreet/memtrace/issues"

--- a/packages/memtrace/memtrace.0.1/opam
+++ b/packages/memtrace/memtrace.0.1/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 synopsis: "Streaming client for Memprof"
 description: "Generates compact traces of a program's memory use."
-maintainer: ["opensource@janestreet.com"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street developers"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/janestreet/memtrace"
 bug-reports: "https://github.com/janestreet/memtrace/issues"

--- a/packages/memtrace/memtrace.0.2.1.2/opam
+++ b/packages/memtrace/memtrace.0.2.1.2/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 synopsis: "Streaming client for Memprof"
 description: "Generates compact traces of a program's memory use."
-maintainer: ["opensource@janestreet.com"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street developers"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/janestreet/memtrace"
 bug-reports: "https://github.com/janestreet/memtrace/issues"

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/memtrace_viewer"
 bug-reports: "https://github.com/janestreet/memtrace_viewer/issues"
 dev-repo: "git+https://github.com/janestreet/memtrace_viewer.git"

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/memtrace_viewer"
 bug-reports: "https://github.com/janestreet/memtrace_viewer/issues"
 dev-repo: "git+https://github.com/janestreet/memtrace_viewer.git"

--- a/packages/mlt_parser/mlt_parser.v0.10.0/opam
+++ b/packages/mlt_parser/mlt_parser.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/mlt_parser"
 bug-reports: "https://github.com/janestreet/mlt_parser/issues"
 dev-repo: "git+https://github.com/janestreet/mlt_parser.git"

--- a/packages/mlt_parser/mlt_parser.v0.11.0/opam
+++ b/packages/mlt_parser/mlt_parser.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/mlt_parser"
 bug-reports: "https://github.com/janestreet/mlt_parser/issues"
 dev-repo: "git+https://github.com/janestreet/mlt_parser.git"

--- a/packages/mlt_parser/mlt_parser.v0.12.0/opam
+++ b/packages/mlt_parser/mlt_parser.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/mlt_parser"
 bug-reports: "https://github.com/janestreet/mlt_parser/issues"
 dev-repo: "git+https://github.com/janestreet/mlt_parser.git"

--- a/packages/mlt_parser/mlt_parser.v0.13.0/opam
+++ b/packages/mlt_parser/mlt_parser.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/mlt_parser"
 bug-reports: "https://github.com/janestreet/mlt_parser/issues"
 dev-repo: "git+https://github.com/janestreet/mlt_parser.git"

--- a/packages/mlt_parser/mlt_parser.v0.14.0/opam
+++ b/packages/mlt_parser/mlt_parser.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/mlt_parser"
 bug-reports: "https://github.com/janestreet/mlt_parser/issues"
 dev-repo: "git+https://github.com/janestreet/mlt_parser.git"

--- a/packages/netsnmp/netsnmp.v0.12.0/opam
+++ b/packages/netsnmp/netsnmp.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/netsnmp"
 bug-reports: "https://github.com/janestreet/netsnmp/issues"
 dev-repo: "git+https://github.com/janestreet/netsnmp.git"

--- a/packages/netsnmp/netsnmp.v0.13.0/opam
+++ b/packages/netsnmp/netsnmp.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/netsnmp"
 bug-reports: "https://github.com/janestreet/netsnmp/issues"
 dev-repo: "git+https://github.com/janestreet/netsnmp.git"

--- a/packages/netsnmp/netsnmp.v0.14.0/opam
+++ b/packages/netsnmp/netsnmp.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/netsnmp"
 bug-reports: "https://github.com/janestreet/netsnmp/issues"
 dev-repo: "git+https://github.com/janestreet/netsnmp.git"

--- a/packages/notty_async/notty_async.v0.12.0/opam
+++ b/packages/notty_async/notty_async.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/notty_async"
 bug-reports: "https://github.com/janestreet/notty_async/issues"
 dev-repo: "git+https://github.com/janestreet/notty_async.git"

--- a/packages/notty_async/notty_async.v0.13.0/opam
+++ b/packages/notty_async/notty_async.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/notty_async"
 bug-reports: "https://github.com/janestreet/notty_async/issues"
 dev-repo: "git+https://github.com/janestreet/notty_async.git"

--- a/packages/notty_async/notty_async.v0.14.0/opam
+++ b/packages/notty_async/notty_async.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/notty_async"
 bug-reports: "https://github.com/janestreet/notty_async/issues"
 dev-repo: "git+https://github.com/janestreet/notty_async.git"

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.10.0/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml-compiler-libs"
 bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.11.0/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml-compiler-libs"
 bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.0/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml-compiler-libs"
 bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.1/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml-compiler-libs"
 bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.3/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml-compiler-libs"
 bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.9.0/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml-compiler-libs"
 bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"

--- a/packages/ocaml_plugin/ocaml_plugin.109.11.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.12.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.13.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.14.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.15.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.17.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.20.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.20.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.22.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.22.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.30.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.30.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.31.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.31.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.32.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.32.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.35.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.35.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.38.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.38.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.41.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.41.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.45.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.45.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.53.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.53.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.109.53.02/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.109.53.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.110.01.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.110.01.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.111.03.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.111.03.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.111.08.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.111.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.111.11.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.111.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.111.17.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.111.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.111.21.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.111.21.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.111.25.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.111.25.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.111.28.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.111.28.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.112.01.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.112.01.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.112.06.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.112.06.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.112.17.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.112.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.112.24.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.112.24.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/ocaml_plugin/ocaml_plugin.112.35.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 build: [
   ["./configure" "--prefix" prefix]

--- a/packages/ocaml_plugin/ocaml_plugin.113.00.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 build: [
   ["./configure" "--prefix" prefix]

--- a/packages/ocaml_plugin/ocaml_plugin.113.24.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml_plugin.git"

--- a/packages/ocaml_plugin/ocaml_plugin.113.24.02/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.113.24.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml_plugin.git"

--- a/packages/ocaml_plugin/ocaml_plugin.113.33.00+4.03/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml_plugin.git"

--- a/packages/ocaml_plugin/ocaml_plugin.113.33.00/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml_plugin.git"

--- a/packages/ocaml_plugin/ocaml_plugin.113.33.03/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml_plugin.git"

--- a/packages/ocaml_plugin/ocaml_plugin.v0.10.0/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml_plugin.git"

--- a/packages/ocaml_plugin/ocaml_plugin.v0.11.0/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml_plugin.git"

--- a/packages/ocaml_plugin/ocaml_plugin.v0.12.0/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml_plugin.git"

--- a/packages/ocaml_plugin/ocaml_plugin.v0.13.0/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml_plugin.git"

--- a/packages/ocaml_plugin/ocaml_plugin.v0.14.0/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml_plugin.git"

--- a/packages/ocaml_plugin/ocaml_plugin.v0.9.0/opam
+++ b/packages/ocaml_plugin/ocaml_plugin.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ocaml_plugin"
 bug-reports: "https://github.com/janestreet/ocaml_plugin/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml_plugin.git"

--- a/packages/pa_bench/pa_bench.109.55.00/opam
+++ b/packages/pa_bench/pa_bench.109.55.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_bench"]]
 depends: [

--- a/packages/pa_bench/pa_bench.109.55.02/opam
+++ b/packages/pa_bench/pa_bench.109.55.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_bench"]]
 depends: [

--- a/packages/pa_bench/pa_bench.111.28.00/opam
+++ b/packages/pa_bench/pa_bench.111.28.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_bench"]]
 depends: [

--- a/packages/pa_bench/pa_bench.112.06.00/opam
+++ b/packages/pa_bench/pa_bench.112.06.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_bench"]]
 depends: [

--- a/packages/pa_bench/pa_bench.113.00.00/opam
+++ b/packages/pa_bench/pa_bench.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pa_bench"
 license: "Apache-2.0"
 build: [

--- a/packages/pa_bin_prot/pa_bin_prot.113.00.00/opam
+++ b/packages/pa_bin_prot/pa_bin_prot.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage:    "https://github.com/janestreet/pa_bin_prot"
 bug-reports: "https://github.com/janestreet/pa_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/pa_bin_prot.git"

--- a/packages/pa_bin_prot/pa_bin_prot.113.00.01/opam
+++ b/packages/pa_bin_prot/pa_bin_prot.113.00.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage:    "https://github.com/janestreet/pa_bin_prot"
 bug-reports: "https://github.com/janestreet/pa_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/pa_bin_prot.git"

--- a/packages/pa_fields_conv/pa_fields_conv.113.00.00/opam
+++ b/packages/pa_fields_conv/pa_fields_conv.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage:    "https://github.com/janestreet/pa_fields_conv"
 bug-reports: "https://github.com/janestreet/pa_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/pa_fields_conv.git"

--- a/packages/pa_fields_conv/pa_fields_conv.113.00.01/opam
+++ b/packages/pa_fields_conv/pa_fields_conv.113.00.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage:    "https://github.com/janestreet/pa_fields_conv"
 bug-reports: "https://github.com/janestreet/pa_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/pa_fields_conv.git"

--- a/packages/pa_ounit/pa_ounit.108.00.02/opam
+++ b/packages/pa_ounit/pa_ounit.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.108.07.00/opam
+++ b/packages/pa_ounit/pa_ounit.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.108.07.01/opam
+++ b/packages/pa_ounit/pa_ounit.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.108.08.00/opam
+++ b/packages/pa_ounit/pa_ounit.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.07.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.08.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.09.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.10.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.11.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.12.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.13.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.14.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.15.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.18.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.18.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.27.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.27.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.34.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.34.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.36.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.36.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.53.00/opam
+++ b/packages/pa_ounit/pa_ounit.109.53.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.109.53.02/opam
+++ b/packages/pa_ounit/pa_ounit.109.53.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.111.28.00/opam
+++ b/packages/pa_ounit/pa_ounit.111.28.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.112.17.00/opam
+++ b/packages/pa_ounit/pa_ounit.112.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.112.24.00/opam
+++ b/packages/pa_ounit/pa_ounit.112.24.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_ounit"]]
 depends: [

--- a/packages/pa_ounit/pa_ounit.112.35.00/opam
+++ b/packages/pa_ounit/pa_ounit.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pa_ounit"
 build: [
   [make]

--- a/packages/pa_ounit/pa_ounit.113.00.00/opam
+++ b/packages/pa_ounit/pa_ounit.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pa_ounit"
 build: [
   [make]

--- a/packages/pa_sexp_conv/pa_sexp_conv.113.00.00/opam
+++ b/packages/pa_sexp_conv/pa_sexp_conv.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage:    "https://github.com/janestreet/pa_sexp_conv"
 bug-reports: "https://github.com/janestreet/pa_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/pa_sexp_conv.git"

--- a/packages/pa_sexp_conv/pa_sexp_conv.113.00.01/opam
+++ b/packages/pa_sexp_conv/pa_sexp_conv.113.00.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage:    "https://github.com/janestreet/pa_sexp_conv"
 bug-reports: "https://github.com/janestreet/pa_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/pa_sexp_conv.git"

--- a/packages/pa_structural_sexp/pa_structural_sexp.112.35.00/opam
+++ b/packages/pa_structural_sexp/pa_structural_sexp.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pa_structural_sexp"
 build: [
   [make]

--- a/packages/pa_structural_sexp/pa_structural_sexp.113.00.00/opam
+++ b/packages/pa_structural_sexp/pa_structural_sexp.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pa_structural_sexp"
 build: [
   [make]

--- a/packages/pa_test/pa_test.109.34.00/opam
+++ b/packages/pa_test/pa_test.109.34.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_test"]]
 depends: [

--- a/packages/pa_test/pa_test.109.45.00/opam
+++ b/packages/pa_test/pa_test.109.45.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_test"]]
 depends: [

--- a/packages/pa_test/pa_test.109.47.00/opam
+++ b/packages/pa_test/pa_test.109.47.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_test"]]
 depends: [

--- a/packages/pa_test/pa_test.109.53.00/opam
+++ b/packages/pa_test/pa_test.109.53.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_test"]]
 depends: [

--- a/packages/pa_test/pa_test.109.53.02/opam
+++ b/packages/pa_test/pa_test.109.53.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_test"]]
 depends: [

--- a/packages/pa_test/pa_test.110.01.00/opam
+++ b/packages/pa_test/pa_test.110.01.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_test"]]
 depends: [

--- a/packages/pa_test/pa_test.111.08.00/opam
+++ b/packages/pa_test/pa_test.111.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_test"]]
 depends: [

--- a/packages/pa_test/pa_test.111.08.01/opam
+++ b/packages/pa_test/pa_test.111.08.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_test"]]
 depends: [

--- a/packages/pa_test/pa_test.112.24.00/opam
+++ b/packages/pa_test/pa_test.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pa_test"
 license: "Apache-2.0"
 build: [

--- a/packages/pa_typerep_conv/pa_typerep_conv.113.00.00/opam
+++ b/packages/pa_typerep_conv/pa_typerep_conv.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage:    "https://github.com/janestreet/pa_typerep_conv"
 bug-reports: "https://github.com/janestreet/pa_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/pa_typerep_conv.git"

--- a/packages/pa_typerep_conv/pa_typerep_conv.113.00.01/opam
+++ b/packages/pa_typerep_conv/pa_typerep_conv.113.00.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage:    "https://github.com/janestreet/pa_typerep_conv"
 bug-reports: "https://github.com/janestreet/pa_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/pa_typerep_conv.git"

--- a/packages/pa_variants_conv/pa_variants_conv.109.15.03/opam
+++ b/packages/pa_variants_conv/pa_variants_conv.109.15.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage:    "https://github.com/janestreet/pa_variants_conv"
 bug-reports: "https://github.com/janestreet/pa_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/pa_variants_conv.git"

--- a/packages/pa_variants_conv/pa_variants_conv.109.15.04/opam
+++ b/packages/pa_variants_conv/pa_variants_conv.109.15.04/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage:    "https://github.com/janestreet/pa_variants_conv"
 bug-reports: "https://github.com/janestreet/pa_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/pa_variants_conv.git"

--- a/packages/pam/pam.v0.12.0/opam
+++ b/packages/pam/pam.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pam"
 bug-reports: "https://github.com/janestreet/pam/issues"
 dev-repo: "git+https://github.com/janestreet/pam.git"

--- a/packages/pam/pam.v0.13.0/opam
+++ b/packages/pam/pam.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pam"
 bug-reports: "https://github.com/janestreet/pam/issues"
 dev-repo: "git+https://github.com/janestreet/pam.git"

--- a/packages/pam/pam.v0.14.0/opam
+++ b/packages/pam/pam.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pam"
 bug-reports: "https://github.com/janestreet/pam/issues"
 dev-repo: "git+https://github.com/janestreet/pam.git"

--- a/packages/parsexp/parsexp.v0.10.0/opam
+++ b/packages/parsexp/parsexp.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp"
 bug-reports: "https://github.com/janestreet/parsexp/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp.git"

--- a/packages/parsexp/parsexp.v0.11.0/opam
+++ b/packages/parsexp/parsexp.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp"
 bug-reports: "https://github.com/janestreet/parsexp/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp.git"

--- a/packages/parsexp/parsexp.v0.12.0/opam
+++ b/packages/parsexp/parsexp.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp"
 bug-reports: "https://github.com/janestreet/parsexp/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp.git"

--- a/packages/parsexp/parsexp.v0.13.0/opam
+++ b/packages/parsexp/parsexp.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp"
 bug-reports: "https://github.com/janestreet/parsexp/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp.git"

--- a/packages/parsexp/parsexp.v0.14.0/opam
+++ b/packages/parsexp/parsexp.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp"
 bug-reports: "https://github.com/janestreet/parsexp/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp.git"

--- a/packages/parsexp/parsexp.v0.9.0/opam
+++ b/packages/parsexp/parsexp.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp"
 bug-reports: "https://github.com/janestreet/parsexp/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp.git"

--- a/packages/parsexp/parsexp.v0.9.1/opam
+++ b/packages/parsexp/parsexp.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp"
 bug-reports: "https://github.com/janestreet/parsexp/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp.git"

--- a/packages/parsexp_io/parsexp_io.v0.10.0/opam
+++ b/packages/parsexp_io/parsexp_io.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp_io"
 bug-reports: "https://github.com/janestreet/parsexp_io/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp_io.git"

--- a/packages/parsexp_io/parsexp_io.v0.11.0/opam
+++ b/packages/parsexp_io/parsexp_io.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp_io"
 bug-reports: "https://github.com/janestreet/parsexp_io/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp_io.git"

--- a/packages/parsexp_io/parsexp_io.v0.12.0/opam
+++ b/packages/parsexp_io/parsexp_io.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp_io"
 bug-reports: "https://github.com/janestreet/parsexp_io/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp_io.git"

--- a/packages/parsexp_io/parsexp_io.v0.13.0/opam
+++ b/packages/parsexp_io/parsexp_io.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp_io"
 bug-reports: "https://github.com/janestreet/parsexp_io/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp_io.git"

--- a/packages/parsexp_io/parsexp_io.v0.14.0/opam
+++ b/packages/parsexp_io/parsexp_io.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp_io"
 bug-reports: "https://github.com/janestreet/parsexp_io/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp_io.git"

--- a/packages/parsexp_io/parsexp_io.v0.9.0/opam
+++ b/packages/parsexp_io/parsexp_io.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp_io"
 bug-reports: "https://github.com/janestreet/parsexp_io/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp_io.git"

--- a/packages/parsexp_io/parsexp_io.v0.9.1/opam
+++ b/packages/parsexp_io/parsexp_io.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/parsexp_io"
 bug-reports: "https://github.com/janestreet/parsexp_io/issues"
 dev-repo: "git+https://github.com/janestreet/parsexp_io.git"

--- a/packages/patdiff/patdiff.109.08.00/opam
+++ b/packages/patdiff/patdiff.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.09.00/opam
+++ b/packages/patdiff/patdiff.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.10.00/opam
+++ b/packages/patdiff/patdiff.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.11.00/opam
+++ b/packages/patdiff/patdiff.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.12.00/opam
+++ b/packages/patdiff/patdiff.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.13.00/opam
+++ b/packages/patdiff/patdiff.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.14.00/opam
+++ b/packages/patdiff/patdiff.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.15.00/opam
+++ b/packages/patdiff/patdiff.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.30.00/opam
+++ b/packages/patdiff/patdiff.109.30.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.34.00/opam
+++ b/packages/patdiff/patdiff.109.34.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.38.00/opam
+++ b/packages/patdiff/patdiff.109.38.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.40.00/opam
+++ b/packages/patdiff/patdiff.109.40.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.41.00/opam
+++ b/packages/patdiff/patdiff.109.41.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.45.00/opam
+++ b/packages/patdiff/patdiff.109.45.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.47.00/opam
+++ b/packages/patdiff/patdiff.109.47.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.53.00/opam
+++ b/packages/patdiff/patdiff.109.53.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.53.02/opam
+++ b/packages/patdiff/patdiff.109.53.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.109.53.03/opam
+++ b/packages/patdiff/patdiff.109.53.03/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.111.13.00/opam
+++ b/packages/patdiff/patdiff.111.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.111.17.00/opam
+++ b/packages/patdiff/patdiff.111.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.111.21.00/opam
+++ b/packages/patdiff/patdiff.111.21.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.111.25.00/opam
+++ b/packages/patdiff/patdiff.111.25.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.111.28.00/opam
+++ b/packages/patdiff/patdiff.111.28.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.112.06.00/opam
+++ b/packages/patdiff/patdiff.112.06.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.112.17.00/opam
+++ b/packages/patdiff/patdiff.112.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.112.24.00/opam
+++ b/packages/patdiff/patdiff.112.24.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: [
   ["./configure" "--prefix" prefix]
   [make]

--- a/packages/patdiff/patdiff.113.00.00/opam
+++ b/packages/patdiff/patdiff.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patdiff"
 license: "Apache-2.0"
 build: [

--- a/packages/patdiff/patdiff.113.24.00/opam
+++ b/packages/patdiff/patdiff.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patdiff"
 bug-reports: "https://github.com/janestreet/patdiff/issues"
 dev-repo: "git+https://github.com/janestreet/patdiff.git"

--- a/packages/patdiff/patdiff.113.33.00/opam
+++ b/packages/patdiff/patdiff.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patdiff"
 bug-reports: "https://github.com/janestreet/patdiff/issues"
 dev-repo: "git+https://github.com/janestreet/patdiff.git"

--- a/packages/patdiff/patdiff.113.33.03/opam
+++ b/packages/patdiff/patdiff.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patdiff"
 bug-reports: "https://github.com/janestreet/patdiff/issues"
 dev-repo: "git+https://github.com/janestreet/patdiff.git"

--- a/packages/patdiff/patdiff.v0.10.0/opam
+++ b/packages/patdiff/patdiff.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patdiff"
 bug-reports: "https://github.com/janestreet/patdiff/issues"
 dev-repo: "git+https://github.com/janestreet/patdiff.git"

--- a/packages/patdiff/patdiff.v0.11.0/opam
+++ b/packages/patdiff/patdiff.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patdiff"
 bug-reports: "https://github.com/janestreet/patdiff/issues"
 dev-repo: "git+https://github.com/janestreet/patdiff.git"

--- a/packages/patdiff/patdiff.v0.12.0/opam
+++ b/packages/patdiff/patdiff.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patdiff"
 bug-reports: "https://github.com/janestreet/patdiff/issues"
 dev-repo: "git+https://github.com/janestreet/patdiff.git"

--- a/packages/patdiff/patdiff.v0.12.1/opam
+++ b/packages/patdiff/patdiff.v0.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patdiff"
 bug-reports: "https://github.com/janestreet/patdiff/issues"
 dev-repo: "git+https://github.com/janestreet/patdiff.git"

--- a/packages/patdiff/patdiff.v0.13.0/opam
+++ b/packages/patdiff/patdiff.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patdiff"
 bug-reports: "https://github.com/janestreet/patdiff/issues"
 dev-repo: "git+https://github.com/janestreet/patdiff.git"

--- a/packages/patdiff/patdiff.v0.14.0/opam
+++ b/packages/patdiff/patdiff.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patdiff"
 bug-reports: "https://github.com/janestreet/patdiff/issues"
 dev-repo: "git+https://github.com/janestreet/patdiff.git"

--- a/packages/patdiff/patdiff.v0.9.0/opam
+++ b/packages/patdiff/patdiff.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patdiff"
 bug-reports: "https://github.com/janestreet/patdiff/issues"
 dev-repo: "git+https://github.com/janestreet/patdiff.git"

--- a/packages/patience_diff/patience_diff.111.13.00/opam
+++ b/packages/patience_diff/patience_diff.111.13.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/patience_diff/patience_diff.111.17.00/opam
+++ b/packages/patience_diff/patience_diff.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/patience_diff/patience_diff.111.21.00/opam
+++ b/packages/patience_diff/patience_diff.111.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/patience_diff/patience_diff.111.25.00/opam
+++ b/packages/patience_diff/patience_diff.111.25.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/patience_diff/patience_diff.111.28.00/opam
+++ b/packages/patience_diff/patience_diff.111.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/patience_diff/patience_diff.112.24.00/opam
+++ b/packages/patience_diff/patience_diff.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patience_diff"
 license: "Apache-2.0"
 build: [

--- a/packages/patience_diff/patience_diff.113.24.00/opam
+++ b/packages/patience_diff/patience_diff.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patience_diff"
 bug-reports: "https://github.com/janestreet/patience_diff/issues"
 dev-repo: "git+https://github.com/janestreet/patience_diff.git"

--- a/packages/patience_diff/patience_diff.113.33.00/opam
+++ b/packages/patience_diff/patience_diff.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patience_diff"
 bug-reports: "https://github.com/janestreet/patience_diff/issues"
 dev-repo: "git+https://github.com/janestreet/patience_diff.git"

--- a/packages/patience_diff/patience_diff.113.33.03/opam
+++ b/packages/patience_diff/patience_diff.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patience_diff"
 bug-reports: "https://github.com/janestreet/patience_diff/issues"
 dev-repo: "git+https://github.com/janestreet/patience_diff.git"

--- a/packages/patience_diff/patience_diff.v0.10.0/opam
+++ b/packages/patience_diff/patience_diff.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patience_diff"
 bug-reports: "https://github.com/janestreet/patience_diff/issues"
 dev-repo: "git+https://github.com/janestreet/patience_diff.git"

--- a/packages/patience_diff/patience_diff.v0.11.0/opam
+++ b/packages/patience_diff/patience_diff.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patience_diff"
 bug-reports: "https://github.com/janestreet/patience_diff/issues"
 dev-repo: "git+https://github.com/janestreet/patience_diff.git"

--- a/packages/patience_diff/patience_diff.v0.12.0/opam
+++ b/packages/patience_diff/patience_diff.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patience_diff"
 bug-reports: "https://github.com/janestreet/patience_diff/issues"
 dev-repo: "git+https://github.com/janestreet/patience_diff.git"

--- a/packages/patience_diff/patience_diff.v0.13.0/opam
+++ b/packages/patience_diff/patience_diff.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patience_diff"
 bug-reports: "https://github.com/janestreet/patience_diff/issues"
 dev-repo: "git+https://github.com/janestreet/patience_diff.git"

--- a/packages/patience_diff/patience_diff.v0.14.0/opam
+++ b/packages/patience_diff/patience_diff.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patience_diff"
 bug-reports: "https://github.com/janestreet/patience_diff/issues"
 dev-repo: "git+https://github.com/janestreet/patience_diff.git"

--- a/packages/patience_diff/patience_diff.v0.9.0/opam
+++ b/packages/patience_diff/patience_diff.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/patience_diff"
 bug-reports: "https://github.com/janestreet/patience_diff/issues"
 dev-repo: "git+https://github.com/janestreet/patience_diff.git"

--- a/packages/pipebang/pipebang.108.00.02/opam
+++ b/packages/pipebang/pipebang.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.108.07.00/opam
+++ b/packages/pipebang/pipebang.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.108.07.01/opam
+++ b/packages/pipebang/pipebang.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.108.08.00/opam
+++ b/packages/pipebang/pipebang.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.109.07.00/opam
+++ b/packages/pipebang/pipebang.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.109.08.00/opam
+++ b/packages/pipebang/pipebang.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.109.09.00/opam
+++ b/packages/pipebang/pipebang.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.109.10.00/opam
+++ b/packages/pipebang/pipebang.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.109.11.00/opam
+++ b/packages/pipebang/pipebang.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.109.12.00/opam
+++ b/packages/pipebang/pipebang.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.109.13.00/opam
+++ b/packages/pipebang/pipebang.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.109.14.00/opam
+++ b/packages/pipebang/pipebang.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.109.15.00/opam
+++ b/packages/pipebang/pipebang.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.109.28.00/opam
+++ b/packages/pipebang/pipebang.109.28.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.109.28.02/opam
+++ b/packages/pipebang/pipebang.109.28.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.109.60.00/opam
+++ b/packages/pipebang/pipebang.109.60.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.110.01.00/opam
+++ b/packages/pipebang/pipebang.110.01.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "pa_pipebang"]]
 depends: [

--- a/packages/pipebang/pipebang.113.00.00/opam
+++ b/packages/pipebang/pipebang.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pipebang"
 license: "Apache-2.0"
 build: [

--- a/packages/posixat/posixat.v0.10.0/opam
+++ b/packages/posixat/posixat.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/posixat"
 bug-reports: "https://github.com/janestreet/posixat/issues"
 dev-repo: "git+https://github.com/janestreet/posixat.git"

--- a/packages/posixat/posixat.v0.11.0/opam
+++ b/packages/posixat/posixat.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/posixat"
 bug-reports: "https://github.com/janestreet/posixat/issues"
 dev-repo: "git+https://github.com/janestreet/posixat.git"

--- a/packages/posixat/posixat.v0.12.0/opam
+++ b/packages/posixat/posixat.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/posixat"
 bug-reports: "https://github.com/janestreet/posixat/issues"
 dev-repo: "git+https://github.com/janestreet/posixat.git"

--- a/packages/posixat/posixat.v0.13.0/opam
+++ b/packages/posixat/posixat.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/posixat"
 bug-reports: "https://github.com/janestreet/posixat/issues"
 dev-repo: "git+https://github.com/janestreet/posixat.git"

--- a/packages/posixat/posixat.v0.14.0/opam
+++ b/packages/posixat/posixat.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/posixat"
 bug-reports: "https://github.com/janestreet/posixat/issues"
 dev-repo: "git+https://github.com/janestreet/posixat.git"

--- a/packages/posixat/posixat.v0.9.0/opam
+++ b/packages/posixat/posixat.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/posixat"
 bug-reports: "https://github.com/janestreet/posixat/issues"
 dev-repo: "git+https://github.com/janestreet/posixat.git"

--- a/packages/posixat/posixat.v0.9.1/opam
+++ b/packages/posixat/posixat.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/posixat"
 bug-reports: "https://github.com/janestreet/posixat/issues"
 dev-repo: "git+https://github.com/janestreet/posixat.git"

--- a/packages/postgres_async/postgres_async.v0.13.0/opam
+++ b/packages/postgres_async/postgres_async.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/postgres_async"
 bug-reports: "https://github.com/janestreet/postgres_async/issues"
 dev-repo: "git+https://github.com/janestreet/postgres_async.git"

--- a/packages/postgres_async/postgres_async.v0.14.0/opam
+++ b/packages/postgres_async/postgres_async.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/postgres_async"
 bug-reports: "https://github.com/janestreet/postgres_async/issues"
 dev-repo: "git+https://github.com/janestreet/postgres_async.git"

--- a/packages/pp/pp.1.0.1/opam
+++ b/packages/pp/pp.1.0.1/opam
@@ -20,7 +20,7 @@ one [2] should be applicable to Pp as well.
 """
 maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
 authors: [
-  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jane Street Group, LLC"
   "Jeremie Dimino <jeremie@dimino.org>"
 ]
 license: "MIT"

--- a/packages/pp/pp.1.1.2/opam
+++ b/packages/pp/pp.1.1.2/opam
@@ -20,7 +20,7 @@ one [2] should be applicable to Pp as well.
 """
 maintainer: ["Jeremie Dimino <jeremie@dimino.org>"]
 authors: [
-  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Jane Street Group, LLC"
   "Jeremie Dimino <jeremie@dimino.org>"
 ]
 license: "MIT"

--- a/packages/ppx_accessor/ppx_accessor.v0.14.0/opam
+++ b/packages/ppx_accessor/ppx_accessor.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_accessor"
 bug-reports: "https://github.com/janestreet/ppx_accessor/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_accessor.git"

--- a/packages/ppx_accessor/ppx_accessor.v0.14.1/opam
+++ b/packages/ppx_accessor/ppx_accessor.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_accessor"
 bug-reports: "https://github.com/janestreet/ppx_accessor/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_accessor.git"

--- a/packages/ppx_accessor/ppx_accessor.v0.14.2/opam
+++ b/packages/ppx_accessor/ppx_accessor.v0.14.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_accessor"
 bug-reports: "https://github.com/janestreet/ppx_accessor/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_accessor.git"

--- a/packages/ppx_assert/ppx_assert.113.09.00/opam
+++ b/packages/ppx_assert/ppx_assert.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_assert"
 bug-reports: "https://github.com/janestreet/ppx_assert/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_assert.git"

--- a/packages/ppx_assert/ppx_assert.113.24.00/opam
+++ b/packages/ppx_assert/ppx_assert.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_assert"
 bug-reports: "https://github.com/janestreet/ppx_assert/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_assert.git"

--- a/packages/ppx_assert/ppx_assert.113.33.00/opam
+++ b/packages/ppx_assert/ppx_assert.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_assert"
 bug-reports: "https://github.com/janestreet/ppx_assert/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_assert.git"

--- a/packages/ppx_assert/ppx_assert.113.33.03/opam
+++ b/packages/ppx_assert/ppx_assert.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_assert"
 bug-reports: "https://github.com/janestreet/ppx_assert/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_assert.git"

--- a/packages/ppx_assert/ppx_assert.v0.10.0/opam
+++ b/packages/ppx_assert/ppx_assert.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_assert"
 bug-reports: "https://github.com/janestreet/ppx_assert/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_assert.git"

--- a/packages/ppx_assert/ppx_assert.v0.11.0/opam
+++ b/packages/ppx_assert/ppx_assert.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_assert"
 bug-reports: "https://github.com/janestreet/ppx_assert/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_assert.git"

--- a/packages/ppx_assert/ppx_assert.v0.12.0/opam
+++ b/packages/ppx_assert/ppx_assert.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_assert"
 bug-reports: "https://github.com/janestreet/ppx_assert/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_assert.git"

--- a/packages/ppx_assert/ppx_assert.v0.13.0/opam
+++ b/packages/ppx_assert/ppx_assert.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_assert"
 bug-reports: "https://github.com/janestreet/ppx_assert/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_assert.git"

--- a/packages/ppx_assert/ppx_assert.v0.14.0/opam
+++ b/packages/ppx_assert/ppx_assert.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_assert"
 bug-reports: "https://github.com/janestreet/ppx_assert/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_assert.git"

--- a/packages/ppx_assert/ppx_assert.v0.9.0/opam
+++ b/packages/ppx_assert/ppx_assert.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_assert"
 bug-reports: "https://github.com/janestreet/ppx_assert/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_assert.git"

--- a/packages/ppx_ast/ppx_ast.v0.10.0/opam
+++ b/packages/ppx_ast/ppx_ast.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_ast"
 bug-reports: "https://github.com/janestreet/ppx_ast/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_ast.git"

--- a/packages/ppx_ast/ppx_ast.v0.11.0/opam
+++ b/packages/ppx_ast/ppx_ast.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_ast"
 bug-reports: "https://github.com/janestreet/ppx_ast/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_ast.git"

--- a/packages/ppx_ast/ppx_ast.v0.9.0/opam
+++ b/packages/ppx_ast/ppx_ast.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_ast"
 bug-reports: "https://github.com/janestreet/ppx_ast/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_ast.git"

--- a/packages/ppx_ast/ppx_ast.v0.9.1/opam
+++ b/packages/ppx_ast/ppx_ast.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_ast"
 bug-reports: "https://github.com/janestreet/ppx_ast/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_ast.git"

--- a/packages/ppx_ast/ppx_ast.v0.9.2/opam
+++ b/packages/ppx_ast/ppx_ast.v0.9.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_ast"
 bug-reports: "https://github.com/janestreet/ppx_ast/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_ast.git"

--- a/packages/ppx_base/ppx_base.v0.10.0/opam
+++ b/packages/ppx_base/ppx_base.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_base"
 bug-reports: "https://github.com/janestreet/ppx_base/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_base.git"

--- a/packages/ppx_base/ppx_base.v0.11.0/opam
+++ b/packages/ppx_base/ppx_base.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_base"
 bug-reports: "https://github.com/janestreet/ppx_base/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_base.git"

--- a/packages/ppx_base/ppx_base.v0.12.0/opam
+++ b/packages/ppx_base/ppx_base.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_base"
 bug-reports: "https://github.com/janestreet/ppx_base/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_base.git"

--- a/packages/ppx_base/ppx_base.v0.13.0/opam
+++ b/packages/ppx_base/ppx_base.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_base"
 bug-reports: "https://github.com/janestreet/ppx_base/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_base.git"

--- a/packages/ppx_base/ppx_base.v0.14.0/opam
+++ b/packages/ppx_base/ppx_base.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_base"
 bug-reports: "https://github.com/janestreet/ppx_base/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_base.git"

--- a/packages/ppx_base/ppx_base.v0.9.0/opam
+++ b/packages/ppx_base/ppx_base.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_base"
 bug-reports: "https://github.com/janestreet/ppx_base/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_base.git"

--- a/packages/ppx_bench/ppx_bench.113.09.00/opam
+++ b/packages/ppx_bench/ppx_bench.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bench/ppx_bench.113.24.00/opam
+++ b/packages/ppx_bench/ppx_bench.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bench/ppx_bench.113.33.00+4.03/opam
+++ b/packages/ppx_bench/ppx_bench.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bench/ppx_bench.113.33.00/opam
+++ b/packages/ppx_bench/ppx_bench.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bench/ppx_bench.113.33.03/opam
+++ b/packages/ppx_bench/ppx_bench.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bench/ppx_bench.v0.10.0/opam
+++ b/packages/ppx_bench/ppx_bench.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bench/ppx_bench.v0.11.0/opam
+++ b/packages/ppx_bench/ppx_bench.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bench/ppx_bench.v0.12.0/opam
+++ b/packages/ppx_bench/ppx_bench.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bench/ppx_bench.v0.13.0/opam
+++ b/packages/ppx_bench/ppx_bench.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bench/ppx_bench.v0.14.0/opam
+++ b/packages/ppx_bench/ppx_bench.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bench/ppx_bench.v0.14.1/opam
+++ b/packages/ppx_bench/ppx_bench.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bench/ppx_bench.v0.9.0/opam
+++ b/packages/ppx_bench/ppx_bench.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bench/ppx_bench.v0.9.1/opam
+++ b/packages/ppx_bench/ppx_bench.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bench"
 bug-reports: "https://github.com/janestreet/ppx_bench/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bench.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.09.00/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.24.00/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.24.01/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.24.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.33.00+4.03/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.33.00/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.113.33.03/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.10.0/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.11.0/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.11.1/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.12.0/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.12.1/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.13.0/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.14.0/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.9.0/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_bin_prot"
 bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"

--- a/packages/ppx_cold/ppx_cold.v0.13.0/opam
+++ b/packages/ppx_cold/ppx_cold.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_cold"
 bug-reports: "https://github.com/janestreet/ppx_cold/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_cold.git"

--- a/packages/ppx_cold/ppx_cold.v0.14.0/opam
+++ b/packages/ppx_cold/ppx_cold.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_cold"
 bug-reports: "https://github.com/janestreet/ppx_cold/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_cold.git"

--- a/packages/ppx_compare/ppx_compare.113.09.00/opam
+++ b/packages/ppx_compare/ppx_compare.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_compare"
 bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"

--- a/packages/ppx_compare/ppx_compare.113.24.00/opam
+++ b/packages/ppx_compare/ppx_compare.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_compare"
 bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"

--- a/packages/ppx_compare/ppx_compare.113.33.00+4.03/opam
+++ b/packages/ppx_compare/ppx_compare.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_compare"
 bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"

--- a/packages/ppx_compare/ppx_compare.113.33.00/opam
+++ b/packages/ppx_compare/ppx_compare.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_compare"
 bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"

--- a/packages/ppx_compare/ppx_compare.113.33.03/opam
+++ b/packages/ppx_compare/ppx_compare.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_compare"
 bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"

--- a/packages/ppx_compare/ppx_compare.v0.10.0/opam
+++ b/packages/ppx_compare/ppx_compare.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_compare"
 bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"

--- a/packages/ppx_compare/ppx_compare.v0.11.0/opam
+++ b/packages/ppx_compare/ppx_compare.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_compare"
 bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"

--- a/packages/ppx_compare/ppx_compare.v0.11.1/opam
+++ b/packages/ppx_compare/ppx_compare.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_compare"
 bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"

--- a/packages/ppx_compare/ppx_compare.v0.12.0/opam
+++ b/packages/ppx_compare/ppx_compare.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_compare"
 bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"

--- a/packages/ppx_compare/ppx_compare.v0.13.0/opam
+++ b/packages/ppx_compare/ppx_compare.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_compare"
 bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"

--- a/packages/ppx_compare/ppx_compare.v0.14.0/opam
+++ b/packages/ppx_compare/ppx_compare.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_compare"
 bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"

--- a/packages/ppx_compare/ppx_compare.v0.9.0/opam
+++ b/packages/ppx_compare/ppx_compare.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_compare"
 bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"

--- a/packages/ppx_conv_func/ppx_conv_func.113.09.00/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_conv_func"
 bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_conv_func.git"

--- a/packages/ppx_conv_func/ppx_conv_func.113.24.00/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_conv_func"
 bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_conv_func.git"

--- a/packages/ppx_conv_func/ppx_conv_func.113.33.00+4.03/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_conv_func"
 bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_conv_func.git"

--- a/packages/ppx_conv_func/ppx_conv_func.113.33.00/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_conv_func"
 bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_conv_func.git"

--- a/packages/ppx_conv_func/ppx_conv_func.113.33.03/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_conv_func"
 bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_conv_func.git"

--- a/packages/ppx_conv_func/ppx_conv_func.v0.10.0/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_conv_func"
 bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_conv_func.git"

--- a/packages/ppx_conv_func/ppx_conv_func.v0.11.0/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_conv_func"
 bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_conv_func.git"

--- a/packages/ppx_conv_func/ppx_conv_func.v0.12.0/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_conv_func"
 bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_conv_func.git"

--- a/packages/ppx_conv_func/ppx_conv_func.v0.13.0/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_conv_func"
 bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_conv_func.git"

--- a/packages/ppx_conv_func/ppx_conv_func.v0.14.0/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_conv_func"
 bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_conv_func.git"

--- a/packages/ppx_conv_func/ppx_conv_func.v0.9.0/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_conv_func"
 bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_conv_func.git"

--- a/packages/ppx_core/ppx_core.113.09.00/opam
+++ b/packages/ppx_core/ppx_core.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_core"
 bug-reports: "https://github.com/janestreet/ppx_core/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_core.git"

--- a/packages/ppx_core/ppx_core.113.24.00/opam
+++ b/packages/ppx_core/ppx_core.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_core"
 bug-reports: "https://github.com/janestreet/ppx_core/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_core.git"

--- a/packages/ppx_core/ppx_core.113.33.00+4.03/opam
+++ b/packages/ppx_core/ppx_core.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_core"
 bug-reports: "https://github.com/janestreet/ppx_core/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_core.git"

--- a/packages/ppx_core/ppx_core.113.33.00/opam
+++ b/packages/ppx_core/ppx_core.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_core"
 bug-reports: "https://github.com/janestreet/ppx_core/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_core.git"

--- a/packages/ppx_core/ppx_core.113.33.01+4.03/opam
+++ b/packages/ppx_core/ppx_core.113.33.01+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_core"
 bug-reports: "https://github.com/janestreet/ppx_core/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_core.git"

--- a/packages/ppx_core/ppx_core.113.33.03/opam
+++ b/packages/ppx_core/ppx_core.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_core"
 bug-reports: "https://github.com/janestreet/ppx_core/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_core.git"

--- a/packages/ppx_core/ppx_core.v0.10.0/opam
+++ b/packages/ppx_core/ppx_core.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_core"
 bug-reports: "https://github.com/janestreet/ppx_core/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_core.git"

--- a/packages/ppx_core/ppx_core.v0.11.0/opam
+++ b/packages/ppx_core/ppx_core.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_core"
 bug-reports: "https://github.com/janestreet/ppx_core/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_core.git"

--- a/packages/ppx_core/ppx_core.v0.9.0/opam
+++ b/packages/ppx_core/ppx_core.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_core"
 bug-reports: "https://github.com/janestreet/ppx_core/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_core.git"

--- a/packages/ppx_core/ppx_core.v0.9.2/opam
+++ b/packages/ppx_core/ppx_core.v0.9.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_core"
 bug-reports: "https://github.com/janestreet/ppx_core/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_core.git"

--- a/packages/ppx_core/ppx_core.v0.9.3/opam
+++ b/packages/ppx_core/ppx_core.v0.9.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
 homepage: "https://github.com/janestreet/ppx_core"
 bug-reports: "https://github.com/janestreet/ppx_core/issues"
 license: "Apache-2.0"

--- a/packages/ppx_csv_conv/ppx_csv_conv.113.09.00/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_csv_conv"
 bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_csv_conv.git"

--- a/packages/ppx_csv_conv/ppx_csv_conv.113.24.00/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_csv_conv"
 bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_csv_conv.git"

--- a/packages/ppx_csv_conv/ppx_csv_conv.113.33.00+4.03/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_csv_conv"
 bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_csv_conv.git"

--- a/packages/ppx_csv_conv/ppx_csv_conv.113.33.00/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_csv_conv"
 bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_csv_conv.git"

--- a/packages/ppx_csv_conv/ppx_csv_conv.113.33.03/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_csv_conv"
 bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_csv_conv.git"

--- a/packages/ppx_csv_conv/ppx_csv_conv.v0.10.0/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_csv_conv"
 bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_csv_conv.git"

--- a/packages/ppx_csv_conv/ppx_csv_conv.v0.11.0/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_csv_conv"
 bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_csv_conv.git"

--- a/packages/ppx_csv_conv/ppx_csv_conv.v0.11.1/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_csv_conv"
 bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_csv_conv.git"

--- a/packages/ppx_csv_conv/ppx_csv_conv.v0.12.0/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_csv_conv"
 bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_csv_conv.git"

--- a/packages/ppx_csv_conv/ppx_csv_conv.v0.13.0/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_csv_conv"
 bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_csv_conv.git"

--- a/packages/ppx_csv_conv/ppx_csv_conv.v0.14.0/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_csv_conv"
 bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_csv_conv.git"

--- a/packages/ppx_csv_conv/ppx_csv_conv.v0.9.0/opam
+++ b/packages/ppx_csv_conv/ppx_csv_conv.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_csv_conv"
 bug-reports: "https://github.com/janestreet/ppx_csv_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_csv_conv.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.09.00/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.24.00/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.33.00+4.03/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.33.00/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.113.33.03/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.10.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.11.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.12.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.12.1/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.13.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.14.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.14.1/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.9.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_custom_printf"
 bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"

--- a/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.v0.12.0/opam
+++ b/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_deriving_hardcaml"
 bug-reports: "https://github.com/janestreet/ppx_deriving_hardcaml/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_deriving_hardcaml.git"

--- a/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.v0.13.0/opam
+++ b/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_deriving_hardcaml"
 bug-reports: "https://github.com/janestreet/ppx_deriving_hardcaml/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_deriving_hardcaml.git"

--- a/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.v0.14.0/opam
+++ b/packages/ppx_deriving_hardcaml/ppx_deriving_hardcaml.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_deriving_hardcaml"
 bug-reports: "https://github.com/janestreet/ppx_deriving_hardcaml/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_deriving_hardcaml.git"

--- a/packages/ppx_driver/ppx_driver.113.09.00/opam
+++ b/packages/ppx_driver/ppx_driver.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.113.24.00/opam
+++ b/packages/ppx_driver/ppx_driver.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.113.33.00+4.03/opam
+++ b/packages/ppx_driver/ppx_driver.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.113.33.00/opam
+++ b/packages/ppx_driver/ppx_driver.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.113.33.01+4.03/opam
+++ b/packages/ppx_driver/ppx_driver.113.33.01+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.113.33.02+4.03/opam
+++ b/packages/ppx_driver/ppx_driver.113.33.02+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.113.33.03/opam
+++ b/packages/ppx_driver/ppx_driver.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.113.33.04/opam
+++ b/packages/ppx_driver/ppx_driver.113.33.04/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.v0.10.0/opam
+++ b/packages/ppx_driver/ppx_driver.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.v0.10.1/opam
+++ b/packages/ppx_driver/ppx_driver.v0.10.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 license: "Apache-2.0"

--- a/packages/ppx_driver/ppx_driver.v0.10.2/opam
+++ b/packages/ppx_driver/ppx_driver.v0.10.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 license: "Apache-2.0"

--- a/packages/ppx_driver/ppx_driver.v0.10.3/opam
+++ b/packages/ppx_driver/ppx_driver.v0.10.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.v0.10.4/opam
+++ b/packages/ppx_driver/ppx_driver.v0.10.4/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 license: "Apache-2.0"

--- a/packages/ppx_driver/ppx_driver.v0.11.0/opam
+++ b/packages/ppx_driver/ppx_driver.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.v0.9.0/opam
+++ b/packages/ppx_driver/ppx_driver.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.v0.9.1/opam
+++ b/packages/ppx_driver/ppx_driver.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_driver/ppx_driver.v0.9.2/opam
+++ b/packages/ppx_driver/ppx_driver.v0.9.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_driver"
 bug-reports: "https://github.com/janestreet/ppx_driver/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_driver.git"

--- a/packages/ppx_enumerate/ppx_enumerate.113.09.00/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_enumerate"
 bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"

--- a/packages/ppx_enumerate/ppx_enumerate.113.24.00/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_enumerate"
 bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"

--- a/packages/ppx_enumerate/ppx_enumerate.113.33.00+4.03/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_enumerate"
 bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"

--- a/packages/ppx_enumerate/ppx_enumerate.113.33.00/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_enumerate"
 bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"

--- a/packages/ppx_enumerate/ppx_enumerate.113.33.03/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_enumerate"
 bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"

--- a/packages/ppx_enumerate/ppx_enumerate.v0.10.0/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_enumerate"
 bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"

--- a/packages/ppx_enumerate/ppx_enumerate.v0.11.0/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_enumerate"
 bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"

--- a/packages/ppx_enumerate/ppx_enumerate.v0.11.1/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_enumerate"
 bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"

--- a/packages/ppx_enumerate/ppx_enumerate.v0.12.0/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_enumerate"
 bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"

--- a/packages/ppx_enumerate/ppx_enumerate.v0.13.0/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_enumerate"
 bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"

--- a/packages/ppx_enumerate/ppx_enumerate.v0.14.0/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_enumerate"
 bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"

--- a/packages/ppx_enumerate/ppx_enumerate.v0.9.0/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_enumerate"
 bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"

--- a/packages/ppx_expect/ppx_expect.113.24.00/opam
+++ b/packages/ppx_expect/ppx_expect.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.113.33.00+4.03/opam
+++ b/packages/ppx_expect/ppx_expect.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.113.33.00/opam
+++ b/packages/ppx_expect/ppx_expect.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.113.33.01+4.03/opam
+++ b/packages/ppx_expect/ppx_expect.113.33.01+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.113.33.01/opam
+++ b/packages/ppx_expect/ppx_expect.113.33.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.113.33.03/opam
+++ b/packages/ppx_expect/ppx_expect.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.v0.10.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.v0.10.1/opam
+++ b/packages/ppx_expect/ppx_expect.v0.10.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.v0.11.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.v0.11.1/opam
+++ b/packages/ppx_expect/ppx_expect.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.v0.12.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.v0.13.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.v0.13.1/opam
+++ b/packages/ppx_expect/ppx_expect.v0.13.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.v0.14.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.v0.14.1/opam
+++ b/packages/ppx_expect/ppx_expect.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_expect/ppx_expect.v0.9.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_expect"
 bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"

--- a/packages/ppx_fail/ppx_fail.113.09.00/opam
+++ b/packages/ppx_fail/ppx_fail.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fail"
 bug-reports: "https://github.com/janestreet/ppx_fail/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fail.git"

--- a/packages/ppx_fail/ppx_fail.113.24.00/opam
+++ b/packages/ppx_fail/ppx_fail.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fail"
 bug-reports: "https://github.com/janestreet/ppx_fail/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fail.git"

--- a/packages/ppx_fail/ppx_fail.113.33.00+4.03/opam
+++ b/packages/ppx_fail/ppx_fail.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fail"
 bug-reports: "https://github.com/janestreet/ppx_fail/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fail.git"

--- a/packages/ppx_fail/ppx_fail.113.33.00/opam
+++ b/packages/ppx_fail/ppx_fail.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fail"
 bug-reports: "https://github.com/janestreet/ppx_fail/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fail.git"

--- a/packages/ppx_fail/ppx_fail.113.33.03/opam
+++ b/packages/ppx_fail/ppx_fail.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fail"
 bug-reports: "https://github.com/janestreet/ppx_fail/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fail.git"

--- a/packages/ppx_fail/ppx_fail.v0.10.0/opam
+++ b/packages/ppx_fail/ppx_fail.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fail"
 bug-reports: "https://github.com/janestreet/ppx_fail/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fail.git"

--- a/packages/ppx_fail/ppx_fail.v0.11.0/opam
+++ b/packages/ppx_fail/ppx_fail.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fail"
 bug-reports: "https://github.com/janestreet/ppx_fail/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fail.git"

--- a/packages/ppx_fail/ppx_fail.v0.12.0/opam
+++ b/packages/ppx_fail/ppx_fail.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fail"
 bug-reports: "https://github.com/janestreet/ppx_fail/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fail.git"

--- a/packages/ppx_fail/ppx_fail.v0.13.0/opam
+++ b/packages/ppx_fail/ppx_fail.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fail"
 bug-reports: "https://github.com/janestreet/ppx_fail/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fail.git"

--- a/packages/ppx_fail/ppx_fail.v0.14.0/opam
+++ b/packages/ppx_fail/ppx_fail.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fail"
 bug-reports: "https://github.com/janestreet/ppx_fail/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fail.git"

--- a/packages/ppx_fail/ppx_fail.v0.9.0/opam
+++ b/packages/ppx_fail/ppx_fail.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fail"
 bug-reports: "https://github.com/janestreet/ppx_fail/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fail.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.113.09.00/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.113.24.00/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.113.33.00+4.03/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.113.33.00/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.113.33.03/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.10.0/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.11.0/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.12.0/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.13.0/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.14.0/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.14.1/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.14.2/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.14.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.9.0/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fields_conv"
 bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"

--- a/packages/ppx_fixed_literal/ppx_fixed_literal.v0.14.0/opam
+++ b/packages/ppx_fixed_literal/ppx_fixed_literal.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_fixed_literal"
 bug-reports: "https://github.com/janestreet/ppx_fixed_literal/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fixed_literal.git"

--- a/packages/ppx_hash/ppx_hash.v0.10.0/opam
+++ b/packages/ppx_hash/ppx_hash.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_hash"
 bug-reports: "https://github.com/janestreet/ppx_hash/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_hash.git"

--- a/packages/ppx_hash/ppx_hash.v0.11.0/opam
+++ b/packages/ppx_hash/ppx_hash.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_hash"
 bug-reports: "https://github.com/janestreet/ppx_hash/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_hash.git"

--- a/packages/ppx_hash/ppx_hash.v0.11.1/opam
+++ b/packages/ppx_hash/ppx_hash.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_hash"
 bug-reports: "https://github.com/janestreet/ppx_hash/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_hash.git"

--- a/packages/ppx_hash/ppx_hash.v0.12.0/opam
+++ b/packages/ppx_hash/ppx_hash.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_hash"
 bug-reports: "https://github.com/janestreet/ppx_hash/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_hash.git"

--- a/packages/ppx_hash/ppx_hash.v0.13.0/opam
+++ b/packages/ppx_hash/ppx_hash.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_hash"
 bug-reports: "https://github.com/janestreet/ppx_hash/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_hash.git"

--- a/packages/ppx_hash/ppx_hash.v0.14.0/opam
+++ b/packages/ppx_hash/ppx_hash.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_hash"
 bug-reports: "https://github.com/janestreet/ppx_hash/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_hash.git"

--- a/packages/ppx_hash/ppx_hash.v0.9.0/opam
+++ b/packages/ppx_hash/ppx_hash.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_hash"
 bug-reports: "https://github.com/janestreet/ppx_hash/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_hash.git"

--- a/packages/ppx_here/ppx_here.113.09.00/opam
+++ b/packages/ppx_here/ppx_here.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_here"
 bug-reports: "https://github.com/janestreet/ppx_here/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_here.git"

--- a/packages/ppx_here/ppx_here.113.24.00/opam
+++ b/packages/ppx_here/ppx_here.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_here"
 bug-reports: "https://github.com/janestreet/ppx_here/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_here.git"

--- a/packages/ppx_here/ppx_here.113.33.00/opam
+++ b/packages/ppx_here/ppx_here.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_here"
 bug-reports: "https://github.com/janestreet/ppx_here/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_here.git"

--- a/packages/ppx_here/ppx_here.113.33.03/opam
+++ b/packages/ppx_here/ppx_here.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_here"
 bug-reports: "https://github.com/janestreet/ppx_here/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_here.git"

--- a/packages/ppx_here/ppx_here.v0.10.0/opam
+++ b/packages/ppx_here/ppx_here.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_here"
 bug-reports: "https://github.com/janestreet/ppx_here/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_here.git"

--- a/packages/ppx_here/ppx_here.v0.11.0/opam
+++ b/packages/ppx_here/ppx_here.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_here"
 bug-reports: "https://github.com/janestreet/ppx_here/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_here.git"

--- a/packages/ppx_here/ppx_here.v0.12.0/opam
+++ b/packages/ppx_here/ppx_here.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_here"
 bug-reports: "https://github.com/janestreet/ppx_here/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_here.git"

--- a/packages/ppx_here/ppx_here.v0.13.0/opam
+++ b/packages/ppx_here/ppx_here.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_here"
 bug-reports: "https://github.com/janestreet/ppx_here/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_here.git"

--- a/packages/ppx_here/ppx_here.v0.14.0/opam
+++ b/packages/ppx_here/ppx_here.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_here"
 bug-reports: "https://github.com/janestreet/ppx_here/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_here.git"

--- a/packages/ppx_here/ppx_here.v0.9.0/opam
+++ b/packages/ppx_here/ppx_here.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_here"
 bug-reports: "https://github.com/janestreet/ppx_here/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_here.git"

--- a/packages/ppx_here/ppx_here.v0.9.1/opam
+++ b/packages/ppx_here/ppx_here.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_here"
 bug-reports: "https://github.com/janestreet/ppx_here/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_here.git"

--- a/packages/ppx_inline_test/ppx_inline_test.113.09.00/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.113.24.00/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.113.33.00+4.03/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.113.33.00/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.113.33.03/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.10.0/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.10.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.10.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.11.0/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.12.0/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.13.0/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.13.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.13.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.14.0/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.14.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.9.0/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.9.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.9.2/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.9.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_inline_test"
 bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"

--- a/packages/ppx_jane/ppx_jane.113.24.00/opam
+++ b/packages/ppx_jane/ppx_jane.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_jane"
 bug-reports: "https://github.com/janestreet/ppx_jane/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_jane.git"

--- a/packages/ppx_jane/ppx_jane.113.24.01/opam
+++ b/packages/ppx_jane/ppx_jane.113.24.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_jane"
 bug-reports: "https://github.com/janestreet/ppx_jane/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_jane.git"

--- a/packages/ppx_jane/ppx_jane.113.33.00/opam
+++ b/packages/ppx_jane/ppx_jane.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_jane"
 bug-reports: "https://github.com/janestreet/ppx_jane/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_jane.git"

--- a/packages/ppx_jane/ppx_jane.113.33.03/opam
+++ b/packages/ppx_jane/ppx_jane.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_jane"
 bug-reports: "https://github.com/janestreet/ppx_jane/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_jane.git"

--- a/packages/ppx_jane/ppx_jane.v0.10.0/opam
+++ b/packages/ppx_jane/ppx_jane.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_jane"
 bug-reports: "https://github.com/janestreet/ppx_jane/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_jane.git"

--- a/packages/ppx_jane/ppx_jane.v0.11.0/opam
+++ b/packages/ppx_jane/ppx_jane.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_jane"
 bug-reports: "https://github.com/janestreet/ppx_jane/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_jane.git"

--- a/packages/ppx_jane/ppx_jane.v0.12.0/opam
+++ b/packages/ppx_jane/ppx_jane.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_jane"
 bug-reports: "https://github.com/janestreet/ppx_jane/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_jane.git"

--- a/packages/ppx_jane/ppx_jane.v0.13.0/opam
+++ b/packages/ppx_jane/ppx_jane.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_jane"
 bug-reports: "https://github.com/janestreet/ppx_jane/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_jane.git"

--- a/packages/ppx_jane/ppx_jane.v0.14.0/opam
+++ b/packages/ppx_jane/ppx_jane.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_jane"
 bug-reports: "https://github.com/janestreet/ppx_jane/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_jane.git"

--- a/packages/ppx_jane/ppx_jane.v0.9.0/opam
+++ b/packages/ppx_jane/ppx_jane.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_jane"
 bug-reports: "https://github.com/janestreet/ppx_jane/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_jane.git"

--- a/packages/ppx_js_style/ppx_js_style.v0.10.0/opam
+++ b/packages/ppx_js_style/ppx_js_style.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_js_style"
 bug-reports: "https://github.com/janestreet/ppx_js_style/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_js_style.git"

--- a/packages/ppx_js_style/ppx_js_style.v0.11.0/opam
+++ b/packages/ppx_js_style/ppx_js_style.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_js_style"
 bug-reports: "https://github.com/janestreet/ppx_js_style/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_js_style.git"

--- a/packages/ppx_js_style/ppx_js_style.v0.12.0/opam
+++ b/packages/ppx_js_style/ppx_js_style.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_js_style"
 bug-reports: "https://github.com/janestreet/ppx_js_style/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_js_style.git"

--- a/packages/ppx_js_style/ppx_js_style.v0.13.0/opam
+++ b/packages/ppx_js_style/ppx_js_style.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_js_style"
 bug-reports: "https://github.com/janestreet/ppx_js_style/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_js_style.git"

--- a/packages/ppx_js_style/ppx_js_style.v0.14.0/opam
+++ b/packages/ppx_js_style/ppx_js_style.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_js_style"
 bug-reports: "https://github.com/janestreet/ppx_js_style/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_js_style.git"

--- a/packages/ppx_js_style/ppx_js_style.v0.9.0/opam
+++ b/packages/ppx_js_style/ppx_js_style.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_js_style"
 bug-reports: "https://github.com/janestreet/ppx_js_style/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_js_style.git"

--- a/packages/ppx_let/ppx_let.113.24.00/opam
+++ b/packages/ppx_let/ppx_let.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_let"
 bug-reports: "https://github.com/janestreet/ppx_let/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_let.git"

--- a/packages/ppx_let/ppx_let.113.33.00+4.03/opam
+++ b/packages/ppx_let/ppx_let.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_let"
 bug-reports: "https://github.com/janestreet/ppx_let/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_let.git"

--- a/packages/ppx_let/ppx_let.113.33.00/opam
+++ b/packages/ppx_let/ppx_let.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_let"
 bug-reports: "https://github.com/janestreet/ppx_let/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_let.git"

--- a/packages/ppx_let/ppx_let.113.33.03/opam
+++ b/packages/ppx_let/ppx_let.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_let"
 bug-reports: "https://github.com/janestreet/ppx_let/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_let.git"

--- a/packages/ppx_let/ppx_let.v0.10.0/opam
+++ b/packages/ppx_let/ppx_let.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_let"
 bug-reports: "https://github.com/janestreet/ppx_let/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_let.git"

--- a/packages/ppx_let/ppx_let.v0.11.0/opam
+++ b/packages/ppx_let/ppx_let.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_let"
 bug-reports: "https://github.com/janestreet/ppx_let/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_let.git"

--- a/packages/ppx_let/ppx_let.v0.12.0/opam
+++ b/packages/ppx_let/ppx_let.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_let"
 bug-reports: "https://github.com/janestreet/ppx_let/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_let.git"

--- a/packages/ppx_let/ppx_let.v0.13.0/opam
+++ b/packages/ppx_let/ppx_let.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_let"
 bug-reports: "https://github.com/janestreet/ppx_let/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_let.git"

--- a/packages/ppx_let/ppx_let.v0.14.0/opam
+++ b/packages/ppx_let/ppx_let.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_let"
 bug-reports: "https://github.com/janestreet/ppx_let/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_let.git"

--- a/packages/ppx_let/ppx_let.v0.9.0/opam
+++ b/packages/ppx_let/ppx_let.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_let"
 bug-reports: "https://github.com/janestreet/ppx_let/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_let.git"

--- a/packages/ppx_log/ppx_log.v0.14.0/opam
+++ b/packages/ppx_log/ppx_log.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_log"
 bug-reports: "https://github.com/janestreet/ppx_log/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_log.git"

--- a/packages/ppx_metaquot/ppx_metaquot.v0.10.0/opam
+++ b/packages/ppx_metaquot/ppx_metaquot.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_metaquot"
 bug-reports: "https://github.com/janestreet/ppx_metaquot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_metaquot.git"

--- a/packages/ppx_metaquot/ppx_metaquot.v0.11.0/opam
+++ b/packages/ppx_metaquot/ppx_metaquot.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_metaquot"
 bug-reports: "https://github.com/janestreet/ppx_metaquot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_metaquot.git"

--- a/packages/ppx_metaquot/ppx_metaquot.v0.9.0/opam
+++ b/packages/ppx_metaquot/ppx_metaquot.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_metaquot"
 bug-reports: "https://github.com/janestreet/ppx_metaquot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_metaquot.git"

--- a/packages/ppx_module_timer/ppx_module_timer.v0.12.0/opam
+++ b/packages/ppx_module_timer/ppx_module_timer.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_module_timer"
 bug-reports: "https://github.com/janestreet/ppx_module_timer/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_module_timer.git"

--- a/packages/ppx_module_timer/ppx_module_timer.v0.13.0/opam
+++ b/packages/ppx_module_timer/ppx_module_timer.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_module_timer"
 bug-reports: "https://github.com/janestreet/ppx_module_timer/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_module_timer.git"

--- a/packages/ppx_module_timer/ppx_module_timer.v0.14.0/opam
+++ b/packages/ppx_module_timer/ppx_module_timer.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_module_timer"
 bug-reports: "https://github.com/janestreet/ppx_module_timer/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_module_timer.git"

--- a/packages/ppx_optcomp/ppx_optcomp.113.09.00/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optcomp/ppx_optcomp.113.24.00/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optcomp/ppx_optcomp.113.33.00+4.03/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optcomp/ppx_optcomp.113.33.00/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optcomp/ppx_optcomp.113.33.01+4.03/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.113.33.01+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optcomp/ppx_optcomp.113.33.03/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optcomp/ppx_optcomp.v0.10.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optcomp/ppx_optcomp.v0.11.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optcomp/ppx_optcomp.v0.12.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optcomp/ppx_optcomp.v0.13.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optcomp/ppx_optcomp.v0.14.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optcomp/ppx_optcomp.v0.14.1/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optcomp/ppx_optcomp.v0.9.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
 bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"

--- a/packages/ppx_optional/ppx_optional.v0.10.0/opam
+++ b/packages/ppx_optional/ppx_optional.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optional"
 bug-reports: "https://github.com/janestreet/ppx_optional/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optional.git"

--- a/packages/ppx_optional/ppx_optional.v0.11.0/opam
+++ b/packages/ppx_optional/ppx_optional.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optional"
 bug-reports: "https://github.com/janestreet/ppx_optional/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optional.git"

--- a/packages/ppx_optional/ppx_optional.v0.12.0/opam
+++ b/packages/ppx_optional/ppx_optional.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optional"
 bug-reports: "https://github.com/janestreet/ppx_optional/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optional.git"

--- a/packages/ppx_optional/ppx_optional.v0.13.0/opam
+++ b/packages/ppx_optional/ppx_optional.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optional"
 bug-reports: "https://github.com/janestreet/ppx_optional/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optional.git"

--- a/packages/ppx_optional/ppx_optional.v0.14.0/opam
+++ b/packages/ppx_optional/ppx_optional.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optional"
 bug-reports: "https://github.com/janestreet/ppx_optional/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optional.git"

--- a/packages/ppx_optional/ppx_optional.v0.9.0/opam
+++ b/packages/ppx_optional/ppx_optional.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_optional"
 bug-reports: "https://github.com/janestreet/ppx_optional/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optional.git"

--- a/packages/ppx_pattern_bind/ppx_pattern_bind.v0.13.0/opam
+++ b/packages/ppx_pattern_bind/ppx_pattern_bind.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pattern_bind"
 bug-reports: "https://github.com/janestreet/ppx_pattern_bind/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pattern_bind.git"

--- a/packages/ppx_pattern_bind/ppx_pattern_bind.v0.13.1/opam
+++ b/packages/ppx_pattern_bind/ppx_pattern_bind.v0.13.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pattern_bind"
 bug-reports: "https://github.com/janestreet/ppx_pattern_bind/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pattern_bind.git"

--- a/packages/ppx_pattern_bind/ppx_pattern_bind.v0.14.0/opam
+++ b/packages/ppx_pattern_bind/ppx_pattern_bind.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pattern_bind"
 bug-reports: "https://github.com/janestreet/ppx_pattern_bind/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pattern_bind.git"

--- a/packages/ppx_pipebang/ppx_pipebang.113.09.00/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pipebang"
 bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"

--- a/packages/ppx_pipebang/ppx_pipebang.113.24.00/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pipebang"
 bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"

--- a/packages/ppx_pipebang/ppx_pipebang.113.33.00+4.03/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pipebang"
 bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"

--- a/packages/ppx_pipebang/ppx_pipebang.113.33.00/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pipebang"
 bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"

--- a/packages/ppx_pipebang/ppx_pipebang.113.33.03/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pipebang"
 bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"

--- a/packages/ppx_pipebang/ppx_pipebang.v0.10.0/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pipebang"
 bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"

--- a/packages/ppx_pipebang/ppx_pipebang.v0.11.0/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pipebang"
 bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"

--- a/packages/ppx_pipebang/ppx_pipebang.v0.12.0/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pipebang"
 bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"

--- a/packages/ppx_pipebang/ppx_pipebang.v0.13.0/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pipebang"
 bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"

--- a/packages/ppx_pipebang/ppx_pipebang.v0.14.0/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pipebang"
 bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"

--- a/packages/ppx_pipebang/ppx_pipebang.v0.9.0/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_pipebang"
 bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"

--- a/packages/ppx_python/ppx_python.v0.12.0/opam
+++ b/packages/ppx_python/ppx_python.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_python"
 bug-reports: "https://github.com/janestreet/ppx_python/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_python.git"

--- a/packages/ppx_python/ppx_python.v0.13.0/opam
+++ b/packages/ppx_python/ppx_python.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_python"
 bug-reports: "https://github.com/janestreet/ppx_python/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_python.git"

--- a/packages/ppx_python/ppx_python.v0.14.0/opam
+++ b/packages/ppx_python/ppx_python.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_python"
 bug-reports: "https://github.com/janestreet/ppx_python/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_python.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.09.00/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.24.00/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.00+4.03/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.00/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.01+4.03/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.01+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.03/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.10.0/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.0/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.1/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.2/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.11.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.12.0/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.13.0/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.0/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.1/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.2/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.3/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.9.0/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_conv"
 bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"

--- a/packages/ppx_sexp_message/ppx_sexp_message.113.24.00/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_message"
 bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"

--- a/packages/ppx_sexp_message/ppx_sexp_message.113.33.00+4.03/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_message"
 bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"

--- a/packages/ppx_sexp_message/ppx_sexp_message.113.33.00/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_message"
 bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"

--- a/packages/ppx_sexp_message/ppx_sexp_message.113.33.03/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_message"
 bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.10.0/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_message"
 bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.11.0/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_message"
 bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.12.0/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_message"
 bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.13.0/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_message"
 bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.14.0/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_message"
 bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.14.1/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_message"
 bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.9.0/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_message"
 bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"

--- a/packages/ppx_sexp_value/ppx_sexp_value.113.09.00/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_value"
 bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"

--- a/packages/ppx_sexp_value/ppx_sexp_value.113.24.00/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_value"
 bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"

--- a/packages/ppx_sexp_value/ppx_sexp_value.113.33.00+4.03/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_value"
 bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"

--- a/packages/ppx_sexp_value/ppx_sexp_value.113.33.00/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_value"
 bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"

--- a/packages/ppx_sexp_value/ppx_sexp_value.113.33.03/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_value"
 bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"

--- a/packages/ppx_sexp_value/ppx_sexp_value.v0.10.0/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_value"
 bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"

--- a/packages/ppx_sexp_value/ppx_sexp_value.v0.11.0/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_value"
 bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"

--- a/packages/ppx_sexp_value/ppx_sexp_value.v0.12.0/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_value"
 bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"

--- a/packages/ppx_sexp_value/ppx_sexp_value.v0.13.0/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_value"
 bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"

--- a/packages/ppx_sexp_value/ppx_sexp_value.v0.14.0/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_value"
 bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"

--- a/packages/ppx_sexp_value/ppx_sexp_value.v0.9.0/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_sexp_value"
 bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"

--- a/packages/ppx_stable/ppx_stable.v0.12.0/opam
+++ b/packages/ppx_stable/ppx_stable.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_stable"
 bug-reports: "https://github.com/janestreet/ppx_stable/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_stable.git"

--- a/packages/ppx_stable/ppx_stable.v0.13.0/opam
+++ b/packages/ppx_stable/ppx_stable.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_stable"
 bug-reports: "https://github.com/janestreet/ppx_stable/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_stable.git"

--- a/packages/ppx_stable/ppx_stable.v0.14.0/opam
+++ b/packages/ppx_stable/ppx_stable.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_stable"
 bug-reports: "https://github.com/janestreet/ppx_stable/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_stable.git"

--- a/packages/ppx_stable/ppx_stable.v0.14.1/opam
+++ b/packages/ppx_stable/ppx_stable.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_stable"
 bug-reports: "https://github.com/janestreet/ppx_stable/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_stable.git"

--- a/packages/ppx_string/ppx_string.v0.14.0/opam
+++ b/packages/ppx_string/ppx_string.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_string"
 bug-reports: "https://github.com/janestreet/ppx_string/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_string.git"

--- a/packages/ppx_string/ppx_string.v0.14.1/opam
+++ b/packages/ppx_string/ppx_string.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_string"
 bug-reports: "https://github.com/janestreet/ppx_string/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_string.git"

--- a/packages/ppx_traverse/ppx_traverse.v0.10.0/opam
+++ b/packages/ppx_traverse/ppx_traverse.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_traverse"
 bug-reports: "https://github.com/janestreet/ppx_traverse/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_traverse.git"

--- a/packages/ppx_traverse/ppx_traverse.v0.11.0/opam
+++ b/packages/ppx_traverse/ppx_traverse.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_traverse"
 bug-reports: "https://github.com/janestreet/ppx_traverse/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_traverse.git"

--- a/packages/ppx_traverse/ppx_traverse.v0.9.0/opam
+++ b/packages/ppx_traverse/ppx_traverse.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_traverse"
 bug-reports: "https://github.com/janestreet/ppx_traverse/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_traverse.git"

--- a/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.10.0/opam
+++ b/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_traverse_builtins"
 bug-reports: "https://github.com/janestreet/ppx_traverse_builtins/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_traverse_builtins.git"

--- a/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.11.0/opam
+++ b/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_traverse_builtins"
 bug-reports: "https://github.com/janestreet/ppx_traverse_builtins/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_traverse_builtins.git"

--- a/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.9.0/opam
+++ b/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_traverse_builtins"
 bug-reports: "https://github.com/janestreet/ppx_traverse_builtins/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_traverse_builtins.git"

--- a/packages/ppx_type_conv/ppx_type_conv.113.09.00/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_type_conv"
 bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_type_conv.git"

--- a/packages/ppx_type_conv/ppx_type_conv.113.24.00/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_type_conv"
 bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_type_conv.git"

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.00+4.03/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_type_conv"
 bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_type_conv.git"

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.00/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_type_conv"
 bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_type_conv.git"

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.01+4.03/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.01+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_type_conv"
 bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_type_conv.git"

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.02+4.03/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.02+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_type_conv"
 bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_type_conv.git"

--- a/packages/ppx_type_conv/ppx_type_conv.113.33.03/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_type_conv"
 bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_type_conv.git"

--- a/packages/ppx_type_conv/ppx_type_conv.v0.10.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_type_conv"
 bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_type_conv.git"

--- a/packages/ppx_type_conv/ppx_type_conv.v0.11.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_type_conv"
 bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_type_conv.git"

--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_type_conv"
 bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_type_conv.git"

--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.1/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+maintainer: "Jane Street developers"
+authors: "Jane Street Group, LLC"
 homepage: "https://github.com/janestreet/ppx_type_conv"
 bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
 license: "Apache-2.0"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.113.09.00/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.113.24.00/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.00+4.03/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.00/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.03/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.10.0/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.11.0/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.11.1/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.12.0/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.13.0/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.14.0/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.14.1/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.14.2/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.14.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.9.0/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_typerep_conv"
 bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.113.09.00/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.113.24.00/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.113.33.00+4.03/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.113.33.00/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.113.33.03/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.10.0/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.11.0/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.11.1/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.12.0/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.13.0/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.14.0/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.14.1/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.9.0/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_variants_conv"
 bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"

--- a/packages/ppx_xml_conv/ppx_xml_conv.113.09.00/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.113.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_xml_conv"
 bug-reports: "https://github.com/janestreet/ppx_xml_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_xml_conv.git"

--- a/packages/ppx_xml_conv/ppx_xml_conv.113.24.00/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_xml_conv"
 bug-reports: "https://github.com/janestreet/ppx_xml_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_xml_conv.git"

--- a/packages/ppx_xml_conv/ppx_xml_conv.113.33.00/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_xml_conv"
 bug-reports: "https://github.com/janestreet/ppx_xml_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_xml_conv.git"

--- a/packages/ppx_xml_conv/ppx_xml_conv.113.33.03/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_xml_conv"
 bug-reports: "https://github.com/janestreet/ppx_xml_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_xml_conv.git"

--- a/packages/ppx_xml_conv/ppx_xml_conv.v0.10.0/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_xml_conv"
 bug-reports: "https://github.com/janestreet/ppx_xml_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_xml_conv.git"

--- a/packages/ppx_xml_conv/ppx_xml_conv.v0.11.0/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_xml_conv"
 bug-reports: "https://github.com/janestreet/ppx_xml_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_xml_conv.git"

--- a/packages/ppx_xml_conv/ppx_xml_conv.v0.12.0/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_xml_conv"
 bug-reports: "https://github.com/janestreet/ppx_xml_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_xml_conv.git"

--- a/packages/ppx_xml_conv/ppx_xml_conv.v0.13.0/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_xml_conv"
 bug-reports: "https://github.com/janestreet/ppx_xml_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_xml_conv.git"

--- a/packages/ppx_xml_conv/ppx_xml_conv.v0.14.0/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_xml_conv"
 bug-reports: "https://github.com/janestreet/ppx_xml_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_xml_conv.git"

--- a/packages/ppx_xml_conv/ppx_xml_conv.v0.9.0/opam
+++ b/packages/ppx_xml_conv/ppx_xml_conv.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_xml_conv"
 bug-reports: "https://github.com/janestreet/ppx_xml_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_xml_conv.git"

--- a/packages/ppx_yojson_conv/ppx_yojson_conv.v0.12.0/opam
+++ b/packages/ppx_yojson_conv/ppx_yojson_conv.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_yojson_conv"
 bug-reports: "https://github.com/janestreet/ppx_yojson_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_yojson_conv.git"

--- a/packages/ppx_yojson_conv/ppx_yojson_conv.v0.13.0/opam
+++ b/packages/ppx_yojson_conv/ppx_yojson_conv.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_yojson_conv"
 bug-reports: "https://github.com/janestreet/ppx_yojson_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_yojson_conv.git"

--- a/packages/ppx_yojson_conv/ppx_yojson_conv.v0.14.0/opam
+++ b/packages/ppx_yojson_conv/ppx_yojson_conv.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_yojson_conv"
 bug-reports: "https://github.com/janestreet/ppx_yojson_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_yojson_conv.git"

--- a/packages/ppx_yojson_conv_lib/ppx_yojson_conv_lib.v0.12.0/opam
+++ b/packages/ppx_yojson_conv_lib/ppx_yojson_conv_lib.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_yojson_conv_lib"
 bug-reports: "https://github.com/janestreet/ppx_yojson_conv_lib/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_yojson_conv_lib.git"

--- a/packages/ppx_yojson_conv_lib/ppx_yojson_conv_lib.v0.13.0/opam
+++ b/packages/ppx_yojson_conv_lib/ppx_yojson_conv_lib.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_yojson_conv_lib"
 bug-reports: "https://github.com/janestreet/ppx_yojson_conv_lib/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_yojson_conv_lib.git"

--- a/packages/ppx_yojson_conv_lib/ppx_yojson_conv_lib.v0.14.0/opam
+++ b/packages/ppx_yojson_conv_lib/ppx_yojson_conv_lib.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/ppx_yojson_conv_lib"
 bug-reports: "https://github.com/janestreet/ppx_yojson_conv_lib/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_yojson_conv_lib.git"

--- a/packages/ppxlib/ppxlib.0.1.0/opam
+++ b/packages/ppxlib/ppxlib.0.1.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.10.0/opam
+++ b/packages/ppxlib/ppxlib.0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.11.0/opam
+++ b/packages/ppxlib/ppxlib.0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.12.0/opam
+++ b/packages/ppxlib/ppxlib.0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.13.0/opam
+++ b/packages/ppxlib/ppxlib.0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.14.0/opam
+++ b/packages/ppxlib/ppxlib.0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.15.0/opam
+++ b/packages/ppxlib/ppxlib.0.15.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.16.0/opam
+++ b/packages/ppxlib/ppxlib.0.16.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.17.0/opam
+++ b/packages/ppxlib/ppxlib.0.17.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.18.0/opam
+++ b/packages/ppxlib/ppxlib.0.18.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.19.0/opam
+++ b/packages/ppxlib/ppxlib.0.19.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.2.0/opam
+++ b/packages/ppxlib/ppxlib.0.2.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.2.1/opam
+++ b/packages/ppxlib/ppxlib.0.2.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.2.2/opam
+++ b/packages/ppxlib/ppxlib.0.2.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.20.0/opam
+++ b/packages/ppxlib/ppxlib.0.20.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.21.0/opam
+++ b/packages/ppxlib/ppxlib.0.21.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.22.0/opam
+++ b/packages/ppxlib/ppxlib.0.22.0/opam
@@ -12,8 +12,8 @@ OCaml syntax directly and `ppxlib.traverse` which provides various
 ways of automatically traversing values of a given type, in particular
 allowing to inject a complex structured value into generated code.
 """
-maintainer: ["opensource@janestreet.com"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street developers"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 doc: "https://ocaml-ppx.github.io/ppxlib/"

--- a/packages/ppxlib/ppxlib.0.3.0/opam
+++ b/packages/ppxlib/ppxlib.0.3.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.3.1/opam
+++ b/packages/ppxlib/ppxlib.0.3.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.4.0/opam
+++ b/packages/ppxlib/ppxlib.0.4.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.5.0/opam
+++ b/packages/ppxlib/ppxlib.0.5.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.6.0/opam
+++ b/packages/ppxlib/ppxlib.0.6.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.7.0/opam
+++ b/packages/ppxlib/ppxlib.0.7.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.8.0/opam
+++ b/packages/ppxlib/ppxlib.0.8.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.8.1/opam
+++ b/packages/ppxlib/ppxlib.0.8.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/ppxlib/ppxlib.0.9.0/opam
+++ b/packages/ppxlib/ppxlib.0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/ocaml-ppx/ppxlib"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"

--- a/packages/protocol_version_header/protocol_version_header.v0.10.0/opam
+++ b/packages/protocol_version_header/protocol_version_header.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/protocol_version_header"
 bug-reports: "https://github.com/janestreet/protocol_version_header/issues"
 dev-repo: "git+https://github.com/janestreet/protocol_version_header.git"

--- a/packages/protocol_version_header/protocol_version_header.v0.11.0/opam
+++ b/packages/protocol_version_header/protocol_version_header.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/protocol_version_header"
 bug-reports: "https://github.com/janestreet/protocol_version_header/issues"
 dev-repo: "git+https://github.com/janestreet/protocol_version_header.git"

--- a/packages/protocol_version_header/protocol_version_header.v0.12.0/opam
+++ b/packages/protocol_version_header/protocol_version_header.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/protocol_version_header"
 bug-reports: "https://github.com/janestreet/protocol_version_header/issues"
 dev-repo: "git+https://github.com/janestreet/protocol_version_header.git"

--- a/packages/protocol_version_header/protocol_version_header.v0.13.0/opam
+++ b/packages/protocol_version_header/protocol_version_header.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/protocol_version_header"
 bug-reports: "https://github.com/janestreet/protocol_version_header/issues"
 dev-repo: "git+https://github.com/janestreet/protocol_version_header.git"

--- a/packages/protocol_version_header/protocol_version_header.v0.14.0/opam
+++ b/packages/protocol_version_header/protocol_version_header.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/protocol_version_header"
 bug-reports: "https://github.com/janestreet/protocol_version_header/issues"
 dev-repo: "git+https://github.com/janestreet/protocol_version_header.git"

--- a/packages/pythonlib/pythonlib.v0.12.0/opam
+++ b/packages/pythonlib/pythonlib.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pythonlib"
 bug-reports: "https://github.com/janestreet/pythonlib/issues"
 dev-repo: "git+https://github.com/janestreet/pythonlib.git"

--- a/packages/pythonlib/pythonlib.v0.13.0/opam
+++ b/packages/pythonlib/pythonlib.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pythonlib"
 bug-reports: "https://github.com/janestreet/pythonlib/issues"
 dev-repo: "git+https://github.com/janestreet/pythonlib.git"

--- a/packages/pythonlib/pythonlib.v0.14.0/opam
+++ b/packages/pythonlib/pythonlib.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/pythonlib"
 bug-reports: "https://github.com/janestreet/pythonlib/issues"
 dev-repo: "git+https://github.com/janestreet/pythonlib.git"

--- a/packages/re2/re2.109.24.00/opam
+++ b/packages/re2/re2.109.24.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.109.24.01/opam
+++ b/packages/re2/re2.109.24.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.109.28.00/opam
+++ b/packages/re2/re2.109.28.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.109.32.00/opam
+++ b/packages/re2/re2.109.32.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.109.40.00/opam
+++ b/packages/re2/re2.109.40.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.109.45.00/opam
+++ b/packages/re2/re2.109.45.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.109.45.01/opam
+++ b/packages/re2/re2.109.45.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.109.45.02/opam
+++ b/packages/re2/re2.109.45.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.109.53.00/opam
+++ b/packages/re2/re2.109.53.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.109.55.00/opam
+++ b/packages/re2/re2.109.55.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.109.55.02/opam
+++ b/packages/re2/re2.109.55.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.109.55.03/opam
+++ b/packages/re2/re2.109.55.03/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.109.55.04/opam
+++ b/packages/re2/re2.109.55.04/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.111.03.00/opam
+++ b/packages/re2/re2.111.03.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.111.03.01/opam
+++ b/packages/re2/re2.111.03.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.111.06.00/opam
+++ b/packages/re2/re2.111.06.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.111.08.00/opam
+++ b/packages/re2/re2.111.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.112.06.00/opam
+++ b/packages/re2/re2.112.06.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "re2"]]
 depends: [

--- a/packages/re2/re2.112.35.00/opam
+++ b/packages/re2/re2.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 build: [
   [make]

--- a/packages/re2/re2.113.00.00/opam
+++ b/packages/re2/re2.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 build: [
   [make]

--- a/packages/re2/re2.113.24.00/opam
+++ b/packages/re2/re2.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2/re2.113.33.00+4.03/opam
+++ b/packages/re2/re2.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2/re2.113.33.00/opam
+++ b/packages/re2/re2.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2/re2.113.33.03/opam
+++ b/packages/re2/re2.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2/re2.v0.10.0/opam
+++ b/packages/re2/re2.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2/re2.v0.10.1/opam
+++ b/packages/re2/re2.v0.10.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2/re2.v0.11.0/opam
+++ b/packages/re2/re2.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2/re2.v0.12.0/opam
+++ b/packages/re2/re2.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2/re2.v0.12.1/opam
+++ b/packages/re2/re2.v0.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2/re2.v0.13.0/opam
+++ b/packages/re2/re2.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2/re2.v0.14.0/opam
+++ b/packages/re2/re2.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2/re2.v0.9.0/opam
+++ b/packages/re2/re2.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2/re2.v0.9.1/opam
+++ b/packages/re2/re2.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2"
 bug-reports: "https://github.com/janestreet/re2/issues"
 dev-repo: "git+https://github.com/janestreet/re2.git"

--- a/packages/re2_stable/re2_stable.v0.14.0/opam
+++ b/packages/re2_stable/re2_stable.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/re2_stable"
 bug-reports: "https://github.com/janestreet/re2_stable/issues"
 dev-repo: "git+https://github.com/janestreet/re2_stable.git"

--- a/packages/record_builder/record_builder.v0.10.0/opam
+++ b/packages/record_builder/record_builder.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/record_builder"
 bug-reports: "https://github.com/janestreet/record_builder/issues"
 dev-repo: "git+https://github.com/janestreet/record_builder.git"

--- a/packages/record_builder/record_builder.v0.11.0/opam
+++ b/packages/record_builder/record_builder.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/record_builder"
 bug-reports: "https://github.com/janestreet/record_builder/issues"
 dev-repo: "git+https://github.com/janestreet/record_builder.git"

--- a/packages/record_builder/record_builder.v0.12.0/opam
+++ b/packages/record_builder/record_builder.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/record_builder"
 bug-reports: "https://github.com/janestreet/record_builder/issues"
 dev-repo: "git+https://github.com/janestreet/record_builder.git"

--- a/packages/record_builder/record_builder.v0.13.0/opam
+++ b/packages/record_builder/record_builder.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/record_builder"
 bug-reports: "https://github.com/janestreet/record_builder/issues"
 dev-repo: "git+https://github.com/janestreet/record_builder.git"

--- a/packages/record_builder/record_builder.v0.14.0/opam
+++ b/packages/record_builder/record_builder.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/record_builder"
 bug-reports: "https://github.com/janestreet/record_builder/issues"
 dev-repo: "git+https://github.com/janestreet/record_builder.git"

--- a/packages/resource_cache/resource_cache.v0.11.0/opam
+++ b/packages/resource_cache/resource_cache.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/resource_cache"
 bug-reports: "https://github.com/janestreet/resource_cache/issues"
 dev-repo: "git+https://github.com/janestreet/resource_cache.git"

--- a/packages/resource_cache/resource_cache.v0.12.0/opam
+++ b/packages/resource_cache/resource_cache.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/resource_cache"
 bug-reports: "https://github.com/janestreet/resource_cache/issues"
 dev-repo: "git+https://github.com/janestreet/resource_cache.git"

--- a/packages/resource_cache/resource_cache.v0.13.0/opam
+++ b/packages/resource_cache/resource_cache.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/resource_cache"
 bug-reports: "https://github.com/janestreet/resource_cache/issues"
 dev-repo: "git+https://github.com/janestreet/resource_cache.git"

--- a/packages/resource_cache/resource_cache.v0.14.0/opam
+++ b/packages/resource_cache/resource_cache.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/resource_cache"
 bug-reports: "https://github.com/janestreet/resource_cache/issues"
 dev-repo: "git+https://github.com/janestreet/resource_cache.git"

--- a/packages/result/result.1.0/opam
+++ b/packages/result/result.1.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/result"
 dev-repo: "git+https://github.com/janestreet/result.git"
 bug-reports: "https://github.com/janestreet/result/issues"

--- a/packages/result/result.1.1/opam
+++ b/packages/result/result.1.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/result"
 dev-repo: "git+https://github.com/janestreet/result.git"
 bug-reports: "https://github.com/janestreet/result/issues"

--- a/packages/result/result.1.2/opam
+++ b/packages/result/result.1.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/result"
 dev-repo: "git+https://github.com/janestreet/result.git"
 bug-reports: "https://github.com/janestreet/result/issues"

--- a/packages/result/result.1.3/opam
+++ b/packages/result/result.1.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/result"
 dev-repo: "git+https://github.com/janestreet/result.git"
 bug-reports: "https://github.com/janestreet/result/issues"

--- a/packages/result/result.1.4/opam
+++ b/packages/result/result.1.4/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/result"
 dev-repo: "git+https://github.com/janestreet/result.git"
 bug-reports: "https://github.com/janestreet/result/issues"

--- a/packages/result/result.1.5/opam
+++ b/packages/result/result.1.5/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/result"
 dev-repo: "git+https://github.com/janestreet/result.git"
 bug-reports: "https://github.com/janestreet/result/issues"

--- a/packages/rpc_parallel/rpc_parallel.112.01.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/rpc_parallel/rpc_parallel.112.17.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/rpc_parallel/rpc_parallel.112.24.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/rpc_parallel/rpc_parallel.112.35.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/rpc_parallel/rpc_parallel.113.00.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 license: "Apache-2.0"
 build: [

--- a/packages/rpc_parallel/rpc_parallel.113.24.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/rpc_parallel.git"

--- a/packages/rpc_parallel/rpc_parallel.113.33.00/opam
+++ b/packages/rpc_parallel/rpc_parallel.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/rpc_parallel.git"

--- a/packages/rpc_parallel/rpc_parallel.113.33.03/opam
+++ b/packages/rpc_parallel/rpc_parallel.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/rpc_parallel.git"

--- a/packages/rpc_parallel/rpc_parallel.v0.10.0/opam
+++ b/packages/rpc_parallel/rpc_parallel.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/rpc_parallel.git"

--- a/packages/rpc_parallel/rpc_parallel.v0.11.0/opam
+++ b/packages/rpc_parallel/rpc_parallel.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/rpc_parallel.git"

--- a/packages/rpc_parallel/rpc_parallel.v0.12.0/opam
+++ b/packages/rpc_parallel/rpc_parallel.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/rpc_parallel.git"

--- a/packages/rpc_parallel/rpc_parallel.v0.13.0/opam
+++ b/packages/rpc_parallel/rpc_parallel.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/rpc_parallel.git"

--- a/packages/rpc_parallel/rpc_parallel.v0.14.0/opam
+++ b/packages/rpc_parallel/rpc_parallel.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/rpc_parallel.git"

--- a/packages/rpc_parallel/rpc_parallel.v0.9.0/opam
+++ b/packages/rpc_parallel/rpc_parallel.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/rpc_parallel"
 bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
 dev-repo: "git+https://github.com/janestreet/rpc_parallel.git"

--- a/packages/sequencer_table/sequencer_table.v0.11.0/opam
+++ b/packages/sequencer_table/sequencer_table.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sequencer_table"
 bug-reports: "https://github.com/janestreet/sequencer_table/issues"
 dev-repo: "git+https://github.com/janestreet/sequencer_table.git"

--- a/packages/sequencer_table/sequencer_table.v0.12.0/opam
+++ b/packages/sequencer_table/sequencer_table.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sequencer_table"
 bug-reports: "https://github.com/janestreet/sequencer_table/issues"
 dev-repo: "git+https://github.com/janestreet/sequencer_table.git"

--- a/packages/sequencer_table/sequencer_table.v0.13.0/opam
+++ b/packages/sequencer_table/sequencer_table.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sequencer_table"
 bug-reports: "https://github.com/janestreet/sequencer_table/issues"
 dev-repo: "git+https://github.com/janestreet/sequencer_table.git"

--- a/packages/sequencer_table/sequencer_table.v0.14.0/opam
+++ b/packages/sequencer_table/sequencer_table.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sequencer_table"
 bug-reports: "https://github.com/janestreet/sequencer_table/issues"
 dev-repo: "git+https://github.com/janestreet/sequencer_table.git"

--- a/packages/sexp/sexp.v0.12.0/opam
+++ b/packages/sexp/sexp.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp"
 bug-reports: "https://github.com/janestreet/sexp/issues"
 dev-repo: "git+https://github.com/janestreet/sexp.git"

--- a/packages/sexp/sexp.v0.13.0/opam
+++ b/packages/sexp/sexp.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp"
 bug-reports: "https://github.com/janestreet/sexp/issues"
 dev-repo: "git+https://github.com/janestreet/sexp.git"

--- a/packages/sexp/sexp.v0.14.0/opam
+++ b/packages/sexp/sexp.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp"
 bug-reports: "https://github.com/janestreet/sexp/issues"
 dev-repo: "git+https://github.com/janestreet/sexp.git"

--- a/packages/sexp_diff_kernel/sexp_diff_kernel.v0.12.0/opam
+++ b/packages/sexp_diff_kernel/sexp_diff_kernel.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_diff_kernel"
 bug-reports: "https://github.com/janestreet/sexp_diff_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_diff_kernel.git"

--- a/packages/sexp_diff_kernel/sexp_diff_kernel.v0.13.0/opam
+++ b/packages/sexp_diff_kernel/sexp_diff_kernel.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_diff_kernel"
 bug-reports: "https://github.com/janestreet/sexp_diff_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_diff_kernel.git"

--- a/packages/sexp_diff_kernel/sexp_diff_kernel.v0.14.0/opam
+++ b/packages/sexp_diff_kernel/sexp_diff_kernel.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_diff_kernel"
 bug-reports: "https://github.com/janestreet/sexp_diff_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_diff_kernel.git"

--- a/packages/sexp_macro/sexp_macro.v0.12.0/opam
+++ b/packages/sexp_macro/sexp_macro.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_macro"
 bug-reports: "https://github.com/janestreet/sexp_macro/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_macro.git"

--- a/packages/sexp_macro/sexp_macro.v0.13.0/opam
+++ b/packages/sexp_macro/sexp_macro.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_macro"
 bug-reports: "https://github.com/janestreet/sexp_macro/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_macro.git"

--- a/packages/sexp_macro/sexp_macro.v0.14.0/opam
+++ b/packages/sexp_macro/sexp_macro.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_macro"
 bug-reports: "https://github.com/janestreet/sexp_macro/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_macro.git"

--- a/packages/sexp_pretty/sexp_pretty.v0.10.0/opam
+++ b/packages/sexp_pretty/sexp_pretty.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_pretty"
 bug-reports: "https://github.com/janestreet/sexp_pretty/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_pretty.git"

--- a/packages/sexp_pretty/sexp_pretty.v0.11.0/opam
+++ b/packages/sexp_pretty/sexp_pretty.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_pretty"
 bug-reports: "https://github.com/janestreet/sexp_pretty/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_pretty.git"

--- a/packages/sexp_pretty/sexp_pretty.v0.12.0/opam
+++ b/packages/sexp_pretty/sexp_pretty.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_pretty"
 bug-reports: "https://github.com/janestreet/sexp_pretty/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_pretty.git"

--- a/packages/sexp_pretty/sexp_pretty.v0.13.0/opam
+++ b/packages/sexp_pretty/sexp_pretty.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_pretty"
 bug-reports: "https://github.com/janestreet/sexp_pretty/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_pretty.git"

--- a/packages/sexp_pretty/sexp_pretty.v0.14.0/opam
+++ b/packages/sexp_pretty/sexp_pretty.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_pretty"
 bug-reports: "https://github.com/janestreet/sexp_pretty/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_pretty.git"

--- a/packages/sexp_pretty/sexp_pretty.v0.9.0/opam
+++ b/packages/sexp_pretty/sexp_pretty.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_pretty"
 bug-reports: "https://github.com/janestreet/sexp_pretty/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_pretty.git"

--- a/packages/sexp_select/sexp_select.v0.13.0/opam
+++ b/packages/sexp_select/sexp_select.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_select"
 bug-reports: "https://github.com/janestreet/sexp_select/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_select.git"

--- a/packages/sexp_select/sexp_select.v0.14.0/opam
+++ b/packages/sexp_select/sexp_select.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexp_select"
 bug-reports: "https://github.com/janestreet/sexp_select/issues"
 dev-repo: "git+https://github.com/janestreet/sexp_select.git"

--- a/packages/sexplib/sexplib.108.00.02/opam
+++ b/packages/sexplib/sexplib.108.00.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.108.07.00/opam
+++ b/packages/sexplib/sexplib.108.07.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.108.07.01/opam
+++ b/packages/sexplib/sexplib.108.07.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.108.08.00/opam
+++ b/packages/sexplib/sexplib.108.08.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.07.00/opam
+++ b/packages/sexplib/sexplib.109.07.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.08.00/opam
+++ b/packages/sexplib/sexplib.109.08.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.09.00/opam
+++ b/packages/sexplib/sexplib.109.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.10.00/opam
+++ b/packages/sexplib/sexplib.109.10.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.11.00/opam
+++ b/packages/sexplib/sexplib.109.11.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.12.00/opam
+++ b/packages/sexplib/sexplib.109.12.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.13.00/opam
+++ b/packages/sexplib/sexplib.109.13.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.14.00/opam
+++ b/packages/sexplib/sexplib.109.14.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.15.00/opam
+++ b/packages/sexplib/sexplib.109.15.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.17.00/opam
+++ b/packages/sexplib/sexplib.109.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.20.00/opam
+++ b/packages/sexplib/sexplib.109.20.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.41.00/opam
+++ b/packages/sexplib/sexplib.109.41.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.47.00/opam
+++ b/packages/sexplib/sexplib.109.47.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.53.00/opam
+++ b/packages/sexplib/sexplib.109.53.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.55.00/opam
+++ b/packages/sexplib/sexplib.109.55.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.55.02/opam
+++ b/packages/sexplib/sexplib.109.55.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.58.00/opam
+++ b/packages/sexplib/sexplib.109.58.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.109.60.00/opam
+++ b/packages/sexplib/sexplib.109.60.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.110.01.00/opam
+++ b/packages/sexplib/sexplib.110.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.111.03.00/opam
+++ b/packages/sexplib/sexplib.111.03.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.111.11.00/opam
+++ b/packages/sexplib/sexplib.111.11.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.111.13.00/opam
+++ b/packages/sexplib/sexplib.111.13.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   [make]

--- a/packages/sexplib/sexplib.111.17.00/opam
+++ b/packages/sexplib/sexplib.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]

--- a/packages/sexplib/sexplib.111.25.00/opam
+++ b/packages/sexplib/sexplib.111.25.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]

--- a/packages/sexplib/sexplib.112.01.00/opam
+++ b/packages/sexplib/sexplib.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]

--- a/packages/sexplib/sexplib.112.06.00/opam
+++ b/packages/sexplib/sexplib.112.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]

--- a/packages/sexplib/sexplib.112.06.01/opam
+++ b/packages/sexplib/sexplib.112.06.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]

--- a/packages/sexplib/sexplib.112.17.00/opam
+++ b/packages/sexplib/sexplib.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]

--- a/packages/sexplib/sexplib.112.17.01/opam
+++ b/packages/sexplib/sexplib.112.17.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]

--- a/packages/sexplib/sexplib.112.24.00/opam
+++ b/packages/sexplib/sexplib.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]

--- a/packages/sexplib/sexplib.112.24.01/opam
+++ b/packages/sexplib/sexplib.112.24.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]

--- a/packages/sexplib/sexplib.112.35.00/opam
+++ b/packages/sexplib/sexplib.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]

--- a/packages/sexplib/sexplib.113.00.00/opam
+++ b/packages/sexplib/sexplib.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 build: [
   ["./configure" "--%{type_conv:enable}%-syntax"]

--- a/packages/sexplib/sexplib.113.24.00/opam
+++ b/packages/sexplib/sexplib.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib/sexplib.113.33.00+4.03/opam
+++ b/packages/sexplib/sexplib.113.33.00+4.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib/sexplib.113.33.00/opam
+++ b/packages/sexplib/sexplib.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib/sexplib.113.33.03/opam
+++ b/packages/sexplib/sexplib.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib/sexplib.v0.10.0/opam
+++ b/packages/sexplib/sexplib.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib/sexplib.v0.11.0/opam
+++ b/packages/sexplib/sexplib.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib/sexplib.v0.12.0/opam
+++ b/packages/sexplib/sexplib.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib/sexplib.v0.13.0/opam
+++ b/packages/sexplib/sexplib.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib/sexplib.v0.14.0/opam
+++ b/packages/sexplib/sexplib.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib/sexplib.v0.9.0/opam
+++ b/packages/sexplib/sexplib.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib/sexplib.v0.9.1/opam
+++ b/packages/sexplib/sexplib.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib/sexplib.v0.9.2/opam
+++ b/packages/sexplib/sexplib.v0.9.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib/sexplib.v0.9.3/opam
+++ b/packages/sexplib/sexplib.v0.9.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib"
 bug-reports: "https://github.com/janestreet/sexplib/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib.git"

--- a/packages/sexplib0/sexplib0.v0.11.0/opam
+++ b/packages/sexplib0/sexplib0.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib0"
 bug-reports: "https://github.com/janestreet/sexplib0/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib0.git"

--- a/packages/sexplib0/sexplib0.v0.12.0/opam
+++ b/packages/sexplib0/sexplib0.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib0"
 bug-reports: "https://github.com/janestreet/sexplib0/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib0.git"

--- a/packages/sexplib0/sexplib0.v0.13.0/opam
+++ b/packages/sexplib0/sexplib0.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib0"
 bug-reports: "https://github.com/janestreet/sexplib0/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib0.git"

--- a/packages/sexplib0/sexplib0.v0.14.0/opam
+++ b/packages/sexplib0/sexplib0.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/sexplib0"
 bug-reports: "https://github.com/janestreet/sexplib0/issues"
 dev-repo: "git+https://github.com/janestreet/sexplib0.git"

--- a/packages/shell/shell.v0.12.0/opam
+++ b/packages/shell/shell.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/shell"
 bug-reports: "https://github.com/janestreet/shell/issues"
 dev-repo: "git+https://github.com/janestreet/shell.git"

--- a/packages/shell/shell.v0.13.0/opam
+++ b/packages/shell/shell.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/shell"
 bug-reports: "https://github.com/janestreet/shell/issues"
 dev-repo: "git+https://github.com/janestreet/shell.git"

--- a/packages/shell/shell.v0.14.0/opam
+++ b/packages/shell/shell.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/shell"
 bug-reports: "https://github.com/janestreet/shell/issues"
 dev-repo: "git+https://github.com/janestreet/shell.git"

--- a/packages/shexp/shexp.v0.10.0/opam
+++ b/packages/shexp/shexp.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/shexp"
 bug-reports: "https://github.com/janestreet/shexp/issues"
 dev-repo: "git+https://github.com/janestreet/shexp.git"

--- a/packages/shexp/shexp.v0.11.0/opam
+++ b/packages/shexp/shexp.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/shexp"
 bug-reports: "https://github.com/janestreet/shexp/issues"
 dev-repo: "git+https://github.com/janestreet/shexp.git"

--- a/packages/shexp/shexp.v0.11.1/opam
+++ b/packages/shexp/shexp.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/shexp"
 bug-reports: "https://github.com/janestreet/shexp/issues"
 dev-repo: "git+https://github.com/janestreet/shexp.git"

--- a/packages/shexp/shexp.v0.12.0/opam
+++ b/packages/shexp/shexp.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/shexp"
 bug-reports: "https://github.com/janestreet/shexp/issues"
 dev-repo: "git+https://github.com/janestreet/shexp.git"

--- a/packages/shexp/shexp.v0.13.0/opam
+++ b/packages/shexp/shexp.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/shexp"
 bug-reports: "https://github.com/janestreet/shexp/issues"
 dev-repo: "git+https://github.com/janestreet/shexp.git"

--- a/packages/shexp/shexp.v0.14.0/opam
+++ b/packages/shexp/shexp.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/shexp"
 bug-reports: "https://github.com/janestreet/shexp/issues"
 dev-repo: "git+https://github.com/janestreet/shexp.git"

--- a/packages/shexp/shexp.v0.9.0/opam
+++ b/packages/shexp/shexp.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/shexp"
 bug-reports: "https://github.com/janestreet/shexp/issues"
 dev-repo: "git+https://github.com/janestreet/shexp.git"

--- a/packages/spawn/spawn.0.14.0/opam
+++ b/packages/spawn/spawn.0.14.0/opam
@@ -18,8 +18,8 @@ fork takes time proportional to the process memory while vfork is
 constant time. In application using a lot of memory, vfork can be
 thousands of times faster than fork.
 """
-maintainer: ["opensource@janestreet.com"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street developers"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/janestreet/spawn"
 doc: "https://janestreet.github.io/spawn/"

--- a/packages/spawn/spawn.v0.10.0/opam
+++ b/packages/spawn/spawn.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/spawn"
 bug-reports: "https://github.com/janestreet/spawn/issues"
 dev-repo: "git+https://github.com/janestreet/spawn.git"

--- a/packages/spawn/spawn.v0.10.1/opam
+++ b/packages/spawn/spawn.v0.10.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/spawn"
 bug-reports: "https://github.com/janestreet/spawn/issues"
 dev-repo: "git+https://github.com/janestreet/spawn.git"

--- a/packages/spawn/spawn.v0.11.0/opam
+++ b/packages/spawn/spawn.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/spawn"
 bug-reports: "https://github.com/janestreet/spawn/issues"
 dev-repo: "git+https://github.com/janestreet/spawn.git"

--- a/packages/spawn/spawn.v0.11.1/opam
+++ b/packages/spawn/spawn.v0.11.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/spawn"
 bug-reports: "https://github.com/janestreet/spawn/issues"
 dev-repo: "git+https://github.com/janestreet/spawn.git"

--- a/packages/spawn/spawn.v0.12.0/opam
+++ b/packages/spawn/spawn.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/spawn"
 bug-reports: "https://github.com/janestreet/spawn/issues"
 dev-repo: "git+https://github.com/janestreet/spawn.git"

--- a/packages/spawn/spawn.v0.13.0/opam
+++ b/packages/spawn/spawn.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/spawn"
 bug-reports: "https://github.com/janestreet/spawn/issues"
 dev-repo: "git+https://github.com/janestreet/spawn.git"

--- a/packages/spawn/spawn.v0.9.0/opam
+++ b/packages/spawn/spawn.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/spawn"
 bug-reports: "https://github.com/janestreet/spawn/issues"
 dev-repo: "git+https://github.com/janestreet/spawn.git"

--- a/packages/splay_tree/splay_tree.v0.10.0/opam
+++ b/packages/splay_tree/splay_tree.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/splay_tree"
 bug-reports: "https://github.com/janestreet/splay_tree/issues"
 dev-repo: "git+https://github.com/janestreet/splay_tree.git"

--- a/packages/splay_tree/splay_tree.v0.11.0/opam
+++ b/packages/splay_tree/splay_tree.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/splay_tree"
 bug-reports: "https://github.com/janestreet/splay_tree/issues"
 dev-repo: "git+https://github.com/janestreet/splay_tree.git"

--- a/packages/splay_tree/splay_tree.v0.12.0/opam
+++ b/packages/splay_tree/splay_tree.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/splay_tree"
 bug-reports: "https://github.com/janestreet/splay_tree/issues"
 dev-repo: "git+https://github.com/janestreet/splay_tree.git"

--- a/packages/splay_tree/splay_tree.v0.13.0/opam
+++ b/packages/splay_tree/splay_tree.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/splay_tree"
 bug-reports: "https://github.com/janestreet/splay_tree/issues"
 dev-repo: "git+https://github.com/janestreet/splay_tree.git"

--- a/packages/splay_tree/splay_tree.v0.14.0/opam
+++ b/packages/splay_tree/splay_tree.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/splay_tree"
 bug-reports: "https://github.com/janestreet/splay_tree/issues"
 dev-repo: "git+https://github.com/janestreet/splay_tree.git"

--- a/packages/splittable_random/splittable_random.v0.11.0/opam
+++ b/packages/splittable_random/splittable_random.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/splittable_random"
 bug-reports: "https://github.com/janestreet/splittable_random/issues"
 dev-repo: "git+https://github.com/janestreet/splittable_random.git"

--- a/packages/splittable_random/splittable_random.v0.12.0/opam
+++ b/packages/splittable_random/splittable_random.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/splittable_random"
 bug-reports: "https://github.com/janestreet/splittable_random/issues"
 dev-repo: "git+https://github.com/janestreet/splittable_random.git"

--- a/packages/splittable_random/splittable_random.v0.13.0/opam
+++ b/packages/splittable_random/splittable_random.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/splittable_random"
 bug-reports: "https://github.com/janestreet/splittable_random/issues"
 dev-repo: "git+https://github.com/janestreet/splittable_random.git"

--- a/packages/splittable_random/splittable_random.v0.14.0/opam
+++ b/packages/splittable_random/splittable_random.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/splittable_random"
 bug-reports: "https://github.com/janestreet/splittable_random/issues"
 dev-repo: "git+https://github.com/janestreet/splittable_random.git"

--- a/packages/stdio/stdio.v0.10.0/opam
+++ b/packages/stdio/stdio.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/stdio"
 bug-reports: "https://github.com/janestreet/stdio/issues"
 dev-repo: "git+https://github.com/janestreet/stdio.git"

--- a/packages/stdio/stdio.v0.11.0/opam
+++ b/packages/stdio/stdio.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/stdio"
 bug-reports: "https://github.com/janestreet/stdio/issues"
 dev-repo: "git+https://github.com/janestreet/stdio.git"

--- a/packages/stdio/stdio.v0.12.0/opam
+++ b/packages/stdio/stdio.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/stdio"
 bug-reports: "https://github.com/janestreet/stdio/issues"
 dev-repo: "git+https://github.com/janestreet/stdio.git"

--- a/packages/stdio/stdio.v0.13.0/opam
+++ b/packages/stdio/stdio.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/stdio"
 bug-reports: "https://github.com/janestreet/stdio/issues"
 dev-repo: "git+https://github.com/janestreet/stdio.git"

--- a/packages/stdio/stdio.v0.14.0/opam
+++ b/packages/stdio/stdio.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/stdio"
 bug-reports: "https://github.com/janestreet/stdio/issues"
 dev-repo: "git+https://github.com/janestreet/stdio.git"

--- a/packages/stdio/stdio.v0.9.0/opam
+++ b/packages/stdio/stdio.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/stdio"
 bug-reports: "https://github.com/janestreet/stdio/issues"
 dev-repo: "git+https://github.com/janestreet/stdio.git"

--- a/packages/stdio/stdio.v0.9.1/opam
+++ b/packages/stdio/stdio.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/stdio"
 bug-reports: "https://github.com/janestreet/stdio/issues"
 dev-repo: "git+https://github.com/janestreet/stdio.git"

--- a/packages/string_dict/string_dict.v0.11.0/opam
+++ b/packages/string_dict/string_dict.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/string_dict"
 bug-reports: "https://github.com/janestreet/string_dict/issues"
 dev-repo: "git+https://github.com/janestreet/string_dict.git"

--- a/packages/string_dict/string_dict.v0.12.0/opam
+++ b/packages/string_dict/string_dict.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/string_dict"
 bug-reports: "https://github.com/janestreet/string_dict/issues"
 dev-repo: "git+https://github.com/janestreet/string_dict.git"

--- a/packages/string_dict/string_dict.v0.13.0/opam
+++ b/packages/string_dict/string_dict.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/string_dict"
 bug-reports: "https://github.com/janestreet/string_dict/issues"
 dev-repo: "git+https://github.com/janestreet/string_dict.git"

--- a/packages/string_dict/string_dict.v0.14.0/opam
+++ b/packages/string_dict/string_dict.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/string_dict"
 bug-reports: "https://github.com/janestreet/string_dict/issues"
 dev-repo: "git+https://github.com/janestreet/string_dict.git"

--- a/packages/textutils/textutils.109.24.00/opam
+++ b/packages/textutils/textutils.109.24.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [

--- a/packages/textutils/textutils.109.35.00/opam
+++ b/packages/textutils/textutils.109.35.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [

--- a/packages/textutils/textutils.109.36.00/opam
+++ b/packages/textutils/textutils.109.36.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [

--- a/packages/textutils/textutils.109.53.00/opam
+++ b/packages/textutils/textutils.109.53.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [

--- a/packages/textutils/textutils.109.53.02/opam
+++ b/packages/textutils/textutils.109.53.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [

--- a/packages/textutils/textutils.109.53.03/opam
+++ b/packages/textutils/textutils.109.53.03/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [

--- a/packages/textutils/textutils.111.03.00/opam
+++ b/packages/textutils/textutils.111.03.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [

--- a/packages/textutils/textutils.111.06.00/opam
+++ b/packages/textutils/textutils.111.06.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [

--- a/packages/textutils/textutils.111.25.00/opam
+++ b/packages/textutils/textutils.111.25.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [

--- a/packages/textutils/textutils.111.28.00/opam
+++ b/packages/textutils/textutils.111.28.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [

--- a/packages/textutils/textutils.112.01.00/opam
+++ b/packages/textutils/textutils.112.01.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [

--- a/packages/textutils/textutils.112.06.00/opam
+++ b/packages/textutils/textutils.112.06.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "textutils"]]
 depends: [

--- a/packages/textutils/textutils.112.17.00/opam
+++ b/packages/textutils/textutils.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils"
 license: "Apache-2.0"
 build: [

--- a/packages/textutils/textutils.113.24.00/opam
+++ b/packages/textutils/textutils.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils"
 bug-reports: "https://github.com/janestreet/textutils/issues"
 dev-repo: "git+https://github.com/janestreet/textutils.git"

--- a/packages/textutils/textutils.113.33.00/opam
+++ b/packages/textutils/textutils.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils"
 bug-reports: "https://github.com/janestreet/textutils/issues"
 dev-repo: "git+https://github.com/janestreet/textutils.git"

--- a/packages/textutils/textutils.113.33.03/opam
+++ b/packages/textutils/textutils.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils"
 bug-reports: "https://github.com/janestreet/textutils/issues"
 dev-repo: "git+https://github.com/janestreet/textutils.git"

--- a/packages/textutils/textutils.v0.10.0/opam
+++ b/packages/textutils/textutils.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils"
 bug-reports: "https://github.com/janestreet/textutils/issues"
 dev-repo: "git+https://github.com/janestreet/textutils.git"

--- a/packages/textutils/textutils.v0.11.0/opam
+++ b/packages/textutils/textutils.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils"
 bug-reports: "https://github.com/janestreet/textutils/issues"
 dev-repo: "git+https://github.com/janestreet/textutils.git"

--- a/packages/textutils/textutils.v0.12.0/opam
+++ b/packages/textutils/textutils.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils"
 bug-reports: "https://github.com/janestreet/textutils/issues"
 dev-repo: "git+https://github.com/janestreet/textutils.git"

--- a/packages/textutils/textutils.v0.13.0/opam
+++ b/packages/textutils/textutils.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils"
 bug-reports: "https://github.com/janestreet/textutils/issues"
 dev-repo: "git+https://github.com/janestreet/textutils.git"

--- a/packages/textutils/textutils.v0.14.0/opam
+++ b/packages/textutils/textutils.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils"
 bug-reports: "https://github.com/janestreet/textutils/issues"
 dev-repo: "git+https://github.com/janestreet/textutils.git"

--- a/packages/textutils/textutils.v0.9.0/opam
+++ b/packages/textutils/textutils.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils"
 bug-reports: "https://github.com/janestreet/textutils/issues"
 dev-repo: "git+https://github.com/janestreet/textutils.git"

--- a/packages/textutils_kernel/textutils_kernel.v0.10.0/opam
+++ b/packages/textutils_kernel/textutils_kernel.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils_kernel"
 bug-reports: "https://github.com/janestreet/textutils_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/textutils_kernel.git"

--- a/packages/textutils_kernel/textutils_kernel.v0.11.0/opam
+++ b/packages/textutils_kernel/textutils_kernel.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils_kernel"
 bug-reports: "https://github.com/janestreet/textutils_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/textutils_kernel.git"

--- a/packages/textutils_kernel/textutils_kernel.v0.12.0/opam
+++ b/packages/textutils_kernel/textutils_kernel.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils_kernel"
 bug-reports: "https://github.com/janestreet/textutils_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/textutils_kernel.git"

--- a/packages/textutils_kernel/textutils_kernel.v0.13.0/opam
+++ b/packages/textutils_kernel/textutils_kernel.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils_kernel"
 bug-reports: "https://github.com/janestreet/textutils_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/textutils_kernel.git"

--- a/packages/textutils_kernel/textutils_kernel.v0.14.0/opam
+++ b/packages/textutils_kernel/textutils_kernel.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/textutils_kernel"
 bug-reports: "https://github.com/janestreet/textutils_kernel/issues"
 dev-repo: "git+https://github.com/janestreet/textutils_kernel.git"

--- a/packages/time_now/time_now.v0.12.0/opam
+++ b/packages/time_now/time_now.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/time_now"
 bug-reports: "https://github.com/janestreet/time_now/issues"
 dev-repo: "git+https://github.com/janestreet/time_now.git"

--- a/packages/time_now/time_now.v0.13.0/opam
+++ b/packages/time_now/time_now.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/time_now"
 bug-reports: "https://github.com/janestreet/time_now/issues"
 dev-repo: "git+https://github.com/janestreet/time_now.git"

--- a/packages/time_now/time_now.v0.14.0/opam
+++ b/packages/time_now/time_now.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/time_now"
 bug-reports: "https://github.com/janestreet/time_now/issues"
 dev-repo: "git+https://github.com/janestreet/time_now.git"

--- a/packages/timezone/timezone.v0.13.0/opam
+++ b/packages/timezone/timezone.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/timezone"
 bug-reports: "https://github.com/janestreet/timezone/issues"
 dev-repo: "git+https://github.com/janestreet/timezone.git"

--- a/packages/timezone/timezone.v0.14.0/opam
+++ b/packages/timezone/timezone.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/timezone"
 bug-reports: "https://github.com/janestreet/timezone/issues"
 dev-repo: "git+https://github.com/janestreet/timezone.git"

--- a/packages/toplevel_backend/toplevel_backend.v0.13.0/opam
+++ b/packages/toplevel_backend/toplevel_backend.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_backend"
 bug-reports: "https://github.com/janestreet/toplevel_backend/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_backend.git"

--- a/packages/toplevel_backend/toplevel_backend.v0.14.0/opam
+++ b/packages/toplevel_backend/toplevel_backend.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_backend"
 bug-reports: "https://github.com/janestreet/toplevel_backend/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_backend.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.113.33.01/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.113.33.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.113.33.02/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.113.33.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.113.33.03/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.10.0/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.11.0/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.12.0/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.12.1/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.12.2/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.12.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.13.0/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.14.0/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.14.1/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.14.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.9.1/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.9.2/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.9.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/toplevel_expect_test"
 bug-reports: "https://github.com/janestreet/toplevel_expect_test/issues"
 dev-repo: "git+https://github.com/janestreet/toplevel_expect_test.git"

--- a/packages/topological_sort/topological_sort.v0.10.0/opam
+++ b/packages/topological_sort/topological_sort.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/topological_sort"
 bug-reports: "https://github.com/janestreet/topological_sort/issues"
 dev-repo: "git+https://github.com/janestreet/topological_sort.git"

--- a/packages/topological_sort/topological_sort.v0.11.0/opam
+++ b/packages/topological_sort/topological_sort.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/topological_sort"
 bug-reports: "https://github.com/janestreet/topological_sort/issues"
 dev-repo: "git+https://github.com/janestreet/topological_sort.git"

--- a/packages/topological_sort/topological_sort.v0.12.0/opam
+++ b/packages/topological_sort/topological_sort.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/topological_sort"
 bug-reports: "https://github.com/janestreet/topological_sort/issues"
 dev-repo: "git+https://github.com/janestreet/topological_sort.git"

--- a/packages/topological_sort/topological_sort.v0.13.0/opam
+++ b/packages/topological_sort/topological_sort.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/topological_sort"
 bug-reports: "https://github.com/janestreet/topological_sort/issues"
 dev-repo: "git+https://github.com/janestreet/topological_sort.git"

--- a/packages/topological_sort/topological_sort.v0.14.0/opam
+++ b/packages/topological_sort/topological_sort.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/topological_sort"
 bug-reports: "https://github.com/janestreet/topological_sort/issues"
 dev-repo: "git+https://github.com/janestreet/topological_sort.git"

--- a/packages/topological_sort/topological_sort.v0.9.0/opam
+++ b/packages/topological_sort/topological_sort.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/topological_sort"
 bug-reports: "https://github.com/janestreet/topological_sort/issues"
 dev-repo: "git+https://github.com/janestreet/topological_sort.git"

--- a/packages/type_conv/type_conv.108.00.02/opam
+++ b/packages/type_conv/type_conv.108.00.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.108.07.00/opam
+++ b/packages/type_conv/type_conv.108.07.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.108.07.01/opam
+++ b/packages/type_conv/type_conv.108.07.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.108.08.00/opam
+++ b/packages/type_conv/type_conv.108.08.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.109.07.00/opam
+++ b/packages/type_conv/type_conv.109.07.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.109.08.00/opam
+++ b/packages/type_conv/type_conv.109.08.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.109.09.00/opam
+++ b/packages/type_conv/type_conv.109.09.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.109.10.00/opam
+++ b/packages/type_conv/type_conv.109.10.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.109.11.00/opam
+++ b/packages/type_conv/type_conv.109.11.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.109.12.00/opam
+++ b/packages/type_conv/type_conv.109.12.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 build: make

--- a/packages/type_conv/type_conv.109.13.00/opam
+++ b/packages/type_conv/type_conv.109.13.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.109.14.00/opam
+++ b/packages/type_conv/type_conv.109.14.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.109.15.00/opam
+++ b/packages/type_conv/type_conv.109.15.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.109.20.00/opam
+++ b/packages/type_conv/type_conv.109.20.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.109.28.00/opam
+++ b/packages/type_conv/type_conv.109.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [

--- a/packages/type_conv/type_conv.109.41.00/opam
+++ b/packages/type_conv/type_conv.109.41.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [

--- a/packages/type_conv/type_conv.109.47.00/opam
+++ b/packages/type_conv/type_conv.109.47.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [

--- a/packages/type_conv/type_conv.109.53.00/opam
+++ b/packages/type_conv/type_conv.109.53.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [

--- a/packages/type_conv/type_conv.109.53.02/opam
+++ b/packages/type_conv/type_conv.109.53.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [

--- a/packages/type_conv/type_conv.109.60.00/opam
+++ b/packages/type_conv/type_conv.109.60.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [

--- a/packages/type_conv/type_conv.109.60.01/opam
+++ b/packages/type_conv/type_conv.109.60.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [

--- a/packages/type_conv/type_conv.111.13.00/opam
+++ b/packages/type_conv/type_conv.111.13.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [

--- a/packages/type_conv/type_conv.112.01.00/opam
+++ b/packages/type_conv/type_conv.112.01.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [

--- a/packages/type_conv/type_conv.112.01.01/opam
+++ b/packages/type_conv/type_conv.112.01.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [

--- a/packages/type_conv/type_conv.112.01.02/opam
+++ b/packages/type_conv/type_conv.112.01.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 license: "Apache-2.0"
 build: [

--- a/packages/type_conv/type_conv.113.00.00/opam
+++ b/packages/type_conv/type_conv.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.113.00.01/opam
+++ b/packages/type_conv/type_conv.113.00.01/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/type_conv/type_conv.113.00.02/opam
+++ b/packages/type_conv/type_conv.113.00.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/type_conv"
 bug-reports: "https://github.com/janestreet/type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/type_conv.git"

--- a/packages/typehashlib/typehashlib.108.00.02/opam
+++ b/packages/typehashlib/typehashlib.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.108.07.00/opam
+++ b/packages/typehashlib/typehashlib.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.108.07.01/opam
+++ b/packages/typehashlib/typehashlib.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.108.08.00/opam
+++ b/packages/typehashlib/typehashlib.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.109.07.00/opam
+++ b/packages/typehashlib/typehashlib.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.109.08.00/opam
+++ b/packages/typehashlib/typehashlib.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.109.09.00/opam
+++ b/packages/typehashlib/typehashlib.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.109.10.00/opam
+++ b/packages/typehashlib/typehashlib.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.109.11.00/opam
+++ b/packages/typehashlib/typehashlib.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.109.12.00/opam
+++ b/packages/typehashlib/typehashlib.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.109.13.00/opam
+++ b/packages/typehashlib/typehashlib.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.109.14.00/opam
+++ b/packages/typehashlib/typehashlib.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.109.15.00/opam
+++ b/packages/typehashlib/typehashlib.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.109.15.01/opam
+++ b/packages/typehashlib/typehashlib.109.15.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.109.15.02/opam
+++ b/packages/typehashlib/typehashlib.109.15.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typehashlib/typehashlib.109.15.04/opam
+++ b/packages/typehashlib/typehashlib.109.15.04/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "typehashlib"]]
 depends: [

--- a/packages/typerep/typerep.109.55.00/opam
+++ b/packages/typerep/typerep.109.55.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/typerep/typerep.109.55.02/opam
+++ b/packages/typerep/typerep.109.55.02/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/typerep/typerep.111.06.00/opam
+++ b/packages/typerep/typerep.111.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/typerep/typerep.111.17.00/opam
+++ b/packages/typerep/typerep.111.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/typerep/typerep.112.06.00/opam
+++ b/packages/typerep/typerep.112.06.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/typerep/typerep.112.17.00/opam
+++ b/packages/typerep/typerep.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/typerep/typerep.112.24.00/opam
+++ b/packages/typerep/typerep.112.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/typerep/typerep.112.35.00/opam
+++ b/packages/typerep/typerep.112.35.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep"
 license: "Apache-2.0"
 build: [

--- a/packages/typerep/typerep.113.00.00/opam
+++ b/packages/typerep/typerep.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep"
 license: "Apache-2.0"
 build: [

--- a/packages/typerep/typerep.113.24.00/opam
+++ b/packages/typerep/typerep.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep"
 bug-reports: "https://github.com/janestreet/typerep/issues"
 dev-repo: "git+https://github.com/janestreet/typerep.git"

--- a/packages/typerep/typerep.113.33.03/opam
+++ b/packages/typerep/typerep.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep"
 bug-reports: "https://github.com/janestreet/typerep/issues"
 dev-repo: "git+https://github.com/janestreet/typerep.git"

--- a/packages/typerep/typerep.v0.10.0/opam
+++ b/packages/typerep/typerep.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep"
 bug-reports: "https://github.com/janestreet/typerep/issues"
 dev-repo: "git+https://github.com/janestreet/typerep.git"

--- a/packages/typerep/typerep.v0.11.0/opam
+++ b/packages/typerep/typerep.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep"
 bug-reports: "https://github.com/janestreet/typerep/issues"
 dev-repo: "git+https://github.com/janestreet/typerep.git"

--- a/packages/typerep/typerep.v0.12.0/opam
+++ b/packages/typerep/typerep.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep"
 bug-reports: "https://github.com/janestreet/typerep/issues"
 dev-repo: "git+https://github.com/janestreet/typerep.git"

--- a/packages/typerep/typerep.v0.13.0/opam
+++ b/packages/typerep/typerep.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep"
 bug-reports: "https://github.com/janestreet/typerep/issues"
 dev-repo: "git+https://github.com/janestreet/typerep.git"

--- a/packages/typerep/typerep.v0.14.0/opam
+++ b/packages/typerep/typerep.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep"
 bug-reports: "https://github.com/janestreet/typerep/issues"
 dev-repo: "git+https://github.com/janestreet/typerep.git"

--- a/packages/typerep/typerep.v0.9.0/opam
+++ b/packages/typerep/typerep.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep"
 bug-reports: "https://github.com/janestreet/typerep/issues"
 dev-repo: "git+https://github.com/janestreet/typerep.git"

--- a/packages/typerep_extended/typerep_extended.112.17.00/opam
+++ b/packages/typerep_extended/typerep_extended.112.17.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 license: "Apache-2.0"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/typerep_extended/typerep_extended.113.00.00/opam
+++ b/packages/typerep_extended/typerep_extended.113.00.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep_extended"
 license: "Apache-2.0"
 build: [

--- a/packages/typerep_extended/typerep_extended.113.24.00/opam
+++ b/packages/typerep_extended/typerep_extended.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep_extended"
 bug-reports: "https://github.com/janestreet/typerep_extended/issues"
 dev-repo: "git+https://github.com/janestreet/typerep_extended.git"

--- a/packages/typerep_extended/typerep_extended.113.33.00/opam
+++ b/packages/typerep_extended/typerep_extended.113.33.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep_extended"
 bug-reports: "https://github.com/janestreet/typerep_extended/issues"
 dev-repo: "git+https://github.com/janestreet/typerep_extended.git"

--- a/packages/typerep_extended/typerep_extended.113.33.03/opam
+++ b/packages/typerep_extended/typerep_extended.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep_extended"
 bug-reports: "https://github.com/janestreet/typerep_extended/issues"
 dev-repo: "git+https://github.com/janestreet/typerep_extended.git"

--- a/packages/typerep_extended/typerep_extended.v0.9.0/opam
+++ b/packages/typerep_extended/typerep_extended.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/typerep_extended"
 bug-reports: "https://github.com/janestreet/typerep_extended/issues"
 dev-repo: "git+https://github.com/janestreet/typerep_extended.git"

--- a/packages/variantslib/variantslib.108.00.02/opam
+++ b/packages/variantslib/variantslib.108.00.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.108.07.00/opam
+++ b/packages/variantslib/variantslib.108.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.108.07.01/opam
+++ b/packages/variantslib/variantslib.108.07.01/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.108.08.00/opam
+++ b/packages/variantslib/variantslib.108.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.109.07.00/opam
+++ b/packages/variantslib/variantslib.109.07.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.109.08.00/opam
+++ b/packages/variantslib/variantslib.109.08.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.109.09.00/opam
+++ b/packages/variantslib/variantslib.109.09.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.109.10.00/opam
+++ b/packages/variantslib/variantslib.109.10.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.109.11.00/opam
+++ b/packages/variantslib/variantslib.109.11.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.109.12.00/opam
+++ b/packages/variantslib/variantslib.109.12.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.109.13.00/opam
+++ b/packages/variantslib/variantslib.109.13.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.109.14.00/opam
+++ b/packages/variantslib/variantslib.109.14.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.109.15.00/opam
+++ b/packages/variantslib/variantslib.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.109.15.02/opam
+++ b/packages/variantslib/variantslib.109.15.02/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "variantslib"]]
 depends: [

--- a/packages/variantslib/variantslib.109.15.03/opam
+++ b/packages/variantslib/variantslib.109.15.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/variantslib"
 license: "Apache-2.0"
 build: [

--- a/packages/variantslib/variantslib.113.24.00/opam
+++ b/packages/variantslib/variantslib.113.24.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/variantslib"
 bug-reports: "https://github.com/janestreet/variantslib/issues"
 dev-repo: "git+https://github.com/janestreet/variantslib.git"

--- a/packages/variantslib/variantslib.113.33.03/opam
+++ b/packages/variantslib/variantslib.113.33.03/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/variantslib"
 bug-reports: "https://github.com/janestreet/variantslib/issues"
 dev-repo: "git+https://github.com/janestreet/variantslib.git"

--- a/packages/variantslib/variantslib.v0.10.0/opam
+++ b/packages/variantslib/variantslib.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/variantslib"
 bug-reports: "https://github.com/janestreet/variantslib/issues"
 dev-repo: "git+https://github.com/janestreet/variantslib.git"

--- a/packages/variantslib/variantslib.v0.11.0/opam
+++ b/packages/variantslib/variantslib.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/variantslib"
 bug-reports: "https://github.com/janestreet/variantslib/issues"
 dev-repo: "git+https://github.com/janestreet/variantslib.git"

--- a/packages/variantslib/variantslib.v0.12.0/opam
+++ b/packages/variantslib/variantslib.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/variantslib"
 bug-reports: "https://github.com/janestreet/variantslib/issues"
 dev-repo: "git+https://github.com/janestreet/variantslib.git"

--- a/packages/variantslib/variantslib.v0.13.0/opam
+++ b/packages/variantslib/variantslib.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/variantslib"
 bug-reports: "https://github.com/janestreet/variantslib/issues"
 dev-repo: "git+https://github.com/janestreet/variantslib.git"

--- a/packages/variantslib/variantslib.v0.14.0/opam
+++ b/packages/variantslib/variantslib.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/variantslib"
 bug-reports: "https://github.com/janestreet/variantslib/issues"
 dev-repo: "git+https://github.com/janestreet/variantslib.git"

--- a/packages/variantslib/variantslib.v0.9.0/opam
+++ b/packages/variantslib/variantslib.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/variantslib"
 bug-reports: "https://github.com/janestreet/variantslib/issues"
 dev-repo: "git+https://github.com/janestreet/variantslib.git"

--- a/packages/vcaml/vcaml.v0.13.0/opam
+++ b/packages/vcaml/vcaml.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/vcaml"
 bug-reports: "https://github.com/janestreet/vcaml/issues"
 dev-repo: "git+https://github.com/janestreet/vcaml.git"

--- a/packages/vcaml/vcaml.v0.14.0/opam
+++ b/packages/vcaml/vcaml.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/vcaml"
 bug-reports: "https://github.com/janestreet/vcaml/issues"
 dev-repo: "git+https://github.com/janestreet/vcaml.git"

--- a/packages/virtual_dom/virtual_dom.v0.10.0/opam
+++ b/packages/virtual_dom/virtual_dom.v0.10.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/virtual_dom"
 bug-reports: "https://github.com/janestreet/virtual_dom/issues"
 dev-repo: "git+https://github.com/janestreet/virtual_dom.git"

--- a/packages/virtual_dom/virtual_dom.v0.11.0/opam
+++ b/packages/virtual_dom/virtual_dom.v0.11.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/virtual_dom"
 bug-reports: "https://github.com/janestreet/virtual_dom/issues"
 dev-repo: "git+https://github.com/janestreet/virtual_dom.git"

--- a/packages/virtual_dom/virtual_dom.v0.12.0/opam
+++ b/packages/virtual_dom/virtual_dom.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/virtual_dom"
 bug-reports: "https://github.com/janestreet/virtual_dom/issues"
 dev-repo: "git+https://github.com/janestreet/virtual_dom.git"

--- a/packages/virtual_dom/virtual_dom.v0.13.0/opam
+++ b/packages/virtual_dom/virtual_dom.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/virtual_dom"
 bug-reports: "https://github.com/janestreet/virtual_dom/issues"
 dev-repo: "git+https://github.com/janestreet/virtual_dom.git"

--- a/packages/virtual_dom/virtual_dom.v0.14.0/opam
+++ b/packages/virtual_dom/virtual_dom.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/virtual_dom"
 bug-reports: "https://github.com/janestreet/virtual_dom/issues"
 dev-repo: "git+https://github.com/janestreet/virtual_dom.git"

--- a/packages/virtual_dom/virtual_dom.v0.9.0/opam
+++ b/packages/virtual_dom/virtual_dom.v0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/virtual_dom"
 bug-reports: "https://github.com/janestreet/virtual_dom/issues"
 dev-repo: "git+https://github.com/janestreet/virtual_dom.git"

--- a/packages/virtual_dom/virtual_dom.v0.9.1/opam
+++ b/packages/virtual_dom/virtual_dom.v0.9.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/virtual_dom"
 bug-reports: "https://github.com/janestreet/virtual_dom/issues"
 dev-repo: "git+https://github.com/janestreet/virtual_dom.git"

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.12.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/zarith_stubs_js"
 bug-reports: "https://github.com/janestreet/zarith_stubs_js/issues"
 dev-repo: "git+https://github.com/janestreet/zarith_stubs_js.git"

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.13.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/zarith_stubs_js"
 bug-reports: "https://github.com/janestreet/zarith_stubs_js/issues"
 dev-repo: "git+https://github.com/janestreet/zarith_stubs_js.git"

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.14.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/zarith_stubs_js"
 bug-reports: "https://github.com/janestreet/zarith_stubs_js/issues"
 dev-repo: "git+https://github.com/janestreet/zarith_stubs_js.git"

--- a/packages/zero/zero.109.15.00/opam
+++ b/packages/zero/zero.109.15.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "zero"]]
 depends: [

--- a/packages/zero/zero.109.17.00/opam
+++ b/packages/zero/zero.109.17.00/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
+maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "zero"]]
 depends: [

--- a/packages/zero/zero.109.19.00/opam
+++ b/packages/zero/zero.109.19.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/zero"
 license: "Apache-2.0"
 build: [

--- a/packages/zero/zero.109.20.00/opam
+++ b/packages/zero/zero.109.20.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/zero"
 license: "Apache-2.0"
 build: [

--- a/packages/zero/zero.109.21.00/opam
+++ b/packages/zero/zero.109.21.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/zero"
 license: "Apache-2.0"
 build: [

--- a/packages/zero/zero.109.27.00/opam
+++ b/packages/zero/zero.109.27.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/zero"
 license: "Apache-2.0"
 build: [

--- a/packages/zero/zero.109.28.00/opam
+++ b/packages/zero/zero.109.28.00/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Capital LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Capital LLC"]
 homepage: "https://github.com/janestreet/zero"
 license: "Apache-2.0"
 bug-reports: "https://github.com/janestreet/zero/issues"

--- a/packages/zstandard/zstandard.v0.12.0/opam
+++ b/packages/zstandard/zstandard.v0.12.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/zstandard"
 bug-reports: "https://github.com/janestreet/zstandard/issues"
 dev-repo: "git+https://github.com/janestreet/zstandard.git"

--- a/packages/zstandard/zstandard.v0.12.1/opam
+++ b/packages/zstandard/zstandard.v0.12.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/zstandard"
 bug-reports: "https://github.com/janestreet/zstandard/issues"
 dev-repo: "git+https://github.com/janestreet/zstandard.git"

--- a/packages/zstandard/zstandard.v0.13.0/opam
+++ b/packages/zstandard/zstandard.v0.13.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/zstandard"
 bug-reports: "https://github.com/janestreet/zstandard/issues"
 dev-repo: "git+https://github.com/janestreet/zstandard.git"

--- a/packages/zstandard/zstandard.v0.14.0/opam
+++ b/packages/zstandard/zstandard.v0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/zstandard"
 bug-reports: "https://github.com/janestreet/zstandard/issues"
 dev-repo: "git+https://github.com/janestreet/zstandard.git"


### PR DESCRIPTION
This PR removes the opensource@janestreet.com email address from Jane Street packages. This is because we are making this list internal to Jane Street only to match the way it is currently being used.

We minted a new email address to use as a point of contact. However, I didn't use it here as it is not meant for opam related queries. Github or slack are the preferred communication channels for such queries.