### PR TITLE
5 packages from gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.5.0/ocaml-bls12-381-0.5.0.tar.bz2

### DIFF
--- a/packages/bls12-381-gen/bls12-381-gen.0.5.0/opam
+++ b/packages/bls12-381-gen/bls12-381-gen.0.5.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Functors to generate BLS12-381 primitives based on stubs"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.5.0/ocaml-bls12-381-0.5.0.tar.bz2"
+  checksum: [
+    "md5=5e550e69578c3b991b661c16f012a644"
+    "sha512=593051b6de70b8aa433161e8e49f9067cfafb9bbabc0c979958d0f7e1ebd6dd8f95cbb525343b7182a773e44da8d466e7b192578a579442eb58416855362ab77"
+  ]
+}

--- a/packages/bls12-381-js-gen/bls12-381-js-gen.0.5.0/opam
+++ b/packages/bls12-381-js-gen/bls12-381-js-gen.0.5.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis:
+  "Functors to generate BLS12-381 JavaScript primitives based on stubs"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "dune-configurator" {build}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "1.12"}
+  "zarith_stubs_js"
+  "js_of_ocaml" {>= "3.7.1"}
+  "js_of_ocaml-compiler" {>= "3.7.1"}
+  "js_of_ocaml-ppx" {>= "3.7.1"}
+  "bls12-381-gen" {= version}
+  "bls12-381" {= version}
+  "alcotest" {with-test}
+  "hex" {with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.5.0/ocaml-bls12-381-0.5.0.tar.bz2"
+  checksum: [
+    "md5=5e550e69578c3b991b661c16f012a644"
+    "sha512=593051b6de70b8aa433161e8e49f9067cfafb9bbabc0c979958d0f7e1ebd6dd8f95cbb525343b7182a773e44da8d466e7b192578a579442eb58416855362ab77"
+  ]
+}

--- a/packages/bls12-381-js/bls12-381-js.0.5.0/opam
+++ b/packages/bls12-381-js/bls12-381-js.0.5.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: """\
+JavaScript version of BLS12-381 primitives implementing the virtual
+package bls12-381"""
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "bls12-381-gen" {= version}
+  "bls12-381" {= version}
+  "bls12-381-js-gen" {= version}
+  "js_of_ocaml" {>= "3.7.1"}
+  "js_of_ocaml-compiler" {>= "3.7.1"}
+  "js_of_ocaml-ppx" {>= "3.7.1"}
+  "alcotest" {with-test}
+  "zarith" {>= "1.10" & < "1.12" & with-test}
+  "zarith_stubs_js" {with-test}
+  "hex" {with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.5.0/ocaml-bls12-381-0.5.0.tar.bz2"
+  checksum: [
+    "md5=5e550e69578c3b991b661c16f012a644"
+    "sha512=593051b6de70b8aa433161e8e49f9067cfafb9bbabc0c979958d0f7e1ebd6dd8f95cbb525343b7182a773e44da8d466e7b192578a579442eb58416855362ab77"
+  ]
+}

--- a/packages/bls12-381-unix/bls12-381-unix.0.5.0/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.0.5.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: """\
+UNIX version of BLS12-381 primitives implementing the virtual package
+bls12-381"""
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "conf-rust" {build}
+  "dune" {>= "2.8.4"}
+  "dune-configurator" {build}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "ctypes" {>= "0.18.0" & < "0.19.0"}
+  "ctypes-foreign"
+  "bls12-381-gen" {= version}
+  "bls12-381" {= version}
+  "tezos-rust-libs" {= "1.1"}
+  "alcotest" {with-test}
+  "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
+  "hex" {with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.5.0/ocaml-bls12-381-0.5.0.tar.bz2"
+  checksum: [
+    "md5=5e550e69578c3b991b661c16f012a644"
+    "sha512=593051b6de70b8aa433161e8e49f9067cfafb9bbabc0c979958d0f7e1ebd6dd8f95cbb525343b7182a773e44da8d466e7b192578a579442eb58416855362ab77"
+  ]
+}

--- a/packages/bls12-381/bls12-381.0.5.0/opam
+++ b/packages/bls12-381/bls12-381.0.5.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Virtual package for BLS12-381 primitives"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "bls12-381-gen" {= version}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.5.0/ocaml-bls12-381-0.5.0.tar.bz2"
+  checksum: [
+    "md5=5e550e69578c3b991b661c16f012a644"
+    "sha512=593051b6de70b8aa433161e8e49f9067cfafb9bbabc0c979958d0f7e1ebd6dd8f95cbb525343b7182a773e44da8d466e7b192578a579442eb58416855362ab77"
+  ]
+}


### PR DESCRIPTION
See release notes [here](https://gitlab.com/dannywillems/ocaml-bls12-381/-/releases/0.5.0)

```
Release with breaking API changes:
- Get rid of the arithmetic over compressed elements of G1 and G2. The implementations were uncompressing the points before performing the arithmetic, therefore it was  useless. Functions `of_compressed_bytes_exn/opt` and `to_compressed_bytes` have been added in the elliptic curve signature (https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/84)
- Add FFT and iFFT functions for G1, G2 and Fr (https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/86 and https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/79)
- Fix compilation flags to make it compatible with Cygwin (https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/82)
```

This pull-request concerns:
-`bls12-381.0.5.0`: Virtual package for BLS12-381 primitives
-`bls12-381-gen.0.5.0`: Functors to generate BLS12-381 primitives based on stubs
-`bls12-381-js.0.5.0`: JavaScript version of BLS12-381 primitives implementing the virtual
 package bls12-381
-`bls12-381-js-gen.0.5.0`: Functors to generate BLS12-381 JavaScript primitives based on stubs
-`bls12-381-unix.0.5.0`: UNIX version of BLS12-381 primitives implementing the virtual package
 bls12-381



---
* Homepage: https://gitlab.com/dannywillems/ocaml-bls12-381
* Source repo: git+https://gitlab.com/dannywillems/ocaml-bls12-381.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-bls12-381/issues

---
:camel: Pull-request generated by opam-publish v2.0.3