### PR TITLE
Release Caqti 1.6.0.

### DIFF
--- a/packages/caqti-async/caqti-async.1.2.0/opam
+++ b/packages/caqti-async/caqti-async.1.2.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-async/caqti-async.1.2.2/opam
+++ b/packages/caqti-async/caqti-async.1.2.2/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-async/caqti-async.1.2.2/opam
+++ b/packages/caqti-async/caqti-async.1.2.2/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "async_kernel" {>= "v0.11.0" & < "v0.15.0~"}
   "async_unix" {>= "v0.11.0" & < "v0.15.0~"}
-  "caqti" {>= "1.2.0" & < "1.3.0~"}
+  "caqti" {>= "1.2.2" & < "1.3.0~"}
   "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
   "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
   "core_kernel" {>= "v0.11.0" & < "v0.15.0~"}

--- a/packages/caqti-async/caqti-async.1.6.0/opam
+++ b/packages/caqti-async/caqti-async.1.6.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "async_kernel" {>= "v0.11.0"}
+  "async_unix" {>= "v0.11.0"}
+  "caqti" {>= "1.6.0" & < "1.7.0~"}
+  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "core_kernel"
+  "dune" {>= "1.11"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Async support for Caqti"
+x-commit-hash: "b8857da5edca852295c1d11f6b185bef196e70b2"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.6.0/caqti-v1.6.0.tbz"
+  checksum: [
+    "sha256=1bf0c0d60547033c10d6148cf5297b25ab66c9a2832b680329df2f3816bc674d"
+    "sha512=0b03bd1788d99bbac59679338768a5633ec473346eed333fca4c104bc88f04c24e138af2228fc20dcf295b7106778328d228643ae8235a3f722f54cc69919295"
+  ]
+}

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.1/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.3/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.3/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.3/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.3/opam
@@ -7,7 +7,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml"
-  "caqti" {>= "1.2.1" & < "1.3.0~"}
+  "caqti" {>= "1.2.3" & < "1.3.0~"}
   "dune" {>= "1.11"}
   "mariadb" {>= "1.1.1"}
 ]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.6.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.6.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.6.0" & < "1.7.0~"}
+  "dune" {>= "1.11"}
+  "mariadb" {>= "1.1.1"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MariaDB driver for Caqti using C bindings"
+x-commit-hash: "b8857da5edca852295c1d11f6b185bef196e70b2"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.6.0/caqti-v1.6.0.tbz"
+  checksum: [
+    "sha256=1bf0c0d60547033c10d6148cf5297b25ab66c9a2832b680329df2f3816bc674d"
+    "sha512=0b03bd1788d99bbac59679338768a5633ec473346eed333fca4c104bc88f04c24e138af2228fc20dcf295b7106778328d228643ae8235a3f722f54cc69919295"
+  ]
+}

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.1/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.1/opam
@@ -4,7 +4,7 @@ authors: [
   "Petter A. Urkedal <paurkedal@gmail.com>"
   "James Owen <james@cryptosense.com>"
 ]
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.3/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.3/opam
@@ -4,7 +4,7 @@ authors: [
   "Petter A. Urkedal <paurkedal@gmail.com>"
   "James Owen <james@cryptosense.com>"
 ]
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.3/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.3/opam
@@ -10,7 +10,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml"
-  "caqti" {>= "1.2.1" & < "1.3.0~"}
+  "caqti" {>= "1.2.3" & < "1.3.0~"}
   "dune" {>= "1.11"}
   "postgresql" {>= "4.6.0"}
 ]

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.4/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.4/opam
@@ -4,7 +4,7 @@ authors: [
   "Petter A. Urkedal <paurkedal@gmail.com>"
   "James Owen <james@cryptosense.com>"
 ]
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.4/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.2.4/opam
@@ -10,7 +10,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml"
-  "caqti" {>= "1.2.1" & < "1.3.0~"}
+  "caqti" {>= "1.2.3" & < "1.3.0~"}
   "dune" {>= "1.11"}
   "postgresql" {>= "4.6.0"}
 ]

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.6.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.6.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.6.0" & < "1.7.0~"}
+  "dune" {>= "1.11"}
+  "postgresql" {>= "5.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+x-commit-hash: "b8857da5edca852295c1d11f6b185bef196e70b2"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.6.0/caqti-v1.6.0.tbz"
+  checksum: [
+    "sha256=1bf0c0d60547033c10d6148cf5297b25ab66c9a2832b680329df2f3816bc674d"
+    "sha512=0b03bd1788d99bbac59679338768a5633ec473346eed333fca4c104bc88f04c24e138af2228fc20dcf295b7106778328d228643ae8235a3f722f54cc69919295"
+  ]
+}

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.2.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.2.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.2.1/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.2.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.2.3/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.2.3/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.2.3/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.2.3/opam
@@ -7,7 +7,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml"
-  "caqti" {>= "1.2.1" & < "1.3.0~"}
+  "caqti" {>= "1.2.3" & < "1.3.0~"}
   "dune" {>= "1.11"}
   "sqlite3"
 ]

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.6.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.6.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.6.0" & < "1.7.0~"}
+  "dune" {>= "1.11"}
+  "sqlite3"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Sqlite3 driver for Caqti using C bindings"
+x-commit-hash: "b8857da5edca852295c1d11f6b185bef196e70b2"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.6.0/caqti-v1.6.0.tbz"
+  checksum: [
+    "sha256=1bf0c0d60547033c10d6148cf5297b25ab66c9a2832b680329df2f3816bc674d"
+    "sha512=0b03bd1788d99bbac59679338768a5633ec473346eed333fca4c104bc88f04c24e138af2228fc20dcf295b7106778328d228643ae8235a3f722f54cc69919295"
+  ]
+}

