### PR TITLE
[new release] ca-certs-nss (3.66)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.66/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.66/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "2.7"}
   "rresult"
   "mirage-crypto"
-  "mirage-clock"
+  "mirage-clock" {>= "3.0.0"}
   "x509" {>= "0.13.0"}
   "ocaml" {>= "4.08.0"}
   "logs" {build}

--- a/packages/ca-certs-nss/ca-certs-nss.3.66/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.66/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "X.509 trust anchors extracted from Mozilla's NSS"
+description: """
+Trust anchors extracted from Mozilla's NSS certdata.txt package,
+to be used in MirageOS unikernels.
+"""
+maintainer: ["Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs-nss"
+doc: "https://mirage.github.io/ca-certs-nss/doc"
+bug-reports: "https://github.com/mirage/ca-certs-nss/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "rresult"
+  "mirage-crypto"
+  "mirage-clock"
+  "x509" {>= "0.13.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs" {build}
+  "fmt" {build}
+  "hex" {build}
+  "bos" {build}
+  "astring" {build}
+  "cmdliner" {build}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ca-certs-nss.git"
+tags: ["org:mirage"]
+x-commit-hash: "b13c128ad6a23001bae04b9444f256f242538e67"
+url {
+  src:
+    "https://github.com/mirage/ca-certs-nss/releases/download/v3.66/ca-certs-nss-v3.66.tbz"
+  checksum: [
+    "sha256=f0f8035b470f2a48360b92d0e6287f41f98e4ba71576a1cd4c9246c468932f09"
+    "sha512=a315941c2133e5782d460dc84fb4675f8eb8281f79d2eb3e6e2578403ce2e64fe96b169ecc7d4f6d3e568ab3aa91412f5d54584d1faed82a6213f9b10d781f5c"
+  ]
+}


### PR DESCRIPTION
X.509 trust anchors extracted from Mozilla's NSS

- Project page: <a href="https://github.com/mirage/ca-certs-nss">https://github.com/mirage/ca-certs-nss</a>
- Documentation: <a href="https://mirage.github.io/ca-certs-nss/doc">https://mirage.github.io/ca-certs-nss/doc</a>

##### CHANGES:

* Update to NSS 3.66 (May 27th 2021)
