### PR TITLE
Add a version constraint on ppxlib in the previous release of visitors.

### DIFF
--- a/packages/visitors/visitors.20210316/opam
+++ b/packages/visitors/visitors.20210316/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.05.0"}
-  "ppxlib" {>= "0.22.0"}
+  "ppxlib" {>= "0.22.0" & < "0.23.0"}
   "ppx_deriving" {>= "5.0"}
   "result"
   "dune" {>= "2.0"}

--- a/packages/visitors/visitors.20210316/opam
+++ b/packages/visitors/visitors.20210316/opam
@@ -6,6 +6,7 @@ authors: [
 homepage: "https://gitlab.inria.fr/fpottier/visitors"
 dev-repo: "git+https://gitlab.inria.fr/fpottier/visitors.git"
 bug-reports: "francois.pottier@inria.fr"
+license: "LGPL-2.1-only"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]


### PR DESCRIPTION
The next release of `ppxlib` makes the type `Parser.token` abstract and is not compatible with visitors.20210316.