### PR TITLE
[new release] albatross (1.2.0)

### DIFF
--- a/packages/albatross/albatross.1.2.0/opam
+++ b/packages/albatross/albatross.1.2.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "cstruct"
+  "logs"
+  "rresult"
+  "bos"
+  "ptime"
+  "cmdliner" {>= "1.0.0"}
+  "fmt"
+  "astring"
+  "jsonm"
+  "x509" {>= "0.13.0"}
+  "tls" {>= "0.13.1"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf"
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "hex"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+available: [
+  arch != "ppc64" & arch != "x86_32" & arch != "arm32"
+]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+x-commit-hash: "7c28bc99833f7b86c2c8227738eaff10e2ff5418"
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v1.2.0/albatross-v1.2.0.tbz"
+  checksum: [
+    "sha256=1b9159e5d01840baf8979386c3fab7dffc36b717f0ff75bc4d1f6fe4ce1cb413"
+    "sha512=b94838ea09fb41b502475ab8a94d2c66a30f3b1d580c528b729419752673cb21fc03fba272e60c7bfed4fb721fbfb244bdfbd71208991c3355de56110939a919"
+  ]
+}


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

- linux packaging albatross_stat -> albatross_stats (roburio/albatross#73 @smorimoto)
- albatross_stats: report runtime in microseconds on linux (roburio/albatross#74 @hannesm)
- use metrics-rusage for albatross processes (to report host system usage)
  (roburio/albatross#76 @hannesm)
- remove albatross_log, instead log to stdandard output (roburio/albatross#75 @hannesm)
