### PR TITLE
Package chamo.3.0

### DIFF
--- a/packages/chamo/chamo.3.0/opam
+++ b/packages/chamo/chamo.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: ["Zoggy <zoggy@bat8.org>"]
+homepage: "https://zoggy.frama.io/chamo"
+license: "LGPL-3.0-only"
+doc: ["https://zoggy.frama.io/chamo/doc.html"]
+dev-repo: "git+https://framagit.org/zoggy/chamo.git"
+bug-reports: "https://framagit.org/zoggy/chamo/issues"
+synopsis: "Chamo is a source code editor, even if it can be used to edit any text file"
+tags: ["editor" "gtk" "development"]
+
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+
+install: [
+  [make "install"]
+]
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind" {build}
+  "ocf" {>= "0.7.0"}
+  "pcre" {>= "7.4.6"}
+  "lablgtk3" { >= "3.1.1" }
+  "lablgtk3-sourceview3" { >= "3.1.1" }
+  "lablgtk3-extras" { >= "3.0" }
+  "lwt" { >= "5.4.0" }
+  "lwt_ppx" { >= "2.0.2" }
+  "uutf" { >= "1.0.0" }
+  "sedlex" { >= "2.3" }
+  "xmlm" { >= "1.3.0" }
+]
+url {
+  src:
+    "https://framagit.org/zoggy/chamo/-/archive/release-3.0/chamo-release-3.0.tar.bz2"
+  checksum: [
+    "md5=d8340ef7bc3f585a7b35eeff3cd6779a"
+    "sha512=d25a8daf316d5c7e75624ba94d2cfb6bd06d3bb3a1f5c0089a7e25f71ec7d488bfb41e8ff70cc23097f3a05491eead0f2fa14307f46f23641365e5ca608d2096"
+  ]
+}


### PR DESCRIPTION
### `chamo.3.0`
Chamo is a source code editor, even if it can be used to edit any text file



---
* Homepage: https://zoggy.frama.io/chamo
* Source repo: git+https://framagit.org/zoggy/chamo.git
* Bug tracker: https://framagit.org/zoggy/chamo/issues

---
:camel: Pull-request generated by opam-publish v2.0.3