### PR TITLE
mirage-crypto: Add missing lower-bound constraint

### DIFF
--- a/packages/mirage-crypto/mirage-crypto.0.6.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.6.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.7"}
   "dune-configurator" {>= "2.0.0"}
-  "cpuid" {build}
+  "cpuid" {build & >= "0.1.2"}
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
   "ocplib-endian"

--- a/packages/mirage-crypto/mirage-crypto.0.6.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.6.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.7"}
   "dune-configurator" {>= "2.0.0"}
-  "cpuid" {build}
+  "cpuid" {build & >= "0.1.2"}
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
   "ocplib-endian"

--- a/packages/mirage-crypto/mirage-crypto.0.6.2/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.6.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.7"}
   "dune-configurator" {>= "2.0.0"}
-  "cpuid" {build}
+  "cpuid" {build & >= "0.1.2"}
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
   "ocplib-endian"


### PR DESCRIPTION
cpuid < 0.1.2 did not link with result and thus Result.result was an abstract type unless result is loaded)

Detected in https://github.com/ocaml/opam-repository/pull/18758