### PR TITLE
Package testu01.1.2.3-0.1

### DIFF
--- a/packages/testu01/testu01.1.2.3-0.1/opam
+++ b/packages/testu01/testu01.1.2.3-0.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for TestU01 1.2.3"
+description: """
+This package provides OCaml bindings for TestU01 1.2.3 TestU01 is
+  a software library, implemented in C, and offering a collection of utilities
+  for the empirical statistical testing of uniform random number generators.
+  The OCaml bindings allow for easy testing of random number generators written
+  in OCaml and that claim to be uniform."""
+maintainer: ["Niols “Niols” Jeannerod <niols@niols.fr>"]
+authors: [
+  "Niols “Niols” Jeannerod <niols@niols.fr>"
+  "Martin Pépin <kerl@wkerl.me>"
+]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/LesBoloss-es/ocaml-testu01"
+doc: "https://lesboloss-es.github.io/ocaml-testu01/"
+bug-reports: "https://github.com/LesBoloss-es/ocaml-testu01/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.06.0"}
+  "md2mld" {build | with-doc}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/LesBoloss-es/ocaml-testu01.git"
+url {
+  src:
+    "https://github.com/LesBoloss-es/ocaml-testu01/archive/1.2.3-0.1.tar.gz"
+  checksum: [
+    "md5=9d4ff607c8c87082753fb4a96ec95588"
+    "sha512=4afc45a5020bc6ae6448d0b7f58a0c7c584c5567e848d8bb76b68ce8db926254ce34d21776bb7eea50ca68f93e5f13cc34846dc083f653d6bcb4874882303573"
+  ]
+}


### PR DESCRIPTION
### `testu01.1.2.3-0.1`
OCaml bindings for TestU01 1.2.3
This package provides OCaml bindings for TestU01 1.2.3 TestU01 is
  a software library, implemented in C, and offering a collection of utilities
  for the empirical statistical testing of uniform random number generators.
  The OCaml bindings allow for easy testing of random number generators written
  in OCaml and that claim to be uniform.



---
* Homepage: https://github.com/LesBoloss-es/ocaml-testu01
* Source repo: git+https://github.com/LesBoloss-es/ocaml-testu01.git
* Bug tracker: https://github.com/LesBoloss-es/ocaml-testu01/issues

---
:camel: Pull-request generated by opam-publish v2.0.3