### PR TITLE
[new release] opam-spin and spin (0.8.1)

### DIFF
--- a/packages/opam-spin/opam-spin.0.8.1/opam
+++ b/packages/opam-spin/opam-spin.0.8.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Opam plugin for Spin, the OCaml project generator"
+description: "Opam plugin for Spin, the OCaml project generator"
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "ISC"
+homepage: "https://github.com/tmattio/spin"
+doc: "https://tmattio.github.io/spin/"
+bug-reports: "https://github.com/tmattio/spin/issues"
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.8"}
+  "spin" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmattio/spin.git"
+flags: plugin
+x-commit-hash: "41fd73b8005d840590927434ad8a7c95e4d26e45"
+url {
+  src:
+    "https://github.com/tmattio/spin/releases/download/0.8.1/opam-spin-0.8.1.tbz"
+  checksum: [
+    "sha256=cd1ca43c7d3bb11be0b525642e57aa98e4d8250aea6c2fdb5c70b120449abdc1"
+    "sha512=0ff1e8886a49773d8ead3a21df1fb46697954fb43e875bd1ddc4cb95542fe0a767c556c432d78b47654a1f3d361800c234486e4cc237b9aa8d4df22e5a3a1ff9"
+  ]
+}

--- a/packages/spin/spin.0.8.0/opam
+++ b/packages/spin/spin.0.8.0/opam
@@ -39,7 +39,6 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-flags: plugin
 x-commit-hash: "5aad207960ded083a948cf0aea2d5fd2eb5dd555"
 url {
   src:

--- a/packages/spin/spin.0.8.1/opam
+++ b/packages/spin/spin.0.8.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "OCaml project generator"
+description: "OCaml project generator"
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "ISC"
+homepage: "https://github.com/tmattio/spin"
+doc: "https://tmattio.github.io/spin/"
+bug-reports: "https://github.com/tmattio/spin/issues"
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.8"}
+  "alcotest" {with-test}
+  "js_of_ocaml" {with-test}
+  "js_of_ocaml-ppx" {with-test}
+  "ppxlib" {with-test}
+  "ctypes" {with-test}
+  "odoc" {with-doc}
+  "crunch" {build}
+  "sexplib" {>= "v0.13"}
+  "spawn" {>= "v0.13"}
+  "jingoo" {>= "1.4.0"}
+  "fmt" {>= "0.8.9"}
+  "fpath"
+  "cmdliner"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmattio/spin.git"
+x-commit-hash: "41fd73b8005d840590927434ad8a7c95e4d26e45"
+url {
+  src:
+    "https://github.com/tmattio/spin/releases/download/0.8.1/opam-spin-0.8.1.tbz"
+  checksum: [
+    "sha256=cd1ca43c7d3bb11be0b525642e57aa98e4d8250aea6c2fdb5c70b120449abdc1"
+    "sha512=0ff1e8886a49773d8ead3a21df1fb46697954fb43e875bd1ddc4cb95542fe0a767c556c432d78b47654a1f3d361800c234486e4cc237b9aa8d4df22e5a3a1ff9"
+  ]
+}


### PR DESCRIPTION
Opam plugin for Spin, the OCaml project generator

- Project page: <a href="https://github.com/tmattio/spin">https://github.com/tmattio/spin</a>
- Documentation: <a href="https://tmattio.github.io/spin/">https://tmattio.github.io/spin/</a>

##### CHANGES:

## Changed

- Split the opam plugin in an `opam-spin` package.
