### PR TITLE
Package testu01.1.2.3-0.2

### DIFF
--- a/packages/testu01/testu01.1.2.3-0.2/opam
+++ b/packages/testu01/testu01.1.2.3-0.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for TestU01 1.2.3"
+description: """
+This package provides OCaml bindings for TestU01 1.2.3 TestU01 is
+  a software library, implemented in C, and offering a collection of utilities
+  for the empirical statistical testing of uniform random number generators.
+  The OCaml bindings allow for easy testing of random number generators written
+  in OCaml and that claim to be uniform."""
+maintainer: ["Niols “Niols” Jeannerod <niols@niols.fr>"]
+authors: [
+  "Niols “Niols” Jeannerod <niols@niols.fr>"
+  "Martin Pépin <kerl@wkerl.me>"
+]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/LesBoloss-es/ocaml-testu01"
+doc: "https://lesboloss-es.github.io/ocaml-testu01/"
+bug-reports: "https://github.com/LesBoloss-es/ocaml-testu01/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.06.0"}
+  "md2mld" {build | with-doc}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/LesBoloss-es/ocaml-testu01.git"
+url {
+  src:
+    "https://github.com/LesBoloss-es/ocaml-testu01/archive/1.2.3-0.2.tar.gz"
+  checksum: [
+    "md5=4af98e5e454867b0cba4a1f9dd01a5b5"
+    "sha512=9ce7eecf68b50c91586711025e0f06b9531ca7298c5e2796337d8a1eaf13938c7a64343e78b66c7e3b17b39f9623eb6240fffe92bd24eba074e52fd43213d6e5"
+  ]
+}


### PR DESCRIPTION
### `testu01.1.2.3-0.2`
OCaml bindings for TestU01 1.2.3
This package provides OCaml bindings for TestU01 1.2.3 TestU01 is
  a software library, implemented in C, and offering a collection of utilities
  for the empirical statistical testing of uniform random number generators.
  The OCaml bindings allow for easy testing of random number generators written
  in OCaml and that claim to be uniform.



---
* Homepage: https://github.com/LesBoloss-es/ocaml-testu01
* Source repo: git+https://github.com/LesBoloss-es/ocaml-testu01.git
* Bug tracker: https://github.com/LesBoloss-es/ocaml-testu01/issues

---
:camel: Pull-request generated by opam-publish v2.0.3