### PR TITLE
2 packages from c-cube/tiny_httpd at 0.8

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.8/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.8/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Minimal HTTP server using good old threads"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "base-threads"
+  "ocaml" { >= "4.04.0" }
+  "odoc" {with-doc}
+  "qtest" { >= "2.9" & with-test}
+  "qcheck" {with-test & >= "0.9" }
+  "ounit2" {with-test}
+]
+tags: [ "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+post-messages: "tiny http server, with blocking IOs. Also ships with a `http_of_dir` program."
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/v0.8.tar.gz"
+  checksum: [
+    "md5=fec41ef42263443e234cc166e571f826"
+    "sha512=1f8bd150e21b66c491b881d3eb689d8aeedbaa88cb95aa7c3c7a49f1deaa2021d76a00769a306008b33e0e3166dfc0693e96f74ec2b2e8e5a20a218e1e99d819"
+  ]
+}

--- a/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.8/opam
+++ b/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.8/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Interface to camlzip for tiny_httpd"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "camlzip"
+  "tiny_httpd" { = version }
+  "ocaml" { >= "4.04.0" }
+  "odoc" {with-doc}
+]
+tags: [ "http" "thread" "server" "gzip" "camlzip" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/v0.8.tar.gz"
+  checksum: [
+    "md5=fec41ef42263443e234cc166e571f826"
+    "sha512=1f8bd150e21b66c491b881d3eb689d8aeedbaa88cb95aa7c3c7a49f1deaa2021d76a00769a306008b33e0e3166dfc0693e96f74ec2b2e8e5a20a218e1e99d819"
+  ]
+}

--- a/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.8/opam
+++ b/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.8/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "dune" { >= "2.0" }
-  "camlzip"
+  "camlzip" {>= "1.06"}
   "tiny_httpd" { = version }
   "ocaml" { >= "4.04.0" }
   "odoc" {with-doc}


### PR DESCRIPTION
This pull-request concerns:
-`tiny_httpd.0.8`: Minimal HTTP server using good old threads
-`tiny_httpd_camlzip.0.8`: Interface to camlzip for tiny_httpd



---
* Homepage: https://github.com/c-cube/tiny_httpd/
* Source repo: git+https://github.com/c-cube/tiny_httpd.git
* Bug tracker: https://github.com/c-cube/tiny_httpd/issues

---
:camel: Pull-request generated by opam-publish v2.0.0