### PR TITLE
dream-serve: live-reloading static site server

### DIFF
--- a/packages/dream-serve/dream-serve.1.0.0/opam
+++ b/packages/dream-serve/dream-serve.1.0.0/opam
@@ -19,7 +19,7 @@ maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 depends: [
   "dream" {>= "1.0.0~alpha2"}
   "dune" {>= "2.0.0"}
-  "lambdasoup"
+  "lambdasoup" {>= "0.6"}
   "luv"
   "lwt" {>= "5.4.0"}
   "lwt_ppx"

--- a/packages/dream-serve/dream-serve.1.0.0/opam
+++ b/packages/dream-serve/dream-serve.1.0.0/opam
@@ -19,7 +19,7 @@ maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 depends: [
   "dream" {>= "1.0.0~alpha2"}
   "dune" {>= "2.0.0"}
-  "lambdasoup" {>= "0.6"}
+  "lambdasoup" {>= "0.6.1"}
   "luv"
   "lwt" {>= "5.4.0"}
   "lwt_ppx"

--- a/packages/dream-serve/dream-serve.1.0.0/opam
+++ b/packages/dream-serve/dream-serve.1.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+
+synopsis: "Static site server with live reload"
+
+description: """
+dream-serve injects a small script into .html files, which reloads Web pages
+when they are updated in the file system.
+"""
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream-serve"
+doc: "https://github.com/aantron/dream-serve#readme"
+bug-reports: "https://github.com/aantron/dream-serve/issues"
+dev-repo: "git+https://github.com/aantron/dream-serve.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "dream" {>= "1.0.0~alpha2"}
+  "dune" {>= "2.0.0"}
+  "lambdasoup"
+  "luv"
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream-serve/archive/refs/tags/1.0.0.tar.gz"
+  checksum: "md5=f3e1ae3fc43fc623a778270a6fc93525"
+}

--- a/packages/dream/dream.1.0.0~alpha1/opam
+++ b/packages/dream/dream.1.0.0~alpha1/opam
@@ -84,7 +84,7 @@ depends: [
   # Dependencies of vendored packages.
   "angstrom" {>= "0.14.0"}
   "bigstringaf" {>= "0.5.0"}
-  "digestif" {>= "0.7"}  # websocket/af, sha1.
+  "digestif" {>= "0.7.2"}  # websocket/af, sha1, default impl.
   "faraday" {>= "0.6.1"}
   "faraday-lwt-unix"
   "psq"  # h2.

--- a/packages/dream/dream.1.0.0~alpha2/opam
+++ b/packages/dream/dream.1.0.0~alpha2/opam
@@ -85,7 +85,7 @@ depends: [
   # Dependencies of vendored packages.
   "angstrom" {>= "0.14.0"}
   "bigstringaf" {>= "0.5.0"}
-  "digestif" {>= "0.7"}  # websocket/af, sha1.
+  "digestif" {>= "0.7.2"}  # websocket/af, sha1, default impl.
   "faraday" {>= "0.6.1"}
   "faraday-lwt-unix"
   "psq"  # h2.


### PR DESCRIPTION
[**dream-serve**](https://github.com/aantron/dream-serve) is a static site (HTML) server that causes pages to automatically reload when any of the source files change. It is great for developing docs and other pages in OCaml.

<br>

![reload](https://user-images.githubusercontent.com/12073668/121299933-c9556f80-c8fe-11eb-8fea-f90ea57e111e.gif)

<br>

dream-serve is only about [170 lines long](https://github.com/aantron/dream-serve/blob/master/dream_serve.ml), with all whitespace. The Web server is based on [Dream](https://github.com/aantron/dream), HTML parsing is done by [Lambda Soup](https://github.com/aantron/lambdasoup), and file watching by [libuv](https://github.com/libuv/libuv).