### PR TITLE
[new release] fromager (0.4.0)

### DIFF
--- a/packages/fromager/fromager.0.4.0/opam
+++ b/packages/fromager/fromager.0.4.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "A CLI to format an ocaml codebase"
+maintainer: "davidwong.crypto@gmail.com"
+authors: "davidwong.crypto@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/mimoo/fromager"
+bug-reports: "davidwong.crypto@gmail.com"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "2.8"}
+  "toml" {>= "7.0"}
+  "core" {>= "v0.12.4"}
+  "ocamlformat"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/mimoo/fromager.git"
+x-commit-hash: "ace45b14dc592d244c30de4dbe553e99685f9009"
+url {
+  src:
+    "https://github.com/mimoo/fromager/releases/download/0.4.0/fromager-0.4.0.tbz"
+  checksum: [
+    "sha256=267f2a741cb068ddbf23de9f7f288fa24d42a6a4870acf0b0f26653da50e6abe"
+    "sha512=081d50123ae2459fa70904db00c62e04e0bc464e4b2c9b781cd3f5862f09ed0af5954ecc42418da2b9aff8d0e407b20e608e16b38c8081997f5342109e2a83a6"
+  ]
+}


### PR DESCRIPTION
A CLI to format an ocaml codebase

- Project page: <a href="https://github.com/mimoo/fromager">https://github.com/mimoo/fromager</a>

##### CHANGES:

Remove version constraint on ocamlformat so that one can use whatever ocamlformat version they want.
