### PR TITLE
kappa-*, KaSim: update urls to opam cache

### DIFF
--- a/packages/KaSim/KaSim.4.0.0/opam
+++ b/packages/KaSim/KaSim.4.0.0/opam
@@ -34,10 +34,8 @@ build: [
   [make "check"] {with-test}
 ]
 install: [ [ make "install-lib" ] ]
-remove: [ [ "ocamlfind" "remove" "KappaLib" ] ]
 
-synopsis: "Software suite for the Kappa language."
-flags: light-uninstall
+synopsis: "Software suite for the Kappa language"
 url {
   src: "https://opam.ocaml.org/cache/md5/89/894a517c7991f42100d2e957efc6cfa2"
   checksum: "md5=894a517c7991f42100d2e957efc6cfa2"

--- a/packages/KaSim/KaSim.4.0.0/opam
+++ b/packages/KaSim/KaSim.4.0.0/opam
@@ -39,6 +39,6 @@ remove: [ [ "ocamlfind" "remove" "KappaLib" ] ]
 synopsis: "Software suite for the Kappa language."
 flags: light-uninstall
 url {
-  src: "https://github.com/Kappa-Dev/KaSim/archive/v4.0.tar.gz"
+  src: "https://opam.ocaml.org/cache/md5/89/894a517c7991f42100d2e957efc6cfa2"
   checksum: "md5=894a517c7991f42100d2e957efc6cfa2"
 }

--- a/packages/KaSim/KaSim.4.0.0/opam
+++ b/packages/KaSim/KaSim.4.0.0/opam
@@ -37,6 +37,6 @@ install: [ [ make "install-lib" ] ]
 
 synopsis: "Software suite for the Kappa language"
 url {
-  src: "https://opam.ocaml.org/cache/md5/89/894a517c7991f42100d2e957efc6cfa2"
-  checksum: "md5=894a517c7991f42100d2e957efc6cfa2"
+  src: "https://github.com/Kappa-Dev/KappaTools/archive/v4.0.tar.gz"
+  checksum: "md5=2f9ee76a8aa8bf2ad6bbb37071759e59"
 }

--- a/packages/kappa-agents/kappa-agents.4.1.0/opam
+++ b/packages/kappa-agents/kappa-agents.4.1.0/opam
@@ -23,9 +23,9 @@ build: ["dune" "build" "-p" name "-j" jobs]
 synopsis: "Backends for an interactive use of the Kappa tool suite"
 
 url {
-  src: "https://opam.ocaml.org/cache/sha256/f2/f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
+  src: "https://github.com/Kappa-Dev/KappaTools/archive/v4.1.tar.gz"
   checksum: [
-    "sha256=f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
-    "sha512=6391d347817a8afc52f9ae121a5778c065cfb21800d462642a962e4c371dc3348e0e5d1c43cf2ab55e800538cff2e384f423343813d446f7353716ac7475df0d"
+    "sha256=8ca79f1917e3b5b0e3606547d8be374321f8eb68dfbe62e805339ac82bc89fd1"
+    "sha512=7c944f27fd2b6752e48e2731b9217954b1f1624b30a5439ab00881d1def5b75aafb044051bdce858a1c766e407a888afeded831705b17fffc35bda02aae45eac"
   ]
 }

--- a/packages/kappa-agents/kappa-agents.4.1.0/opam
+++ b/packages/kappa-agents/kappa-agents.4.1.0/opam
@@ -23,7 +23,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 synopsis: "Backends for an interactive use of the Kappa tool suite"
 
 url {
-  src: "https://github.com/Kappa-Dev/KappaTools/archive/v4.1.tar.gz"
+  src: "https://opam.ocaml.org/cache/sha256/f2/f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
   checksum: [
     "sha256=f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
     "sha512=6391d347817a8afc52f9ae121a5778c065cfb21800d462642a962e4c371dc3348e0e5d1c43cf2ab55e800538cff2e384f423343813d446f7353716ac7475df0d"

--- a/packages/kappa-binaries/kappa-binaries.4.1.0/opam
+++ b/packages/kappa-binaries/kappa-binaries.4.1.0/opam
@@ -27,9 +27,9 @@ build: [
 synopsis: "Command line interfaces of the Kappa tool suite"
 
 url {
-  src: "https://opam.ocaml.org/cache/sha256/f2/f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
+  src: "https://github.com/Kappa-Dev/KappaTools/archive/v4.1.tar.gz"
   checksum: [
-    "sha256=f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
-    "sha512=6391d347817a8afc52f9ae121a5778c065cfb21800d462642a962e4c371dc3348e0e5d1c43cf2ab55e800538cff2e384f423343813d446f7353716ac7475df0d"
+    "sha256=8ca79f1917e3b5b0e3606547d8be374321f8eb68dfbe62e805339ac82bc89fd1"
+    "sha512=7c944f27fd2b6752e48e2731b9217954b1f1624b30a5439ab00881d1def5b75aafb044051bdce858a1c766e407a888afeded831705b17fffc35bda02aae45eac"
   ]
 }

--- a/packages/kappa-binaries/kappa-binaries.4.1.0/opam
+++ b/packages/kappa-binaries/kappa-binaries.4.1.0/opam
@@ -27,7 +27,7 @@ build: [
 synopsis: "Command line interfaces of the Kappa tool suite"
 
 url {
-  src: "https://github.com/Kappa-Dev/KappaTools/archive/v4.1.tar.gz"
+  src: "https://opam.ocaml.org/cache/sha256/f2/f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
   checksum: [
     "sha256=f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
     "sha512=6391d347817a8afc52f9ae121a5778c065cfb21800d462642a962e4c371dc3348e0e5d1c43cf2ab55e800538cff2e384f423343813d446f7353716ac7475df0d"

--- a/packages/kappa-library/kappa-library.4.1.0/opam
+++ b/packages/kappa-library/kappa-library.4.1.0/opam
@@ -27,7 +27,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 synopsis: "Public internals of the Kappa tool suite"
 
 url {
-  src: "https://github.com/Kappa-Dev/KappaTools/archive/v4.1.tar.gz"
+  src: "https://opam.ocaml.org/cache/sha256/f2/f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
   checksum: [
     "sha256=f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
     "sha512=6391d347817a8afc52f9ae121a5778c065cfb21800d462642a962e4c371dc3348e0e5d1c43cf2ab55e800538cff2e384f423343813d446f7353716ac7475df0d"

--- a/packages/kappa-library/kappa-library.4.1.0/opam
+++ b/packages/kappa-library/kappa-library.4.1.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/Kappa-Dev/KappaTools/issues"
 dev-repo: "git+https://github.com/Kappa-Dev/KappaTools.git"
 
 depends : [
-  "ocaml" { >= "4.05.0" }
+  "ocaml" { >= "4.05.0" & < "4.12" }
   "num"
   "re"
   "dune" {>= "1.1"}

--- a/packages/kappa-library/kappa-library.4.1.0/opam
+++ b/packages/kappa-library/kappa-library.4.1.0/opam
@@ -27,9 +27,9 @@ build: ["dune" "build" "-p" name "-j" jobs]
 synopsis: "Public internals of the Kappa tool suite"
 
 url {
-  src: "https://opam.ocaml.org/cache/sha256/f2/f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
+  src: "https://github.com/Kappa-Dev/KappaTools/archive/v4.1.tar.gz"
   checksum: [
-    "sha256=f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
-    "sha512=6391d347817a8afc52f9ae121a5778c065cfb21800d462642a962e4c371dc3348e0e5d1c43cf2ab55e800538cff2e384f423343813d446f7353716ac7475df0d"
+    "sha256=8ca79f1917e3b5b0e3606547d8be374321f8eb68dfbe62e805339ac82bc89fd1"
+    "sha512=7c944f27fd2b6752e48e2731b9217954b1f1624b30a5439ab00881d1def5b75aafb044051bdce858a1c766e407a888afeded831705b17fffc35bda02aae45eac"
   ]
 }

--- a/packages/kappa-server/kappa-server.4.1.0/opam
+++ b/packages/kappa-server/kappa-server.4.1.0/opam
@@ -24,9 +24,9 @@ build: ["dune" "build" "-p" name "-j" jobs]
 synopsis:"HTTP server delivering the Kappa tool suite capabilities"
 
 url {
-  src: "https://opam.ocaml.org/cache/sha256/f2/f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
+  src: "https://github.com/Kappa-Dev/KappaTools/archive/v4.1.tar.gz"
   checksum: [
-    "sha256=f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
-    "sha512=6391d347817a8afc52f9ae121a5778c065cfb21800d462642a962e4c371dc3348e0e5d1c43cf2ab55e800538cff2e384f423343813d446f7353716ac7475df0d"
+    "sha256=8ca79f1917e3b5b0e3606547d8be374321f8eb68dfbe62e805339ac82bc89fd1"
+    "sha512=7c944f27fd2b6752e48e2731b9217954b1f1624b30a5439ab00881d1def5b75aafb044051bdce858a1c766e407a888afeded831705b17fffc35bda02aae45eac"
   ]
 }

--- a/packages/kappa-server/kappa-server.4.1.0/opam
+++ b/packages/kappa-server/kappa-server.4.1.0/opam
@@ -24,7 +24,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 synopsis:"HTTP server delivering the Kappa tool suite capabilities"
 
 url {
-  src: "https://github.com/Kappa-Dev/KappaTools/archive/v4.1.tar.gz"
+  src: "https://opam.ocaml.org/cache/sha256/f2/f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
   checksum: [
     "sha256=f24a38f73a88f1b3d8137aa083bad8d76c679c4b6c59ec29e1567ad95bf1df13"
     "sha512=6391d347817a8afc52f9ae121a5778c065cfb21800d462642a962e4c371dc3348e0e5d1c43cf2ab55e800538cff2e384f423343813d446f7353716ac7475df0d"


### PR DESCRIPTION
The git archives have changed checksum since some time and they
keep failing in the CI. See also https://github.com/Kappa-Dev/KappaTools/issues/636

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>