### PR TITLE
uucp.10.0.0: Add missing depopt

### DIFF
--- a/packages/uucp/uucp.10.0.0/opam
+++ b/packages/uucp/uucp.10.0.0/opam
@@ -20,13 +20,13 @@ depends: [
   "uunf" {with-test}
   "uutf" {with-test}
 ]
-depopts: [ "uutf" "cmdliner" ]
+depopts: [ "uutf" "uunf" "cmdliner" ]
 conflicts: [ "uutf" {< "1.0.1"}
              "cmdliner" {< "1.0.0"} ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--dev-pkg" "%{pinned}%"
-          "--with-uutf" "%{uutf:installed}%"
+          "--with-uutf" "%{uutf+uunf:installed}%"
           "--with-cmdliner" "%{cmdliner:installed}%"
 ]]
 synopsis: "Unicode character properties for OCaml"


### PR DESCRIPTION
Fixed in 10.0.1
Detected in https://github.com/ocaml/opam-repository/pull/18817