### PR TITLE
spawn.v0.12.0: Fix constraint (uses (inline_tests) without any arguments)

### DIFF
--- a/packages/spawn/spawn.v0.12.0/opam
+++ b/packages/spawn/spawn.v0.12.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder" {>= "1.0+beta18.1"}
+  "jbuilder" {>= "1.0+beta19"}
 ]
 synopsis: "Spawning sub-processes"
 description: """


### PR DESCRIPTION
Spotted in https://github.com/ocaml/opam-repository/pull/18849
```
#=== ERROR while compiling spawn.v0.12.0 ======================================#
# context              2.1.0~beta4 | linux/x86_64 | ocaml-base-compiler.4.07.1 | file:///src
# path                 ~/.opam/4.07/.opam-switch/build/spawn.v0.12.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p spawn -j 47
# exit-code            1
# env-file             ~/.opam/log/spawn-23-37489d.env
# output-file          ~/.opam/log/spawn-23-37489d.out
### output ###
# File "test/jbuild", line 4, characters 2-16:
# Error: field inline_tests needs a value
```