### PR TITLE
[new release] fromager (0.3.0)

### DIFF
--- a/packages/fromager/fromager.0.3.0/opam
+++ b/packages/fromager/fromager.0.3.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "A CLI to format an ocaml codebase"
+maintainer: "davidwong.crypto@gmail.com"
+authors: "davidwong.crypto@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/mimoo/fromager"
+bug-reports: "davidwong.crypto@gmail.com"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "2.8"}
+  "toml" {>= "7.0"}
+  "core" {>= "v0.12.4"}
+  "ocamlformat" {>= "0.9.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/mimoo/fromager.git"
+x-commit-hash: "4b38923ef6391fcef6876d67f431605511e204f1"
+url {
+  src:
+    "https://github.com/mimoo/fromager/releases/download/0.3.0/fromager-0.3.0.tbz"
+  checksum: [
+    "sha256=d05d47c041c6ebbfbbda317001ae9379733353929a072929cb72243bd2bbabd2"
+    "sha512=b323b4abcf76fbb745381442879a83ca1da7669ab4bd6b5ffce84e79dc4430f769e215ba67cf662c329518246dfff1924dd85c360604f51bc2df234df84b1d7a"
+  ]
+}


### PR DESCRIPTION
A CLI to format an ocaml codebase

- Project page: <a href="https://github.com/mimoo/fromager">https://github.com/mimoo/fromager</a>

##### CHANGES:

You can now enforce the ocamlformat version used.
