### PR TITLE
Update OCaml dev packages for 4.13

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.14.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0+trunk/opam
@@ -1,12 +1,12 @@
 opam-version: "2.0"
-synopsis: "Latest 4.13 developmet"
+synopsis: "Current trunk"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
 depends: [
-  "ocaml" {= "4.13.0" & post}
+  "ocaml" {= "4.14.0" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -51,7 +51,7 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/4.13.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 }
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism

--- a/packages/ocaml/ocaml.4.14.0/opam
+++ b/packages/ocaml/ocaml.4.14.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-config" {>= "2"}
+  "ocaml-base-compiler" {= "4.14.0"} |
+  "ocaml-variants" {>= "4.14.0" & < "4.14.1~"} |
+  "ocaml-system" {>= "4.14.0" & < "4.14.1~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: CAML_LD_LIBRARY_PATH = ""
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]


### PR DESCRIPTION
This PR updates the dev packages (4.13.0+trunk, 4.14.0+trunk and the virtual package for 4.14.0) for the compiler after the branching of OCaml 4.13 . 