### PR TITLE
4 packages from gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz

### DIFF
--- a/packages/ff-bench/ff-bench.0.6.2/opam
+++ b/packages/ff-bench/ff-bench.0.6.2/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 synopsis: "Benchmark library for finite fields over the package ff-sig"
-description: "Benchmark library for finite fields over the package ff-sig"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"

--- a/packages/ff-bench/ff-bench.0.6.2/opam
+++ b/packages/ff-bench/ff-bench.0.6.2/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Benchmark library for finite fields over the package ff-sig"
+description: "Benchmark library for finite fields over the package ff-sig"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-ff"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "ff-sig" {= version}
+  "core" {= "v0.13.0"}
+  "core_bench" {= "v0.13.0"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz"
+  checksum: [
+    "md5=fa68c430de8cba04fb8b7819e4cc4b38"
+    "sha512=2046126f30704c16bd2dcd735b7eb9b8a6c8751892f895e6c992b0ebb921f7d2c824b9507b74368e3b66b53330dc70a57e70633105b642d021710b34fbc54a5c"
+  ]
+}

--- a/packages/ff-bench/ff-bench.0.6.2/opam
+++ b/packages/ff-bench/ff-bench.0.6.2/opam
@@ -9,8 +9,8 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
   "ff-sig" {= version}
-  "core" {>= "v0.13.0" & < "v0.14"}
-  "core_bench" {>= "v0.13.0" & < "v0.14"}
+  "core" {>= "v0.13.0"}
+  "core_bench" {>= "v0.13.0"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"

--- a/packages/ff-bench/ff-bench.0.6.2/opam
+++ b/packages/ff-bench/ff-bench.0.6.2/opam
@@ -10,8 +10,8 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
   "ff-sig" {= version}
-  "core" {= "v0.13.0"}
-  "core_bench" {= "v0.13.0"}
+  "core" {>= "v0.13.0" & < "v0.14"}
+  "core_bench" {>= "v0.13.0" & < "v0.14"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"

--- a/packages/ff-pbt/ff-pbt.0.6.2/opam
+++ b/packages/ff-pbt/ff-pbt.0.6.2/opam
@@ -1,8 +1,6 @@
 opam-version: "2.0"
 synopsis:
   "Property based testing library for finite fields over the package ff-sig"
-description:
-  "Property based testing library for finite fields over the package ff-sig"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"

--- a/packages/ff-pbt/ff-pbt.0.6.2/opam
+++ b/packages/ff-pbt/ff-pbt.0.6.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis:
+  "Property based testing library for finite fields over the package ff-sig"
+description:
+  "Property based testing library for finite fields over the package ff-sig"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-ff"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "zarith" {>= "1.9.1" & < "2.0"}
+  "ff-sig" {= version}
+  "alcotest"
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz"
+  checksum: [
+    "md5=fa68c430de8cba04fb8b7819e4cc4b38"
+    "sha512=2046126f30704c16bd2dcd735b7eb9b8a6c8751892f895e6c992b0ebb921f7d2c824b9507b74368e3b66b53330dc70a57e70633105b642d021710b34fbc54a5c"
+  ]
+}

--- a/packages/ff-sig/ff-sig.0.6.2/opam
+++ b/packages/ff-sig/ff-sig.0.6.2/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 synopsis: "Minimal finite field signatures"
-description: "Minimal finite field signatures"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"

--- a/packages/ff-sig/ff-sig.0.6.2/opam
+++ b/packages/ff-sig/ff-sig.0.6.2/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Minimal finite field signatures"
+description: "Minimal finite field signatures"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-ff"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "zarith" {>= "1.9.1" & < "2.0"}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz"
+  checksum: [
+    "md5=fa68c430de8cba04fb8b7819e4cc4b38"
+    "sha512=2046126f30704c16bd2dcd735b7eb9b8a6c8751892f895e6c992b0ebb921f7d2c824b9507b74368e3b66b53330dc70a57e70633105b642d021710b34fbc54a5c"
+  ]
+}

--- a/packages/ff/ff.0.6.2/opam
+++ b/packages/ff/ff.0.6.2/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 synopsis: "OCaml implementation of Finite Field operations"
-description: "OCaml implementation of Finite Field operations"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"

--- a/packages/ff/ff.0.6.2/opam
+++ b/packages/ff/ff.0.6.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml implementation of Finite Field operations"
+description: "OCaml implementation of Finite Field operations"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-ff"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "zarith" {>= "1.9.1" & < "2.0"}
+  "ff-sig" {= version}
+  "alcotest" {with-test}
+  "ff-pbt" {= version & with-test}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz"
+  checksum: [
+    "md5=fa68c430de8cba04fb8b7819e4cc4b38"
+    "sha512=2046126f30704c16bd2dcd735b7eb9b8a6c8751892f895e6c992b0ebb921f7d2c824b9507b74368e3b66b53330dc70a57e70633105b642d021710b34fbc54a5c"
+  ]
+}


### PR DESCRIPTION
See release notes: https://gitlab.com/dannywillems/ocaml-ff/-/releases/0.6.2

This pull-request concerns:
-`ff.0.6.2`: OCaml implementation of Finite Field operations
-`ff-bench.0.6.2`: Benchmark library for finite fields over the package ff-sig
-`ff-pbt.0.6.2`: Property based testing library for finite fields over the package ff-sig
-`ff-sig.0.6.2`: Minimal finite field signatures



---
* Homepage: https://gitlab.com/dannywillems/ocaml-ff
* Source repo: git+https://gitlab.com/dannywillems/ocaml-ff.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-ff/issues

---
:camel: Pull-request generated by opam-publish v2.0.3