### PR TITLE
mm >= 0.6.0: Add missing constraint

### DIFF
--- a/packages/mm/mm.0.6.0/opam
+++ b/packages/mm/mm.0.6.0/opam
@@ -25,6 +25,9 @@ depopts: [
   "ocamlsdl"
   "theora"
 ]
+conflicts: [
+  "alsa" {< "0.3.0"}
+]
 bug-reports: "https://github.com/savonet/ocaml-mm/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-mm.git"
 synopsis:

--- a/packages/mm/mm.0.7.0/opam
+++ b/packages/mm/mm.0.7.0/opam
@@ -23,6 +23,7 @@ depexts: [
 ]
 conflicts: [
   "mad" {< "0.5.0"}
+  "alsa" {< "0.3.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/mm/mm.0.7.1/opam
+++ b/packages/mm/mm.0.7.1/opam
@@ -13,6 +13,7 @@ depends: [
 depopts: ["alsa" "ao" "mad" "pulseaudio" "ocamlsdl" "theora"]
 conflicts: [
   "mad" {< "0.5.0"}
+  "alsa" {< "0.3.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Should fix https://github.com/ocaml/opam-repository/issues/18801
cc @toots @smimram 