### PR TITLE
jsonxt isn't compatible with OCaml == 4.11 (the compiler infinit-loops)

### DIFF
--- a/packages/jsonxt/jsonxt.1.0.0/opam
+++ b/packages/jsonxt/jsonxt.1.0.0/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/stevebleazard/ocaml-jsonxt"
 doc: "https://stevebleazard.github.io/ocaml-jsonxt/"
 bug-reports: "https://github.com/stevebleazard/ocaml-jsonxt/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {(>= "4.03.0" & < "4.11") | (>= "4.12")} # infinit-loops on 4.11
   "dune" {>= "2.0"}
   "alcotest" {with-test}
   "cmdliner" {with-test}


### PR DESCRIPTION
cc @stevebleazard 