### PR TITLE
[new release] current_slack, current_rpc, current_examples, current_docker, current_incr, current_git, current_web, current_github and current (0.5)

### DIFF
--- a/packages/current/current.0.5/opam
+++ b/packages/current/current.0.5/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Pipeline language for keeping things up-to-date"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+It is used in ocaml-ci (which provides CI for OCaml projects on GitHub),
+and in docker-base-images (a pipeline that builds Docker images for various
+Linux distributions, OCaml compiler versions and CPU types, and pushes them
+to Docker Hub).
+
+A pipeline is written much like you would write a one-shot sequential script,
+but OCurrent will automatically re-run steps when the inputs change, and will
+run steps in parallel where possible."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "current_incr" {= version}
+  "fmt" {>= "0.8.9"}
+  "bos"
+  "ppx_deriving"
+  "lwt" {>= "4.3.0"}
+  "cmdliner"
+  "sqlite3"
+  "duration"
+  "prometheus"
+  "dune" {>= "2.0"}
+  "re" {>= "1.9.0"}
+  "lwt-dllist"
+  "alcotest" {>= "1.2.0" & with-test}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "astring" {>= "0.8.5"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
+  "prometheus-app" {>= "0.7" & with-test}
+]
+conflicts: [
+  "seq" {< "base"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "439d1b539335ee3aa974ff6c02e09885f40056b5"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.5/current-v0.5.tbz"
+  checksum: [
+    "sha256=f8c884318a46a568d965c7e8bac00dfe2339efac04ca6f0cbabef916d8b917ca"
+    "sha512=e0633239a7d02cdde6264db96c39ed7e3d1adf3a7f09bb25ad002d388f203b561e8c808daee90539bc0ee15c547d2ab4bef1789dcc9c22ed00b151bad0083f64"
+  ]
+}
+license: "Apache-2.0"

--- a/packages/current_docker/current_docker.0.5/opam
+++ b/packages/current_docker/current_docker.0.5/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "OCurrent Docker plugin"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a plugin for interacting with Docker.
+It can pull, build, run and push images, and can coordinate
+multiple Docker Engine instances."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "ppx_deriving"
+  "lwt"
+  "dockerfile"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune" {>= "2.0"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "duration" {>= "0.1.3"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "439d1b539335ee3aa974ff6c02e09885f40056b5"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.5/current-v0.5.tbz"
+  checksum: [
+    "sha256=f8c884318a46a568d965c7e8bac00dfe2339efac04ca6f0cbabef916d8b917ca"
+    "sha512=e0633239a7d02cdde6264db96c39ed7e3d1adf3a7f09bb25ad002d388f203b561e8c808daee90539bc0ee15c547d2ab4bef1789dcc9c22ed00b151bad0083f64"
+  ]
+}
+license: "Apache-2.0"

--- a/packages/current_examples/current_examples.0.5/opam
+++ b/packages/current_examples/current_examples.0.5/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Example pipelines for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides some example pipelines.
+It exists mainly to test the integration of various OCurrent
+plugins."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "lwt"
+  "cmdliner"
+  "duration"
+  "current" {= version}
+  "current_web" {= version}
+  "current_git" {= version}
+  "current_github" {= version}
+  "current_docker" {= version}
+  "current_rpc" {= version}
+  "capnp-rpc-unix" {>= "0.5"}
+  "dune" {>= "2.0"}
+  "capnp-rpc" {>= "0.8.0"}
+  "capnp-rpc-lwt" {>= "0.8.0"}
+  "capnp-rpc-net" {>= "0.8.0"}
+  "dockerfile" {>= "7.0.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "routes" {>= "0.8.0"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+  "prometheus-app" {>= "1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "439d1b539335ee3aa974ff6c02e09885f40056b5"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.5/current-v0.5.tbz"
+  checksum: [
+    "sha256=f8c884318a46a568d965c7e8bac00dfe2339efac04ca6f0cbabef916d8b917ca"
+    "sha512=e0633239a7d02cdde6264db96c39ed7e3d1adf3a7f09bb25ad002d388f203b561e8c808daee90539bc0ee15c547d2ab4bef1789dcc9c22ed00b151bad0083f64"
+  ]
+}
+license: "Apache-2.0"

--- a/packages/current_git/current_git.0.5/opam
+++ b/packages/current_git/current_git.0.5/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Git plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Git.
+It can pull from remote repositories, or monitor local ones for changes."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "conf-git"
+  "fmt" {>= "0.8.9"}
+  "ppx_deriving"
+  "lwt"
+  "irmin-watcher"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune" {>= "2.0"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
+  "cstruct" {>= "5.0.0"}
+  "mirage-crypto" {>= "0.8.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "439d1b539335ee3aa974ff6c02e09885f40056b5"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.5/current-v0.5.tbz"
+  checksum: [
+    "sha256=f8c884318a46a568d965c7e8bac00dfe2339efac04ca6f0cbabef916d8b917ca"
+    "sha512=e0633239a7d02cdde6264db96c39ed7e3d1adf3a7f09bb25ad002d388f203b561e8c808daee90539bc0ee15c547d2ab4bef1789dcc9c22ed00b151bad0083f64"
+  ]
+}
+license: "Apache-2.0"

