### PR TITLE
Package lablgtk3-extras.3.0

### DIFF
--- a/packages/lablgtk3-extras/lablgtk3-extras.3.0/opam
+++ b/packages/lablgtk3-extras/lablgtk3-extras.3.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis:
+  "A collection of additional tools and libraries to develop ocaml applications based on Lablgtk3"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: " LGPL-3.0-only"
+tags: ["gtk" "utils" "configuration"]
+homepage: "https://framagit.org/zoggy/lablgtk-extras/"
+doc: "https://framagit.org/zoggy/lablgtk-extras/"
+bug-reports: "https://framagit.org/zoggy/lablgtk-extras/-/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind" {build}
+  "ocf" {>= "0.6.0"}
+  "xmlm" {>= "1.3.0"}
+  "lablgtk3" {>= "3.1.1"}
+  "lablgtk3-sourceview3" {>= "3.1.1"}
+]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://framagit.org/zoggy/lablgtk-extras.git"
+url {
+  src:
+    "https://framagit.org/zoggy/lablgtk-extras/-/archive/3.0/lablgtk-extras-3.0.tar.bz2"
+  checksum: [
+    "md5=ae0c74174ab197d47c859d2ae0bc00f8"
+    "sha512=0d3e64f62d9614623daea7e7752695987c0d05a793714ff500b3c75d6e4d8069d736f947825aa69a2c3f265c41f9965d4496e7fb2ab54757f8837ee44f5ec8fc"
+  ]
+}

--- a/packages/lablgtk3-extras/lablgtk3-extras.3.0/opam
+++ b/packages/lablgtk3-extras/lablgtk3-extras.3.0/opam
@@ -26,7 +26,7 @@ url {
   src:
     "https://framagit.org/zoggy/lablgtk-extras/-/archive/3.0/lablgtk-extras-3.0.tar.bz2"
   checksum: [
-    "md5=ae0c74174ab197d47c859d2ae0bc00f8"
-    "sha512=0d3e64f62d9614623daea7e7752695987c0d05a793714ff500b3c75d6e4d8069d736f947825aa69a2c3f265c41f9965d4496e7fb2ab54757f8837ee44f5ec8fc"
+    "md5=194c7d39d1c74d4b371a748ff187a4d0"
+    "sha512=fb393c1cb439fd07ab9654feef0dd961d0257e4a96d1d5961ae80f67e9643945c922ce4eff5b40ed25f17d14c833420f44380d815ff6e2f80369a3bfcd719ba8"
   ]
 }


### PR DESCRIPTION
### `lablgtk3-extras.3.0`
A collection of additional tools and libraries to develop ocaml applications based on Lablgtk3



---
* Homepage: https://framagit.org/zoggy/lablgtk-extras/
* Source repo: git+https://framagit.org/zoggy/lablgtk-extras.git
* Bug tracker: https://framagit.org/zoggy/lablgtk-extras/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3