### PR TITLE
dokeysto < 3.0.0: Add missing constraint (uses jbuilder build -p)

### DIFF
--- a/packages/dokeysto/dokeysto.1.0.1/opam
+++ b/packages/dokeysto/dokeysto.1.0.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "base-unix"
   "extunix"

--- a/packages/dokeysto/dokeysto.2.0.0/opam
+++ b/packages/dokeysto/dokeysto.2.0.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "base-unix"
   "extunix"

--- a/packages/dokeysto/dokeysto.2.0.0/opam
+++ b/packages/dokeysto/dokeysto.2.0.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {>= "1.0+beta7"}
+  "jbuilder" {>= "1.0+beta19"}
   "base-bytes"
   "base-unix"
   "extunix"


### PR DESCRIPTION
Detected in #18840
```
#=== ERROR while compiling dokeysto.1.0.1 =====================================#
# context              2.1.0~beta4 | linux/x86_64 | ocaml-base-compiler.4.07.1 | file:///src
# path                 ~/.opam/4.07/.opam-switch/build/dokeysto.1.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p dokeysto -j 47
# exit-code            1
# env-file             ~/.opam/log/dokeysto-23-3af1b7.env
# output-file          ~/.opam/log/dokeysto-23-3af1b7.out
### output ###
# jbuilder: unknown option `-p'.
# Usage: jbuilder build [OPTION]... TARGET...
# Try `jbuilder build --help' or `jbuilder --help' for more information.
```