### PR TITLE
Package gpiod.0.4

### DIFF
--- a/packages/gpiod/gpiod.0.4/opam
+++ b/packages/gpiod/gpiod.0.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "A wrapper around the C libgpiod library for GPIO on recent (>4.8) Linux kernels"
+maintainer: ["Blake Loring <blake@parsed.uk>"]
+authors: ["Blake Loring"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/jawline/ocamlGpiod/"
+bug-reports: "https://github.com/jawline/ocamlGpiod/"
+depends: [
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+depexts: [
+  ["libgpiod-dev"]
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jawline/ocamlGpiod.git"
+url {
+  src: "https://github.com/jawline/ocamlGpiod/archive/v0.4.tar.gz"
+  checksum: [
+    "md5=0c2542a45a4e6a763feba6f85645e569"
+    "sha512=3af1c49b95971ae0b0a7275bfb65543fc63a27a1ddf0c967457eff17dd166d3bcf77057a3a3f33421304136a1e30671845bf143bb9ceb4d7454ec909b4e97bdf"
+  ]
+}


### PR DESCRIPTION
### `gpiod.0.4`
A wrapper around the C libgpiod library for GPIO on recent (>4.8) Linux kernels



---
* Homepage: https://github.com/jawline/ocamlGpiod/
* Source repo: git+https://github.com/jawline/ocamlGpiod.git
* Bug tracker: https://github.com/jawline/ocamlGpiod/

---
:camel: Pull-request generated by opam-publish v2.0.3