### PR TITLE
[new release] spin (0.8.0)

### DIFF
--- a/packages/spin/spin.0.8.0/opam
+++ b/packages/spin/spin.0.8.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "OCaml project generator"
+description: "OCaml project generator"
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "ISC"
+homepage: "https://github.com/tmattio/spin"
+doc: "https://tmattio.github.io/spin/"
+bug-reports: "https://github.com/tmattio/spin/issues"
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.7"}
+  "alcotest" {with-test}
+  "js_of_ocaml" {with-test}
+  "js_of_ocaml-ppx" {with-test}
+  "ppxlib" {with-test}
+  "ctypes" {with-test}
+  "odoc" {with-doc}
+  "crunch" {build}
+  "sexplib" {>= "v0.13"}
+  "spawn" {>= "v0.13"}
+  "jingoo" {>= "1.4.0"}
+  "fmt" {>= "0.8.9"}
+  "fpath"
+  "cmdliner"
+  "logs"
+]
+dev-repo: "git+https://github.com/tmattio/spin.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+flags: plugin
+x-commit-hash: "5aad207960ded083a948cf0aea2d5fd2eb5dd555"
+url {
+  src:
+    "https://github.com/tmattio/spin/releases/download/0.8.0/spin-0.8.0.tbz"
+  checksum: [
+    "sha256=2d612f7a55a2cd71177e96c6a5a5d3a7c258b19b4eef9cf994a24b1ec77c3764"
+    "sha512=1b46b047c6f3d3ed38ba38912680e2af802517f30d27ae42ceca4fa1b3954d28ba6922535a322230a57e466f009df499823b39a325f476a9bf938fa2e0cd8f4a"
+  ]
+}


### PR DESCRIPTION
OCaml project generator

- Project page: <a href="https://github.com/tmattio/spin">https://github.com/tmattio/spin</a>
- Documentation: <a href="https://tmattio.github.io/spin/">https://tmattio.github.io/spin/</a>

##### CHANGES:

## Added

- Added a `parse_binaries` stanza that can be `true` to force Spin to parse binary files
- Added a `raw_files` stanza that takes a list of file or glob expressions to instruct Spin to copy files instead of parsing them
- Added a new `c-bindings` template for C bindings using `ctypes`
- Added a new `js` template for javascript applications with `js_of_ocaml`

## Changed

- Removed the `gen` subcommand. The generators will come back with a much better workflow
- Dropped support for Esy and Reason. The templates are now using the recommended OCaml setup only. The previous templates are hosted at https://github.com/ocaml-templates/
- Changed the templates to use the `ISC` license
- Increase version of `ocamlformat` to `0.18.0` in templates
- Do not install merlin when installing dev dependencies in templates
- Drop support for BuckleScript in PPX
- Drop support for publishing on NPM for CLI and PPX templates
- Update CI scripts to `avsm/setup-ocaml@v2`
- Remove python dependency to serve documentation in Makefile
- Inline release script in Makefile
- Remove global `-open StdLabels` in templates
- The `spa` template has been removed from the official templates and now lives at https://github.com/ocaml-templates/spin-incr-dom
- Spin does not parse binary files by default anymore, they are simply copied to the destination folder
- Use `test` stanza for unit tests now that Alcotest prints colors by default
- Remove unused flags defined in the root's `dune` file

## Fixes

- The project generation will now fail before the configurations prompt if the output directory is not empty
- By default, Spin now creates a local switch for the generated projects. This can be changed with `spin config`, or by setting the env variable `SPIN_CREATE_SWITCH=false`
- Fix an CLI incompatibility between `opam.2.0.X` and `opam.2.1.X` that made Spin unusable with the former.
