### PR TITLE
[new release] tls-mirage, tls and tls-async (0.13.2)

### DIFF
--- a/packages/tls-async/tls-async.0.13.2/opam
+++ b/packages/tls-async/tls-async.0.13.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "tls" {= version}
+  "x509" {>= "0.13.0"}
+  "ptime" {>= "0.8.1"}
+  "async"
+  "async_unix"
+  "core"
+  "cstruct-async"
+  "ppx_jane"
+  "mirage-crypto-rng-async"
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Async layer"
+description: """
+Tls-async provides Async-friendly tls bindings
+"""
+x-commit-hash: "befd1ab0e38a6a4971002be9e58db7081685ab12"
+authors: [
+  "David Kaloper <david@numm.org>"
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Eric Ebinger <github@eric.theebingers.com>"
+  "Calascibetta Romain <romain.calascibetta@gmail.com>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.13.2/tls-v0.13.2.tbz"
+  checksum: [
+    "sha256=204e85baf7a6f00de567f33c18b358370086fafec16cf43841d612f9f293e747"
+    "sha512=dabfbcc1bb096e00f0b11ab171aa9b59553230091453796417f2b0901427335ab81f690e45fb5313c903e2eecb1020eb10e6171debf881abbfeebee02fb30bcd"
+  ]
+}

--- a/packages/tls-async/tls-async.0.13.2/opam
+++ b/packages/tls-async/tls-async.0.13.2/opam
@@ -18,11 +18,11 @@ depends: [
   "tls" {= version}
   "x509" {>= "0.13.0"}
   "ptime" {>= "0.8.1"}
-  "async"
-  "async_unix"
-  "core"
+  "async" {>= "v0.14"}
+  "async_unix" {>= "v0.14"}
+  "core" {>= "v0.14"}
   "cstruct-async"
-  "ppx_jane"
+  "ppx_jane" {>= "v0.14"}
   "mirage-crypto-rng-async"
 ]
 tags: [ "org:mirage"]

--- a/packages/tls-mirage/tls-mirage.0.13.2/opam
+++ b/packages/tls-mirage/tls-mirage.0.13.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "tls" {= version}
+  "x509" {>= "0.13.0"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"
+description: """
+Tls-mirage provides an effectful FLOW module to be used in the MirageOS
+ecosystem.
+"""
+x-commit-hash: "befd1ab0e38a6a4971002be9e58db7081685ab12"
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.13.2/tls-v0.13.2.tbz"
+  checksum: [
+    "sha256=204e85baf7a6f00de567f33c18b358370086fafec16cf43841d612f9f293e747"
+    "sha512=dabfbcc1bb096e00f0b11ab171aa9b59553230091453796417f2b0901427335ab81f690e45fb5313c903e2eecb1020eb10e6171debf881abbfeebee02fb30bcd"
+  ]
+}

--- a/packages/tls/tls.0.13.2/opam
+++ b/packages/tls/tls.0.13.2/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_cstruct" {>= "3.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "cstruct-sexp"
+  "sexplib"
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "x509" {>= "0.13.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt"
+  "rresult"
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "ounit2" {with-test & >= "2.2.0"}
+  "lwt" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "hkdf"
+  "logs"
+  "alcotest" {with-test}
+  "randomconv" {with-test}
+]
+
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+x-commit-hash: "befd1ab0e38a6a4971002be9e58db7081685ab12"
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.13.2/tls-v0.13.2.tbz"
+  checksum: [
+    "sha256=204e85baf7a6f00de567f33c18b358370086fafec16cf43841d612f9f293e747"
+    "sha512=dabfbcc1bb096e00f0b11ab171aa9b59553230091453796417f2b0901427335ab81f690e45fb5313c903e2eecb1020eb10e6171debf881abbfeebee02fb30bcd"
+  ]
+}


### PR DESCRIPTION
Transport Layer Security purely in OCaml, MirageOS layer

- Project page: <a href="https://github.com/mirleft/ocaml-tls">https://github.com/mirleft/ocaml-tls</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-tls/doc">https://mirleft.github.io/ocaml-tls/doc</a>

##### CHANGES:

* New package tls-async that provides an effectful layer of TLS using async.
  (mirleft/ocaml-tls#432, @torinnd, @dinosaure, @kit-ty-kate, reviews by @hannesm @avsm @seliopou)
