### PR TITLE
Package itauto.8.13+no

### DIFF
--- a/packages/itauto/itauto.8.13+no/opam
+++ b/packages/itauto/itauto.8.13+no/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
 maintainer: "frederic.besson@inria.fr"
 homepage: "https://gitlab.inria.fr/fbesson/itauto"
-dev-repo: "git://gitlab.inria.fr:fbesson/itauto.git"
+dev-repo: "git://gitlab.inria.fr/fbesson/itauto.git"
 authors: ["Frédéric Besson"]
 bug-reports: "frederic.besson@inria.fr"
-license: "GPL 3"
+license: "GPL-3.0-only"
 synopsis: "'itauto' is a reflexive SAT solver parameterised by a leaf tactic and Nelson-Oppen support"
 build: [
   [make]

--- a/packages/itauto/itauto.8.13+no/opam
+++ b/packages/itauto/itauto.8.13+no/opam
@@ -12,7 +12,6 @@ build: [
 install: [
   [make "install"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cdcl"]
 depends: [
   "ocaml" {>= "4.9~"}
   "coq" {>= "8.13.~" }

--- a/packages/itauto/itauto.8.13+no/opam
+++ b/packages/itauto/itauto.8.13+no/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "frederic.besson@inria.fr"
+homepage: "https://gitlab.inria.fr/fbesson/itauto"
+dev-repo: "git://gitlab.inria.fr:fbesson/itauto.git"
+authors: ["Frédéric Besson"]
+bug-reports: "frederic.besson@inria.fr"
+license: "GPL 3"
+synopsis: "'itauto' is a reflexive SAT solver parameterised by a leaf tactic and Nelson-Oppen support"
+build: [
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cdcl"]
+depends: [
+  "ocaml" {>= "4.9~"}
+  "coq" {>= "8.13.~" }
+  "ocamlbuild" {build }
+]
+depopts: [ "ocamlformat" {build} ]
+
+tags: [
+  "keyword:integers" "keyword:SAT" "keyword:SMT" "keyword:Nelson-Oppen" "keyword:automation"
+  "logpath:Cdcl"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fbesson/itauto/-/archive/8.13+no/itauto-8.13+no.tar.gz"
+  checksum: [
+    "md5=2d7d832b1c36a3726ea8e0995f50f156"
+    "sha512=14574dcb3b98870b5ae37de93800493fc21c6ae1d44517bdcbbf4a5fda839f78968454e2ebdba19225b7db16ada0bdbaccf50c3ba8c890bbd94250c5e48c3719"
+  ]
+}


### PR DESCRIPTION
### `itauto.8.13+no`
'itauto' is a reflexive SAT solver parameterised by a leaf tactic and Nelson-Oppen support



---
* Homepage: https://gitlab.inria.fr/fbesson/itauto
* Source repo: git+ssh://gitlab.inria.fr/fbesson/itauto.git
* Bug tracker: frederic.besson@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.3