### PR TITLE
Package gpiod.0.7

### DIFF
--- a/packages/gpiod/gpiod.0.7/opam
+++ b/packages/gpiod/gpiod.0.7/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "A wrapper around the C libgpiod library for GPIO on recent (>4.8) Linux kernels"
+maintainer: ["Blake Loring <blake@parsed.uk>"]
+authors: ["Blake Loring"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/jawline/ocamlGpiod/"
+bug-reports: "https://github.com/jawline/ocamlGpiod/"
+depends: [
+  "dune" {>= "2.8"}
+  "re"
+  "core"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jawline/ocamlGpiod.git"
+depexts: [
+  "libgpiod-dev"
+]
+available: [ os = "linux" ]
+url {
+  src: "https://github.com/jawline/ocamlGpiod/archive/v0.7.tar.gz"
+  checksum: [
+    "md5=dfd5ec0d7c35a7337837deebe539f756"
+    "sha512=84964ed9a8b2108c0a03a67f87a71ad12dbc7124c230ecb3201665849c771e1f3009da033d56f0dbdded5e48817d6cbe3cac02b479f3dddf22f70c64f25bc439"
+  ]
+}


### PR DESCRIPTION
### `gpiod.0.7`
A wrapper around the C libgpiod library for GPIO on recent (>4.8) Linux kernels



---
* Homepage: https://github.com/jawline/ocamlGpiod/
* Source repo: git+https://github.com/jawline/ocamlGpiod.git
* Bug tracker: https://github.com/jawline/ocamlGpiod/

---
:camel: Pull-request generated by opam-publish v2.0.3