--- a/packages/current_github/current_github.0.5/opam
+++ b/packages/current_github/current_github.0.5/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "GitHub plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with GitHub.
+It can monitor and clone remote GitHub repositories, and can
+push GitHub status messages to show the results of testing
+PRs and branches."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "current_web" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "lwt"
+  "duration"
+  "ptime"
+  "yojson"
+  "cohttp-lwt-unix" {< "3.0.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "x509" {>= "0.10.0"}
+  "tls" {>= "0.11.0"}
+  "dune" {>= "2.0"}
+  "astring" {>= "0.8.5"}
+  "base64" {>= "3.4.0"}
+  "cmdliner" {>= "1.0.4"}
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "cstruct" {>= "5.2.0"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "tyxml" {>= "4.4.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "439d1b539335ee3aa974ff6c02e09885f40056b5"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.5/current-v0.5.tbz"
+  checksum: [
+    "sha256=f8c884318a46a568d965c7e8bac00dfe2339efac04ca6f0cbabef916d8b917ca"
+    "sha512=e0633239a7d02cdde6264db96c39ed7e3d1adf3a7f09bb25ad002d388f203b561e8c808daee90539bc0ee15c547d2ab4bef1789dcc9c22ed00b151bad0083f64"
+  ]
+}
+license: "Apache-2.0"

--- a/packages/current_incr/current_incr.0.5/opam
+++ b/packages/current_incr/current_incr.0.5/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Self-adjusting computations"
+description: """\
+This is a small, self-contained library for self-adjusting (incremental) computations.
+It was written for OCurrent, but can be used separately too.
+
+It is similar to Jane Street's incremental library, but much smaller and
+has no external dependencies.
+
+It is also similar to the react library, but the results do not depend on the
+behaviour of the garbage collector. In particular, functions stop being called
+as soon as they are no longer needed."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "439d1b539335ee3aa974ff6c02e09885f40056b5"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.5/current-v0.5.tbz"
+  checksum: [
+    "sha256=f8c884318a46a568d965c7e8bac00dfe2339efac04ca6f0cbabef916d8b917ca"
+    "sha512=e0633239a7d02cdde6264db96c39ed7e3d1adf3a7f09bb25ad002d388f203b561e8c808daee90539bc0ee15c547d2ab4bef1789dcc9c22ed00b151bad0083f64"
+  ]
+}
+license: "Apache-2.0"

--- a/packages/current_rpc/current_rpc.0.5/opam
+++ b/packages/current_rpc/current_rpc.0.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Cap'n Proto RPC plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a Cap'n Proto RPC interface, allowing
+an OCurrent engine to be controlled remotely."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {>= "0.8.0"}
+  "capnp-rpc-lwt" {>= "0.4"}
+  "fpath"
+  "dune" {>= "2.0"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "stdint" {>= "0.7.0"}
+]
+conflicts: [
+  "x509" {= "0.11.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "439d1b539335ee3aa974ff6c02e09885f40056b5"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.5/current-v0.5.tbz"
+  checksum: [
+    "sha256=f8c884318a46a568d965c7e8bac00dfe2339efac04ca6f0cbabef916d8b917ca"
+    "sha512=e0633239a7d02cdde6264db96c39ed7e3d1adf3a7f09bb25ad002d388f203b561e8c808daee90539bc0ee15c547d2ab4bef1789dcc9c22ed00b151bad0083f64"
+  ]
+}
+license: "Apache-2.0"

--- a/packages/current_slack/current_slack.0.5/opam
+++ b/packages/current_slack/current_slack.0.5/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Slack plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Slack.
+It can post messages to slack channels."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "yojson"
+  "lwt"
+  "tls" {>= "0.12.0"}
+  "cohttp" {>= "2.2.0" & < "3.0.0"}
+  "cohttp-lwt" {>= "2.2.0" & < "3.0.0"}
+  "cohttp-lwt-unix" {>= "2.2.0" & < "3.0.0"}
+  "dune" {>= "2.0"}
+  "logs" {>= "0.7.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "439d1b539335ee3aa974ff6c02e09885f40056b5"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.5/current-v0.5.tbz"
+  checksum: [
+    "sha256=f8c884318a46a568d965c7e8bac00dfe2339efac04ca6f0cbabef916d8b917ca"
+    "sha512=e0633239a7d02cdde6264db96c39ed7e3d1adf3a7f09bb25ad002d388f203b561e8c808daee90539bc0ee15c547d2ab4bef1789dcc9c22ed00b151bad0083f64"
+  ]
+}
+license: "Apache-2.0"

--- a/packages/current_web/current_web.0.5/opam
+++ b/packages/current_web/current_web.0.5/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "Test web UI for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a basic web UI for service administrators.
+It shows the current pipeline visually and allows viewing job
+logs and configuring the log analyser."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "current_ansi" {>= "0.4"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "base64"
+  "session"
+  "session-cohttp-lwt"
+  "mirage-crypto" {>= "0.8.7"}
+  "mirage-crypto-rng"
+  "fmt" {>= "0.8.9"}
+  "bos"
+  "lwt"
+  "cmdliner"
+  "prometheus" {>= "0.7"}
+  "prometheus-app"
+  "cohttp" {>= "2.2.0" & < "3.0.0"}
+  "cohttp-lwt" {>= "2.2.0" & < "3.0.0"}
+  "cohttp-lwt-unix" {>= "2.2.0" & < "3.0.0"}
+  "tyxml" {>= "4.4.0"}
+  "routes" {>= "0.8.0"}
+  "dune" {>= "2.0"}
+  "conf-graphviz"
+  "astring" {>= "0.8.5"}
+  "conduit-lwt-unix" {>= "2.2.2"}
+  "cstruct" {>= "5.2.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_sexp_conv" {>= "v0.14.1"}
+  "re" {>= "1.9.0"}
+  "result" {>= "1.5"}
+  "sexplib" {>= "v0.14.0"}
+  "sqlite3" {>= "5.0.2"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+x-commit-hash: "439d1b539335ee3aa974ff6c02e09885f40056b5"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.5/current-v0.5.tbz"
+  checksum: [
+    "sha256=f8c884318a46a568d965c7e8bac00dfe2339efac04ca6f0cbabef916d8b917ca"
+    "sha512=e0633239a7d02cdde6264db96c39ed7e3d1adf3a7f09bb25ad002d388f203b561e8c808daee90539bc0ee15c547d2ab4bef1789dcc9c22ed00b151bad0083f64"
+  ]
+}
+license: "Apache-2.0"


### PR DESCRIPTION
Slack plugin for OCurrent

- Project page: <a href="https://github.com/ocurrent/ocurrent">https://github.com/ocurrent/ocurrent</a>

##### CHANGES:

Web UI:

- Space and color rows in query page (@MisterDA ocurrent/ocurrent#265).

- Duplicate the Rebuild selected button on top (@MisterDA ocurrent/ocurrent#265).

- Add a 'select-all' checkbox to the query page (@MisterDA ocurrent/ocurrent#265).

- Better printing of job duration (@MisterDA ocurrent/ocurrent#252, @ewanmellor ocurrent/ocurrent#259).

- Speed up rendering of the Query page (@talex5 ocurrent/ocurrent#262).

Windows support:

- Remove RO bit on Windows file when deleting tmpdir (@MisterDA ocurrent/ocurrent#270).

- Use `open_in_bin` instead of `open_in` to open log files (@MisterDA ocurrent/ocurrent#246).

- Support Windows file separators (@MisterDA ocurrent/ocurrent#246).

API:

- GitHub: add `staleness` argument to allow ignoring inactive branches (@patricoferris ocurrent/ocurrent#231).

- GitHub: add `default_ref` to get the default branch name (@patricoferris ocurrent/ocurrent#231).

- Git: expose `Current_git.Local.repo` (@ewanmellor ocurrent/ocurrent#257).
  This means that callers can use this for debugging or labelling.

Other:

- Log a message when cancelling a job finishes (@talex5 ocurrent/ocurrent#261).
  This avoids the confusing situation where the job finishes as you cancel, and you see the success message from the build as the last thing in the log, even though the job actually failed.

- Move ANSI parser to its own repository (@talex5 ocurrent/ocurrent#267, @MisterDA ocurrent/ocurrent#268).
  It's now at https://github.com/ocurrent/ansi

- `current_git` depends on `conf-git` (@MisterDA ocurrent/ocurrent#253).

- Update Dockerfile to latest opam-repository (@ewanmellor ocurrent/ocurrent#251).

- Fix typo in doc-strings (@tatchi ocurrent/ocurrent#250).

- Replace deprecated `Fmt` functions (@MisterDA ocurrent/ocurrent#245).

- Update to latest x509 API changes (@talex5 ocurrent/ocurrent#264).

- Use mirage-crypto for id-of-repo digests (@talex5 ocurrent/ocurrent#243).
