### PR TITLE
[new release] metrics-influx, metrics-unix, metrics-lwt, metrics-mirage, metrics and metrics-rusage (0.3.0)

### DIFF
--- a/packages/metrics-influx/metrics-influx.0.3.0/opam
+++ b/packages/metrics-influx/metrics-influx.0.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Hannes Mehnert"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "astring"
+  "fmt"
+  "duration"
+  "lwt"
+]
+synopsis: "Influx reporter for the Metrics library"
+x-commit-hash: "0f48d63c5e1c0e33d7043b2c6e053ba380516433"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.3.0/metrics-v0.3.0.tbz"
+  checksum: [
+    "sha256=49e917c8c4500ff04723c6845d3c726fe340bfc8724430702a5ce5026dfc50b1"
+    "sha512=eb14762a34b78d5b27ac4b312815a6b5aaaf8316eb458bfd9685f60feefa924fdb09ee39b7d4b4007bf49deb7e4eb0eb80464ba86a7feeaaed30f58f9dce432c"
+  ]
+}

--- a/packages/metrics-lwt/metrics-lwt.0.3.0/opam
+++ b/packages/metrics-lwt/metrics-lwt.0.3.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "lwt"
+  "logs"
+]
+synopsis: "Lwt backend for the Metrics library"
+x-commit-hash: "0f48d63c5e1c0e33d7043b2c6e053ba380516433"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.3.0/metrics-v0.3.0.tbz"
+  checksum: [
+    "sha256=49e917c8c4500ff04723c6845d3c726fe340bfc8724430702a5ce5026dfc50b1"
+    "sha512=eb14762a34b78d5b27ac4b312815a6b5aaaf8316eb458bfd9685f60feefa924fdb09ee39b7d4b4007bf49deb7e4eb0eb80464ba86a7feeaaed30f58f9dce432c"
+  ]
+}

--- a/packages/metrics-mirage/metrics-mirage.0.3.0/opam
+++ b/packages/metrics-mirage/metrics-mirage.0.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Hannes Mehnert"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "metrics-influx" {= version}
+  "ipaddr"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
+  "cstruct"
+  "logs"
+]
+synopsis: "Mirage backend for the Metrics library"
+x-commit-hash: "0f48d63c5e1c0e33d7043b2c6e053ba380516433"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.3.0/metrics-v0.3.0.tbz"
+  checksum: [
+    "sha256=49e917c8c4500ff04723c6845d3c726fe340bfc8724430702a5ce5026dfc50b1"
+    "sha512=eb14762a34b78d5b27ac4b312815a6b5aaaf8316eb458bfd9685f60feefa924fdb09ee39b7d4b4007bf49deb7e4eb0eb80464ba86a7feeaaed30f58f9dce432c"
+  ]
+}

--- a/packages/metrics-rusage/metrics-rusage.0.3.0/opam
+++ b/packages/metrics-rusage/metrics-rusage.0.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "team@robur.coop"
+authors:      ["Reynir Bjoernsson" "Hannes Mehnert"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "logs"
+  "fmt"
+  "rresult"
+]
+synopsis: "Resource usage (getrusage) sources for the Metrics library"
+x-commit-hash: "0f48d63c5e1c0e33d7043b2c6e053ba380516433"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.3.0/metrics-v0.3.0.tbz"
+  checksum: [
+    "sha256=49e917c8c4500ff04723c6845d3c726fe340bfc8724430702a5ce5026dfc50b1"
+    "sha512=eb14762a34b78d5b27ac4b312815a6b5aaaf8316eb458bfd9685f60feefa924fdb09ee39b7d4b4007bf49deb7e4eb0eb80464ba86a7feeaaed30f58f9dce432c"
+  ]
+}

--- a/packages/metrics-unix/metrics-unix.0.3.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.3.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.4"}
-  "uuidm"
+  "uuidm" {>= "0.9.6"}
   "metrics" {= version}
   "mtime" {>= "1.0.0"}
   "lwt"

--- a/packages/metrics-unix/metrics-unix.0.3.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "uuidm"
+  "metrics" {= version}
+  "mtime" {>= "1.0.0"}
+  "lwt"
+  "metrics-lwt" {= version & with-test}
+  "conf-gnuplot"
+  "fmt"
+]
+synopsis: "Unix backend for the Metrics library"
+x-commit-hash: "0f48d63c5e1c0e33d7043b2c6e053ba380516433"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.3.0/metrics-v0.3.0.tbz"
+  checksum: [
+    "sha256=49e917c8c4500ff04723c6845d3c726fe340bfc8724430702a5ce5026dfc50b1"
+    "sha512=eb14762a34b78d5b27ac4b312815a6b5aaaf8316eb458bfd9685f60feefa924fdb09ee39b7d4b4007bf49deb7e4eb0eb80464ba86a7feeaaed30f58f9dce432c"
+  ]
+}

--- a/packages/metrics-unix/metrics-unix.0.3.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.3.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "metrics-lwt" {= version & with-test}
   "conf-gnuplot"
-  "fmt"
+  "fmt" {>= "0.8.5"}
 ]
 synopsis: "Unix backend for the Metrics library"
 x-commit-hash: "0f48d63c5e1c0e33d7043b2c6e053ba380516433"

--- a/packages/metrics/metrics.0.3.0/opam
+++ b/packages/metrics/metrics.0.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.4"}
+  "fmt"
+  "alcotest" {with-test}
+]
+synopsis: "Metrics infrastructure for OCaml"
+description: """
+Metrics provides a basic infrastructure to monitor and gather runtime
+metrics for OCaml program. Monitoring is performed on sources, indexed
+by tags, allowing users to enable or disable at runtime the gathering
+of data-points. As disabled metric sources have a low runtime cost
+(only a closure allocation), the library is designed to instrument
+production systems.
+
+Metric reporting is decoupled from monitoring and is handled by a
+custom reporter. A few reporters are (will be) provided by default.
+
+Metrics is heavily inspired by
+[Logs](http://erratique.ch/software/logs).
+"""
+x-commit-hash: "0f48d63c5e1c0e33d7043b2c6e053ba380516433"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.3.0/metrics-v0.3.0.tbz"
+  checksum: [
+    "sha256=49e917c8c4500ff04723c6845d3c726fe340bfc8724430702a5ce5026dfc50b1"
+    "sha512=eb14762a34b78d5b27ac4b312815a6b5aaaf8316eb458bfd9685f60feefa924fdb09ee39b7d4b4007bf49deb7e4eb0eb80464ba86a7feeaaed30f58f9dce432c"
+  ]
+}


### PR DESCRIPTION
Influx reporter for the Metrics library

- Project page: <a href="https://github.com/mirage/metrics">https://github.com/mirage/metrics</a>
- Documentation: <a href="https://mirage.github.io/metrics/">https://mirage.github.io/metrics/</a>

##### CHANGES:

- Add a metrics-rusage opam package that collects data from getrusage and
  /proc/self/stat (and /proc/self/statm). (mirage/metrics#50, @reynir and @hannesm)
- Update ocamlformat to 0.18.0
- "pinned" is now "dev" in opam files
