### PR TITLE
[new release] msgpck and msgpck-repr (1.7)

### DIFF
--- a/packages/msgpck-repr/msgpck-repr.1.7/opam
+++ b/packages/msgpck-repr/msgpck-repr.1.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-msgpck"
+license: "ISC"
+dev-repo: "git+https://github.com/vbmithr/ocaml-msgpck.git"
+bug-reports: "https://github.com/vbmithr/ocaml-msgpck/issues"
+depends: [
+  "dune" {>= "1.11.4"}
+  "msgpck" {= version}
+  "ocplib-json-typed" {>= "0.7.1"}
+  "ocaml" {>= "4.08.0"}
+]
+build:[ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Fast MessagePack (http://msgpack.org) library -- ocplib-json-typed interface"
+description: """
+Interface between msgpck and ocplib-json-typed.
+"""
+x-commit-hash: "657d0ecddec4e08c4ffc30a3a3a4b395cd87d4a7"
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-msgpck/releases/download/1.7/msgpck-1.7.tbz"
+  checksum: [
+    "sha256=c8fe0b605496f23feb67a82bfd42c46e6c0a1ca493b7f5164912ff7e83112676"
+    "sha512=cf6826c8e74ba7fc1546195f4f50b405905c0f7a5eafddfb93a274a3a4064a7fb4d82c9d2c69e37cde5197c5b0a8e79b0e7021c0d74a0a7c440d641ce696df0c"
+  ]
+}

--- a/packages/msgpck/msgpck.1.7/opam
+++ b/packages/msgpck/msgpck.1.7/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-msgpck"
+license: "ISC"
+dev-repo: "git+https://github.com/vbmithr/ocaml-msgpck.git"
+bug-reports: "https://github.com/vbmithr/ocaml-msgpck/issues"
+doc: "https://vbmithr.github.io/ocaml-msgpck/doc"
+tags: ["messagepack" "msgpack" "binary" "serialization"]
+depends: [
+  "dune" {>= "1.11.4"}
+  "ocplib-endian" {>= "1.0"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {with-test & >= "0.8.5"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test:  [ "dune" "runtest" "-p" name "-j" jobs ]
+
+synopsis: "Fast MessagePack (http://msgpack.org) library"
+description: """
+msgpck is written in pure OCaml.
+
+MessagePack is an efficient binary serialization format. It lets you
+exchange data among multiple languages like JSON. But it's faster and
+smaller. Small integers are encoded into a single byte, and typical
+short strings require only one extra byte in addition to the strings
+themselves."""
+x-commit-hash: "657d0ecddec4e08c4ffc30a3a3a4b395cd87d4a7"
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-msgpck/releases/download/1.7/msgpck-1.7.tbz"
+  checksum: [
+    "sha256=c8fe0b605496f23feb67a82bfd42c46e6c0a1ca493b7f5164912ff7e83112676"
+    "sha512=cf6826c8e74ba7fc1546195f4f50b405905c0f7a5eafddfb93a274a3a4064a7fb4d82c9d2c69e37cde5197c5b0a8e79b0e7021c0d74a0a7c440d641ce696df0c"
+  ]
+}


### PR DESCRIPTION
Fast MessagePack (http://msgpack.org) library

- Project page: <a href="https://github.com/vbmithr/ocaml-msgpck">https://github.com/vbmithr/ocaml-msgpck</a>
- Documentation: <a href="https://vbmithr.github.io/ocaml-msgpck/doc">https://vbmithr.github.io/ocaml-msgpck/doc</a>

##### CHANGES:

* bugfix: fix buffer overflows by not using _unsafe ocplib-endian functions