--- a/packages/caqti-dynload/caqti-dynload.1.2.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.1.2.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-dynload/caqti-dynload.1.3.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.1.3.0/opam
@@ -7,7 +7,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "caqti" {>= "1.3.0" & < "1.6.0~"}
+  "caqti" {>= "1.3.0" & < "1.7.0~"}
   "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
   "dune" {>= "1.11"}
   "ocamlfind"

--- a/packages/caqti-lwt/caqti-lwt.1.2.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.1.2.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti-lwt/caqti-lwt.1.6.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.1.6.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.6.0" & < "1.7.0~"}
+  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "dune" {>= "1.11"}
+  "logs"
+  "lwt" {>= "3.2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Lwt support for Caqti"
+x-commit-hash: "b8857da5edca852295c1d11f6b185bef196e70b2"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.6.0/caqti-v1.6.0.tbz"
+  checksum: [
+    "sha256=1bf0c0d60547033c10d6148cf5297b25ab66c9a2832b680329df2f3816bc674d"
+    "sha512=0b03bd1788d99bbac59679338768a5633ec473346eed333fca4c104bc88f04c24e138af2228fc20dcf295b7106778328d228643ae8235a3f722f54cc69919295"
+  ]
+}

--- a/packages/caqti-type-calendar/caqti-type-calendar.1.2.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.1.2.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti/caqti.1.2.0/opam
+++ b/packages/caqti/caqti.1.2.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: "Petter A. Urkedal <paurkedal@gmail.com>"
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti/caqti.1.2.0/opam
+++ b/packages/caqti/caqti.1.2.0/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "1.11"}
   "logs"
   "ocaml" {>= "4.04.0"}
-  "ppx_deriving"
+  "ppx_deriving" {>= "4.2"}
   "ptime"
   "uri" {>= "1.9.0"}
 ]

--- a/packages/caqti/caqti.1.2.0/opam
+++ b/packages/caqti/caqti.1.2.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "http://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.11"}
   "logs"
   "ocaml" {>= "4.04.0"}

--- a/packages/caqti/caqti.1.2.1/opam
+++ b/packages/caqti/caqti.1.2.1/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.11"}
   "logs"
   "ocaml" {>= "4.04.0"}

--- a/packages/caqti/caqti.1.2.1/opam
+++ b/packages/caqti/caqti.1.2.1/opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "1.11"}
   "logs"
   "ocaml" {>= "4.04.0"}
-  "ppx_deriving"
+  "ppx_deriving" {>= "4.2"}
   "ptime"
   "uri" {>= "1.9.0"}
 ]

