### PR TITLE
Package smtlib-utils.0.3.1

### DIFF
--- a/packages/smtlib-utils/smtlib-utils.0.3.1/opam
+++ b/packages/smtlib-utils/smtlib-utils.0.3.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Parser for SMTLIB2"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-bytes"
+  "result"
+  "menhir" {build}
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "SMTLIB" "smt2" "parse" "logic" ]
+homepage: "https://github.com/c-cube/smtlib-utils/"
+bug-reports: "https://github.com/c-cube/smtlib-utils/issues"
+dev-repo: "git+https://github.com/c-cube/smtlib-utils.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/smtlib-utils/archive/v0.3.1.tar.gz"
+  checksum: [
+    "md5=503837ab6749d36b18da5a1900232137"
+    "sha512=c441195b5941ffafb80eee8745c3b76bd8103047915fe8aa89cd0eac8f2531e92246fafddc16b0aa4b8b14845f7365b9eac7408669deb2a9bb684b7236548363"
+  ]
+}


### PR DESCRIPTION
### `smtlib-utils.0.3.1`
Parser for SMTLIB2



---
* Homepage: https://github.com/c-cube/smtlib-utils/
* Source repo: git+https://github.com/c-cube/smtlib-utils.git
* Bug tracker: https://github.com/c-cube/smtlib-utils/issues

---
:camel: Pull-request generated by opam-publish v2.0.3