### PR TITLE
conformist: Add missing conflict

### DIFF
--- a/packages/conformist/conformist.0.5.0/opam
+++ b/packages/conformist/conformist.0.5.0/opam
@@ -21,6 +21,9 @@ depends: [
   "alcotest" {>= "1.2.3" & with-test}
   "sexplib" {>= "v0.13.0" & with-test}
 ]
+conflicts: [
+  "result" {< "1.5"} # uses Result.t from result implicitly through ptime
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/conformist/conformist.0.6.0/opam
+++ b/packages/conformist/conformist.0.6.0/opam
@@ -21,6 +21,9 @@ depends: [
   "alcotest" {>= "1.2.3" & with-test}
   "sexplib" {>= "v0.13.0" & with-test}
 ]
+conflicts: [
+  "result" {< "1.5"} # uses Result.t from result implicitly through ptime
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/18819
cc @jberdine 
```
#=== ERROR while compiling conformist.0.6.0 ===================================#
# context              2.1.0~rc | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///src
# path                 ~/.opam/4.08/.opam-switch/build/conformist.0.6.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p conformist -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/conformist-24-77a5c0.env
# output-file          ~/.opam/log/conformist-24-77a5c0.out
### output ###
#       ocamlc src/.conformist.objs/byte/conformist.{cmi,cmti} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.conformist.objs/byte -I /home/opam/.opam/4.08/lib/ptime -I /home/opam/.opam/4.08/lib/result -no-alias-deps -o src/.conformist.objs/byte/conformist.cmi -c -intf src/conformist.mli)
# File "src/conformist.mli", line 407, characters 23-31:
# 407 |   -> ('ty, error list) Result.t
#                              ^^^^^^^^
# Error: Unbound type constructor Result.t
```