### PR TITLE
ocaml-base-compiler.4.02.3: use the git release tarball

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
@@ -39,8 +39,8 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
-  checksum: "md5=ef1a324608c97031cbd92a442d685ab7"
+  src: "https://github.com/ocaml/ocaml/archive/4.02.3.tar.gz"
+  checksum: "md5=01e76397e6861773df73b84c5c6c9e8e"
 }
 patches: ["fix-gcc10.patch" "gpr1330.patch"]
 extra-files: [


### PR DESCRIPTION
caml.inria.fr is currently down, so this swaps the 4.02.3 release archive to the one found off the git release tag. Oddly, this is a different checksum due to the following extra files being found in the ocaml git release:

Only in ocaml-4.02.3/compilerlibs: .gitignore
Only in ocaml-4.02.3: experimental
Only in ocaml-4.02.3/ocamlbuild: test

These all look like harmless extra directories that appear to have been stripped out of the caml.inria.fr 4.02.3 release tarball, so this change should be safe enough in opam-repo

(this change is fairly urgent to unbreak the docker-base-images build used in our CI)