### PR TITLE
[new release] fromager (0.2.0)

### DIFF
--- a/packages/fromager/fromager.0.2.0/opam
+++ b/packages/fromager/fromager.0.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "A CLI to format an ocaml codebase"
+maintainer: "davidwong.crypto@gmail.com"
+authors: "davidwong.crypto@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/mimoo/fromager"
+bug-reports: "davidwong.crypto@gmail.com"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "2.8"}
+  "toml" {>= "7.0"}
+  "core" {>= "v0.12.4"}
+  "ocamlformat" {>= "0.9.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/mimoo/fromager.git"
+x-commit-hash: "2e0313f2522ce886c1acf2d3ea7c334ea32cac65"
+url {
+  src:
+    "https://github.com/mimoo/fromager/releases/download/0.2.0/fromager-0.2.0.tbz"
+  checksum: [
+    "sha256=4dada8384b94f5a0d88f04c0264de3b37df4f54f66e96efd8972db23eeb58c1d"
+    "sha512=7e2d33fcabc9b4badfaaabfcb9cc9773e378967a36d2a5aad71fc1f02c4bfc3a10c1c0450ca1108ee0bff0b599ebe1d7774b7eb0b99f2cba8cdce4b166572d03"
+  ]
+}


### PR DESCRIPTION
A CLI to format an ocaml codebase

- Project page: <a href="https://github.com/mimoo/fromager">https://github.com/mimoo/fromager</a>

##### CHANGES:

Fixed the ignored dirs/files feature. It now understands relative paths that start with `./`. Also, removed the debug printfs.
