### PR TITLE
Package gpiod.0.7

### DIFF
--- a/packages/gpiod/gpiod.0.7/opam
+++ b/packages/gpiod/gpiod.0.7/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "A wrapper around the C libgpiod library for GPIO on recent (>4.8) Linux kernels"
+maintainer: ["Blake Loring <blake@parsed.uk>"]
+authors: ["Blake Loring"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/jawline/ocamlGpiod/"
+bug-reports: "https://github.com/jawline/ocamlGpiod/"
+depends: [
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jawline/ocamlGpiod.git"
+depexts: [
+  "libgpiod-dev"
+]
+available: [ os = "linux" ]
+url {
+  src: "https://github.com/jawline/ocamlGpiod/archive/v0.7.tar.gz"
+  checksum: [
+    "md5=f23984ac3571701b251937eb82adb6a4"
+    "sha512=60b0c17e81b4195da144073b14371edeb7897dd1ed3c8c107a616463f65d4ced6a2024c64fbb5fad11a9d3f5120c3554020cff07f2d0cd26151c1cdd20dd0f5a"
+  ]
+}


### PR DESCRIPTION
### `gpiod.0.7`
A wrapper around the C libgpiod library for GPIO on recent (>4.8) Linux kernels



---
* Homepage: https://github.com/jawline/ocamlGpiod/
* Source repo: git+https://github.com/jawline/ocamlGpiod.git
* Bug tracker: https://github.com/jawline/ocamlGpiod/

---
:camel: Pull-request generated by opam-publish v2.0.3