--- a/packages/caqti/caqti.1.2.1/opam
+++ b/packages/caqti/caqti.1.2.1/opam
@@ -4,7 +4,7 @@ authors: [
   "Petter A. Urkedal <paurkedal@gmail.com>"
   "Nathan Rebours <nathan@cryptosense.com>"
 ]
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti/caqti.1.2.3/opam
+++ b/packages/caqti/caqti.1.2.3/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.11"}
   "logs"
   "ocaml" {>= "4.04.0"}

--- a/packages/caqti/caqti.1.2.3/opam
+++ b/packages/caqti/caqti.1.2.3/opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "1.11"}
   "logs"
   "ocaml" {>= "4.04.0"}
-  "ppx_deriving"
+  "ppx_deriving" {>= "4.2"}
   "ptime"
   "uri" {>= "1.9.0"}
 ]

--- a/packages/caqti/caqti.1.2.3/opam
+++ b/packages/caqti/caqti.1.2.3/opam
@@ -4,7 +4,7 @@ authors: [
   "Petter A. Urkedal <paurkedal@gmail.com>"
   "Nathan Rebours <nathan@cryptosense.com>"
 ]
-license: "LGPL-3 with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"

--- a/packages/caqti/caqti.1.3.0/opam
+++ b/packages/caqti/caqti.1.3.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.11"}
   "logs"
   "ocaml" {>= "4.04.0"}

--- a/packages/caqti/caqti.1.4.0/opam
+++ b/packages/caqti/caqti.1.4.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.11"}
   "logs"
   "ocaml" {>= "4.04.0"}

--- a/packages/caqti/caqti.1.5.0/opam
+++ b/packages/caqti/caqti.1.5.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.11"}
   "logs"
   "ocaml" {>= "4.04.0"}

--- a/packages/caqti/caqti.1.6.0/opam
+++ b/packages/caqti/caqti.1.6.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.11"}
   "logs"
   "ocaml" {>= "4.04.0"}

--- a/packages/caqti/caqti.1.6.0/opam
+++ b/packages/caqti/caqti.1.6.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "Nathan Rebours <nathan@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "cppo" {build}
+  "dune" {>= "1.11"}
+  "logs"
+  "ocaml" {>= "4.04.0"}
+  "ptime"
+  "uri" {>= "1.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Unified interface to relational database libraries"
+description: """
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators."""
+x-commit-hash: "b8857da5edca852295c1d11f6b185bef196e70b2"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.6.0/caqti-v1.6.0.tbz"
+  checksum: [
+    "sha256=1bf0c0d60547033c10d6148cf5297b25ab66c9a2832b680329df2f3816bc674d"
+    "sha512=0b03bd1788d99bbac59679338768a5633ec473346eed333fca4c104bc88f04c24e138af2228fc20dcf295b7106778328d228643ae8235a3f722f54cc69919295"
+  ]
+}


### PR DESCRIPTION
I have accumulated some bug fixes and a few minor improvements in need of a release. From the change log:

- Set the time zone of PostgreSQL connections to UTC to mitigate an
  undesirable implicit conversion to the local time zone for `timestamp`.
  This issue was exposed by the specification of field types introduced in
  version 1.4.0.  Earlier versions worked as expected, if only accidentally,
  since the time zone is ignored when a string is converted to a
  `timestamp`.  While this change makes `timestamp` more usable again for
  storing UTC time stamps, I strongly recommend using `timestamp with time
  zone` since it's interpretation is unambiguous.  The API reference is now
  updated with details about how the `ptime` OCaml type is mapped for
  different database systems.
- Drop specification of OCaml `string` as SQL `text` for PostgreSQL. This is
  due to issues with implicit conversions and function overloading when the
  desired type on the SQL side is `char`, `varchar`, or `jsonb`.
- Add `Caqti_type.redact` to protect sensitive information from being
  logged.
- Only log parameters if `$CAQTI_DEBUG_PARAM` is set to "`true`".
- When logging requests, show underlying values for custom types.
- Reject multi-row response in `find_opt` implementation for sqlite3.
- Tolerate Lwt promise rejections in `Pool.use`.
