### PR TITLE
vhd-format is not compatible with OCaml 4.13

### DIFF
--- a/packages/vhd-format/vhd-format.0.12.0/opam
+++ b/packages/vhd-format/vhd-format.0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "rresult" {>= "0.2.0"}
   "uuidm"
   "dune" {>= "1.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct" {build & >= "3.0.0"}
 ]
 available: os = "linux" | os = "macos"
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/vhd-format/vhd-format.0.12.0/opam
+++ b/packages/vhd-format/vhd-format.0.12.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.13"}
   "cstruct" {>= "1.9"}
   "io-page"
-  "rresult" {>= "0.2.0"}
+  "rresult" {>= "0.3.0"}
   "uuidm"
   "dune" {>= "1.0"}
   "ppx_cstruct" {build & >= "3.0.0"}

--- a/packages/vhd-format/vhd-format.0.12.0/opam
+++ b/packages/vhd-format/vhd-format.0.12.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.13"}
   "cstruct" {>= "1.9"}
   "io-page"
   "rresult" {>= "0.2.0"}

--- a/packages/vhd-format/vhd-format.0.12.1/opam
+++ b/packages/vhd-format/vhd-format.0.12.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.13"}
   "cstruct" {>= "1.9"}
   "io-page"
-  "rresult" {>= "0.2.0"}
+  "rresult" {>= "0.3.0"}
   "uuidm"
   "dune" {>= "1.0"}
   "ppx_cstruct" {build & >= "3.0.0"}

--- a/packages/vhd-format/vhd-format.0.12.1/opam
+++ b/packages/vhd-format/vhd-format.0.12.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.13"}
   "cstruct" {>= "1.9"}
   "io-page"
   "rresult" {>= "0.2.0"}


### PR DESCRIPTION
Fix sent upstream in https://github.com/mirage/ocaml-vhd/pull/71
```
#=== ERROR while compiling vhd-format.0.12.1 ==================================#
# context              2.1.0~beta4 | linux/x86_64 | ocaml-variants.4.13.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.13.0+trunk/.opam-switch/build/vhd-format.0.12.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p vhd-format -j 47
# exit-code            1
# env-file             ~/.opam/log/vhd-format-15-fc1b94.env
# output-file          ~/.opam/log/vhd-format-15-fc1b94.out
### output ###
#       ocamlc vhd_format/.vhd_format.objs/byte/vhd_format__F.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13.0+trunk/bin/ocamlc.opt -w -40 -w -32-34-37 -g -bin-annot -I vhd_format/.vhd_format.objs/byte -I /home/opam/.opam/4.13.0+trunk/lib/bigarray-compat -I /home/opam/.opam/4.13.0+trunk/lib/bytes -I /home/opam/.opam/4.13.0+trunk/lib/cstruct -I /home/opam/.opam/4.13.0+trunk/lib/io-page -I /home/opam/.opam/4.13.0+trunk/lib/result -I /home/opam/.opam/4.13.0+trunk/lib/rresult -I /home/opam/.opam/4.13.0+trunk/lib/stdlib-shims -I /home/opam/.opam/4.13.0+trunk/lib/uuidm -intf-suffix .ml -no-alias-deps -open Vhd_format -o vhd_format/.vhd_format.objs/byte/vhd_format__F.cmo -c -impl vhd_format/f.pp.ml)
# File "vhd_format/f.ml", line 1517, characters 36-56:
# 1517 |     let useful_bytes_to_write = min (Cstruct.len buffer) (to_int (write_this_time -- offset ++ sector_start)) in
#                                            ^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type int but an expression was expected of type
#          Int64.t = int64
```