### PR TITLE
Package visitors.20210608

### DIFF
--- a/packages/visitors/visitors.20210608/opam
+++ b/packages/visitors/visitors.20210608/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/visitors"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/visitors.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ppxlib" {>= "0.22.0"}
+  "ppx_deriving" {>= "5.0"}
+  "result"
+  "dune" {>= "2.0"}
+]
+synopsis: "An OCaml syntax extension for generating visitor classes"
+description: """
+Annotating an algebraic data type definition with [@@deriving visitors { ... }]
+causes visitor classes to be automatically generated. A visitor is an object
+that knows how to traverse and transform a data structure."""
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/visitors/-/archive/20210608/archive.tar.gz"
+  checksum: [
+    "md5=c56a86f81e0c1531e22c89cb8691d02c"
+    "sha512=1ddd6654325ce47394239ea36b64e4c11ddbfa4f8061e0a22dac9bc1b822253abd0cbf8d4607c7fc3bb572b0e12075a3cea7632536230057e3e069536c6a5c3b"
+  ]
+}

--- a/packages/visitors/visitors.20210608/opam
+++ b/packages/visitors/visitors.20210608/opam
@@ -6,6 +6,7 @@ authors: [
 homepage: "https://gitlab.inria.fr/fpottier/visitors"
 dev-repo: "git+https://gitlab.inria.fr/fpottier/visitors.git"
 bug-reports: "francois.pottier@inria.fr"
+license: "LGPL-2.1-only"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]


### PR DESCRIPTION
### `visitors.20210608`
An OCaml syntax extension for generating visitor classes
Annotating an algebraic data type definition with [@@deriving visitors { ... }]
causes visitor classes to be automatically generated. A visitor is an object
that knows how to traverse and transform a data structure.



---
* Homepage: https://gitlab.inria.fr/fpottier/visitors
* Source repo: git+https://gitlab.inria.fr/fpottier/visitors.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.0.3