### PR TITLE
Release Orsetto 1.1

### DIFF
--- a/packages/orsetto/orsetto.1.0.1/opam
+++ b/packages/orsetto/orsetto.1.0.1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "orsetto" version: "1.0.1"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
@@ -7,6 +6,7 @@ homepage: "https://bitbucket.org/jhw/orsetto/"
 bug-reports: "https://conjury.atlassian.net/browse/ORS"
 dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
+license: "BSD-2-Clause"
 depends: [
     ("ocaml" { >= "4.07" & < "4.09" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
     "stdlib-shims" { >= "0.1" }
@@ -24,7 +24,7 @@ install: [
 ]
 url {
     src: "https://bitbucket.org/jhw/orsetto/get/r1.0.1.tar.gz"
-    checksum: "md5=81e0f8a5f2c0cf364e3c8e9acbadef93"
+    checksum: "md5=3a15a377800cf988a310b4082406c685"
 }
 extra-source "ucd.all.grouped.zip" {
     src: "http://www.unicode.org/Public/12.0.0/ucdxml/ucd.all.grouped.zip"

--- a/packages/orsetto/orsetto.1.0.1/opam
+++ b/packages/orsetto/orsetto.1.0.1/opam
@@ -28,7 +28,7 @@ url {
 }
 extra-source "ucd.all.grouped.zip" {
     src: "http://www.unicode.org/Public/12.0.0/ucdxml/ucd.all.grouped.zip"
-    checksum: "md5=3a15a377800cf988a310b4082406c685"
+    checksum: "md5=31c0d979d71f0aba02bb3fc74fd8a96b"
 }
 extra-source "NormalizationTest.txt" {
     src: "http://www.unicode.org/Public/12.0.0/ucd/NormalizationTest.txt"

--- a/packages/orsetto/orsetto.1.0.1/opam
+++ b/packages/orsetto/orsetto.1.0.1/opam
@@ -1,9 +1,10 @@
 opam-version: "2.0"
+name: "orsetto" version: "1.0.1"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
 homepage: "https://bitbucket.org/jhw/orsetto/"
-bug-reports: "https://bitbucket.org/jhw/orsetto/issues"
+bug-reports: "https://conjury.atlassian.net/browse/ORS"
 dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
 depends: [

--- a/packages/orsetto/orsetto.1.0.2/opam
+++ b/packages/orsetto/orsetto.1.0.2/opam
@@ -1,9 +1,10 @@
 opam-version: "2.0"
+name: "orsetto" version: "1.0.2"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
 homepage: "https://bitbucket.org/jhw/orsetto/"
-bug-reports: "https://bitbucket.org/jhw/orsetto/issues"
+bug-reports: "https://conjury.atlassian.net/browse/ORS"
 dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
 depends: [

--- a/packages/orsetto/orsetto.1.0.2/opam
+++ b/packages/orsetto/orsetto.1.0.2/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "orsetto" version: "1.0.2"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
@@ -7,6 +6,7 @@ homepage: "https://bitbucket.org/jhw/orsetto/"
 bug-reports: "https://conjury.atlassian.net/browse/ORS"
 dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
+license: "BSD-2-Clause"
 depends: [
     ("ocaml" { >= "4.07" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
     "stdlib-shims" { >= "0.1" }

--- a/packages/orsetto/orsetto.1.0.3/opam
+++ b/packages/orsetto/orsetto.1.0.3/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "orsetto" version: "1.0.3"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
@@ -7,6 +6,7 @@ homepage: "https://bitbucket.org/jhw/orsetto/"
 bug-reports: "https://conjury.atlassian.net/browse/ORS"
 dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
+license: "BSD-2-Clause"
 depends: [
     ("ocaml" { >= "4.07" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
     "stdlib-shims" { >= "0.1" }

--- a/packages/orsetto/orsetto.1.0/opam
+++ b/packages/orsetto/orsetto.1.0/opam
@@ -1,9 +1,10 @@
 opam-version: "2.0"
+name: "orsetto" version: "1.0"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
 homepage: "https://bitbucket.org/jhw/orsetto/"
-bug-reports: "https://bitbucket.org/jhw/orsetto/issues"
+bug-reports: "https://conjury.atlassian.net/browse/ORS"
 dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
 depends: [

--- a/packages/orsetto/orsetto.1.0/opam
+++ b/packages/orsetto/orsetto.1.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "orsetto" version: "1.0"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
@@ -7,6 +6,7 @@ homepage: "https://bitbucket.org/jhw/orsetto/"
 bug-reports: "https://conjury.atlassian.net/browse/ORS"
 dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
+license: "BSD-2-Clause"
 depends: [
     ("ocaml" { >= "4.07" & < "4.09" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
     "stdlib-shims" { >= "0.1" }

--- a/packages/orsetto/orsetto.1.1/opam
+++ b/packages/orsetto/orsetto.1.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "orsetto" version: "1.0.3"
+name: "orsetto" version: "1.2"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
@@ -8,9 +8,9 @@ bug-reports: "https://conjury.atlassian.net/browse/ORS"
 dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
 depends: [
-    ("ocaml" { >= "4.07" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
-    "stdlib-shims" { >= "0.1" }
+    "ocaml" { >= "4.08.1" }
     "conjury" { build & >= "2.0.1" }
+    "omake" { build & >= "0.10.3" }
     "uucd" { build & = "13.0.0" }
     "ounit2" { build & with-test & >= "2.2" }
 ]
@@ -23,8 +23,8 @@ install: [
     [ "omake" "--verbose" "install" "MODE=develop" ] { dev }
 ]
 url {
-    src: "https://bitbucket.org/jhw/orsetto/get/r1.0.3.tar.gz"
-    checksum: "md5=00393728b481c2bf15919a8202732335"
+    src: "https://bitbucket.org/jhw/orsetto/get/r1.1.tar.gz"
+    checksum: "md5=533153cd4a9fe8093d3b98afc1073bc8"
 }
 extra-source "ucd.all.grouped.zip" {
     src: "http://www.unicode.org/Public/13.0.0/ucdxml/ucd.all.grouped.zip"

--- a/packages/orsetto/orsetto.1.1/opam
+++ b/packages/orsetto/orsetto.1.1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "orsetto" version: "1.2"
 synopsis: "A library of assorted structured data interchange languages"
 maintainer: "james woodyatt <jhw@conjury.org>"
 authors: "james woodyatt <jhw@conjury.org>"
@@ -7,6 +6,7 @@ homepage: "https://bitbucket.org/jhw/orsetto/"
 bug-reports: "https://conjury.atlassian.net/browse/ORS"
 dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
+license: "BSD-2-Clause"
 depends: [
     "ocaml" { >= "4.08.1" }
     "conjury" { build & >= "2.0.1" }


### PR DESCRIPTION
- Update the issue tracker URL in all previous releases.
- Add license to OPAM files in all previous releases.
- Correct the MD5 checksum for the Unicode 12.0.0 database.
