### PR TITLE
sedlex 2.0 and 2.1: Add missing constraint

### DIFF
--- a/packages/sedlex/sedlex.2.0/opam
+++ b/packages/sedlex/sedlex.2.0/opam
@@ -25,7 +25,7 @@ build: [
 depends: [
   "ocaml" {build & >= "4.02.3"}
   "dune" {>= "1.0"}
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.2"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "gen"
   "uchar"

--- a/packages/sedlex/sedlex.2.1/opam
+++ b/packages/sedlex/sedlex.2.1/opam
@@ -24,7 +24,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.8"}
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.2"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "gen"
   "uchar"


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/18850
```
#=== ERROR while compiling sedlex.2.0 =========================================#
# context              2.1.0~beta4 | linux/x86_64 | ocaml-base-compiler.4.07.1 | file:///src
# path                 ~/.opam/4.07/.opam-switch/build/sedlex.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p sedlex -j 47
# exit-code            1
# env-file             ~/.opam/log/sedlex-24-3739f8.env
# output-file          ~/.opam/log/sedlex-24-3739f8.out
### output ###
# File "src/syntax/dune", line 8, characters 2-40:
# 8 |   (pps ppx_tools_versioned.metaquot_405))
#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: No ppx driver were found. It seems that
# ppx_tools_versioned.metaquot_405 is not compatible with Dune. Examples of ppx
# rewriters that are compatible with Dune are ones using
# ocaml-migrate-parsetree, ppxlib or ppx_driver.
```