### PR TITLE
2 packages from darioteixeira/pgocaml at 4.3.0

### DIFF
--- a/packages/pgocaml/pgocaml.4.3.0/opam
+++ b/packages/pgocaml/pgocaml.4.3.0/opam
@@ -12,7 +12,7 @@ authors: ["Richard W.M. Jones <rich@annexia.org>"]
 homepage: "https://github.com/darioteixeira/pgocaml"
 bug-reports: "https://github.com/darioteixeira/pgocaml/issues"
 dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
-license: "LGPL-2.0 with OCaml linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "calendar" {>= "2.0"}

--- a/packages/pgocaml/pgocaml.4.3.0/opam
+++ b/packages/pgocaml/pgocaml.4.3.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Native OCaml interface to PostgreSQL databases"
+description: """
+PGOCaml provides an interface to PostgreSQL databases for OCaml applications.
+Note that it speaks the PostgreSQL wire protocol directly, and therefore does
+not need to create bindings to the PostgreSQL libpq C library.
+The PPX syntax extension is now packaged separately as 'pgocaml_ppx'.
+You will want to take a look at it if you're considering using PGOCaml.
+"""
+maintainer: "dario.teixeira@nleyten.com"
+authors: ["Richard W.M. Jones <rich@annexia.org>"]
+homepage: "https://github.com/darioteixeira/pgocaml"
+bug-reports: "https://github.com/darioteixeira/pgocaml/issues"
+dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
+license: "LGPL-2.0 with OCaml linking exception"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "calendar"
+  "csv"
+  "dune" {>= "1.10"}
+  "hex"
+  "ocaml" {>= "4.07"}
+  "ppx_sexp_conv"
+  "re"
+  "ppx_deriving" {>= "4.0"}
+  "rresult"
+  "sexplib"
+]
+url {
+  src: "https://github.com/darioteixeira/pgocaml/archive/4.3.0.tar.gz"
+  checksum: [
+    "md5=1f97480892969d3ab371be4b95a0a5bb"
+    "sha512=3b82ea8be88b1e9f169d52fd48491d4d756d65e962fd35a4211994e011aa0ec959408bd7092905942f60493859d6f17a89a7fbcd9f88b500b4d3c3da3a51bc4f"
+  ]
+}

--- a/packages/pgocaml/pgocaml.4.3.0/opam
+++ b/packages/pgocaml/pgocaml.4.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "hex"
   "ocaml" {>= "4.07"}
   "ppx_sexp_conv"
-  "re"
+  "re" {>= "1.5.0"}
   "ppx_deriving" {>= "4.2"}
   "rresult"
   "sexplib"

--- a/packages/pgocaml/pgocaml.4.3.0/opam
+++ b/packages/pgocaml/pgocaml.4.3.0/opam
@@ -15,14 +15,14 @@ dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
 license: "LGPL-2.0 with OCaml linking exception"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "calendar"
+  "calendar" {>= "2.0"}
   "csv"
   "dune" {>= "1.10"}
   "hex"
   "ocaml" {>= "4.07"}
   "ppx_sexp_conv"
   "re"
-  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving" {>= "4.2"}
   "rresult"
   "sexplib"
 ]

--- a/packages/pgocaml_ppx/pgocaml_ppx.4.3.0/opam
+++ b/packages/pgocaml_ppx/pgocaml_ppx.4.3.0/opam
@@ -12,7 +12,7 @@ authors: ["Richard W.M. Jones <rich@annexia.org>"]
 homepage: "https://github.com/darioteixeira/pgocaml"
 bug-reports: "https://github.com/darioteixeira/pgocaml/issues"
 dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
-license: "LGPL-2.0 with OCaml linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "dune" {>= "1.10"}

--- a/packages/pgocaml_ppx/pgocaml_ppx.4.3.0/opam
+++ b/packages/pgocaml_ppx/pgocaml_ppx.4.3.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "PPX extension for PGOCaml"
+description: """
+PGOCaml provides an interface to PostgreSQL databases for OCaml applications.
+This PPX syntax extension enables one to directly embed SQL statements inside
+the OCaml code. The extension uses the 'describe' feature of PostgreSQL to
+obtain type information about the database. This allows PGOCaml to check at
+compile-time if the program is indeed consistent with the database structure.
+"""
+maintainer: "dario.teixeira@nleyten.com"
+authors: ["Richard W.M. Jones <rich@annexia.org>"]
+homepage: "https://github.com/darioteixeira/pgocaml"
+bug-reports: "https://github.com/darioteixeira/pgocaml/issues"
+dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
+license: "LGPL-2.0 with OCaml linking exception"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {>= "1.10"}
+  "ocaml" {>= "4.07"}
+  "pgocaml" {= version}
+  "ppxlib" {>= "0.16.0"}
+  "ppx_optcomp"
+]
+url {
+  src: "https://github.com/darioteixeira/pgocaml/archive/4.3.0.tar.gz"
+  checksum: [
+    "md5=1f97480892969d3ab371be4b95a0a5bb"
+    "sha512=3b82ea8be88b1e9f169d52fd48491d4d756d65e962fd35a4211994e011aa0ec959408bd7092905942f60493859d6f17a89a7fbcd9f88b500b4d3c3da3a51bc4f"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`pgocaml.4.3.0`: Native OCaml interface to PostgreSQL databases
-`pgocaml_ppx.4.3.0`: PPX extension for PGOCaml



---
* Homepage: https://github.com/darioteixeira/pgocaml
* Source repo: git+https://github.com/darioteixeira/pgocaml.git
* Bug tracker: https://github.com/darioteixeira/pgocaml/issues

---
:camel: Pull-request generated by opam-publish v2.0.3