### PR TITLE
Package testu01.1.2.3_0.1

### DIFF
--- a/packages/testu01/testu01.1.2.3_0.1/opam
+++ b/packages/testu01/testu01.1.2.3_0.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for TestU01 1.2.3"
+description: """
+This package provides OCaml bindings for TestU01 1.2.3 TestU01 is
+  a software library, implemented in C, and offering a collection of utilities
+  for the empirical statistical testing of uniform random number generators.
+  The OCaml bindings allow for easy testing of random number generators written
+  in OCaml and that claim to be uniform."""
+maintainer: ["Niols “Niols” Jeannerod <niols@niols.fr>"]
+authors: [
+  "Niols “Niols” Jeannerod <niols@niols.fr>"
+  "Martin Pépin <kerl@wkerl.me>"
+]
+homepage: "https://github.com/LesBoloss-es/ocaml-testu01"
+doc: "https://lesboloss-es.github.io/ocaml-testu01/"
+bug-reports: "https://github.com/LesBoloss-es/ocaml-testu01/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.06.0"}
+  "md2mld" {build | with-doc}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/LesBoloss-es/ocaml-testu01.git"
+url {
+  src:
+    "https://github.com/LesBoloss-es/ocaml-testu01/archive/1.2.3_0.1.tar.gz"
+  checksum: [
+    "md5=cbfd65e260acbe0333b8f981158010d1"
+    "sha512=b173b23120f12a69e795fee0568b3dd91d9f82de5778e735c388a2fdeaf614f65e3e667a5e88bfe7f31f17fc04416a6626c9acf0d4fd4c83842ba3a817759d17"
+  ]
+}


### PR DESCRIPTION
### `testu01.1.2.3_0.1`
OCaml bindings for TestU01 1.2.3
This package provides OCaml bindings for TestU01 1.2.3 TestU01 is
  a software library, implemented in C, and offering a collection of utilities
  for the empirical statistical testing of uniform random number generators.
  The OCaml bindings allow for easy testing of random number generators written
  in OCaml and that claim to be uniform.



---
* Homepage: https://github.com/LesBoloss-es/ocaml-testu01
* Source repo: git+https://github.com/LesBoloss-es/ocaml-testu01.git
* Bug tracker: https://github.com/LesBoloss-es/ocaml-testu01/issues

---
:camel: Pull-request generated by opam-publish v2.0.3