### PR TITLE
obuild < 0.1.10 is not compatible with ocamlfind 1.8.0

### DIFF
--- a/packages/obuild/obuild.0.0.1/opam
+++ b/packages/obuild/obuild.0.0.1/opam
@@ -24,6 +24,9 @@ working, adapting parts where necessary to support OCaml fully."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/vincenthz/obuild/archive/v0.0.1.tar.gz"

--- a/packages/obuild/obuild.0.0.2/opam
+++ b/packages/obuild/obuild.0.0.2/opam
@@ -24,6 +24,9 @@ working, adapting parts where necessary to support OCaml fully."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/vincenthz/obuild/archive/v0.0.2.tar.gz"

--- a/packages/obuild/obuild.0.0.3/opam
+++ b/packages/obuild/obuild.0.0.3/opam
@@ -24,6 +24,9 @@ working, adapting parts where necessary to support OCaml fully."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/vincenthz/obuild/archive/v0.0.3.tar.gz"

--- a/packages/obuild/obuild.0.0.4/opam
+++ b/packages/obuild/obuild.0.0.4/opam
@@ -24,6 +24,9 @@ working, adapting parts where necessary to support OCaml fully."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/vincenthz/obuild/archive/obuild-v0.0.4.tar.gz"

--- a/packages/obuild/obuild.0.0.5/opam
+++ b/packages/obuild/obuild.0.0.5/opam
@@ -24,6 +24,9 @@ working, adapting parts where necessary to support OCaml fully."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.0.5.tar.gz"

--- a/packages/obuild/obuild.0.0.6/opam
+++ b/packages/obuild/obuild.0.0.6/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.0.6.tar.gz"

--- a/packages/obuild/obuild.0.0.7/opam
+++ b/packages/obuild/obuild.0.0.7/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.0.7.tar.gz"

--- a/packages/obuild/obuild.0.0.8/opam
+++ b/packages/obuild/obuild.0.0.8/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.0.8.tar.gz"

--- a/packages/obuild/obuild.0.0.9/opam
+++ b/packages/obuild/obuild.0.0.9/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.0.9.tar.gz"

--- a/packages/obuild/obuild.0.1.0/opam
+++ b/packages/obuild/obuild.0.1.0/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.1.0.tar.gz"

--- a/packages/obuild/obuild.0.1.1/opam
+++ b/packages/obuild/obuild.0.1.1/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.1.1.tar.gz"

--- a/packages/obuild/obuild.0.1.2/opam
+++ b/packages/obuild/obuild.0.1.2/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.1.2.tar.gz"

--- a/packages/obuild/obuild.0.1.3/opam
+++ b/packages/obuild/obuild.0.1.3/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 extra-files: ["obuild.install" "md5=473285d99104b78287c58bea4795edc7"]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.1.3.tar.gz"

--- a/packages/obuild/obuild.0.1.4/opam
+++ b/packages/obuild/obuild.0.1.4/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.1.4.tar.gz"
   checksum: "md5=b323f202f29f05eec5a6aee6679f0047"

--- a/packages/obuild/obuild.0.1.5/opam
+++ b/packages/obuild/obuild.0.1.5/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.1.5.tar.gz"
   checksum: "md5=049268cf62e51da405f8198ff5465170"

--- a/packages/obuild/obuild.0.1.6/opam
+++ b/packages/obuild/obuild.0.1.6/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.1.6.tar.gz"
   checksum: "md5=f56a076664448f78e59f2122186e776c"

--- a/packages/obuild/obuild.0.1.7/opam
+++ b/packages/obuild/obuild.0.1.7/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.1.7.tar.gz"
   checksum: "md5=7df458da991e8c3534ebcca02670e67d"

--- a/packages/obuild/obuild.0.1.8/opam
+++ b/packages/obuild/obuild.0.1.8/opam
@@ -22,6 +22,9 @@ and way of working, adapting parts where necessary to fully support OCaml."""
 depends: [
   "ocaml" {< "4.06.0"}
 ]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.1.8.tar.gz"
   checksum: "md5=5178265fec699c2c7da1cd7bd739996c"

--- a/packages/obuild/obuild.0.1.9/opam
+++ b/packages/obuild/obuild.0.1.9/opam
@@ -20,6 +20,9 @@ build it.
 The design is based on Haskell's Cabal and borrows most of the layout
 and way of working, adapting parts where necessary to fully support OCaml."""
 depends: ["ocaml"]
+conflicts: [
+  "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
+]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.1.9.tar.gz"
   checksum: "md5=63d08d56fb8cba245c05cc5b3b558ebd"


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/18840
This was fixed in 0.1.10: https://github.com/ocaml-obuild/obuild/commit/6d2eb3ce5a7e7622920a14c75b9db08c8b3da8bd
ocamlfind installs the META file for the `threads` library with a warning and obuild will fail to parse it everytime