### PR TITLE
Package ocf.0.7.0

### DIFF
--- a/packages/ocf/ocf.0.7.0/opam
+++ b/packages/ocf/ocf.0.7.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis:
+  "OCaml library to read and write configuration files in JSON syntax"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["configuration" "options" "json"]
+homepage: "https://zoggy.frama.io/ocf/"
+doc: "https://zoggy.frama.io/ocf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocf/-/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind" {build}
+  "yojson" {>= "1.7.0"}
+  "ppx_tools" {>= "6.3"}
+]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://framagit.org/zoggy/ocf.git"
+url {
+  src: "https://framagit.org/zoggy/ocf/-/archive/0.7.0/ocf-0.7.0.tar.gz"
+  checksum: [
+    "md5=14ad78d1710360954cf75fa5a6aba5d4"
+    "sha512=fbe8a05e30a83446c065538819ce834989a3945be9bc838741ba38346a1d27296d65691b9cb8b1f8a897885e236eb80ada0d9d0c78908a31c3d1160b3962908c"
+  ]
+}


### PR DESCRIPTION
### `ocf.0.7.0`
OCaml library to read and write configuration files in JSON syntax



---
* Homepage: https://zoggy.frama.io/ocf/
* Source repo: git+https://framagit.org/zoggy/ocf.git
* Bug tracker: https://framagit.org/zoggy/ocf/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3