### PR TITLE
Package gpiod.0.3

### DIFF
--- a/packages/gpiod/gpiod.0.3/opam
+++ b/packages/gpiod/gpiod.0.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis:
+  "A wrapper around the C libgpiod library for GPIO on recent (>4.8) Linux kernels"
+maintainer: ["Blake Loring <blake@parsed.uk>"]
+authors: ["Blake Loring"]
+license: "BSD"
+homepage: "https://github.com/jawline/ocamlGpiod/"
+bug-reports: "https://github.com/jawline/ocamlGpiod/"
+depends: [
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/jawline/ocamlGpiod/archive/v0.3.tar.gz"
+  checksum: [
+    "md5=6ee17af34755bcf3c6a178361ac44abf"
+    "sha512=fcc92ba242aa55839b4b7e4865a382a0235d555f67bc0f2dce188110735e1d8a813a412326fc0bca79d9f4758b338d01db6e3075c705f6a8b56f0081c0979aca"
+  ]
+}


### PR DESCRIPTION
### `gpiod.0.3`
A wrapper around the C libgpiod library for GPIO on recent (>4.8) Linux kernels



---
* Homepage: https://github.com/jawline/ocamlGpiod/
* Bug tracker: https://github.com/jawline/ocamlGpiod/

---
:camel: Pull-request generated by opam-publish v2.0.3