### PR TITLE
genet.0.6 isn't compatible with OCaml >= 4.06 (uses unsafe strings)

### DIFF
--- a/packages/genet/genet.0.6/opam
+++ b/packages/genet/genet.0.6/opam
@@ -17,7 +17,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "genet"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "4.06"}
   "ocamlfind"
   "config-file" {>= "1.1"}
   "lablgtk-extras" {>= "1.2"}


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/18777
cc @zoggy 