### PR TITLE
[new release] capnp-rpc-mirage, capnp-rpc-net, capnp-rpc, capnp-rpc-unix and capnp-rpc-lwt (1.2)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.1.2/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "lwt"
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "asetmap"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "a2f1b2f1fe058a34d7c8a7b0e3e8a5139cef90ed"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2/capnp-rpc-v1.2.tbz"
+  checksum: [
+    "sha256=9eca53503ab4a33700184af3a30d2ab0578991aff255113199ba279db6911b92"
+    "sha512=d570e7c919b391fd9c4603067c5f618ed125f8c4017d2c47e742eb8147b9bed8e99bfe020214ee1f994b6035377d6cfacffad86163be4893ac91daec511f63e0"
+  ]
+}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp" {>= "3.1.0"}
+  "capnp-rpc-net" {= version}
+  "astring" {with-test}
+  "fmt"
+  "logs"
+  "dns-client" {>= "5.0.0"}
+  "tls-mirage"
+  "mirage-stack" {>= "2.0.0"}
+  "arp" {>= "2.3.0" & with-test}
+  "alcotest" {>= "1.0.1" & with-test}
+  "alcotest-lwt" {>= "1.0.1" & with-test}
+  "io-page-unix" {with-test}
+  "tcpip" {>= "6.0.0" & with-test}
+  "mirage-vnetif" {with-test}
+  "mirage-crypto-rng" {>= "0.7.0" & with-test}
+  "dune" {>= "2.0"}
+  "asetmap" {with-test}
+  "ethernet" {>= "2.2.0" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "a2f1b2f1fe058a34d7c8a7b0e3e8a5139cef90ed"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2/capnp-rpc-v1.2.tbz"
+  checksum: [
+    "sha256=9eca53503ab4a33700184af3a30d2ab0578991aff255113199ba279db6911b92"
+    "sha512=d570e7c919b391fd9c4603067c5f618ed125f8c4017d2c47e742eb8147b9bed8e99bfe020214ee1f994b6035377d6cfacffad86163be4893ac91daec511f63e0"
+  ]
+}

--- a/packages/capnp-rpc-net/capnp-rpc-net.1.2/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "capnp-rpc-lwt" {= version}
+  "astring"
+  "fmt"
+  "logs"
+  "asetmap"
+  "mirage-flow" {>="2.0.0"}
+  "tls" {>= "0.13.1"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "0.13.0"}
+  "tls-mirage"
+  "dune" {>= "2.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "a2f1b2f1fe058a34d7c8a7b0e3e8a5139cef90ed"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2/capnp-rpc-v1.2.tbz"
+  checksum: [
+    "sha256=9eca53503ab4a33700184af3a30d2ab0578991aff255113199ba279db6911b92"
+    "sha512=d570e7c919b391fd9c4603067c5f618ed125f8c4017d2c47e742eb8147b9bed8e99bfe020214ee1f994b6035377d6cfacffad86163be4893ac91daec511f63e0"
+  ]
+}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.1.2/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.1.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp-rpc-net" {= version}
+  "cmdliner"
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.4"}
+  "logs"
+  "extunix"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "2.0"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "alcotest-lwt" { >= "1.0.1" & with-test}
+  "mirage-crypto-rng" {>= "0.7.0"}
+  "lwt"
+  "asetmap" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "a2f1b2f1fe058a34d7c8a7b0e3e8a5139cef90ed"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2/capnp-rpc-v1.2.tbz"
+  checksum: [
+    "sha256=9eca53503ab4a33700184af3a30d2ab0578991aff255113199ba279db6911b92"
+    "sha512=d570e7c919b391fd9c4603067c5f618ed125f8c4017d2c47e742eb8147b9bed8e99bfe020214ee1f994b6035377d6cfacffad86163be4893ac91daec511f63e0"
+  ]
+}

--- a/packages/capnp-rpc/capnp-rpc.1.2/opam
+++ b/packages/capnp-rpc/capnp-rpc.1.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "stdint"
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "asetmap"
+  "dune" {>= "2.0"}
+  "alcotest" {with-test & >= "1.0.1"}
+  "afl-persistent" {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-commit-hash: "a2f1b2f1fe058a34d7c8a7b0e3e8a5139cef90ed"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2/capnp-rpc-v1.2.tbz"
+  checksum: [
+    "sha256=9eca53503ab4a33700184af3a30d2ab0578991aff255113199ba279db6911b92"
+    "sha512=d570e7c919b391fd9c4603067c5f618ed125f8c4017d2c47e742eb8147b9bed8e99bfe020214ee1f994b6035377d6cfacffad86163be4893ac91daec511f63e0"
+  ]
+}


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

- Don't crash if the peer disconnects before the bootstrap reply is ready (@talex5 mirage/capnp-rpc#234).
  When replying to a normal question we checked that the answer was still needed before trying to reply, but didn't for bootstrap requests.

- Replace `wait_until_settled` with safer `await_settled` (@talex5 mirage/capnp-rpc#233).
  `wait_until_settled` makes it too easy to ignore errors.

- Require fmt >= 0.8.7 for `kstr` and set OCaml 4.08 as the minimum version everywhere (@talex5 mirage/capnp-rpc#232).
  Older versions aren't tested in CI because the unix and mirage packages require at least OCaml 4.08.
