### PR TITLE
bst < 6.0.0: Add missing constraint (uses jbuilder build -p)

### DIFF
--- a/packages/bst/bst.1.0.1/opam
+++ b/packages/bst/bst.1.0.1/opam
@@ -8,7 +8,7 @@ license: "BSD-3-Clause"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Bisector tree implementation in OCaml."
 description: """

--- a/packages/bst/bst.3.0.0/opam
+++ b/packages/bst/bst.3.0.0/opam
@@ -8,7 +8,7 @@ license: "BSD-3-Clause"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Bisector tree implementation in OCaml."
 description: """

--- a/packages/bst/bst.3.0.0/opam
+++ b/packages/bst/bst.3.0.0/opam
@@ -8,7 +8,7 @@ license: "BSD-3-Clause"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder" {>= "1.0+beta7"}
+  "jbuilder" {>= "1.0+beta19"}
 ]
 synopsis: "Bisector tree implementation in OCaml."
 description: """

--- a/packages/bst/bst.5.0.0/opam
+++ b/packages/bst/bst.5.0.0/opam
@@ -8,7 +8,7 @@ license: "BSD-3-Clause"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "batteries"
 ]
 synopsis: "Bisector tree implementation in OCaml."

--- a/packages/bst/bst.5.0.0/opam
+++ b/packages/bst/bst.5.0.0/opam
@@ -8,7 +8,7 @@ license: "BSD-3-Clause"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder" {>= "1.0+beta7"}
+  "jbuilder" {>= "1.0+beta19"}
   "batteries"
 ]
 synopsis: "Bisector tree implementation in OCaml."


### PR DESCRIPTION
Detected in #18840
```
#=== ERROR while compiling bst.3.0.0 ==========================================#
# context              2.1.0~beta4 | linux/x86_64 | ocaml-base-compiler.4.07.1 | file:///src
# path                 ~/.opam/4.07/.opam-switch/build/bst.3.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p bst -j 47
# exit-code            1
# env-file             ~/.opam/log/bst-23-79ada4.env
# output-file          ~/.opam/log/bst-23-79ada4.out
### output ###
# jbuilder: unknown option `-p'.
# Usage: jbuilder build [OPTION]... TARGET...
# Try `jbuilder build --help' or `jbuilder --help' for more information.
```