### PR TITLE
[new release] ppxlib (0.22.1)

### DIFF
--- a/packages/ppxlib/ppxlib.0.22.1/opam
+++ b/packages/ppxlib/ppxlib.0.22.1/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "2.1.0"}
   "ppx_derivers" {>= "1.0"}
-  "sexplib0"
+  "sexplib0" {>= "v0.12"}
   "stdlib-shims"
   "ocamlfind" {with-test}
   "re" {with-test & >= "1.9.0"}

--- a/packages/ppxlib/ppxlib.0.22.1/opam
+++ b/packages/ppxlib/ppxlib.0.22.1/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Standard library for ppx rewriters"
+description: """
+Ppxlib is the standard library for ppx rewriters and other programs
+that manipulate the in-memory reprensation of OCaml programs, a.k.a
+the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1" & < "4.13"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "2.1.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0"
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "base" {with-test}
+  "stdio" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-commit-hash: "5830d89a7cbe3a683a5d7d9948e2d14cffffa8d3"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.22.1/ppxlib-0.22.1.tbz"
+  checksum: [
+    "sha256=216c802ee606c9d9f0d1e60dfe29bb69b9ae0bf12828cb148e9867abf568c5f7"
+    "sha512=3a35c3638316ee7c3acfa2e3ffbe1f7d17687e2eb1cfea6461e1be140498515d3593b5f2bf2517d5f231f214414f7cbec761403b459a7f147dcf713bf3f78106"
+  ]
+}


### PR DESCRIPTION
Standard library for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Fix location in parse error reporting (ocaml-ppx/ppxlib#257, @pitag-ha)
