### PR TITLE
Package smtlib-utils.0.3.1

### DIFF
--- a/packages/smtlib-utils/smtlib-utils.0.3.1/opam
+++ b/packages/smtlib-utils/smtlib-utils.0.3.1/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes.2007@m4x.org"
 synopsis: "Parser for SMTLIB2"
+license: "BSD-2-Clause"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/smtlib-utils/smtlib-utils.0.3.1/opam
+++ b/packages/smtlib-utils/smtlib-utils.0.3.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Parser for SMTLIB2"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-bytes"
+  "result"
+  "menhir" {build}
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "SMTLIB" "smt2" "parse" "logic" ]
+homepage: "https://github.com/c-cube/smtlib-utils/"
+bug-reports: "https://github.com/c-cube/smtlib-utils/issues"
+dev-repo: "git+https://github.com/c-cube/smtlib-utils.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/smtlib-utils/archive/v0.3.1.tar.gz"
+  checksum: [
+    "md5=e7d7756bcd31a576f1bfe368445d9b72"
+    "sha512=757d99214708f3331baac71f21572e57ce6d54a5eb591a3612bad3d86c4b722c7dbd27bd4a5edbeba96159b9fc192f14d5371395133bbc7db9b6a1c803caeba6"
+  ]
+}


### PR DESCRIPTION
### `smtlib-utils.0.3.1`
Parser for SMTLIB2



---
* Homepage: https://github.com/c-cube/smtlib-utils/
* Source repo: git+https://github.com/c-cube/smtlib-utils.git
* Bug tracker: https://github.com/c-cube/smtlib-utils/issues

---
:camel: Pull-request generated by opam-publish v2.0.3