### PR TITLE
Package gpiod.0.7

### DIFF
--- a/packages/conf-gpiod/conf-gpiod.1/opam
+++ b/packages/conf-gpiod/conf-gpiod.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "C libgpiod library for GPIO on recent (>4.8) Linux kernels"
+description:
+  "This package can only install if the libgpiod library is installed on the system."
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+license: "LGPL-2.0-or-later"
+homepage: "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/"
+depends: [
+  "conf-pkg-config" {build}
+]
+build: ["pkg-config" "--exists" "libgpiod"]
+depexts: [
+  [ "libgpiod-dev" ] { os-distribution = "alpine" }
+  [ "libgpiod-dev" ] { os-family = "debian" }
+  [ "libgpiod-dev" ] { os-family = "ubuntu" }
+  [ "libgpiod-devel" ] { os-distribution = "fedora" }
+  [ "libgpiod-devel" ] { os-distribution = "centos" }
+  [ "libgpiod-devel" ] { os-family = "suse" }
+]
+available: [ os = "linux" ]
+flags: conf

--- a/packages/gpiod/gpiod.0.7/opam
+++ b/packages/gpiod/gpiod.0.7/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "A wrapper around the C libgpiod library for GPIO on recent (>4.8) Linux kernels"
+maintainer: ["Blake Loring <blake@parsed.uk>"]
+authors: ["Blake Loring"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/jawline/ocamlGpiod/"
+bug-reports: "https://github.com/jawline/ocamlGpiod/"
+depends: [
+  "dune" {>= "2.8"}
+  "re" {>= "1.9.0"}
+  "core" {>= "v0.14.1"}
+  "ctypes" {>= "0.17.1"}
+  "ctypes-foreign" {>= "0.18.0"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jawline/ocamlGpiod.git"
+depexts: [
+  [ "libgpiod-dev" ] { os-distribution = "alpine" }
+  [ "libgpiod-dev" ] { os-family = "debian" }
+  [ "libgpiod-devel" ] { os-family = "fedora" }
+  [ "libgpiod-devel" ] { os-distribution = "opensuse" }
+]
+available: [ os = "linux" ]
+url {
+  src: "https://github.com/jawline/ocamlGpiod/archive/v0.7.tar.gz"
+  checksum: [
+    "md5=5c7cc97227025d483b181a22dc22481f"
+    "sha512=4a12ef0e1b53adcf5e61495df1b27e0800da035eb21716b757199a852d94502de1d31cb401e4bb39662b7ac33cea7e88971bcfc86d8620d44c03e6593d13d168"
+  ]
+}

--- a/packages/gpiod/gpiod.0.7/opam
+++ b/packages/gpiod/gpiod.0.7/opam
@@ -12,6 +12,7 @@ depends: [
   "core" {>= "v0.14.1"}
   "ctypes" {>= "0.17.1"}
   "ctypes-foreign" {>= "0.18.0"}
+  "conf-gpiod"
   "ocaml" {>= "4.08.0"}
   "odoc" {with-doc}
 ]
@@ -30,13 +31,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/jawline/ocamlGpiod.git"
-depexts: [
-  [ "libgpiod-dev" ] { os-distribution = "alpine" }
-  [ "libgpiod-dev" ] { os-family = "debian" }
-  [ "libgpiod-devel" ] { os-family = "fedora" }
-  [ "libgpiod-devel" ] { os-distribution = "opensuse" }
-]
-available: [ os = "linux" ]
 url {
   src: "https://github.com/jawline/ocamlGpiod/archive/v0.7.tar.gz"
   checksum: [


### PR DESCRIPTION
### `gpiod.0.7`
A wrapper around the C libgpiod library for GPIO on recent (>4.8) Linux kernels



---
* Homepage: https://github.com/jawline/ocamlGpiod/
* Source repo: git+https://github.com/jawline/ocamlGpiod.git
* Bug tracker: https://github.com/jawline/ocamlGpiod/

---
:camel: Pull-request generated by opam-publish v2.0.3