### PR TITLE
lwt < 3.1.0 is not compatible with ocamlbuild.0.9.0

### DIFF
--- a/packages/lwt/lwt.2.4.5/opam
+++ b/packages/lwt/lwt.2.4.5/opam
@@ -35,6 +35,7 @@ conflicts: [
   "ocaml-variants" {= "4.02.1+BER"}
   "react" {< "1.0.0"}
   "ssl" {>= "0.5.0"}
+  "ocamlbuild" {= "0.9.0"}
 ]
 authors: [
   "Jérôme Vouillon"

--- a/packages/lwt/lwt.2.5.2/opam
+++ b/packages/lwt/lwt.2.5.2/opam
@@ -45,6 +45,7 @@ conflicts: [
   "react" {< "1.0.0"}
   "ssl" {< "0.5.0"}
   "ppx_tools" {< "1.0.0"}
+  "ocamlbuild" {= "0.9.0"}
 ]
 synopsis: "A cooperative threads library for OCaml"
 description: """

--- a/packages/lwt/lwt.2.6.0/opam
+++ b/packages/lwt/lwt.2.6.0/opam
@@ -52,6 +52,7 @@ conflicts: [
   "react" {< "1.0.0"}
   "ssl" {< "0.5.0"}
   "ppx_tools" {< "1.0.0"}
+  "ocamlbuild" {= "0.9.0"}
 ]
 synopsis: "Cooperative threads and I/O in monadic style"
 description: """

--- a/packages/lwt/lwt.2.7.0/opam
+++ b/packages/lwt/lwt.2.7.0/opam
@@ -53,6 +53,7 @@ conflicts: [
   "react" {< "1.0.0"}
   "ssl" {< "0.5.0"}
   "ppx_tools" {< "1.0.0"}
+  "ocamlbuild" {= "0.9.0"}
 ]
 messages: [
   "For module Lwt_ssl, please install package lwt_ssl"

--- a/packages/lwt/lwt.2.7.1/opam
+++ b/packages/lwt/lwt.2.7.1/opam
@@ -59,6 +59,7 @@ conflicts: [
   "react" {< "1.0.0"}
   "ssl" {< "0.5.0"}
   "ppx_tools" {< "1.0.0"}
+  "ocamlbuild" {= "0.9.0"}
 ]
 messages: [
   "For module Lwt_ssl, please install package lwt_ssl"

--- a/packages/lwt/lwt.3.0.0/opam
+++ b/packages/lwt/lwt.3.0.0/opam
@@ -51,6 +51,7 @@ depopts: [
 conflicts: [
   "ocaml-variants" {= "4.02.1+BER"}
   "ppx_tools" {< "1.0.0"}
+  "ocamlbuild" {= "0.9.0"}
 ]
 messages: [
   "For module Lwt_ssl, please install package lwt_ssl"


### PR DESCRIPTION
Detected in #18846 
```
#=== ERROR while compiling lwt.2.4.5 ==========================================#
# context              2.1.0~beta4 | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///src
# path                 ~/.opam/4.03/.opam-switch/build/lwt.2.4.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build make build
# exit-code            2
# env-file             ~/.opam/log/lwt-23-2e09d7.env
# output-file          ~/.opam/log/lwt-23-2e09d7.out
### output ###
# /home/opam/.opam/4.03/bin/ocamlfind ocamlmklib -o src/unix/lwt-unix_stubs -L/usr/lib -lpthread src/unix/lwt_unix_stubs.o src/unix/lwt_libev_stubs.o src/unix/lwt_process_stubs.o src/unix/jobs-unix/lwt_unix_job_access.o src/unix/jobs-unix/lwt_unix_job_chdir.o src/unix/jobs-unix/lwt_unix_job_chmod.o src/unix/jobs-unix/lwt_unix_job_chown.o src/unix/jobs-unix/lwt_unix_job_chroot.o src/unix/jobs-unix/lwt_unix_job_close.o src/unix/jobs-unix/lwt_unix_job_fchmod.o src/unix/jobs-unix/lwt_unix_job_fchown.o src/unix/jobs-unix/lwt_unix_job_fdatasync.o src/unix/jobs-unix/lwt_unix_job_fsync.o src/unix/jobs-unix/lwt_unix_job_ftruncate.o src/unix/jobs-unix/lwt_unix_job_link.o src/unix/jobs-unix/lwt_unix_job_lseek.o src/unix/jobs-unix/lwt_unix_job_mkdir.o src/unix/jobs-unix/lwt_unix_job_mkfifo.o src/unix/jobs-unix/lwt_unix_job_rename.o src/unix/jobs-unix/lwt_unix_job_rmdir.o src/unix/jobs-unix/lwt_unix_job_symlink.o src/unix/jobs-unix/lwt_unix_job_tcdrain.o src/unix/jobs-unix/lwt_unix_job_tcflow.o src/unix/jobs-unix/lwt_unix_job_tcflush.o src/unix/jobs-unix/lwt_unix_job_tcsendbreak.o src/unix/jobs-unix/lwt_unix_job_truncate.o src/unix/jobs-unix/lwt_unix_job_unlink.o
# + /home/opam/.opam/4.03/bin/ocamlfind ocamlmklib -o src/unix/lwt-unix_stubs -L/usr/lib -lpthread src/unix/lwt_unix_stubs.o src/unix/lwt_libev_stubs.o src/unix/lwt_process_stubs.o src/unix/jobs-unix/lwt_unix_job_access.o src/unix/jobs-unix/lwt_unix_job_chdir.o src/unix/jobs-unix/lwt_unix_job_chmod.o src/unix/jobs-unix/lwt_unix_job_chown.o src/unix/jobs-unix/lwt_unix_job_chroot.o src/unix/jobs-unix/lwt_unix_job_close.o src/unix/jobs-unix/lwt_unix_job_fchmod.o src/unix/jobs-unix/lwt_unix_job_fchown.o src/unix/jobs-unix/lwt_unix_job_fdatasync.o src/unix/jobs-unix/lwt_unix_job_fsync.o src/unix/jobs-unix/lwt_unix_job_ftruncate.o src/unix/jobs-unix/lwt_unix_job_link.o src/unix/jobs-unix/lwt_unix_job_lseek.o src/unix/jobs-unix/lwt_unix_job_mkdir.o src/unix/jobs-unix/lwt_unix_job_mkfifo.o src/unix/jobs-unix/lwt_unix_job_rename.o src/unix/jobs-unix/lwt_unix_job_rmdir.o src/unix/jobs-unix/lwt_unix_job_symlink.o src/unix/jobs-unix/lwt_unix_job_tcdrain.o src/unix/jobs-unix/lwt_unix_job_tcflow.o src/unix/jobs-unix/lwt_unix_job_tcflush.o src/unix/jobs-unix/lwt_unix_job_tcsendbreak.o src/unix/jobs-unix/lwt_unix_job_truncate.o src/unix/jobs-unix/lwt_unix_job_unlink.o
# gcc: error: src/unix/lwt_unix_stubs.o: No such file or directory
# gcc: error: src/unix/lwt_libev_stubs.o: No such file or directory
# gcc: error: src/unix/lwt_process_stubs.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_access.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_chdir.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_chmod.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_chown.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_chroot.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_close.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_fchmod.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_fchown.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_fdatasync.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_fsync.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_ftruncate.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_link.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_lseek.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_mkdir.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_mkfifo.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_rename.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_rmdir.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_symlink.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_tcdrain.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_tcflow.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_tcflush.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_tcsendbreak.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_truncate.o: No such file or directory
# gcc: error: src/unix/jobs-unix/lwt_unix_job_unlink.o: No such file or directory
# Command exited with code 2.
# + /home/opam/.opam/4.03/bin/ocamlopt.opt unix.cmxa -I /home/opam/.opam/4.03/lib/ocamlbuild /home/opam/.opam/4.03/lib/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/opam/.opam/4.03/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# File "myocamlbuild.ml", line 492, characters 43-62:
# Warning 3: deprecated: Ocamlbuild_plugin.String.uncapitalize
# Use String.uncapitalize_ascii instead.
# File "myocamlbuild.ml", line 505, characters 51-70:
# Warning 3: deprecated: Ocamlbuild_plugin.String.uncapitalize
# Use String.uncapitalize_ascii instead.
# E: Failure("Command ''/home/opam/.opam/4.03/bin/ocamlbuild' syntax/optcomp.cma syntax/optcomp.cmxa syntax/optcomp.a syntax/optcomp.cmxs src/core/lwt.cma src/core/lwt.cmxa src/core/lwt.a src/core/lwt.cmxs src/logger/lwt-log.cma src/logger/lwt-log.cmxa src/logger/lwt-log.a src/logger/lwt-log.cmxs src/unix/liblwt-unix_stubs.a src/unix/dlllwt-unix_stubs.so src/unix/lwt-unix.cma src/unix/lwt-unix.cmxa src/unix/lwt-unix.a src/unix/lwt-unix.cmxs src/simple_top/lwt-simple-top.cma src/simple_top/lwt-simple-top.cmxa src/simple_top/lwt-simple-top.a src/simple_top/lwt-simple-top.cmxs src/preemptive/lwt-preemptive.cma src/preemptive/lwt-preemptive.cmxa src/preemptive/lwt-preemptive.a src/preemptive/lwt-preemptive.cmxs src/extra/lwt-extra.cma src/extra/lwt-extra.cmxa src/extra/lwt-extra.a src/extra/lwt-extra.cmxs syntax/lwt-syntax.cma syntax/lwt-syntax.cmxa syntax/lwt-syntax.a syntax/lwt-syntax.cmxs syntax/lwt-syntax-options.cma syntax/lwt-syntax-options.cmxa syntax/lwt-syntax-options.a syntax/lwt-syntax-options.cmxs syntax/lwt-syntax-log.cma syntax/lwt-syntax-log.cmxa syntax/lwt-syntax-log.a syntax/lwt-syntax-log.cmxs examples/unix/logging.native examples/unix/relay.native examples/unix/parallelize.native -tag debug' terminated with error code 10")
# make: *** [Makefile:27: build] Error 1
```