### PR TITLE
Package minisat.0.4

### DIFF
--- a/packages/minisat/minisat.0.4/opam
+++ b/packages/minisat/minisat.0.4/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Bindings to Minisat-C-1.14.1, with the solver included"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+license: "BSD-2-clause"
+depends: [
+  "ocaml" {>= "4.03" }
+  "dune" {>= "1.0"}
+  "odoc" {with-doc}
+]
+tags: [ "minisat" "solver" "SAT" ]
+homepage: "https://github.com/c-cube/ocaml-minisat/"
+dev-repo: "git+https://github.com/c-cube/ocaml-minisat.git"
+bug-reports: "https://github.com/c-cube/ocaml-minisat/issues"
+authors: "simon.cruanes.2007@m4x.org"
+url {
+  src: "https://github.com/c-cube/ocaml-minisat/archive/v0.4.tar.gz"
+  checksum: [
+    "md5=a17f04229fcba9f454b3499386f35d5e"
+    "sha512=e05d49ea0f6b8379c61795f20331b930daba0cb1dde8eb5c0a2810e18d43b997252af5f97fffbf427b890f982ca09b195b8591648bb702e819a191ce13cdee46"
+  ]
+}


### PR DESCRIPTION
### `minisat.0.4`
Bindings to Minisat-C-1.14.1, with the solver included



---
* Homepage: https://github.com/c-cube/ocaml-minisat/
* Source repo: git+https://github.com/c-cube/ocaml-minisat.git
* Bug tracker: https://github.com/c-cube/ocaml-minisat/issues

---
:camel: Pull-request generated by opam-publish v2.0.3