### PR TITLE
[new release] macaddr-sexp, ipaddr, ipaddr-cstruct, macaddr-cstruct, ipaddr-sexp and macaddr (5.1.0)

### DIFF
--- a/packages/ipaddr-cstruct/ipaddr-cstruct.5.1.0/opam
+++ b/packages/ipaddr-cstruct/ipaddr-cstruct.5.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.9.0"}
   "ipaddr" {= version}
-  "cstruct"
+  "cstruct" {>= "0.6.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/ipaddr-cstruct/ipaddr-cstruct.5.1.0/opam
+++ b/packages/ipaddr-cstruct/ipaddr-cstruct.5.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations using Cstructs"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.9.0"}
+  "ipaddr" {= version}
+  "cstruct"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Cstruct convertions for macaddr
+"""
+x-commit-hash: "2a851641fc0fcdb553879a909ab0e8bad1b86f29"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.1.0/ipaddr-v5.1.0.tbz"
+  checksum: [
+    "sha256=7e9328222c1a5f39b0751baecd7e27a842bdb0082fd48126eacbbad8816fbf5a"
+    "sha512=ff02662864a2cc8db0c64dcd3bbf3d958bcd5ffff6e80ce73e0913b9fcb3e3b3f491e0ae2aa86cd1e3c56c12c3e46a3559a4c5e8169b2fffb7390322610802f2"
+  ]
+}

--- a/packages/ipaddr-sexp/ipaddr-sexp.5.1.0/opam
+++ b/packages/ipaddr-sexp/ipaddr-sexp.5.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations using sexp"
+description: """
+Sexp convertions for ipaddr
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.9.0"}
+  "ipaddr" {= version}
+  "ipaddr-cstruct" {with-test & = version}
+  "ounit" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+x-commit-hash: "2a851641fc0fcdb553879a909ab0e8bad1b86f29"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.1.0/ipaddr-v5.1.0.tbz"
+  checksum: [
+    "sha256=7e9328222c1a5f39b0751baecd7e27a842bdb0082fd48126eacbbad8816fbf5a"
+    "sha512=ff02662864a2cc8db0c64dcd3bbf3d958bcd5ffff6e80ce73e0913b9fcb3e3b3f491e0ae2aa86cd1e3c56c12c3e46a3559a4c5e8169b2fffb7390322610802f2"
+  ]
+}

--- a/packages/ipaddr/ipaddr.5.1.0/opam
+++ b/packages/ipaddr/ipaddr.5.1.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP (and MAC) address representations"
+description: """
+Features:
+ * Depends only on sexplib (conditionalization under consideration)
+ * oUnit-based tests
+ * IPv4 and IPv6 support
+ * IPv4 and IPv6 CIDR prefix support
+ * IPv4 and IPv6 [CIDR-scoped address](http://tools.ietf.org/html/rfc4291#section-2.3) support
+ * `Ipaddr.V4` and `Ipaddr.V4.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr.V6` and `Ipaddr.V6.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr` and `Ipaddr.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr_unix` in findlib subpackage `ipaddr.unix` provides compatibility with the standard library `Unix` module
+ * `Ipaddr_top` in findlib subpackage `ipaddr.top` provides top-level pretty printers (requires compiler-libs default since OCaml 4.0)
+ * IP address scope classification
+ * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "stdlib-shims"
+  "domain-name" {>= "0.3.0"}
+  "ounit" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+x-commit-hash: "2a851641fc0fcdb553879a909ab0e8bad1b86f29"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.1.0/ipaddr-v5.1.0.tbz"
+  checksum: [
+    "sha256=7e9328222c1a5f39b0751baecd7e27a842bdb0082fd48126eacbbad8816fbf5a"
+    "sha512=ff02662864a2cc8db0c64dcd3bbf3d958bcd5ffff6e80ce73e0913b9fcb3e3b3f491e0ae2aa86cd1e3c56c12c3e46a3559a4c5e8169b2fffb7390322610802f2"
+  ]
+}

--- a/packages/macaddr-cstruct/macaddr-cstruct.5.1.0/opam
+++ b/packages/macaddr-cstruct/macaddr-cstruct.5.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations using Cstructs"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "cstruct"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Cstruct convertions for macaddr
+"""
+x-commit-hash: "2a851641fc0fcdb553879a909ab0e8bad1b86f29"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.1.0/ipaddr-v5.1.0.tbz"
+  checksum: [
+    "sha256=7e9328222c1a5f39b0751baecd7e27a842bdb0082fd48126eacbbad8816fbf5a"
+    "sha512=ff02662864a2cc8db0c64dcd3bbf3d958bcd5ffff6e80ce73e0913b9fcb3e3b3f491e0ae2aa86cd1e3c56c12c3e46a3559a4c5e8169b2fffb7390322610802f2"
+  ]
+}

--- a/packages/macaddr-cstruct/macaddr-cstruct.5.1.0/opam
+++ b/packages/macaddr-cstruct/macaddr-cstruct.5.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.9.0"}
   "macaddr" {= version}
-  "cstruct"
+  "cstruct" {>= "0.6.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/macaddr-sexp/macaddr-sexp.5.1.0/opam
+++ b/packages/macaddr-sexp/macaddr-sexp.5.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations using sexp"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "macaddr-cstruct" {with-test & = version}
+  "ounit" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+]
+conflicts: [ "ipaddr" {< "3.0.0"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Sexp convertions for macaddr
+"""
+x-commit-hash: "2a851641fc0fcdb553879a909ab0e8bad1b86f29"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.1.0/ipaddr-v5.1.0.tbz"
+  checksum: [
+    "sha256=7e9328222c1a5f39b0751baecd7e27a842bdb0082fd48126eacbbad8816fbf5a"
+    "sha512=ff02662864a2cc8db0c64dcd3bbf3d958bcd5ffff6e80ce73e0913b9fcb3e3b3f491e0ae2aa86cd1e3c56c12c3e46a3559a4c5e8169b2fffb7390322610802f2"
+  ]
+}

--- a/packages/macaddr/macaddr.5.1.0/opam
+++ b/packages/macaddr/macaddr.5.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.9.0"}
+  "ounit" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+]
+conflicts: [ "ipaddr" {< "3.0.0"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+A library for manipulation of MAC address representations.
+
+Features:
+
+ * oUnit-based tests
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers optionally via the `Macaddr_sexp` library.
+ """
+x-commit-hash: "2a851641fc0fcdb553879a909ab0e8bad1b86f29"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.1.0/ipaddr-v5.1.0.tbz"
+  checksum: [
+    "sha256=7e9328222c1a5f39b0751baecd7e27a842bdb0082fd48126eacbbad8816fbf5a"
+    "sha512=ff02662864a2cc8db0c64dcd3bbf3d958bcd5ffff6e80ce73e0913b9fcb3e3b3f491e0ae2aa86cd1e3c56c12c3e46a3559a4c5e8169b2fffb7390322610802f2"
+  ]
+}


### PR DESCRIPTION
A library for manipulation of MAC address representations using sexp

- Project page: <a href="https://github.com/mirage/ocaml-ipaddr">https://github.com/mirage/ocaml-ipaddr</a>
- Documentation: <a href="https://mirage.github.io/ocaml-ipaddr/">https://mirage.github.io/ocaml-ipaddr/</a>

##### CHANGES:

* Reject octal notation in IPv4 (cve-2021-29921, mirage/ocaml-ipaddr#104, @jsachs)
* CI fixes, upgrade to ocamlformat 0.18 (@hannesm)
